### PR TITLE
feat: driver IOCTL discovery & user-mode reachability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Driver IOCTL discovery & user-mode reachability.** A new
+  [`driver-ioctl.md`](skills/windbg-debugging/driver-ioctl.md) playbook documents a
+  static-first, dynamic-confirm workflow for enumerating a driver's IOCTL surface and
+  testing whether each code is reachable from user mode (the openable → namespace →
+  deliverable → handled gate model), with WinDbg-native (`uf`) static enumeration by
+  default and Binary Ninja as an optional escalation. Five supporting tools:
+  - `decode_ioctl` — decode a 32-bit control code into its `CTL_CODE` fields and flag
+    `METHOD_NEITHER` / `FILE_ANY_ACCESS` (pure; no session needed).
+  - `driver_object` — dump a driver's dispatch table + devices (`!drvobj <name> 7`).
+  - `device_object` — inspect a device object's type/characteristics/SecurityDescriptor
+    (`!devobj`) to answer the *openable* gate.
+  - `irp_stack` — dump an IRP's current `IO_STACK_LOCATION` (`!irp`), defaulting the IRP
+    to `@rdx` at a dispatch break.
+  - `ioctl_trace` — install a conditional logging breakpoint at the IOCTL dispatch
+    routine that prints each `IoControlCode` + buffer lengths and continues.
+  - An `examples/sweep_ioctls.ps1` harness driving the dynamic confirm sweep.
+
 ## [0.1.3] - 2026-06-14
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     to `@rdx` at a dispatch break.
   - `ioctl_trace` — install a conditional logging breakpoint at the IOCTL dispatch
     routine that prints each `IoControlCode` + buffer lengths and continues.
-  - An `examples/sweep_ioctls.ps1` harness driving the dynamic confirm sweep.
+  - An `examples/sweep_ioctls.ps1` harness (host) + `examples/send_ioctls_target.ps1`
+    (target-side `DeviceIoControl` sender) driving the dynamic confirm sweep.
+  - `attach_kernel` / `attach_kernel_local` now `.load kdexts` automatically so the
+    `!drvobj`/`!devobj`/`!irp` commands behind `driver_object`/`device_object`/`irp_stack`
+    resolve; `setup.md` bundles `winxp\kdexts.dll`. Verified end-to-end against a live
+    KDNET kernel (the tools captured real mountmgr IOCTLs).
 
 ## [0.1.3] - 2026-06-14
 

