### PR TITLE
Add CI workflow with Swatinem Rust cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]
@@ -12,18 +15,12 @@ concurrency:
 jobs:
   build:
     runs-on: windows-latest
+    timeout-minutes: 30
     steps:
-      - name: Checkout windbg-mcp
+      - name: Checkout
         uses: actions/checkout@v4
         with:
-          path: windbg-mcp
-
-      - name: Checkout win-kexp (path dependency)
-        uses: actions/checkout@v4
-        with:
-          repository: glslang/win-kexp
-          ref: main
-          path: win-kexp
+          persist-credentials: false
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -32,21 +29,15 @@ jobs:
 
       - name: Cache cargo registry and build
         uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: windbg-mcp
 
       - name: Format check
         run: cargo fmt --all --check
-        working-directory: windbg-mcp
 
       - name: Clippy
         run: cargo clippy --all-targets
-        working-directory: windbg-mcp
 
       - name: Build
         run: cargo build --release
-        working-directory: windbg-mcp
 
       - name: Test
         run: cargo test
-        working-directory: windbg-mcp

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: glslang/win-kexp
-          ref: dbgeng-dump-launch-attach-ttd
+          ref: main
           path: win-kexp
 
       - name: Install Rust toolchain

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,52 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout windbg-mcp
+        uses: actions/checkout@v4
+        with:
+          path: windbg-mcp
+
+      - name: Checkout win-kexp (path dependency)
+        uses: actions/checkout@v4
+        with:
+          repository: glslang/win-kexp
+          ref: dbgeng-dump-launch-attach-ttd
+          path: win-kexp
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Cache cargo registry and build
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: windbg-mcp
+
+      - name: Format check
+        run: cargo fmt --all --check
+        working-directory: windbg-mcp
+
+      - name: Clippy
+        run: cargo clippy --all-targets
+        working-directory: windbg-mcp
+
+      - name: Build
+        run: cargo build --release
+        working-directory: windbg-mcp
+
+      - name: Test
+        run: cargo test
+        working-directory: windbg-mcp

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,9 +99,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "num-traits",
@@ -328,9 +328,9 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "log"
-version = "0.4.30"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
+checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "matchers"
@@ -814,6 +814,7 @@ dependencies = [
 [[package]]
 name = "win-kexp"
 version = "0.1.0"
+source = "git+https://github.com/glslang/win-kexp?branch=main#b92e9230172b164e182a9c6a0971f5c938cc2f40"
 dependencies = [
  "byte-strings",
  "goblin",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-win-kexp = { path = "../win-kexp" }
+win-kexp = { git = "https://github.com/glslang/win-kexp", branch = "main" }
 rmcp = { version = "1", features = ["server", "transport-io", "macros", "schemars"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "io-std", "sync", "time"] }
 serde = { version = "1", features = ["derive"] }

--- a/src/server.rs
+++ b/src/server.rs
@@ -52,7 +52,13 @@ fn hexdump(base: u64, bytes: &[u8]) -> String {
         let hex: Vec<String> = chunk.iter().map(|b| format!("{b:02x}")).collect();
         let ascii: String = chunk
             .iter()
-            .map(|&b| if (0x20..0x7f).contains(&b) { b as char } else { '.' })
+            .map(|&b| {
+                if (0x20..0x7f).contains(&b) {
+                    b as char
+                } else {
+                    '.'
+                }
+            })
             .collect();
         out.push_str(&format!("{addr:016x}  {:<47}  {ascii}\n", hex.join(" ")));
     }
@@ -188,7 +194,8 @@ impl WindbgServer {
                 e.open_trace(&args.path).map_err(es)?;
                 e.wait_for_event(LOAD_WAIT_MS).map_err(es)?;
                 // Confirm TTD replay is active and report the trace's position span.
-                e.execute_command("dx @$curprocess.TTD.Lifetime").map_err(es)
+                e.execute_command("dx @$curprocess.TTD.Lifetime")
+                    .map_err(es)
             })
             .await?;
         text_result(out)
@@ -265,7 +272,11 @@ impl WindbgServer {
     async fn end_session(&self) -> Result<CallToolResult, ErrorData> {
         let out = self
             .engine
-            .run(move |e| e.end_session().map(|_| "session ended".to_string()).map_err(es))
+            .run(move |e| {
+                e.end_session()
+                    .map(|_| "session ended".to_string())
+                    .map_err(es)
+            })
             .await?;
         text_result(out)
     }
@@ -357,10 +368,7 @@ impl WindbgServer {
 
     /// Evaluate a data-model (LINQ) expression with `dx` — ideal for TTD queries.
     #[rmcp::tool]
-    async fn dx(
-        &self,
-        Parameters(args): Parameters<DxArgs>,
-    ) -> Result<CallToolResult, ErrorData> {
+    async fn dx(&self, Parameters(args): Parameters<DxArgs>) -> Result<CallToolResult, ErrorData> {
         let cmd = format!("dx {}", args.expression);
         let out = self
             .engine
@@ -421,7 +429,10 @@ impl WindbgServer {
     async fn ttd_events(&self) -> Result<CallToolResult, ErrorData> {
         let out = self
             .engine
-            .run(move |e| e.execute_command("dx -r2 @$curprocess.TTD.Events").map_err(es))
+            .run(move |e| {
+                e.execute_command("dx -r2 @$curprocess.TTD.Events")
+                    .map_err(es)
+            })
             .await?;
         text_result(out)
     }


### PR DESCRIPTION
## Summary

Adds the project's first CI workflow (`.github/workflows/ci.yml`). Runs `fmt`, `clippy`, `build`, and `test` on `windows-latest` with a warm Rust cache via `Swatinem/rust-cache@v2`.

## Design notes

- **Windows-only matrix.** `windbg-mcp` links DbgEng / `windows-sys` with no `cfg` guards, so it only compiles on Windows. The matrix is `windows-latest` only.
- **`win-kexp` path dependency.** `Cargo.toml` declares `win-kexp = { path = "../win-kexp" }`. CI checks out both repos into sibling subdirectories under the workspace (`windbg-mcp/` and `win-kexp/`) so the `../win-kexp` relationship resolves, then runs cargo with `working-directory: windbg-mcp`. `win-kexp` is cloned from `glslang/win-kexp` at branch `dbgeng-dump-launch-attach-ttd` (public, no token needed).
- **Toolchain:** `dtolnay/rust-toolchain@stable` (edition 2024 needs Rust ≥ 1.85) with `rustfmt` + `clippy`.
- **Cache:** `Swatinem/rust-cache@v2` with `workspaces: windbg-mcp`, as requested to match other repos.
- **clippy** is run without `-D warnings` initially to avoid turning CI red on never-before-linted code; can tighten later.

## Verification

Can't build locally (Linux container, Windows-only crate) — needs the GitHub Actions run on `windows-latest` to confirm the `win-kexp` checkout, cache priming, and build/test succeed. If the `win-kexp` branch name differs, adjust the `ref:`.

https://claude.ai/code/session_011iwoCSBRTP1oa6eK8rAdQC

---
_Generated by [Claude Code](https://claude.ai/code/session_011iwoCSBRTP1oa6eK8rAdQC)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated CI workflow that runs on pushes to main and on pull requests; it checks formatting, runs static analysis, builds a release and executes tests, and cancels redundant concurrent runs.

* **Chores**
  * Switched a dependency from a local path to a remote Git source.

* **Style**
  * Reformatted server-side code for improved readability without changing behaviour.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->