### PR TITLE
Add reachable_from_dispatch: static IOCTL block reachability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Static IOCTL dispatch reachability.** A new `reachable_from_dispatch` tool answers
+  whether a code block — given as an absolute address or `module`+`rva` — is reachable from
+  a driver's IOCTL dispatch routine, via a bounded breadth-first walk over the call graph
+  built from repeated `uf` disassembly. It follows direct calls and cross-function tail
+  jumps; it does **not** follow indirect calls through function pointers or unresolved
+  compiler jump tables, so a `REACHABLE` verdict is sound (and reports the call path) while
+  `NOT REACHABLE` is a best-effort within-bounds result. The `uf`-parsing and graph-walk
+  logic is pure and unit-tested (no debugger needed).
 - **Driver IOCTL discovery & user-mode reachability.** A new
   [`driver-ioctl.md`](skills/windbg-debugging/driver-ioctl.md) playbook documents a
   static-first, dynamic-confirm workflow for enumerating a driver's IOCTL surface and

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ gh attestation verify <zip> --repo glslang/windbg-mcp `
 | Control | `go`, `step_over`, `step_into`, `set_breakpoint` |
 | TTD nav | `step_back` (`t-`), `step_over_back` (`p-`), `reverse_go` (`g-`), `goto_position` (`!tt`) |
 | TTD analysis | `ttd_calls`, `ttd_memory`, `ttd_events`, `index_trace`, `record_trace` |
-| Driver IOCTL | `decode_ioctl`, `driver_object`, `device_object`, `irp_stack`, `ioctl_trace` |
+| Driver IOCTL | `decode_ioctl`, `driver_object`, `device_object`, `irp_stack`, `ioctl_trace`, `reachable_from_dispatch` |
 | Raw     | `execute` — run any debugger command, returns full text output |
 
 The forward (`go`/`step_over`/`step_into`) and reverse (`reverse_go`/`step_over_back`/`step_back`)
@@ -195,6 +195,12 @@ timeline). For anything else, `dx` evaluates arbitrary data-model/LINQ expressio
   can hit `0xD000010A` (that PID is a transient launcher) — attach to a classic Win32 process.
 - `read_memory` takes a numeric/`0x`-hex address only; for register/symbol expressions use
   `execute` with `db`/`dd` (e.g. `db @rip`).
+- `reachable_from_dispatch` is a **static** call-graph walk over `uf` disassembly: it follows
+  direct calls and cross-function tail jumps but **not** indirect calls through function pointers
+  or unresolved compiler jump tables. So a `REACHABLE` verdict is sound (a concrete static path
+  exists, and the path is reported), while `NOT REACHABLE` is best-effort within the explored
+  bounds. If the dispatch uses a `switch(IoControlCode)` jump table (common), pass the specific
+  handler VA as `from` to scope past it, or confirm dynamically with a breakpoint + `go`.
 - **Crash-dump triage uses `!ext.analyze -v`**, not `!analyze` — the bundled engine only resolves
   the module-qualified form (see *Bundling the WinDbg engine*). On a **partial minidump**, reads of
   pages that weren't captured raise `An unexpected exception was raised (0x80040205)` rather than a

--- a/src/server.rs
+++ b/src/server.rs
@@ -642,15 +642,17 @@ pub struct ReachabilityArgs {
     /// "fffff8033e254750"). Recover it via `driver_object` (MajorFunction[0x0e]). Pass
     /// a specific handler VA instead to scope the walk past a jump-table switch.
     pub from: String,
-    /// Target code block as an absolute virtual address (decimal or 0x-hex). Provide
-    /// this OR `module`+`rva`, not both.
+    /// Target code block as an absolute virtual address, in any WinDbg form — a bare
+    /// value is hex (e.g. "fffff803`3e254750" or "00401234"), and "0x"-hex or a symbol
+    /// also work. Provide this OR `module`+`rva`, not both.
     #[serde(default)]
     pub address: Option<String>,
     /// Module name for a module+RVA target, e.g. "mydriver". Its live base is read from
     /// `lm m <module>` and added to `rva`. Required (with `rva`) when `address` is omitted.
     #[serde(default)]
     pub module: Option<String>,
-    /// Relative virtual address (decimal or 0x-hex) added to `module`'s live base.
+    /// Relative virtual address added to `module`'s live base, in WinDbg form (a bare
+    /// value is hex; "0x"-hex also works).
     #[serde(default)]
     pub rva: Option<String>,
     /// Max distinct functions to disassemble before giving up (default 256). Bounds runtime.