--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ gh attestation verify <zip> --repo glslang/windbg-mcp `
 | Control | `go`, `step_over`, `step_into`, `set_breakpoint` |
 | TTD nav | `step_back` (`t-`), `step_over_back` (`p-`), `reverse_go` (`g-`), `goto_position` (`!tt`) |
 | TTD analysis | `ttd_calls`, `ttd_memory`, `ttd_events`, `index_trace`, `record_trace` |
+| Driver IOCTL | `decode_ioctl`, `driver_object`, `device_object`, `irp_stack`, `ioctl_trace` |
 | Raw     | `execute` — run any debugger command, returns full text output |
 
 The forward (`go`/`step_over`/`step_into`) and reverse (`reverse_go`/`step_over_back`/`step_back`)

--- a/examples/README.md
+++ b/examples/README.md
@@ -16,3 +16,13 @@ so build the server first: `cargo build --release`. For symbol resolution, set
 - **`verify_fixes.ps1`** — regression checks: `go`/step with no debuggee returns a
   clean "No active debuggee" error (no process crash), and a failed kernel attach is a
   clean error (no panic). The kernel-attach check needs a real KDNET key filled in.
+- **`sweep_ioctls.ps1`** — driver IOCTL sweep, **host side** (see
+  [`driver-ioctl.md`](../skills/windbg-debugging/driver-ioctl.md)). Attaches over KDNET,
+  prints the driver's dispatch table (`driver_object`) and load base, and — given the
+  rebased dispatch VA via `-Dispatch` — installs the `ioctl_trace` logging breakpoint and
+  collects the IOCTL log during a `go` window. Needs a real `-Connection` and a benign test
+  driver.
+- **`send_ioctls_target.ps1`** — the **target-side** companion: run it on the target VM
+  during the `go` window (once as a normal user, once elevated). It opens the device and
+  fires each `-Codes` IOCTL via `DeviceIoControl`; comparing which codes reach the host log
+  under each token is the per-token reachability answer.

--- a/examples/send_ioctls_target.ps1
+++ b/examples/send_ioctls_target.ps1
@@ -1,0 +1,47 @@
+# Runs on the TARGET VM (not the debugger host). Opens the device and fires each
+# candidate IOCTL so the host-side logging breakpoint (ioctl_trace) records it.
+# Run once as a normal user, then again from an elevated prompt, and compare which
+# codes appear in the host log under each token -- that difference IS the per-token
+# reachability answer. See ../skills/windbg-debugging/driver-ioctl.md.
+#
+#   .\send_ioctls_target.ps1 -DeviceName "\\.\MyDevice" -Codes 0x0022e004,0x0022e008
+param(
+    [string]$DeviceName = "\\.\MyDevice",
+    [int[]]$Codes = @(0x0022e004)
+)
+
+Add-Type @"
+using System;
+using System.Runtime.InteropServices;
+public static class Io {
+    [DllImport("kernel32.dll", SetLastError=true, CharSet=CharSet.Unicode)]
+    public static extern IntPtr CreateFile(string name, uint access, uint share,
+        IntPtr sec, uint disp, uint flags, IntPtr templ);
+    [DllImport("kernel32.dll", SetLastError=true)]
+    public static extern bool DeviceIoControl(IntPtr h, uint code, byte[] inBuf,
+        uint inLen, byte[] outBuf, uint outLen, out uint ret, IntPtr ov);
+    [DllImport("kernel32.dll", SetLastError=true)]
+    public static extern bool CloseHandle(IntPtr h);
+}
+"@
+
+# GENERIC_READ | GENERIC_WRITE. The `L` suffix forces Int64 so 0xC0000000 isn't
+# parsed as a negative Int32 before the cast to the uint `access` parameter.
+$GENERIC_RW = [uint32]0xC0000000L
+$OPEN_EXISTING = 3
+$h = [Io]::CreateFile($DeviceName, $GENERIC_RW, 0, [IntPtr]::Zero, $OPEN_EXISTING, 0, [IntPtr]::Zero)
+if ($h -eq [IntPtr]-1) {
+    $gle = [Runtime.InteropServices.Marshal]::GetLastWin32Error()
+    Write-Host "CreateFile failed (gle=$gle) -- device not openable as this token (the *openable* gate)."
+    exit 1
+}
+
+$inBuf = New-Object byte[] 16
+$outBuf = New-Object byte[] 16
+$ret = 0
+foreach ($c in $Codes) {
+    $ok = [Io]::DeviceIoControl($h, [uint32]$c, $inBuf, $inBuf.Length, $outBuf, $outBuf.Length, [ref]$ret, [IntPtr]::Zero)
+    $gle = [Runtime.InteropServices.Marshal]::GetLastWin32Error()
+    Write-Host ("IOCTL 0x{0:x8}  ok={1} gle={2} ret={3}" -f $c, $ok, $gle, $ret)
+}
+[Io]::CloseHandle($h) | Out-Null

--- a/examples/send_ioctls_target.ps1
+++ b/examples/send_ioctls_target.ps1
@@ -5,10 +5,27 @@
 # reachability answer. See ../skills/windbg-debugging/driver-ioctl.md.
 #
 #   .\send_ioctls_target.ps1 -DeviceName "\\.\MyDevice" -Codes 0x0022e004,0x0022e008
+#   .\send_ioctls_target.ps1 -DeviceName "\\.\MyDevice" -DesiredAccess 0xC0000000
 param(
     [string]$DeviceName = "\\.\MyDevice",
-    [int[]]$Codes = @(0x0022e004)
+    # Candidate IOCTL codes as strings (0x-hex or decimal) so the full unsigned 32-bit
+    # space works -- e.g. a vendor code whose device type sets bit 31, 0x80008003, which
+    # would overflow a signed [int].
+    [string[]]$Codes = @("0x0022e004"),
+    # Handle access to request. Reachability is per (token, access): run with 0 (minimal
+    # -- tests pure openability and FILE_ANY_ACCESS IOCTLs), 0x80000000 (GENERIC_READ),
+    # 0x40000000 (GENERIC_WRITE), or 0xC0000000 (both). An IOCTL whose RequiredAccess
+    # exceeds the handle's granted access is dropped by the I/O manager. 0x-hex or decimal.
+    [string]$DesiredAccess = "0"
 )
+
+# Parse 0x-hex or decimal into a UInt32 (PowerShell would otherwise read 0x8000xxxx as a
+# negative [int] and fail the cast to the unsigned CreateFile/DeviceIoControl arguments).
+function ConvertTo-UInt32([string]$s) {
+    $t = $s.Trim()
+    if ($t -match '^0[xX]') { return [Convert]::ToUInt32($t.Substring(2), 16) }
+    return [Convert]::ToUInt32($t, 10)
+}
 
 Add-Type @"
 using System;
@@ -25,22 +42,27 @@ public static class Io {
 }
 "@
 
-# GENERIC_READ | GENERIC_WRITE. The `L` suffix forces Int64 so 0xC0000000 isn't
-# parsed as a negative Int32 before the cast to the uint `access` parameter.
-$GENERIC_RW = [uint32]0xC0000000L
+# Share read+write so a device another process already holds open doesn't fail with
+# ERROR_SHARING_VIOLATION (32) -- which would be a false "not openable", distinct from a
+# genuine access-denied (5).
+$FILE_SHARE_RW = 0x00000003
 $OPEN_EXISTING = 3
-$h = [Io]::CreateFile($DeviceName, $GENERIC_RW, 0, [IntPtr]::Zero, $OPEN_EXISTING, 0, [IntPtr]::Zero)
+$access = ConvertTo-UInt32 $DesiredAccess
+
+$h = [Io]::CreateFile($DeviceName, $access, $FILE_SHARE_RW, [IntPtr]::Zero, $OPEN_EXISTING, 0, [IntPtr]::Zero)
 if ($h -eq [IntPtr]-1) {
     $gle = [Runtime.InteropServices.Marshal]::GetLastWin32Error()
-    Write-Host "CreateFile failed (gle=$gle) -- device not openable as this token (the *openable* gate)."
+    Write-Host ("CreateFile({0}, access=0x{1:x8}) failed (gle={2})." -f $DeviceName, $access, $gle)
+    Write-Host "  gle=5 access denied (not openable as this token) | gle=32 sharing violation | gle=2 no such device/symlink"
     exit 1
 }
 
 $inBuf = New-Object byte[] 16
 $outBuf = New-Object byte[] 16
 $ret = 0
-foreach ($c in $Codes) {
-    $ok = [Io]::DeviceIoControl($h, [uint32]$c, $inBuf, $inBuf.Length, $outBuf, $outBuf.Length, [ref]$ret, [IntPtr]::Zero)
+foreach ($cs in $Codes) {
+    $c = ConvertTo-UInt32 $cs
+    $ok = [Io]::DeviceIoControl($h, $c, $inBuf, $inBuf.Length, $outBuf, $outBuf.Length, [ref]$ret, [IntPtr]::Zero)
     $gle = [Runtime.InteropServices.Marshal]::GetLastWin32Error()
     Write-Host ("IOCTL 0x{0:x8}  ok={1} gle={2} ret={3}" -f $c, $ok, $gle, $ret)
 }

--- a/examples/sweep_ioctls.ps1
+++ b/examples/sweep_ioctls.ps1
@@ -7,8 +7,10 @@ param(
     # from the driver_object output). Leave empty on a first pass to just inspect the
     # dispatch table, then re-run with -Dispatch to install the logging sweep.
     [string]$Dispatch = "",
-    # How long (ms) to hold the target running while you drive the target-side sender.
-    [int]$RunMs = 120000,
+    # Number of consecutive collection windows. The server caps each `go` at
+    # EXEC_WAIT_MS (~60s) regardless of the client timeout, so to keep logging while the
+    # target-side sender runs we issue several back-to-back `go`s rather than one long one.
+    [int]$Sweeps = 2,
     [string]$Exe = "$PSScriptRoot\..\target\release\windbg-mcp.exe"
 )
 
@@ -125,9 +127,13 @@ try {
     Write-Host "`n[driver] >>> Now run send_ioctls_target.ps1 on the TARGET VM (normal user, then" -ForegroundColor Green
     Write-Host "[driver] >>> elevated). The logging bp prints each delivered IOCTL into 'go' below." -ForegroundColor Green
 
-    # `go` runs while the bp logs-and-continues (gc); it returns the accumulated
-    # IOCTL log when the per-call window elapses.
-    Show-ToolResult "go (collecting IOCTL log)" (Call-Tool "go" @{} $RunMs)
+    # Each `go` runs while the bp logs-and-continues (gc) and is force-broken at the
+    # server's ~60s cap, returning that window's accumulated IOCTL log. The client timeout
+    # (90s) stays above the server cap so we wait for its return, not time out first. Loop
+    # so the operator's sender (normal user, then elevated) can span more than one window.
+    for ($i = 1; $i -le $Sweeps; $i++) {
+        Show-ToolResult "go (collection window $i/$Sweeps, server-capped ~60s)" (Call-Tool "go" @{} 90000)
+    }
 
     # ---- Cleanup ----
     Show-ToolResult "execute: bc * (clear breakpoints)" (Call-Tool "execute" @{ command = "bc *" } 60000)

--- a/examples/sweep_ioctls.ps1
+++ b/examples/sweep_ioctls.ps1
@@ -1,0 +1,142 @@
+param(
+    # Pass your target's real KDNET connection string via -Connection.
+    [string]$Connection = "net:port=50000,key=<KDNET-KEY>",
+    # Driver object name for !drvobj, e.g. "mydriver" or "\Driver\mydriver".
+    [string]$Driver = "mydriver",
+    # Rebased VA of the IRP_MJ_DEVICE_CONTROL dispatch routine (MajorFunction[0x0e],
+    # from the driver_object output). Leave empty on a first pass to just inspect the
+    # dispatch table, then re-run with -Dispatch to install the logging sweep.
+    [string]$Dispatch = "",
+    # How long (ms) to hold the target running while you drive the target-side sender.
+    [int]$RunMs = 120000,
+    [string]$Exe = "$PSScriptRoot\..\target\release\windbg-mcp.exe"
+)
+
+$ErrorActionPreference = "Stop"
+
+# ----------------------------------------------------------------------------
+# This is the HOST side. The debugger attaches over KDNET and installs the
+# logging breakpoint. The user-mode sender that actually issues the IOCTLs runs
+# on the TARGET VM (it cannot cross the KDNET boundary from here) -- run the
+# companion script send_ioctls_target.ps1 on the target during the `go` window,
+# once as a normal user and once elevated. Reachability is answered per token:
+# a code rejected by the I/O manager's RequiredAccess check never reaches the bp.
+# ----------------------------------------------------------------------------
+
+# Start the MCP server with stdin/stdout redirected (UTF-8, no BOM).
+# stderr is left inheriting the console so logs are visible and no buffer deadlock occurs.
+$psi = New-Object System.Diagnostics.ProcessStartInfo
+$psi.FileName = $Exe
+$psi.UseShellExecute = $false
+$psi.RedirectStandardInput = $true
+$psi.RedirectStandardOutput = $true
+$psi.RedirectStandardError = $false
+$utf8 = New-Object System.Text.UTF8Encoding($false)
+# .NET Framework (PS 5.1) has StandardOutputEncoding but not StandardInputEncoding.
+$psi.StandardOutputEncoding = $utf8
+$psi.WorkingDirectory = Split-Path $Exe
+
+$proc = [System.Diagnostics.Process]::Start($psi)
+# Wrap stdin with a UTF-8 (no BOM) writer so we control the encoding ourselves.
+$stdin = New-Object System.IO.StreamWriter($proc.StandardInput.BaseStream, $utf8)
+$stdin.AutoFlush = $true
+Write-Host "[driver] started windbg-mcp pid=$($proc.Id)" -ForegroundColor Cyan
+
+$script:nextId = 1
+
+function Send-Notification([string]$method, $params) {
+    $msg = @{ jsonrpc = "2.0"; method = $method }
+    if ($params) { $msg.params = $params }
+    $json = $msg | ConvertTo-Json -Depth 20 -Compress
+    $stdin.WriteLine($json)
+}
+
+function Send-Request([string]$method, $params, [int]$timeoutMs = 120000) {
+    $id = $script:nextId; $script:nextId++
+    $msg = @{ jsonrpc = "2.0"; id = $id; method = $method }
+    if ($params) { $msg.params = $params }
+    $json = $msg | ConvertTo-Json -Depth 20 -Compress
+    $stdin.WriteLine($json)
+
+    $deadline = [DateTime]::UtcNow.AddMilliseconds($timeoutMs)
+    while ($true) {
+        $remaining = ($deadline - [DateTime]::UtcNow).TotalMilliseconds
+        if ($remaining -le 0) { throw "timeout waiting for response id=$id ($method)" }
+        $task = $proc.StandardOutput.ReadLineAsync()
+        if (-not $task.Wait([int]$remaining)) { throw "timeout waiting for response id=$id ($method)" }
+        $line = $task.Result
+        if ($null -eq $line) { throw "server closed stdout while waiting for id=$id ($method)" }
+        if ($line.Trim() -eq "") { continue }
+        try { $obj = $line | ConvertFrom-Json } catch { Write-Host "[driver] non-JSON stdout: $line"; continue }
+        if ($obj.PSObject.Properties.Name -contains 'id' -and $obj.id -eq $id) { return $obj }
+        # ignore notifications / mismatched ids
+    }
+}
+
+function Show-ToolResult([string]$label, $resp) {
+    Write-Host "`n========== $label ==========" -ForegroundColor Yellow
+    if ($resp.error) {
+        Write-Host "ERROR: $($resp.error | ConvertTo-Json -Depth 20 -Compress)" -ForegroundColor Red
+        return
+    }
+    $r = $resp.result
+    if ($null -ne $r.isError -and $r.isError) { Write-Host "[isError=true]" -ForegroundColor Red }
+    if ($r.content) {
+        foreach ($c in $r.content) { if ($c.type -eq 'text') { Write-Host $c.text } }
+    } else {
+        Write-Host ($r | ConvertTo-Json -Depth 20 -Compress)
+    }
+}
+
+function Call-Tool([string]$name, $arguments, [int]$timeoutMs = 120000) {
+    $params = @{ name = $name }
+    if ($arguments) { $params.arguments = $arguments } else { $params.arguments = @{} }
+    return Send-Request "tools/call" $params $timeoutMs
+}
+
+try {
+    # ---- MCP handshake ----
+    $init = Send-Request "initialize" @{
+        protocolVersion = "2024-11-05"
+        capabilities    = @{}
+        clientInfo      = @{ name = "ioctl-sweep"; version = "0.1" }
+    } 30000
+    Write-Host "[driver] initialize ok: server=$($init.result.serverInfo.name) v$($init.result.serverInfo.version)" -ForegroundColor Cyan
+    Send-Notification "notifications/initialized" $null
+
+    # ---- Attach to the live kernel (connects + breaks in) ----
+    Show-ToolResult "attach_kernel  (BREAK IN)" (Call-Tool "attach_kernel" @{ connection = $Connection } 120000)
+
+    # ---- Static: dispatch table + load base (for rebasing the dispatch VA) ----
+    Show-ToolResult "driver_object (MajorFunction index 0x0e = IOCTL dispatch)" (Call-Tool "driver_object" @{ name = $Driver } 60000)
+    Show-ToolResult "modules (lm) -- rebase the static RVA to the live base" (Call-Tool "modules" @{} 60000)
+
+    if ([string]::IsNullOrWhiteSpace($Dispatch)) {
+        Write-Host "`n[driver] No -Dispatch given. Note MajorFunction[0x0e] above, rebase it to" -ForegroundColor Cyan
+        Write-Host "[driver] the live load base, then re-run with -Dispatch to install the sweep." -ForegroundColor Cyan
+        Show-ToolResult "end_session (resume + detach)" (Call-Tool "end_session" @{} 30000)
+        return
+    }
+
+    # ---- Dynamic: install the logging-bp sweep, then run the target sender ----
+    Show-ToolResult "ioctl_trace (logging bp + gc)" (Call-Tool "ioctl_trace" @{ dispatch = $Dispatch } 60000)
+    Show-ToolResult "execute: bl (confirm breakpoint)" (Call-Tool "execute" @{ command = "bl" } 60000)
+
+    Write-Host "`n[driver] >>> Now run send_ioctls_target.ps1 on the TARGET VM (normal user, then" -ForegroundColor Green
+    Write-Host "[driver] >>> elevated). The logging bp prints each delivered IOCTL into 'go' below." -ForegroundColor Green
+
+    # `go` runs while the bp logs-and-continues (gc); it returns the accumulated
+    # IOCTL log when the per-call window elapses.
+    Show-ToolResult "go (collecting IOCTL log)" (Call-Tool "go" @{} $RunMs)
+
+    # ---- Cleanup ----
+    Show-ToolResult "execute: bc * (clear breakpoints)" (Call-Tool "execute" @{ command = "bc *" } 60000)
+    Show-ToolResult "end_session (resume + detach, leaves target running)" (Call-Tool "end_session" @{} 30000)
+
+    Write-Host "`n[driver] sweep complete" -ForegroundColor Green
+}
+finally {
+    try { $stdin.Close() } catch {}
+    Start-Sleep -Milliseconds 500
+    try { if (-not $proc.HasExited) { $proc.Kill() } } catch {}
+}

--- a/skills/windbg-debugging/SKILL.md
+++ b/skills/windbg-debugging/SKILL.md
@@ -21,6 +21,7 @@ session of a workflow you haven't run yet in this environment.
 | Triage a `.dmp` crash dump | [crash-dump.md](crash-dump.md) |
 | Launch/attach a process, or debug the kernel | [live-and-kernel.md](live-and-kernel.md) |
 | Record / open / navigate / analyze a `.run` trace | [ttd.md](ttd.md) |
+| Enumerate a driver's IOCTLs & test user-mode reachability | [driver-ioctl.md](driver-ioctl.md) |
 
 ## Tool map
 

--- a/skills/windbg-debugging/driver-ioctl.md
+++ b/skills/windbg-debugging/driver-ioctl.md
@@ -19,7 +19,7 @@ caller token. An IOCTL is only useful to a user if it passes all four:
 
 | Gate | Question | How to answer |
 |------|----------|---------------|
-| **Openable** | Can this token open the device at all? | `device_object` → device DACL (`!sd` on its `SecurityDescriptor`); `FILE_DEVICE_SECURE_OPEN` |
+| **Openable** | Can this token open the device at all? | `device_object` → `SecurityDescriptor` pointer + `FILE_DEVICE_SECURE_OPEN` (decode the DACL with `!sd <ptr>` where that extension is present) |
 | **Namespace-visible** | Does `CreateFile(\\.\Foo)` resolve in the caller's session? | symbolic-link scope (`\GLOBAL??\Foo` vs. session-local) via `execute` → `!object \GLOBAL??` |
 | **Deliverable** | Does the I/O manager forward the IRP to the driver? | `decode_ioctl` → `RequiredAccess` (bits 14–15) checked against the handle's *granted* access **before** the IRP reaches the driver |
 | **Handled** | Does the driver do something, or reject it? | `irp_stack` at the break + `Irp->IoStatus.Status` on return (a `default:` case returns `STATUS_INVALID_DEVICE_REQUEST` / `STATUS_NOT_SUPPORTED`) |
@@ -57,9 +57,10 @@ reads.
 3. **Decode each candidate** with `decode_ioctl` to get its method + required access (and the
    `METHOD_NEITHER`/`FILE_ANY_ACCESS` flags).
 4. **Device surface.** `device_object { "device": "\\Device\\MyDevice" }` (`!devobj`) for the
-   device type and characteristics; then `execute { "command": "!sd <SecurityDescriptor> 1" }`
-   on the pointer it prints to decode the DACL (the *openable* gate). Inspect the symbolic link
-   with `execute { "command": "!object \\GLOBAL??" }` for the *namespace* gate.
+   device type, characteristics, and `SecurityDescriptor` pointer (the *openable* gate). Where the
+   `!sd` extension is present, `execute { "command": "!sd <SecurityDescriptor> 1" }` decodes the
+   DACL; it is not in the bundled engine, so otherwise inspect the SD by address. Inspect the
+   symbolic link with `execute { "command": "!object \\GLOBAL??" }` for the *namespace* gate.
 
 > **No PDBs.** Third-party drivers ship no symbols, so `module!Dispatch` won't resolve —
 > everything is **address-based**. RVAs from static analysis must be **rebased to the live load
@@ -131,6 +132,10 @@ sweep requires a real **KDNET/VM** target via `attach_kernel`.
 - **Local kernel = read-only.** `attach_kernel_local` cannot set code breakpoints or step — the
   `ioctl_trace`/`irp_stack` sweep needs `attach_kernel` (KDNET/VM). The static walk
   (`driver_object`/`device_object`/`uf`/`decode_ioctl`) works fine locally.
+- **Kernel-object commands need `kdexts.dll`.** `!drvobj`/`!devobj`/`!irp` (behind
+  `driver_object`/`device_object`/`irp_stack`) come from `kdexts.dll`. `attach_kernel` /
+  `attach_kernel_local` `.load` it automatically, but it must be bundled (`winxp\kdexts.dll`,
+  see [setup.md](setup.md)); without it the tools return *"No export drvobj found"*.
 - **The dispatch bp fires for *every* delivered IOCTL**, handled or not — it is noisy by design.
   The `default:` case still fires the bp; distinguish it by the return status, not the entry.
 - **An IOCTL rejected by the I/O manager's `RequiredAccess` check never reaches the driver**, so

--- a/skills/windbg-debugging/driver-ioctl.md
+++ b/skills/windbg-debugging/driver-ioctl.md
@@ -20,7 +20,7 @@ caller token. An IOCTL is only useful to a user if it passes all four:
 | Gate | Question | How to answer |
 |------|----------|---------------|
 | **Openable** | Can this token open the device at all? | `device_object` → device DACL (`!sd` on its `SecurityDescriptor`); `FILE_DEVICE_SECURE_OPEN` |
-| **Namespace-visible** | Does `CreateFile(\\.\Foo)` resolve in the caller's session? | symbolic-link scope (`\GLOBAL??\Foo` vs. session-local) via `execute` → `!object \GLOBAL?? ` |
+| **Namespace-visible** | Does `CreateFile(\\.\Foo)` resolve in the caller's session? | symbolic-link scope (`\GLOBAL??\Foo` vs. session-local) via `execute` → `!object \GLOBAL??` |
 | **Deliverable** | Does the I/O manager forward the IRP to the driver? | `decode_ioctl` → `RequiredAccess` (bits 14–15) checked against the handle's *granted* access **before** the IRP reaches the driver |
 | **Handled** | Does the driver do something, or reject it? | `irp_stack` at the break + `Irp->IoStatus.Status` on return (a `default:` case returns `STATUS_INVALID_DEVICE_REQUEST` / `STATUS_NOT_SUPPORTED`) |
 
@@ -31,7 +31,7 @@ already passed, and you still have to watch the return path for the *handled* ga
 
 A control code is a packed 32-bit value:
 
-```
+```text
  31              16 15 14 13            2 1  0
 +------------------+-----+---------------+----+
 |   DeviceType     | Acc |  FunctionCode | Mth|
@@ -59,7 +59,7 @@ reads.
 4. **Device surface.** `device_object { "device": "\\Device\\MyDevice" }` (`!devobj`) for the
    device type and characteristics; then `execute { "command": "!sd <SecurityDescriptor> 1" }`
    on the pointer it prints to decode the DACL (the *openable* gate). Inspect the symbolic link
-   with `execute { "command": "!object \\GLOBAL?? " }` for the *namespace* gate.
+   with `execute { "command": "!object \\GLOBAL??" }` for the *namespace* gate.
 
 > **No PDBs.** Third-party drivers ship no symbols, so `module!Dispatch` won't resolve —
 > everything is **address-based**. RVAs from static analysis must be **rebased to the live load
@@ -75,7 +75,15 @@ table), load the `.sys` in Binary Ninja:
    calls.
 2. Recover the `IoControlCode` switch constants, the expected input/output sizes per case, and
    the SDDL string passed to `IoCreateDeviceSecure`.
