### PR TITLE
Release 0.1.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -3,7 +3,7 @@
   "name": "windbg-mcp",
   "displayName": "WinDbg MCP",
   "description": "WinDbg/DbgEng debugging: crash dumps, live user-mode and kernel, and Time Travel Debugging (TTD) — MCP server plus a skill that drives it.",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "author": { "name": "glslang", "email": "glslang@gmail.com" },
   "homepage": "https://github.com/glslang/windbg-mcp",
   "repository": "https://github.com/glslang/windbg-mcp",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1] - 2026-06-12
+
 ### Added
 
 - Prebuilt Windows x64 binary releases: pushing a `vX.Y.Z` tag now builds
@@ -40,5 +42,6 @@ Initial release, packaged as a single-plugin Claude Code marketplace.
 - Crash-dump `!analyze` support via automatic WinDbg extension DLL loading.
 - Windows CI (format, clippy, build, test) and walkthrough docs with sample dumps.
 
-[Unreleased]: https://github.com/glslang/windbg-mcp/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/glslang/windbg-mcp/compare/v0.1.1...HEAD
+[0.1.1]: https://github.com/glslang/windbg-mcp/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/glslang/windbg-mcp/releases/tag/v0.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -827,7 +827,7 @@ dependencies = [
 
 [[package]]
 name = "windbg-mcp"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "rmcp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "windbg-mcp"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 
 [dependencies]


### PR DESCRIPTION
## What

Release prep for the first tagged release since the binary pipeline landed (#7, #8, #9):

- `Cargo.toml`, `.claude-plugin/plugin.json` → `0.1.1` (the plugin's explicit `version` is what triggers updates for installed users).
- `Cargo.lock`'s own `windbg-mcp` entry → `0.1.1` — required because the release workflow builds with `--locked`, which fails if the lockfile lags the manifest.
- `CHANGELOG.md`: Unreleased entries cut into a dated `[0.1.1]` section (prebuilt binaries + no-Rust install path, provenance attestations, SHA-pinned actions); compare links updated.

## Verification

- Simulated the release workflow's version gate: tag `v0.1.1` == `Cargo.toml` == `plugin.json` == `Cargo.lock` (using the same `[package]`-anchored regex).
- `claude plugin validate . --strict` passes; markdownlint over the CI globs: 0 errors.

## After merge — cutting the release

Tag the merge commit on `main` and push the tag:

```
git tag v0.1.1 <merge-commit>
git push origin v0.1.1
```

That triggers `release.yml`: version gate → locked build + tests → `windbg-mcp-v0.1.1-windows-x64.zip` + `SHA256SUMS.txt` → signed provenance attestation → GitHub release with generated notes. Verify the artifact end-to-end with:

```pwsh
gh attestation verify windbg-mcp-v0.1.1-windows-x64.zip --repo glslang/windbg-mcp `
   --signer-workflow glslang/windbg-mcp/.github/workflows/release.yml
```

https://claude.ai/code/session_01BakFbYREVug4d9jT93J277

---
_Generated by [Claude Code](https://claude.ai/code/session_01BakFbYREVug4d9jT93J277)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 0.1.1
  * Release documentation and package manifest updated

<!-- end of auto-generated comment: release notes by coderabbit.ai -->