@@ -1191,6 +1193,22 @@ impl WindbgServer {
         let out = self
             .engine
             .run(move |e| {
+                // Resolve an address/offset expression the way `uf`/WinDbg read it:
+                // evaluate `? <expr>` first (the MASM evaluator's default base is hex, so
+                // a bare `00401234` is 0x00401234 and `module!Dispatch+0x123` resolves),
+                // then fall back to pure parsing (backtick / bare-hex, then `0x`/decimal).
+                // Applied to both the target VA and the `from` seed so a value pasted from
+                // WinDbg — a `hi`lo` backtick address or a digit-only 32-bit address — is
+                // read consistently on both sides.
+                let resolve = |expr: &str| -> Option<u64> {
+                    e.execute_command(&format!("? {expr}"))
+                        .ok()
+                        .as_deref()
+                        .and_then(parse_eval)
+                        .or_else(|| parse_windbg_addr(expr))
+                        .or_else(|| parse_u64(expr).ok())
+                };
+
                 // Resolve the target VA: an absolute address, or module+RVA rebased
                 // against the module's live base from `lm m <module>`.
                 let target = match (&args.address, &args.module, &args.rva) {
@@ -1199,9 +1217,11 @@ impl WindbgServer {
                     (Some(_), Some(_), _) | (Some(_), _, Some(_)) => {
                         return Err("provide `address` OR `module`+`rva`, not both".to_string());
                     }
-                    (Some(a), None, None) => parse_u64(a)?,
+                    (Some(a), None, None) => resolve(a)
+                        .ok_or_else(|| format!("could not resolve target address `{a}`"))?,
                     (None, Some(m), Some(r)) => {
-                        let rva = parse_u64(r)?;
+                        let rva =
+                            resolve(r).ok_or_else(|| format!("could not resolve rva `{r}`"))?;
                         let lm = e.execute_command(&format!("lm m {m}")).map_err(es)?;
                         let base = parse_lm_base(&lm).ok_or_else(|| {
                             format!("module `{m}` not found (`lm m {m}` returned):\n{lm}")
@@ -1217,20 +1237,9 @@ impl WindbgServer {
                 let max_functions = args.max_functions.unwrap_or(256);
                 let max_depth = args.max_depth.unwrap_or(32);
 
-                // Resolve `from` to a numeric VA so a mid-function start (a handler
-                // scoped past a switch) is honored. Evaluate via `?` first so the seed is
-                // read *exactly* as `uf` reads the same string — the MASM evaluator's
-                // default base is hex, so a digit-only WinDbg address like `00401234` is
-                // 0x00401234 (not decimal), and `module!Dispatch+0x123` resolves too. Fall
-                // back to pure parsing (backtick / bare-hex, then `0x`/decimal) only if `?`
-                // is unavailable; if nothing resolves, the walk starts at the entry.
-                let seed_start = e
-                    .execute_command(&format!("? {}", args.from))
-                    .ok()
-                    .as_deref()
-                    .and_then(parse_eval)
-                    .or_else(|| parse_windbg_addr(&args.from))
-                    .or_else(|| parse_u64(&args.from).ok());
+                // Resolve `from` to a numeric VA so a mid-function start (a handler scoped
+                // past a switch) is honored; `None` (unresolvable) starts at the entry.
+                let seed_start = resolve(&args.from);
 
                 let rpt = reachability(
                     &args.from,

--- a/src/server.rs
+++ b/src/server.rs
@@ -311,6 +311,15 @@ fn parse_lm_base(text: &str) -> Option<u64> {
         .find_map(|l| l.split_whitespace().next().and_then(parse_windbg_addr))
 }
 
+/// Parses the value from WinDbg `?` (evaluate-expression) output, e.g.
+/// "Evaluate expression: 18446735277667370832 = fffff803`3e254750" — the address
+/// is the hex token after the `=`. Used to resolve a symbolic/backtick `from` (like
+/// `mydriver!Dispatch+0x123`) to the numeric VA the intra-function walk starts at.
+fn parse_eval(text: &str) -> Option<u64> {
+    let rhs = text.split('=').nth(1)?;
+    parse_windbg_addr(rhs.split_whitespace().next()?)
+}
+
 /// Outcome of a reachability walk. `verdict_reachable` is sound (a concrete static
 /// path exists); a false verdict is best-effort within the explored bounds.
 struct Report {
@@ -335,16 +344,20 @@ struct Report {
 /// until `target` is found among the reachable instructions, the graph is exhausted,
 /// or a bound is hit. `uf` returns the raw `uf <arg>` text or `None` (bad address /
 /// forwarded export / disassembly failure) to prune that branch.
+///
+/// `seed_start` is the resolved numeric VA of `from` (the caller resolves symbols /
+/// backtick / `module!sym+off` forms). When it points *inside* the seed function — a
+/// handler scoped past a switch — the intra-function walk begins there, not at the
+/// entry, so sibling switch cases aren't spuriously reachable. `None` (unresolvable)
+/// falls back to the function entry.
 fn reachability(
     from: &str,
+    seed_start: Option<u64>,
     target: u64,
     max_functions: usize,
     max_depth: usize,
     mut uf: impl FnMut(&str) -> Option<String>,
 ) -> Report {
-    // If `from` is a bare address it may point *inside* a function (a handler scoped
-    // past a switch); start the intra-function walk there rather than at the entry.
-    let seed_start = parse_u64(from).ok();
     let mut visited: HashSet<u64> = HashSet::new(); // walk start addresses already done
     let mut enqueued: HashSet<u64> = HashSet::new(); // target tokens scheduled
     // child token -> (caller token (None = seed), call site, kind).
@@ -1204,15 +1217,37 @@ impl WindbgServer {
                 let max_functions = args.max_functions.unwrap_or(256);
                 let max_depth = args.max_depth.unwrap_or(32);
 
-                let rpt = reachability(&args.from, target, max_functions, max_depth, |arg| {
-                    // A real `uf` lists backtick addresses or at least a "module!Func:"
-                    // label; error text ("Couldn't resolve...", "no code") lacks both
-                    // and prunes the branch. parse_uf then discards any non-disassembly.
-                    match e.execute_command(&format!("uf {arg}")) {
-                        Ok(t) if t.contains('`') || t.contains(':') => Some(t),
-                        _ => None,
-                    }
-                });
+                // Resolve `from` to a numeric VA so a mid-function start (a handler
+                // scoped past a switch) is honored even in WinDbg's own forms: a plain
+                // number, a `hi`lo` backtick address, or a `module!sym+off` expression
+                // evaluated via `?`. If it can't be resolved the walk starts at the
+                // function entry.
+                let seed_start = parse_u64(&args.from)
+                    .ok()
+                    .or_else(|| parse_windbg_addr(&args.from))
+                    .or_else(|| {
+                        e.execute_command(&format!("? {}", args.from))
+                            .ok()
+                            .as_deref()
+                            .and_then(parse_eval)
+                    });
+
+                let rpt = reachability(
+                    &args.from,
+                    seed_start,
+                    target,
+                    max_functions,
+                    max_depth,
+                    |arg| {
+                        // A real `uf` lists backtick addresses or at least a "module!Func:"
+                        // label; error text ("Couldn't resolve...", "no code") lacks both
+                        // and prunes the branch. parse_uf then discards any non-disassembly.
+                        match e.execute_command(&format!("uf {arg}")) {
+                            Ok(t) if t.contains('`') || t.contains(':') => Some(t),
+                            _ => None,
+                        }
+                    },
+                );
 
                 if rpt.from_entry.is_none() {
                     return Err(format!(
@@ -1421,6 +1456,21 @@ fffff803`3e250000 fffff803`3e270000   mydriver   (pdb symbols)
         assert_eq!(parse_lm_base("Unable to enumerate modules\n"), None);
     }
 
+    #[test]
+    fn parse_eval_reads_expression_value() {
+        // `? mydriver!Dispatch+0x123` → the address is the hex after the `=`.
+        assert_eq!(
+            parse_eval("Evaluate expression: 18446735277667370832 = fffff803`3e254750"),
+            Some(0xfffff803_3e254750)
+        );
+        assert_eq!(
+            parse_eval("Evaluate expression: 4096 = 00000000`00001000"),
+            Some(0x1000)
+        );
+        // A failed evaluation ("Couldn't resolve error ...") has no `=`/address.
+        assert_eq!(parse_eval("Couldn't resolve error at 'bogus'"), None);
+    }
+
     // ---- reachability: graph walk -----------------------------------------
 
     /// Builds a `uf` block whose entry is `entry`, with the given follow-on lines
@@ -1453,7 +1503,7 @@ fffff803`3e250000 fffff803`3e270000   mydriver   (pdb symbols)
             "0x2000".to_string(),
             uf_fn("B", 0x2000, &[&format!("{} c3 ret", fmt_addr(0x2008))]),
         );
-        let r = reachability("start", 0x2008, 256, 32, |a| m.get(a).cloned());
+        let r = reachability("start", None, 0x2008, 256, 32, |a| m.get(a).cloned());
         assert!(r.verdict_reachable);
         assert_eq!(r.from_entry, Some(0x1000));
         assert_eq!(r.containing_fn, Some(0x2000));
@@ -1479,7 +1529,7 @@ fffff803`3e250000 fffff803`3e270000   mydriver   (pdb symbols)
             "0x2000".to_string(),
             uf_fn("B", 0x2000, &[&format!("{} c3 ret", fmt_addr(0x2008))]),
         );
-        let r = reachability("start", 0x2008, 256, 32, |a| m.get(a).cloned());
+        let r = reachability("start", None, 0x2008, 256, 32, |a| m.get(a).cloned());
         assert!(r.verdict_reachable);
         assert_eq!(r.path, vec![(0x1004, "jmp", 0x2000)]);
     }
@@ -1491,7 +1541,7 @@ fffff803`3e250000 fffff803`3e270000   mydriver   (pdb symbols)
             "start".to_string(),
             uf_fn("A", 0x1000, &[&format!("{} c3 ret", fmt_addr(0x1004))]),
         );
-        let r = reachability("start", 0x1004, 256, 32, |a| m.get(a).cloned());
+        let r = reachability("start", None, 0x1004, 256, 32, |a| m.get(a).cloned());
         assert!(r.verdict_reachable);
         assert_eq!(r.containing_fn, Some(0x1000));
         assert!(r.path.is_empty());
@@ -1513,7 +1563,7 @@ fffff803`3e250000 fffff803`3e270000   mydriver   (pdb symbols)
             ),
         );
         // The target sits behind the indirect call, which is never followed.
-        let r = reachability("start", 0x2008, 256, 32, |a| m.get(a).cloned());
+        let r = reachability("start", None, 0x2008, 256, 32, |a| m.get(a).cloned());
         assert!(!r.verdict_reachable);
         assert!(!r.bound_hit); // graph exhausted, not a bound
     }
@@ -1546,7 +1596,7 @@ fffff803`3e250000 fffff803`3e270000   mydriver   (pdb symbols)
             ),
         );
         // Target is absent — the A<->B cycle must not loop forever.
-        let r = reachability("start", 0x7777, 256, 32, |a| m.get(a).cloned());
+        let r = reachability("start", None, 0x7777, 256, 32, |a| m.get(a).cloned());
         assert!(!r.verdict_reachable);
         assert_eq!(r.funcs_explored, 2);
     }
@@ -1571,7 +1621,7 @@ fffff803`3e250000 fffff803`3e270000   mydriver   (pdb symbols)
             uf_fn("B", 0x2000, &[&format!("{} c3 ret", fmt_addr(0x2004))]),
         );
         // Bound to a single function: B (which contains the target) is never explored.
-        let r = reachability("start", 0x2004, 1, 32, |a| m.get(a).cloned());
+        let r = reachability("start", None, 0x2004, 1, 32, |a| m.get(a).cloned());
         assert!(!r.verdict_reachable);
         assert!(r.bound_hit);
         assert_eq!(r.funcs_explored, 1);
@@ -1606,11 +1656,11 @@ fffff803`3e250000 fffff803`3e270000   mydriver   (pdb symbols)
             _ => None,
         };
 
-        // Starting inside case 1, case 1's own body IS reachable.
-        assert!(reachability("0x1008", 0x100c, 256, 32, &mut uf).verdict_reachable);
+        // Starting inside case 1 (seed_start resolved to 0x1008), case 1's body IS reachable.
+        assert!(reachability("0x1008", Some(0x1008), 0x100c, 256, 32, &mut uf).verdict_reachable);
         // ...but case 2's body is NOT reachable from case 1 (no intra-function path).
-        assert!(!reachability("0x1008", 0x1014, 256, 32, &mut uf).verdict_reachable);
+        assert!(!reachability("0x1008", Some(0x1008), 0x1014, 256, 32, &mut uf).verdict_reachable);
         // From the entry, the switch cases are unreachable — the jump table isn't followed.
-        assert!(!reachability("0x1000", 0x1008, 256, 32, &mut uf).verdict_reachable);
+        assert!(!reachability("0x1000", Some(0x1000), 0x1008, 256, 32, &mut uf).verdict_reachable);
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -154,26 +154,69 @@ fn branch_target(line: &str) -> Option<u64> {
     parse_windbg_addr(&rest[..=close])
 }
 
-/// One function's `uf` disassembly, reduced to what the call-graph walk needs.
+/// The control-flow behavior of one instruction, used to walk *within* a function.
+/// Only *direct*, resolvable targets are carried; memory-indirect (`call qword ptr
+/// [..]`) and register-indirect (`call rax`) operands become the `*Indirect` variants
+/// with no target, so a REACHABLE verdict never rests on a guessed edge.
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum Flow {
+    /// Falls through to the next instruction (the common case).
+    Fallthrough,
+    /// Direct `call`: schedules the target, then falls through.
+    Call(u64),
+    /// Indirect `call`: falls through (target unknown, not followed).
+    CallIndirect,
+    /// Unconditional direct `jmp`: control goes to the target only (no fall-through).
+    Jmp(u64),
+    /// Indirect `jmp` (function pointer / jump table): flow stops; target not followed.
+    JmpIndirect,
+    /// Conditional branch (je/jne/jz/jg/...): the target OR the next instruction.
+    Branch(u64),
+    /// `ret`/`iret`: flow stops.
+    Return,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+struct Insn {
+    addr: u64,
+    flow: Flow,
+}
+
+/// One function's `uf` disassembly as an ordered instruction list.
 #[derive(Debug, Default, PartialEq)]
 struct UfBlock {
     /// First instruction address (the function entry), if any lines parsed.
     entry: Option<u64>,
-    /// Address of every instruction in the function body.
-    instrs: Vec<u64>,
-    /// (call-site, resolved direct-call target).
-    calls: Vec<(u64, u64)>,
-    /// (site, unconditional `jmp` target).
-    jmps: Vec<(u64, u64)>,
-    /// (site, conditional-branch target: je/jne/jz/jg/...).
-    branches: Vec<(u64, u64)>,
+    /// Every instruction, in listing order, with its control-flow classification.
+    insns: Vec<Insn>,
+}
+
+/// Classifies one `uf` instruction line into a [`Flow`]. A memory-operand (`[..]`)
+/// line has no directly-resolvable target; otherwise the target is the parenthesized
+/// address WinDbg prints ([`branch_target`]).
+fn classify_flow(line: &str, mnem: &str) -> Flow {
+    let target = if line.contains('[') {
+        None
+    } else {
+        branch_target(line)
+    };
+    if mnem.starts_with("ret") || mnem.starts_with("iret") {
+        Flow::Return
+    } else if mnem == "jmp" {
+        target.map_or(Flow::JmpIndirect, Flow::Jmp)
+    } else if mnem.starts_with("call") {
+        target.map_or(Flow::CallIndirect, Flow::Call)
+    } else if mnem.starts_with('j') {
+        // A conditional branch; a jcc without a resolvable rel target just falls through.
+        target.map_or(Flow::Fallthrough, Flow::Branch)
+    } else {
+        Flow::Fallthrough
+    }
 }
 
 /// Parses `uf <fn>` output. Each instruction line is `<addr> <bytes> <mnem> <ops>`;
 /// label lines ("module!Foo:"), blanks, and jump-table data lines have no leading
-/// address token and are skipped. Only *direct*, resolvable branch/call targets are
-/// recorded — memory-indirect operands (`call qword ptr [..]`) and register-indirect
-/// (`call rax`) are skipped so a REACHABLE verdict stays sound.
+/// address token and are skipped.
 fn parse_uf(text: &str) -> UfBlock {
     let mut b = UfBlock::default();
     for line in text.lines() {
@@ -185,27 +228,79 @@ fn parse_uf(text: &str) -> UfBlock {
         if b.entry.is_none() {
             b.entry = Some(addr);
         }
-        b.instrs.push(addr);
-        let Some(mnem) = toks.next() else {
-            continue; // address with no mnemonic — treat as a bare instr line
+        let flow = match toks.next() {
+            Some(mnem) => classify_flow(line, mnem),
+            None => Flow::Fallthrough, // address with no mnemonic — treat as a bare line
         };
-        // Memory-indirect operands are not directly resolvable; skip them (register-
-        // indirect operands have no parenthesized target and are dropped below).
-        if line.contains('[') {
-            continue;
-        }
-        let Some(t) = branch_target(line) else {
-            continue;
-        };
-        if mnem.starts_with("call") {
-            b.calls.push((addr, t));
-        } else if mnem == "jmp" {
-            b.jmps.push((addr, t));
-        } else if mnem.starts_with('j') {
-            b.branches.push((addr, t));
-        }
+        b.insns.push(Insn { addr, flow });
     }
     b
+}
+
+/// Instructions reachable from `start` by walking *inside* one function — following
+/// fall-through, direct conditional branches, and direct `jmp`s that stay in the
+/// function — and stopping at `ret` or an unfollowed indirect/jump-table `jmp`. This
+/// keeps a mid-function start (a handler scoped past a switch) from spuriously
+/// treating sibling switch cases as reachable.
+struct FnWalk {
+    /// Instruction addresses reachable from `start` within the function.
+    reachable: HashSet<u64>,
+    /// Edges leaving the function, gathered only from reachable instructions:
+    /// (site, target, "call"/"jmp").
+    external: Vec<(u64, u64, &'static str)>,
+}
+
+/// Returns `None` if `start` is not an instruction boundary in `block` (the caller
+/// then falls back to the function entry).
+fn walk_function(block: &UfBlock, start: u64) -> Option<FnWalk> {
+    let idx: HashMap<u64, usize> = block
+        .insns
+        .iter()
+        .enumerate()
+        .map(|(i, x)| (x.addr, i))
+        .collect();
+    let start_i = *idx.get(&start)?;
+    let mut reachable: HashSet<u64> = HashSet::new();
+    let mut external: Vec<(u64, u64, &'static str)> = Vec::new();
+    let mut stack = vec![start_i];
+    while let Some(i) = stack.pop() {
+        let insn = block.insns[i];
+        if !reachable.insert(insn.addr) {
+            continue;
+        }
+        let next = (i + 1 < block.insns.len()).then_some(i + 1);
+        match insn.flow {
+            Flow::Return | Flow::JmpIndirect => {}
+            Flow::Jmp(t) => match idx.get(&t) {
+                Some(&j) => stack.push(j),
+                None => external.push((insn.addr, t, "jmp")),
+            },
+            Flow::Branch(t) => {
+                match idx.get(&t) {
+                    Some(&j) => stack.push(j),
+                    None => external.push((insn.addr, t, "jmp")),
+                }
+                if let Some(n) = next {
+                    stack.push(n);
+                }
+            }
+            Flow::Call(t) => {
+                external.push((insn.addr, t, "call"));
+                if let Some(n) = next {
+                    stack.push(n);
+                }
+            }
+            Flow::CallIndirect | Flow::Fallthrough => {
+                if let Some(n) = next {
+                    stack.push(n);
+                }
+            }
+        }
+    }
+    Some(FnWalk {
+        reachable,
+        external,
+    })
 }
 
 /// The first address token in `lm m <module>` output is the module's live start
@@ -236,9 +331,10 @@ struct Report {
 }
 
 /// Walks the call/branch graph from `from`, running `uf(arg)` for each discovered
-/// function, until `target` is found among some function's instructions, the graph
-/// is exhausted, or a bound is hit. `uf` returns the raw `uf <arg>` text or `None`
-/// (bad address / forwarded export / disassembly failure) to prune that branch.
+/// function and an intra-function control-flow walk ([`walk_function`]) within each,
+/// until `target` is found among the reachable instructions, the graph is exhausted,
+/// or a bound is hit. `uf` returns the raw `uf <arg>` text or `None` (bad address /
+/// forwarded export / disassembly failure) to prune that branch.
 fn reachability(
     from: &str,
     target: u64,
@@ -246,7 +342,10 @@ fn reachability(
     max_depth: usize,
     mut uf: impl FnMut(&str) -> Option<String>,
 ) -> Report {
-    let mut visited: HashSet<u64> = HashSet::new(); // function entries already uf'd
+    // If `from` is a bare address it may point *inside* a function (a handler scoped
+    // past a switch); start the intra-function walk there rather than at the entry.
+    let seed_start = parse_u64(from).ok();
+    let mut visited: HashSet<u64> = HashSet::new(); // walk start addresses already done
     let mut enqueued: HashSet<u64> = HashSet::new(); // target tokens scheduled
     // child token -> (caller token (None = seed), call site, kind).
     let mut parent: HashMap<u64, (Option<u64>, u64, &'static str)> = HashMap::new();
@@ -278,8 +377,19 @@ fn reachability(
         let Some(entry) = block.entry else {
             continue;
         };
-        if !visited.insert(entry) {
-            continue; // this function was already explored (dedupe cycles)
+        // Enter discovered functions at their call/jmp target (`token`); enter the
+        // seed at its resolved address, or the entry if `from` was a symbol. Fall back
+        // to the entry if the requested address isn't an instruction boundary.
+        let desired = token.or(seed_start).unwrap_or(entry);
+        let (start_used, walk) = match walk_function(&block, desired) {
+            Some(w) => (desired, w),
+            None => (
+                entry,
+                walk_function(&block, entry).expect("entry is always an instruction"),
+            ),
+        };
+        if !visited.insert(start_used) {
+            continue; // this (function, start) was already explored (dedupe cycles)
         }
         if token.is_none() {
             rpt.from_entry = Some(entry);
@@ -287,32 +397,20 @@ fn reachability(
         rpt.funcs_explored += 1;
         rpt.max_depth_seen = rpt.max_depth_seen.max(depth);
 
-        if block.instrs.iter().any(|&i| i == target) {
+        if walk.reachable.contains(&target) {
             rpt.verdict_reachable = true;
             rpt.containing_fn = Some(entry);
             rpt.path = reconstruct(&parent, token);
             return rpt;
         }
 
-        let in_func: HashSet<u64> = block.instrs.iter().copied().collect();
-        let mut schedule =
-            |site: u64,
-             t: u64,
-             kind: &'static str,
-             q: &mut VecDeque<(String, Option<u64>, usize)>| {
-                if enqueued.insert(t) {
-                    parent.insert(t, (token, site, kind));
-                    q.push_back((format!("0x{t:x}"), Some(t), depth + 1));
-                }
-            };
-        for &(site, t) in &block.calls {
-            schedule(site, t, "call", &mut queue);
-        }
-        // Follow only jmp/branch targets that LEAVE this function (tail calls,
-        // cross-function jumps). Intra-function branches are already inside this `uf`.
-        for &(site, t) in block.jmps.iter().chain(block.branches.iter()) {
-            if !in_func.contains(&t) {
-                schedule(site, t, "jmp", &mut queue);
+        // Schedule edges that leave this function, gathered only from instructions
+        // actually reachable from the start (so a mid-function start can't pull in
+        // calls from unrelated switch cases).
+        for (site, t, kind) in walk.external {
+            if enqueued.insert(t) {
+                parent.insert(t, (token, site, kind));
+                queue.push_back((format!("0x{t:x}"), Some(t), depth + 1));
             }
         }
     }
@@ -1083,7 +1181,12 @@ impl WindbgServer {
                 // Resolve the target VA: an absolute address, or module+RVA rebased
                 // against the module's live base from `lm m <module>`.
                 let target = match (&args.address, &args.module, &args.rva) {
-                    (Some(a), _, _) => parse_u64(a)?,
+                    // Reject conflicting target forms rather than silently ignoring one —
+                    // analysing the wrong target would give a misleading verdict.
+                    (Some(_), Some(_), _) | (Some(_), _, Some(_)) => {
+                        return Err("provide `address` OR `module`+`rva`, not both".to_string());
+                    }
+                    (Some(a), None, None) => parse_u64(a)?,
                     (None, Some(m), Some(r)) => {
                         let rva = parse_u64(r)?;
                         let lm = e.execute_command(&format!("lm m {m}")).map_err(es)?;
@@ -1275,9 +1378,10 @@ mod tests {
     }
 
     #[test]
-    fn parse_uf_classifies_targets_and_skips_indirect() {
-        // A function with a direct call, a conditional branch, an unconditional jmp,
-        // and a memory-indirect call (which must NOT be recorded as a direct target).
+    fn parse_uf_classifies_flow_and_skips_indirect() {
+        // A function with a direct call, a conditional branch, a memory-indirect call
+        // (which must classify as CallIndirect, not a resolved target), an unconditional
+        // jmp, and a ret.
         let text = "\
 mydriver!Dispatch:
 fffff803`3e254750 4c8bdc          mov     r11,rsp
@@ -1290,12 +1394,20 @@ fffff803`3e254770 c3              ret
 ";
         let b = parse_uf(text);
         assert_eq!(b.entry, Some(0xfffff803_3e254750));
-        assert_eq!(b.instrs.len(), 7); // 7 instruction lines; the label line is not one
-        assert_eq!(b.calls, vec![(0xfffff803_3e254758, 0xfffff803_3e2547f0)]);
-        assert_eq!(b.branches, vec![(0xfffff803_3e25475f, 0xfffff803_3e2547a6)]);
-        assert_eq!(b.jmps, vec![(0xfffff803_3e25476b, 0xfffff803_3e254830)]);
-        // The `call qword ptr [..]` line contributed an instruction but no direct call.
-        assert!(!b.calls.iter().any(|&(_, t)| t == 0xfffff803_3e260000));
+        assert_eq!(b.insns.len(), 7); // 7 instruction lines; the label line is not one
+        let flows: Vec<Flow> = b.insns.iter().map(|i| i.flow).collect();
+        assert_eq!(
+            flows,
+            vec![
+                Flow::Fallthrough,                 // mov
+                Flow::Call(0xfffff803_3e2547f0),   // direct call
+                Flow::Fallthrough,                 // test
+                Flow::Branch(0xfffff803_3e2547a6), // jne
+                Flow::CallIndirect,                // call qword ptr [..]
+                Flow::Jmp(0xfffff803_3e254830),    // jmp
+                Flow::Return,                      // ret
+            ]
+        );
     }
 
     #[test]
@@ -1463,5 +1575,42 @@ fffff803`3e250000 fffff803`3e270000   mydriver   (pdb symbols)
         assert!(!r.verdict_reachable);
         assert!(r.bound_hit);
         assert_eq!(r.funcs_explored, 1);
+    }
+
+    #[test]
+    fn reachability_scopes_from_mid_function_start() {
+        // A single dispatch function: the entry does an indirect jump-table `jmp`
+        // (which we don't follow), then two independent switch-case blocks. `uf` of
+        // any address returns the whole function, so a mid-function `from` must NOT
+        // treat the *other* case as reachable.
+        let dispatch = format!(
+            "Dispatch:\n\
+             {} 90 nop\n\
+             {} ff2500000000 jmp qword ptr [Dispatch!tbl ({})]\n\
+             {} 90 nop\n\
+             {} c3 ret\n\
+             {} 90 nop\n\
+             {} c3 ret\n",
+            fmt_addr(0x1000), // entry
+            fmt_addr(0x1004), // indirect jump-table switch
+            fmt_addr(0x9000), // (table pointer address, not a code target)
+            fmt_addr(0x1008), // case 1 block
+            fmt_addr(0x100c), // case 1 body (target A)
+            fmt_addr(0x1010), // case 2 block
+            fmt_addr(0x1014), // case 2 body (target B)
+        );
+        // `uf` of any address in the function returns the whole function. `&mut uf`
+        // implements FnMut, so the same disassembler can drive several walks.
+        let mut uf = |a: &str| match a {
+            "0x1008" | "0x1000" => Some(dispatch.clone()),
+            _ => None,
+        };
+
+        // Starting inside case 1, case 1's own body IS reachable.
+        assert!(reachability("0x1008", 0x100c, 256, 32, &mut uf).verdict_reachable);
+        // ...but case 2's body is NOT reachable from case 1 (no intra-function path).
+        assert!(!reachability("0x1008", 0x1014, 256, 32, &mut uf).verdict_reachable);
+        // From the entry, the switch cases are unreachable — the jump table isn't followed.
+        assert!(!reachability("0x1000", 0x1008, 256, 32, &mut uf).verdict_reachable);
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -5,6 +5,8 @@
 //! hatch, returning full text); session-management tools call the typed
 //! `win-kexp` methods and then wait for the target to stop.
 
+use std::collections::{HashMap, HashSet, VecDeque};
+
 use rmcp::ErrorData;
 use rmcp::handler::server::wrapper::Parameters;
 use rmcp::model::{CallToolResult, Content};
@@ -113,6 +115,286 @@ fn decode_ioctl_text(c: u32) -> String {
              on any handle, even one opened with minimal access.\n",
         );
     }
+    out
+}
+
+// ---- IOCTL dispatch reachability (static call-graph walk) ----------------
+//
+// Answers "is the code block at <target> reachable from the IOCTL dispatch
+// routine?" with a bounded breadth-first walk over the call graph, built from
+// repeated `uf` (unassemble-function) disassembly parsed as text. The whole
+// algorithm is engine-free — `reachability` takes a disassembler closure — so it
+// unit-tests without a live debugger (like `decode_ioctl_text` above).
+
+/// Parses a WinDbg address token into a `u64`. Accepts the `hi`lo` backtick form
+/// ("fffff803`3e254750"), a plain hex run ("00401000"), and tokens wrapped or
+/// trailed by parens/commas ("(fffff803`3e2547f0)"). Requires >= 8 hex digits so
+/// it never mistakes a mnemonic, a short immediate, or a "module!Symbol:" label
+/// for an address.
+fn parse_windbg_addr(tok: &str) -> Option<u64> {
+    let cleaned: String = tok
+        .trim_matches(|c| c == '(' || c == ')' || c == ',')
+        .chars()
+        .filter(|&c| c != '`')
+        .collect();
+    if cleaned.len() < 8 || !cleaned.chars().all(|c| c.is_ascii_hexdigit()) {
+        return None;
+    }
+    u64::from_str_radix(&cleaned, 16).ok()
+}
+
+/// The resolved target of a direct branch/call is the last parenthesized address
+/// WinDbg prints on the line ("... (fffff803`3e2547f0)"). Register/memory-indirect
+/// operands print no such address (or the *pointer's* address, which callers
+/// exclude via the `[` guard in [`parse_uf`]) and are not followed.
+fn branch_target(line: &str) -> Option<u64> {
+    let open = line.rfind('(')?;
+    let rest = &line[open..];
+    let close = rest.find(')')?;
+    parse_windbg_addr(&rest[..=close])
+}
+
+/// One function's `uf` disassembly, reduced to what the call-graph walk needs.
+#[derive(Debug, Default, PartialEq)]
+struct UfBlock {
+    /// First instruction address (the function entry), if any lines parsed.
+    entry: Option<u64>,
+    /// Address of every instruction in the function body.
+    instrs: Vec<u64>,
+    /// (call-site, resolved direct-call target).
+    calls: Vec<(u64, u64)>,
+    /// (site, unconditional `jmp` target).
+    jmps: Vec<(u64, u64)>,
+    /// (site, conditional-branch target: je/jne/jz/jg/...).
+    branches: Vec<(u64, u64)>,
+}
+
+/// Parses `uf <fn>` output. Each instruction line is `<addr> <bytes> <mnem> <ops>`;
+/// label lines ("module!Foo:"), blanks, and jump-table data lines have no leading
+/// address token and are skipped. Only *direct*, resolvable branch/call targets are
+/// recorded — memory-indirect operands (`call qword ptr [..]`) and register-indirect
+/// (`call rax`) are skipped so a REACHABLE verdict stays sound.
+fn parse_uf(text: &str) -> UfBlock {
+    let mut b = UfBlock::default();
+    for line in text.lines() {
+        let mut toks = line.split_whitespace();
+        let Some(addr) = toks.next().and_then(parse_windbg_addr) else {
+            continue;
+        };
+        let _bytes = toks.next(); // raw opcode-bytes column
+        if b.entry.is_none() {
+            b.entry = Some(addr);
+        }
+        b.instrs.push(addr);
+        let Some(mnem) = toks.next() else {
+            continue; // address with no mnemonic — treat as a bare instr line
+        };
+        // Memory-indirect operands are not directly resolvable; skip them (register-
+        // indirect operands have no parenthesized target and are dropped below).
+        if line.contains('[') {
+            continue;
+        }
+        let Some(t) = branch_target(line) else {
+            continue;
+        };
+        if mnem.starts_with("call") {
+            b.calls.push((addr, t));
+        } else if mnem == "jmp" {
+            b.jmps.push((addr, t));
+        } else if mnem.starts_with('j') {
+            b.branches.push((addr, t));
+        }
+    }
+    b
+}
+
+/// The first address token in `lm m <module>` output is the module's live start
+/// (its base). Header lines ("Browse full module list", the "start end module"
+/// legend) have no leading address and are skipped by the >= 8 hex-digit rule.
+fn parse_lm_base(text: &str) -> Option<u64> {
+    text.lines()
+        .find_map(|l| l.split_whitespace().next().and_then(parse_windbg_addr))
+}
+
+/// Outcome of a reachability walk. `verdict_reachable` is sound (a concrete static
+/// path exists); a false verdict is best-effort within the explored bounds.
+struct Report {
+    verdict_reachable: bool,
+    /// Resolved entry of the `from` function (None if `from` didn't disassemble).
+    from_entry: Option<u64>,
+    target: u64,
+    /// Entry of the function containing `target`, when reachable.
+    containing_fn: Option<u64>,
+    /// Call path seed -> ... -> containing function: (site, "call"/"jmp", callee).
+    path: Vec<(u64, &'static str, u64)>,
+    funcs_explored: usize,
+    max_depth_seen: usize,
+    /// True if a function/depth bound was hit (so the caller can raise it and retry).
+    bound_hit: bool,
+    max_functions: usize,
+    max_depth: usize,
+}
+
+/// Walks the call/branch graph from `from`, running `uf(arg)` for each discovered
+/// function, until `target` is found among some function's instructions, the graph
+/// is exhausted, or a bound is hit. `uf` returns the raw `uf <arg>` text or `None`
+/// (bad address / forwarded export / disassembly failure) to prune that branch.
+fn reachability(
+    from: &str,
+    target: u64,
+    max_functions: usize,
+    max_depth: usize,
+    mut uf: impl FnMut(&str) -> Option<String>,
+) -> Report {
+    let mut visited: HashSet<u64> = HashSet::new(); // function entries already uf'd
+    let mut enqueued: HashSet<u64> = HashSet::new(); // target tokens scheduled
+    // child token -> (caller token (None = seed), call site, kind).
+    let mut parent: HashMap<u64, (Option<u64>, u64, &'static str)> = HashMap::new();
+    let mut queue: VecDeque<(String, Option<u64>, usize)> = VecDeque::new();
+    queue.push_back((from.to_string(), None, 0));
+
+    let mut rpt = Report {
+        verdict_reachable: false,
+        from_entry: None,
+        target,
+        containing_fn: None,
+        path: Vec::new(),
+        funcs_explored: 0,
+        max_depth_seen: 0,
+        bound_hit: false,
+        max_functions,
+        max_depth,
+    };
+
+    while let Some((arg, token, depth)) = queue.pop_front() {
+        if rpt.funcs_explored >= max_functions || depth > max_depth {
+            rpt.bound_hit = true;
+            continue;
+        }
+        let Some(text) = uf(&arg) else {
+            continue; // disassembly failed — prune this branch
+        };
+        let block = parse_uf(&text);
+        let Some(entry) = block.entry else {
+            continue;
+        };
+        if !visited.insert(entry) {
+            continue; // this function was already explored (dedupe cycles)
+        }
+        if token.is_none() {
+            rpt.from_entry = Some(entry);
+        }
+        rpt.funcs_explored += 1;
+        rpt.max_depth_seen = rpt.max_depth_seen.max(depth);
+
+        if block.instrs.iter().any(|&i| i == target) {
+            rpt.verdict_reachable = true;
+            rpt.containing_fn = Some(entry);
+            rpt.path = reconstruct(&parent, token);
+            return rpt;
+        }
+
+        let in_func: HashSet<u64> = block.instrs.iter().copied().collect();
+        let mut schedule =
+            |site: u64,
+             t: u64,
+             kind: &'static str,
+             q: &mut VecDeque<(String, Option<u64>, usize)>| {
+                if enqueued.insert(t) {
+                    parent.insert(t, (token, site, kind));
+                    q.push_back((format!("0x{t:x}"), Some(t), depth + 1));
+                }
+            };
+        for &(site, t) in &block.calls {
+            schedule(site, t, "call", &mut queue);
+        }
+        // Follow only jmp/branch targets that LEAVE this function (tail calls,
+        // cross-function jumps). Intra-function branches are already inside this `uf`.
+        for &(site, t) in block.jmps.iter().chain(block.branches.iter()) {
+            if !in_func.contains(&t) {
+                schedule(site, t, "jmp", &mut queue);
+            }
+        }
+    }
+    rpt
+}
+
+/// Rebuilds the call path from the seed to the function reached via `token`, by
+/// walking the `parent` chain backward and reversing it.
+fn reconstruct(
+    parent: &HashMap<u64, (Option<u64>, u64, &'static str)>,
+    token: Option<u64>,
+) -> Vec<(u64, &'static str, u64)> {
+    let mut hops = Vec::new();
+    let mut cur = token;
+    while let Some(t) = cur {
+        let Some(&(caller, site, kind)) = parent.get(&t) else {
+            break;
+        };
+        hops.push((site, kind, t));
+        cur = caller;
+    }
+    hops.reverse();
+    hops
+}
+
+/// Formats a WinDbg-style `hi`lo` address.
+fn fmt_addr(a: u64) -> String {
+    format!("{:08x}`{:08x}", a >> 32, a & 0xffff_ffff)
+}
+
+/// Renders a [`Report`] as the tool's text output.
+fn format_report(r: &Report) -> String {
+    let mut out = String::new();
+    out.push_str("IOCTL dispatch reachability\n");
+    match r.from_entry {
+        Some(e) => out.push_str(&format!("  from   : entry {}\n", fmt_addr(e))),
+        None => out.push_str("  from   : <unresolved>\n"),
+    }
+    out.push_str(&format!("  target : {}\n", fmt_addr(r.target)));
+    if r.verdict_reachable {
+        out.push_str("VERDICT: REACHABLE\n");
+        if let Some(f) = r.containing_fn {
+            out.push_str(&format!("  Containing function entry: {}\n", fmt_addr(f)));
+        }
+        if r.path.is_empty() {
+            out.push_str("  Call path: target is inside the start function (0 hops)\n");
+        } else {
+            out.push_str(&format!("  Call path ({} hops):\n", r.path.len()));
+            for (site, kind, callee) in &r.path {
+                out.push_str(&format!(
+                    "    {}  {:<4} -> {}\n",
+                    fmt_addr(*site),
+                    kind,
+                    fmt_addr(*callee)
+                ));
+            }
+        }
+    } else {
+        out.push_str("VERDICT: NOT REACHABLE (within bounds)\n");
+        out.push_str(&format!(
+            "  Bound hit: {}\n",
+            if r.bound_hit {
+                "yes — raise max_functions/max_depth and retry"
+            } else {
+                "no — the reachable call graph was fully explored"
+            }
+        ));
+    }
+    out.push_str(&format!(
+        "  Functions explored: {} (bound {})   Max depth reached: {} (bound {})\n",
+        r.funcs_explored, r.max_functions, r.max_depth_seen, r.max_depth
+    ));
+    out.push_str(
+        "  Caveats: indirect/computed calls (call [ptr], call reg) and unresolved jump tables\n",
+    );
+    out.push_str(
+        "           are NOT followed. REACHABLE is sound; NOT REACHABLE within bounds does not\n",
+    );
+    out.push_str(
+        "           prove unreachability — raise max_functions/max_depth, or pass a specific\n",
+    );
+    out.push_str("           handler VA as `from` to scope past a jump-table switch dispatch.\n");
     out
 }
 
@@ -240,6 +522,32 @@ pub struct IoctlTraceArgs {
     /// Virtual address of the IRP_MJ_DEVICE_CONTROL dispatch routine, rebased to the
     /// live load base. Recover it via `driver_object` (MajorFunction[0x0e]).
     pub dispatch: String,
+}
+
+#[derive(Deserialize, JsonSchema)]
+pub struct ReachabilityArgs {
+    /// Start of the search: the IRP_MJ_DEVICE_CONTROL dispatch routine — a symbol,
+    /// address, or expression `uf` accepts (e.g. "mydriver!DispatchDeviceControl" or
+    /// "fffff8033e254750"). Recover it via `driver_object` (MajorFunction[0x0e]). Pass
+    /// a specific handler VA instead to scope the walk past a jump-table switch.
+    pub from: String,
+    /// Target code block as an absolute virtual address (decimal or 0x-hex). Provide
+    /// this OR `module`+`rva`, not both.
+    #[serde(default)]
+    pub address: Option<String>,
+    /// Module name for a module+RVA target, e.g. "mydriver". Its live base is read from
+    /// `lm m <module>` and added to `rva`. Required (with `rva`) when `address` is omitted.
+    #[serde(default)]
+    pub module: Option<String>,
+    /// Relative virtual address (decimal or 0x-hex) added to `module`'s live base.
+    #[serde(default)]
+    pub rva: Option<String>,
+    /// Max distinct functions to disassemble before giving up (default 256). Bounds runtime.
+    #[serde(default)]
+    pub max_functions: Option<usize>,
+    /// Max call-graph depth to explore from `from` (default 32).
+    #[serde(default)]
+    pub max_depth: Option<usize>,
 }
 
 // ---- Tools ---------------------------------------------------------------
@@ -756,6 +1064,65 @@ impl WindbgServer {
             .await?;
         text_result(out)
     }
+
+    /// Static, best-effort control-flow reachability: is the code block at `address`
+    /// (or `module`+`rva`) reachable from the IOCTL dispatch routine `from`? Runs a
+    /// bounded breadth-first walk over the call graph via repeated `uf` disassembly,
+    /// following direct calls and cross-function tail jumps. "REACHABLE" is sound (a
+    /// concrete static path exists, and the call path is reported); "NOT REACHABLE"
+    /// means only that the block was not found within the bounds — indirect calls
+    /// through function pointers and unresolved compiler jump tables are NOT followed.
+    #[rmcp::tool]
+    async fn reachable_from_dispatch(
+        &self,
+        Parameters(args): Parameters<ReachabilityArgs>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let out = self
+            .engine
+            .run(move |e| {
+                // Resolve the target VA: an absolute address, or module+RVA rebased
+                // against the module's live base from `lm m <module>`.
+                let target = match (&args.address, &args.module, &args.rva) {
+                    (Some(a), _, _) => parse_u64(a)?,
+                    (None, Some(m), Some(r)) => {
+                        let rva = parse_u64(r)?;
+                        let lm = e.execute_command(&format!("lm m {m}")).map_err(es)?;
+                        let base = parse_lm_base(&lm).ok_or_else(|| {
+                            format!("module `{m}` not found (`lm m {m}` returned):\n{lm}")
+                        })?;
+                        base.checked_add(rva)
+                            .ok_or_else(|| "module base + rva overflowed u64".to_string())?
+                    }
+                    _ => {
+                        return Err("provide `address`, or both `module` and `rva`".to_string());
+                    }
+                };
+
+                let max_functions = args.max_functions.unwrap_or(256);
+                let max_depth = args.max_depth.unwrap_or(32);
+
+                let rpt = reachability(&args.from, target, max_functions, max_depth, |arg| {
+                    // A real `uf` lists backtick addresses or at least a "module!Func:"
+                    // label; error text ("Couldn't resolve...", "no code") lacks both
+                    // and prunes the branch. parse_uf then discards any non-disassembly.
+                    match e.execute_command(&format!("uf {arg}")) {
+                        Ok(t) if t.contains('`') || t.contains(':') => Some(t),
+                        _ => None,
+                    }
+                });
+
+                if rpt.from_entry.is_none() {
+                    return Err(format!(
+                        "could not disassemble `from` ({}): `uf` returned no function. \
+                         Check the symbol/address and that the module is loaded.",
+                        args.from
+                    ));
+                }
+                Ok(format_report(&rpt))
+            })
+            .await?;
+        text_result(out)
+    }
 }
 
 #[rmcp::tool_handler(
@@ -765,8 +1132,11 @@ Navigate a TTD trace in both directions: go/step_over/step_into forward, and rev
 or jump with goto_position. Analyze a trace with the data-model tools ttd_calls (calls to a function), ttd_memory (accesses \
 to an address range), and ttd_events (module/thread/exception events), or run any data-model query with dx. Record new traces \
 with record_trace (needs elevation). For driver IOCTL work: decode_ioctl (decode a control code), driver_object \
-and device_object (walk the driver/device tree and security), irp_stack (dump an IRP's IO_STACK_LOCATION), and \
-ioctl_trace (log every dispatched IOCTL). Use `execute` for any raw command not covered by a dedicated tool."
+and device_object (walk the driver/device tree and security), irp_stack (dump an IRP's IO_STACK_LOCATION), \
+ioctl_trace (log every dispatched IOCTL), and reachable_from_dispatch (statically test, via a bounded \
+uf-based call-graph walk, whether a code block — by address or module+RVA — is reachable from the IOCTL \
+dispatch routine; REACHABLE is sound, NOT REACHABLE is best-effort). Use `execute` for any raw command not \
+covered by a dedicated tool."
 )]
 impl rmcp::ServerHandler for WindbgServer {}
 
@@ -881,5 +1251,217 @@ mod tests {
         assert!(out.contains("[!] METHOD_NEITHER"), "got: {out}");
         // FILE_WRITE_DATA is an access gate, so the ANY_ACCESS warning must be absent.
         assert!(!out.contains("[!] FILE_ANY_ACCESS"), "got: {out}");
+    }
+
+    // ---- reachability: parsing --------------------------------------------
+
+    #[test]
+    fn parse_windbg_addr_forms() {
+        assert_eq!(
+            parse_windbg_addr("fffff803`3e254750"),
+            Some(0xfffff803_3e254750)
+        );
+        assert_eq!(
+            parse_windbg_addr("(fffff803`3e2547f0)"),
+            Some(0xfffff803_3e2547f0)
+        );
+        // Plain 32-bit (x86) hex, no backtick.
+        assert_eq!(parse_windbg_addr("00401000"), Some(0x0040_1000));
+        // Mnemonics, registers, labels, and short immediates are not addresses.
+        assert_eq!(parse_windbg_addr("call"), None);
+        assert_eq!(parse_windbg_addr("rax"), None);
+        assert_eq!(parse_windbg_addr("mydriver!Foo:"), None);
+        assert_eq!(parse_windbg_addr("28h"), None);
+    }
+
+    #[test]
+    fn parse_uf_classifies_targets_and_skips_indirect() {
+        // A function with a direct call, a conditional branch, an unconditional jmp,
+        // and a memory-indirect call (which must NOT be recorded as a direct target).
+        let text = "\
+mydriver!Dispatch:
+fffff803`3e254750 4c8bdc          mov     r11,rsp
+fffff803`3e254758 e893000000      call    mydriver!Helper (fffff803`3e2547f0)
+fffff803`3e25475d 85c0            test    eax,eax
+fffff803`3e25475f 0f8541000000    jne     mydriver!Dispatch+0x56 (fffff803`3e2547a6)
+fffff803`3e254765 ff15aabbccdd    call    qword ptr [mydriver!Ptr (fffff803`3e260000)]
+fffff803`3e25476b e9c0000000      jmp     mydriver!Tail (fffff803`3e254830)
+fffff803`3e254770 c3              ret
+";
+        let b = parse_uf(text);
+        assert_eq!(b.entry, Some(0xfffff803_3e254750));
+        assert_eq!(b.instrs.len(), 7); // 7 instruction lines; the label line is not one
+        assert_eq!(b.calls, vec![(0xfffff803_3e254758, 0xfffff803_3e2547f0)]);
+        assert_eq!(b.branches, vec![(0xfffff803_3e25475f, 0xfffff803_3e2547a6)]);
+        assert_eq!(b.jmps, vec![(0xfffff803_3e25476b, 0xfffff803_3e254830)]);
+        // The `call qword ptr [..]` line contributed an instruction but no direct call.
+        assert!(!b.calls.iter().any(|&(_, t)| t == 0xfffff803_3e260000));
+    }
+
+    #[test]
+    fn parse_lm_base_reads_module_start() {
+        let text = "\
+Browse full module list
+start             end                 module name
+fffff803`3e250000 fffff803`3e270000   mydriver   (pdb symbols)
+";
+        assert_eq!(parse_lm_base(text), Some(0xfffff803_3e250000));
+        assert_eq!(parse_lm_base("Unable to enumerate modules\n"), None);
+    }
+
+    // ---- reachability: graph walk -----------------------------------------
+
+    /// Builds a `uf` block whose entry is `entry`, with the given follow-on lines
+    /// appended (each already a full `uf` instruction line).
+    fn uf_fn(label: &str, entry: u64, body: &[&str]) -> String {
+        let mut s = format!("{label}:\n{} 90              nop\n", fmt_addr(entry));
+        for l in body {
+            s.push_str(l);
+            s.push('\n');
+        }
+        s
+    }
+
+    #[test]
+    fn reachability_direct_call_chain() {
+        let mut m: HashMap<String, String> = HashMap::new();
+        m.insert(
+            "start".to_string(),
+            uf_fn(
+                "A",
+                0x1000,
+                &[&format!(
+                    "{} e8xx call A!B ({})",
+                    fmt_addr(0x1004),
+                    fmt_addr(0x2000)
+                )],
+            ),
+        );
+        m.insert(
+            "0x2000".to_string(),
+            uf_fn("B", 0x2000, &[&format!("{} c3 ret", fmt_addr(0x2008))]),
+        );
+        let r = reachability("start", 0x2008, 256, 32, |a| m.get(a).cloned());
+        assert!(r.verdict_reachable);
+        assert_eq!(r.from_entry, Some(0x1000));
+        assert_eq!(r.containing_fn, Some(0x2000));
+        assert_eq!(r.path, vec![(0x1004, "call", 0x2000)]);
+    }
+
+    #[test]
+    fn reachability_follows_tail_jmp() {
+        let mut m: HashMap<String, String> = HashMap::new();
+        m.insert(
+            "start".to_string(),
+            uf_fn(
+                "A",
+                0x1000,
+                &[&format!(
+                    "{} e9xx jmp A!B ({})",
+                    fmt_addr(0x1004),
+                    fmt_addr(0x2000)
+                )],
+            ),
+        );
+        m.insert(
+            "0x2000".to_string(),
+            uf_fn("B", 0x2000, &[&format!("{} c3 ret", fmt_addr(0x2008))]),
+        );
+        let r = reachability("start", 0x2008, 256, 32, |a| m.get(a).cloned());
+        assert!(r.verdict_reachable);
+        assert_eq!(r.path, vec![(0x1004, "jmp", 0x2000)]);
+    }
+
+    #[test]
+    fn reachability_target_in_seed_is_zero_hops() {
+        let mut m: HashMap<String, String> = HashMap::new();
+        m.insert(
+            "start".to_string(),
+            uf_fn("A", 0x1000, &[&format!("{} c3 ret", fmt_addr(0x1004))]),
+        );
+        let r = reachability("start", 0x1004, 256, 32, |a| m.get(a).cloned());
+        assert!(r.verdict_reachable);
+        assert_eq!(r.containing_fn, Some(0x1000));
+        assert!(r.path.is_empty());
+    }
+
+    #[test]
+    fn reachability_indirect_only_is_not_reached() {
+        let mut m: HashMap<String, String> = HashMap::new();
+        m.insert(
+            "start".to_string(),
+            uf_fn(
+                "A",
+                0x1000,
+                &[&format!(
+                    "{} ff15aa call qword ptr [A!Ptr ({})]",
+                    fmt_addr(0x1004),
+                    fmt_addr(0x9000)
+                )],
+            ),
+        );
+        // The target sits behind the indirect call, which is never followed.
+        let r = reachability("start", 0x2008, 256, 32, |a| m.get(a).cloned());
+        assert!(!r.verdict_reachable);
+        assert!(!r.bound_hit); // graph exhausted, not a bound
+    }
+
+    #[test]
+    fn reachability_cycle_terminates() {
+        let mut m: HashMap<String, String> = HashMap::new();
+        m.insert(
+            "start".to_string(),
+            uf_fn(
+                "A",
+                0x1000,
+                &[&format!(
+                    "{} e8xx call A!B ({})",
+                    fmt_addr(0x1004),
+                    fmt_addr(0x2000)
+                )],
+            ),
+        );
+        m.insert(
+            "0x2000".to_string(),
+            uf_fn(
+                "B",
+                0x2000,
+                &[&format!(
+                    "{} e8xx call B!A ({})",
+                    fmt_addr(0x2004),
+                    fmt_addr(0x1000)
+                )],
+            ),
+        );
+        // Target is absent — the A<->B cycle must not loop forever.
+        let r = reachability("start", 0x7777, 256, 32, |a| m.get(a).cloned());
+        assert!(!r.verdict_reachable);
+        assert_eq!(r.funcs_explored, 2);
+    }
+
+    #[test]
+    fn reachability_respects_function_bound() {
+        let mut m: HashMap<String, String> = HashMap::new();
+        m.insert(
+            "start".to_string(),
+            uf_fn(
+                "A",
+                0x1000,
+                &[&format!(
+                    "{} e8xx call A!B ({})",
+                    fmt_addr(0x1004),
+                    fmt_addr(0x2000)
+                )],
+            ),
+        );
+        m.insert(
+            "0x2000".to_string(),
+            uf_fn("B", 0x2000, &[&format!("{} c3 ret", fmt_addr(0x2004))]),
+        );
+        // Bound to a single function: B (which contains the target) is never explored.
+        let r = reachability("start", 0x2004, 1, 32, |a| m.get(a).cloned());
+        assert!(!r.verdict_reachable);
+        assert!(r.bound_hit);
+        assert_eq!(r.funcs_explored, 1);
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -1218,19 +1218,19 @@ impl WindbgServer {
                 let max_depth = args.max_depth.unwrap_or(32);
 
                 // Resolve `from` to a numeric VA so a mid-function start (a handler
-                // scoped past a switch) is honored even in WinDbg's own forms: a plain
-                // number, a `hi`lo` backtick address, or a `module!sym+off` expression
-                // evaluated via `?`. If it can't be resolved the walk starts at the
-                // function entry.
-                let seed_start = parse_u64(&args.from)
+                // scoped past a switch) is honored. Evaluate via `?` first so the seed is
+                // read *exactly* as `uf` reads the same string — the MASM evaluator's
+                // default base is hex, so a digit-only WinDbg address like `00401234` is
+                // 0x00401234 (not decimal), and `module!Dispatch+0x123` resolves too. Fall
+                // back to pure parsing (backtick / bare-hex, then `0x`/decimal) only if `?`
+                // is unavailable; if nothing resolves, the walk starts at the entry.
+                let seed_start = e
+                    .execute_command(&format!("? {}", args.from))
                     .ok()
+                    .as_deref()
+                    .and_then(parse_eval)
                     .or_else(|| parse_windbg_addr(&args.from))
-                    .or_else(|| {
-                        e.execute_command(&format!("? {}", args.from))
-                            .ok()
-                            .as_deref()
-                            .and_then(parse_eval)
-                    });
+                    .or_else(|| parse_u64(&args.from).ok());
 
                 let rpt = reachability(
                     &args.from,

--- a/src/server.rs
+++ b/src/server.rs
@@ -174,6 +174,9 @@ enum Flow {
     Branch(u64),
     /// `ret`/`iret`: flow stops.
     Return,
+    /// A `noreturn` trap — `int 29h` (`__fastfail`/stack-cookie failure), `int 3`,
+    /// `ud2`, `hlt`: execution stops, so the walk must not fall through it.
+    Trap,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -209,6 +212,10 @@ fn classify_flow(line: &str, mnem: &str) -> Flow {
     } else if mnem.starts_with('j') {
         // A conditional branch; a jcc without a resolvable rel target just falls through.
         target.map_or(Flow::Fallthrough, Flow::Branch)
+    } else if mnem == "ud2" || mnem == "hlt" || mnem == "int" || mnem == "int3" || mnem == "int1" {
+        // `noreturn` traps: `int 29h`/`int 3` (WinDbg emits mnemonic `int` + operand),
+        // a single `int3` token, `ud2`, `hlt`. Execution stops here.
+        Flow::Trap
     } else {
         Flow::Fallthrough
     }
@@ -270,7 +277,7 @@ fn walk_function(block: &UfBlock, start: u64) -> Option<FnWalk> {
         }
         let next = (i + 1 < block.insns.len()).then_some(i + 1);
         match insn.flow {
-            Flow::Return | Flow::JmpIndirect => {}
+            Flow::Return | Flow::JmpIndirect | Flow::Trap => {}
             Flow::Jmp(t) => match idx.get(&t) {
                 Some(&j) => stack.push(j),
                 None => external.push((insn.addr, t, "jmp")),
@@ -1671,5 +1678,41 @@ fffff803`3e250000 fffff803`3e270000   mydriver   (pdb symbols)
         assert!(!reachability("0x1008", Some(0x1008), 0x1014, 256, 32, &mut uf).verdict_reachable);
         // From the entry, the switch cases are unreachable — the jump table isn't followed.
         assert!(!reachability("0x1000", Some(0x1000), 0x1008, 256, 32, &mut uf).verdict_reachable);
+    }
+
+    #[test]
+    fn parse_uf_classifies_traps() {
+        // WinDbg emits `int 29h` / `int 3` as mnemonic `int` + operand; plus `ud2`/`hlt`.
+        let text = "\
+mydriver!Guard:
+fffff803`3e254750 cd29            int     29h
+fffff803`3e254752 0f0b            ud2
+fffff803`3e254754 f4              hlt
+fffff803`3e254755 cc              int     3
+";
+        let flows: Vec<Flow> = parse_uf(text).insns.iter().map(|i| i.flow).collect();
+        assert_eq!(flows, vec![Flow::Trap, Flow::Trap, Flow::Trap, Flow::Trap]);
+    }
+
+    #[test]
+    fn reachability_stops_at_trap() {
+        // A function: entry, a call, then `int 29h` (fastfail, noreturn), then a block
+        // that is reachable ONLY by falling through the trap. It must not be reachable.
+        let func = format!(
+            "Guard:\n\
+             {} 90 nop\n\
+             {} cd29 int 29h\n\
+             {} 90 nop\n\
+             {} c3 ret\n",
+            fmt_addr(0x1000), // entry
+            fmt_addr(0x1004), // int 29h — execution stops here
+            fmt_addr(0x1006), // dead code, only reachable by falling through the trap
+            fmt_addr(0x1007),
+        );
+        let mut uf = |a: &str| (a == "0x1000").then(|| func.clone());
+        // The entry (before the trap) is reachable...
+        assert!(reachability("0x1000", Some(0x1000), 0x1000, 256, 32, &mut uf).verdict_reachable);
+        // ...but code after the trap is not (the walk stops at `int 29h`).
+        assert!(!reachability("0x1000", Some(0x1000), 0x1006, 256, 32, &mut uf).verdict_reachable);
     }
 }


### PR DESCRIPTION
## Summary

Adds a new `reachable_from_dispatch` MCP tool that answers a control-flow question the toolset couldn't before: **is the code block at a given address (or `module`+`rva`) reachable from a driver's IOCTL dispatch routine?**

The existing driver-IOCTL tools cover *access-control* reachability (can a user reach an IOCTL code — the openable → namespace → deliverable gate model). This adds the missing *control-flow* notion — "does this vulnerable block sit on a path from the `IRP_MJ_DEVICE_CONTROL` handler?" — which is a common question during driver bug-hunting.

## How it works

- Starting from `from` (the dispatch routine VA/symbol, recovered via `driver_object`'s `MajorFunction[0x0e]`), it runs a **bounded breadth-first walk over the call graph**, built from repeated `uf` (unassemble-function) disassembly parsed as text.
- It follows **direct calls** and **cross-function tail jumps**, deduping by function entry (cycles/recursion terminate) and bounded by `max_functions` (default 256) / `max_depth` (default 32).
- The target is given as an absolute `address`, or `module`+`rva` (rebased against the module's live base from `lm m <module>`). Matching is against *every* instruction address in each explored function, so a block jumped into mid-function is still found.
- Output reports the verdict, the containing function, and the discovered call path.

### Soundness

`REACHABLE` is sound — a concrete static path exists and is reported. `NOT REACHABLE` is best-effort *within bounds*: indirect calls through function pointers and unresolved compiler jump tables are **not** followed. If the dispatch uses a `switch(IoControlCode)` jump table (common), pass the specific handler VA as `from` to scope past it, or confirm dynamically with a breakpoint.

## Design

Following the repo's pattern (cf. `decode_ioctl_text`), the whole algorithm is **pure and engine-free**: `reachability(...)` takes a disassembler closure `FnMut(&str) -> Option<String>`, so the parser *and* the graph walk are unit-testable without a live debugger. The thin `#[rmcp::tool]` wrapper supplies a real closure over `execute_command("uf …")`.

## Changes

- `src/server.rs` — `parse_windbg_addr`, `branch_target`, `parse_uf`, `parse_lm_base`, `reachability`/`reconstruct`, `format_report`; `ReachabilityArgs`; the `reachable_from_dispatch` tool; extended `tool_handler` instructions; unit tests.
- `README.md` — Tools table entry + a limitations note on the static/soundness caveat.
- `CHANGELOG.md` — `[Unreleased]` entry.

## Testing

- Added `#[cfg(test)]` unit tests (pure, no debugger): `parse_windbg_addr` forms, `parse_uf` target classification (incl. skipping memory-indirect operands), `parse_lm_base`, and `reachability` cases — direct-call chain, tail-jmp, target-in-seed (0 hops), indirect-only → not reachable, cycle termination, and the function-count bound.
- `cargo fmt --all --check` passes locally. The crate's `win-kexp`/DbgEng dependency chain is Windows-only, so `cargo build`/`clippy`/`test` run in CI on `windows-latest` rather than in this Linux dev environment.
- End-to-end (manual, needs a live/kernel Windows target): `attach_kernel` → `driver_object` for the dispatch VA → `reachable_from_dispatch { from, module, rva }`, cross-checking the reported path against `uf`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018SdJufnTof3zA5qW82iz92

---
_Generated by [Claude Code](https://claude.ai/code/session_018SdJufnTof3zA5qW82iz92)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new **Driver IOCTL** reachability check tool to determine whether a target address can be reached from a dispatch routine.
  * You can now provide the target by absolute address or by **module + RVA**.
  * Results indicate whether the target is **reachable** or **not reachable**, and may include the path found.

* **Documentation**
  * Updated the README and changelog with usage notes, limitations, and guidance for validating results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->