### PR TITLE
Pin all GitHub Actions to commit SHAs; add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+# Keeps the SHA-pinned actions in .github/workflows current: Dependabot
+# bumps each pin (and its trailing version comment) when upstream releases.
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,17 +19,19 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        # Pinned to a SHA, so the toolchain comes from the input, not the ref.
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
+          toolchain: stable
           components: rustfmt, clippy
 
       - name: Cache cargo registry and build
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Format check
         run: cargo fmt --all --check
@@ -59,12 +61,12 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
 
       - name: Markdown lint
-        uses: DavidAnson/markdownlint-cli2-action@v20
+        uses: DavidAnson/markdownlint-cli2-action@992badcdf24e3b8eb7e87ff9287fe931bcb00c6e # v20
         with:
           globs: |
             README.md
@@ -81,12 +83,15 @@ jobs:
     continue-on-error: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
 
       - name: Install cargo-audit
-        uses: taiki-e/install-action@cargo-audit
+        # Pinned to a SHA, so the tool comes from the input, not the ref.
+        uses: taiki-e/install-action@7a79fe8c3a13344501c80d99cae481c1c9085912 # v2
+        with:
+          tool: cargo-audit
 
       - name: Audit dependencies
         run: cargo audit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,10 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        # Pinned to a SHA, so the toolchain comes from the input, not the ref.
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        # Pinned to a master-history SHA (per the action's README — toolchain
+        # branch commits get force-pushed), so the toolchain comes from the
+        # input, not the ref.
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: stable
           components: rustfmt, clippy

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,8 +38,10 @@ jobs:
           }
 
       - name: Install Rust toolchain
-        # Pinned to a SHA, so the toolchain comes from the input, not the ref.
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        # Pinned to a master-history SHA (per the action's README — toolchain
+        # branch commits get force-pushed), so the toolchain comes from the
+        # input, not the ref.
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: stable
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
 
@@ -38,10 +38,13 @@ jobs:
           }
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        # Pinned to a SHA, so the toolchain comes from the input, not the ref.
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: stable
 
       - name: Cache cargo registry and build
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Build
         run: cargo build --release --locked
@@ -63,7 +66,7 @@ jobs:
         # Records a signed SLSA provenance statement linking the zip to this
         # workflow run; users verify with `gh attestation verify`.
         if: github.event_name == 'push' && github.ref_type == 'tag'
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4
         with:
           subject-path: dist/*.zip
 
@@ -71,7 +74,7 @@ jobs:
         # event_name guard: a workflow_dispatch run from a tag ref also has
         # ref_type == 'tag', and a dry run must never publish.
         if: github.event_name == 'push' && github.ref_type == 'tag'
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           files: |
             dist/*.zip
@@ -80,7 +83,7 @@ jobs:
 
       - name: Upload artifact (dry run)
         if: github.event_name != 'push'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: windbg-mcp-windows-x64
           path: dist/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Signed build-provenance attestations for release zips, verifiable with
   `gh attestation verify` (see the README's *Releasing* section).
 
+### Security
+
+- GitHub Actions in the CI and release workflows are pinned to immutable
+  commit SHAs, with Dependabot configured to keep the pins (and their
+  version comments) up to date.
+
 ## [0.1.0]
 
 Initial release, packaged as a single-plugin Claude Code marketplace.


### PR DESCRIPTION
## Why

Follows up the open review threads on #7 and #8: GitHub recommends pinning third-party actions to immutable commit SHAs so a compromised or re-pointed upstream tag can't inject code into CI or, worse, into the release/attestation pipeline. Doing it repo-wide (rather than one workflow at a time, as the bots suggested) keeps the convention consistent and pairs it with automation so the pins don't rot.

## What

- **`ci.yml` + `release.yml`**: every `uses:` reference (13 total across 8 distinct actions) now points at a full commit SHA, with the original ref preserved as a trailing comment (`# v4`, `# stable`, …) — the format Dependabot understands and keeps in sync.
- **Behavior-carrying refs handled**: `dtolnay/rust-toolchain@stable` and `taiki-e/install-action@cargo-audit` selected the toolchain/tool *via the ref name*, which a SHA pin erases — they now pass explicit `toolchain: stable` / `tool: cargo-audit` inputs (each with a comment explaining why).
- **`.github/dependabot.yml`** (new): `github-actions` ecosystem, weekly, so the pins and their version comments get bumped automatically.
- **`CHANGELOG.md`**: Unreleased → Security entry.

## SHA provenance

All SHAs were resolved independently via `git ls-remote` against the upstream repos (not taken from review-bot comments). Notably, `Swatinem/rust-cache@v2` and `actions/attest-build-provenance@v4` are **annotated tags** — the SHAs quoted in the earlier CodeRabbit review were the tag *objects*, which Actions cannot resolve; this PR pins the peeled commit SHAs (`e18b4977…`, `a2bbfa25…`).

| Action | Ref | Pinned commit |
|---|---|---|
| actions/checkout | v4 | `34e114876b0b11c390a56381ad16ebd13914f8d5` |
| dtolnay/rust-toolchain | stable | `29eef336d9b2848a0b548edc03f92a220660cdb8` |
| Swatinem/rust-cache | v2 (peeled) | `e18b497796c12c097a38f9edb9d0641fb99eee32` |
| DavidAnson/markdownlint-cli2-action | v20 | `992badcdf24e3b8eb7e87ff9287fe931bcb00c6e` |
| taiki-e/install-action | v2 | `7a79fe8c3a13344501c80d99cae481c1c9085912` |
| actions/attest-build-provenance | v4 (peeled) | `a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32` |
| softprops/action-gh-release | v2 | `3bb12739c298aeb8a4eeaf626c5b8d85266b0e65` |
| actions/upload-artifact | v4 | `ea165f8d65b6e75b540449e92b4886f43607fa02` |

## Verification

- All three YAML files parse; markdownlint over the CI globs: 0 errors.
- This PR's own CI run exercises the pinned `ci.yml` end-to-end (checkout, toolchain-via-input, cache, markdownlint, install-action-via-input).
- The pinned `release.yml` is exercised by the next `vX.Y.Z` tag (or a `workflow_dispatch` dry run from `main` after merge).

Closes the SHA-pinning threads on #7 and #8.

https://claude.ai/code/session_01BakFbYREVug4d9jT93J277

---
_Generated by [Claude Code](https://claude.ai/code/session_01BakFbYREVug4d9jT93J277)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * CI and release workflows now pin GitHub Actions to immutable commit SHAs to strengthen supply-chain security.
  * Dependabot configured to monitor and automatically keep those pins up to date on a weekly schedule.
  * CHANGELOG updated to document the security pinning and Dependabot configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->