### PR TITLE
Post-merge cleanup: repoint win-kexp to main; track deferred follow-ups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -814,7 +814,7 @@ dependencies = [
 [[package]]
 name = "win-kexp"
 version = "0.1.0"
-source = "git+https://github.com/glslang/win-kexp?branch=feature%2Frun-to-address#cbe48a4111ca286c354da8a54e0b07ab2e7b3d5e"
+source = "git+https://github.com/glslang/win-kexp?branch=main#2272e4ac674160a96f323df67426046bb2f171f6"
 dependencies = [
  "byte-strings",
  "goblin",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,9 +4,7 @@ version = "0.1.3"
 edition = "2024"
 
 [dependencies]
-# Temporarily tracks the run_to_address feature branch until it merges to win-kexp main;
-# move back to `branch = "main"` (and bump the pin) once both PRs land.
-win-kexp = { git = "https://github.com/glslang/win-kexp", branch = "feature/run-to-address" }
+win-kexp = { git = "https://github.com/glslang/win-kexp", branch = "main" }
 rmcp = { version = "1", features = ["server", "transport-io", "macros", "schemars"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "io-std", "sync", "time"] }
 serde = { version = "1", features = ["derive"] }

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -1,0 +1,62 @@
+# Follow-ups
+
+Deferred work from the reachability-confirmation effort (path recipe + `run_to_address`, merged
+2026-07-04). Each item notes its repo, why it was deferred, and where it picks up. See
+[`DECISIONS.md`](./DECISIONS.md) for the design rationale (D1–D5) these extend.
+
+Items are roughly ordered by how soon they're worth doing.
+
+## 1. [win-kexp] Managed breakpoint lifecycle for `run_to_address`
+
+`run_to_address` uses a one-shot `g <addr>` (WinDbg's temporary breakpoint), which DbgEng does **not**
+hand back a handle for. On a non-live timeout the target is now broken in (SetInterrupt + WaitForEvent),
+but the one-shot breakpoint at `address` can remain armed. Replace `g <addr>` with an explicitly
+managed `AddBreakpoint2` + `RemoveBreakpoint` lifecycle so the breakpoint is cleaned up deterministically
+in **all** exit paths (hit, stopped-elsewhere, timeout, error).
+
+- **Why deferred:** the interrupt + breakpoint-teardown semantics need a live KDNET/VM kernel target to
+  validate; landing it blind risks a worse regression (hang, or clearing the caller's breakpoints).
+- **Picks up from:** win-kexp PR #62 review thread on `src/dbgeng.rs` (`run_to_address`, the `Timeout`
+  branch). A stale one-shot at `address` is currently harmless to this API's own flow (a later
+  `run_to`/`go` arms its own), so it is low-severity until an explicit rewrite is validated on hardware.
+
+## 2. [win-kexp] Typed write primitives
+
+`write_virtual`, a typed register **write**, and `ba` (data) breakpoints. Today only the `execute` raw
+text path exists (`eb`/`ed`/`r reg=`).
+
+- **Why deferred:** primarily needed by the state-injection path (item 3); no consumer without it.
+- **Note:** win-kexp is the right home for these (DECISIONS.md D3 — typed `DebugEngine` methods, not the
+  text hatch), mirroring how `run_to_address`/`instruction_pointer` were added.
+
+## 3. [windbg-mcp + win-kexp] State-injection confirmation path (DECISIONS.md D4)
+
+Alternative to driving a real IOCTL client: break at the dispatch entry, craft an IRP +
+IO_STACK_LOCATION + SystemBuffer in memory, set `rcx`/`rdx`, and run to the target block.
+
+- **Why deferred:** a wrong/partial IRP mutates live kernel state and can bugcheck the target,
+  destroying the reproducible state the analysis depends on. Deprioritized behind the drive-a-client
+  path (`ioctl_harness.ps1` + `run_to_address`).
+- **Depends on:** item 2 (typed write primitives) and the item-1 breakpoint work; the same path-recipe
+  data the drive path uses. Prefer a snapshot-restorable VM when building it.
+
+## 4. [win-kexp] Typed `read_register`
+
+Generalize the private `instruction_pointer` helper (added for `run_to_address`) into a public typed
+register read, per DECISIONS.md D5 step 1. Only the instruction pointer is implemented today.
+
+## 5. [windbg-mcp] Path-recipe decode limits (heuristic boundary)
+
+The operand → IO_STACK_LOCATION field mapping (`+0x18`/`+0x10`/`+0x08`) is heuristic: it holds only
+when the compare's memory base is the current stack-location pointer, and complex predicates
+(multi-instruction conditions, computed offsets, table lookups) aren't decoded. This is the documented
+boundary where item 6 would take over.
+
+## 6. [windbg-mcp] Concolic/symbolic buffer synthesis (DECISIONS.md L3 — scoped out)
+
+Auto-emit a concrete `(code, buffer, lengths)` by SMT-solving the on-path branch predicates, rather
+than the human/LLM-readable recipe emitted today.
+
+- **Status:** scoped **out** of the current effort. If ever needed, offload to angr/Triton over a
+  debugger memory snapshot rather than building an in-house solver — kernel state modeling, loops,
+  hashing, and stateful protocols make it brittle and a separate project.

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -16,9 +16,10 @@ in **all** exit paths (hit, stopped-elsewhere, timeout, error).
 
 - **Why deferred:** the interrupt + breakpoint-teardown semantics need a live KDNET/VM kernel target to
   validate; landing it blind risks a worse regression (hang, or clearing the caller's breakpoints).
-- **Picks up from:** win-kexp PR #62 review thread on `src/dbgeng.rs` (`run_to_address`, the `Timeout`
-  branch). A stale one-shot at `address` is currently harmless to this API's own flow (a later
-  `run_to`/`go` arms its own), so it is low-severity until an explicit rewrite is validated on hardware.
+- **Tracked as:** [glslang/win-kexp#63](https://github.com/glslang/win-kexp/issues/63) (picks up from
+  win-kexp PR #62's `src/dbgeng.rs` review thread on the `Timeout` branch). A stale one-shot at
+  `address` is currently harmless to this API's own flow (a later `run_to`/`go` arms its own), so it is
+  low-severity until an explicit rewrite is validated on hardware.
 
 ## 2. [win-kexp] Typed write primitives
 


### PR DESCRIPTION
Follows the merge of the path-recipe / `run_to_address` PRs (windbg-mcp #30, win-kexp #62).

## Fix: win-kexp pin references a deleted branch
`main`'s `Cargo.toml` still pointed at `branch = "feature/run-to-address"`, which was deleted when win-kexp #62 merged. A fresh `cargo build` / CI on `main` would fail to resolve the dependency. Repointed to `branch = "main"` (`2272e4a`, which contains the merged `run_to_address`) and refreshed `Cargo.lock`. Verified `cargo build` + `cargo test` (34 pass).

## Track deferred follow-ups
Adds `FOLLOWUPS.md` recording the work deferred from this effort, with repo tags, why-deferred, and where each picks up:
1. **[win-kexp]** Managed breakpoint lifecycle for `run_to_address` (replace `g <addr>` with `AddBreakpoint2`/`RemoveBreakpoint` — needs a live KDNET/VM target to validate; from #62's `:562` thread).
2. **[win-kexp]** Typed write primitives (`write_virtual`, register write, `ba`).
3. **[windbg-mcp + win-kexp]** State-injection confirmation path (DECISIONS.md D4).
4. **[win-kexp]** Typed `read_register` (generalize the `instruction_pointer` helper).
5. **[windbg-mcp]** Path-recipe decode heuristic limits.
6. **[windbg-mcp]** Concolic/symbolic buffer synthesis (L3 — scoped out).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new follow-up list capturing deferred work and next steps, with references to the related design decisions.

* **Chores**
  * Updated the `win-kexp` dependency to follow the latest main branch.
  * Removed an outdated note about the temporary branch pin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->