### PR TITLE
Package as Claude Code plugin with windbg-debugging skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,12 @@
+{
+  "name": "windbg-mcp",
+  "description": "WinDbg/DbgEng debugging tools for Claude Code: an MCP server plus a skill that drives crash-dump, live, and Time Travel Debugging workflows.",
+  "owner": { "name": "glslang", "email": "glslang@gmail.com" },
+  "plugins": [
+    {
+      "name": "windbg-mcp",
+      "source": ".",
+      "description": "WinDbg/DbgEng MCP server + debugging skill."
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,16 @@
+{
+  "name": "windbg-mcp",
+  "description": "WinDbg/DbgEng debugging: crash dumps, live user-mode and kernel, and Time Travel Debugging (TTD) — MCP server plus a skill that drives it.",
+  "version": "0.1.0",
+  "author": { "name": "glslang", "email": "glslang@gmail.com" },
+  "homepage": "https://github.com/glslang/windbg-mcp",
+  "repository": "https://github.com/glslang/windbg-mcp",
+  "license": "Apache-2.0",
+  "mcpServers": {
+    "windbg": {
+      "type": "stdio",
+      "command": "${CLAUDE_PLUGIN_ROOT}/target/release/windbg-mcp.exe",
+      "args": []
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -85,6 +85,23 @@ Point your client at the built binary, e.g. Claude Code:
 }
 ```
 
+### As a Claude Code plugin
+
+This repo is also a single-plugin [Claude Code marketplace](https://code.claude.com/docs/en/plugin-marketplaces):
+installing it registers the `windbg` MCP server **and** a `windbg-debugging` skill that
+knows how to drive it (setup, crash-dump, live/kernel, and TTD playbooks).
+
+```
+/plugin marketplace add glslang/windbg-mcp
+/plugin install windbg-mcp@windbg-mcp
+```
+
+The plugin ships source, not a binary, so after installing you still build it in place and
+(for `.run` replay) bundle the WinDbg engine — the skill's `setup.md` walks through it, and
+it mirrors the [*Build*](#build) and [*TTD engine*](#ttd-engine-required-for-run-replay)
+sections above. Then `/reload-plugins` to connect the server. The plugin points at
+`${CLAUDE_PLUGIN_ROOT}/target/release/windbg-mcp.exe`.
+
 ## Walkthrough
 
 [`docs/ttd-walkthrough.md`](docs/ttd-walkthrough.md) is a hands-on tour of the TTD tools against the

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ This repo is also a single-plugin [Claude Code marketplace](https://code.claude.
 installing it registers the `windbg` MCP server **and** a `windbg-debugging` skill that
 knows how to drive it (setup, crash-dump, live/kernel, and TTD playbooks).
 
-```
+```text
 /plugin marketplace add glslang/windbg-mcp
 /plugin install windbg-mcp@windbg-mcp
 ```

--- a/skills/windbg-debugging/SKILL.md
+++ b/skills/windbg-debugging/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: windbg-debugging
+description: Drive WinDbg/DbgEng via the `windbg` MCP server to debug Windows crash dumps, live user-mode and kernel targets, and Time Travel Debugging (.run) traces. Use when analyzing a .dmp, attaching to a process or the kernel, or recording/navigating/analyzing a TTD trace.
+---
+
+# WinDbg debugging via the `windbg` MCP server
+
+This skill drives the `windbg` MCP server, which wraps WinDbg/DbgEng for four kinds of
+Windows debugging: **crash-dump** analysis, **live user-mode** debugging, **kernel**
+debugging, and **Time Travel Debugging (TTD)** of `.run` traces.
+
+**Verify the environment first.** Most failures are setup, not debugging — wrong engine
+DLL, missing symbols, or no elevation. Read **[setup.md](setup.md)** before the first
+session of a workflow you haven't run yet in this environment.
+
+## Pick a playbook
+
+| Task | Playbook |
+|------|----------|
+| Build / engine bundling / symbols / elevation | [setup.md](setup.md) |
+| Triage a `.dmp` crash dump | [crash-dump.md](crash-dump.md) |
+| Launch/attach a process, or debug the kernel | [live-and-kernel.md](live-and-kernel.md) |
+| Record / open / navigate / analyze a `.run` trace | [ttd.md](ttd.md) |
+
+## Tool map
+
+Knowing which verb exists keeps you from reaching for raw `execute` when a typed tool
+already does the job.
+
+| Group | Tools |
+|-------|-------|
+| Session | `open_dump`, `open_trace`, `attach_kernel_local`, `attach_kernel`, `attach_process`, `launch`, `end_session` |
+| State | `registers`, `read_memory`, `backtrace`, `modules`, `threads`, `disassemble`, `dx` |
+| Control | `go`, `step_over`, `step_into`, `set_breakpoint` |
+| TTD nav | `step_back` (`t-`), `step_over_back` (`p-`), `reverse_go` (`g-`), `goto_position` (`!tt`) |
+| TTD analysis | `ttd_calls`, `ttd_memory`, `ttd_events`, `index_trace`, `record_trace` |
+| Raw | `execute` — run any debugger command, returns full text output |
+
+The forward control tools (`go`/`step_over`/`step_into`) and the reverse ones
+(`reverse_go`/`step_over_back`/`step_back`) mirror a debugger UI's F9/F8/F7 and their
+Shift variants. They issue the command **and pump the engine to the next stop** — unlike
+a bare `execute`, which only sets the run state and doesn't move the target.
+
+## Cross-cutting gotchas (apply to every workflow)
+
+- **One debug session at a time** (single engine instance). End one with `end_session`
+  before opening another target.
+- **Symbol *names* (`module!func`) need three things together:** (a) `msdia140.dll`
+  bundled next to the binary, (b) a symbol path (`execute` →
+  `.sympath srv*C:\ProgramData\Dbg\sym*https://msdl.microsoft.com/download/symbols`), and
+  (c) a `.reload /f` at a *stopped* position (after a `go`/breakpoint, **not** straight off
+  a `goto_position`/`!tt`). Without these you silently get export symbols only and
+  `module!name` lookups fail. Address-based queries, navigation, and memory reads still
+  work without symbols — query by address.
+- **`read_memory` takes a numeric/`0x`-hex address only.** For a register/symbol
+  expression use `execute` with `db`/`dd` (e.g. `db @rip`).
+- **Single-stepping needs a live thread context** — valid only once the target is stopped
+  after a `go`/step or a breakpoint hit. Stepping straight after `goto_position 0` (before
+  any thread is live) returns `0x80040205`; `go` to a breakpoint first.
+- **`dx` is the escape hatch for the data model** — any LINQ query beyond the
+  `ttd_calls`/`ttd_memory`/`ttd_events` wrappers, e.g.
+  `@$cursession.TTD.Calls("ntdll!NtCreateFile").Where(c => c.ReturnValue != 0)`.
+- **TTD is user-mode only** (a Microsoft limitation) — you cannot time-travel a kernel target.
+- **Each tool call is bounded by a per-call timeout** (~60s for load/exec waits); a `go`
+  against a long-running live target may hit it.

--- a/skills/windbg-debugging/crash-dump.md
+++ b/skills/windbg-debugging/crash-dump.md
@@ -1,0 +1,38 @@
+# Playbook: crash-dump (`.dmp`) triage
+
+**Goal:** open a crash dump and identify the faulting thread, the exception, and the
+offending frame. No elevation needed; works on System32's engine.
+
+## Steps
+
+1. **Open the dump.** `open_dump { "path": "C:\\path\\to\\crash.dmp" }`
+   — loads the dump, waits for it to settle, and returns the module list (`lm`).
+   (`open_dump` also accepts a `.run` trace, but for TTD use `open_trace` — see
+   [ttd.md](ttd.md).)
+
+2. **Auto-analyze.** `execute { "command": "!analyze -v" }`
+   — WinDbg's built-in triage: the exception record, the probable faulting frame, the
+   bugcheck (for kernel dumps), and `FAILURE_BUCKET_ID`. Read this first; it usually names
+   the culprit module and call.
+
+3. **Locate the faulting context.** `threads {}` (`~`) to see all threads; `!analyze -v`
+   already switches to the faulting thread. Confirm with `registers {}`.
+
+4. **Read the stack.** `backtrace {}` (`k`). If frames show `module!name` you have symbols;
+   if not, set up symbols (see [setup.md](setup.md)) and `execute { "command": ".reload /f" }`,
+   then `backtrace {}` again.
+
+5. **Inspect the crash site.**
+   - `disassemble {}` at the current IP, or `disassemble { "address": "module!func" }`.
+   - `read_memory { "address": "0x...", "size": 64 }` for a hex dump (numeric/hex address
+     only — for a register expression use `execute { "command": "db @rsp" }`).
+   - `execute { "command": "dt module!_STRUCT <addr>" }` to format a structure.
+
+## Pitfalls
+
+- **Symbols matter most here.** A stack of raw addresses tells you little — get
+  `(pdb symbols)` working ([setup.md](setup.md)) before drawing conclusions.
+- **Minidumps are partial.** `read_memory` can fail for pages not captured in the dump;
+  that's the dump's limitation, not a tool error.
+- For a kernel dump, `!analyze -v` reports the **bugcheck code and arguments** — start
+  there rather than from the raw stack.

--- a/skills/windbg-debugging/live-and-kernel.md
+++ b/skills/windbg-debugging/live-and-kernel.md
@@ -1,0 +1,43 @@
+# Playbook: live user-mode & kernel debugging
+
+**Goal:** drive a running target (or the kernel) — break in, set breakpoints, step, and
+inspect state. Kernel debugging needs **Administrator** (see [setup.md](setup.md)).
+
+## Start a session
+
+Pick one entry point:
+
+- **Launch a new process.** `launch { "command_line": "C:\\path\\app.exe arg1 arg2" }`
+  — stops at the initial breakpoint with a live thread context (the binding enables the
+  `sxe ibp` initial-breakpoint filter, which a bare host leaves off).
+- **Attach to a running process.** `attach_process { "pid": 1234 }` — breaks in.
+- **Local kernel.** `attach_kernel_local {}` (returns `vertarget`).
+- **Remote kernel (KDNET).** `attach_kernel { "connection": "net:port=50000,key=..." }`.
+
+End with `end_session {}` before opening another target (one session at a time).
+
+## Inspect and control
+
+1. **Survey.** `modules {}` (`lm`), `threads {}` (`~`), `registers {}`.
+2. **Set a breakpoint.** `set_breakpoint { "expression": "kernelbase!CreateFileW" }`
+   (symbol, address, or expression). For kernel, e.g. `nt!NtCreateFile`.
+3. **Run to it.** `go {}` — continues and pumps to the next stop. On hit, inspect with
+   `backtrace {}`, `registers {}`, `disassemble {}`, `read_memory {...}`.
+4. **Step.** `step_over {}` (`p`) / `step_into {}` (`t`) — only valid once stopped with a
+   real thread context (after a `go`/breakpoint).
+5. **Anything else.** `execute { "command": "..." }` for raw commands (e.g. `!peb`,
+   `dt nt!_EPROCESS`), or `dx {...}` for data-model queries.
+
+## Pitfalls
+
+- **Store-app PID gotcha:** on Windows 11 `notepad` is a Store app, so attaching to the PID
+  that `Start-Process notepad` returns can hit `0xD000010A` (that PID is a transient
+  launcher). Attach to a classic Win32 process instead.
+- **`read_memory` is numeric/hex only.** Use `execute` → `db @rip` for register/symbol
+  expressions.
+- **`go` is bounded by the per-call timeout** (~60s). A long-running live target may not
+  reach a breakpoint within one call.
+- **TTD is user-mode only** — you cannot time-travel a kernel target. For reverse
+  execution, record a user-mode trace instead (see [ttd.md](ttd.md)).
+- Symbol names need the full setup (`msdia140.dll` + `.sympath` + `.reload /f` at a stop) —
+  see [setup.md](setup.md).

--- a/skills/windbg-debugging/setup.md
+++ b/skills/windbg-debugging/setup.md
@@ -1,0 +1,82 @@
+# Setup: build, engine bundling, symbols, elevation
+
+Most `windbg` failures are environment problems, not debugging mistakes. Work through the
+section for the workflow you're about to run before blaming the target.
+
+## Platform
+
+- **Windows x64 only.** Host bitness must match the target.
+- `dbgeng.dll` / `dbghelp.dll` ship in `System32` on modern Windows 11 (verified on
+  `10.0.26100`). That is enough for live user-mode/kernel debugging and crash-dump
+  analysis — **but not for TTD `.run` replay** (see below).
+
+## Build the server
+
+The plugin ships the source, not a binary. Build it in place so the path in
+`plugin.json` (`${CLAUDE_PLUGIN_ROOT}/target/release/windbg-mcp.exe`) resolves:
+
+```pwsh
+# From the installed plugin / repo directory. Expects win-kexp as a sibling: ..\win-kexp
+cargo build --release
+```
+
+This crate has a path dependency on [`win-kexp`](https://github.com/glslang/win-kexp) and
+needs its dbgeng MCP-support changes. Until those merge upstream, check out the matching
+branch in the sibling checkout, e.g.:
+
+```pwsh
+git -C ..\win-kexp fetch origin dbgeng-dump-launch-attach-ttd
+git -C ..\win-kexp checkout dbgeng-dump-launch-attach-ttd
+```
+
+After `cargo build`, run `/reload-plugins` so Claude Code connects the `windbg` MCP server.
+
+## TTD engine — required for `.run` replay only
+
+System32's `dbgeng.dll` **rejects** `.run` traces with `0x80070057`. `DebugCreate` binds to
+whichever `dbgeng.dll` the loader finds first, and the app directory is searched before
+`System32` — so drop the **WinDbg** engine next to the built binary. One-time, from the
+installed WinDbg store package:
+
+```pwsh
+$wd  = (Get-AppxPackage Microsoft.WinDbg).InstallLocation + "\amd64"
+$dst = "<plugin dir>\target\release"
+Copy-Item "$wd\dbgeng.dll","$wd\dbghelp.dll","$wd\dbgcore.dll","$wd\dbgmodel.dll",`
+          "$wd\symsrv.dll","$wd\msdia140.dll" $dst -Force
+Copy-Item "$wd\ttd" "$dst\ttd" -Recurse -Force   # TTDReplay*.dll, TtdExt.dll, TTDAnalyze.dll, ...
+```
+
+- The `ttd\` subdir provides the `@$cursession.TTD` / `@$curprocess.TTD` data model and the
+  `!tt` time-travel commands.
+- `cargo clean` wipes `target\`, so re-copy after one.
+
+## Symbols — required for `module!func` name resolution
+
+Symbol *names* fail silently without all three of:
+
+1. **`msdia140.dll` bundled next to the binary** (the copy above). Without it `dbghelp`
+   can't parse any PDB (`dia error 0x8007007e`) and falls back to *export* symbols, so
+   `module!name` lookups fail even with the right PDB cached. `symsrv.dll` is needed to
+   read a symbol-store cache.
+2. **A symbol path:** `execute` →
+   `.sympath srv*C:\ProgramData\Dbg\sym*https://msdl.microsoft.com/download/symbols`
+3. **A `.reload /f` at a stopped position** (after a `go`/breakpoint, not off a bare
+   `!tt`). Confirm with `execute` → `lm m <mod>`: `(pdb symbols)` means it worked,
+   `(export symbols)` means it didn't.
+
+Offline / no symbols? Navigation, memory reads, disassembly, and the data model still work
+— query by address instead of by name.
+
+## Elevation matrix
+
+| Operation | Administrator? |
+|-----------|----------------|
+| Crash-dump analysis (`open_dump`) | No |
+| TTD replay (`open_trace`) | No |
+| Live user-mode (`launch` / `attach_process`) | No (unless the target requires it) |
+| Live kernel (`attach_kernel_local` / `attach_kernel`) | **Yes** |
+| TTD recording (`record_trace`) | **Yes** + `TTD.exe` on `PATH` |
+
+`record_trace` captures the recorder's startup output to `<out_dir>\ttd_record.log` and
+watches it briefly, so a fast failure (e.g. un-elevated → `0x80070005 Access is denied`)
+is reported as an error rather than a false "recording started".

--- a/skills/windbg-debugging/ttd.md
+++ b/skills/windbg-debugging/ttd.md
@@ -60,7 +60,7 @@ either direction. Jump anywhere with `goto_position { "position": "25:508" }`.
 
 Symbol names like `ucrtbase!__stdio_common_vfprintf` only resolve after a settled context:
 
-```
+```text
 execute { "command": ".sympath srv*C:\\ProgramData\\Dbg\\sym*https://msdl.microsoft.com/download/symbols" }
 set_breakpoint { "expression": "0x..." }
 goto_position  { "position": "0" }

--- a/skills/windbg-debugging/ttd.md
+++ b/skills/windbg-debugging/ttd.md
@@ -1,0 +1,85 @@
+# Playbook: Time Travel Debugging (`.run` traces)
+
+**Goal:** record (or open) a deterministic user-mode trace, navigate it forward and
+backward, and answer questions with the TTD data model (every call to a function, every
+access to an address, the module/thread/exception timeline).
+
+**Prerequisite:** the **WinDbg engine must be bundled** next to the binary — System32's
+engine rejects `.run` files with `0x80070057`. See [setup.md](setup.md). Replay needs no
+elevation; **recording does**.
+
+TTD positions are `major:minor` (a sequencing point and a step within it), not wall-clock.
+
+## 1. Get a trace
+
+- **Record** (Administrator, `TTD.exe` on `PATH`):
+  `record_trace { "out_dir": "C:\\traces", "target": "C:\\path\\app.exe arg" }`
+- **Open** an existing trace:
+  `open_trace { "path": "C:\\traces\\app01.run" }` — returns
+  `@$curprocess.TTD.Lifetime` (e.g. `[C:0, 124:8C2]`), confirming replay is live and giving
+  the position span. If the index is stale, `index_trace {}` (`!tt.index`).
+
+## 2. Navigate — forward and backward
+
+| Tool | cmd | UI |
+|------|-----|----|
+| `go` | `g` | F9 continue |
+| `step_over` / `step_into` | `p` / `t` | F8 / F7 |
+| `reverse_go` | `g-` | Shift+F9 reverse continue |
+| `step_over_back` / `step_back` | `p-` / `t-` | Shift+F8 / Shift+F7 |
+| `goto_position` | `!tt` | go to timestamp |
+
+Typical loop: `set_breakpoint { "expression": "0x..." }` → `goto_position { "position": "0" }`
+→ `go {}` (stops at the first hit, reporting `Time Travel Position`). From there `go` again
+for the next hit forward, `reverse_go` to step back to the previous hit, or single-step in
+either direction. Jump anywhere with `goto_position { "position": "25:508" }`.
+
+> **Stepping needs a stop context.** Step *after* a `go`/breakpoint hit. Stepping straight
+> off `goto_position 0` (before any thread is live) returns `0x80040205` — `go` somewhere
+> first.
+
+## 3. Analyze with the data model
+
+- **Calls to a function (across the whole trace):**
+  `ttd_calls { "function": "ucrtbase!__stdio_common_vfprintf" }` — each result carries
+  time, thread, parameters, and return value. Wrap with `dx` LINQ to filter or project:
+  `dx { "expression": "@$cursession.TTD.Calls(\"ntdll!NtCreateFile\").Where(c => c.ReturnValue != 0).Count()" }`
+  Wildcards work: `ttd_calls { "function": "ntdll!Nt*" }`.
+- **Accesses to a memory range:**
+  `ttd_memory { "address": "0x...", "size": 14, "mode": "r" }` — every read/write/execute
+  (`mode` = any combination of `r`/`w`/`e`/`c`; omit for all). Reports position, IP, and
+  access type for each.
+- **Event timeline (modules / threads / exceptions):** `ttd_events {}`
+  (`dx -r2 @$curprocess.TTD.Events`). Note: `Events` and `Threads` hang off
+  `@$curprocess.TTD`; `Calls` and `Memory` hang off `@$cursession.TTD`.
+- **Anything else:** raw `dx { "expression": "..." }`, e.g.
+  `-g @$curprocess.TTD.Threads` or
+  `-g @$curprocess.TTD.Events.Where(e => e.Type == "ModuleLoaded")`.
+
+## 4. Calls with symbols (the part that needs PDBs)
+
+Symbol names like `ucrtbase!__stdio_common_vfprintf` only resolve after a settled context:
+
+```
+execute { "command": ".sympath srv*C:\\ProgramData\\Dbg\\sym*https://msdl.microsoft.com/download/symbols" }
+set_breakpoint { "expression": "0x..." }
+goto_position  { "position": "0" }
+go {}
+execute { "command": ".reload /f" }
+execute { "command": "lm m <mod>" }     # want "(pdb symbols)", not "(export symbols)"
+```
+
+Then `ttd_calls`/`dx` by name work. To inspect a specific call, travel to it
+(`goto_position { "position": "25:508" }`) and read `registers {}` / arguments.
+
+## Pitfalls
+
+- **`.run` won't open / `0x80070057`** → System32 engine; bundle the WinDbg engine
+  ([setup.md](setup.md)).
+- **`module!name` won't resolve / `(export symbols)` only** → `msdia140.dll` not bundled,
+  no `.sympath`, or you reloaded off a bare `!tt`. Bundle it, set the path, `go` to a stop,
+  `.reload /f`.
+- **`lm m <mod>` looks empty but full `lm` shows the module** → its symbols aren't loaded;
+  `.reload` at a stopped position.
+- The `__stdio_common_vfprintf` display alias has two underscores; `_stdio_common_vfprintf`
+  is the alias — match the real symbol.


### PR DESCRIPTION
## Why

`windbg-mcp` shipped only as a raw MCP server: users hand-edited `.mcp.json` with a binary path, and all the operational know-how lived in prose in `README.md` and `docs/ttd-walkthrough.md`. The server gives an agent the *verbs* but not the *expertise* — and Windows debugging is full of non-obvious gotchas (symbol names need `msdia140.dll` + `.sympath` + a `.reload` at a *stopped* position; `.run` replay needs the bundled WinDbg engine, not System32's; stepping needs a live thread context; one session at a time).

This packages the repo as a **single-plugin Claude Code marketplace** that installs the MCP server **and** a skill that knows how to drive it, in one step.

## What

- **`.claude-plugin/plugin.json`** — manifest with the `windbg` MCP server registered inline (via `${CLAUDE_PLUGIN_ROOT}/target/release/windbg-mcp.exe`). Inline registration avoids colliding with project-scoped MCP config when developing the server in-repo.
- **`.claude-plugin/marketplace.json`** — single-plugin marketplace, `source: "."`. Install with `/plugin marketplace add glslang/windbg-mcp` → `/plugin install windbg-mcp@windbg-mcp`.
- **`skills/windbg-debugging/`** — a router `SKILL.md` (tool map + cross-cutting gotchas) plus four progressively-loaded playbooks distilled from the existing docs:
  - `setup.md` — build, WinDbg-engine bundling, symbols, elevation matrix (most failures are setup)
  - `crash-dump.md` — `.dmp` triage
  - `live-and-kernel.md` — launch/attach + kernel
  - `ttd.md` — record/open/navigate/analyze a `.run` trace
- **`README.md`** — a "As a Claude Code plugin" subsection documenting the install flow.

The Rust crate, `docs/`, and CI are unchanged — this is purely additive packaging.

## Caveats

A plugin can't pre-build the Rust binary or bundle the WinDbg engine DLLs, so those steps stay manual after install (`cargo build --release` in place, copy the engine, `/reload-plugins`) — which is exactly why `setup.md` earns its place.

## Verification

- `claude plugin validate .` → passes clean.
- Both `.claude-plugin/*.json` are valid JSON.
- Full end-to-end (open a trace, run `ttd_calls`) requires a Windows host with the engine bundled per `setup.md`.

https://claude.ai/code/session_01Tegwu6UvtZREjVseYLdBCA

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tegwu6UvtZREjVseYLdBCA)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * WinDbg/DbgEng debugging available as a Claude Code plugin, including a debugging skill and marketplace registration for easy installation.

* **Documentation**
  * Added install and plugin registration instructions.
  * Added comprehensive guides: crash-dump triage, live & kernel debugging, Time Travel Debugging, setup and environment notes, tool reference, and common workflow gotchas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->