### PR TITLE
ci(release): publish to the official MCP Registry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -170,11 +170,22 @@ jobs:
         # io.github.glslang/* namespace against this repo's owner — the
         # id-token: write permission above is what mints that token, so no secret
         # is needed. Tag pushes only (a dry run must not touch the registry).
+        #
+        # This runs a downloaded binary in a job holding id-token/contents: write,
+        # so pin it to a specific release and verify the archive's SHA-256 before
+        # executing it — same defense as the SHA-pinned Actions above. To bump,
+        # update both $ver and $sha together; the hash is the
+        # mcp-publisher_windows_amd64.tar.gz line from that release's
+        # registry_<ver>_checksums.txt.
         if: github.event_name == 'push' && github.ref_type == 'tag'
         shell: pwsh
         run: |
-          $url = "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_windows_amd64.tar.gz"
+          $ver = "v1.8.0"
+          $sha = "697df4aaf7941ad6fbac9ebc48bd23ff87a3131ae7bb6ee0543cb857d8029939"
+          $url = "https://github.com/modelcontextprotocol/registry/releases/download/$ver/mcp-publisher_windows_amd64.tar.gz"
           Invoke-WebRequest -Uri $url -OutFile mcp-publisher.tar.gz
+          $got = (Get-FileHash mcp-publisher.tar.gz -Algorithm SHA256).Hash.ToLower()
+          if ($got -ne $sha) { throw "mcp-publisher checksum mismatch: expected $sha, got $got" }
           tar xf mcp-publisher.tar.gz mcp-publisher.exe
           ./mcp-publisher.exe login github-oidc
           ./mcp-publisher.exe publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,9 +75,41 @@ jobs:
           $ver  = [regex]::Match((Get-Content Cargo.toml -Raw), '(?ms)^\[package\].*?^version\s*=\s*"([^"]+)"').Groups[1].Value
           $name = "windbg-mcp-v$ver-windows-x64"
           New-Item dist -ItemType Directory | Out-Null
+
+          # Zip: the manual / plugin download path (setup.md, README).
           Compress-Archive -Path target/release/windbg-mcp.exe, LICENSE -DestinationPath "dist/$name.zip"
-          $hash = (Get-FileHash "dist/$name.zip" -Algorithm SHA256).Hash.ToLower()
-          Set-Content dist/SHA256SUMS.txt "$hash  $name.zip"
+
+          # MCPB bundle: the one-click / MCP-registry path. An .mcpb is a zip with
+          # manifest.json at its root, so stamp the version into the committed
+          # manifest template, stage it beside the binary + LICENSE, and zip the
+          # staging dir's contents (they land at the archive root). Compress-Archive
+          # insists on a .zip destination, so build one and rename.
+          $stage = "mcpb_stage"
+          New-Item $stage -ItemType Directory | Out-Null
+          $m = Get-Content packaging/mcpb/manifest.json -Raw | ConvertFrom-Json
+          $m.version = $ver
+          $m | ConvertTo-Json -Depth 20 | Set-Content "$stage/manifest.json"
+          Copy-Item target/release/windbg-mcp.exe, LICENSE $stage
+          Compress-Archive -Path "$stage/*" -DestinationPath "dist/$name-mcpb.zip"
+          Move-Item "dist/$name-mcpb.zip" "dist/$name.mcpb"
+
+          # One checksum file covering both artifacts.
+          $zipHash  = (Get-FileHash "dist/$name.zip"  -Algorithm SHA256).Hash.ToLower()
+          $mcpbHash = (Get-FileHash "dist/$name.mcpb" -Algorithm SHA256).Hash.ToLower()
+          Set-Content dist/SHA256SUMS.txt @("$zipHash  $name.zip", "$mcpbHash  $name.mcpb")
+
+          # Point server.json at this release's .mcpb. CI is the source of truth for
+          # the version-derived fields (version, identifier URL, fileSha256); the
+          # committed server.json is a readable template. Copied into dist so a dry
+          # run's artifact carries the exact metadata that would be published.
+          $url = "https://github.com/$env:GITHUB_REPOSITORY/releases/download/v$ver/$name.mcpb"
+          $srv = Get-Content server.json -Raw | ConvertFrom-Json
+          $srv.version = $ver
+          $srv.packages[0].identifier = $url
+          $srv.packages[0].fileSha256 = $mcpbHash
+          $srv | ConvertTo-Json -Depth 20 | Set-Content server.json
+          Copy-Item server.json dist/server.json
+          Write-Host (Get-Content server.json -Raw)
 
       - name: Prepare release notes
         # Body = this version's curated CHANGELOG section, not the
