### PR TITLE
ci(release): use the CHANGELOG section as the release body

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,15 +29,20 @@ jobs:
         shell: pwsh
         run: |
           # The release checklist says: bump Cargo.toml + plugin.json + the
-          # README release badge, then tag vX.Y.Z. Fail the release if they
-          # disagree. The README badge is static, so this guard keeps it from
-          # silently going stale.
+          # README release badge, add the CHANGELOG section, then tag vX.Y.Z.
+          # Fail the release if they disagree. The README badge is static, so
+          # this guard keeps it from silently going stale.
           $tag    = $env:GITHUB_REF_NAME -replace '^v', ''
           $cargo  = [regex]::Match((Get-Content Cargo.toml -Raw), '(?ms)^\[package\].*?^version\s*=\s*"([^"]+)"').Groups[1].Value
           $plugin = (Get-Content .claude-plugin/plugin.json -Raw | ConvertFrom-Json).version
           $readme = [regex]::Match((Get-Content README.md -Raw), 'img\.shields\.io/badge/release-v([^-]+)-').Groups[1].Value
           if ($cargo -ne $tag -or $plugin -ne $tag -or $readme -ne $tag) {
             Write-Error "Version mismatch: tag v$tag, Cargo.toml $cargo, plugin.json $plugin, README badge $readme"
+          }
+          # The release body comes from this section (see "Prepare release
+          # notes"), so a missing one must fail here, not after a 4-minute build.
+          if ((Get-Content CHANGELOG.md -Raw) -notmatch "(?m)^## \[$([regex]::Escape($tag))\]") {
+            Write-Error "CHANGELOG.md has no '## [$tag]' section"
           }
 
       - name: Install Rust toolchain
@@ -67,6 +72,32 @@ jobs:
           $hash = (Get-FileHash "dist/$name.zip" -Algorithm SHA256).Hash.ToLower()
           Set-Content dist/SHA256SUMS.txt "$hash  $name.zip"
 
+      - name: Prepare release notes
+        # Body = this version's curated CHANGELOG section, not the
+        # auto-generated commit list. Runs on dry runs too (it lands in the
+        # uploaded artifact), so the extraction is testable without tagging.
+        shell: pwsh
+        run: |
+          $ver  = [regex]::Match((Get-Content Cargo.toml -Raw), '(?ms)^\[package\].*?^version\s*=\s*"([^"]+)"').Groups[1].Value
+          $log  = Get-Content CHANGELOG.md -Raw
+          $rx   = [regex]::Escape($ver)
+
+          # Everything between this version's heading and the next one.
+          $body = [regex]::Match($log, "(?ms)^## \[$rx\][^\r\n]*\r?\n(.*?)(?=^## \[|\z)").Groups[1].Value.Trim()
+          if (-not $body) { Write-Error "CHANGELOG.md section for $ver is missing or empty" }
+
+          # CHANGELOG links are repo-relative; a release body is not rendered in
+          # a file context, so repoint them at this tag's blobs.
+          $blob = "https://github.com/$env:GITHUB_REPOSITORY/blob/v$ver"
+          $body = [regex]::Replace($body, '\]\((?!\w+:|//|#)([^)\s]+)\)', "](" + $blob + "/`$1)")
+
+          # Reuse the compare URL the CHANGELOG already defines for this version.
+          $compare = [regex]::Match($log, "(?m)^\[$rx\]:\s*(\S+)\s*$")
+          if ($compare.Success) { $body += "`n`n**Full Changelog**: $($compare.Groups[1].Value)" }
+
+          Set-Content dist/RELEASE_NOTES.md $body
+          Write-Host $body
+
       - name: Attest build provenance
         # Records a signed SLSA provenance statement linking the zip to this
         # workflow run; users verify with `gh attestation verify`.