-3. Emit a **JSON IOCTL map** for the dynamic step to join against. Suggested schema (one object
+3. **Pin the `IO_STACK_LOCATION` offsets exactly.** With NT types applied (the wdm/ntddk type
+   library, or the platform PDB), Binary Ninja shows the precise layout — and the dispatch
+   routine's own prologue *reads* it, so you can lift the exact offsets from the disassembly
+   instead of trusting a generic constant: `Irp->Tail.Overlay.CurrentStackLocation`
+   (`Irp+0xb8` on x64), then within the `IO_STACK_LOCATION` `IoControlCode` (`+0x18`),
+   `InputBufferLength` (`+0x10`), `OutputBufferLength` (`+0x08`), `Type3InputBuffer`/`UserBuffer`
+   (`+0x20`). These confirm the `poi(@rdx+0xb8)+…` chain `ioctl_trace` uses — no runtime
+   guesswork.
+4. Emit a **JSON IOCTL map** for the dynamic step to join against. Suggested schema (one object
    per code):
 
    ```json
@@ -104,8 +112,9 @@ sweep requires a real **KDNET/VM** target via `attach_kernel`.
 2. **Install the sweep.** `ioctl_trace { "dispatch": "<dispatchVA-rebased>" }` installs a
    conditional logging breakpoint that prints `IOCTL <code> in=<n> out=<n>` and continues
    (`gc`) for every delivered IOCTL. It reads the current `IO_STACK_LOCATION` via
-   `poi(@rdx+0xb8)` on x64 — **verify that offset** with `execute { "command": "dt nt!_IRP" }`
-   and `dt nt!_IO_STACK_LOCATION` for the target build before trusting the log.
+   `poi(@rdx+0xb8)` on x64. These offsets are the standard x64 layout — confirm them exactly
+   from the Binary Ninja analysis above (the dispatch routine dereferences them directly), or
+   at runtime with `execute { "command": "dt nt!_IRP" }` / `dt nt!_IO_STACK_LOCATION`.
 3. **Drive the harness as the target token.** `go {}`, then from user mode run a sender (see
    `examples/sweep_ioctls.ps1`) that issues each candidate code **once as a low-priv token and
    again as admin**. Reachability is answered *as that user*: a code whose `RequiredAccess`
@@ -133,4 +142,3 @@ sweep requires a real **KDNET/VM** target via `attach_kernel`.
 - **No PDBs → rebase.** Static RVAs are ASLR-relative; rebase to `lm m <driver>` before setting
   any breakpoint. See the symbol/elevation notes in [setup.md](setup.md) and
   [live-and-kernel.md](live-and-kernel.md).
-</content>

--- a/skills/windbg-debugging/driver-ioctl.md
+++ b/skills/windbg-debugging/driver-ioctl.md
@@ -1,0 +1,136 @@
+# Playbook: driver IOCTL discovery & user-mode reachability
+
+**Goal:** enumerate the IOCTLs a kernel driver exposes through its
+`IRP_MJ_DEVICE_CONTROL` dispatch routine, and decide — per caller token — whether each
+one is actually **reachable from user mode**. This is **static-first, dynamic-confirm**:
+static analysis produces the candidate IOCTL map; live debugging confirms delivery and
+observes the taken case + return status. Kernel debugging needs **Administrator** (see
+[setup.md](setup.md)).
+
+> **Breakpoints confirm; they do not enumerate.** A breakpoint on the dispatch routine only
+> fires for IOCTLs you actually *send*. The set of *available* IOCTLs is defined statically by
+> the `switch (IoControlCode)` in the dispatch routine — recover it with `uf` or Binary Ninja,
+> not with a breakpoint.
+
+## Reachability is a multi-layer gate
+
+"Reachable from user mode" is not one yes/no — it is four gates, evaluated for a specific
+caller token. An IOCTL is only useful to a user if it passes all four:
+
+| Gate | Question | How to answer |
+|------|----------|---------------|
+| **Openable** | Can this token open the device at all? | `device_object` → device DACL (`!sd` on its `SecurityDescriptor`); `FILE_DEVICE_SECURE_OPEN` |
+| **Namespace-visible** | Does `CreateFile(\\.\Foo)` resolve in the caller's session? | symbolic-link scope (`\GLOBAL??\Foo` vs. session-local) via `execute` → `!object \GLOBAL?? ` |
+| **Deliverable** | Does the I/O manager forward the IRP to the driver? | `decode_ioctl` → `RequiredAccess` (bits 14–15) checked against the handle's *granted* access **before** the IRP reaches the driver |
+| **Handled** | Does the driver do something, or reject it? | `irp_stack` at the break + `Irp->IoStatus.Status` on return (a `default:` case returns `STATUS_INVALID_DEVICE_REQUEST` / `STATUS_NOT_SUPPORTED`) |
+
+A dispatch breakpoint firing means **delivered**, not **useful** — the *deliverable* gate
+already passed, and you still have to watch the return path for the *handled* gate.
+
+## IOCTL decode reference
+
+A control code is a packed 32-bit value:
+
+```
+ 31              16 15 14 13            2 1  0
++------------------+-----+---------------+----+
+|   DeviceType     | Acc |  FunctionCode | Mth|
++------------------+-----+---------------+----+
+  CTL_CODE(DeviceType, FunctionCode, Method, RequiredAccess)
+```
+
+`decode_ioctl { "code": "0x70000" }` renders all four fields and flags two that matter:
+**`METHOD_NEITHER`** (the driver gets raw user-mode pointers — classic bug surface) and
+**`FILE_ANY_ACCESS`** (no access gate — the *deliverable* gate is wide open).
+
+## Static enumeration — WinDbg-native (default)
+
+Works on a **local** kernel (`attach_kernel_local`) — it is read-only, but enumeration only
+reads.
+
+1. **Find the dispatch routine.** `driver_object { "name": "mydriver" }` (`!drvobj <name> 7`)
+   dumps the `MajorFunction` table. Index **`0x0e`** (`IRP_MJ_DEVICE_CONTROL`) is the IOCTL
+   dispatch handler's address.
+2. **Recover the switch.** `disassemble { "address": "<dispatchVA>" }` or `execute { "command":
+   "uf <dispatchVA>" }` to read the `IoControlCode` comparisons / jump-table constants. Each
+   `cmp`/case constant is a candidate IOCTL.
+3. **Decode each candidate** with `decode_ioctl` to get its method + required access (and the
+   `METHOD_NEITHER`/`FILE_ANY_ACCESS` flags).
+4. **Device surface.** `device_object { "device": "\\Device\\MyDevice" }` (`!devobj`) for the
+   device type and characteristics; then `execute { "command": "!sd <SecurityDescriptor> 1" }`
+   on the pointer it prints to decode the DACL (the *openable* gate). Inspect the symbolic link
+   with `execute { "command": "!object \\GLOBAL?? " }` for the *namespace* gate.
+
+> **No PDBs.** Third-party drivers ship no symbols, so `module!Dispatch` won't resolve —
+> everything is **address-based**. RVAs from static analysis must be **rebased to the live load
+> base** (`modules {}` / `lm m <driver>`) before use, because of ASLR.
+
+## Static enumeration — Binary Ninja (optional escalation)
+
+When `uf` can't recover the switch (optimized/obfuscated dispatch, a computed sub-dispatch
+table), load the `.sys` in Binary Ninja:
+
+1. Find the dispatch routine (cross-reference the `MajorFunction[0x0e]` store near
+   `DriverEntry`) and the `IoCreateDevice`/`IoCreateDeviceSecure` + `IoCreateSymbolicLink`
+   calls.
+2. Recover the `IoControlCode` switch constants, the expected input/output sizes per case, and
+   the SDDL string passed to `IoCreateDeviceSecure`.
+3. Emit a **JSON IOCTL map** for the dynamic step to join against. Suggested schema (one object
+   per code):
+
+   ```json
+   {
+     "code": "0x0022e004",
+     "device_type": "0x0022",
+     "function": "0x801",
+     "method": "METHOD_BUFFERED",
+     "required_access": "FILE_ANY_ACCESS",
+     "case_rva": "0x14c0",
+     "in_size": 8,
+     "out_size": 4,
+     "predicted_reachable": true
+   }
+   ```
+
+   RVAs (`case_rva`) rebase to the live load base (`lm m <driver>`).
+
+## Dynamic confirm (needs KDNET/VM)
+
+A **local** kernel session is read-only — you cannot set code breakpoints or single-step. The
+sweep requires a real **KDNET/VM** target via `attach_kernel`.
+
+1. **Attach.** `attach_kernel { "connection": "net:port=<n>,key=<w.x.y.z>" }` — **ask the user
+   for the real connection string** (see [live-and-kernel.md](live-and-kernel.md)).
+2. **Install the sweep.** `ioctl_trace { "dispatch": "<dispatchVA-rebased>" }` installs a
+   conditional logging breakpoint that prints `IOCTL <code> in=<n> out=<n>` and continues
+   (`gc`) for every delivered IOCTL. It reads the current `IO_STACK_LOCATION` via
+   `poi(@rdx+0xb8)` on x64 — **verify that offset** with `execute { "command": "dt nt!_IRP" }`
+   and `dt nt!_IO_STACK_LOCATION` for the target build before trusting the log.
+3. **Drive the harness as the target token.** `go {}`, then from user mode run a sender (see
+   `examples/sweep_ioctls.ps1`) that issues each candidate code **once as a low-priv token and
+   again as admin**. Reachability is answered *as that user*: a code whose `RequiredAccess`
+   exceeds the handle's granted access is rejected by the I/O manager and the breakpoint
+   **never fires**.
+4. **Classify.** For codes that do break in, `irp_stack {}` (defaults to `@rdx`) shows the
+   `IoControlCode` + buffer lengths; let `go {}` return and read `Irp->IoStatus.Status` to tell
+   a real handler (success / pending) from a `default:` rejection. Join the log against the
+   static candidate map → label each code **delivered / taken-case / return-status /
+   reachable-as-whom**.
+
+## Pitfalls
+
+- **Local kernel = read-only.** `attach_kernel_local` cannot set code breakpoints or step — the
+  `ioctl_trace`/`irp_stack` sweep needs `attach_kernel` (KDNET/VM). The static walk
+  (`driver_object`/`device_object`/`uf`/`decode_ioctl`) works fine locally.
+- **The dispatch bp fires for *every* delivered IOCTL**, handled or not — it is noisy by design.
+  The `default:` case still fires the bp; distinguish it by the return status, not the entry.
+- **An IOCTL rejected by the I/O manager's `RequiredAccess` check never reaches the driver**, so
+  the dispatch bp never fires for it. "bp didn't fire" can mean *not deliverable as this token*,
+  not *not implemented* — that's why you run the harness under more than one token.
+- **`@rdx` holds the PIRP only at the dispatch *entry*** (x64 fastcall arg2). After any
+  `step_over`/`step_into` the register is clobbered; read `irp_stack` before stepping, or pass an
+  explicit IRP address.
+- **No PDBs → rebase.** Static RVAs are ASLR-relative; rebase to `lm m <driver>` before setting
+  any breakpoint. See the symbol/elevation notes in [setup.md](setup.md) and
+  [live-and-kernel.md](live-and-kernel.md).
+</content>

--- a/skills/windbg-debugging/setup.md
+++ b/skills/windbg-debugging/setup.md
@@ -88,12 +88,18 @@ Copy-Item "$wd\dbgeng.dll","$wd\dbghelp.dll","$wd\dbgcore.dll","$wd\dbgmodel.dll
           "$wd\symsrv.dll","$wd\msdia140.dll" $dst -Force
 Copy-Item "$wd\ttd"    "$dst\ttd"    -Recurse -Force   # TTDReplay*.dll, TtdExt.dll, TTDAnalyze.dll, ...
 Copy-Item "$wd\winext" "$dst\winext" -Recurse -Force   # ext.dll (!analyze), kext.dll, … — for crash dumps
+New-Item   "$dst\winxp" -ItemType Directory -Force | Out-Null
+Copy-Item "$wd\winxp\kdexts.dll" "$dst\winxp" -Force   # !drvobj/!devobj/!irp — for the driver-IOCTL tools (kernel)
 ```
 
 - The `ttd\` subdir provides the `@$cursession.TTD` / `@$curprocess.TTD` data model and the
   `!tt` time-travel commands.
 - The `winext\` subdir provides `ext.dll` (which exports `!analyze`) and the other `!`-extensions.
   Required for crash-dump triage — without it `!analyze` returns *"No export analyze found"*.
+- `winxp\kdexts.dll` provides the kernel-object extensions `!drvobj`/`!devobj`/`!irp` used by the
+  `driver_object`/`device_object`/`irp_stack` tools. `attach_kernel` / `attach_kernel_local`
+  `.load kdexts` automatically; without the file those tools return *"No export drvobj found"*.
+  (Note it lives in `winxp\`, not `winext\`, and the engine already searches a `WINXP` subdir.)
 - `cargo clean` (when building from source) wipes `target\`, so re-copy after one.
 
 ## Symbols — required for `module!func` name resolution

--- a/skills/windbg-debugging/setup.md
+++ b/skills/windbg-debugging/setup.md
@@ -53,6 +53,19 @@ cargo build --release
 [`win-kexp`](https://github.com/glslang/win-kexp) is fetched automatically as a git
 dependency — no sibling checkout needed.
 
+> **Developing from the repo? Disconnect the `windbg` MCP server before a release build.**
+> While the server is connected it *runs* `target\release\windbg-mcp.exe`, so the file is
+> locked and `cargo build --release` fails with `failed to remove file … windbg-mcp.exe:
+> Access is denied (os error 5)`. End-to-end testing of a change can't happen until the
+> rebuilt binary is in place, so:
+>
+> 1. Disconnect it — disable the `windbg` server (the `/mcp` menu) or the plugin for this session.
+> 2. `cargo build --release` (or download a release), then `/reload-plugins` to reconnect.
+>
+> To iterate on logic without disconnecting, use the **dev profile** (writes `target\debug`,
+> which is *not* locked): `cargo test` compiles everything and runs the unit tests, and
+> `cargo clippy --all-targets` lints — neither touches the locked release binary.
+
 Either way, run `/reload-plugins` afterwards so Claude Code connects the `windbg` MCP server.
 
 ## WinDbg engine + extensions — for `.run` replay and crash-dump `!analyze`

--- a/src/server.rs
+++ b/src/server.rs
@@ -302,6 +302,11 @@ impl WindbgServer {
                 // attach_local_kernel breaks the target in internally (INITIAL_BREAK +
                 // an INFINITE wait, as a live kernel requires).
                 e.attach_local_kernel().map_err(es)?;
+                // The driver_object/device_object/irp_stack tools use kernel-extension
+                // commands (!drvobj/!devobj/!irp) from kdexts.dll, which a bare engine does
+                // not auto-load. Best-effort, like open_dump's `.load ext`; harmless if the
+                // extension isn't bundled (those tools then report a clean "no export").
+                let _ = e.execute_command(".load kdexts");
                 e.execute_command("vertarget").map_err(es)
             })
             .await?;
@@ -320,6 +325,9 @@ impl WindbgServer {
                 // attach_kernel connects, requests an initial break, and waits (INFINITE,
                 // as a live kernel requires) for the break-in — all internally.
                 e.attach_kernel(&args.connection).map_err(es)?;
+                // Load kdexts.dll so the driver_object/device_object/irp_stack tools'
+                // !drvobj/!devobj/!irp commands resolve (see attach_kernel_local). Best-effort.
+                let _ = e.execute_command(".load kdexts");
                 e.execute_command("vertarget").map_err(es)
             })
             .await?;
@@ -691,8 +699,9 @@ impl WindbgServer {
     }
 
     /// Inspect a device object (`!devobj <device>`): device type, characteristics
-    /// (e.g. FILE_DEVICE_SECURE_OPEN), and the SecurityDescriptor pointer. To answer the
-    /// *openable* gate, decode that DACL with `!sd <SecurityDescriptor>` via `execute`.
+    /// (e.g. FILE_DEVICE_SECURE_OPEN), and the SecurityDescriptor pointer — the inputs to the
+    /// *openable* gate. (`!sd <SecurityDescriptor>` decodes the DACL where that extension is
+    /// available; it is not in the bundled engine.)
     #[rmcp::tool]
     async fn device_object(
         &self,

--- a/src/server.rs
+++ b/src/server.rs
@@ -71,8 +71,7 @@ fn hexdump(base: u64, bytes: &[u8]) -> String {
 ///
 /// Layout: `DeviceType` = bits 16–31, `RequiredAccess` = bits 14–15,
 /// `FunctionCode` = bits 2–13, `Method` = bits 0–1.
-fn decode_ioctl_text(code: u64) -> String {
-    let c = code as u32;
+fn decode_ioctl_text(c: u32) -> String {
     let device_type = (c >> 16) & 0xFFFF;
     let access = (c >> 14) & 0x3;
     let function = (c >> 2) & 0xFFF;
@@ -664,6 +663,14 @@ impl WindbgServer {
         Parameters(args): Parameters<DecodeIoctlArgs>,
     ) -> Result<CallToolResult, ErrorData> {
         let code = parse_u64(&args.code).map_err(|e| ErrorData::invalid_params(e, None))?;
+        // An IOCTL is a 32-bit value; reject anything wider rather than silently
+        // truncating it to a different code.
+        let code = u32::try_from(code).map_err(|_| {
+            ErrorData::invalid_params(
+                format!("IOCTL must be a 32-bit value (got 0x{code:x})"),
+                None,
+            )
+        })?;
         text_result(decode_ioctl_text(code))
     }
 
@@ -849,8 +856,9 @@ mod tests {
     #[test]
     fn decode_ioctl_neither_write_flags_both_warnings() {
         // CTL_CODE(DeviceType=0x8000, Function=0x800, METHOD_NEITHER, FILE_WRITE_DATA).
+        // Device type 0x8000 sets bit 31 — exercises a full 32-bit (unsigned) code.
         let code = (0x8000u32 << 16) | (2u32 << 14) | (0x800u32 << 2) | 3;
-        let out = decode_ioctl_text(code as u64);
+        let out = decode_ioctl_text(code);
         assert!(out.contains("DeviceType     0x8000"), "got: {out}");
         assert!(out.contains("FunctionCode   0x800"), "got: {out}");
         assert!(

--- a/src/server.rs
+++ b/src/server.rs
@@ -65,6 +65,58 @@ fn hexdump(base: u64, bytes: &[u8]) -> String {
     out
 }
 
+/// Decodes a 32-bit Windows IOCTL control code into its `CTL_CODE` fields and
+/// renders a human-readable report. Pure (no debugger) so it is unit-testable and
+/// works without a live session.
+///
+/// Layout: `DeviceType` = bits 16–31, `RequiredAccess` = bits 14–15,
+/// `FunctionCode` = bits 2–13, `Method` = bits 0–1.
+fn decode_ioctl_text(code: u64) -> String {
+    let c = code as u32;
+    let device_type = (c >> 16) & 0xFFFF;
+    let access = (c >> 14) & 0x3;
+    let function = (c >> 2) & 0xFFF;
+    let method = c & 0x3;
+
+    let method_name = match method {
+        0 => "METHOD_BUFFERED",
+        1 => "METHOD_IN_DIRECT",
+        2 => "METHOD_OUT_DIRECT",
+        _ => "METHOD_NEITHER",
+    };
+    let access_name = match access {
+        0 => "FILE_ANY_ACCESS",
+        1 => "FILE_READ_DATA",
+        2 => "FILE_WRITE_DATA",
+        _ => "FILE_READ_DATA | FILE_WRITE_DATA",
+    };
+
+    let mut out = String::new();
+    out.push_str(&format!("IOCTL 0x{c:08x}\n"));
+    out.push_str(&format!(
+        "  CTL_CODE(0x{device_type:04x}, 0x{function:03x}, {method_name}, {access_name})\n"
+    ));
+    out.push_str(&format!("  DeviceType     0x{device_type:04x}\n"));
+    out.push_str(&format!("  FunctionCode   0x{function:03x}\n"));
+    out.push_str(&format!("  Method         {method} ({method_name})\n"));
+    out.push_str(&format!("  RequiredAccess {access} ({access_name})\n"));
+
+    // Surface the two fields that matter most for reachability / bug-class triage.
+    if method == 3 {
+        out.push_str(
+            "  [!] METHOD_NEITHER: the driver receives raw user-mode pointers \
+             (Type3InputBuffer / UserBuffer) — classic input-validation bug surface.\n",
+        );
+    }
+    if access == 0 {
+        out.push_str(
+            "  [!] FILE_ANY_ACCESS: no access gate — the I/O manager delivers this IOCTL \
+             on any handle, even one opened with minimal access.\n",
+        );
+    }
+    out
+}
+
 // ---- Tool parameter types ------------------------------------------------
 
 #[derive(Deserialize, JsonSchema)]
@@ -155,6 +207,40 @@ pub struct TtdMemoryArgs {
     /// Omit to report every access.
     #[serde(default)]
     pub mode: Option<String>,
+}
+
+#[derive(Deserialize, JsonSchema)]
+pub struct DecodeIoctlArgs {
+    /// 32-bit IOCTL control code (decimal or 0x-hex), e.g. "0x70000".
+    pub code: String,
+}
+
+#[derive(Deserialize, JsonSchema)]
+pub struct DriverObjectArgs {
+    /// Driver object name, e.g. "mydriver" or "\\Driver\\mydriver".
+    pub name: String,
+}
+
+#[derive(Deserialize, JsonSchema)]
+pub struct DeviceObjectArgs {
+    /// Device object: a name (e.g. "\\Device\\MyDevice") or an address (0x-hex).
+    pub device: String,
+}
+
+#[derive(Deserialize, JsonSchema)]
+pub struct IrpStackArgs {
+    /// IRP address (decimal or 0x-hex). Defaults to `@rdx` — the PIRP passed to the
+    /// dispatch routine on x64, valid only at the dispatch *entry*, before any step
+    /// clobbers the register.
+    #[serde(default)]
+    pub irp: Option<String>,
+}
+
+#[derive(Deserialize, JsonSchema)]
+pub struct IoctlTraceArgs {
+    /// Virtual address of the IRP_MJ_DEVICE_CONTROL dispatch routine, rebased to the
+    /// live load base. Recover it via `driver_object` (MajorFunction[0x0e]).
+    pub dispatch: String,
 }
 
 // ---- Tools ---------------------------------------------------------------
@@ -568,6 +654,92 @@ impl WindbgServer {
             Err(e) => Err(ErrorData::internal_error(e, None)),
         }
     }
+
+    /// Decode a 32-bit IOCTL control code into its CTL_CODE fields (DeviceType,
+    /// FunctionCode, Method, RequiredAccess) and flag METHOD_NEITHER / FILE_ANY_ACCESS.
+    /// Pure — needs no debug session.
+    #[rmcp::tool]
+    async fn decode_ioctl(
+        &self,
+        Parameters(args): Parameters<DecodeIoctlArgs>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let code = parse_u64(&args.code).map_err(|e| ErrorData::invalid_params(e, None))?;
+        text_result(decode_ioctl_text(code))
+    }
+
+    /// Dump a driver object's dispatch table and devices (`!drvobj <name> 7`).
+    /// The MajorFunction table's index 0x0e is the IRP_MJ_DEVICE_CONTROL handler — the
+    /// IOCTL dispatch routine. Root of the device-tree walk.
+    #[rmcp::tool]
+    async fn driver_object(
+        &self,
+        Parameters(args): Parameters<DriverObjectArgs>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let cmd = format!("!drvobj {} 7", args.name);
+        let out = self
+            .engine
+            .run(move |e| e.execute_command(&cmd).map_err(es))
+            .await?;
+        text_result(out)
+    }
+
+    /// Inspect a device object (`!devobj <device>`): device type, characteristics
+    /// (e.g. FILE_DEVICE_SECURE_OPEN), and the SecurityDescriptor pointer. To answer the
+    /// *openable* gate, decode that DACL with `!sd <SecurityDescriptor>` via `execute`.
+    #[rmcp::tool]
+    async fn device_object(
+        &self,
+        Parameters(args): Parameters<DeviceObjectArgs>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let cmd = format!("!devobj {}", args.device);
+        let out = self
+            .engine
+            .run(move |e| e.execute_command(&cmd).map_err(es))
+            .await?;
+        text_result(out)
+    }
+
+    /// Dump the current IO_STACK_LOCATION of an IRP (`!irp <irp> 1`): major/minor,
+    /// IoControlCode, input/output buffer lengths, and buffer pointers. Defaults the IRP
+    /// to `@rdx` (the PIRP at the dispatch entry on x64) — valid only before stepping.
+    #[rmcp::tool]
+    async fn irp_stack(
+        &self,
+        Parameters(args): Parameters<IrpStackArgs>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let irp = args.irp.unwrap_or_else(|| "@rdx".to_string());
+        let cmd = format!("!irp {irp} 1");
+        let out = self
+            .engine
+            .run(move |e| e.execute_command(&cmd).map_err(es))
+            .await?;
+        text_result(out)
+    }
+
+    /// Install a conditional logging breakpoint at the IOCTL dispatch routine that prints
+    /// each IoControlCode + input/output lengths and continues (`gc`), so the IOCTL sweep
+    /// needs no hand-assembled offsets. Reads the current IO_STACK_LOCATION via
+    /// `poi(@rdx+0xb8)` (x64); confirm the offset with `dt nt!_IRP` / `dt nt!_IO_STACK_LOCATION`
+    /// on the target. Requires a real KDNET/VM target — a local kernel cannot set code bp's.
+    #[rmcp::tool]
+    async fn ioctl_trace(
+        &self,
+        Parameters(args): Parameters<IoctlTraceArgs>,
+    ) -> Result<CallToolResult, ErrorData> {
+        // IRP in @rdx at dispatch entry (x64). CurrentStackLocation = poi(Irp+0xb8).
+        // Within IO_STACK_LOCATION: OutputBufferLength +0x08, InputBufferLength +0x10,
+        // IoControlCode +0x18 (Parameters union begins at +0x08).
+        let cmd = format!(
+            "bp {} \".printf \\\"IOCTL %08x in=%x out=%x\\\\n\\\", \
+             dwo(poi(@rdx+0xb8)+0x18), dwo(poi(@rdx+0xb8)+0x10), dwo(poi(@rdx+0xb8)+0x08); gc\"",
+            args.dispatch
+        );
+        let out = self
+            .engine
+            .run(move |e| e.execute_command(&cmd).map_err(es))
+            .await?;
+        text_result(out)
+    }
 }
 
 #[rmcp::tool_handler(
@@ -576,7 +748,9 @@ Open a dump or .run trace, attach to a process or the kernel, inspect registers/
 Navigate a TTD trace in both directions: go/step_over/step_into forward, and reverse_go/step_over_back/step_back backward, \
 or jump with goto_position. Analyze a trace with the data-model tools ttd_calls (calls to a function), ttd_memory (accesses \
 to an address range), and ttd_events (module/thread/exception events), or run any data-model query with dx. Record new traces \
-with record_trace (needs elevation). Use `execute` for any raw command not covered by a dedicated tool."
+with record_trace (needs elevation). For driver IOCTL work: decode_ioctl (decode a control code), driver_object \
+and device_object (walk the driver/device tree and security), irp_stack (dump an IRP's IO_STACK_LOCATION), and \
+ioctl_trace (log every dispatched IOCTL). Use `execute` for any raw command not covered by a dedicated tool."
 )]
 impl rmcp::ServerHandler for WindbgServer {}
 
@@ -651,5 +825,44 @@ mod tests {
         // 0x00 and 0x7f are non-printable; 'A' (0x41) is printable.
         let out = hexdump(0, &[0x00, 0x41, 0x7f]);
         assert!(out.ends_with(".A.\n"), "got: {out:?}");
+    }
+
+    #[test]
+    fn decode_ioctl_disk_get_drive_geometry() {
+        // IOCTL_DISK_GET_DRIVE_GEOMETRY = CTL_CODE(IOCTL_DISK_BASE=0x7, 0, BUFFERED, ANY).
+        let out = decode_ioctl_text(0x70000);
+        assert!(out.contains("DeviceType     0x0007"), "got: {out}");
+        assert!(out.contains("FunctionCode   0x000"), "got: {out}");
+        assert!(
+            out.contains("Method         0 (METHOD_BUFFERED)"),
+            "got: {out}"
+        );
+        assert!(
+            out.contains("RequiredAccess 0 (FILE_ANY_ACCESS)"),
+            "got: {out}"
+        );
+        // FILE_ANY_ACCESS is flagged; METHOD_NEITHER is not.
+        assert!(out.contains("[!] FILE_ANY_ACCESS"), "got: {out}");
+        assert!(!out.contains("[!] METHOD_NEITHER"), "got: {out}");
+    }
+
+    #[test]
+    fn decode_ioctl_neither_write_flags_both_warnings() {
+        // CTL_CODE(DeviceType=0x8000, Function=0x800, METHOD_NEITHER, FILE_WRITE_DATA).
+        let code = (0x8000u32 << 16) | (2u32 << 14) | (0x800u32 << 2) | 3;
+        let out = decode_ioctl_text(code as u64);
+        assert!(out.contains("DeviceType     0x8000"), "got: {out}");
+        assert!(out.contains("FunctionCode   0x800"), "got: {out}");
+        assert!(
+            out.contains("Method         3 (METHOD_NEITHER)"),
+            "got: {out}"
+        );
+        assert!(
+            out.contains("RequiredAccess 2 (FILE_WRITE_DATA)"),
+            "got: {out}"
+        );
+        assert!(out.contains("[!] METHOD_NEITHER"), "got: {out}");
+        // FILE_WRITE_DATA is an access gate, so the ANY_ACCESS warning must be absent.
+        assert!(!out.contains("[!] FILE_ANY_ACCESS"), "got: {out}");
     }
 }


### PR DESCRIPTION
## What

Adds a **static-first, dynamic-confirm** workflow for enumerating a driver's IOCTL surface and deciding, per caller token, whether each code is actually reachable from user mode. Motivated by using the live-kernel capability to debug a **driver**.

The framing "breakpoint and verify which IOCTLs are available and whether they're reachable" is reframed honestly:
- **Breakpoints confirm; they don't enumerate** — the available set is the static `switch (IoControlCode)` in the dispatch routine (recovered with `uf`/Binary Ninja); the bp sweep only confirms candidates and observes runtime behavior.
- **"Reachable" is a four-layer gate, per token:** *openable* (device DACL) → *namespace-visible* (symbolic-link scope) → *deliverable* (IOCTL `RequiredAccess` checked by the I/O manager before the IRP reaches the driver) → *handled vs. rejected* (`default:` → `STATUS_INVALID_DEVICE_REQUEST`).

## New MCP tools (`src/server.rs`)

| Tool | Wraps | Purpose |
|------|-------|---------|
| `decode_ioctl` | *(pure)* | Decode a 32-bit `CTL_CODE`; flags `METHOD_NEITHER` / `FILE_ANY_ACCESS` |
| `driver_object` | `!drvobj <name> 7` | Dispatch table — `MajorFunction[0x0e]` is the IOCTL handler |
| `device_object` | `!devobj` | Device type / characteristics / `SecurityDescriptor` (openable gate) |
| `irp_stack` | `!irp` | Current `IO_STACK_LOCATION`; IRP defaults to `@rdx` at a dispatch break |
| `ioctl_trace` | logging `bp` + `gc` | Prints each `IoControlCode` + buffer lengths for the sweep |

## Docs & examples

- **New playbook** `skills/windbg-debugging/driver-ioctl.md` — the gate model, WinDbg-native `uf` enumeration (default), Binary Ninja escalation with a JSON IOCTL-map handoff schema, the dynamic-confirm sweep, and a pitfalls/constraints box (local kernel = read-only; no-PDB → rebase).
- Surfaced in `SKILL.md`, `README.md`, `CHANGELOG.md` (`[Unreleased]`, no version bump).
- `examples/sweep_ioctls.ps1` (host-side KDNET driver) + `examples/send_ioctls_target.ps1` (target-side `DeviceIoControl` sender, run low-priv then elevated).

## Verification

- `cargo test` — **16 pass**, including two new `decode_ioctl_text` cases (`IOCTL_DISK_GET_DRIVE_GEOMETRY`; a `METHOD_NEITHER` + `FILE_WRITE_DATA` case).
- `cargo fmt --check` and `cargo clippy --all-targets` — clean.
- `claude plugin validate . --strict` — passed.
- Both PowerShell scripts parse; the target sender's embedded C# (`Add-Type`) compiles and fails cleanly on a missing device.

> **Note:** the optimized `cargo build --release` was not run locally because the running `windbg` MCP server holds `target/release/windbg-mcp.exe` locked (compilation succeeds; only the final file-replace is blocked). The identical code compiles clean under the dev profile + clippy, and CI's `release.yml` builds release on a fresh runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new MCP tools to decode IOCTLs, inspect driver/device details, view IRP stack information, and perform breakpoint-based IOCTL tracing.
  * Added example PowerShell scripts to sweep likely IOCTLs from a host and probe user-mode reachability from a target VM.

* **Documentation**
  * Added a new driver IOCTL playbook covering static-first enumeration with dynamic confirmation using an openable → namespace-visible → deliverable → handled reachability model.
  * Updated the changelog, Tools table, and example documentation, plus setup guidance for required debugger extensions.

* **Tests**
  * Added unit coverage for IOCTL decoding output and warning rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->