### PR TITLE
docs: driver-ioctl walkthrough + report-step playbook update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     `!drvobj`/`!devobj`/`!irp` commands behind `driver_object`/`device_object`/`irp_stack`
     resolve; `setup.md` bundles `winxp\kdexts.dll`. Verified end-to-end against a live
     KDNET kernel (the tools captured real mountmgr IOCTLs).
+  - [`docs/driver-ioctl-walkthrough.md`](docs/driver-ioctl-walkthrough.md): a worked
+    `\Driver\mountmgr` enumeration + reachability report against a live kernel. The
+    playbook now ends with a "Write the report" step + template.
 
 ## [0.1.3] - 2026-06-14
 

--- a/README.md
+++ b/README.md
@@ -154,6 +154,11 @@ gh attestation verify <zip> --repo glslang/windbg-mcp `
   [`xusheng6/TTD_lab`](https://github.com/xusheng6/TTD_lab) `helloworld` sample: opening a `.run`,
   surveying events/threads, forward/reverse navigation, memory analysis, and counting `printf` calls
   with symbols (with the real outputs and the gotchas). It maps each tool to the lab's exercises.
+- [`docs/driver-ioctl-walkthrough.md`](docs/driver-ioctl-walkthrough.md) — enumerating a driver's IOCTL
+  surface and deciding user-mode reachability on a live KDNET kernel: `driver_object`/`uf` to recover
+  the `\Driver\mountmgr` dispatch switch, `decode_ioctl` for the access tiers, the device DACL parsed
+  from memory, and an `ioctl_trace` sweep — ending with a reachability report (which codes a standard
+  user can reach vs. what the I/O manager blocks).
 
 ## Tools
 

--- a/docs/driver-ioctl-walkthrough.md
+++ b/docs/driver-ioctl-walkthrough.md
@@ -1,0 +1,210 @@
+# Driver IOCTL walkthrough: enumerating & gating `\Driver\mountmgr`
+
+A hands-on tour of the driver-IOCTL tools against a **live KDNET kernel** (Windows
+26100.32995), mirroring the skill's
+[`driver-ioctl.md`](../skills/windbg-debugging/driver-ioctl.md) playbook. It shows the real
+`windbg` MCP tool calls, their output, and the gotchas — ending with a **reachability report**:
+which IOCTLs the Mount Point Manager exposes and which a normal user can actually reach. The
+target is a built-in driver (no test driver needed); the same flow applies to a third-party
+`.sys`.
+
+> **Verdict up front:** `\Device\MountPointManager` exposes IOCTLs in three access tiers. A
+> **standard user** can reach **only the four `FILE_ANY_ACCESS` query codes** (`0x6d0008`,
+> `0x6d0030`, `0x6d0034`, `0x6d003c`), and only by opening the device with *minimal* access.
+> Every read-gated (`0x6d40xx`) and mutating (`0x6dc0xx`) IOCTL is rejected by the I/O manager's
+> `RequiredAccess` check **before** the IRP reaches the driver, because the device DACL grants
+> normal users neither `FILE_READ_DATA` nor `FILE_WRITE_DATA`. Admin/SYSTEM reach everything.
+
+## 1. Attach (kernel extensions auto-load)
+
+```jsonc
+attach_kernel { "connection": "net:port=<n>,key=<w.x.y.z>" }
+```
+
+Breaks in and returns `vertarget`. `attach_kernel` also `.load`s `kdexts.dll` for you, so the
+`!drvobj`/`!devobj`/`!irp` commands behind the next tools resolve. (Without it they fail
+*"No export drvobj found"* — see [setup.md](../skills/windbg-debugging/setup.md) for bundling.)
+
+For readable analysis, point at symbols once stopped:
+
+```jsonc
+execute { "command": ".sympath srv*C:\\ProgramData\\Dbg\\sym*https://msdl.microsoft.com/download/symbols" }
+execute { "command": ".reload /f mountmgr.sys" }   // → mountmgr (pdb symbols)
+```
+
+> **Gotcha:** `.sympath` consumes the rest of the line, so run it on its own — don't `;`-chain
+> other commands after it.
+
+## 2. Find the IOCTL dispatch routine
+
+```jsonc
+driver_object { "name": "\\Driver\\mountmgr" }
+```
+
+The `MajorFunction` table's index **`0x0e`** (`IRP_MJ_DEVICE_CONTROL`) is the IOCTL dispatch:
+
+```text
+[0e] IRP_MJ_DEVICE_CONTROL   fffff803`3e254750   mountmgr!MountMgrDeviceControl
+```
+
+(On a live target these are already the rebased VAs — no ASLR math needed. For a third-party
+driver with no PDB, you'd rebase an RVA to `lm m <driver>`.)
+
+## 3. Static enumeration — recover the switch
+
+```jsonc
+execute { "command": "uf mountmgr!MountMgrDeviceControl" }
+```
+
+The prologue loads the control code (`r13d = [IRP_SP+0x18]`, `IRP_SP = [Irp+0xb8]`), then a chain
+of comparisons + a jump table — the authoritative candidate set:
+
+```text
+cmp r13d, 6D0030h  → MountMgrQueryDosVolumePath
+cmp r13d, 6D0008h  → MountMgrQueryPoints
+cmp r13d, 6D4020h  → MountMgrChangeNotify
+sub eax, 6D0034h   → MountMgrQueryDosVolumePaths
+...
+cmp r13d, 6DC000h  → MountMgrCreatePoint        ; + jump table 0x6dc004..0x6dc054
+default            → STATUS_INVALID_DEVICE_REQUEST (0xC0000010)
+```
+
+The three **prefixes** — `0x6d00xx`, `0x6d40xx`, `0x6dc0xx` — are the whole story, because the
+bits 14–15 of the code (`RequiredAccess`) are exactly what the I/O manager gates on.
+
+## 4. Decode the access tiers
+
+```jsonc
+decode_ioctl { "code": "0x6d0008" }   // FILE_ANY_ACCESS
+decode_ioctl { "code": "0x6d4020" }   // FILE_READ_DATA
+decode_ioctl { "code": "0x6dc000" }   // FILE_READ_DATA | FILE_WRITE_DATA
+```
+
+```text
+0x006d0008  CTL_CODE(0x006d, 0x002, METHOD_BUFFERED, FILE_ANY_ACCESS)
+0x006d4020  CTL_CODE(0x006d, 0x008, METHOD_BUFFERED, FILE_READ_DATA)
+0x006dc000  CTL_CODE(0x006d, 0x000, METHOD_BUFFERED, FILE_READ_DATA | FILE_WRITE_DATA)
+```
+
+All `METHOD_BUFFERED` (no `METHOD_NEITHER` raw-pointer surface).
+
+## 5. Openable gate — the device DACL
+
+```jsonc
+device_object { "device": "\\Device\\MountPointManager" }
+```
+
+```text
+SecurityDescriptor ffff8680fc6912a0   Characteristics (0x100) FILE_DEVICE_SECURE_OPEN
+```
+
+> **Gotcha:** `!sd` is **not** in the bundled engine, so `device_object` surfaces the SD pointer
+> and you decode the DACL by reading the structure:
+
+```jsonc
+execute { "command": "dt nt!_SECURITY_DESCRIPTOR_RELATIVE ffff8680fc6912a0" }  // Control 0x8004, Dacl +0x14
+execute { "command": "dt nt!_ACL ffff8680fc6912b4" }                            // 4 ACEs
+execute { "command": "db ffff8680fc6912b4 L5c" }                                // raw ACEs → parse
+```
+
+Parsed DACL:
+
+| Principal | SID | Granted access |
+|---|---|---|
+| Everyone | `S-1-1-0` | `0x001200a0` (`READ_CONTROL\|SYNCHRONIZE\|READ_ATTRIBUTES\|EXECUTE`) — **no** `READ_DATA`/`WRITE_DATA` |
+| RESTRICTED | `S-1-5-12` | `0x001200a0` |
+| SYSTEM | `S-1-5-18` | `0x001f01ff` (`FILE_ALL_ACCESS`) |
+| Administrators | `S-1-5-32-544` | `0x001f01ff` |
+
+A standard user matches only the *Everyone* ACE → the handle has neither `FILE_READ_DATA` (0x1)
+nor `FILE_WRITE_DATA` (0x2). It must open with `DesiredAccess = 0` / `FILE_READ_ATTRIBUTES`;
+asking for `GENERIC_READ` is itself access-denied.
+
+## 6. Namespace gate
+
+```jsonc
+execute { "command": "!object \\GLOBAL??\\MountPointManager" }
+```
+
+```text
+SymbolicLink … Target String is '\Device\MountPointManager'
+```
+
+A global symbolic link → `CreateFile("\\.\MountPointManager")` resolves from any session. Not a
+barrier for normal users here.
+
+## 7. Dynamic confirmation
+
+```jsonc
+ioctl_trace { "dispatch": "fffff8033e254750" }   // logging bp: prints code + in/out, then gc
+go {}                                            // run mountvol in the guest during the window
+```
+
+```text
+IOCTL 006d0030 in=200 out=8
+IOCTL 006d0008 in=46 out=20
+IOCTL 006d0034 in=208 out=8
+```
+
+`mountvol` (run as admin here) drove three `FILE_ANY_ACCESS` queries; `in=200 out=8` for
+`0x6d0030` matches what `irp_stack {}` decodes at a normal breakpoint on the dispatch
+(`IRP_MJ_DEVICE_CONTROL`, `IoControlCode 0x6d0030`). No `0x6d40xx`/`0x6dc0xx` appeared — `mountvol`
+only queries.
+
+## 8. The report — discovered IOCTLs & reachability
+
+DeviceType `0x6d`, all `METHOD_BUFFERED`. **Std user** = reachable by a non-admin token.
+
+### `FILE_ANY_ACCESS` — reachable by a standard user
+
+| Code | Handler | Meaning |
+|---|---|---|
+| `0x6d0008` | `MountMgrQueryPoints` | QUERY_POINTS |
+| `0x6d0030` | `MountMgrQueryDosVolumePath` | QUERY_DOS_VOLUME_PATH |
+| `0x6d0034` | `MountMgrQueryDosVolumePaths` | QUERY_DOS_VOLUME_PATHS |
+| `0x6d003c` | `MountMgrQueryAutoMount` | QUERY_AUTO_MOUNT |
+
+### `FILE_READ_DATA` — blocked for a standard user (handle lacks READ_DATA)
+
+`0x6d4008` (QueryPoints, read variant), `0x6d4020` (ChangeNotify), `0x6d4028`, `0x6d402c`
+(VolumeArrival), `0x6d4048` (TracelogCache), `0x6d4058` (VolumeRemoval).
+
+### `FILE_READ_DATA | FILE_WRITE_DATA` — blocked for a standard user (no WRITE_DATA)
+
+`0x6dc000` (CreatePoint) and the `0x6dc004`–`0x6dc054` jump-table group (DeletePoints,
+NextDriveLetter, SetAutoMount, ScrubRegistry, …). Exact membership is a compiler jump table
+(`mountmgr+0x5b80`/`+0x5b90`); unused slots route to the default. Doesn't change the verdict —
+every `0x6dc0xx` carries `RequiredAccess = READ|WRITE`.
+
+### Verdict
+
+- **Standard user:** `0x6d0008`, `0x6d0030`, `0x6d0034`, `0x6d003c` only (opened with minimal
+  access). All read-gated and mutating codes are rejected at the I/O-manager `RequiredAccess`
+  check before reaching `mountmgr`.
+- **Admin / SYSTEM:** all reachable (`FILE_ALL_ACCESS` on the device).
+- **Hygiene:** no `METHOD_NEITHER` codes; no `FILE_ANY_ACCESS` *mutators* — the privileged ops
+  are correctly gated behind write access.
+
+### Confirm empirically (optional)
+
+Run [`examples/send_ioctls_target.ps1`](../examples/send_ioctls_target.ps1) in the guest **as a
+standard user**:
+
+```text
+.\send_ioctls_target.ps1 -DeviceName "\\.\MountPointManager" -DesiredAccess 0 `
+    -Codes 0x6d0008,0x6d0030,0x6d4020,0x6dc000
+```
+
+Expect `0x6d0008`/`0x6d0030` to succeed and `0x6d4020`/`0x6dc000` to fail with
+`ERROR_ACCESS_DENIED (5)` — and confirm on the host that the denied codes never reach an
+`ioctl_trace` breakpoint.
+
+## Gotchas recap
+
+- `attach_kernel` auto-loads `kdexts.dll`; it must be bundled (`winxp\kdexts.dll`).
+- `!sd` isn't in the bundled engine — parse the DACL from the SD pointer (§5).
+- `.sympath` swallows the rest of the line — run it alone.
+- While broken in, the **whole guest is frozen**: start the trigger (`mountvol`, the sender),
+  then `go`. The logging bp continues with `gc`, so `go` returns its log at the ~60s cap.
+- Local kernel (`attach_kernel_local`) is read-only — the `ioctl_trace`/`irp_stack` sweep needs a
+  KDNET/VM target.

--- a/docs/driver-ioctl-walkthrough.md
+++ b/docs/driver-ioctl-walkthrough.md
@@ -195,9 +195,18 @@ standard user**:
     -Codes 0x6d0008,0x6d0030,0x6d4020,0x6dc000
 ```
 
-Expect `0x6d0008`/`0x6d0030` to succeed and `0x6d4020`/`0x6dc000` to fail with
-`ERROR_ACCESS_DENIED (5)` — and confirm on the host that the denied codes never reach an
-`ioctl_trace` breakpoint.
+Reachability is "**delivered to the driver**", not "`DeviceIoControl` succeeded". With an
+`ioctl_trace` breakpoint on the host:
+
+- `0x6d0008`/`0x6d0030` (ANY_ACCESS) → the **breakpoint fires** (reachable). `DeviceIoControl`
+  itself will usually still *fail* — the sender's 16-byte zeroed buffers don't satisfy the
+  MountMgr query structures, so you'll see `ERROR_INSUFFICIENT_BUFFER (122)` /
+  `ERROR_INVALID_PARAMETER (87)`, **not** access-denied. That's fine: the IRP reached the driver.
+- `0x6d4020`/`0x6dc000` (READ / READ|WRITE) → `DeviceIoControl` fails with
+  `ERROR_ACCESS_DENIED (5)` at the I/O-manager gate and the **breakpoint never fires** (blocked).
+
+So the decisive signal is *bp fired / `gle != 5`* (reachable) vs *`gle == 5` / no bp* (blocked) —
+don't read `DeviceIoControl` success as the reachability verdict.
 
 ## Gotchas recap
 

--- a/skills/windbg-debugging/driver-ioctl.md
+++ b/skills/windbg-debugging/driver-ioctl.md
@@ -145,7 +145,11 @@ Manager). Structure:
 4. **Reachability** — per tier, the verdict for **standard user** vs **admin/SYSTEM**, with the
    reason (DACL grant vs `RequiredAccess`, plus any in-dispatch privilege check).
 5. **Dynamic confirmation** — what `ioctl_trace`/`irp_stack` actually observed, and the token it
