### PR TITLE
Attest build provenance for release zips

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,8 @@ jobs:
     runs-on: windows-latest
     permissions:
       contents: write # create the GitHub release and upload its assets
+      id-token: write # sign the build-provenance attestation (Sigstore OIDC)
+      attestations: write # store the attestation in the repo
     timeout-minutes: 30
     steps:
       - name: Checkout
@@ -56,6 +58,14 @@ jobs:
           Compress-Archive -Path target/release/windbg-mcp.exe, LICENSE -DestinationPath "dist/$name.zip"
           $hash = (Get-FileHash "dist/$name.zip" -Algorithm SHA256).Hash.ToLower()
           Set-Content dist/SHA256SUMS.txt "$hash  $name.zip"
+
+      - name: Attest build provenance
+        # Records a signed SLSA provenance statement linking the zip to this
+        # workflow run; users verify with `gh attestation verify`.
+        if: github.event_name == 'push' && github.ref_type == 'tag'
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-path: dist/*.zip
 
       - name: Publish GitHub release
         # event_name guard: a workflow_dispatch run from a tag ref also has

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `windbg-mcp.exe` and attaches `windbg-mcp-vX.Y.Z-windows-x64.zip` (plus a SHA256
   checksum) to the GitHub release, and the setup docs gained a no-Rust install path
   that downloads it into `target\release\`.
+- Signed build-provenance attestations for release zips, verifiable with
+  `gh attestation verify <zip> --repo glslang/windbg-mcp`.
 
 ## [0.1.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   checksum) to the GitHub release, and the setup docs gained a no-Rust install path
   that downloads it into `target\release\`.
 - Signed build-provenance attestations for release zips, verifiable with
-  `gh attestation verify <zip> --repo glslang/windbg-mcp`.
+  `gh attestation verify` (see the README's *Releasing* section).
 
 ## [0.1.0]
 

--- a/README.md
+++ b/README.md
@@ -127,8 +127,15 @@ when that version changes — pushing commits alone does not trigger one. To cut
 versions, builds `windbg-mcp.exe`, and attaches the zip + SHA256 checksum to the GitHub release.
 The zip also gets a signed
 [build-provenance attestation](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations)
-tying it to the workflow run that built it — verify with
-`gh attestation verify <zip> --repo glslang/windbg-mcp`.
+tying it to the workflow run that built it — verify with:
+
+```pwsh
+gh attestation verify <zip> --repo glslang/windbg-mcp `
+   --signer-workflow glslang/windbg-mcp/.github/workflows/release.yml
+```
+
+(`--repo` alone only proves the attestation came from *some* workflow in this repo;
+`--signer-workflow` pins it to the release workflow.)
 
 ## Walkthroughs
 

--- a/README.md
+++ b/README.md
@@ -125,6 +125,10 @@ when that version changes — pushing commits alone does not trigger one. To cut
 `claude plugin validate . --strict` before publishing. Pushing the tag runs
 [`release.yml`](.github/workflows/release.yml), which verifies the tag matches both manifest
 versions, builds `windbg-mcp.exe`, and attaches the zip + SHA256 checksum to the GitHub release.
+The zip also gets a signed
+[build-provenance attestation](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations)
+tying it to the workflow run that built it — verify with
+`gh attestation verify <zip> --repo glslang/windbg-mcp`.
 
 ## Walkthroughs
 

--- a/skills/windbg-debugging/setup.md
+++ b/skills/windbg-debugging/setup.md
@@ -37,7 +37,11 @@ Expand-Archive $zip $dst -Force
 
 Optionally, with the [GitHub CLI](https://cli.github.com/), verify the zip's build provenance
 (proves it was built by this repo's release workflow, not tampered with):
-`gh attestation verify $zip --repo glslang/windbg-mcp`.
+
+```pwsh
+gh attestation verify $zip --repo glslang/windbg-mcp `
+   --signer-workflow glslang/windbg-mcp/.github/workflows/release.yml
+```
 
 ### Option B — build from source
 

--- a/skills/windbg-debugging/setup.md
+++ b/skills/windbg-debugging/setup.md
@@ -35,6 +35,10 @@ Unblock-File $zip   # clear Mark-of-the-Web so the extracted exe isn't blocked
 Expand-Archive $zip $dst -Force
 ```
 
+Optionally, with the [GitHub CLI](https://cli.github.com/), verify the zip's build provenance
+(proves it was built by this repo's release workflow, not tampered with):
+`gh attestation verify $zip --repo glslang/windbg-mcp`.
+
 ### Option B — build from source
 
 ```pwsh


### PR DESCRIPTION
## Why

Follow-up to #7, which noted build-provenance attestation as an easy next step. The release zip is now the supported install path for users without Rust, so giving them a cryptographic way to confirm a download was built by this repo's release workflow (and not tampered with) closes the gap that a same-origin SHA256 checksum can't.

## What

- **`.github/workflows/release.yml`**: tag-push releases run `actions/attest-build-provenance@v4` on `dist/*.zip` before publishing, recording a signed SLSA provenance statement that links the asset to the workflow run. Job permissions gain `id-token: write` (Sigstore OIDC signing) and `attestations: write` (storing the attestation), each with an explanatory comment. The step is gated on `github.event_name == 'push' && github.ref_type == 'tag'` like the publish step, so dry runs don't generate attestations.
- **Docs**: the README *Releasing* section and setup.md's download option now show the verification command — `gh attestation verify <zip> --repo glslang/windbg-mcp` — and `CHANGELOG.md` gets an Unreleased entry.

Version note: `attest-build-provenance` v4 is a wrapper over the generic `actions/attest`, but remains GitHub's documented path for build provenance, and the `@v4` major-tag reference follows the repo's existing pinning convention.

## Verification

- `release.yml` parses; markdownlint over the CI globs reports 0 errors.
- End-to-end proof requires a tag (post-merge): cut the next `vX.Y.Z`, then run `gh attestation verify` against the downloaded zip and confirm it reports the release workflow as the builder.

https://claude.ai/code/session_01BakFbYREVug4d9jT93J277

---
_Generated by [Claude Code](https://claude.ai/code/session_01BakFbYREVug4d9jT93J277)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Release archives now include signed build‑provenance attestations so users can verify download authenticity and integrity.

* **Documentation**
  * Added release‑verification instructions to the README and setup guide showing how to verify attestations with the GitHub CLI.

* **Changelog**
  * Recorded that release zips are shipped with signed build‑provenance attestations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->