### PR TITLE
docs: add status badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # windbg-mcp
 
+[![CI](https://github.com/glslang/windbg-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/glslang/windbg-mcp/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![CodeRabbit Pull Request Reviews](https://img.shields.io/coderabbit/prs/github/glslang/windbg-mcp?utm_source=oss&utm_medium=github&utm_campaign=glslang%2Fwindbg-mcp&labelColor=171717&color=FF570A&label=CodeRabbit+Reviews)](https://coderabbit.ai)
+[![GitHub release](https://img.shields.io/github/v/release/glslang/windbg-mcp)](https://github.com/glslang/windbg-mcp/releases/latest)
+[![Platform: Windows x64](https://img.shields.io/badge/platform-Windows%20x64-0078D6)](https://github.com/glslang/windbg-mcp#requirements)
+
 An [MCP](https://modelcontextprotocol.io) server that exposes **WinDbg/DbgEng** to AI agents
 (Claude Code, Claude Desktop, Cursor, …) over stdio. It drives a live debugger engine for
 **user-mode**, **kernel-mode**, **crash-dump**, and **Time Travel Debugging (TTD)** workflows.


### PR DESCRIPTION
Adds a badge row under the title:

- **CI** — links to the `ci.yml` workflow runs.
- **License: MIT** — links to `LICENSE`.
- **CodeRabbit Reviews** — live PR-review count (renders `15` today; no `.coderabbit.yml` needed).
- **GitHub release** — latest release version (renders `v0.1.3`), linking to `/releases/latest`; prebuilt zips are the primary distribution path.
- **Platform: Windows x64** — surfaces the hard Windows-x64-only constraint at a glance, linking to the Requirements section.

All five URLs verified live (HTTP 200); the two dynamic badges render real values, not placeholders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README with additional badges displaying CI status, MIT licence information, CodeRabbit PR review status, GitHub release version, and Windows x64 platform support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->