@@ -84,7 +115,7 @@ jobs:
           files: |
             dist/*.zip
             dist/SHA256SUMS.txt
-          generate_release_notes: true
+          body_path: dist/RELEASE_NOTES.md
 
       - name: Upload artifact (dry run)
         if: github.event_name != 'push'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,10 +39,17 @@ jobs:
           if ($cargo -ne $tag -or $plugin -ne $tag -or $readme -ne $tag) {
             Write-Error "Version mismatch: tag v$tag, Cargo.toml $cargo, plugin.json $plugin, README badge $readme"
           }
-          # The release body comes from this section (see "Prepare release
-          # notes"), so a missing one must fail here, not after a 4-minute build.
-          if ((Get-Content CHANGELOG.md -Raw) -notmatch "(?m)^## \[$([regex]::Escape($tag))\]") {
-            Write-Error "CHANGELOG.md has no '## [$tag]' section"
+
+      - name: Verify the CHANGELOG has this version's section
+        # Ungated on purpose: the release body comes from this section (see
+        # "Prepare release notes"), so a missing one must fail here rather than
+        # after a four-minute build — on dry runs too, which have no tag to key
+        # off. The tag guard above already pins Cargo.toml to the tag.
+        shell: pwsh
+        run: |
+          $ver = [regex]::Match((Get-Content Cargo.toml -Raw), '(?ms)^\[package\].*?^version\s*=\s*"([^"]+)"').Groups[1].Value
+          if ((Get-Content CHANGELOG.md -Raw) -notmatch "(?m)^## \[$([regex]::Escape($ver))\]") {
+            Write-Error "CHANGELOG.md has no '## [$ver]' section"
           }
 
       - name: Install Rust toolchain
@@ -87,9 +94,12 @@ jobs:
           if (-not $body) { Write-Error "CHANGELOG.md section for $ver is missing or empty" }
 
           # CHANGELOG links are repo-relative; a release body is not rendered in
-          # a file context, so repoint them at this tag's blobs.
+          # a file context, so repoint them at this tag's blobs. The `/?` eats a
+          # root-relative link's leading slash (the lookahead has already let
+          # schemes, protocol-relative `//`, and bare fragments through
+          # untouched).
           $blob = "https://github.com/$env:GITHUB_REPOSITORY/blob/v$ver"
-          $body = [regex]::Replace($body, '\]\((?!\w+:|//|#)([^)\s]+)\)', "](" + $blob + "/`$1)")
+          $body = [regex]::Replace($body, '\]\((?!\w+:|//|#)/?([^)\s]+)\)', "](" + $blob + "/`$1)")
 
           # Reuse the compare URL the CHANGELOG already defines for this version.
           $compare = [regex]::Match($log, "(?m)^\[$rx\]:\s*(\S+)\s*$")


### PR DESCRIPTION
The release body was `generate_release_notes: true` — GitHub's raw commit list, which repeats what the compare link already shows and buries the curated prose the CHANGELOG already carries. This extracts the version's `## [x.y.z]` section and passes it as `body_path` instead.

Two wrinkles the extraction handles:

- **Relative links.** CHANGELOG links like `[driver-ioctl.md](skills/windbg-debugging/driver-ioctl.md)` have no file context in a release body, so they are repointed at the tag's blob URLs. Absolute links are left alone.
- **Compare link.** `**Full Changelog**` reuses the link reference the CHANGELOG already defines for the version (`[0.2.0]: …/compare/v0.1.3...v0.2.0`) rather than re-deriving the previous tag.

The early version guard now also requires the `## [x.y.z]` section, so a missing one fails in ~10s instead of after the four-minute build.

## Testing

- `workflow_dispatch` dry run on this branch: https://github.com/glslang/windbg-mcp/actions/runs/29953206595 (green, 3m29s). The extraction step runs on dry runs too, so `RELEASE_NOTES.md` lands in the uploaded artifact — verified its content is byte-identical (modulo CRLF) to the notes now published on v0.2.0.
- v0.2.0's release body has been backfilled with the same output: https://github.com/glslang/windbg-mcp/releases/tag/v0.2.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Release notes now use the curated changelog entry for the relevant version.
  * Relative links in release notes are converted into version-specific links for easier navigation.
  * A “Full Changelog” link is included when available.

* **Bug Fixes**
  * Releases are prevented when version information is missing or inconsistent across the project’s published documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->