### PR TITLE
README: update Build section for git dependency on win-kexp

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,14 +39,10 @@ The low-level engine bindings live in [`win-kexp`](https://github.com/glslang/wi
 ## Build
 
 ```pwsh
-# Expects win-kexp checked out as a sibling: ..\win-kexp
 cargo build --release --manifest-path C:\workspace\windbg-mcp\Cargo.toml
 ```
 
-> This crate uses a path dependency on [`win-kexp`](https://github.com/glslang/win-kexp) and needs its
-> dbgeng MCP-support changes ([glslang/win-kexp#54](https://github.com/glslang/win-kexp/pull/54)).
-> Until that merges, check out that branch in the sibling `win-kexp` checkout:
-> `git -C ..\win-kexp fetch origin dbgeng-dump-launch-attach-ttd && git -C ..\win-kexp checkout dbgeng-dump-launch-attach-ttd`.
+`win-kexp` is fetched automatically as a git dependency from [`glslang/win-kexp`](https://github.com/glslang/win-kexp) — no sibling checkout needed.
 
 ### Bundling the WinDbg engine
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The low-level engine bindings live in [`win-kexp`](https://github.com/glslang/wi
 ## Build
 
 ```pwsh
-cargo build --release --manifest-path C:\workspace\windbg-mcp\Cargo.toml
+cargo build --release
 ```
 
 `win-kexp` is fetched automatically as a git dependency from [`glslang/win-kexp`](https://github.com/glslang/win-kexp) — no sibling checkout needed.


### PR DESCRIPTION
## Summary

- Remove the sibling-checkout instruction (`# Expects win-kexp checked out as a sibling: ..\win-kexp`) from the build command
- Drop the blockquote note about the path dependency and the temporary `dbgeng-dump-launch-attach-ttd` branch checkout
- Add a one-liner noting that `win-kexp` is now fetched automatically as a git dependency from GitHub

## Test plan

- [ ] Verify `cargo build --release` works without a sibling `win-kexp` checkout (Cargo fetches it from GitHub automatically)
- [ ] Review README renders correctly on GitHub

https://claude.ai/code/session_01XVKKEY72csfzbCy53kiMmp

---
_Generated by [Claude Code](https://claude.ai/code/session_01XVKKEY72csfzbCy53kiMmp)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Simplified build instructions to use a single release build command for all platforms, improving clarity and reducing setup steps.
  * Removed prior manual Windows setup guidance; the required Windows helper is now declared as a git dependency and is fetched automatically during the build, eliminating the need for a separate checkout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->