### PR TITLE
fix: bound execute/dx/ttd_* commands so a runaway search can't wedge the engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`registers` no longer returns a blank result** when there is no thread context (a
   module-load break or a bare `goto_position 0`); it explains why and how to get a context.
 
+### Fixed
+
+- **A runaway debugger command no longer wedges the session.** `execute`, `dx`, and the
+  `ttd_*` query tools now run through a bounded path
+  ([`win-kexp`](https://github.com/glslang/win-kexp)'s `execute_command_bounded`) that
+  `SetInterrupt`s the engine shortly before the per-call timeout. Previously an unbounded
+  command — most importantly a broad `s` memory search — could pin the single engine thread
+  indefinitely, so every later tool call timed out behind it and the only recovery was to
+  kill and reconnect the server. Now such a command self-aborts (with a note) and the engine
+  stays usable. (win-kexp pin bumped to include `execute_command_bounded` + its interrupt drain.)
+
 ## [0.1.3] - 2026-06-14
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -814,7 +814,7 @@ dependencies = [
 [[package]]
 name = "win-kexp"
 version = "0.1.0"
-source = "git+https://github.com/glslang/win-kexp?branch=main#758a065e35b3b5a2175bc9687543b71fb03996b4"
+source = "git+https://github.com/glslang/win-kexp?branch=main#6644f0f2224544deea01b11c46bcf1e14979f696"
 dependencies = [
  "byte-strings",
  "goblin",

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -86,4 +86,26 @@ impl EngineHandle {
             )),
         }
     }
+
+    /// Runs a raw debugger command **bounded** by an engine-side watchdog. If the command
+    /// runs longer than the call budget, win-kexp's `execute_command_bounded` Ctrl+Breaks the
+    /// engine so it aborts and frees the thread — instead of a runaway command (most importantly
+    /// an unbounded `s` memory search) pinning the single engine thread and wedging every later
+    /// call. Use this for command-executing tools (`execute`, `dx`, the `ttd_*` wrappers); the
+    /// quick, inherently-bounded operations can keep using [`Self::run`].
+    pub async fn run_command(&self, command: String) -> Result<String, ErrorData> {
+        // Interrupt slightly before our own async timeout fires, so the engine returns a
+        // (possibly partial, and annotated) result rather than the timeout tripping while the
+        // engine thread is still busy — which is exactly the wedge this avoids.
+        let budget_ms = self
+            .call_timeout
+            .saturating_sub(Duration::from_secs(15))
+            .as_millis()
+            .min(u32::MAX as u128) as u32;
+        self.run(move |e| {
+            e.execute_command_bounded(&command, budget_ms)
+                .map_err(|e| e.to_string())
+        })
+        .await
+    }
 }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -7,7 +7,7 @@
 
 use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use rmcp::ErrorData;
 use tokio::sync::{mpsc, oneshot};
