### PR TITLE
Document the "one command at a time" concurrency contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,14 @@ timeline). For anything else, `dx` evaluates arbitrary data-model/LINQ expressio
   (after a `go`/breakpoint, not straight off a `!tt`) so the module's PDB is matched and loaded.
   With those, e.g. `ttd_calls("ucrtbase!__stdio_common_vfprintf")` returns the exact call count.
   Without symbols, the data model, navigation, and memory reads still work — query by address.
-- One debug session at a time (single engine instance).
+- **One debug session, one command at a time.** A single engine instance runs on a dedicated
+  thread and processes operations serially. Issue tool calls **sequentially — await each result
+  before sending the next**; the server does not order concurrent in-flight requests, so pipelining
+  them (firing several calls before their results return) can run a command before the one that
+  establishes its state (a call racing ahead of `open_dump` fails with `0x80040205`), and is
+  meaningless for stateful, order-dependent debugger commands anyway. Standard MCP clients already
+  serialize call→result, so this is only a concern for custom/batched callers. End a session with
+  `end_session` before opening another target.
 - TTD **replay** (`open_trace`) needs `TTDReplay.dll` discoverable but **not** elevation; TTD
   **recording** (`record_trace`) needs `TTD.exe` **and** Administrator. `record_trace` captures the
   recorder's startup output to `<out_dir>\ttd_record.log` and watches it briefly, so a fast failure

--- a/skills/windbg-debugging/SKILL.md
+++ b/skills/windbg-debugging/SKILL.md
@@ -43,8 +43,12 @@ a bare `execute`, which only sets the run state and doesn't move the target.
 
 ## Cross-cutting gotchas (apply to every workflow)
 
-- **One debug session at a time** (single engine instance). End one with `end_session`
-  before opening another target.
+- **One debug session, and one command at a time** (single engine instance, run serially on
+  one thread). End a session with `end_session` before opening another target. Issue tool calls
+  **sequentially — await each result before the next**: concurrent in-flight requests aren't
+  ordered, so a pipelined call can run before `open_dump` establishes a target and fail with
+  `0x80040205`, and pipelining stateful debugger commands is unsafe regardless. (Normal MCP
+  clients serialize call→result; this only bites custom/batched callers.)
 - **Symbol *names* (`module!func`) need three things together:** (a) `msdia140.dll`
   bundled next to the binary, (b) a symbol path (`execute` →
   `.sympath srv*C:\ProgramData\Dbg\sym*https://msdl.microsoft.com/download/symbols`), and


### PR DESCRIPTION
## Why

Follow-up to #3. While verifying that PR I observed that the server dispatches **concurrent in-flight requests in nondeterministic order** — a pipelined tool call can race ahead of `open_dump` and fail with `0x80040205`. The engine serializes *execution* (single mpsc consumer on one thread), but not *submission order*.

This is **not worth a code fix**: standard MCP clients await each call→result before sending the next, so it never occurs in practice; debugger commands are stateful/order-dependent, so ordering guarantees wouldn't make pipelining safe anyway; and forcing sequential dispatch in rmcp would block `end_session`/cancellation from arriving during a long-running `go`. So this PR just **documents the contract**.

## Changes (docs only)

- **README** "Limitations & notes" — expand the single-session bullet into "one debug session, one command at a time": issue calls sequentially, await each result; concurrent pipelining can race `open_dump` (`0x80040205`) and is unsafe for stateful commands.
- **skill `SKILL.md`** cross-cutting gotchas — the same contract, concisely.

Both note that this only affects custom/batched callers, not standard MCP clients.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Enhanced debugging session guidance to clarify command sequencing requirements for reliable operations.
* Expanded instructions on ending active sessions before opening new debugging targets.
* Clarified that debug commands must be issued sequentially to prevent operational failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->