### PR TITLE
fix(ttd): repair index_trace, add record_trace env/cwd, clearer messaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - [`docs/driver-ioctl-walkthrough.md`](docs/driver-ioctl-walkthrough.md): a worked
     `\Driver\mountmgr` enumeration + reachability report against a live kernel. The
     playbook now ends with a "Write the report" step + template.
+- **`record_trace` `env` and `working_dir` options** — pass extra `KEY=VALUE` environment
+  entries and a working directory to the recorded target, for programs that refuse to run
+  without a specific environment (e.g. a Qt app's `QT_QPA_PLATFORM_PLUGIN_PATH`, or an
+  anti-analysis "run me from here" guard). Previously the recorder only inherited the
+  server's environment.
+
+### Fixed
+
+- **`index_trace` now works.** It invoked `!tt.index`, which fails with `LoadLibrary(tt)` —
+  there is no `tt` extension. The bundled engine exposes trace indexing through `TtdExt.dll`,
+  so `index_trace` now runs `!ttdext.index` (building a persistent `.idx` next to the `.run`).
+- **`open_trace` flags an unindexed trace.** A freshly recorded `.run` has no `.idx`, so the
+  first data-model query silently builds an in-memory index and can run long; `open_trace`
+  now says so up front (via `!ttdext.index -status`) and points at `index_trace`.
+- **`registers` no longer returns a blank result** when there is no thread context (a
+  module-load break or a bare `goto_position 0`); it explains why and how to get a context.
 
 ## [0.1.3] - 2026-06-14
 

--- a/skills/windbg-debugging/ttd.md
+++ b/skills/windbg-debugging/ttd.md
@@ -13,11 +13,18 @@ TTD positions are `major:minor` (a sequencing point and a step within it), not w
 ## 1. Get a trace
 
 - **Record** (Administrator, `TTD.exe` on `PATH`):