@@ -94,15 +94,22 @@ impl EngineHandle {
     /// call. Use this for command-executing tools (`execute`, `dx`, the `ttd_*` wrappers); the
     /// quick, inherently-bounded operations can keep using [`Self::run`].
     pub async fn run_command(&self, command: String) -> Result<String, ErrorData> {
-        // Interrupt slightly before our own async timeout fires, so the engine returns a
-        // (possibly partial, and annotated) result rather than the timeout tripping while the
-        // engine thread is still busy — which is exactly the wedge this avoids.
-        let budget_ms = self
-            .call_timeout
-            .saturating_sub(Duration::from_secs(15))
-            .as_millis()
-            .min(u32::MAX as u128) as u32;
+        // The outer timeout in `run` starts counting at *submission*, but this command may sit
+        // in the engine queue behind another job (e.g. a backgrounded `go`) before reaching the
+        // worker. Compute the watchdog budget from the time *remaining* until that timeout — not
+        // the full `call_timeout` — so it Ctrl+Breaks ~15s before the caller gives up regardless
+        // of queue wait. `submitted.elapsed()` (evaluated on the engine thread) is that wait.
+        let call_timeout = self.call_timeout;
+        let submitted = Instant::now();
         self.run(move |e| {
+            // Floor the budget so a command dequeued near the deadline still arms the watchdog
+            // (a 0 budget disables it) and thus still frees the engine promptly.
+            let budget_ms = call_timeout
+                .saturating_sub(submitted.elapsed())
+                .saturating_sub(Duration::from_secs(15))
+                .max(Duration::from_secs(15))
+                .as_millis()
+                .min(u32::MAX as u128) as u32;
             e.execute_command_bounded(&command, budget_ms)
                 .map_err(|e| e.to_string())
         })

--- a/src/server.rs
+++ b/src/server.rs
@@ -1379,10 +1379,9 @@ impl WindbgServer {
         &self,
         Parameters(args): Parameters<ExecuteArgs>,
     ) -> Result<CallToolResult, ErrorData> {
-        let out = self
-            .engine
-            .run(move |e| e.execute_command(&args.command).map_err(es))
-            .await?;
+        // Bounded: a runaway raw command (e.g. an unbounded `s` search) self-aborts instead
+        // of pinning the engine thread and wedging every later call.
+        let out = self.engine.run_command(args.command).await?;
         text_result(out)
     }
 
@@ -1472,10 +1471,9 @@ impl WindbgServer {
     #[rmcp::tool]
     async fn dx(&self, Parameters(args): Parameters<DxArgs>) -> Result<CallToolResult, ErrorData> {
         let cmd = format!("dx {}", args.expression);
-        let out = self
-            .engine
-            .run(move |e| e.execute_command(&cmd).map_err(es))
-            .await?;
+        // Bounded: a data-model query that runs away (e.g. a heavy LINQ or index build on a
+        // huge trace) self-aborts rather than pinning the engine thread.
+        let out = self.engine.run_command(cmd).await?;
         text_result(out)
     }
 
@@ -1489,10 +1487,7 @@ impl WindbgServer {
         Parameters(args): Parameters<TtdCallsArgs>,
     ) -> Result<CallToolResult, ErrorData> {
         let cmd = format!("dx @$cursession.TTD.Calls(\"{}\")", args.function);
-        let out = self
-            .engine
-            .run(move |e| e.execute_command(&cmd).map_err(es))
-            .await?;
+        let out = self.engine.run_command(cmd).await?;
         text_result(out)
     }
 
@@ -1504,23 +1499,16 @@ impl WindbgServer {
         &self,
         Parameters(args): Parameters<TtdMemoryArgs>,
     ) -> Result<CallToolResult, ErrorData> {
-        let size = args.size;
-        let mode = args.mode.clone();
-        let out = self
-            .engine
-            .run(move |e| {
-                let start = parse_u64(&args.address)?;
-                let end = start.saturating_add(size as u64);
-                let cmd = match mode {
-                    Some(m) if !m.trim().is_empty() => format!(
-                        "dx @$cursession.TTD.Memory(0x{start:x}, 0x{end:x}, \"{}\")",
-                        m.trim()
-                    ),
-                    _ => format!("dx @$cursession.TTD.Memory(0x{start:x}, 0x{end:x})"),
-                };
-                e.execute_command(&cmd).map_err(es)
-            })
-            .await?;
+        let start = parse_u64(&args.address).map_err(|e| ErrorData::internal_error(e, None))?;
+        let end = start.saturating_add(args.size as u64);
+        let cmd = match args.mode.as_deref() {
+            Some(m) if !m.trim().is_empty() => format!(
+                "dx @$cursession.TTD.Memory(0x{start:x}, 0x{end:x}, \"{}\")",
+                m.trim()
+            ),
+            _ => format!("dx @$cursession.TTD.Memory(0x{start:x}, 0x{end:x})"),
+        };
+        let out = self.engine.run_command(cmd).await?;
         text_result(out)
     }
 
@@ -1531,10 +1519,7 @@ impl WindbgServer {
     async fn ttd_events(&self) -> Result<CallToolResult, ErrorData> {
         let out = self
             .engine
-            .run(move |e| {
-                e.execute_command("dx -r2 @$curprocess.TTD.Events")
-                    .map_err(es)
-            })
+            .run_command("dx -r2 @$curprocess.TTD.Events".to_string())
             .await?;
         text_result(out)
     }


### PR DESCRIPTION
## What

Closes the engine-wedge end to end — the companion adoption of the now-merged glslang/win-kexp#68. An unbounded debugger command (most importantly a broad `s` memory search) used to pin the single engine thread indefinitely, so every subsequent tool call timed out behind it and the only recovery was to kill and reconnect the server.

## Change

- **Pin bump.** `win-kexp` → the commit that adds `execute_command_bounded` (+ its stale-interrupt drain).
- **`EngineHandle::run_command`** (`engine.rs`) — runs a raw command bounded by an engine-side watchdog that `SetInterrupt`s ~15 s before the per-call timeout, so a runaway command self-aborts (with a note) and frees the thread rather than wedging the session. Quick, inherently-bounded ops keep using `run`.
- **Routed** `execute`, `dx`, `ttd_calls`, `ttd_memory`, `ttd_events` through `run_command` — the surface where a runaway `s`/`dx` actually happens.

The budget is `call_timeout − 15 s` (285 s), so nothing that would have completed within the server's own timeout is aborted; only commands that exceed it — i.e. the wedge case — get interrupted.

## Testing

- `cargo fmt --all --check`, `cargo clippy --all-targets`, `cargo test` — all clean (34 tests).
- Builds against the bumped pin.

## Notes

Independent of #40 (the TTD index/record/messaging fixes); both touch `src/server.rs` but different tools, so at most a trivial merge. The wedge pitfall stays documented in the `ttd.md` skill for the manual-recovery case (older pins).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented long-running debugger commands from permanently blocking the session.
  * Commands that exceed their execution limit now stop automatically and provide an explanatory message.
  * Improved reliability for `execute`, `dx`, and time-travel debugging commands, keeping subsequent tool calls responsive.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->