### PR TITLE
Add set_symbol_path tool + live driver-IOCTL workflow docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,103 @@
+# CLAUDE.md
+
+Guidance for Claude Code working in this repo. See `README.md` for architecture and the full tool
+surface; this file covers the non-obvious operational workflows.
+
+## What this is
+
+`windbg-mcp` is a Rust MCP server (stdio, `rmcp`) exposing **WinDbg/DbgEng** for live user-mode,
+kernel, crash-dump, and Time Travel Debugging (TTD) work. The low-level DbgEng bindings come from
+the sibling crate [`win-kexp`](https://github.com/glslang/win-kexp) (a **path/git dependency we grow
+ourselves** — do not add third-party DbgEng crates). Key source: `src/engine.rs` (single dedicated
+engine thread), `src/server.rs` (the MCP tools), `src/ttd.rs`, `src/main.rs`.
+
+## Updating the running windbg MCP after code changes
+
+The MCP server registered for this repo runs `target\release\windbg-mcp.exe`. **While that server is
+connected in a Claude Code session, it holds an open handle to the exe**, so a plain
+`cargo build --release` fails at the final replace step with `Access is denied (os error 5)` — but
+only *after* compilation has already succeeded.
+
+To rebuild and load the new code without stopping the session:
+
+1. **Rename the locked exe out of the way** (Windows allows renaming a running image, just not
+   deleting/overwriting it):
+   ```
+   mv target/release/windbg-mcp.exe target/release/windbg-mcp.exe.stale
+   ```
+2. **Build** into the now-free path:
+   ```
+   cargo build --release
+   ```
+   This pulls the latest `win-kexp` `main` (per `Cargo.toml`) and writes a fresh
+   `target\release\windbg-mcp.exe`. The running server keeps executing the *old* code from the
+   renamed `.stale` file until its connection is recycled.
+3. **Load the new binary** by reconnecting the server: `/mcp` → reconnect `windbg` (or restart
+   Claude Code). Only after this reconnect do the windbg tools run the new code.
+4. Once reconnected (the old process is gone), delete `target/release/windbg-mcp.exe.stale`. Do
+   **not** delete it while the old process is still alive — it demand-pages code from that file.
+
+## Changing win-kexp (the DbgEng bindings)
+
+`win-kexp` is a **git dependency pinned to `main`**, not a path dependency — a `windbg-mcp` build
+pulls it from GitHub, so **local edits to `C:\workspace\win-kexp` are invisible to a `windbg-mcp`
+build until they are pushed to `win-kexp` `main`** (then bump the pin / rebuild). Add new DbgEng
+primitives as typed `win-kexp` methods (returning `Result<_, DbgEngError>`, not `panic!`/`.expect`),
+not via the `execute` text hatch.
+
+To compile-check a `windbg-mcp` change that depends on un-pushed `win-kexp` edits, add a temporary
+patch and `cargo check`, then revert it (do **not** commit it — it breaks CI/other contributors):
+
+```toml
+[patch.'https://github.com/glslang/win-kexp']
+win-kexp = { path = "../win-kexp" }
+```
+`git checkout -- Cargo.toml Cargo.lock` afterwards.
+
+## Local verification (no session restart needed)
+
+For a compile/behavior check without touching the locked release exe, use the **dev profile**
+(writes `target/debug`, never locked): `cargo test` and `cargo clippy --all-targets`. The release
+build differs only in optimization and is exercised by CI on a fresh runner.
+
+## Live kernel + driver IOCTL gotchas (learned driving HEVD over KDNET)
+
+**KDNET attach is a blocking wait, by design.** A live kernel needs `WaitForEvent(INFINITE)` (a finite
+timeout returns `E_NOTIMPL` and never drives the link). So if the target isn't reachable, the
+`attach_kernel` MCP call reports a *timeout* while the engine thread stays **parked** in the wait —
+it self-heals and completes the attach the moment the target actually connects. Consequences:
+- When an attach "hangs", **diagnose out-of-band** (PowerShell), never by firing more windbg tools —
+  they queue behind the parked engine thread and also time out. Check the debugger is listening
+  (`Get-NetUDPEndpoint -LocalPort 50000` → owned by `windbg-mcp.exe`) and whether any VM is running.
+- The **target must dial this host**: on the target, `bcdedit /dbgsettings net hostip:<debugger-ip>
+  port:50000 key:<key>` — **colons, not `=`**. `hostip` must be the debugger host's current IP.
+  Symbols are **not** pulled over the KD wire (see below).
+- After a target reboot, the settling KD link shows repeated break-ins in **`kdnic.sys`** (the KD NIC
+  transport: `nt!DbgBreakPointWithStatus` ← `kdnic!TXTransmitQueuedSends`). These are not real stops —
+  `go` through them until boot proceeds.
+
+**Walking a service-loaded driver's IOCTLs live.** `sxe ld:<drv>.sys` breaks on module load, which is
+**before DriverEntry runs** — so the driver object's `MajorFunction` table is *not* populated yet
+(`driver_object` shows defaults / "is not a driver object"). To let DriverEntry run and populate it:
+1. Compute the PE entry point from the header: `? <base> + dwo(<base> + dwo(<base>+0x3c) + 0x28)`.
+2. `bp` it, `go`. At entry, `@rcx` = `DriverObject`, `poi(@rsp)` = return addr (into
+   `nt!PnpCallDriverEntry`). `bp` that return, `go` — now the table is populated.
+3. `MajorFunction[0x0e]` (IRP_MJ_DEVICE_CONTROL, the IOCTL dispatch) is at **`DriverObject+0xe0`**.
+   In the dispatch, the `IoControlCode` is `IO_STACK_LOCATION+0x18`; the current stack location is
+   `IRP+0xB8`. `uf` the dispatch to read the (usually binary-search) IOCTL switch, `decode_ioctl`
+   each code, and read each case's `DbgPrintEx` string (`da`) for the human name.
+
+**Symbols must be on the debugger host.** PDBs are never fetched from the target over KD. Find the
+exact PDB identity the engine wants with `!sym noisy; .reload /f <mod>` (it prints `<pdb>\<GUID>\...`),
+then get that PDB onto this host. **Gotcha: `.sympath` / `.sympath+` swallow the *rest of the command
+line* — they ignore `;`, so anything chained after them (`; .reload ...`) is parsed as path text.**
+Issue `.sympath` alone, or use the **`set_symbol_path`** tool (goes through the DbgEng
+`AppendSymbolPath`/`SetSymbolPath` API, immune to the quirk; appends + reloads). When a driver's
+`module!Symbol` names don't resolve, **ask the user for the PDB folder** and apply it with that tool.
+
+## Plugin vs. dev build
+
+This project is also installed as a user-scope Claude Code plugin (`windbg-mcp@windbg-mcp`), which is
+a snapshot of the last *published* release and does **not** track working-tree edits. In this repo
+the plugin is **disabled locally** (`.claude/settings.local.json`) so the dev build above is what
+runs. Keep machine-specific server wiring (absolute paths) out of version control.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -814,7 +814,7 @@ dependencies = [
 [[package]]
 name = "win-kexp"
 version = "0.1.0"
-source = "git+https://github.com/glslang/win-kexp?branch=main#2272e4ac674160a96f323df67426046bb2f171f6"
+source = "git+https://github.com/glslang/win-kexp?branch=main#758a065e35b3b5a2175bc9687543b71fb03996b4"
 dependencies = [
  "byte-strings",
  "goblin",

--- a/docs/hevd-ioctl-walkthrough.md
+++ b/docs/hevd-ioctl-walkthrough.md
@@ -1,0 +1,194 @@
+# Driver IOCTL walkthrough: HEVD — service-loaded driver, user PDB, static→live reachability
+
+A companion to the [`\Driver\mountmgr` walkthrough](driver-ioctl-walkthrough.md), run against
+**HEVD** (the [HackSys Extreme Vulnerable Driver](https://github.com/hacksysteam/HackSysExtremeVulnerableDriver),
+`win10-klfh` build) on a **live KDNET kernel** (Windows 26100). Where the mountmgr tour covered the
+four reachability *gates* on a built-in driver with public symbols, this one covers the pieces that
+differ for a **third-party, service-loaded** driver you have a **PDB** for, and closes the loop with
+the `reachable_from_dispatch` / `run_to_address` tools. It mirrors the
+[`driver-ioctl.md`](../skills/windbg-debugging/driver-ioctl.md) playbook.
+
+> **Verdict up front:** HEVD exposes **28 IOCTLs**, `0x222003`–`0x22206F` (function codes
+> `0x800`–`0x81b`), **every one** `CTL_CODE(FILE_DEVICE_UNKNOWN, …, METHOD_NEITHER, FILE_ANY_ACCESS)`.
+> METHOD_NEITHER hands the driver raw user-mode pointers and FILE_ANY_ACCESS means the I/O manager
+> delivers on any handle; the device is openable by anyone — so all 28 are reachable from an
+> unprivileged user. That is the entire point of HEVD: no gates, maximum bug surface. The write-
+> what-where handler (`HEVD!ArbitraryWriteIoctlHandler`, IOCTL `0x22200B`) is confirmed reachable
+> from the dispatch entry by a concrete static path.
+
+## 1. Attach over KDNET (and let the link settle)
+
+```jsonc
+attach_kernel { "connection": "net:port=50000,key=<w.x.y.z>" }   // ask the user for the real string
+```
+
+> **Gotcha — the attach *blocks*.** A live kernel needs `WaitForEvent(INFINITE)`, so if the target
+> isn't reachable the tool reports a *timeout* while the engine stays parked, waiting — it completes
+> the moment the target connects. Don't fire more windbg tools into a parked attach; **diagnose
+> out-of-band** (`Get-NetUDPEndpoint -LocalPort 50000` → owned by `windbg-mcp.exe`; is a VM running?).
+> The target must dial this host: `bcdedit /dbgsettings net hostip:<debugger-ip> port:50000 key:<key>`
+> (**colons**, not `=`). After a target reboot the settling KD link throws repeated break-ins in
+> `kdnic.sys` (`nt!DbgBreakPointWithStatus` ← `kdnic!TXTransmitQueuedSends`) — just `go` through them.
+
+## 2. Wait for the driver to load — it loads *after* boot
+
+HEVD is a service, not a boot driver, so at attach it isn't present (`lm m HEVD` is empty). Break on
+its load:
+
+```jsonc
+execute { "command": "sxe ld:HEVD.sys" }
+go {}     // continues boot; breaks when HEVD maps in
+```
+
+```text
+Last event: Load module HEVD.sys at fffff800`11820000
+```
+
+> **Gotcha — the load event fires *before* `DriverEntry` runs.** So the driver object's dispatch
+> table isn't populated yet: `driver_object { "name": "HEVD" }` reports *"is not a driver object"*.
+> Let `DriverEntry` run first by breaking on its return:
+
+```jsonc
+// PE entry point = base + AddressOfEntryPoint (read straight from the header):
+execute { "command": "? 0xfffff80011820000 + dwo(0xfffff80011820000 + dwo(0xfffff80011820000+0x3c) + 0x28)" }
+//   → fffff800`118aa140
+set_breakpoint { "expression": "0xfffff800118aa140" }
+go {}   // at entry: @rcx = DriverObject, poi(@rsp) = return into nt!PnpCallDriverEntry
+set_breakpoint { "expression": "<poi(@rsp)>" }   // e.g. 0xfffff8007cab3ff0
+go {}   // DriverEntry has now run; the MajorFunction table is populated
+```
+
+(A driver already loaded when you attach needs none of this — go straight to §4.)
+
+## 3. Resolve symbols from the user's PDB
+
+Third-party drivers ship no public symbols, but HEVD is built by the user, so the **PDB exists**.
+Find exactly which one the engine wants, then ask the user for it:
+
+```jsonc
+execute { "command": "!sym noisy; .reload /f HEVD.sys" }
+//   → wants HEVD.pdb, GUID 0971DD2656BD43C49F6B1BE314AB3F8C1
+```
+
+The PDB must be reachable from **this** (debugger) host — symbols are never pulled from the target
+over the KD wire. Ask the user for the folder, then apply it with the `set_symbol_path` tool (it uses
+the DbgEng `AppendSymbolPath` API, so it's immune to the `.sympath` line-eating quirk below):
+
+```jsonc
+set_symbol_path { "path": "C:\\HEVD\\bin", "reload": "/f HEVD.sys" }
+//   → HEVD (private pdb symbols)  c:\hevd\bin\HEVD.pdb
+```
+
+> **Gotcha:** the raw `.sympath` / `.sympath+` commands swallow the *rest of the line* — they ignore
+> `;`, so anything chained after (`; .reload …`) is parsed as path text. Use `set_symbol_path`, or
+> issue `.sympath` alone. Names now resolve: `HEVD!IrpDeviceIoCtlHandler`,
+> `HEVD!ArbitraryWriteIoctlHandler`, etc.
+
+## 4. Find the dispatch routine
+
+```jsonc
+driver_object { "name": "HEVD" }
+```
+
+```text
+Device object … \Driver\HEVD   DeviceObject ffff930f1af3ee10
+MajorFunction[0x0e]  fffff800`118a5074   HEVD!IrpDeviceIoCtlHandler
+```
+
+Index **`0x0e`** (`IRP_MJ_DEVICE_CONTROL`) at `DriverObject+0xe0` is the IOCTL dispatch.
+
+## 5. Static enumeration — recover the switch
+
+```jsonc
+execute { "command": "uf HEVD!IrpDeviceIoCtlHandler" }
+```
+
+The prologue loads the control code (`r9d = [IRP_SP+0x18]`, `IRP_SP = [Irp+0xb8]`), then a compiler
+**binary-search** chain of `cmp`/`sub`+`je` on the code — 28 cases, each `DbgPrintEx`-ing a name
+string and calling its trigger handler, with a `default:` returning `STATUS_INVALID_DEVICE_REQUEST`:
+
+```text
+sub ecx, 222003h ; je → ArbitraryWrite path is +8 codes up …
+0x222003 BUFFER_OVERFLOW_STACK          0x22200B ARBITRARY_WRITE (write-what-where)
+0x222007 BUFFER_OVERFLOW_STACK_GS       0x22200F BUFFER_OVERFLOW_NON_PAGED_POOL
+… (function codes 0x800..0x81b, step 4) …
+0x22206F DELETE_ARW_HELPER_OBJECT_NON_PAGED_POOL_NX
+default  → STATUS_INVALID_DEVICE_REQUEST (0xC0000010)
+```
+
+Names come from each case's `DbgPrintEx` string (read with `da`); the trigger handler is the second
+`call` in each case block.
+
+## 6. Decode — the tier is uniform
+
+```jsonc
+decode_ioctl { "code": "0x22200B" }   // ARBITRARY_WRITE
+decode_ioctl { "code": "0x22206F" }   // the last code
+```
+
+```text
+0x0022200b  CTL_CODE(0x0022, 0x802, METHOD_NEITHER, FILE_ANY_ACCESS)
+0x0022206f  CTL_CODE(0x0022, 0x81b, METHOD_NEITHER, FILE_ANY_ACCESS)
+  [!] METHOD_NEITHER: driver receives raw user-mode pointers — classic bug surface.
+  [!] FILE_ANY_ACCESS: no access gate — delivered on any handle.
+```
+
+All 28 are identical in method/access; only the function code differs. Unlike mountmgr's tiered
+`FILE_ANY_ACCESS`/`READ`/`READ|WRITE` codes, HEVD gates **nothing**.
+
+## 7. Openable gate
+
+```jsonc
+device_object { "device": "0xffff930f1af3ee10" }
+```
+
+```text
+HackSysExtremeVulnerableDriver \Driver\HEVD   Type 0x22
+Characteristics (0x100) FILE_DEVICE_SECURE_OPEN   ExtensionFlags DOE_DEFAULT_SD_PRESENT
+```
+
+`FILE_DEVICE_SECURE_OPEN` with the **default** device SD (`!sd` isn't in the bundled engine; the SD
+pointer is surfaced). Combined with `FILE_ANY_ACCESS`, an unprivileged process opens
+`\Device\HackSysExtremeVulnerableDriver` and reaches every IOCTL — no `RequiredAccess` gate to fail.
+
+## 8. Static reachability → live confirm (the new tools)
+
+Prove a specific bug block is reachable from the dispatch entry, and read the input that routes there:
+
+```jsonc
+reachable_from_dispatch {
+  "from": "HEVD!IrpDeviceIoCtlHandler",
+  "address": "HEVD!ArbitraryWriteIoctlHandler",
+  "recipe": true
+}
+```
+
+```text
+VERDICT: REACHABLE
+  Call path (1 hops):  fffff800`118a51ea  call -> HEVD!ArbitraryWriteIoctlHandler
+Path recipe (input that keeps control on the path):
+  … sub ecx,222003h  (tests != 0x222003) … je — must take   ; sub ecx,eax
+```
+
+The recipe's compare chain pins the gating input to **`IoControlCode == 0x22200B`** — the write-
+what-where IOCTL. Then confirm it live (needs KDNET/VM), once a user-mode client sends that code:
+
+```jsonc
+run_to_address { "address": "HEVD!ArbitraryWriteIoctlHandler" }   // → HIT / STOPPED-ELSEWHERE / TIMEOUT
+```
+
+> `reachable_from_dispatch` doesn't follow indirect `call [ptr]`/`call reg` or unresolved jump
+> tables — REACHABLE is sound, NOT-REACHABLE only means "not found within bounds". HEVD's dispatch
+> is a direct compare chain, so the walk follows it and decodes the gate. (The tool prints a generic
+> "indirect jump table" caveat even here, where it doesn't apply.)
+
+## Gotchas recap
+
+- **Attach blocks on an INFINITE wait** — diagnose a hung attach out-of-band, don't hammer tools.
+- **Target dials the debugger:** `bcdedit /dbgsettings net hostip:… port: key:` (colons).
+- **`sxe ld` stops before `DriverEntry`** — the dispatch table isn't populated; run DriverEntry via
+  the PE-entry + return-address breakpoint (§2) before `driver_object`.
+- **Symbols live on the debugger host, not the target** — find the PDB GUID with `!sym noisy`, ask
+  the user for the folder, apply with `set_symbol_path`.
+- **`.sympath` swallows the rest of the line** — use `set_symbol_path`, or run `.sympath` alone.
+- **While broken in the whole guest is frozen** — start any user-mode client, then `go`.

--- a/docs/hevd-ioctl-walkthrough.md
+++ b/docs/hevd-ioctl-walkthrough.md
@@ -54,7 +54,7 @@ execute { "command": "? 0xfffff80011820000 + dwo(0xfffff80011820000 + dwo(0xffff
 //   → fffff800`118aa140
 set_breakpoint { "expression": "0xfffff800118aa140" }
 go {}   // at entry: @rcx = DriverObject, poi(@rsp) = return into nt!PnpCallDriverEntry
-set_breakpoint { "expression": "<poi(@rsp)>" }   // e.g. 0xfffff8007cab3ff0
+set_breakpoint { "expression": "poi(@rsp)" }   // WinDbg evaluates it; here → 0xfffff8007cab3ff0
 go {}   // DriverEntry has now run; the MajorFunction table is populated
 ```
 

--- a/skills/windbg-debugging/driver-ioctl.md
+++ b/skills/windbg-debugging/driver-ioctl.md
@@ -62,9 +62,35 @@ reads.
    DACL; it is not in the bundled engine, so otherwise inspect the SD by address. Inspect the
    symbolic link with `execute { "command": "!object \\GLOBAL??" }` for the *namespace* gate.
 
-> **No PDBs.** Third-party drivers ship no symbols, so `module!Dispatch` won't resolve —
-> everything is **address-based**. RVAs from static analysis must be **rebased to the live load
-> base** (`modules {}` / `lm m <driver>`) before use, because of ASLR.
+> **Symbols — ask for the PDB when it exists.** Production/third-party drivers usually ship no
+> PDB, so `module!Dispatch` won't resolve and you work **address-based** (rebase static RVAs to the
+> live load base — `modules {}` / `lm m <driver>` — because of ASLR). **But if the user built the
+> driver or has its PDB, symbols are available** and make everything readable. Find the exact PDB
+> the engine wants with `execute { "command": "!sym noisy; .reload /f <driver>.sys" }` (it prints
+> `<pdb>\<GUID>\…`), then **ask the user for the folder holding that PDB** — it must be on *this*
+> debugger host (symbols are never pulled from the target over the KD wire) — and apply it with
+> `set_symbol_path { "path": "<folder>", "reload": "/f <driver>.sys" }`. Names like
+> `HEVD!IrpDeviceIoCtlHandler` / `HEVD!ArbitraryWriteIoctlHandler` then resolve.
+
+## Static reachability — dispatch → handler (`reachable_from_dispatch`)
+
+Once you have the dispatch VA and a handler VA of interest, `reachable_from_dispatch { "from":
+"<dispatchVA-or-symbol>", "address": "<handlerVA>" }` runs a bounded control-flow walk and returns
+**REACHABLE** (with the call path) or **NOT REACHABLE** (within bounds). With `recipe: true`
+(default) it also emits the **on-path branch directions and the compare that gates each** — for the
+common MSVC binary-search `switch (IoControlCode)`, that recipe pins the **exact `IoControlCode`**
+routing to that handler. This is the fast way to answer "which IOCTL triggers handler X" and to
+prove a bug block is reachable from the dispatch entry.
+
+Then **confirm it live** (needs KDNET/VM): `run_to_address { "address": "<handlerVA>" }` runs the
+target and reports **HIT / STOPPED-ELSEWHERE / TIMEOUT** once a user-mode client sends that IOCTL —
+closing the static→dynamic loop without a scripted breakpoint.
+
+> `reachable_from_dispatch` does **not** follow indirect `call [ptr]`/`call reg` or unresolved jump
+> tables — REACHABLE is sound; NOT-REACHABLE only means "not found within bounds". For a jump-table
+> dispatch, pass the specific handler VA as `from` to scope past the switch. (Its boilerplate
+> "indirect jump table" note prints even when the dispatch is actually a direct compare chain it
+> *did* follow.)
 
 ## Static enumeration — Binary Ninja (optional escalation)
 
@@ -131,9 +157,12 @@ sweep requires a real **KDNET/VM** target via `attach_kernel`.
 
 Close the workflow with a written report so the result is reviewable. Keep it grounded in the
 tool output you gathered (cite the live addresses / DACL / codes — don't assert from memory). A
-worked end-to-end example is
-[`docs/driver-ioctl-walkthrough.md`](../../docs/driver-ioctl-walkthrough.md) (Mount Point
-Manager). Structure:
+worked end-to-end examples are
+[`docs/driver-ioctl-walkthrough.md`](../../docs/driver-ioctl-walkthrough.md) (Mount Point Manager —
+the four reachability gates on a built-in driver) and
+[`docs/hevd-ioctl-walkthrough.md`](../../docs/hevd-ioctl-walkthrough.md) (HEVD — a *service-loaded*
+third-party driver with a user PDB, `set_symbol_path`, and the `reachable_from_dispatch` /
+`run_to_address` loop). Structure:
 
 1. **Verdict up front** — one paragraph: which IOCTLs a standard user can reach, which are
    blocked and by which gate. State the target driver/device + build.
@@ -172,6 +201,13 @@ Save it under `docs/` (the repo's walkthrough convention) or hand it back inline
 - **`@rdx` holds the PIRP only at the dispatch *entry*** (x64 fastcall arg2). After any
   `step_over`/`step_into` the register is clobbered; read `irp_stack` before stepping, or pass an
   explicit IRP address.
+- **Caught the driver at *load*? Its dispatch table isn't populated yet.** For a driver that loads
+  after boot, `sxe ld:<drv>.sys` + `go` stops *before* `DriverEntry` runs, so `driver_object` shows
+  default handlers (or "is not a driver object"). Let `DriverEntry` finish first: compute the PE
+  entry point `? <base> + dwo(<base> + dwo(<base>+0x3c) + 0x28)`, `set_breakpoint` it and `go`; at
+  entry `@rcx` is the `DriverObject` and `poi(@rsp)` the return into `nt!PnpCallDriverEntry` —
+  breakpoint that return, `go`, and now `MajorFunction[0x0e]` (at `DriverObject+0xe0`) is the real
+  dispatch. (A driver already loaded when you attach needs none of this — just `driver_object`.)
 - **No PDBs → rebase.** Static RVAs are ASLR-relative; rebase to `lm m <driver>` before setting
   any breakpoint. See the symbol/elevation notes in [setup.md](setup.md) and
   [live-and-kernel.md](live-and-kernel.md).

--- a/src/server.rs
+++ b/src/server.rs
@@ -1077,6 +1077,24 @@ pub struct DecodeIoctlArgs {
 }
 
 #[derive(Deserialize, JsonSchema)]
+pub struct SymbolPathArgs {
+    /// Symbol search path to apply: a directory holding a module's PDB, a
+    /// `srv*downstream*server` spec, or a `;`-separated list. Point it at the folder
+    /// whose PDB matches the module's PDB GUID so `module!Symbol` names resolve. Must be
+    /// reachable from THIS (debugger) host — symbols are not pulled from the target over
+    /// the KD wire.
+    pub path: String,
+    /// Append to the existing path (default true) rather than replacing it. Appending
+    /// keeps the OS/`nt` symbol server already configured.
+    #[serde(default)]
+    pub append: Option<bool>,
+    /// Optional `.reload` argument applied after setting the path, e.g. "/f HEVD.sys" to
+    /// force-load one module's symbols. Omit to reload all deferred modules.
+    #[serde(default)]
+    pub reload: Option<String>,
+}
+
+#[derive(Deserialize, JsonSchema)]
 pub struct DriverObjectArgs {
     /// Driver object name, e.g. "mydriver" or "\\Driver\\mydriver".
     pub name: String,
@@ -1236,6 +1254,36 @@ impl WindbgServer {
                 // !drvobj/!devobj/!irp commands resolve (see attach_kernel_local). Best-effort.
                 let _ = e.execute_command(".load kdexts");
                 e.execute_command("vertarget").map_err(es)
+            })
+            .await?;
+        text_result(out)
+    }
+
+    /// Set or extend the symbol search path, then reload symbols, so `module!Symbol`
+    /// names resolve. Use it when a driver's PDB isn't on the default path: ask the user
+    /// for the folder holding the matching PDB (by GUID) and apply it here. The path must
+    /// be reachable from THIS (debugger) host — symbols are not fetched from the target
+    /// over the KD wire. Goes through the DbgEng API, so it avoids the `.sympath` command
+    /// quirk of swallowing the rest of the command line.
+    #[rmcp::tool]
+    async fn set_symbol_path(
+        &self,
+        Parameters(args): Parameters<SymbolPathArgs>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let append = args.append.unwrap_or(true);
+        let out = self
+            .engine
+            .run(move |e| {
+                if append {
+                    e.append_symbol_path(&args.path).map_err(es)?;
+                } else {
+                    e.set_symbol_path(&args.path).map_err(es)?;
+                }
+                // Reload so the new path takes effect (default: all deferred modules).
+                e.reload_symbols(args.reload.as_deref().unwrap_or(""))
+                    .map_err(es)?;
+                // Echo the effective path so the caller can confirm what resolved.
+                e.execute_command(".sympath").map_err(es)
             })
             .await?;
         text_result(out)


### PR DESCRIPTION
Adds a first-class symbol-path tool and documents the end-to-end live driver-IOCTL workflow,
validated this session against **HEVD** over a live KDNET kernel.

> Stacked on #32 (base `chore/post-merge-cleanup`) — it carries the win-kexp→main repoint this
> change's lock bump depends on. Rebase/retarget to `main` once #32 merges.

### Tool
- **`set_symbol_path`** (`src/server.rs`): append (default) or replace the symbol search path, then
  reload, so a driver's `module!Symbol` names resolve from a **user-supplied PDB folder**. Goes
  through the DbgEng `AppendSymbolPath`/`SetSymbolPath` API, so it is immune to the `.sympath`
  command's habit of swallowing the rest of the line.
- Backed by win-kexp `append_symbol_path` + `set_symbol_path`/`reload_symbols` returning `Result`
  (already on win-kexp `main` at `758a065`); `Cargo.lock` bumped to pick it up.

### Docs
- **`CLAUDE.md`**: the rename-trick rebuild, the win-kexp git-dependency (edits invisible until
  pushed to `main`) + temp-`[patch]` compile-check recipe, and the live-kernel + driver-IOCTL
  gotchas (INFINITE-wait attach, `bcdedit … net hostip: port: key:` colons, kdnic link-settling,
  `sxe ld` stops before DriverEntry, `.sympath` line-eating).
- **`skills/windbg-debugging/driver-ioctl.md`**: symbols-can-be-available (ask for the PDB), the
  service-load / DriverEntry-timing pitfall, and a static-reachability section using
  `reachable_from_dispatch` + `run_to_address`.
- **`docs/hevd-ioctl-walkthrough.md`**: a worked HEVD example — service-loaded driver, user PDB via
  `set_symbol_path`, all 28 IOCTLs (`METHOD_NEITHER`/`FILE_ANY_ACCESS`), and the write-what-where
  reachability proof.

Verified: win-kexp and windbg-mcp `cargo check` clean; release rebuilt; `reachable_from_dispatch`
`HEVD!IrpDeviceIoCtlHandler` → `HEVD!ArbitraryWriteIoctlHandler` returns REACHABLE with the recipe
pinning `IoControlCode == 0x22200B`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)