@@ -109,12 +141,15 @@ jobs:
           Write-Host $body
 
       - name: Attest build provenance
-        # Records a signed SLSA provenance statement linking the zip to this
-        # workflow run; users verify with `gh attestation verify`.
+        # Records a signed SLSA provenance statement linking each distributed
+        # artifact (zip + .mcpb) to this workflow run; users verify with
+        # `gh attestation verify`.
         if: github.event_name == 'push' && github.ref_type == 'tag'
         uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4
         with:
-          subject-path: dist/*.zip
+          subject-path: |
+            dist/*.zip
+            dist/*.mcpb
 
       - name: Publish GitHub release
         # event_name guard: a workflow_dispatch run from a tag ref also has
@@ -124,8 +159,25 @@ jobs:
         with:
           files: |
             dist/*.zip
+            dist/*.mcpb
             dist/SHA256SUMS.txt
           body_path: dist/RELEASE_NOTES.md
+
+      - name: Publish to the MCP Registry
+        # Lists the server at registry.modelcontextprotocol.io so MCP clients can
+        # discover it. Runs after the release so the .mcpb the server.json
+        # identifier points at already exists. GitHub OIDC authorizes the
+        # io.github.glslang/* namespace against this repo's owner — the
+        # id-token: write permission above is what mints that token, so no secret
+        # is needed. Tag pushes only (a dry run must not touch the registry).
+        if: github.event_name == 'push' && github.ref_type == 'tag'
+        shell: pwsh
+        run: |
+          $url = "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_windows_amd64.tar.gz"
+          Invoke-WebRequest -Uri $url -OutFile mcp-publisher.tar.gz
+          tar xf mcp-publisher.tar.gz mcp-publisher.exe
+          ./mcp-publisher.exe login github-oidc
+          ./mcp-publisher.exe publish
 
       - name: Upload artifact (dry run)
         if: github.event_name != 'push'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   [registry.modelcontextprotocol.io](https://registry.modelcontextprotocol.io) via the
   `mcp-publisher` CLI, authenticated with GitHub OIDC (no secrets). The bundle's
   descriptor is [`packaging/mcpb/manifest.json`](packaging/mcpb/manifest.json); CI stamps
-  the release version and the artifact's SHA-256 into both files, so a release keeps the
-  same manual bump list as before (Cargo.toml + plugin.json + README badge + CHANGELOG).
+  the release version into both files and the bundle's SHA-256 into `server.json`, so a
+  release keeps the same manual bump list as before (Cargo.toml + plugin.json + README badge
+  + CHANGELOG).
 
 ## [0.2.0] - 2026-07-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `mcp-publisher` CLI, authenticated with GitHub OIDC (no secrets). The bundle's
   descriptor is [`packaging/mcpb/manifest.json`](packaging/mcpb/manifest.json); CI stamps
   the release version into both files and the bundle's SHA-256 into `server.json`, so a
-  release keeps the same manual bump list as before (Cargo.toml + plugin.json + README badge
-  + CHANGELOG).
+  release keeps the same manual bump list as before — Cargo.toml, plugin.json, the README
+  badge, and CHANGELOG.
 
 ## [0.2.0] - 2026-07-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Discoverable via the official MCP Registry.** Each release now also builds an
+  `.mcpb` bundle (`windbg-mcp-vX.Y.Z-windows-x64.mcpb`) next to the existing zip and
+  publishes a [`server.json`](server.json) entry (`io.github.glslang/windbg-mcp`) to
+  [registry.modelcontextprotocol.io](https://registry.modelcontextprotocol.io) via the
+  `mcp-publisher` CLI, authenticated with GitHub OIDC (no secrets). The bundle's
+  descriptor is [`packaging/mcpb/manifest.json`](packaging/mcpb/manifest.json); CI stamps
+  the release version and the artifact's SHA-256 into both files, so a release keeps the
+  same manual bump list as before (Cargo.toml + plugin.json + README badge + CHANGELOG).
+
 ## [0.2.0] - 2026-07-22
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -137,8 +137,8 @@ It also builds an [MCPB](https://github.com/anthropics/mcpb) bundle
 [`packaging/mcpb/manifest.json`](packaging/mcpb/manifest.json)) and publishes a
 [`server.json`](server.json) entry to the [official MCP Registry](https://registry.modelcontextprotocol.io)
 (`io.github.glslang/windbg-mcp`) with the `mcp-publisher` CLI over GitHub OIDC — no secrets. CI
-stamps the release version and the bundle's SHA-256 into `server.json` and the MCPB manifest, so
-those two files are **not** part of the manual bump list above.
+stamps the release version into both files and the bundle's SHA-256 into `server.json`, so
+neither is part of the manual bump list above.
 The zip also gets a signed
 [build-provenance attestation](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations)
 tying it to the workflow run that built it — verify with:

--- a/README.md
+++ b/README.md
@@ -132,6 +132,13 @@ add a matching entry to
 `claude plugin validate . --strict` before publishing. Pushing the tag runs
 [`release.yml`](.github/workflows/release.yml), which verifies the tag matches both manifest
 versions and the README badge, builds `windbg-mcp.exe`, and attaches the zip + SHA256 checksum to the GitHub release.
+It also builds an [MCPB](https://github.com/anthropics/mcpb) bundle
+(`windbg-mcp-vX.Y.Z-windows-x64.mcpb`, described by
+[`packaging/mcpb/manifest.json`](packaging/mcpb/manifest.json)) and publishes a
+[`server.json`](server.json) entry to the [official MCP Registry](https://registry.modelcontextprotocol.io)
+(`io.github.glslang/windbg-mcp`) with the `mcp-publisher` CLI over GitHub OIDC — no secrets. CI
+stamps the release version and the bundle's SHA-256 into `server.json` and the MCPB manifest, so
+those two files are **not** part of the manual bump list above.
 The zip also gets a signed
 [build-provenance attestation](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations)
 tying it to the workflow run that built it — verify with:

--- a/packaging/mcpb/manifest.json
+++ b/packaging/mcpb/manifest.json
@@ -1,0 +1,41 @@
+{
+  "manifest_version": "0.3",
+  "name": "windbg-mcp",
+  "display_name": "WinDbg MCP",
+  "version": "0.2.0",
+  "description": "WinDbg/DbgEng over MCP: crash dumps, live user & kernel, driver IOCTLs, and TTD.",
+  "long_description": "Requires Windows x64. Basic live/user-mode and crash-dump analysis work on the in-box System32 DbgEng, so the server connects out of the box. TTD .run replay and crash-dump !analyze additionally require bundling the WinDbg store engine DLLs next to the binary — see the repository's setup guide.",
+  "author": {
+    "name": "Gonçalo Carvalho",
+    "email": "glslang@gmail.com"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/glslang/windbg-mcp"
+  },
+  "homepage": "https://github.com/glslang/windbg-mcp",
+  "documentation": "https://github.com/glslang/windbg-mcp#readme",
+  "support": "https://github.com/glslang/windbg-mcp/issues",
+  "license": "MIT",
+  "keywords": [
+    "windbg",
+    "dbgeng",
+    "debugging",
+    "crash-dump",
+    "kernel",
+    "ttd",
+    "time-travel-debugging",
+    "windows"
+  ],
+  "server": {
+    "type": "binary",
+    "entry_point": "windbg-mcp.exe",
+    "mcp_config": {
+      "command": "${__dirname}/windbg-mcp.exe",
+      "args": []
+    }
+  },
+  "compatibility": {
+    "platforms": ["win32"]
+  }
+}

--- a/server.json
+++ b/server.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.glslang/windbg-mcp",
+  "description": "WinDbg/DbgEng over MCP: crash dumps, live user & kernel, driver IOCTLs, and TTD.",
+  "repository": {
+    "url": "https://github.com/glslang/windbg-mcp",
+    "source": "github"
+  },
+  "version": "0.2.0",
+  "packages": [
+    {
+      "registryType": "mcpb",
+      "identifier": "https://github.com/glslang/windbg-mcp/releases/download/v0.2.0/windbg-mcp-v0.2.0-windows-x64.mcpb",
+      "fileSha256": "0000000000000000000000000000000000000000000000000000000000000000",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## What & why

Lists `windbg-mcp` on the [official MCP Registry](https://registry.modelcontextprotocol.io) (`registry.modelcontextprotocol.io`) so MCP clients can discover it — independent of the community-plugin pipeline.

**Why not crates.io?** It's a dead end here: the `win-kexp` git dependency makes the crate unpublishable (crates.io forbids git/path deps), and even unblocked, `cargo install` ships source only — it wouldn't touch the WinDbg engine-DLL bundling that is the real setup friction. The MCP Registry via an MCPB bundle is self-service (GitHub OIDC), gives cross-client discovery, and rides the existing release flow.

## How it works

Each `vX.Y.Z` release now **also**:
1. Builds `windbg-mcp-vX.Y.Z-windows-x64.mcpb` (a zip with `manifest.json` at its root) next to the existing zip, and adds it to `SHA256SUMS.txt`.
2. Stamps `server.json` with the version, the release-download URL, and the bundle's SHA-256.
3. Attaches the `.mcpb` to the GitHub release and attests its provenance (alongside the zip).
4. **(tag pushes only)** installs the `mcp-publisher` CLI, `login github-oidc`, `publish`.

Auth is GitHub OIDC — **no secrets**, reusing the job's existing `id-token: write` (already present for attestation).

## Files

- **`server.json`** (new) — registry entry `io.github.glslang/windbg-mcp`, one `mcpb` package. Committed values are a readable template; **CI is the source of truth** for `version` / `identifier` / `fileSha256`.
- **`packaging/mcpb/manifest.json`** (new) — the MCPB bundle's `binary`-server descriptor, `win32`-only. Version is CI-stamped.
- **`.github/workflows/release.yml`** — build/checksum/attest the `.mcpb`, stamp `server.json`, publish to the registry.
- **`CHANGELOG.md`** / **`README.md`** — document the new artifact and that `server.json`/`manifest.json` are CI-stamped.

## Notes for the reviewer

- The manual release bump list is **unchanged** (`Cargo.toml` + `plugin.json` + README badge + `CHANGELOG`, all still guarded against the tag). `server.json`/`manifest.json` versions are stamped by CI and deliberately **not** guarded, so they're not a sixth thing to remember to bump.
- **Activates on the next tag** — the already-published `v0.2.0` has no `.mcpb`. Cut a `v0.2.1` (or later) to exercise it.
- mcpb registry ownership check = identifier URL must contain "mcp" (satisfied by the repo name) + `fileSha256` present.

## Verified locally

- Both JSON files parse; `server.json` description is 80 chars (under the registry's 100 limit).
- Simulated the exact CI stamping — `version` / `identifier` / `fileSha256` inject correctly and `$schema` survives the round-trip.
- Simulated the `.mcpb` build — `manifest.json` lands at the archive root with the stamped version and author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Windows releases now include MCPB bundles alongside ZIP packages.
  - Releases publish a corresponding `server.json` entry to the official MCP Registry.
  - Release downloads now include SHA-256 checksums for package verification.
  - Build provenance coverage now includes MCPB bundles.

- **Documentation**
  - Added MCPB and registry publishing details to the changelog.
  - Updated release documentation with versioning, checksum, and publishing information.
  - Added MCP server bundle and registry manifest metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->