### PR TITLE
Release prebuilt Windows binaries; document the no-Rust install path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,75 @@
+name: Release
+
+permissions:
+  contents: write
+
+on:
+  push:
+    tags: ["v*"]
+  # Dry run: build and package, upload as a workflow artifact, no release.
+  workflow_dispatch:
+
+concurrency:
+  group: release-${{ github.ref }}
+
+jobs:
+  release:
+    name: Build & publish binary
+    runs-on: windows-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Verify tag matches manifest versions
+        if: github.ref_type == 'tag'
+        shell: pwsh
+        run: |
+          # The release checklist says: bump Cargo.toml + plugin.json, then tag
+          # vX.Y.Z. Fail the release if the three disagree.
+          $tag    = $env:GITHUB_REF_NAME.TrimStart('v')
+          $cargo  = (Select-String -Path Cargo.toml -Pattern '^version\s*=\s*"(.+)"').Matches[0].Groups[1].Value
+          $plugin = (Get-Content .claude-plugin/plugin.json -Raw | ConvertFrom-Json).version
+          if ($cargo -ne $tag -or $plugin -ne $tag) {
+            Write-Error "Version mismatch: tag v$tag, Cargo.toml $cargo, plugin.json $plugin"
+          }
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry and build
+        uses: Swatinem/rust-cache@v2
+
+      - name: Build
+        run: cargo build --release --locked
+
+      - name: Test
+        run: cargo test --locked
+
+      - name: Package
+        shell: pwsh
+        run: |
+          $ver  = (Select-String -Path Cargo.toml -Pattern '^version\s*=\s*"(.+)"').Matches[0].Groups[1].Value
+          $name = "windbg-mcp-v$ver-windows-x64"
+          New-Item dist -ItemType Directory | Out-Null
+          Compress-Archive -Path target/release/windbg-mcp.exe, LICENSE -DestinationPath "dist/$name.zip"
+          $hash = (Get-FileHash "dist/$name.zip" -Algorithm SHA256).Hash.ToLower()
+          Set-Content dist/SHA256SUMS.txt "$hash  $name.zip"
+
+      - name: Publish GitHub release
+        if: github.ref_type == 'tag'
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            dist/*.zip
+            dist/SHA256SUMS.txt
+          generate_release_notes: true
+
+      - name: Upload artifact (dry run)
+        if: github.ref_type != 'tag'
+        uses: actions/upload-artifact@v4
+        with:
+          name: windbg-mcp-windows-x64
+          path: dist/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,5 @@
 name: Release
 
-permissions:
-  contents: write
-
 on:
   push:
     tags: ["v*"]
@@ -16,6 +13,8 @@ jobs:
   release:
     name: Build & publish binary
     runs-on: windows-latest
+    permissions:
+      contents: write # create the GitHub release and upload its assets
     timeout-minutes: 30
     steps:
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           # The release checklist says: bump Cargo.toml + plugin.json, then tag
           # vX.Y.Z. Fail the release if the three disagree.
-          $tag    = $env:GITHUB_REF_NAME.TrimStart('v')
+          $tag    = $env:GITHUB_REF_NAME -replace '^v', ''
           $cargo  = [regex]::Match((Get-Content Cargo.toml -Raw), '(?ms)^\[package\].*?^version\s*=\s*"([^"]+)"').Groups[1].Value
           $plugin = (Get-Content .claude-plugin/plugin.json -Raw | ConvertFrom-Json).version
           if ($cargo -ne $tag -or $plugin -ne $tag) {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
           persist-credentials: false
 
       - name: Verify tag matches manifest versions
-        if: github.ref_type == 'tag'
+        if: github.event_name == 'push' && github.ref_type == 'tag'
         shell: pwsh
         run: |
           # The release checklist says: bump Cargo.toml + plugin.json, then tag
@@ -59,7 +59,9 @@ jobs:
           Set-Content dist/SHA256SUMS.txt "$hash  $name.zip"
 
       - name: Publish GitHub release
-        if: github.ref_type == 'tag'
+        # event_name guard: a workflow_dispatch run from a tag ref also has
+        # ref_type == 'tag', and a dry run must never publish.
+        if: github.event_name == 'push' && github.ref_type == 'tag'
         uses: softprops/action-gh-release@v2
         with:
           files: |
@@ -68,7 +70,7 @@ jobs:
           generate_release_notes: true
 
       - name: Upload artifact (dry run)
-        if: github.ref_type != 'tag'
+        if: github.event_name != 'push'
         uses: actions/upload-artifact@v4
         with:
           name: windbg-mcp-windows-x64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
           # The release checklist says: bump Cargo.toml + plugin.json, then tag
           # vX.Y.Z. Fail the release if the three disagree.
           $tag    = $env:GITHUB_REF_NAME.TrimStart('v')
-          $cargo  = (Select-String -Path Cargo.toml -Pattern '^version\s*=\s*"(.+)"').Matches[0].Groups[1].Value
+          $cargo  = [regex]::Match((Get-Content Cargo.toml -Raw), '(?ms)^\[package\].*?^version\s*=\s*"([^"]+)"').Groups[1].Value
           $plugin = (Get-Content .claude-plugin/plugin.json -Raw | ConvertFrom-Json).version
           if ($cargo -ne $tag -or $plugin -ne $tag) {
             Write-Error "Version mismatch: tag v$tag, Cargo.toml $cargo, plugin.json $plugin"
@@ -51,7 +51,7 @@ jobs:
       - name: Package
         shell: pwsh
         run: |
-          $ver  = (Select-String -Path Cargo.toml -Pattern '^version\s*=\s*"(.+)"').Matches[0].Groups[1].Value
+          $ver  = [regex]::Match((Get-Content Cargo.toml -Raw), '(?ms)^\[package\].*?^version\s*=\s*"([^"]+)"').Groups[1].Value
           $name = "windbg-mcp-v$ver-windows-x64"
           New-Item dist -ItemType Directory | Out-Null
           Compress-Archive -Path target/release/windbg-mcp.exe, LICENSE -DestinationPath "dist/$name.zip"

--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -4,5 +4,8 @@
   "MD013": false,
   // Tables use compact `|---|` separators; the table-pipe-spacing rule is
   // purely cosmetic, so it is not enforced.
-  "MD060": false
+  "MD060": false,
+  // Keep a Changelog repeats "### Added"/"### Fixed" under every version, so
+  // only flag duplicate headings that share the same parent.
+  "MD024": { "siblings_only": true }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Prebuilt Windows x64 binary releases: pushing a `vX.Y.Z` tag now builds
+  `windbg-mcp.exe` and attaches `windbg-mcp-vX.Y.Z-windows-x64.zip` (plus a SHA256
+  checksum) to the GitHub release, and the setup docs gained a no-Rust install path
+  that downloads it into `target\release\`.
+
 ## [0.1.0]
 
 Initial release, packaged as a single-plugin Claude Code marketplace.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ The low-level engine bindings live in [`win-kexp`](https://github.com/glslang/wi
 
 Prebuilt Windows x64 binaries are attached to each
 [GitHub release](https://github.com/glslang/windbg-mcp/releases) as
-`windbg-mcp-vX.Y.Z-windows-x64.zip` (with a SHA256 checksum) — no Rust toolchain needed.
+`windbg-mcp-vX.Y.Z-windows-x64.zip` (with a `SHA256SUMS.txt` to verify the download
+against — the skill's `setup.md` snippet does this for you) — no Rust toolchain needed.
 To build from source instead:
 
 ```pwsh

--- a/README.md
+++ b/README.md
@@ -36,7 +36,12 @@ The low-level engine bindings live in [`win-kexp`](https://github.com/glslang/wi
   data model still work; symbol *names* won't resolve.
 - **Administrator** for live kernel debugging and TTD recording (not for replay).
 
-## Build
+## Build or download
+
+Prebuilt Windows x64 binaries are attached to each
+[GitHub release](https://github.com/glslang/windbg-mcp/releases) as
+`windbg-mcp-vX.Y.Z-windows-x64.zip` (with a SHA256 checksum) — no Rust toolchain needed.
+To build from source instead:
 
 ```pwsh
 cargo build --release
@@ -102,9 +107,10 @@ knows how to drive it (setup, crash-dump, live/kernel, and TTD playbooks).
 /plugin install windbg-mcp@windbg-mcp
 ```
 
-The plugin ships source, not a binary, so after installing you still build it in place and
-(for `.run` replay and crash-dump `!analyze`) bundle the WinDbg engine — the skill's `setup.md`
-walks through it, and it mirrors the [*Build*](#build) and
+The plugin ships source, not a binary, so after installing you still put the server binary in
+place — download a prebuilt release or build from source — and (for `.run` replay and
+crash-dump `!analyze`) bundle the WinDbg engine — the skill's `setup.md`
+walks through it, and it mirrors the [*Build or download*](#build-or-download) and
 [*Bundling the WinDbg engine*](#bundling-the-windbg-engine) sections above. Then `/reload-plugins`
 to connect the server. The plugin points at `${CLAUDE_PLUGIN_ROOT}/target/release/windbg-mcp.exe`.
 
@@ -113,8 +119,11 @@ to connect the server. The plugin points at `${CLAUDE_PLUGIN_ROOT}/target/releas
 The plugin sets an explicit `version` in
 [`.claude-plugin/plugin.json`](.claude-plugin/plugin.json), so users only receive an update
 when that version changes — pushing commits alone does not trigger one. To cut a release, bump
-`version` in `plugin.json`, add a matching entry to [`CHANGELOG.md`](CHANGELOG.md), and tag the
-commit `vX.Y.Z`. Run `claude plugin validate . --strict` before publishing.
+`version` in `plugin.json` and `Cargo.toml`, add a matching entry to
+[`CHANGELOG.md`](CHANGELOG.md), and tag the commit `vX.Y.Z`. Run
+`claude plugin validate . --strict` before publishing. Pushing the tag runs
+[`release.yml`](.github/workflows/release.yml), which verifies the tag matches both manifest
+versions, builds `windbg-mcp.exe`, and attaches the zip + SHA256 checksum to the GitHub release.
 
 ## Walkthroughs
 

--- a/skills/windbg-debugging/setup.md
+++ b/skills/windbg-debugging/setup.md
@@ -25,10 +25,12 @@ plugin / repo directory:
 ```pwsh
 $dst = "target\release"
 New-Item $dst -ItemType Directory -Force | Out-Null
-$asset = (Invoke-RestMethod https://api.github.com/repos/glslang/windbg-mcp/releases/latest).assets |
-         Where-Object name -Like 'windbg-mcp-*-windows-x64.zip'
-$zip = Join-Path $env:TEMP $asset.name
+$rel   = Invoke-RestMethod https://api.github.com/repos/glslang/windbg-mcp/releases/latest
+$asset = $rel.assets | Where-Object name -Like 'windbg-mcp-*-windows-x64.zip'
+$zip   = Join-Path $env:TEMP $asset.name
 Invoke-WebRequest $asset.browser_download_url -OutFile $zip
+$sum = ((Invoke-RestMethod ($rel.assets | Where-Object name -EQ 'SHA256SUMS.txt').browser_download_url) -split '\s+')[0]
+if ((Get-FileHash $zip -Algorithm SHA256).Hash.ToLower() -ne $sum) { throw "SHA256 mismatch for $($asset.name)" }
 Unblock-File $zip   # clear Mark-of-the-Web so the extracted exe isn't blocked
 Expand-Archive $zip $dst -Force
 ```

--- a/skills/windbg-debugging/setup.md
+++ b/skills/windbg-debugging/setup.md
@@ -10,26 +10,40 @@ section for the workflow you're about to run before blaming the target.
   `10.0.26100`). That is enough for live user-mode/kernel debugging and crash-dump
   analysis — **but not for TTD `.run` replay** (see below).
 
-## Build the server
+## Get the server binary
 
-The plugin ships the source, not a binary. Build it in place so the path in
-`plugin.json` (`${CLAUDE_PLUGIN_ROOT}/target/release/windbg-mcp.exe`) resolves:
+The plugin ships the source, not a binary. Put `windbg-mcp.exe` in place so the path in
+`plugin.json` (`${CLAUDE_PLUGIN_ROOT}/target/release/windbg-mcp.exe`) resolves — either
+option below lands it there.
+
+### Option A — download a prebuilt release (no Rust required)
+
+Each `vX.Y.Z` tag publishes a Windows x64 build on the
+[releases page](https://github.com/glslang/windbg-mcp/releases). From the installed
+plugin / repo directory:
 
 ```pwsh
-# From the installed plugin / repo directory. Expects win-kexp as a sibling: ..\win-kexp
+$dst = "target\release"
+New-Item $dst -ItemType Directory -Force | Out-Null
+$asset = (Invoke-RestMethod https://api.github.com/repos/glslang/windbg-mcp/releases/latest).assets |
+         Where-Object name -Like 'windbg-mcp-*-windows-x64.zip'
+$zip = Join-Path $env:TEMP $asset.name
+Invoke-WebRequest $asset.browser_download_url -OutFile $zip
+Unblock-File $zip   # clear Mark-of-the-Web so the extracted exe isn't blocked
+Expand-Archive $zip $dst -Force
+```
+
+### Option B — build from source
+
+```pwsh
+# From the installed plugin / repo directory.
 cargo build --release
 ```
 
-This crate has a path dependency on [`win-kexp`](https://github.com/glslang/win-kexp) and
-needs its dbgeng MCP-support changes. Until those merge upstream, check out the matching
-branch in the sibling checkout, e.g.:
+[`win-kexp`](https://github.com/glslang/win-kexp) is fetched automatically as a git
+dependency — no sibling checkout needed.
 
-```pwsh
-git -C ..\win-kexp fetch origin dbgeng-dump-launch-attach-ttd
-git -C ..\win-kexp checkout dbgeng-dump-launch-attach-ttd
-```
-
-After `cargo build`, run `/reload-plugins` so Claude Code connects the `windbg` MCP server.
+Either way, run `/reload-plugins` afterwards so Claude Code connects the `windbg` MCP server.
 
 ## WinDbg engine + extensions — for `.run` replay and crash-dump `!analyze`
 
@@ -57,7 +71,7 @@ Copy-Item "$wd\winext" "$dst\winext" -Recurse -Force   # ext.dll (!analyze), kex
   `!tt` time-travel commands.
 - The `winext\` subdir provides `ext.dll` (which exports `!analyze`) and the other `!`-extensions.
   Required for crash-dump triage — without it `!analyze` returns *"No export analyze found"*.
-- `cargo clean` wipes `target\`, so re-copy after one.
+- `cargo clean` (when building from source) wipes `target\`, so re-copy after one.
 
 ## Symbols — required for `module!func` name resolution
 


### PR DESCRIPTION
## Why

The plugin ships source only — `plugin.json` points at `${CLAUDE_PLUGIN_ROOT}/target/release/windbg-mcp.exe`, and setup.md's first step is `cargo build --release` — so environments without a Rust toolchain can't use it at all. The WinDbg engine DLLs can't be redistributed (Microsoft store-package binaries), but that bundling step is pure PowerShell; shipping just `windbg-mcp.exe` fully removes the Rust requirement.

## What

- **`.github/workflows/release.yml`** (new): on a `vX.Y.Z` tag push, verifies the tag matches `version` in both `Cargo.toml` and `.claude-plugin/plugin.json`, builds and tests with `--locked` (Cargo.lock pins the `win-kexp` git dependency), and publishes `windbg-mcp-vX.Y.Z-windows-x64.zip` + `SHA256SUMS.txt` to the GitHub release with generated notes. `workflow_dispatch` does a dry run that uploads a workflow artifact instead of creating a release.
- **`skills/windbg-debugging/setup.md`**: "Build the server" becomes "Get the server binary" with Option A (download the latest release into `target\release\` — no Rust, includes `Unblock-File` for Mark-of-the-Web) and Option B (build from source). Also fixes the stale text describing `win-kexp` as a sibling path dependency on a feature branch; `Cargo.toml` uses a git dependency.
- **`README.md`**: prebuilt option in the (renamed) *Build or download* section, updated plugin-install wording, and the *Releasing* section now documents what the tag push automates.
- **`CHANGELOG.md`**: Unreleased entry. `.markdownlint.jsonc` sets `MD024: siblings_only` since Keep a Changelog repeats `### Added` under every version.

Downloaded binaries land in the same `target\release\` path the build produces, so `plugin.json` is unchanged and both install paths converge on one layout.

## Verification

- `markdownlint-cli2` over the CI globs: 0 errors.
- `release.yml` parses; structure mirrors `ci.yml` (same toolchain/cache actions, `persist-credentials: false`, timeout).
- The Windows build itself is exercised by existing CI on this PR. End-to-end release proof requires a tag (post-merge): a `workflow_dispatch` dry run from `main`, then cutting `v0.1.1`.

## Out of scope

Code signing (unsigned exe → SmartScreen; mitigated by the documented `Unblock-File`), redistributing WinDbg engine DLLs, and build-provenance attestation (easy follow-up if wanted).

https://claude.ai/code/session_01BakFbYREVug4d9jT93J277

---
_Generated by [Claude Code](https://claude.ai/code/session_01BakFbYREVug4d9jT93J277)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Prebuilt Windows x64 binaries are now produced and published, with accompanying SHA256 checksums for verification.

* **Documentation**
  * Setup docs updated to show an easy “download or build” path and verify binaries via published checksums.
  * Release docs expanded to describe the automated release process and required version synchronisation.

* **Style**
  * Markdown linting rules adjusted to reduce duplicate-heading noise.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->