-   ran under (note: a sweep run as admin does *not* prove standard-user reachability).
+   ran under (note: a sweep run as admin does *not* prove standard-user reachability). Reachable
+   means **delivered** (the dispatch bp fires), *not* that `DeviceIoControl` returned success — a
+   dummy/short buffer often makes the call fail (`ERROR_INSUFFICIENT_BUFFER`/`INVALID_PARAMETER`)
+   while the IRP still reached the driver. The blocked signal is `ERROR_ACCESS_DENIED (5)` with no
+   bp hit (rejected at the I/O-manager gate).
 6. **Caveats** — anything not fully expanded (e.g. a jump-table group), and the optional
    empirical check: run `examples/send_ioctls_target.ps1` as a non-admin token in the guest.
 

--- a/skills/windbg-debugging/driver-ioctl.md
+++ b/skills/windbg-debugging/driver-ioctl.md
@@ -127,6 +127,30 @@ sweep requires a real **KDNET/VM** target via `attach_kernel`.
    static candidate map → label each code **delivered / taken-case / return-status /
    reachable-as-whom**.
 
+## Write the report
+
+Close the workflow with a written report so the result is reviewable. Keep it grounded in the
+tool output you gathered (cite the live addresses / DACL / codes — don't assert from memory). A
+worked end-to-end example is
+[`docs/driver-ioctl-walkthrough.md`](../../docs/driver-ioctl-walkthrough.md) (Mount Point
+Manager). Structure:
+
+1. **Verdict up front** — one paragraph: which IOCTLs a standard user can reach, which are
+   blocked and by which gate. State the target driver/device + build.
+2. **Openable gate** — the device DACL (principal → granted access) and `FILE_DEVICE_SECURE_OPEN`;
+   note the access a normal user's handle actually gets.
+3. **Discovered IOCTLs** — the full static set from `uf`, grouped by `RequiredAccess` tier
+   (`FILE_ANY_ACCESS` / `READ` / `READ|WRITE`), each row: code, handler/name, function, method.
+   Flag any `METHOD_NEITHER` or `FILE_ANY_ACCESS` *mutators*.
+4. **Reachability** — per tier, the verdict for **standard user** vs **admin/SYSTEM**, with the
+   reason (DACL grant vs `RequiredAccess`, plus any in-dispatch privilege check).
+5. **Dynamic confirmation** — what `ioctl_trace`/`irp_stack` actually observed, and the token it
+   ran under (note: a sweep run as admin does *not* prove standard-user reachability).
+6. **Caveats** — anything not fully expanded (e.g. a jump-table group), and the optional
+   empirical check: run `examples/send_ioctls_target.ps1` as a non-admin token in the guest.
+
+Save it under `docs/` (the repo's walkthrough convention) or hand it back inline.
+
 ## Pitfalls
 
 - **Local kernel = read-only.** `attach_kernel_local` cannot set code breakpoints or step — the


### PR DESCRIPTION
## What

Follow-up to #21 (driver-IOCTL tools): documentation + a report step.

- **`docs/driver-ioctl-walkthrough.md`** — a worked, end-to-end tour of the driver-IOCTL tools against a **live KDNET kernel**, mirroring the other `docs/` walkthroughs (real tool calls, outputs, gotchas, verdict-up-front). It enumerates `\Driver\mountmgr`'s IOCTL switch (`driver_object` → `uf`), decodes the access tiers (`decode_ioctl`), parses the `\Device\MountPointManager` DACL from kernel memory, runs an `ioctl_trace` sweep, and ends with a **reachability report**: a standard user can reach only the four `FILE_ANY_ACCESS` query IOCTLs; every read-gated (`0x6d40xx`) and mutating (`0x6dc0xx`) code is blocked by the I/O manager's `RequiredAccess` check.
- **`skills/windbg-debugging/driver-ioctl.md`** — the playbook now ends with a **"Write the report"** step + template (verdict / openable gate / discovered IOCTLs by tier / reachability / dynamic confirmation / caveats), linking the walkthrough as the worked example.
- **README / CHANGELOG** — list the new walkthrough.

## Notes

All findings in the walkthrough are grounded in real output captured this session (live kernel, build 26100.32995): the dispatch VA + `MajorFunction` table, the `uf` switch constants, the 4-ACE DACL parsed from the `SecurityDescriptor`, and the `ioctl_trace` capture. No code changes.

## Verification

`markdownlint-cli2` clean across `docs/**`, `skills/**`, `README.md`, `CHANGELOG.md` (the CI doc-lint set).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive new walkthrough guide for enumerating and analysing Windows driver IOCTL surfaces against live kernel debugging sessions, including access tier assessment and reachability reporting.
  * Enhanced driver analysis playbook with detailed report-writing procedures and structured templates for documenting findings.
  * Updated project documentation index with links to new walkthrough resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->