### PR TITLE
Auto-load ext for crash-dump !analyze; add 0x9F walkthrough + sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,13 @@ cargo build --release --manifest-path C:\workspace\windbg-mcp\Cargo.toml
 > Until that merges, check out that branch in the sibling `win-kexp` checkout:
 > `git -C ..\win-kexp fetch origin dbgeng-dump-launch-attach-ttd && git -C ..\win-kexp checkout dbgeng-dump-launch-attach-ttd`.
 
-### Bundling the WinDbg engine (TTD replay + crash-dump `!analyze`)
+### Bundling the WinDbg engine
 
+Needed for two things: TTD `.run` replay (System32's engine rejects traces with `0x80070057`) and
+crash-dump `!analyze` (which lives in the `winext\` extensions that System32 doesn't ship).
 `DebugCreate` binds to whichever `dbgeng.dll` the loader finds first, and the app directory is
-searched before `System32`. So drop the **WinDbg** engine (which can replay TTD traces and ships the
-debugger extensions) next to the built binary. One-time, from the installed WinDbg store package:
+searched before `System32`, so the copied **WinDbg** engine (which replays TTD traces and ships the
+extensions) wins. One-time, from the installed WinDbg store package:
 
 ```pwsh
 $wd  = (Get-AppxPackage Microsoft.WinDbg).InstallLocation + "\amd64"
@@ -105,10 +107,10 @@ knows how to drive it (setup, crash-dump, live/kernel, and TTD playbooks).
 ```
 
 The plugin ships source, not a binary, so after installing you still build it in place and
-(for `.run` replay) bundle the WinDbg engine — the skill's `setup.md` walks through it, and
-it mirrors the [*Build*](#build) and [*TTD engine*](#ttd-engine-required-for-run-replay)
-sections above. Then `/reload-plugins` to connect the server. The plugin points at
-`${CLAUDE_PLUGIN_ROOT}/target/release/windbg-mcp.exe`.
+(for `.run` replay and crash-dump `!analyze`) bundle the WinDbg engine — the skill's `setup.md`
+walks through it, and it mirrors the [*Build*](#build) and
+[*Bundling the WinDbg engine*](#bundling-the-windbg-engine) sections above. Then `/reload-plugins`
+to connect the server. The plugin points at `${CLAUDE_PLUGIN_ROOT}/target/release/windbg-mcp.exe`.
 
 ## Walkthroughs
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ The low-level engine bindings live in [`win-kexp`](https://github.com/glslang/wi
 - Windows x64 (host bitness must match the target).
 - `dbgeng.dll` / `dbghelp.dll` — present in `System32` on modern Windows 11 (verified with
   `10.0.26100`). This is enough for live user-mode/kernel debugging and crash-dump analysis.
+- **For crash-dump `!analyze`** (and any other `!`-extension command), the engine needs the
+  WinDbg `winext\` extensions bundled next to the binary — System32's engine ships none, so
+  `!analyze` would return *"No export analyze found"*. See *Bundling the WinDbg engine* below.
 - **For Time Travel Debugging (`.run`) replay**, the System32 engine is *not* enough — it rejects
   `.run` traces (`0x80070057`). You need the **WinDbg engine** (which bundles the TTD replay
   components) loaded next to the binary — see *TTD engine* below.
@@ -45,22 +48,27 @@ cargo build --release --manifest-path C:\workspace\windbg-mcp\Cargo.toml
 > Until that merges, check out that branch in the sibling `win-kexp` checkout:
 > `git -C ..\win-kexp fetch origin dbgeng-dump-launch-attach-ttd && git -C ..\win-kexp checkout dbgeng-dump-launch-attach-ttd`.
 
-### TTD engine (required for `.run` replay)
+### Bundling the WinDbg engine (TTD replay + crash-dump `!analyze`)
 
 `DebugCreate` binds to whichever `dbgeng.dll` the loader finds first, and the app directory is
-searched before `System32`. So drop the **WinDbg** engine (which can replay TTD traces) next to the
-built binary. One-time, from the installed WinDbg store package:
+searched before `System32`. So drop the **WinDbg** engine (which can replay TTD traces and ships the
+debugger extensions) next to the built binary. One-time, from the installed WinDbg store package:
 
 ```pwsh
 $wd  = (Get-AppxPackage Microsoft.WinDbg).InstallLocation + "\amd64"
 $dst = "C:\workspace\windbg-mcp\target\release"
 Copy-Item "$wd\dbgeng.dll","$wd\dbghelp.dll","$wd\dbgcore.dll","$wd\dbgmodel.dll",`
           "$wd\symsrv.dll","$wd\msdia140.dll" $dst -Force
-Copy-Item "$wd\ttd" "$dst\ttd" -Recurse -Force   # TTDReplay*.dll, TtdExt.dll, TTDAnalyze.dll, ...
+Copy-Item "$wd\ttd"    "$dst\ttd"    -Recurse -Force   # TTDReplay*.dll, TtdExt.dll, TTDAnalyze.dll, ...
+Copy-Item "$wd\winext" "$dst\winext" -Recurse -Force   # ext.dll (!analyze), kext.dll, … — crash-dump triage
 ```
 
 - The `ttd\` subdir provides the `@$cursession.TTD` / `@$curprocess.TTD` data model and the `!tt`
   time-travel commands.
+- The `winext\` subdir provides `ext.dll` (which exports `!analyze`) and the other `!`-extensions.
+  `open_dump` runs `.load ext` for you, but note the **unqualified `!analyze` does not resolve** on
+  this minimal engine — use the module-qualified **`!ext.analyze -v`** for crash-dump triage. Without
+  `winext\`, `!analyze` returns *"No export analyze found"*.
 - **`msdia140.dll` is required for PDB symbols.** Without it, `dbghelp` can't parse any PDB
   (`dia error 0x8007007e`) and silently falls back to *export* symbols — which makes `module!name`
   lookups (and so `ttd_calls("ucrtbase!__stdio_common_vfprintf")`) fail even with the right PDB in
@@ -102,12 +110,16 @@ it mirrors the [*Build*](#build) and [*TTD engine*](#ttd-engine-required-for-run
 sections above. Then `/reload-plugins` to connect the server. The plugin points at
 `${CLAUDE_PLUGIN_ROOT}/target/release/windbg-mcp.exe`.
 
-## Walkthrough
+## Walkthroughs
 
-[`docs/ttd-walkthrough.md`](docs/ttd-walkthrough.md) is a hands-on tour of the TTD tools against the
-[`xusheng6/TTD_lab`](https://github.com/xusheng6/TTD_lab) `helloworld` sample — opening a `.run`,
-surveying events/threads, forward/reverse navigation, memory analysis, and counting `printf` calls
-with symbols (with the real outputs and the gotchas). It maps each tool to the lab's exercises.
+- [`docs/crash-dump-walkthrough.md`](docs/crash-dump-walkthrough.md) — triaging a real kernel
+  minidump ([`docs/samples/052126-34312-01.dmp`](docs/samples/052126-34312-01.dmp)): a
+  `0x9F DRIVER_POWER_STATE_FAILURE` traced to `nvlddmkm.sys` via `!ext.analyze -v` and a manual
+  device-stack walk, with the real outputs and the partial-minidump (`0x80040205`) gotcha.
+- [`docs/ttd-walkthrough.md`](docs/ttd-walkthrough.md) — a hands-on tour of the TTD tools against the
+  [`xusheng6/TTD_lab`](https://github.com/xusheng6/TTD_lab) `helloworld` sample: opening a `.run`,
+  surveying events/threads, forward/reverse navigation, memory analysis, and counting `printf` calls
+  with symbols (with the real outputs and the gotchas). It maps each tool to the lab's exercises.
 
 ## Tools
 
@@ -143,6 +155,12 @@ timeline). For anything else, `dx` evaluates arbitrary data-model/LINQ expressio
   can hit `0xD000010A` (that PID is a transient launcher) — attach to a classic Win32 process.
 - `read_memory` takes a numeric/`0x`-hex address only; for register/symbol expressions use
   `execute` with `db`/`dd` (e.g. `db @rip`).
+- **Crash-dump triage uses `!ext.analyze -v`**, not `!analyze` — the bundled engine only resolves
+  the module-qualified form (see *Bundling the WinDbg engine*). On a **partial minidump**, reads of
+  pages that weren't captured raise `An unexpected exception was raised (0x80040205)` rather than a
+  clean "memory read error"; query the specific field you need (e.g.
+  `dt nt!_DRIVER_OBJECT <addr> DriverName`) instead of dumping whole structures. See the
+  [crash-dump walkthrough](docs/crash-dump-walkthrough.md).
 - Single-stepping is only valid once the target is stopped with a real thread context (after a
   `go`/step or a breakpoint hit). Stepping straight after a bare `goto_position` to the very start of
   a trace (before any thread is live) returns `0x80040205` — `go` to a breakpoint first.

--- a/docs/crash-dump-walkthrough.md
+++ b/docs/crash-dump-walkthrough.md
@@ -1,0 +1,133 @@
+# Crash-dump walkthrough: a `0x9F DRIVER_POWER_STATE_FAILURE`
+
+A hands-on tour of the crash-dump tools against a real kernel minidump,
+[`docs/samples/052126-34312-01.dmp`](samples/052126-34312-01.dmp) (a 5.8 MB
+kernel-generated triage dump). It mirrors the skill's
+[`crash-dump.md`](../skills/windbg-debugging/crash-dump.md) playbook and shows the
+real `windbg` MCP tool calls, their output, and the gotchas — ending with the
+culprit driver named by a manual device-stack walk when `!analyze` couldn't.
+
+> **Verdict up front:** Bug check **`0x9F DRIVER_POWER_STATE_FAILURE`**, subtype 3 — the
+> NVIDIA display driver **`nvlddmkm.sys`** failed to complete an `IRP_MN_SET_POWER`
+> request within the power-manager watchdog timeout.
+
+## 1. Open the dump
+
+```jsonc
+open_dump { "path": "…/docs/samples/052126-34312-01.dmp" }
+```
+
+`open_dump` loads the dump, waits for it to settle, **loads `ext.dll`** (so
+`!ext.analyze` resolves — see [§5](#5-why-ext-analyze-and-not-analyze)), and returns the
+module list (`lm`). The module list already tells a story: third-party drivers present
+include `nvlddmkm` (NVIDIA), `nvhda64v` (NVIDIA HD-audio, many unloaded instances),
+`RzDev_*`/`RzCommon` (Razer), and the virtualization stack (`VBox*`, `vmx86`/`hcmon`/`vmnet*`,
+plus Hyper-V `Vid`/`winhvr`). `nt` resolves to `(pdb symbols)`.
+
+## 2. Triage with `!ext.analyze -v`
+
+```jsonc
+execute { "command": "!ext.analyze -v" }
+```
+
+The essential fields:
+
+```text
+DRIVER_POWER_STATE_FAILURE (9f)
+Arg1: 0000000000000003, A device object has been blocking an IRP for too long a time
+Arg2: ffffe284ffe59060, Physical Device Object of the stack
+Arg3: ffffd38c2d84f580, nt!TRIAGE_9F_POWER …
+Arg4: ffffe2850787bc20, The blocked IRP
+
+*** WARNING: Unable to verify timestamp for nvlddmkm.sys
+
+DRVPOWERSTATE_SUBCODE:  3
+DRIVER_OBJECT: ffffe284fe503e10
+FAULTING_THREAD:  ffffe284fe4dd040   (PROCESS_NAME: System)
+
+MODULE_NAME: Unknown_Module
+IMAGE_NAME:  Unknown_Image
+FAILURE_BUCKET_ID:  0x9F_3
+```
+
+`!analyze` already hints at NVIDIA (the timestamp warning) but leaves
+`MODULE_NAME: Unknown_Module` — it didn't auto-attribute the bug to a driver. The
+faulting stack is the watchdog firing from a timer DPC on an idle CPU (normal for `0x9F`;
+the blame is on whoever holds the IRP, not this stack):
+
+```text
+nt!KeBugCheckEx
+nt!PopIrpWatchdogBugcheck
+nt!PopIrpWatchdog
+nt!KiProcessExpiredTimerList
+nt!KiTimerExpiration
+nt!KiRetireDpcList
+nt!KiIdleLoop
+```
+
+## 3. Name the culprit by walking the device stack
+
+`!analyze` left the module unknown, so resolve it from the bug-check arguments by hand.
+Arg2 is the **PDO** and Arg4 is the **blocked IRP** — these address-based reads work even
+on this partial minidump:
+
+```jsonc
+// PDO's owning driver — the bus driver, not the culprit
+execute { "command": "dt nt!_DEVICE_OBJECT ffffe284ffe59060 DriverObject AttachedDevice" }
+//   +0x008 DriverObject   : 0xffffe284fe503e10 _DRIVER_OBJECT   ("\Driver\pci")
+//   +0x018 AttachedDevice : 0xffffe284fe535df0 _DEVICE_OBJECT
+
+// The blocked power IRP and where it is stuck
+execute { "command": "dt nt!_IRP ffffe2850787bc20 Type StackCount CurrentLocation" }
+execute { "command": "dt nt!_IO_STACK_LOCATION poi(ffffe2850787bc20+b8) MajorFunction MinorFunction DeviceObject" }
+//   MajorFunction : 0x16 (IRP_MJ_POWER)   MinorFunction : 0x2 (IRP_MN_SET_POWER)
+//   DeviceObject  : 0xffffe28503b85030   <- top of the stack, holds the IRP
+
+// Whose driver owns that device object?
+execute { "command": "dt nt!_DRIVER_OBJECT poi(ffffe28503b85030+8) DriverName DriverStart" }
+//   +0x018 DriverStart : 0xfffff803`32320000 Void          (matches the nvlddmkm module range)
+//   +0x038 DriverName  : _UNICODE_STRING "\Driver\nvlddmkm"
+```
+
+The full device stack for the stalled PCI device:
+
+```text
+PDO  ffffe284ffe59060   \Driver\pci         (bus driver — owns the PDO)
+ └ FDO ffffe284fe535df0  \Driver\ACPI        (ACPIDispatchIrp)
+    └ FiDO ffffe28503b85030  \Driver\nvlddmkm  <-- blocked IRP_MN_SET_POWER sits here
+```
+
+So **`nvlddmkm` did not complete a `SET_POWER` IRP in time** → `0x9F`. This matches the
+`Unable to verify timestamp for nvlddmkm.sys` note. In practice this is the GPU driver
+hanging during a power transition (sleep/resume, monitor power-off, or a TDR/restart).
+Remediation for the machine: update / clean-reinstall the NVIDIA driver; if it recurs,
+test with sleep / fast-startup disabled.
+
+## 4. Pitfall: partial minidumps and `0x80040205`
+
+This is a small triage minidump, so most of pool isn't captured. Reads of non-captured
+pages don't return a clean "memory read error" — the engine raises an exception that the
+server surfaces as:
+
+```text
+Debug command failed: An unexpected exception was raised (0x80040205)
+```
+
+`dq`/`dps` of an uncaptured range, or a full-struct `dt` that has to follow a pointer into
+a missing page, will hit this. **Query the exact field you need** (e.g.
+`dt _DRIVER_OBJECT <addr> DriverName`) rather than dumping whole structures, and prefer the
+addresses `!analyze` hands you (PDO, IRP, DRIVER_OBJECT) — those are in the triage data.
+
+## 5. Why `!ext.analyze` and not `!analyze`?
+
+The bundled WinDbg engine has no debugger extensions next to it unless you copy the
+`winext\` directory (see [setup.md](../skills/windbg-debugging/setup.md) /
+[README](../README.md)). Without it, `!analyze` returns **empty** with
+*"No export analyze found."* With `winext\` bundled:
+
+- `open_dump` runs `.load ext` for you, **but** the unqualified `!analyze` still won't
+  resolve on this minimal engine — only the module-qualified **`!ext.analyze -v`** does.
+- All `!`-extension commands (`!ext.analyze`, `!process`, …) similarly need the
+  module-qualified form or an explicit `.load`.
+
+That's why this walkthrough uses `!ext.analyze -v`.

--- a/docs/crash-dump-walkthrough.md
+++ b/docs/crash-dump-walkthrough.md
@@ -17,8 +17,8 @@ culprit driver named by a manual device-stack walk when `!analyze` couldn't.
 open_dump { "path": "…/docs/samples/052126-34312-01.dmp" }
 ```
 
-`open_dump` loads the dump, waits for it to settle, **loads `ext.dll`** (so
-`!ext.analyze` resolves — see [§5](#5-why-ext-analyze-and-not-analyze)), and returns the
+`open_dump` loads the dump, waits for it to settle, **loads `ext.dll`** so
+`!ext.analyze` resolves (see [§5](#5-why-extanalyze-and-not-analyze)), and returns the
 module list (`lm`). The module list already tells a story: third-party drivers present
 include `nvlddmkm` (NVIDIA), `nvhda64v` (NVIDIA HD-audio, many unloaded instances),
 `RzDev_*`/`RzCommon` (Razer), and the virtualization stack (`VBox*`, `vmx86`/`hcmon`/`vmnet*`,
@@ -105,7 +105,7 @@ test with sleep / fast-startup disabled.
 
 ## 4. Pitfall: partial minidumps and `0x80040205`
 
-This is a small triage minidump, so most of pool isn't captured. Reads of non-captured
+This is a small triage minidump, so most of the pool isn't captured. Reads of non-captured
 pages don't return a clean "memory read error" — the engine raises an exception that the
 server surfaces as:
 

--- a/skills/windbg-debugging/SKILL.md
+++ b/skills/windbg-debugging/SKILL.md
@@ -52,6 +52,10 @@ a bare `execute`, which only sets the run state and doesn't move the target.
   a `goto_position`/`!tt`). Without these you silently get export symbols only and
   `module!name` lookups fail. Address-based queries, navigation, and memory reads still
   work without symbols — query by address.
+- **`!`-extension commands need the WinDbg `winext\` extensions bundled** next to the engine
+  ([setup.md](setup.md)) **and** the module-qualified form: use `!ext.analyze -v`, not bare
+  `!analyze` (which this engine resolves to *"No export analyze found"* even after `.load ext`).
+  `open_dump` runs `.load ext` for you.
 - **`read_memory` takes a numeric/`0x`-hex address only.** For a register/symbol
   expression use `execute` with `db`/`dd` (e.g. `db @rip`).
 - **Single-stepping needs a live thread context** — valid only once the target is stopped

--- a/skills/windbg-debugging/crash-dump.md
+++ b/skills/windbg-debugging/crash-dump.md
@@ -10,12 +10,19 @@ offending frame. No elevation needed; works on System32's engine.
    (`open_dump` also accepts a `.run` trace, but for TTD use `open_trace` — see
    [ttd.md](ttd.md).)
 
-2. **Auto-analyze.** `execute { "command": "!analyze -v" }`
+2. **Auto-analyze.** `execute { "command": "!ext.analyze -v" }`
    — WinDbg's built-in triage: the exception record, the probable faulting frame, the
    bugcheck (for kernel dumps), and `FAILURE_BUCKET_ID`. Read this first; it usually names
    the culprit module and call.
+   — **Use the module-qualified `!ext.analyze`, not bare `!analyze`.** `open_dump` auto-runs
+   `.load ext`, but this engine only resolves the qualified form; bare `!analyze` returns
+   *"No export analyze found"*. If even `!ext.analyze` says that, the `winext\` extensions
+   aren't bundled — see [setup.md](setup.md).
+   — When `!ext.analyze` leaves `MODULE_NAME: Unknown_Module` (common for power/IRP bugchecks
+   like `0x9F`), name the driver yourself from the bugcheck args by walking the device stack —
+   see step 6.
 
-3. **Locate the faulting context.** `threads {}` (`~`) to see all threads; `!analyze -v`
+3. **Locate the faulting context.** `threads {}` (`~`) to see all threads; `!ext.analyze -v`
    already switches to the faulting thread. Confirm with `registers {}`.
 
 4. **Read the stack.** `backtrace {}` (`k`). If frames show `module!name` you have symbols;
@@ -28,11 +35,26 @@ offending frame. No elevation needed; works on System32's engine.
      only — for a register expression use `execute { "command": "db @rsp" }`).
    - `execute { "command": "dt module!_STRUCT <addr>" }` to format a structure.
 
+6. **Name the driver by hand when `!ext.analyze` can't** (e.g. `0x9F`
+   `DRIVER_POWER_STATE_FAILURE`). The bugcheck args hand you the device object and the blocked
+   IRP; walk to the owning driver by *field*, not by dumping whole structs (see the pitfall
+   below):
+   - `dt nt!_IO_STACK_LOCATION poi(<IRP>+b8) MajorFunction MinorFunction DeviceObject`
+     — the device object currently sitting on the IRP.
+   - `dt nt!_DRIVER_OBJECT poi(<DeviceObject>+8) DriverName DriverStart`
+     — the culprit driver's name, and a `DriverStart` you can match against `lm`.
+   - Walk the stack with `dt nt!_DEVICE_OBJECT <devobj> AttachedDevice` (PDO → FDO → FiDO).
+   The worked example is [docs/crash-dump-walkthrough.md](../../docs/crash-dump-walkthrough.md).
+
 ## Pitfalls
 
 - **Symbols matter most here.** A stack of raw addresses tells you little — get
   `(pdb symbols)` working ([setup.md](setup.md)) before drawing conclusions.
 - **Minidumps are partial.** `read_memory` can fail for pages not captured in the dump;
-  that's the dump's limitation, not a tool error.
-- For a kernel dump, `!analyze -v` reports the **bugcheck code and arguments** — start
+  that's the dump's limitation, not a tool error. A `dt`/`dq`/`dps` against an *uncaptured*
+  page raises `An unexpected exception was raised (0x80040205)` (not a clean read error), and a
+  full-struct `dt` can hit it just by following a pointer into a missing page — read the one
+  field you need (`dt nt!_DRIVER_OBJECT <addr> DriverName`) and prefer the addresses
+  `!ext.analyze` already resolved (PDO, IRP, DRIVER_OBJECT live in the triage data).
+- For a kernel dump, `!ext.analyze -v` reports the **bugcheck code and arguments** — start
   there rather than from the raw stack.

--- a/skills/windbg-debugging/setup.md
+++ b/skills/windbg-debugging/setup.md
@@ -43,11 +43,14 @@ $wd  = (Get-AppxPackage Microsoft.WinDbg).InstallLocation + "\amd64"
 $dst = "<plugin dir>\target\release"
 Copy-Item "$wd\dbgeng.dll","$wd\dbghelp.dll","$wd\dbgcore.dll","$wd\dbgmodel.dll",`
           "$wd\symsrv.dll","$wd\msdia140.dll" $dst -Force
-Copy-Item "$wd\ttd" "$dst\ttd" -Recurse -Force   # TTDReplay*.dll, TtdExt.dll, TTDAnalyze.dll, ...
+Copy-Item "$wd\ttd"    "$dst\ttd"    -Recurse -Force   # TTDReplay*.dll, TtdExt.dll, TTDAnalyze.dll, ...
+Copy-Item "$wd\winext" "$dst\winext" -Recurse -Force   # ext.dll (!analyze), kext.dll, … — for crash dumps
 ```
 
 - The `ttd\` subdir provides the `@$cursession.TTD` / `@$curprocess.TTD` data model and the
   `!tt` time-travel commands.
+- The `winext\` subdir provides `ext.dll` (which exports `!analyze`) and the other `!`-extensions.
+  Required for crash-dump triage — without it `!analyze` returns *"No export analyze found"*.
 - `cargo clean` wipes `target\`, so re-copy after one.
 
 ## Symbols — required for `module!func` name resolution

--- a/skills/windbg-debugging/setup.md
+++ b/skills/windbg-debugging/setup.md
@@ -31,12 +31,18 @@ git -C ..\win-kexp checkout dbgeng-dump-launch-attach-ttd
 
 After `cargo build`, run `/reload-plugins` so Claude Code connects the `windbg` MCP server.
 
-## TTD engine — required for `.run` replay only
+## WinDbg engine + extensions — for `.run` replay and crash-dump `!analyze`
 
-System32's `dbgeng.dll` **rejects** `.run` traces with `0x80070057`. `DebugCreate` binds to
-whichever `dbgeng.dll` the loader finds first, and the app directory is searched before
-`System32` — so drop the **WinDbg** engine next to the built binary. One-time, from the
-installed WinDbg store package:
+Drop the **WinDbg** store-package binaries next to the built binary for two reasons:
+
+- **TTD `.run` replay** — System32's `dbgeng.dll` **rejects** traces with `0x80070057`.
+- **Crash-dump `!analyze`** — it lives in the `winext\` extensions, which System32 doesn't ship
+  (so a `.dmp`-only user still needs the `winext\` copy below, even though dump *loading* itself
+  works on System32's engine).
+
+`DebugCreate` binds to whichever `dbgeng.dll` the loader finds first, and the app directory is
+searched before `System32`, so the copied engine wins. One-time, from the installed WinDbg store
+package:
 
 ```pwsh
 $wd  = (Get-AppxPackage Microsoft.WinDbg).InstallLocation + "\amd64"

--- a/src/server.rs
+++ b/src/server.rs
@@ -176,6 +176,13 @@ impl WindbgServer {
             .run(move |e| {
                 e.open_dump(&args.path).map_err(es)?;
                 e.wait_for_event(LOAD_WAIT_MS).map_err(es)?;
+                // Load the WinDbg extension DLL so `!`-extension commands resolve — most
+                // importantly `!ext.analyze -v`, the crash-dump triage workhorse. A bare
+                // engine doesn't auto-load it, and even after `.load ext` the unqualified
+                // `!analyze` won't resolve, so callers must use `!ext.analyze`. Best-effort:
+                // a minimal engine without a bundled `winext\` directory simply won't have
+                // ext.dll, which must not fail the open (live/dump state is still usable).
+                let _ = e.execute_command(".load ext");
                 e.execute_command("lm").map_err(es)
             })
             .await?;


### PR DESCRIPTION
## Why

The crash-dump playbook's first real step — `!analyze -v` — silently returned **empty** ("No export analyze found"). Root cause: the bundled WinDbg engine ships **no debugger extensions** (`winext\ext.dll` etc.), so no `!`-command resolves. The `ttd\` engine bits are bundled but `winext\` was not.

## Changes

- **`src/server.rs`** — `open_dump` now runs a best-effort `.load ext` after the dump settles, so `!`-extension commands resolve. No-op (open still succeeds) when `winext\` isn't bundled.
- **README + skill** (`setup.md`, `crash-dump.md`, `SKILL.md`) — bundle the WinDbg `winext\` extensions alongside `ttd\`, and use the **module-qualified `!ext.analyze -v`** (this minimal engine doesn't resolve bare `!analyze` even after `.load ext`). Also document:
  - naming a driver by hand (device-stack walk) when `!ext.analyze` leaves `MODULE_NAME: Unknown_Module`, and
  - the partial-minidump `0x80040205` read gotcha (uncaptured pages raise an engine exception, not a clean read error).
- **`docs/crash-dump-walkthrough.md` + `docs/samples/052126-34312-01.dmp`** — a worked example: a real `0x9F DRIVER_POWER_STATE_FAILURE` kernel minidump traced to `nvlddmkm.sys` (NVIDIA) via `!ext.analyze -v` and a manual `_DEVICE_OBJECT`/`_DRIVER_OBJECT`/`_IRP` walk.

## Verification

`cargo build --release` clean. Driving the rebuilt server as a sequential MCP client (`open_dump` → `execute {!ext.analyze -v}`): `.chain` confirms `winext\ext.dll`/`kext.dll` loaded by `open_dump`, and `!ext.analyze -v` returns the full triage (`DRIVER_POWER_STATE_FAILURE (9f)`, `FAILURE_BUCKET_ID: 0x9F_3`) with **no manual `.load`**.

## Notes

- `docs/samples/052126-34312-01.dmp` is a 5.8 MB binary committed as the walkthrough's sample.
- Out of scope (intentionally no fix): under *pipelined* concurrent requests the server dispatches tool calls in nondeterministic order (a call can race ahead of `open_dump`). Standard MCP clients await each call→result, so it doesn't occur in practice, and forcing sequential dispatch would block cancellation during a long `go`. Judged not worth a code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic attempt to load WinDbg extensions when opening crash dumps, improving availability of debugger extension commands.

* **Documentation**
  * Added a crash-dump triage walkthrough with a worked example.
  * Expanded WinDbg engine bundling/setup guidance and skills docs to explain extension bundling and using module-qualified ext.analyze -v.
  * Notes on partial minidump pitfalls and targeted-field querying.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->