### PR TITLE
examples: drop redundant execute(g) before end_session

### DIFF
--- a/examples/drive_kernel_test.ps1
+++ b/examples/drive_kernel_test.ps1
@@ -106,10 +106,9 @@ try {
     Show-ToolResult "registers @ breakpoint" (Call-Tool "registers" @{} 60000)
     Show-ToolResult "backtrace @ breakpoint" (Call-Tool "backtrace" @{} 60000)
 
-    # ---- Cleanup: clear breakpoints and let the target run, then detach ----
+    # ---- Cleanup: clear the breakpoint, then end_session (resumes the kernel and detaches) ----
     Show-ToolResult "execute: bc * (clear breakpoints)" (Call-Tool "execute" @{ command = "bc *" } 60000)
-    Show-ToolResult "execute: g (set running, no wait)" (Call-Tool "execute" @{ command = "g" } 15000)
-    Show-ToolResult "end_session (detach, leave target running)" (Call-Tool "end_session" @{} 30000)
+    Show-ToolResult "end_session (resume + detach, leaves target running)" (Call-Tool "end_session" @{} 30000)
 
     Write-Host "`n[driver] sequence complete" -ForegroundColor Green
 }


### PR DESCRIPTION
end_session now resumes a live kernel and detaches itself (0.1.3), so the manual execute(g) in drive_kernel_test.ps1's cleanup is redundant. Comment/labels tidied to match.