### PR TITLE
docs(setup): point engine bundling at the actual windbg-mcp.exe dir

### DIFF
--- a/skills/windbg-debugging/setup.md
+++ b/skills/windbg-debugging/setup.md
@@ -77,7 +77,9 @@ Either way, run `/reload-plugins` afterwards so Claude Code connects the `windbg
 
 ## WinDbg engine + extensions — for `.run` replay and crash-dump `!analyze`
 
-Drop the **WinDbg** store-package binaries next to the built binary for two reasons:
+Drop the **WinDbg** store-package binaries next to `windbg-mcp.exe` (the `$dst` below — for a
+registry/MCPB install that's the client's extraction directory, **not** `target\release`) for
+two reasons:
 
 - **TTD `.run` replay** — System32's `dbgeng.dll` **rejects** traces with `0x80070057`.
 - **Crash-dump `!analyze`** — it lives in the `winext\` extensions, which System32 doesn't ship
@@ -90,6 +92,10 @@ package:
 
 ```pwsh
 $wd  = (Get-AppxPackage Microsoft.WinDbg).InstallLocation + "\amd64"
+# $dst = the folder that actually holds windbg-mcp.exe:
+#   plugin / build-from-source layout      -> <plugin dir>\target\release
+#   installed from the MCP registry / MCPB -> the client's extraction dir (the
+#     extension's ${__dirname}; e.g. under the client's extensions folder)
 $dst = "<plugin dir>\target\release"
 Copy-Item "$wd\dbgeng.dll","$wd\dbghelp.dll","$wd\dbgcore.dll","$wd\dbgmodel.dll",`
           "$wd\symsrv.dll","$wd\msdia140.dll" $dst -Force

--- a/skills/windbg-debugging/setup.md
+++ b/skills/windbg-debugging/setup.md
@@ -92,11 +92,12 @@ package:
 
 ```pwsh
 $wd  = (Get-AppxPackage Microsoft.WinDbg).InstallLocation + "\amd64"
-# $dst = the folder that actually holds windbg-mcp.exe:
+# Set $dst to the folder that actually holds windbg-mcp.exe — pick the one for
+# your install (do not leave it as the placeholder):
 #   plugin / build-from-source layout      -> <plugin dir>\target\release
 #   installed from the MCP registry / MCPB -> the client's extraction dir (the
-#     extension's ${__dirname}; e.g. under the client's extensions folder)
-$dst = "<plugin dir>\target\release"
+#     extension's ${__dirname}, under the client's extensions folder)
+$dst = "<folder that holds windbg-mcp.exe>"
 Copy-Item "$wd\dbgeng.dll","$wd\dbghelp.dll","$wd\dbgcore.dll","$wd\dbgmodel.dll",`
           "$wd\symsrv.dll","$wd\msdia140.dll" $dst -Force
 Copy-Item "$wd\ttd"    "$dst\ttd"    -Recurse -Force   # TTDReplay*.dll, TtdExt.dll, TTDAnalyze.dll, ...


### PR DESCRIPTION
## What

Follow-up to a **Codex review comment on #49** (which merged before the review landed).

The registry/MCPB install path added in #49 tells users to skip Options A/B and let their client extract `windbg-mcp.exe` into its extension dir. But the engine-bundling snippet in `setup.md` still hardcoded:

```pwsh
$dst = "<plugin dir>\target\release"
```

Following that verbatim after an MCPB install copies the WinDbg DLLs / `winext` / `winxp` to an **unused** source-layout path — not next to the actually-running exe (`${__dirname}`) — so TTD `.run` replay and crash-dump `!analyze` stay broken on the System32 engine.

## Fix

Clarify that `$dst` must be the folder that **actually holds `windbg-mcp.exe`**:
- plugin / build-from-source layout → `target\release`
- installed from the MCP registry / an MCPB bundle → the client's extraction dir (`${__dirname}`)

Prose intro and an inline comment in the snippet both updated. Docs lint clean locally (`markdownlint-cli2` v0.23.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated WinDbg setup instructions to copy store-package binaries next to `windbg-mcp.exe`.
  * Added guidance for identifying the correct destination path across different installation layouts.
  * Clarified support for `.run` replay and crash-dump `!analyze` workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->