### PR TITLE
docs: document the MCP registry / MCPB install path

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,19 @@ walks through it, and it mirrors the [*Build or download*](#build-or-download) a
 [*Bundling the WinDbg engine*](#bundling-the-windbg-engine) sections above. Then `/reload-plugins`
 to connect the server. The plugin points at `${CLAUDE_PLUGIN_ROOT}/target/release/windbg-mcp.exe`.
 
+### From the official MCP registry
+
+The server is listed in the [official MCP registry](https://registry.modelcontextprotocol.io) as
+**`io.github.glslang/windbg-mcp`**. Clients that support the registry — or that install
+[MCPB](https://github.com/anthropics/mcpb) bundles directly — can add it by name: the client
+downloads that release's `.mcpb` bundle, verifies its SHA-256, and wires up the `windbg-mcp.exe`
+inside it as an stdio server, with no Rust build or manual binary placement.
+
+The bundle is **Windows x64 only** and ships just the server binary, so the one-time engine setup
+still applies — for TTD `.run` replay and crash-dump `!analyze`, drop the WinDbg engine DLLs next
+to the client-extracted `windbg-mcp.exe` (the skill's `setup.md` covers it). Basic live and
+crash-dump work runs on the in-box `System32` engine without them.
+
 ### Releasing
 
 The plugin sets an explicit `version` in

--- a/skills/windbg-debugging/setup.md
+++ b/skills/windbg-debugging/setup.md
@@ -16,6 +16,13 @@ The plugin ships the source, not a binary. Put `windbg-mcp.exe` in place so the 
 `plugin.json` (`${CLAUDE_PLUGIN_ROOT}/target/release/windbg-mcp.exe`) resolves — either
 option below lands it there.
 
+> **Installing from the [MCP registry](https://registry.modelcontextprotocol.io) or an
+> [MCPB](https://github.com/anthropics/mcpb) bundle instead?** Add
+> **`io.github.glslang/windbg-mcp`** and your client fetches + SHA-256-verifies the prebuilt
+> `.mcpb` itself — skip Options A/B, which exist to populate the plugin's source layout. You
+> still do the one-time **engine bundling below**, dropping those DLLs next to the
+> *client-extracted* `windbg-mcp.exe` (its `${__dirname}`).
+
 ### Option A — download a prebuilt release (no Rust required)
 
 Each `vX.Y.Z` tag publishes a Windows x64 build on the


### PR DESCRIPTION
## What

Documents the third install path now that **`io.github.glslang/windbg-mcp`** is live on the [official MCP registry](https://registry.modelcontextprotocol.io) (published at v0.2.1).

- **README** → new *"From the official MCP registry"* subsection under *Use with an MCP client*: clients that support the registry or install [MCPB](https://github.com/anthropics/mcpb) bundles can add it by name; the client downloads the release's `.mcpb`, verifies its SHA-256, and wires up the `windbg-mcp.exe` inside it — no Rust build or manual binary placement.
- **`skills/windbg-debugging/setup.md`** → a callout under *Get the server binary* noting this path skips Options A/B (which populate the plugin's `target/release` source layout).

Both restate the standing caveats: **Windows x64 only**, and the bundle ships **only the binary**, so the one-time WinDbg engine bundling still applies — next to the *client-extracted* `windbg-mcp.exe`.

## Sanity check (done before writing this)

Resolved the entry from the live registry and validated the published bundle end-to-end:

1. Registry entry `active` / `isLatest`, v0.2.1, `registryType: mcpb`.
2. Downloaded the `.mcpb` from the recorded `identifier` → its SHA-256 **matches** the registry's `fileSha256` (a client's integrity check passes).
3. Valid MCPB zip: `manifest.json` at the archive root, `version 0.2.1`, `type binary`, `entry_point windbg-mcp.exe`, `platforms win32`.
4. Extracted the entry-point exe → real PE, **boots and speaks MCP** over stdio (initialize handshake + `tools/list` → 36 tools).

Docs lint clean locally (`markdownlint-cli2` v0.23.1, same as CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
