### PR TITLE
ci: auto-approve and auto-merge Dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,33 @@
+name: Dependabot auto-merge
+
+# Auto-approve Dependabot PRs and enable squash auto-merge. The approval here
+# satisfies the "Main Branch" ruleset's required review; GitHub still holds the
+# merge until that ruleset's required status checks (Build & test, Documentation
+# lint) pass, so a red CI run never merges. Requires the repo setting
+# "Allow GitHub Actions to create and approve pull requests".
+
+on: pull_request
+
+# Dependabot-triggered pull_request runs get a read-only token by default; this
+# block elevates it for the bot's own PRs. Scoped to the minimum needed.
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot-auto-merge:
+    name: Dependabot auto-merge
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    steps:
+      - name: Approve the PR
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -6,19 +6,26 @@ name: Dependabot auto-merge
 # lint) pass, so a red CI run never merges. Requires the repo setting
 # "Allow GitHub Actions to create and approve pull requests".
 
-on: pull_request
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
 
-# Dependabot-triggered pull_request runs get a read-only token by default; this
-# block elevates it for the bot's own PRs. Scoped to the minimum needed.
-permissions:
-  contents: write
-  pull-requests: write
+# Serialise per PR so a rapid sequence of Dependabot pushes can't launch
+# overlapping approve/merge attempts.
+concurrency:
+  group: dependabot-auto-merge-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   dependabot-auto-merge:
     name: Dependabot auto-merge
     runs-on: ubuntu-latest
     if: github.event.pull_request.user.login == 'dependabot[bot]'
+    # Write scope lives on the job, not the workflow, so nothing else inherits
+    # it. Dependabot-triggered runs start read-only; this elevates just this job.
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Approve the PR
         run: gh pr review --approve "$PR_URL"


### PR DESCRIPTION
Adds `.github/workflows/dependabot-auto-merge.yml`: for Dependabot PRs it submits an approving review (satisfying the "Main Branch" ruleset's required review) and enables squash auto-merge.

The merge remains gated on the ruleset's **required status checks** (`Build & test`, `Documentation lint`), so a red CI run never auto-merges. Scope is **all updates** — CI is the gate.

Companion settings changes already applied to the repo:
- Enabled **Allow GitHub Actions to create and approve pull requests** (without it the bot's review can't count).
- Added `Build & test` + `Documentation lint` as **required status checks** on the `main` ruleset (non-strict, so branches aren't forced up-to-date). This now also applies to human PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved automated dependency update workflow to streamline approvals and enable automatic merging of dependency PRs, reducing manual intervention and helping keep dependencies up to date more reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->