-  `record_trace { "out_dir": "C:\\traces", "target": "C:\\path\\app.exe arg" }`
+  `record_trace { "out_dir": "C:\\traces", "target": "C:\\path\\app.exe arg" }`.
+  If the target needs a specific environment or working directory to run — a Qt app's
+  `QT_QPA_PLATFORM_PLUGIN_PATH`, or an anti-analysis "run me from here" guard — pass
+  `"env": ["KEY=VALUE", …]` and/or `"working_dir": "C:\\path"`; they're applied to the
+  recorded target (the recorder inherits the server's env otherwise).
 - **Open** an existing trace:
   `open_trace { "path": "C:\\traces\\app01.run" }` — returns
-  `@$curprocess.TTD.Lifetime` (e.g. `[C:0, 124:8C2]`), confirming replay is live and giving
-  the position span. If the index is stale, `index_trace {}` (`!tt.index`).
+  `@$curprocess.TTD.Lifetime` (e.g. `[C:0, 124:8C2]`), confirming replay is live. It also
+  flags an **unindexed** `.run` (freshly recorded traces have no `.idx`): the first
+  data-model query then builds an in-memory index and can run long — let it finish.
+  `index_trace {}` builds a **persistent** `.idx` (`!ttdext.index`) so queries and re-opens
+  are fast.
 
 ## 2. Navigate — forward and backward
 
@@ -83,3 +90,24 @@ Then `ttd_calls`/`dx` by name work. To inspect a specific call, travel to it
   `.reload` at a stopped position.
 - The `__stdio_common_vfprintf` display alias has two underscores; `_stdio_common_vfprintf`
   is the alias — match the real symbol.
+- **Never run an unbounded memory search on a trace.** A whole-address-space
+  `execute { "command": "s -u 0 L?0x400000000000 …" }` sends the engine into a scan that can
+  run for minutes — and it wedges the single engine thread, so every later tool call times
+  out queued behind it. **Scope every search** to a real region: a module range (`lm`), a
+  heap segment from the PEB (`dt ntdll!_PEB @$peb ProcessHeap`), or a stack window — and
+  prefer the indexed data model (`ttd_calls`/`ttd_memory`) over raw `s`. If you do wedge it,
+  the only recovery is to kill `windbg-mcp.exe` and reconnect (`/mcp`), then re-open the trace.
+- **`registers {}` empty** → no thread context at this position (a module-load break, or a
+  bare `goto_position 0`). Travel to a settled position after a `go`/breakpoint, or read one
+  register with `execute { "command": "r rip" }`.
+
+## Technique: tabulate a pure function for a solver
+
+To recover "what input passes this check" when the check is a math function of the input
+(a hash, a per-digit transform), **evaluate the function directly** instead of reversing it.
+On a **live** target (`attach_process`), break at the function's call site, then loop:
+set the argument registers, set `rip` to the call site, `go` to just past the call, read the
+return — for every input you care about. A WinDbg `.for` script with `.logopen` dumps the
+whole table to a file; feed it to an SMT solver (e.g. Z3). See the FlareAuthenticator TTD
+walkthrough (`docs/flareauthenticator-ttd-walkthrough.md`) for a full worked example.
+(Watch the `.for` **radix**: the default is 16, so `10` means `0x10` — write bounds as `0xa`.)

--- a/src/server.rs
+++ b/src/server.rs
@@ -1681,16 +1681,18 @@ impl WindbgServer {
         text_result(out)
     }
 
-    /// Build the persistent index of the currently open TTD trace (`!ttdext.index`),
-    /// writing an `.idx` next to the `.run` so later queries and re-opens are fast.
-    /// No-op if already indexed. (The bundled engine exposes this as `!ttdext.index`,
-    /// not `!tt.index` — the latter fails with `LoadLibrary(tt)` because there is no
-    /// `tt` extension; the TTD commands come from `TtdExt.dll`.)
+    /// Build (or repair) the persistent index of the currently open TTD trace
+    /// (`!ttdext.index -force`), writing an `.idx` next to the `.run` so later queries and
+    /// re-opens are fast. `-force` is a fast no-op on an already-loaded index but deletes and
+    /// rebuilds an unloadable/corrupt one — which plain `!ttdext.index` cannot repair, so this
+    /// is the mode that actually fixes the "index not loaded" state `open_trace` warns about.
+    /// (The bundled engine exposes these via `TtdExt.dll`; `!tt.index` fails with
+    /// `LoadLibrary(tt)` because there is no `tt` extension.)
     #[rmcp::tool]
     async fn index_trace(&self) -> Result<CallToolResult, ErrorData> {
         let out = self
             .engine
-            .run(move |e| e.execute_command("!ttdext.index").map_err(es))
+            .run(move |e| e.execute_command("!ttdext.index -force").map_err(es))
             .await?;
         text_result(out)
     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -1219,19 +1219,23 @@ impl WindbgServer {
             .run(move |e| {
                 e.open_trace(&args.path).map_err(es)?;
                 e.wait_for_event(LOAD_WAIT_MS).map_err(es)?;
-                // Confirm TTD replay is active and report the trace's position span.
+                // Check the index state *before* any data-model query: `!ttdext.index -status`
+                // only reads the on-disk .idx (never builds), whereas a `dx` on an unindexed
+                // trace can itself trigger the long in-memory index build.
+                let unindexed = {
+                    let status = e
+                        .execute_command("!ttdext.index -status")
+                        .unwrap_or_default();
+                    status.contains("does not exist")
+                        || status.to_ascii_lowercase().contains("not indexed")
+                };
+                // Confirm TTD replay is active and report the trace's position span. Lifetime
+                // is cheap metadata (min/max position); the expensive indexing is triggered by
+                // Calls/Memory/Events queries, which is what the note below warns about.
                 let mut out = e
                     .execute_command("dx @$curprocess.TTD.Lifetime")
                     .map_err(es)?;
-                // Surface the index state. `-status` only reports (never builds), so it is
-                // safe here. On an unindexed .run the first data-model query builds an
-                // in-memory index and can run long — worth warning about up front.
-                let status = e
-                    .execute_command("!ttdext.index -status")
-                    .unwrap_or_default();
-                if status.contains("does not exist")
-                    || status.to_ascii_lowercase().contains("not indexed")
-                {
+                if unindexed {
                     out.push_str(
                         "\nNote: this trace is not indexed. The first data-model query \
                          (ttd_calls/ttd_memory/ttd_events/dx) builds an in-memory index and \

--- a/src/server.rs
+++ b/src/server.rs
@@ -1221,13 +1221,16 @@ impl WindbgServer {
                 e.wait_for_event(LOAD_WAIT_MS).map_err(es)?;
                 // Check the index state *before* any data-model query: `!ttdext.index -status`
                 // only reads the on-disk .idx (never builds), whereas a `dx` on an unindexed
-                // trace can itself trigger the long in-memory index build.
-                let unindexed = {
+                // trace can itself trigger the long in-memory index build. TtdExt reports a
+                // healthy, ready index as exactly "Index file loaded."; per MS guidance treat
+                // anything else (missing, out of date, corrupt, unloadable) as needing an index.
+                // A blank result means the status query itself failed — don't warn then.
+                let needs_index = {
                     let status = e
                         .execute_command("!ttdext.index -status")
                         .unwrap_or_default();
-                    status.contains("does not exist")
-                        || status.to_ascii_lowercase().contains("not indexed")
+                    !status.trim().is_empty()
+                        && !status.to_ascii_lowercase().contains("index file loaded")
                 };
                 // Confirm TTD replay is active and report the trace's position span. Lifetime
                 // is cheap metadata (min/max position); the expensive indexing is triggered by
@@ -1235,12 +1238,13 @@ impl WindbgServer {
                 let mut out = e
                     .execute_command("dx @$curprocess.TTD.Lifetime")
                     .map_err(es)?;
-                if unindexed {
+                if needs_index {
                     out.push_str(
-                        "\nNote: this trace is not indexed. The first data-model query \
-                         (ttd_calls/ttd_memory/ttd_events/dx) builds an in-memory index and \
-                         can run long — let it finish before issuing more queries. Run \
-                         index_trace to build a persistent .idx (fast queries and re-opens).",
+                        "\nNote: this trace's index is not loaded (missing, out of date, or \
+                         unusable). The first data-model query (ttd_calls/ttd_memory/ttd_events/dx) \
+                         then builds an in-memory index and can run long — let it finish before \
+                         issuing more queries. Run index_trace to (re)build a persistent .idx \
+                         (fast queries and re-opens).",
                     );
                 }
                 Ok(out)

--- a/src/server.rs
+++ b/src/server.rs
@@ -1049,6 +1049,15 @@ pub struct RecordArgs {
     pub out_dir: String,
     /// Program (with optional arguments) to launch and record.
     pub target: String,
+    /// Extra environment variables for the recorded target, each as "KEY=VALUE".
+    /// Useful when the target refuses to run without a specific environment (e.g. a Qt
+    /// app that needs `QT_QPA_PLATFORM_PLUGIN_PATH`, or an anti-analysis env guard).
+    #[serde(default)]
+    pub env: Vec<String>,
+    /// Working directory for the recorded target (defaults to TTD.exe's cwd). Set this
+    /// when the target loads resources relative to its own directory.
+    #[serde(default)]
+    pub working_dir: Option<String>,
 }
 
 #[derive(Deserialize, JsonSchema)]
@@ -1211,8 +1220,26 @@ impl WindbgServer {
                 e.open_trace(&args.path).map_err(es)?;
                 e.wait_for_event(LOAD_WAIT_MS).map_err(es)?;
                 // Confirm TTD replay is active and report the trace's position span.
-                e.execute_command("dx @$curprocess.TTD.Lifetime")
-                    .map_err(es)
+                let mut out = e
+                    .execute_command("dx @$curprocess.TTD.Lifetime")
+                    .map_err(es)?;
+                // Surface the index state. `-status` only reports (never builds), so it is
+                // safe here. On an unindexed .run the first data-model query builds an
+                // in-memory index and can run long — worth warning about up front.
+                let status = e
+                    .execute_command("!ttdext.index -status")
+                    .unwrap_or_default();
+                if status.contains("does not exist")
+                    || status.to_ascii_lowercase().contains("not indexed")
+                {
+                    out.push_str(
+                        "\nNote: this trace is not indexed. The first data-model query \
+                         (ttd_calls/ttd_memory/ttd_events/dx) builds an in-memory index and \
+                         can run long — let it finish before issuing more queries. Run \
+                         index_trace to build a persistent .idx (fast queries and re-opens).",
+                    );
+                }
+                Ok(out)
             })
             .await?;
         text_result(out)
@@ -1355,6 +1382,16 @@ impl WindbgServer {
     #[rmcp::tool]
     async fn registers(&self) -> Result<CallToolResult, ErrorData> {
         let out = self.engine.run(move |e| e.registers().map_err(es)).await?;
+        if out.trim().is_empty() {
+            // DbgEng prints nothing for `r` when there is no live thread context (e.g. a
+            // module-load break, or a bare goto_position to the very start of a trace).
+            return text_result(
+                "(no thread register context at this position — e.g. a module-load break or \
+                 the start of a trace. Travel to a settled position after a go/breakpoint, or \
+                 read a specific register with execute { \"command\": \"r rip\" }.)"
+                    .to_string(),
+            );
+        }
         text_result(out)
     }
 
@@ -1636,18 +1673,25 @@ impl WindbgServer {
         text_result(out)
     }
 
-    /// Rebuild the index of the currently open TTD trace (`!tt.index`).
+    /// Build the persistent index of the currently open TTD trace (`!ttdext.index`),
+    /// writing an `.idx` next to the `.run` so later queries and re-opens are fast.
+    /// No-op if already indexed. (The bundled engine exposes this as `!ttdext.index`,
+    /// not `!tt.index` — the latter fails with `LoadLibrary(tt)` because there is no
+    /// `tt` extension; the TTD commands come from `TtdExt.dll`.)
     #[rmcp::tool]
     async fn index_trace(&self) -> Result<CallToolResult, ErrorData> {
         let out = self
             .engine
-            .run(move |e| e.execute_command("!tt.index").map_err(es))
+            .run(move |e| e.execute_command("!ttdext.index").map_err(es))
             .await?;
         text_result(out)
     }
 
     /// Record a new TTD trace by launching a target under TTD.exe (requires elevation).
     /// Reports an error if the recorder fails to start (e.g. not running elevated).
+    /// Optional `env` (KEY=VALUE entries) and `working_dir` are applied to the recorded
+    /// target — use them when it needs a specific environment or cwd to run (e.g. a Qt
+    /// app's `QT_QPA_PLATFORM_PLUGIN_PATH`, or an anti-analysis "run me from here" guard).
     #[rmcp::tool]
     async fn record_trace(
         &self,
@@ -1660,7 +1704,13 @@ impl WindbgServer {
             let ttd = ttd::find_ttd().ok_or_else(|| {
                 "TTD.exe not found (install the Windows debugging tools / WinDbg)".to_string()
             })?;
-            ttd::record_launch(&ttd, &args.out_dir, &args.target)
+            ttd::record_launch(
+                &ttd,
+                &args.out_dir,
+                &args.target,
+                &args.env,
+                args.working_dir.as_deref(),
+            )
         })
         .await
         .map_err(|e| ErrorData::internal_error(format!("record task panicked: {e}"), None))?;

--- a/src/ttd.rs
+++ b/src/ttd.rs
@@ -76,7 +76,13 @@ const STARTUP_WATCH: Duration = Duration::from_millis(2500);
 /// error instead of falsely reporting success.
 ///
 /// Requires Administrator privileges.
-pub fn record_launch(ttd: &Path, out_dir: &str, target: &str) -> Result<String, String> {
+pub fn record_launch(
+    ttd: &Path,
+    out_dir: &str,
+    target: &str,
+    env: &[String],
+    working_dir: Option<&str>,
+) -> Result<String, String> {
     // TTD requires the output directory to exist; create it up front.
     std::fs::create_dir_all(out_dir)
         .map_err(|e| format!("failed to create output dir `{out_dir}`: {e}"))?;
@@ -91,14 +97,24 @@ pub fn record_launch(ttd: &Path, out_dir: &str, target: &str) -> Result<String, 
         .try_clone()
         .map_err(|e| format!("failed to set up TTD logging: {e}"))?;
 
-    let mut child = Command::new(ttd)
-        .arg("-accepteula")
+    let mut cmd = Command::new(ttd);
+    cmd.arg("-accepteula")
         .arg("-out")
         .arg(out_dir)
         .arg("-launch")
         .arg(target)
         .stdout(Stdio::from(log))
-        .stderr(Stdio::from(log_err))
+        .stderr(Stdio::from(log_err));
+    // Pass through caller-supplied environment (e.g. an anti-analysis env guard) and cwd
+    // to the recorded target. TTD.exe launches `target` with this environment inherited.
+    for kv in env {
+        let (key, val) = split_env_entry(kv)?;
+        cmd.env(key, val);
+    }
+    if let Some(dir) = working_dir {
+        cmd.current_dir(dir);
+    }
+    let mut child = cmd
         .spawn()
         .map_err(|e| format!("failed to launch TTD.exe: {e}"))?;
 
@@ -137,6 +153,15 @@ pub fn record_launch(ttd: &Path, out_dir: &str, target: &str) -> Result<String, 
     }
 }
 
+/// Splits a `KEY=VALUE` environment entry. The value may itself contain `=`; the key must
+/// be non-empty. Returns a clear error for malformed input rather than silently dropping it.
+fn split_env_entry(entry: &str) -> Result<(&str, &str), String> {
+    match entry.split_once('=') {
+        Some((key, val)) if !key.is_empty() => Ok((key, val)),
+        _ => Err(format!("invalid env entry `{entry}` (expected KEY=VALUE)")),
+    }
+}
+
 /// First non-empty, non-banner line of TTD's output — the part that usually carries
 /// the actual error (e.g. the "Administrative privileges are required" line).
 fn first_meaningful_line(log: &str) -> Option<&str> {
@@ -154,7 +179,27 @@ fn first_meaningful_line(log: &str) -> Option<&str> {
 
 #[cfg(test)]
 mod tests {
-    use super::first_meaningful_line;
+    use super::{first_meaningful_line, split_env_entry};
+
+    #[test]
+    fn split_env_entry_parses_key_value() {
+        assert_eq!(
+            split_env_entry("QT_QPA_PLATFORM_PLUGIN_PATH=C:\\app"),
+            Ok(("QT_QPA_PLATFORM_PLUGIN_PATH", "C:\\app"))
+        );
+    }
+
+    #[test]
+    fn split_env_entry_allows_equals_and_empty_value() {
+        assert_eq!(split_env_entry("K=a=b"), Ok(("K", "a=b")));
+        assert_eq!(split_env_entry("K="), Ok(("K", "")));
+    }
+
+    #[test]
+    fn split_env_entry_rejects_missing_equals_or_empty_key() {
+        assert!(split_env_entry("NOEQUALS").is_err());
+        assert!(split_env_entry("=value").is_err());
+    }
 
     #[test]
     fn empty_or_whitespace_has_no_meaningful_line() {

--- a/src/ttd.rs
+++ b/src/ttd.rs
@@ -83,14 +83,26 @@ pub fn record_launch(
     env: &[String],
     working_dir: Option<&str>,
 ) -> Result<String, String> {
-    // TTD requires the output directory to exist; create it up front.
-    std::fs::create_dir_all(out_dir)
-        .map_err(|e| format!("failed to create output dir `{out_dir}`: {e}"))?;
+    // Validate the caller-supplied environment up front — before any filesystem side effect —
+    // so a malformed entry doesn't leave a stray log file behind.
+    let mut parsed_env = Vec::with_capacity(env.len());
+    for kv in env {
+        parsed_env.push(split_env_entry(kv)?);
+    }
+
+    // Resolve out_dir to an absolute path. When `working_dir` is set, TTD.exe would otherwise
+    // resolve a relative `-out` against the *target's* cwd — mismatching where we create the
+    // directory and log (the server's cwd). `absolute` makes it absolute lexically: no cwd
+    // dependence, and unlike `canonicalize` it needs no existing path and adds no `\\?\` prefix.
+    let out_dir = std::path::absolute(out_dir)
+        .map_err(|e| format!("failed to resolve output dir `{out_dir}`: {e}"))?;
+    std::fs::create_dir_all(&out_dir)
+        .map_err(|e| format!("failed to create output dir `{}`: {e}", out_dir.display()))?;
 
     // Capture the recorder's banner/diagnostics to a file (not a pipe): a pipe would
     // deadlock a long, successful recording once its buffer filled and we stopped
     // draining it.
-    let log_path = Path::new(out_dir).join("ttd_record.log");
+    let log_path = out_dir.join("ttd_record.log");
     let log = std::fs::File::create(&log_path)
         .map_err(|e| format!("failed to create log `{}`: {e}", log_path.display()))?;
     let log_err = log
@@ -100,15 +112,14 @@ pub fn record_launch(
     let mut cmd = Command::new(ttd);
     cmd.arg("-accepteula")
         .arg("-out")
-        .arg(out_dir)
+        .arg(&out_dir)
         .arg("-launch")
         .arg(target)
         .stdout(Stdio::from(log))
         .stderr(Stdio::from(log_err));
-    // Pass through caller-supplied environment (e.g. an anti-analysis env guard) and cwd
-    // to the recorded target. TTD.exe launches `target` with this environment inherited.
-    for kv in env {
-        let (key, val) = split_env_entry(kv)?;
+    // Pass through the validated environment (e.g. an anti-analysis env guard) and cwd to the
+    // recorded target. TTD.exe launches `target` with this environment inherited.
+    for (key, val) in parsed_env {
         cmd.env(key, val);
     }
     if let Some(dir) = working_dir {
@@ -141,8 +152,9 @@ pub fn record_launch(
                     // Still running after the watch window → recording is underway.
                     return Ok(format!(
                         "TTD recording started (recorder pid {pid}). Tracing `{target}`; \
-                         output (.run/.idx) goes to `{out_dir}`. Recording finalizes when the \
+                         output (.run/.idx) goes to `{}`. Recording finalizes when the \
                          target exits. Recorder log: {}",
+                        out_dir.display(),
                         log_path.display()
                     ));
                 }


### PR DESCRIPTION
## What

Fixes and small improvements to the TTD tools, all surfaced while using them to solve an obfuscated crackme (companion to the walkthrough in #39).

## Fixes

- **`index_trace` was broken.** It ran `!tt.index`, which fails with `LoadLibrary(tt) failed, Win32 error 0n2` — there is no `tt` extension. The bundled engine provides TTD indexing through `TtdExt.dll`, so it now runs **`!ttdext.index`**, building a persistent `.idx` next to the `.run` (verified against a real trace: 73 keyframes in ~1.6 s).
- **`open_trace` now flags an unindexed trace.** A freshly recorded `.run` has no `.idx`, so the first data-model query silently builds an in-memory index and can run long. `open_trace` now reports this (via the read-only `!ttdext.index -status`) and points at `index_trace`.
- **`registers` no longer returns a blank result** when there's no thread context (a module-load break or a bare `goto_position 0`) — it explains why and how to get a settled context.

## Added

- **`record_trace` `env` + `working_dir` options.** Pass `"env": ["KEY=VALUE", …]` and/or `"working_dir"`, applied to the recorded target — for programs that won't run without a specific environment (a Qt app's `QT_QPA_PLATFORM_PLUGIN_PATH`, an anti-analysis "run me from here" guard). Previously the recorder only inherited the server's environment, so such targets couldn't be recorded through `record_trace` at all.
- **Skill `ttd.md`** — the corrected index/record guidance, the **unbounded-search-wedges-the-engine** pitfall + recovery, and a "tabulate a pure function for a solver" technique.

## Not included (offered as a follow-up)

The deeper wedge fix — *interrupting* a runaway engine command (an unbounded `s` scan pins the single engine thread, so every later call times out behind it) — belongs one layer down in `win-kexp`'s `execute_command`. It already has the `InterruptHandle`/`SetInterrupt` watchdog used by `wait_for_event_bounded`; that pattern just needs applying around `Execute`. Happy to send it as a companion `win-kexp` PR + a pin bump here.

## Testing

- `cargo fmt --all --check`, `cargo clippy --all-targets`, `cargo test` — all clean (37 tests, +3 for `KEY=VALUE` parsing).
- `markdownlint-cli2` clean on the changed docs.
- Verified `!ttdext.index` and `!ttdext.index -status` against a real `.run` with the bundled engine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Trace recording can now pass extra environment variables and set an optional working directory.
  * Added guidance for evaluating pure functions directly on a trace.
* **Bug Fixes**
  * Improved pre-flight detection and messaging for unindexed traces, including guidance to index first.
  * Updated trace indexing/opening to use the correct tooling and build/repair persistent indexes.
  * Register queries now explain when live thread context isn’t available.
* **Documentation**
  * Refreshed “Get a trace” and troubleshooting guidance, including cautions for memory-intensive searches.
* **Tests**
  * Added coverage for strict `KEY=VALUE` environment entry parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->