### PR TITLE
docs: fix broken release badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/glslang/windbg-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/glslang/windbg-mcp/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![CodeRabbit Pull Request Reviews](https://img.shields.io/coderabbit/prs/github/glslang/windbg-mcp?utm_source=oss&utm_medium=github&utm_campaign=glslang%2Fwindbg-mcp&labelColor=171717&color=FF570A&label=CodeRabbit+Reviews)](https://coderabbit.ai)
-[![GitHub release](https://img.shields.io/github/v/release/glslang/windbg-mcp)](https://github.com/glslang/windbg-mcp/releases/latest)
+[![GitHub release](https://img.shields.io/github/v/release/glslang/windbg-mcp?sort=semver)](https://github.com/glslang/windbg-mcp/releases/latest)
 [![Platform: Windows x64](https://img.shields.io/badge/platform-Windows%20x64-0078D6)](https://github.com/glslang/windbg-mcp#requirements)
 
 An [MCP](https://modelcontextprotocol.io) server that exposes **WinDbg/DbgEng** to AI agents


### PR DESCRIPTION
## Summary

- Adds `?sort=semver` to the shields.io GitHub release badge URL

## Why

shields.io's `github/v/release` endpoint can return an error/broken state for repos where its internal GitHub API cache hasn't populated yet. Adding `?sort=semver` routes the request through a different API code path (fetches all releases and picks the highest semver) which is consistently reliable.

## Test plan

- [ ] Verify the release badge renders correctly in the GitHub README after merge

https://claude.ai/code/session_019pvSjTQp8nUehT41Nd9txS

---
_Generated by [Claude Code](https://claude.ai/code/session_019pvSjTQp8nUehT41Nd9txS)_