### PR TITLE
Live kernel debugging: win-kexp attach break-in + robustness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -814,7 +814,7 @@ dependencies = [
 [[package]]
 name = "win-kexp"
 version = "0.1.0"
-source = "git+https://github.com/glslang/win-kexp?branch=main#0c4dd189e0297e16dcc3ac5884f4c692b8c423be"
+source = "git+https://github.com/glslang/win-kexp?branch=main#13977d15e4c3fe0d00412c7db0022cb491fe7560"
 dependencies = [
  "byte-strings",
  "goblin",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -814,7 +814,7 @@ dependencies = [
 [[package]]
 name = "win-kexp"
 version = "0.1.0"
-source = "git+https://github.com/glslang/win-kexp?branch=main#c569532449b39b71bd133ee445cdd8495e6720e8"
+source = "git+https://github.com/glslang/win-kexp?branch=main#0c4dd189e0297e16dcc3ac5884f4c692b8c423be"
 dependencies = [
  "byte-strings",
  "goblin",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -814,7 +814,7 @@ dependencies = [
 [[package]]
 name = "win-kexp"
 version = "0.1.0"
-source = "git+https://github.com/glslang/win-kexp?branch=main#b92e9230172b164e182a9c6a0971f5c938cc2f40"
+source = "git+https://github.com/glslang/win-kexp?branch=main#c569532449b39b71bd133ee445cdd8495e6720e8"
 dependencies = [
  "byte-strings",
  "goblin",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -814,7 +814,7 @@ dependencies = [
 [[package]]
 name = "win-kexp"
 version = "0.1.0"
-source = "git+https://github.com/glslang/win-kexp?branch=main#13977d15e4c3fe0d00412c7db0022cb491fe7560"
+source = "git+https://github.com/glslang/win-kexp?branch=main#8a4bd20889791cad7a41316e9c2fe356504db445"
 dependencies = [
  "byte-strings",
  "goblin",

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,18 @@
+# Example drivers
+
+Throwaway stdio JSON-RPC drivers written while developing the live-kernel support,
+kept for re-use in future debugging. They are plain PowerShell (`.ps1`) — Cargo does
+not build them.
+
+Each script spawns `..\target\release\windbg-mcp.exe` and drives it over stdio (MCP),
+so build the server first: `cargo build --release`. For symbol resolution, set
+`_NT_SYMBOL_PATH` (e.g. `srv*C:\ProgramData\Dbg\sym*https://msdl.microsoft.com/download/symbols`).
+
+- **`drive_kernel_test.ps1`** — attach to a live KDNET kernel, break in, set
+  `bp nt!NtCreateFile`, `go` to it, then resume and detach. Pass your target's real
+  connection string: `-Connection "net:port=<n>,key=<w.x.y.z>"`.
+- **`test_usermode.ps1`** — launch `cmd.exe` under the debugger and exercise the
+  user-mode break-in (registers, modules, breakpoint).
+- **`verify_fixes.ps1`** — regression checks: `go`/step with no debuggee returns a
+  clean "No active debuggee" error (no process crash), and a failed kernel attach is a
+  clean error (no panic). The kernel-attach check needs a real KDNET key filled in.

--- a/examples/drive_kernel_test.ps1
+++ b/examples/drive_kernel_test.ps1
@@ -1,0 +1,120 @@
+param(
+    # Pass your target's real KDNET connection string via -Connection.
+    [string]$Connection = "net:port=50000,key=<KDNET-KEY>",
+    [string]$Exe = "$PSScriptRoot\..\target\release\windbg-mcp.exe"
+)
+
+$ErrorActionPreference = "Stop"
+
+# Start the MCP server with stdin/stdout redirected (UTF-8, no BOM).
+# stderr is left inheriting the console so logs are visible and no buffer deadlock occurs.
+$psi = New-Object System.Diagnostics.ProcessStartInfo
+$psi.FileName = $Exe
+$psi.UseShellExecute = $false
+$psi.RedirectStandardInput = $true
+$psi.RedirectStandardOutput = $true
+$psi.RedirectStandardError = $false
+$utf8 = New-Object System.Text.UTF8Encoding($false)
+# .NET Framework (PS 5.1) has StandardOutputEncoding but not StandardInputEncoding.
+$psi.StandardOutputEncoding = $utf8
+$psi.WorkingDirectory = Split-Path $Exe
+
+$proc = [System.Diagnostics.Process]::Start($psi)
+# Wrap stdin with a UTF-8 (no BOM) writer so we control the encoding ourselves.
+$stdin = New-Object System.IO.StreamWriter($proc.StandardInput.BaseStream, $utf8)
+$stdin.AutoFlush = $true
+Write-Host "[driver] started windbg-mcp pid=$($proc.Id)" -ForegroundColor Cyan
+
+$script:nextId = 1
+
+function Send-Notification([string]$method, $params) {
+    $msg = @{ jsonrpc = "2.0"; method = $method }
+    if ($params) { $msg.params = $params }
+    $json = $msg | ConvertTo-Json -Depth 20 -Compress
+    $stdin.WriteLine($json)
+}
+
+function Send-Request([string]$method, $params, [int]$timeoutMs = 120000) {
+    $id = $script:nextId; $script:nextId++
+    $msg = @{ jsonrpc = "2.0"; id = $id; method = $method }
+    if ($params) { $msg.params = $params }
+    $json = $msg | ConvertTo-Json -Depth 20 -Compress
+    $stdin.WriteLine($json)
+
+    $deadline = [DateTime]::UtcNow.AddMilliseconds($timeoutMs)
+    while ($true) {
+        $remaining = ($deadline - [DateTime]::UtcNow).TotalMilliseconds
+        if ($remaining -le 0) { throw "timeout waiting for response id=$id ($method)" }
+        $task = $proc.StandardOutput.ReadLineAsync()
+        if (-not $task.Wait([int]$remaining)) { throw "timeout waiting for response id=$id ($method)" }
+        $line = $task.Result
+        if ($null -eq $line) { throw "server closed stdout while waiting for id=$id ($method)" }
+        if ($line.Trim() -eq "") { continue }
+        try { $obj = $line | ConvertFrom-Json } catch { Write-Host "[driver] non-JSON stdout: $line"; continue }
+        if ($obj.PSObject.Properties.Name -contains 'id' -and $obj.id -eq $id) { return $obj }
+        # ignore notifications / mismatched ids
+    }
+}
+
+function Show-ToolResult([string]$label, $resp) {
+    Write-Host "`n========== $label ==========" -ForegroundColor Yellow
+    if ($resp.error) {
+        Write-Host "ERROR: $($resp.error | ConvertTo-Json -Depth 20 -Compress)" -ForegroundColor Red
+        return
+    }
+    $r = $resp.result
+    if ($null -ne $r.isError -and $r.isError) { Write-Host "[isError=true]" -ForegroundColor Red }
+    if ($r.content) {
+        foreach ($c in $r.content) { if ($c.type -eq 'text') { Write-Host $c.text } }
+    } else {
+        Write-Host ($r | ConvertTo-Json -Depth 20 -Compress)
+    }
+}
+
+function Call-Tool([string]$name, $arguments, [int]$timeoutMs = 120000) {
+    $params = @{ name = $name }
+    if ($arguments) { $params.arguments = $arguments } else { $params.arguments = @{} }
+    return Send-Request "tools/call" $params $timeoutMs
+}
+
+try {
+    # ---- MCP handshake ----
+    $init = Send-Request "initialize" @{
+        protocolVersion = "2024-11-05"
+        capabilities    = @{}
+        clientInfo      = @{ name = "ps-driver"; version = "0.1" }
+    } 30000
+    Write-Host "[driver] initialize ok: server=$($init.result.serverInfo.name) v$($init.result.serverInfo.version) proto=$($init.result.protocolVersion)" -ForegroundColor Cyan
+    Send-Notification "notifications/initialized" $null
+
+    # ---- 1. Attach to the live kernel (this connects + breaks in) ----
+    $r = Call-Tool "attach_kernel" @{ connection = $Connection } 120000
+    Show-ToolResult "attach_kernel  (BREAK IN)" $r
+
+    # ---- Confirm we have a live, stopped context ----
+    Show-ToolResult "execute: .echo connected" (Call-Tool "execute" @{ command = ".echo === post-attach ===" } 60000)
+    Show-ToolResult "registers" (Call-Tool "registers" @{} 60000)
+    Show-ToolResult "backtrace (k)" (Call-Tool "backtrace" @{} 60000)
+    Show-ToolResult "execute: !running -t (current state)" (Call-Tool "execute" @{ command = "!pcr" } 60000)
+
+    # ---- 2. Set a breakpoint that the running system will hit promptly ----
+    Show-ToolResult "set_breakpoint nt!NtCreateFile" (Call-Tool "set_breakpoint" @{ expression = "nt!NtCreateFile" } 60000)
+    Show-ToolResult "execute: bl (list breakpoints)" (Call-Tool "execute" @{ command = "bl" } 60000)
+
+    # ---- 3. Resume; should run until the breakpoint is hit ----
+    Show-ToolResult "go  (RESUME -> expect breakpoint hit)" (Call-Tool "go" @{} 120000)
+    Show-ToolResult "registers @ breakpoint" (Call-Tool "registers" @{} 60000)
+    Show-ToolResult "backtrace @ breakpoint" (Call-Tool "backtrace" @{} 60000)
+
+    # ---- Cleanup: clear breakpoints and let the target run, then detach ----
+    Show-ToolResult "execute: bc * (clear breakpoints)" (Call-Tool "execute" @{ command = "bc *" } 60000)
+    Show-ToolResult "execute: g (set running, no wait)" (Call-Tool "execute" @{ command = "g" } 15000)
+    Show-ToolResult "end_session (detach, leave target running)" (Call-Tool "end_session" @{} 30000)
+
+    Write-Host "`n[driver] sequence complete" -ForegroundColor Green
+}
+finally {
+    try { $stdin.Close() } catch {}
+    Start-Sleep -Milliseconds 500
+    try { if (-not $proc.HasExited) { $proc.Kill() } } catch {}
+}

--- a/examples/test_usermode.ps1
+++ b/examples/test_usermode.ps1
@@ -1,0 +1,33 @@
+param([string]$Exe = "$PSScriptRoot\..\target\release\windbg-mcp.exe")
+$ErrorActionPreference = "Stop"
+$psi = New-Object System.Diagnostics.ProcessStartInfo
+$psi.FileName = $Exe; $psi.UseShellExecute = $false
+$psi.RedirectStandardInput = $true; $psi.RedirectStandardOutput = $true; $psi.RedirectStandardError = $false
+$utf8 = New-Object System.Text.UTF8Encoding($false); $psi.StandardOutputEncoding = $utf8
+$psi.WorkingDirectory = Split-Path $Exe
+$proc = [System.Diagnostics.Process]::Start($psi)
+$stdin = New-Object System.IO.StreamWriter($proc.StandardInput.BaseStream, $utf8); $stdin.AutoFlush = $true
+$script:nextId = 1
+function Note($m,$p){ $msg=@{jsonrpc="2.0";method=$m}; if($p){$msg.params=$p}; $stdin.WriteLine(($msg|ConvertTo-Json -Depth 20 -Compress)) }
+function Req($m,$p,[int]$t=90000){
+  $id=$script:nextId; $script:nextId++; $msg=@{jsonrpc="2.0";id=$id;method=$m}; if($p){$msg.params=$p}
+  $stdin.WriteLine(($msg|ConvertTo-Json -Depth 20 -Compress))
+  $dl=[DateTime]::UtcNow.AddMilliseconds($t)
+  while($true){ $rem=($dl-[DateTime]::UtcNow).TotalMilliseconds; if($rem-le 0){throw "timeout $m"}
+    $tk=$proc.StandardOutput.ReadLineAsync(); if(-not $tk.Wait([int]$rem)){throw "timeout $m"}
+    $ln=$tk.Result; if($null -eq $ln){throw "SERVER CLOSED STDOUT (crash) $m"}; if($ln.Trim()-eq""){continue}
+    try{$o=$ln|ConvertFrom-Json}catch{continue}; if(($o.PSObject.Properties.Name -contains 'id') -and $o.id -eq $id){return $o} }
+}
+function Tool($n,$a,[int]$t=90000){ if(-not $a){$a=@{}}; return Req "tools/call" @{name=$n;arguments=$a} $t }
+function Show($label,$r){ Write-Host "`n--- $label ---" -ForegroundColor Yellow
+  if($r.error){Write-Host "error: $($r.error.message)" -ForegroundColor Red}
+  elseif($r.result.content){ ($r.result.content|?{$_.type -eq 'text'}|%{$_.text}) -join "`n" | Write-Host } }
+try{
+  Req "initialize" @{protocolVersion="2024-11-05";capabilities=@{};clientInfo=@{name="um";version="0.1"}} 30000 | Out-Null
+  Note "notifications/initialized" $null
+  Show "launch cmd.exe (breaks at loader bp; result is 'r')" (Tool "launch" @{command_line="cmd.exe"} 90000)
+  Show "registers" (Tool "registers" @{} 60000)
+  Show "modules (head)" (Tool "modules" @{} 60000)
+  Show "set_breakpoint kernel32!CreateFileW" (Tool "set_breakpoint" @{expression="kernel32!CreateFileW"} 60000)
+  Show "end_session" (Tool "end_session" @{} 30000)
+}finally{ try{$stdin.Close()}catch{}; Start-Sleep -Milliseconds 400; try{if(-not $proc.HasExited){$proc.Kill()}}catch{} }

--- a/examples/verify_fixes.ps1
+++ b/examples/verify_fixes.ps1
@@ -1,0 +1,98 @@
+param(
+    [string]$Exe = "$PSScriptRoot\..\target\release\windbg-mcp.exe"
+)
+$ErrorActionPreference = "Stop"
+
+$psi = New-Object System.Diagnostics.ProcessStartInfo
+$psi.FileName = $Exe
+$psi.UseShellExecute = $false
+$psi.RedirectStandardInput = $true
+$psi.RedirectStandardOutput = $true
+$psi.RedirectStandardError = $false
+$utf8 = New-Object System.Text.UTF8Encoding($false)
+$psi.StandardOutputEncoding = $utf8
+$psi.WorkingDirectory = Split-Path $Exe
+$proc = [System.Diagnostics.Process]::Start($psi)
+$stdin = New-Object System.IO.StreamWriter($proc.StandardInput.BaseStream, $utf8)
+$stdin.AutoFlush = $true
+Write-Host "[verify] windbg-mcp pid=$($proc.Id)" -ForegroundColor Cyan
+
+$script:nextId = 1
+function Send-Notification([string]$m, $p) {
+    $msg = @{ jsonrpc = "2.0"; method = $m }; if ($p) { $msg.params = $p }
+    $stdin.WriteLine(($msg | ConvertTo-Json -Depth 20 -Compress))
+}
+function Send-Request([string]$m, $p, [int]$timeoutMs = 60000) {
+    $id = $script:nextId; $script:nextId++
+    $msg = @{ jsonrpc = "2.0"; id = $id; method = $m }; if ($p) { $msg.params = $p }
+    $stdin.WriteLine(($msg | ConvertTo-Json -Depth 20 -Compress))
+    $deadline = [DateTime]::UtcNow.AddMilliseconds($timeoutMs)
+    while ($true) {
+        $rem = ($deadline - [DateTime]::UtcNow).TotalMilliseconds
+        if ($rem -le 0) { throw "timeout id=$id ($m)" }
+        $t = $proc.StandardOutput.ReadLineAsync()
+        if (-not $t.Wait([int]$rem)) { throw "timeout id=$id ($m)" }
+        $line = $t.Result
+        if ($null -eq $line) { throw "SERVER CLOSED STDOUT (crash) while waiting id=$id ($m)" }
+        if ($line.Trim() -eq "") { continue }
+        try { $o = $line | ConvertFrom-Json } catch { continue }
+        if (($o.PSObject.Properties.Name -contains 'id') -and $o.id -eq $id) { return $o }
+    }
+}
+function Call([string]$name, $toolArgs, [int]$t = 60000) {
+    if (-not $toolArgs) { $toolArgs = @{} }
+    $p = @{ name = $name; arguments = $toolArgs }
+    return Send-Request "tools/call" $p $t
+}
+function Report([string]$label, $resp, [string]$expectSubstr) {
+    Write-Host "`n--- $label ---" -ForegroundColor Yellow
+    $msg = $null
+    if ($resp.error) { $msg = $resp.error.message; Write-Host "error.message: $msg" }
+    elseif ($resp.result.content) { $msg = ($resp.result.content | Where-Object { $_.type -eq 'text' } | ForEach-Object { $_.text }) -join "`n"; Write-Host "result: $msg" }
+    if ($expectSubstr) {
+        if ($msg -match [regex]::Escape($expectSubstr)) { Write-Host "PASS: contains '$expectSubstr'" -ForegroundColor Green }
+        else { Write-Host "FAIL: expected '$expectSubstr'" -ForegroundColor Red }
+    }
+}
+
+try {
+    Send-Request "initialize" @{ protocolVersion = "2024-11-05"; capabilities = @{}; clientInfo = @{ name = "verify"; version = "0.1" } } 30000 | Out-Null
+    Send-Notification "notifications/initialized" $null
+
+    Write-Host "`n========== BUG 2: execution control with no debuggee must not crash ==========" -ForegroundColor Magenta
+    Report "go (no target)"         (Call "go" @{})        "No active debuggee"
+    Report "step_into (no target)"  (Call "step_into" @{}) "No active debuggee"
+    Report "step_over (no target)"  (Call "step_over" @{}) "No active debuggee"
+    # Liveness probe: if the process had crashed on the go calls above, this throws "SERVER CLOSED STDOUT".
+    Report "modules (server still alive?)" (Call "modules" @{}) $null
+    Write-Host "[verify] server survived execution-control-with-no-debuggee calls" -ForegroundColor Green
+
+    Write-Host "`n========== BUG 1: attach failure must be a clean error, not a panic ==========" -ForegroundColor Magenta
+    # Occupy UDP 50000 with a background kd so windbg-mcp's AttachKernel fails (port in use).
+    $kd  = "C:\Program Files\WindowsApps\Microsoft.WinDbg_1.2603.20001.0_x64__8wekyb3d8bbwe\amd64\kd.exe"
+    $key = "<KDNET-KEY>" # replace with your target's KDNET key to exercise this path
+    $kdout = "$PSScriptRoot\..\target\kd_hold.out"
+    $kp = $null
+    if (Test-Path $kd) {
+        $kp = Start-Process -FilePath $kd -ArgumentList ('-k net:port=50000,key=' + $key) -RedirectStandardOutput $kdout -PassThru -WindowStyle Hidden
+        Start-Sleep -Seconds 3  # let kd bind the port
+        $bound = Get-NetUDPEndpoint -LocalPort 50000 -ErrorAction SilentlyContinue
+        Write-Host "[verify] port 50000 held by kd pid=$($kp.Id): $([bool]$bound)"
+    } else { Write-Host "[verify] kd.exe not found; attach will hit no_debuggee path instead" }
+
+    $r = Call "attach_kernel" @{ connection = "net:port=50000,key=$key" } 90000
+    Report "attach_kernel (port held / failure path)" $r $null
+    $m = if ($r.error) { $r.error.message } else { "" }
+    if ($m -match 'panic') { Write-Host "FAIL: still panics ($m)" -ForegroundColor Red }
+    elseif ($m -match 'attach|Failed to attach|Not implemented|0x') { Write-Host "PASS: clean error, no panic" -ForegroundColor Green }
+    else { Write-Host "NOTE: unexpected: $m" -ForegroundColor Yellow }
+
+    if ($kp -and -not $kp.HasExited) { Stop-Process -Id $kp.Id -Force -ErrorAction SilentlyContinue }
+
+    Write-Host "`n[verify] done" -ForegroundColor Green
+}
+finally {
+    try { $stdin.Close() } catch {}
+    Start-Sleep -Milliseconds 400
+    try { if (-not $proc.HasExited) { $proc.Kill() } } catch {}
+}

--- a/skills/windbg-debugging/live-and-kernel.md
+++ b/skills/windbg-debugging/live-and-kernel.md
@@ -11,8 +11,12 @@ Pick one entry point:
   — stops at the initial breakpoint with a live thread context (the binding enables the
   `sxe ibp` initial-breakpoint filter, which a bare host leaves off).
 - **Attach to a running process.** `attach_process { "pid": 1234 }` — breaks in.
-- **Local kernel.** `attach_kernel_local {}` (returns `vertarget`).
-- **Remote kernel (KDNET).** `attach_kernel { "connection": "net:port=50000,key=..." }`.
+- **Local kernel.** `attach_kernel_local {}` — breaks in and returns `vertarget`.
+- **Remote kernel (KDNET).** `attach_kernel { "connection": "net:port=<n>,key=<w.x.y.z>" }`
+  — connects, breaks in, and returns `vertarget`. **Ask the user for the actual
+  connection string**; the port and key are specific to the target's KDNET setup (from
+  `bcdedit /dbgsettings` on the target, or the `windbgx -k` / `kd -k` command they use)
+  and cannot be guessed — never invent a placeholder key.
 
 End with `end_session {}` before opening another target (one session at a time).
 
@@ -36,7 +40,11 @@ End with `end_session {}` before opening another target (one session at a time).
 - **`read_memory` is numeric/hex only.** Use `execute` → `db @rip` for register/symbol
   expressions.
 - **`go` is bounded by the per-call timeout** (~60s). A long-running live target may not
-  reach a breakpoint within one call.
+  reach a breakpoint within one call; on a live kernel it is force-broken at the cap.
+- **Unreachable kernel target blocks.** `attach_kernel` to a target that never establishes
+  the KDNET link waits like `kd` does (a connecting link can't be cancelled mid-handshake),
+  so confirm the target is up and the port/key are correct. A *connected* target that
+  doesn't break in is bounded and returns an error.
 - **TTD is user-mode only** — you cannot time-travel a kernel target. For reverse
   execution, record a user-mode trace instead (see [ttd.md](ttd.md)).
 - Symbol names need the full setup (`msdia140.dll` + `.sympath` + `.reload /f` at a stop) —

--- a/src/server.rs
+++ b/src/server.rs
@@ -214,7 +214,7 @@ impl WindbgServer {
         let out = self
             .engine
             .run(move |e| {
-                e.attach_local_kernel();
+                e.attach_local_kernel().map_err(es)?;
                 e.wait_for_event(LOAD_WAIT_MS).map_err(es)?;
                 e.execute_command("vertarget").map_err(es)
             })
@@ -231,7 +231,7 @@ impl WindbgServer {
         let out = self
             .engine
             .run(move |e| {
-                e.attach_kernel(&args.connection);
+                e.attach_kernel(&args.connection).map_err(es)?;
                 e.wait_for_event(LOAD_WAIT_MS).map_err(es)?;
                 e.execute_command("vertarget").map_err(es)
             })

--- a/src/server.rs
+++ b/src/server.rs
@@ -214,8 +214,9 @@ impl WindbgServer {
         let out = self
             .engine
             .run(move |e| {
+                // attach_local_kernel breaks the target in internally (INITIAL_BREAK +
+                // an INFINITE wait, as a live kernel requires).
                 e.attach_local_kernel().map_err(es)?;
-                e.wait_for_event(LOAD_WAIT_MS).map_err(es)?;
                 e.execute_command("vertarget").map_err(es)
             })
             .await?;
@@ -231,8 +232,9 @@ impl WindbgServer {
         let out = self
             .engine
             .run(move |e| {
+                // attach_kernel connects, requests an initial break, and waits (INFINITE,
+                // as a live kernel requires) for the break-in — all internally.
                 e.attach_kernel(&args.connection).map_err(es)?;
-                e.wait_for_event(LOAD_WAIT_MS).map_err(es)?;
                 e.execute_command("vertarget").map_err(es)
             })
             .await?;


### PR DESCRIPTION
## Summary

Makes live **kernel** debugging actually work and hardens the attach path, by consuming the corresponding win-kexp fixes (now on `main`, pinned at `13977d15`).

### Server changes (`src/server.rs`)
- `attach_kernel` / `attach_kernel_local` now rely on win-kexp to break the target in internally (it sets `DEBUG_ENGOPT_INITIAL_BREAK`, waits with an **INFINITE** timeout — mandatory for a live kernel; a finite timeout returns `E_NOTIMPL` — then absorbs the one spurious break-in). The server no longer issues a second, finite `wait_for_event`.
- Propagate win-kexp's now-fallible `attach_kernel`/`attach_local_kernel` (`Result` instead of panic), so a failed attach surfaces as a clean tool error instead of `"debugger operation panicked"`.

### Dependency
- Bump win-kexp `b92e923 → 13977d15` (latest `main`): adds the live-kernel attach fix, the `Result`-returning attach, and the `execute_and_wait` `NoDebuggee` guard (go/step with no target returns a clean error instead of crashing the server via an uncatchable SEH abort).

### Verification
End-to-end against a live KDNET target through the MCP server:
- `attach_kernel` breaks in (`vertarget` → Windows Kernel 26100; registers; backtrace)
- `set_breakpoint nt!NtCreateFile` resolves
- `go` → **`Breakpoint 0 hit`** at `nt!NtCreateFile` (stack `nt!NtCreateFile → nt!KiSystemServiceCopyEnd`)
- clean resume + detach

`cargo build --release` and `cargo test` (14 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
