### PR TITLE
Prepare plugin for marketplace publication; add tests and CI guards

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,22 @@
     {
       "name": "windbg-mcp",
       "source": ".",
-      "description": "WinDbg/DbgEng MCP server + debugging skill."
+      "description": "WinDbg/DbgEng MCP server + debugging skill.",
+      "category": "debugging",
+      "keywords": [
+        "windbg",
+        "dbgeng",
+        "debugging",
+        "crash-dump",
+        "kernel",
+        "ttd",
+        "time-travel-debugging",
+        "windows"
+      ],
+      "license": "MIT",
+      "homepage": "https://github.com/glslang/windbg-mcp",
+      "repository": "https://github.com/glslang/windbg-mcp",
+      "author": { "name": "glslang", "email": "glslang@gmail.com" }
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,11 +1,23 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "windbg-mcp",
+  "displayName": "WinDbg MCP",
   "description": "WinDbg/DbgEng debugging: crash dumps, live user-mode and kernel, and Time Travel Debugging (TTD) — MCP server plus a skill that drives it.",
   "version": "0.1.0",
   "author": { "name": "glslang", "email": "glslang@gmail.com" },
   "homepage": "https://github.com/glslang/windbg-mcp",
   "repository": "https://github.com/glslang/windbg-mcp",
-  "license": "Apache-2.0",
+  "license": "MIT",
+  "keywords": [
+    "windbg",
+    "dbgeng",
+    "debugging",
+    "crash-dump",
+    "kernel",
+    "ttd",
+    "time-travel-debugging",
+    "windows"
+  ],
   "mcpServers": {
     "windbg": {
       "type": "stdio",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,3 +41,49 @@ jobs:
 
       - name: Test
         run: cargo test
+
+      - name: Validate plugin manifests
+        shell: pwsh
+        run: |
+          # Guard against malformed plugin/marketplace manifests (the JSON that
+          # tells the marketplace how to install this plugin).
+          foreach ($f in '.claude-plugin/plugin.json', '.claude-plugin/marketplace.json') {
+            Write-Host "Validating $f"
+            Get-Content $f -Raw | ConvertFrom-Json | Out-Null
+          }
+
+  docs:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Markdown lint
+        uses: DavidAnson/markdownlint-cli2-action@v20
+        with:
+          globs: |
+            README.md
+            CHANGELOG.md
+            docs/**/*.md
+            skills/**/*.md
+
+  audit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    # Soft-warn: a freshly-disclosed advisory in a transitive dependency should
+    # surface here without blocking unrelated PRs.
+    continue-on-error: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Install cargo-audit
+        uses: taiki-e/install-action@cargo-audit
+
+      - name: Audit dependencies
+        run: cargo audit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ concurrency:
 
 jobs:
   build:
+    name: Build & test
     runs-on: windows-latest
     timeout-minutes: 30
     steps:
@@ -53,6 +54,7 @@ jobs:
           }
 
   docs:
+    name: Documentation lint
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -71,6 +73,7 @@ jobs:
             skills/**/*.md
 
   audit:
+    name: Security audit
     runs-on: ubuntu-latest
     timeout-minutes: 15
     # Soft-warn: a freshly-disclosed advisory in a transitive dependency should

--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -1,0 +1,8 @@
+{
+  // Documentation and skill playbooks intentionally use long lines (command
+  // output, prose paragraphs), so line-length is not enforced.
+  "MD013": false,
+  // Tables use compact `|---|` separators; the table-pipe-spacing rule is
+  // purely cosmetic, so it is not enforced.
+  "MD060": false
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0]
+
+Initial release, packaged as a single-plugin Claude Code marketplace.
+
+### Added
+
+- **`windbg` MCP server** (Rust, stdio) exposing DbgEng-backed debugging tools:
+  session management (open dump/trace, attach to process/kernel, launch, end),
+  state queries (registers, memory read, backtrace, modules, threads,
+  disassemble, `dx`), execution control (go, step over/into, breakpoints), Time
+  Travel Debugging navigation (step back, reverse go, goto position) and
+  analysis (`ttd_calls`, `ttd_memory`, `ttd_events`, index), TTD trace recording,
+  and a raw `execute` command passthrough.
+- **`windbg-debugging` skill** with task playbooks: setup, crash-dump triage,
+  live/kernel debugging, and TTD recording/replay/analysis.
+- Crash-dump `!analyze` support via automatic WinDbg extension DLL loading.
+- Windows CI (format, clippy, build, test) and walkthrough docs with sample dumps.
+
+[Unreleased]: https://github.com/glslang/windbg-mcp/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/glslang/windbg-mcp/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -108,6 +108,14 @@ walks through it, and it mirrors the [*Build*](#build) and
 [*Bundling the WinDbg engine*](#bundling-the-windbg-engine) sections above. Then `/reload-plugins`
 to connect the server. The plugin points at `${CLAUDE_PLUGIN_ROOT}/target/release/windbg-mcp.exe`.
 
+### Releasing
+
+The plugin sets an explicit `version` in
+[`.claude-plugin/plugin.json`](.claude-plugin/plugin.json), so users only receive an update
+when that version changes — pushing commits alone does not trigger one. To cut a release, bump
+`version` in `plugin.json`, add a matching entry to [`CHANGELOG.md`](CHANGELOG.md), and tag the
+commit `vX.Y.Z`. Run `claude plugin validate . --strict` before publishing.
+
 ## Walkthroughs
 
 - [`docs/crash-dump-walkthrough.md`](docs/crash-dump-walkthrough.md) — triaging a real kernel

--- a/docs/ttd-walkthrough.md
+++ b/docs/ttd-walkthrough.md
@@ -35,10 +35,11 @@ It was recorded with no extra arguments (`argc == 1`), so it makes **3** `printf
 
 ## 1. Open the trace
 
-```
+```text
 open_trace { "path": "C:\\workspace\\TTD_lab\\helloworld01.run" }
 ```
-```
+
+```text
 @$curprocess.TTD.Lifetime : [C:0, 124:8C2]
     MinPosition : C:0
     MaxPosition : 124:8C2
@@ -52,19 +53,21 @@ The reported `Lifetime` confirms TTD replay is live and gives the position span.
 `ttd_events` lists module loads/unloads, thread create/exit and exceptions — it runs
 `dx -r2 @$curprocess.TTD.Events`, so you get the full event objects. For just a tally:
 
-```
+```text
 dx { "expression": "@$curprocess.TTD.Events.Count()" }
 ```
-```
+
+```text
 @$curprocess.TTD.Events.Count() : 0x16        # 22 events
 ```
 
 Module-load timeline (a raw `dx` with LINQ — `ttd_events` is the convenience wrapper):
 
-```
+```text
 dx { "expression": "-g @$curprocess.TTD.Events.Where(e => e.Type == \"ModuleLoaded\").Select(e => new { Pos = e.Position, Mod = e.Module.Name })" }
 ```
-```
+
+```text
 =          = Pos   = Mod
 = [0x0]    - 2:0   - C:\workspace\TTD_lab\helloworld.exe
 = [0x1]    - 3:0   - C:\Windows\SYSTEM32\VCRUNTIME140.dll
@@ -79,10 +82,11 @@ dx { "expression": "-g @$curprocess.TTD.Events.Where(e => e.Type == \"ModuleLoad
 
 Threads (`@$curprocess.TTD.Threads`) — the main thread plus a short-lived worker:
 
-```
+```text
 dx { "expression": "-g @$curprocess.TTD.Threads" }
 ```
-```
+
+```text
 = [0x0] UID:2 TID:0x1324 Lifetime [A:0, 125:0]  ActiveTime [C:0, 124:8C2]
 = [0x1] UID:3 TID:0xFE4  Lifetime [0:0, ...]    ActiveTime [91:0, B3:0]
 ```
@@ -101,16 +105,18 @@ The control tools map to a debugger UI's F-keys and their Shift (reverse) varian
 
 Set a code breakpoint, jump to the start, and continue forward to it — then reverse:
 
-```
+```text
 set_breakpoint { "expression": "0x7ff887e453e4" }     # ucrtbase format-string read loop
 goto_position  { "position": "0" }                    # start of trace
 go {}
 ```
-```
+
+```text
 Breakpoint 0 hit
 Time Travel Position: 27:50E
 ```
-```
+
+```text
 go {}            → Time Travel Position: 27:550       # next hit, forward
 reverse_go {}    → Time Travel Position: 27:50E       # back to previous hit  ← time travel
 step_into {}     → 27:50F   step_into {} → 27:510     # single-step forward
@@ -127,10 +133,11 @@ step_back {}     → 27:50F                             # single-step backward
 `"Hello, world!"` string (its address comes from a memory search — see §5 for how, or just read it
 with `execute { "command": "s -a helloworld L?0x7000 \"Hello\"" }`):
 
-```
+```text
 ttd_memory { "address": "0x7ff629fe2210", "size": 14, "mode": "r" }
 ```
-```
+
+```text
 # 14 read records — one per byte — all from the same instruction:
 = Pos     = IP             = Acc
 = 27:50E  - 0x7ff887e453e4 - Read
@@ -147,7 +154,7 @@ This is the only part that needs PDB symbols. Point at a symbol store, then **re
 position** (after a `go`, not straight off a `!tt` — the settled context is what lets the module's
 PDB load and `module!name` lookups resolve):
 
-```
+```text
 execute { "command": ".sympath srv*C:\\ProgramData\\Dbg\\sym*https://msdl.microsoft.com/download/symbols" }
 set_breakpoint { "expression": "0x7ff887e453e4" }
 goto_position  { "position": "0" }
@@ -155,17 +162,19 @@ go {}
 execute { "command": ".reload /f" }
 execute { "command": "lm m ucrtbase" }
 ```
-```
+
+```text
 ucrtbase   (pdb symbols)   ...\ucrtbase.pdb\ACEA08EF1B94F30576F5085FC95B3A841\ucrtbase.pdb
 ```
 
 `(pdb symbols)` (not `(export symbols)`) means it worked. Now count the `printf` implementation:
 
-```
+```text
 ttd_calls { "function": "ucrtbase!__stdio_common_vfprintf" }
 dx        { "expression": "@$cursession.TTD.Calls(\"ucrtbase!__stdio_common_vfprintf\").Count()" }
 ```
-```
+
+```text
 @$cursession.TTD.Calls("ucrtbase!__stdio_common_vfprintf").Count() : 0x3
 ```
 
@@ -173,10 +182,11 @@ dx        { "expression": "@$cursession.TTD.Calls(\"ucrtbase!__stdio_common_vfpr
 underscores; the lab's `_stdio_common_vfprintf` is the display alias.) Pull the format string of
 each call (3rd x64 argument → `r8` → `Parameters[2]`):
 
-```
+```text
 dx { "expression": "-g @$cursession.TTD.Calls(\"ucrtbase!__stdio_common_vfprintf\").Select(c => new { Time = c.TimeStart, Format = ((char*)c.Parameters[2]) })" }
 ```
-```
+
+```text
 = Time     = Format
 = 25:508   - "Hello, world!."
 = 29:12D   - "argc: %d."
@@ -185,7 +195,7 @@ dx { "expression": "-g @$cursession.TTD.Calls(\"ucrtbase!__stdio_common_vfprintf
 
 Double-click equivalent — travel to the first call and inspect it:
 
-```
+```text
 goto_position { "position": "25:508" }
 registers {}                              # r8 holds the format pointer
 ```

--- a/src/server.rs
+++ b/src/server.rs
@@ -577,3 +577,77 @@ to an address range), and ttd_events (module/thread/exception events), or run an
 with record_trace (needs elevation). Use `execute` for any raw command not covered by a dedicated tool."
 )]
 impl rmcp::ServerHandler for WindbgServer {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_u64_decimal() {
+        assert_eq!(parse_u64("4096"), Ok(4096));
+        assert_eq!(parse_u64("0"), Ok(0));
+    }
+
+    #[test]
+    fn parse_u64_hex_either_case_prefix() {
+        assert_eq!(parse_u64("0x1000"), Ok(0x1000));
+        assert_eq!(parse_u64("0X1000"), Ok(0x1000));
+        assert_eq!(parse_u64("0xdeadbeef"), Ok(0xdead_beef));
+    }
+
+    #[test]
+    fn parse_u64_trims_surrounding_whitespace() {
+        assert_eq!(parse_u64("  4096  "), Ok(4096));
+        assert_eq!(parse_u64("\t0x10\n"), Ok(0x10));
+    }
+
+    #[test]
+    fn parse_u64_boundaries() {
+        assert_eq!(parse_u64("18446744073709551615"), Ok(u64::MAX));
+        assert_eq!(parse_u64("0xffffffffffffffff"), Ok(u64::MAX));
+    }
+
+    #[test]
+    fn parse_u64_rejects_invalid() {
+        for bad in ["xyz", "", "0xZZ", "0x", "-1", "12.3"] {
+            let err = parse_u64(bad).unwrap_err();
+            assert!(
+                err.starts_with("invalid number:"),
+                "unexpected error for {bad:?}: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn hexdump_empty_is_empty() {
+        assert_eq!(hexdump(0, &[]), "");
+    }
+
+    #[test]
+    fn hexdump_short_row_pads_hex_column() {
+        // Three bytes: the hex column is left-aligned to 47 chars, then the ASCII
+        // column follows. Printable bytes pass through verbatim. Build the expected
+        // padding with the same width constant rather than hand-counting spaces.
+        let out = hexdump(0, b"abc");
+        let expected = format!("0000000000000000  {:<47}  abc\n", "61 62 63");
+        assert_eq!(out, expected);
+    }
+
+    #[test]
+    fn hexdump_full_row_then_partial_advances_address() {
+        let bytes: Vec<u8> = (0u8..18).collect();
+        let out = hexdump(0x1000, &bytes);
+        let lines: Vec<&str> = out.lines().collect();
+        assert_eq!(lines.len(), 2);
+        assert!(lines[0].starts_with("0000000000001000  "));
+        // Second chunk starts 16 bytes (0x10) on.
+        assert!(lines[1].starts_with("0000000000001010  "));
+    }
+
+    #[test]
+    fn hexdump_renders_nonprintable_as_dot() {
+        // 0x00 and 0x7f are non-printable; 'A' (0x41) is printable.
+        let out = hexdump(0, &[0x00, 0x41, 0x7f]);
+        assert!(out.ends_with(".A.\n"), "got: {out:?}");
+    }
+}

--- a/src/ttd.rs
+++ b/src/ttd.rs
@@ -151,3 +151,48 @@ fn first_meaningful_line(log: &str) -> Option<&str> {
                 && !lower.starts_with("eula")
         })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::first_meaningful_line;
+
+    #[test]
+    fn empty_or_whitespace_has_no_meaningful_line() {
+        assert_eq!(first_meaningful_line(""), None);
+        assert_eq!(first_meaningful_line("   \n\t\n  "), None);
+    }
+
+    #[test]
+    fn banner_only_has_no_meaningful_line() {
+        let log = "Microsoft (R) TTD 1.01.11\n\
+                   Release: 1.11.428.0\n\
+                   Copyright (C) Microsoft Corporation. All rights reserved.\n\
+                   EULA accepted.\n";
+        assert_eq!(first_meaningful_line(log), None);
+    }
+
+    #[test]
+    fn banner_prefix_match_is_case_insensitive() {
+        let log = "MICROSOFT (R) TTD 1.01.11\nRELEASE: 1.11\nCOPYRIGHT foo\nEULA bar\n";
+        assert_eq!(first_meaningful_line(log), None);
+    }
+
+    #[test]
+    fn returns_first_error_after_banner_trimmed() {
+        let log = "Microsoft (R) TTD 1.01.11\n\
+                   Release: 1.11.428.0\n\
+                   \n\
+                   \tAdministrative privileges are required to record a trace.\n\
+                   Some later line.\n";
+        assert_eq!(
+            first_meaningful_line(log),
+            Some("Administrative privileges are required to record a trace.")
+        );
+    }
+
+    #[test]
+    fn skips_leading_blank_lines() {
+        let log = "\n\n   \nactual message\n";
+        assert_eq!(first_meaningful_line(log), Some("actual message"));
+    }
+}


### PR DESCRIPTION
## Why

The repo is structurally ready to publish as a single-plugin Claude Code marketplace, but a few gaps blocked a clean release: a license mismatch, thin discoverability metadata, no changelog, zero automated tests, and no CI guard on the manifests.

## Publish-readiness

- **Fix license mismatch** — `plugin.json` declared `Apache-2.0` while `LICENSE` is MIT; now both say **MIT**.
- **Enrich `plugin.json`** — add `$schema`, `displayName`, and `keywords`.
- **Enrich the marketplace entry** — add `category`, `keywords`, `license`, `homepage`, `repository`, `author`.
- **Add `CHANGELOG.md`** (0.1.0) and a README **Releasing** note documenting the explicit-version bump policy (users only update on a version bump).

## Quality tests

Added inline `#[cfg(test)]` unit tests (no new dependencies) for the pure functions that carry real correctness risk:

- `parse_u64` — decimal/hex/whitespace/boundaries/invalid (`src/server.rs`)
- `hexdump` — alignment, multi-row addressing, non-printable bytes (`src/server.rs`)
- `first_meaningful_line` — TTD banner-skipping / error extraction (`src/ttd.rs`)

The crate is Windows-only (DbgEng), so these run on the Windows CI job. Logic verified locally by extracting the functions and running them standalone (14/14 pass).

## CI guards (`.github/workflows/ci.yml`)

- **Manifest validation** — parse both `.claude-plugin/*.json` on the Windows build job (would have caught the license-class bug).
- **`docs` job** — markdownlint over README/CHANGELOG/docs/skills, with `.markdownlint.jsonc` disabling line-length (MD013) and the cosmetic table-pipe-spacing rule (MD060). Normalized `docs/ttd-walkthrough.md` fences (languages + blank lines) so it lints clean.
- **`audit` job** — `cargo audit` for dependency advisories, soft-warn (`continue-on-error`) so a fresh upstream advisory doesn't block unrelated PRs.

## Follow-ups (not in this PR)

- Real end-to-end engine/tool integration tests need Windows + bundled DbgEng + a sample dump — documented as future `tests/` work.
- After merge: tag `v0.1.0`, run `claude plugin validate . --strict`, and submit to the community marketplace via the web form (manual step).

https://claude.ai/code/session_01GjfyaED57tVBCnWBrUHtT4

---
_Generated by [Claude Code](https://claude.ai/code/session_01GjfyaED57tVBCnWBrUHtT4)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added release process to README.
  * Created CHANGELOG with initial release notes.
  * Improved walkthrough formatting for time-travel debugging examples.

* **Tests**
  * Added unit tests covering utility parsing, hexdump and log-processing behaviour.

* **Chores**
  * Expanded marketplace metadata and declared manifest schema.
  * Updated licence to MIT.
  * Strengthened CI with manifest JSON validation, markdown linting and an audit job.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->