### PR TITLE
fix(mcp): report debugger failures as tool errors, add session handles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,12 +38,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   So does a *panic* in the report — several win-kexp methods use `.expect`, and an unwind
   would otherwise skip straight past the code that attaches the handle.
 
-  `execute` is the one path that can swap the target without going through a typed tool, so
-  the session-control commands (`.opendump`, `.attach`, `.detach`, `.kill`, `.restart`,
-  `.abandon`, `.remote`, `q`/`qd`/`qq`) retire the current handle. The match is biased
-  toward retiring — over-matching costs a re-open, under-matching would let a stale handle
-  through — but it cannot be exhaustive, so inside `execute` a handle is a strong hint
-  rather than a guarantee.
+  `execute` and `dx` are the two paths that can swap the target without going through a
+  typed tool. For `execute` the session-control commands (`.opendump`, `.attach`, `.detach`,
+  `.kill`, `.restart`, `.abandon`, `.remote`, `q`/`qd`/`qq`) retire the current handle. `dx`
+  reaches command execution through the data model's
+  `Debugger.Utility.Control.ExecuteCommand`, which runs any command string, so an expression
+  touching command execution retires the handle too — conservatively, because the command is
+  a runtime string this server never sees. Both matches are biased toward retiring —
+  over-matching costs a re-open, under-matching would let a stale handle through — and
+  neither can be exhaustive, so inside `execute` and `dx` a handle is a strong hint rather
+  than a guarantee. Everywhere else it is a guarantee.
 - **`session_status`.** Reports the handle of the session the server currently holds, or
   that none is open. It exists to recover a `session_id` a caller never received: the
   per-call timeout can fire while the engine thread is still working, and if that job then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`index_trace` is now annotated destructive.** It runs `!ttdext.index -force`, which
   deletes and rebuilds an unloadable `.idx` — replacing an on-disk artifact, whatever the
   intent. `destructiveHint: false` told clients otherwise and could bypass confirmation.
+- **Typed tools reject operands that would end the command they build.** They interpolate
+  their arguments — `u {address}`, `bp {expression}`, `!drvobj {name} 7` — and DbgEng reads
+  `;` as a command separator, so `disassemble { address: "rip; .opendump C:\other.dmp" }`
+  ran a target swap from a tool advertising `readOnlyHint: true`, and did it without going
+  through the check that retires session handles. `;`, line breaks, and (for operands
+  interpolated inside a quoted data-model string) `"` are now refused with a tool error.
+  These parameters were always documented as single operands, so nothing legitimate is
+  lost: `execute` remains available for command lists, and is annotated destructive and
+  handle-checked accordingly.
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,8 +72,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   each opener's outcome is recorded (pending / landed / failed) and `session_status` takes
   an optional `session_id` to ask about one. Outcomes are written from inside the job, under
   `catch_unwind`, so a panicking transition cannot leave an open recorded as pending
-  forever; a job that never reaches the engine is recorded as failed on the caller side. The
-  history is bounded to the last few opens.
+  forever; a job that never reaches the engine is recorded as failed on the caller side.
+
+  Only *settled* outcomes are evicted when the history fills. Forgetting a pending open
+  would be worse than remembering it indefinitely: `session_status` would report it as
+  unknown, which tells the caller to open again — duplicating an attach or a launch, and
+  letting the original land afterwards and replace the target underneath them. The history
+  can therefore exceed its bound while opens are in flight, which is self-limiting, since
+  the engine runs jobs one at a time and every job settles.
 - **Tool behaviour annotations.** All 37 tools now declare a title and the
   read-only / destructive / idempotent / open-world hints, so a client can tell
   `read_memory` apart from `execute` before prompting the user. `openWorldHint` is true for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   handle, so holding one does not prevent a replacement, it makes any later call of yours
   that supplies the handle fail instead of acting on the wrong target.
 
+  The opening tools commit the handle as soon as the target transition succeeds, before
+  their follow-up diagnostic (`lm`, `vertarget`, `r`, the TTD lifetime query) runs. A failed
+  diagnostic then reports the error *with* the `session_id` rather than swallowing it — the
+  target is genuinely open at that point, and the only other way to obtain a handle is to
+  open again, which for `launch` means spawning a second process.
+
   `execute` is the one path that can swap the target without going through a typed tool, so
   the session-control commands (`.opendump`, `.attach`, `.detach`, `.kill`, `.restart`,
   `.abandon`, `.remote`, `q`/`qd`/`qq`) retire the current handle. The match is biased

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,10 +57,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   It reports *the current* handle, not *your* handle, so recovery is a two-step check. A
   timed-out open now names the handle it would commit — the id is minted before the job is
   queued, so it can be stated up front — and the caller adopts the session only if
-  `session_status` reports that same id. A different id means another caller's open landed
-  while theirs was in flight, and the loaded target is not theirs. Without that correlation,
-  "ask for the current handle" would quietly hand the wrong target to a caller following the
-  documented recovery flow, with every later session check passing.
+  `session_status` reports that same id. Without that correlation, "ask for the current
+  handle" would quietly hand the wrong target to a caller following the documented recovery
+  flow, with every later session check passing.
+
+  A mismatch means "not yours *yet*", not "yours failed": the timeout abandons the wait, not
+  the job, so a timed-out open can still be queued and can still land. Recovery is therefore
+  a poll, and re-running the open is never the answer.
 - **Tool behaviour annotations.** All 37 tools now declare a title and the
   read-only / destructive / idempotent / open-world hints, so a client can tell
   `read_memory` apart from `execute` before prompting the user. `openWorldHint` is true for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,14 +27,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   close B. The guarantee is detection rather than exclusion — the opening tools take no
   handle, so holding one does not prevent a replacement, it makes any later call of yours
   that supplies the handle fail instead of acting on the wrong target.
+
+  `execute` is the one path that can swap the target without going through a typed tool, so
+  the session-control commands (`.opendump`, `.attach`, `.detach`, `.kill`, `.restart`,
+  `.abandon`, `.remote`, `q`/`qd`/`qq`) retire the current handle. The match is biased
+  toward retiring — over-matching costs a re-open, under-matching would let a stale handle
+  through — but it cannot be exhaustive, so inside `execute` a handle is a strong hint
+  rather than a guarantee.
 - **Tool behaviour annotations.** All 36 tools now declare a title and the
   read-only / destructive / idempotent / open-world hints, so a client can tell
-  `read_memory` apart from `execute` before prompting the user. `openWorldHint` is true
-  for every tool that can make DbgEng pull a PDB from the configured symbol server, which
-  is nearly all of them once a symbol server is on the path — `r` symbolizes the current
-  instruction, `k` symbolizes every frame, `bp module!Symbol` resolves a name. It is false
-  only for `read_memory` (raw bytes), `decode_ioctl` (pure), and `end_session` (teardown),
-  since a client may be gating network consent on that hint.
+  `read_memory` apart from `execute` before prompting the user. `openWorldHint` is true for
+  everything that touches a debug target and false only for `decode_ioctl`, which never
+  reaches the engine. Two reasons put the rest over the line: a symbol server on the path
+  means almost any command can pull a PDB (`r` symbolizes the current instruction, `k`
+  symbolizes every frame, `bp module!Symbol` resolves a name), and a KDNET session puts the
+  target itself across a network link, so even a raw `read_memory` is remote traffic. A
+  client may be gating network consent on that hint.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,11 +42,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   toward retiring — over-matching costs a re-open, under-matching would let a stale handle
   through — but it cannot be exhaustive, so inside `execute` a handle is a strong hint
   rather than a guarantee.
-- **Tool behaviour annotations.** All 36 tools now declare a title and the
+- **`session_status`.** Reports the handle of the session the server currently holds, or
+  that none is open. It exists to recover a `session_id` a caller never received: the
+  per-call timeout can fire while the engine thread is still working, and if that job then
+  succeeds it commits a handle no reply ever carried. A live `attach_kernel` is the case
+  that matters — it waits indefinitely by design, so the call reporting a timeout while the
+  attach completes later is normal, not exceptional. Recovering the handle beats the
+  alternative of retrying an attach or launch that would connect or spawn a second time.
+  Deliberately does not queue on the engine thread, since the situation it addresses is
+  that thread being parked.
+- **Tool behaviour annotations.** All 37 tools now declare a title and the
   read-only / destructive / idempotent / open-world hints, so a client can tell
   `read_memory` apart from `execute` before prompting the user. `openWorldHint` is true for
-  everything that touches a debug target and false only for `decode_ioctl`, which never
-  reaches the engine. Two reasons put the rest over the line: a symbol server on the path
+  everything that touches a debug target and false only for `decode_ioctl` and
+  `session_status`, which never reach the engine. Two reasons put the rest over the line: a
+  symbol server on the path
   means almost any command can pull a PDB (`r` symbolizes the current instruction, `k`
   symbolizes every frame, `bp module!Symbol` resolves a name), and a KDNET session puts the
   target itself across a network link, so even a raw `read_memory` is remote traffic. A
@@ -67,6 +77,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   failed operation apart from an engine that never came up: a `DebugEngine::new()` failure
   (missing or unusable `dbgeng.dll`) is permanent and now reports as a protocol error, not
   as a retryable tool error that invites the model to try again forever.
+
+- **`index_trace` is now annotated destructive.** It runs `!ttdext.index -force`, which
+  deletes and rebuilds an unloadable `.idx` — replacing an on-disk artifact, whatever the
+  intent. `destructiveHint: false` told clients otherwise and could bypass confirmation.
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Explicit session handles.** The tools that open a target (`open_dump`, `open_trace`,
+  `attach_kernel_local`, `attach_kernel`, `attach_process`, `launch`) now return a
+  `session_id`, and every tool that touches the debug target accepts it as an optional
+  argument, refusing to run when it no longer matches the session the engine holds. One
+  process drives one DbgEng session, but an MCP connection is not a session — a client may
+  interleave unrelated requests over the same stdio process — so without a handle a call
+  could silently act on a target it never opened. Omitting the argument keeps the previous
+  behaviour, so existing callers are unaffected. `decode_ioctl` (pure) and `record_trace`
+  (independent of the session) do not take it.
+- **Tool behaviour annotations.** All 36 tools now declare a title and the
+  read-only / destructive / idempotent / open-world hints, so a client can tell
+  `read_memory` apart from `execute` before prompting the user.
+
+### Changed
+
+- **Debugger failures are now tool-execution errors, not protocol errors.** An unresolvable
+  symbol, an unreadable address, a target that never stopped, or a recorder that won't
+  start now comes back as a normal tool result with `isError: true` and the debugger's text
+  intact, which is what lets the model see the failure and correct itself. Previously every
+  such failure became a JSON-RPC `-32603`, which clients surface as a transport-level fault
+  and models largely cannot act on. Only a dead engine thread remains a protocol error.
+  Semantic input validation (`decode_ioctl`'s code, `ttd_memory`'s address) moved the same
+  way — the request satisfies the schema, so the complaint belongs in the result.
+
+### Documentation
+
+- README now states which MCP protocol revision the server speaks (the `initialize`-handshake
+  era: `2025-11-25` / `2025-06-18`) and why `2026-07-28` is not supported yet.
+
 ## [0.2.1] - 2026-07-23
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   alternative of retrying an attach or launch that would connect or spawn a second time.
   Deliberately does not queue on the engine thread, since the situation it addresses is
   that thread being parked.
+
+  It reports *the current* handle, not *your* handle, so recovery is a two-step check. A
+  timed-out open now names the handle it would commit — the id is minted before the job is
+  queued, so it can be stated up front — and the caller adopts the session only if
+  `session_status` reports that same id. A different id means another caller's open landed
+  while theirs was in flight, and the loaded target is not theirs. Without that correlation,
+  "ask for the current handle" would quietly hand the wrong target to a caller following the
+  documented recovery flow, with every later session check passing.
 - **Tool behaviour annotations.** All 37 tools now declare a title and the
   read-only / destructive / idempotent / open-world hints, so a client can tell
   `read_memory` apart from `execute` before prompting the user. `openWorldHint` is true for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   rather than swallowing it. The target is genuinely open at that point, and the only other
   way to obtain a handle is to open again, which for `launch` means spawning a second
   process. A `wait_for_event` that times out counts: the dump or trace is loaded either way.
+  So does a *panic* in the report — several win-kexp methods use `.expect`, and an unwind
+  would otherwise skip straight past the code that attaches the handle.
 
   `execute` is the one path that can swap the target without going through a typed tool, so
   the session-control commands (`.opendump`, `.attach`, `.detach`, `.kill`, `.restart`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   `execute` and `dx` are the two paths that can swap the target without going through a
   typed tool. For `execute` the session-control commands (`.opendump`, `.attach`, `.detach`,
-  `.kill`, `.restart`, `.abandon`, `.remote`, `q`/`qd`/`qq`) retire the current handle. `dx`
+  `.kill`, `.restart`, `.abandon`, `.remote`, `q`/`qd`/`qq`) retire the current handle,
+  matched per command across every DbgEng command boundary — `;` and line breaks alike,
+  since `r\n.opendump other.dmp` is two commands and a scanner that split only on `;` would
+  see nothing but `r`. `dx`
   reaches command execution through the data model's
   `Debugger.Utility.Control.ExecuteCommand`, which runs any command string, so an expression
   touching command execution retires the handle too — conservatively, because the command is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,8 +98,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   their arguments — `u {address}`, `bp {expression}`, `!drvobj {name} 7` — and DbgEng reads
   `;` as a command separator, so `disassemble { address: "rip; .opendump C:\other.dmp" }`
   ran a target swap from a tool advertising `readOnlyHint: true`, and did it without going
-  through the check that retires session handles. `;`, line breaks, and (for operands
-  interpolated inside a quoted data-model string) `"` are now refused with a tool error.
+  through the check that retires session handles. Quotes are the same problem deferred:
+  `bp <location> "command"` is real WinDbg syntax — `ioctl_trace` builds exactly that form —
+  so a quote in a breakpoint location arms a target swap that fires on the next hit, outside
+  any tool call. `;`, line breaks, and `"` are now refused with a tool error, the last
+  everywhere except `dx`, whose data-model expressions use quoted literals legitimately.
   These parameters were always documented as single operands, so nothing legitimate is
   lost: `execute` remains available for command lists, and is annotated destructive and
   handle-checked accordingly.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   could silently act on a target it never opened. Omitting the argument keeps the previous
   behaviour, so existing callers are unaffected. `decode_ioctl` (pure) and `record_trace`
   (independent of the session) do not take it.
+
+  The check and the session transition both run **on the engine thread**, in the same
+  queued job as the debugger call, so they are ordered by the queue that already serialises
+  DbgEng access. Validating on the caller side would leave a time-of-check/time-of-use
+  window: with session A current, an `open_dump` for B can be in flight while the session
+  still reads A, so an `end_session(session_id=A)` would pass, queue behind the open, and
+  close B. The guarantee is detection rather than exclusion — the opening tools take no
+  handle, so holding one does not prevent a replacement, it makes any later call of yours
+  that supplies the handle fail instead of acting on the wrong target.
 - **Tool behaviour annotations.** All 36 tools now declare a title and the
   read-only / destructive / idempotent / open-world hints, so a client can tell
   `read_memory` apart from `execute` before prompting the user.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   So does a *panic* in the report — several win-kexp methods use `.expect`, and an unwind
   would otherwise skip straight past the code that attaches the handle.
 
+  One limit is documented rather than fixed: win-kexp bundles the wait for the initial
+  break into `launch_process`, `attach_process` and the kernel attaches, so from this server
+  a failure there can mean "nothing happened" or "the process started / the attach
+  succeeded, then the wait failed", and the two are indistinguishable. Those tools therefore
+  say so on failure and point at `vertarget` rather than advising a blind retry, which for
+  `launch` would start a second process. Splitting them properly is a win-kexp change.
+
   `execute` and `dx` are the two paths that can swap the target without going through a
   typed tool. For `execute` the session-control commands (`.opendump`, `.attach`, `.detach`,
   `.kill`, `.restart`, `.abandon`, `.remote`, `q`/`qd`/`qq`) retire the current handle,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,9 +65,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   handle" would quietly hand the wrong target to a caller following the documented recovery
   flow, with every later session check passing.
 
-  A mismatch means "not yours *yet*", not "yours failed": the timeout abandons the wait, not
-  the job, so a timed-out open can still be queued and can still land. Recovery is therefore
-  a poll, and re-running the open is never the answer.
+  The current handle alone cannot say *which* of those a mismatch means — "not yours" is
+  equally true while an open is still queued and after it has permanently failed — and the
+  two need opposite responses: a pending open must not be re-run (that attaches or launches
+  a second time), while a failed one must be, since nothing else will produce a target. So
+  each opener's outcome is recorded (pending / landed / failed) and `session_status` takes
+  an optional `session_id` to ask about one. Outcomes are written from inside the job, under
+  `catch_unwind`, so a panicking transition cannot leave an open recorded as pending
+  forever; a job that never reaches the engine is recorded as failed on the caller side. The
+  history is bounded to the last few opens.
 - **Tool behaviour annotations.** All 37 tools now declare a title and the
   read-only / destructive / idempotent / open-world hints, so a client can tell
   `read_memory` apart from `execute` before prompting the user. `openWorldHint` is true for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   that supplies the handle fail instead of acting on the wrong target.
 - **Tool behaviour annotations.** All 36 tools now declare a title and the
   read-only / destructive / idempotent / open-world hints, so a client can tell
-  `read_memory` apart from `execute` before prompting the user.
+  `read_memory` apart from `execute` before prompting the user. `openWorldHint` is true
+  for every tool that can make DbgEng pull a PDB from the configured symbol server, which
+  is nearly all of them once a symbol server is on the path — `r` symbolizes the current
+  instruction, `k` symbolizes every frame, `bp module!Symbol` resolves a name. It is false
+  only for `read_memory` (raw bytes), `decode_ioctl` (pure), and `end_session` (teardown),
+  since a client may be gating network consent on that hint.
 
 ### Changed
 
@@ -41,6 +46,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and models largely cannot act on. Only a dead engine thread remains a protocol error.
   Semantic input validation (`decode_ioctl`'s code, `ttd_memory`'s address) moved the same
   way — the request satisfies the schema, so the complaint belongs in the result.
+
+  The classification is made by the engine worker, which is the only place that can tell a
+  failed operation apart from an engine that never came up: a `DebugEngine::new()` failure
+  (missing or unusable `dbgeng.dll`) is permanent and now reports as a protocol error, not
+  as a retryable tool error that invites the model to try again forever.
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,11 +28,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   handle, so holding one does not prevent a replacement, it makes any later call of yours
   that supplies the handle fail instead of acting on the wrong target.
 
-  The opening tools commit the handle as soon as the target transition succeeds, before
-  their follow-up diagnostic (`lm`, `vertarget`, `r`, the TTD lifetime query) runs. A failed
-  diagnostic then reports the error *with* the `session_id` rather than swallowing it — the
-  target is genuinely open at that point, and the only other way to obtain a handle is to
-  open again, which for `launch` means spawning a second process.
+  The opening tools commit the handle as soon as the target transition succeeds — the
+  transition being exactly the one DbgEng call that replaces the target, and nothing else.
+  Everything after it (the load wait, and the `lm` / `vertarget` / `r` / TTD lifetime
+  diagnostic) runs post-commit, so a failure there reports the error *with* the `session_id`
+  rather than swallowing it. The target is genuinely open at that point, and the only other
+  way to obtain a handle is to open again, which for `launch` means spawning a second
+  process. A `wait_for_event` that times out counts: the dump or trace is loaded either way.
 
   `execute` is the one path that can swap the target without going through a typed tool, so
   the session-control commands (`.opendump`, `.attach`, `.detach`, `.kill`, `.restart`,

--- a/README.md
+++ b/README.md
@@ -255,6 +255,17 @@ may still be queued behind other work and may still run. Keep polling rather tha
 in either case do not re-run the open. `session_status` does not queue on the engine thread, so it
 still answers while a parked attach holds it.
 
+### Typed operands are operands, not commands
+
+The typed tools build debugger commands by interpolation (`u {address}`, `bp {expression}`,
+`!drvobj {name} 7`), and DbgEng treats `;` as a command separator. So those parameters refuse `;`,
+line breaks, and — where the operand lands inside a quoted data-model string — `"`. Without that,
+`disassemble { address: "rip; .opendump C:\other.dmp" }` would replace the debug target from a tool
+that reports itself read-only, and would do it without retiring anyone's session handle.
+
+Nothing legitimate is lost: these parameters were always single operands. Use `execute` to run a
+command list — it is annotated destructive and retires the handle when a command changes the target.
+
 ### Error reporting
 
 A failed *debugger operation* — an unresolvable symbol, an unreadable address, a target that never

--- a/README.md
+++ b/README.md
@@ -229,6 +229,13 @@ The guarantee is *detection, not exclusion*: the opening tools deliberately take
 holding a handle does not stop another caller replacing your target — it guarantees that any later
 call of yours which supplies the handle fails loudly instead of acting on a target you did not open.
 
+One caveat, in `execute`. The typed tools announce their own transitions, but the raw hatch can
+replace the target directly (`.opendump`, `.attach`, `.detach`, `.kill`, `.restart`, `.abandon`,
+`.remote`, `q`/`qd`/`qq`), and those commands retire the current handle. The match is deliberately
+biased toward retiring: over-matching costs one re-open, under-matching would let a stale handle
+through. It cannot be exhaustive, though — DbgEng has more ways to reach the target than a name list
+can enumerate — so inside `execute` a handle is a strong hint rather than a guarantee.
+
 The argument is optional — omit it and a call operates on whatever session is current, exactly as
 before. `decode_ioctl` (pure) and `record_trace` (independent of the debug session) do not take it.
 

--- a/README.md
+++ b/README.md
@@ -250,16 +250,19 @@ not the job, so the open may still be running and may still commit a handle no r
 `attach_kernel` is the case that matters: it waits indefinitely by design, so a call reporting a
 timeout while the attach completes moments later is normal (see *Limitations & notes*).
 
-A timed-out open therefore names the handle it *would* commit. Recovery is a two-step check:
+A timed-out open therefore names the handle it *would* commit, and **`session_status`** answers for
+it: pass that id and it reports whether the open is still **pending**, has **landed**, or has
+**failed**.
 
-1. Note the `session_id` the timeout message gives you.
-2. Poll **`session_status`**, which reports the handle the server currently holds.
+That three-way answer is the point. The current handle alone cannot distinguish them — "not yours"
+is equally true while you wait and after you have failed — and the two cases need opposite
+responses. While pending, re-running the open would attach to or start a *second* target. Once
+failed, opening again is the only way forward. Guessing either way is a real mistake, so the server
+tracks the outcome rather than leaving you to infer it.
 
-The session is yours once `session_status` reports that same id. A *different* id means yours has
-not landed **yet** — not that it failed: the timeout abandons the wait, not the job, so your open
-may still be queued behind other work and may still run. Keep polling rather than concluding, and
-in either case do not re-run the open. `session_status` does not queue on the engine thread, so it
-still answers while a parked attach holds it.
+Only the last few opens are remembered; an id older than that reads as forgotten, which you should
+treat as gone. `session_status` does not queue on the engine thread, so it still answers while a
+parked attach holds it.
 
 ### Typed operands are operands, not commands
 

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ gh attestation verify <zip> --repo glslang/windbg-mcp `
 
 | Group | Tools |
 |-------|-------|
-| Session | `open_dump`, `open_trace`, `attach_kernel_local`, `attach_kernel`, `attach_process`, `launch`, `end_session` |
+| Session | `open_dump`, `open_trace`, `attach_kernel_local`, `attach_kernel`, `attach_process`, `launch`, `end_session`, `session_status` |
 | State   | `registers`, `read_memory`, `backtrace`, `modules`, `threads`, `disassemble`, `dx` |
 | Control | `go`, `step_over`, `step_into`, `set_breakpoint` |
 | TTD nav | `step_back` (`t-`), `step_over_back` (`p-`), `reverse_go` (`g-`), `goto_position` (`!tt`) |
@@ -238,6 +238,14 @@ can enumerate — so inside `execute` a handle is a strong hint rather than a gu
 
 The argument is optional — omit it and a call operates on whatever session is current, exactly as
 before. `decode_ioctl` (pure) and `record_trace` (independent of the debug session) do not take it.
+
+If you never received a handle, ask for it with **`session_status`** rather than opening again. The
+per-call timeout can fire while the engine thread is still working, and a job that then succeeds
+commits a handle no reply carried. A live `attach_kernel` is the case that matters: it waits
+indefinitely by design, so a call that reports a timeout while the attach completes moments later is
+normal (see *Limitations & notes*). Retrying the attach would connect a second time; `session_status`
+just hands you the handle. It does not queue on the engine thread, so it still answers while a parked
+attach holds it.
 
 ### Error reporting
 

--- a/README.md
+++ b/README.md
@@ -258,10 +258,15 @@ still answers while a parked attach holds it.
 ### Typed operands are operands, not commands
 
 The typed tools build debugger commands by interpolation (`u {address}`, `bp {expression}`,
-`!drvobj {name} 7`), and DbgEng treats `;` as a command separator. So those parameters refuse `;`,
-line breaks, and — where the operand lands inside a quoted data-model string — `"`. Without that,
+`!drvobj {name} 7`), so those parameters refuse `;`, line breaks, and `"` — the last everywhere
+except `dx`, whose data-model expressions use quoted literals legitimately.
+
+Two things go wrong without that. DbgEng treats `;` as a command separator, so
 `disassemble { address: "rip; .opendump C:\other.dmp" }` would replace the debug target from a tool
-that reports itself read-only, and would do it without retiring anyone's session handle.
+that reports itself read-only. And `bp <location> "command"` is real WinDbg syntax — `ioctl_trace`
+builds exactly that form — so a quote in a breakpoint location arms a command that runs on every
+hit, replacing the target at some arbitrary later moment, outside any tool call and outside anything
+that could retire the session handle.
 
 Nothing legitimate is lost: these parameters were always single operands. Use `execute` to run a
 command list — it is annotated destructive and retires the handle when a command changes the target.

--- a/README.md
+++ b/README.md
@@ -260,9 +260,10 @@ responses. While pending, re-running the open would attach to or start a *second
 failed, opening again is the only way forward. Guessing either way is a real mistake, so the server
 tracks the outcome rather than leaving you to infer it.
 
-Only the last few opens are remembered; an id older than that reads as forgotten, which you should
-treat as gone. `session_status` does not queue on the engine thread, so it still answers while a
-parked attach holds it.
+Only the last few *settled* opens are remembered — an open still in flight is never forgotten, so an
+id `session_status` does not recognise is one that finished a while ago, and re-opening is safe.
+`session_status` does not queue on the engine thread, so it still answers while a parked attach
+holds it.
 
 ### Typed operands are operands, not commands
 

--- a/README.md
+++ b/README.md
@@ -239,13 +239,20 @@ can enumerate — so inside `execute` a handle is a strong hint rather than a gu
 The argument is optional — omit it and a call operates on whatever session is current, exactly as
 before. `decode_ioctl` (pure) and `record_trace` (independent of the debug session) do not take it.
 
-If you never received a handle, ask for it with **`session_status`** rather than opening again. The
-per-call timeout can fire while the engine thread is still working, and a job that then succeeds
-commits a handle no reply carried. A live `attach_kernel` is the case that matters: it waits
-indefinitely by design, so a call that reports a timeout while the attach completes moments later is
-normal (see *Limitations & notes*). Retrying the attach would connect a second time; `session_status`
-just hands you the handle. It does not queue on the engine thread, so it still answers while a parked
-attach holds it.
+If an open times out, do not open again — recover instead. The per-call timeout abandons the *wait*,
+not the job, so the open may still be running and may still commit a handle no reply carried. A live
+`attach_kernel` is the case that matters: it waits indefinitely by design, so a call reporting a
+timeout while the attach completes moments later is normal (see *Limitations & notes*).
+
+A timed-out open therefore names the handle it *would* commit. Recovery is a two-step check:
+
+1. Note the `session_id` the timeout message gives you.
+2. Call **`session_status`**, which reports the handle the server currently holds.
+
+Adopt the session only if the two match. If `session_status` reports a *different* id, another
+caller's open landed while yours was in flight and that target is not yours — the mismatch is the
+point of naming the id up front. `session_status` does not queue on the engine thread, so it still
+answers while a parked attach holds it.
 
 ### Error reporting
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,13 @@ The low-level engine bindings live in [`win-kexp`](https://github.com/glslang/wi
 - **`ttd.rs`** — locates `TTD.exe` and launches trace recording.
 - **`main.rs`** — tokio + stdio transport. **Logs go to stderr** (stdout is the JSON-RPC channel).
 
+**MCP protocol revision:** this server speaks the `initialize`-handshake ("legacy") era of MCP —
+`2025-11-25` and `2025-06-18`, whichever the client negotiates — because that is what `rmcp` 1.x
+implements. The `2026-07-28` revision replaces the handshake with a stateless, per-request model
+(`server/discover`, `resultType`, per-request `_meta`); clients that speak *only* `2026-07-28` cannot
+talk to this server. Support for it waits on a stable `rmcp` 3.x (`2026-07-28` support currently
+exists only in its beta line).
+
 ## Requirements
 
 - Windows x64 (host bitness must match the target).
@@ -200,6 +207,28 @@ gh attestation verify <zip> --repo glslang/windbg-mcp `
 | TTD analysis | `ttd_calls`, `ttd_memory`, `ttd_events`, `index_trace`, `record_trace` |
 | Driver IOCTL | `decode_ioctl`, `driver_object`, `device_object`, `irp_stack`, `ioctl_trace`, `reachable_from_dispatch` |
 | Raw     | `execute` — run any debugger command, returns full text output |
+
+### Session handles
+
+The six Session tools that open a target (`open_dump`, `open_trace`, `attach_kernel_local`,
+`attach_kernel`, `attach_process`, `launch`) return a **`session_id`**. Every tool that touches the
+debug target accepts it as an optional argument and refuses to run if it no longer matches the
+session the engine is attached to.
+
+This matters because one server process drives one DbgEng session, while an MCP connection is *not*
+a session: a client may interleave unrelated requests over the same stdio process. Without a handle,
+a `read_memory` issued after someone else's `open_dump` silently reads the wrong target. Passing
+`session_id` turns that into a visible error instead.
+
+The argument is optional — omit it and a call operates on whatever session is current, exactly as
+before. `decode_ioctl` (pure) and `record_trace` (independent of the debug session) do not take it.
+
+### Error reporting
+
+A failed *debugger operation* — an unresolvable symbol, an unreadable address, a target that never
+stopped — comes back as a normal tool result with `isError: true` and the debugger's own text, so
+the model can read it and correct itself. Only a dead engine thread is reported as a JSON-RPC
+protocol error.
 
 The forward (`go`/`step_over`/`step_into`) and reverse (`reverse_go`/`step_over_back`/`step_back`)
 control tools mirror a debugger UI's F9/F8/F7 and Shift+F9/F8/F7, so an agent can drive a trace in

--- a/README.md
+++ b/README.md
@@ -247,12 +247,13 @@ timeout while the attach completes moments later is normal (see *Limitations & n
 A timed-out open therefore names the handle it *would* commit. Recovery is a two-step check:
 
 1. Note the `session_id` the timeout message gives you.
-2. Call **`session_status`**, which reports the handle the server currently holds.
+2. Poll **`session_status`**, which reports the handle the server currently holds.
 
-Adopt the session only if the two match. If `session_status` reports a *different* id, another
-caller's open landed while yours was in flight and that target is not yours — the mismatch is the
-point of naming the id up front. `session_status` does not queue on the engine thread, so it still
-answers while a parked attach holds it.
+The session is yours once `session_status` reports that same id. A *different* id means yours has
+not landed **yet** — not that it failed: the timeout abandons the wait, not the job, so your open
+may still be queued behind other work and may still run. Keep polling rather than concluding, and
+in either case do not re-run the open. `session_status` does not queue on the engine thread, so it
+still answers while a parked attach holds it.
 
 ### Error reporting
 

--- a/README.md
+++ b/README.md
@@ -229,12 +229,18 @@ The guarantee is *detection, not exclusion*: the opening tools deliberately take
 holding a handle does not stop another caller replacing your target — it guarantees that any later
 call of yours which supplies the handle fails loudly instead of acting on a target you did not open.
 
-One caveat, in `execute`. The typed tools announce their own transitions, but the raw hatch can
-replace the target directly (`.opendump`, `.attach`, `.detach`, `.kill`, `.restart`, `.abandon`,
-`.remote`, `q`/`qd`/`qq`), and those commands retire the current handle. The match is deliberately
-biased toward retiring: over-matching costs one re-open, under-matching would let a stale handle
-through. It cannot be exhaustive, though — DbgEng has more ways to reach the target than a name list
-can enumerate — so inside `execute` a handle is a strong hint rather than a guarantee.
+Two caveats, both in the command hatches. The typed tools announce their own transitions, but
+`execute` can replace the target directly (`.opendump`, `.attach`, `.detach`, `.kill`, `.restart`,
+`.abandon`, `.remote`, `q`/`qd`/`qq`), and those commands retire the current handle. `dx` is the
+second hatch: the data model reaches `Debugger.Utility.Control.ExecuteCommand`, which runs any
+command, so an expression that touches command execution retires the handle too — conservatively,
+since the command it runs is a runtime string this server never sees.
+
+Both matches are deliberately biased toward retiring: over-matching costs one re-open,
+under-matching would let a stale handle through. Neither can be exhaustive — DbgEng has more ways to
+reach the target than a name list can enumerate, and the data model is extensible — so inside
+`execute` and `dx` a handle is a strong hint rather than a guarantee. Everywhere else it is a
+guarantee.
 
 The argument is optional — omit it and a call operates on whatever session is current, exactly as
 before. `decode_ioctl` (pure) and `record_trace` (independent of the debug session) do not take it.

--- a/README.md
+++ b/README.md
@@ -220,6 +220,15 @@ a session: a client may interleave unrelated requests over the same stdio proces
 a `read_memory` issued after someone else's `open_dump` silently reads the wrong target. Passing
 `session_id` turns that into a visible error instead.
 
+The check runs **on the engine thread**, in the same queued job as the debugger call it guards.
+That ordering is what makes it sound: checking on the caller side would leave a window in which a
+concurrently-issued `open_dump` is queued ahead of a call that already passed validation, so the
+call would still execute against the replaced target.
+
+The guarantee is *detection, not exclusion*: the opening tools deliberately take no `session_id`, so
+holding a handle does not stop another caller replacing your target — it guarantees that any later
+call of yours which supplies the handle fails loudly instead of acting on a target you did not open.
+
 The argument is optional — omit it and a call operates on whatever session is current, exactly as
 before. `decode_ioctl` (pure) and `record_trace` (independent of the debug session) do not take it.
 

--- a/skills/windbg-debugging/SKILL.md
+++ b/skills/windbg-debugging/SKILL.md
@@ -56,9 +56,9 @@ a bare `execute`, which only sets the run state and doesn't move the target.
   that quietly returns someone else's memory. Omitting it means "whatever session is current".
   If an open **times out**, do not retry it — that connects or spawns a second time. The timeout
   abandons the wait, not the job, so the open may still land; the message names the `session_id`
-  it would commit. Poll `session_status` and adopt the session **only once it reports that same
-  id**. A different id means yours hasn't landed *yet* — it may still be queued — not that it
-  failed, so keep polling rather than concluding, and never re-run the open.
+  it would commit. Ask `session_status { "session_id": "<that id>" }` — it reports **pending**,
+  **landed**, or **failed**. While pending, do not re-run the open (that attaches or launches a
+  second time); once failed, re-running is the only way forward.
 - **A failed debugger operation comes back as a normal tool result**, flagged as an error and
   carrying the debugger's own text — read it and adjust (wrong symbol, unmapped address, target
   still running). Only a dead engine surfaces as a transport-level protocol error.

--- a/skills/windbg-debugging/SKILL.md
+++ b/skills/windbg-debugging/SKILL.md
@@ -56,8 +56,9 @@ a bare `execute`, which only sets the run state and doesn't move the target.
   that quietly returns someone else's memory. Omitting it means "whatever session is current".
   If an open **times out**, do not retry it — that connects or spawns a second time. The timeout
   abandons the wait, not the job, so the open may still land; the message names the `session_id`
-  it would commit. Call `session_status` and adopt the session **only if it reports that same
-  id** — a different id means someone else's open landed and that target is not yours.
+  it would commit. Poll `session_status` and adopt the session **only once it reports that same
+  id**. A different id means yours hasn't landed *yet* — it may still be queued — not that it
+  failed, so keep polling rather than concluding, and never re-run the open.
 - **A failed debugger operation comes back as a normal tool result**, flagged as an error and
   carrying the debugger's own text — read it and adjust (wrong symbol, unmapped address, target
   still running). Only a dead engine surfaces as a transport-level protocol error.

--- a/skills/windbg-debugging/SKILL.md
+++ b/skills/windbg-debugging/SKILL.md
@@ -30,7 +30,7 @@ already does the job.
 
 | Group | Tools |
 |-------|-------|
-| Session | `open_dump`, `open_trace`, `attach_kernel_local`, `attach_kernel`, `attach_process`, `launch`, `end_session` |
+| Session | `open_dump`, `open_trace`, `attach_kernel_local`, `attach_kernel`, `attach_process`, `launch`, `end_session`, `session_status` |
 | State | `registers`, `read_memory`, `backtrace`, `modules`, `threads`, `disassemble`, `dx` |
 | Control | `go`, `step_over`, `step_into`, `set_breakpoint` |
 | TTD nav | `step_back` (`t-`), `step_over_back` (`p-`), `reverse_go` (`g-`), `goto_position` (`!tt`) |
@@ -54,6 +54,9 @@ a bare `execute`, which only sets the run state and doesn't move the target.
   call. The server process is shared, so another caller can replace the target underneath you —
   with the handle that becomes a clear "stale session handle" error instead of a `read_memory`
   that quietly returns someone else's memory. Omitting it means "whatever session is current".
+  If you never got one back — most likely after an `attach_kernel` that reported a timeout while
+  the engine completed the attach later — call `session_status` to recover it. Do **not** retry
+  the attach or launch; that connects or spawns a second time.
 - **A failed debugger operation comes back as a normal tool result**, flagged as an error and
   carrying the debugger's own text — read it and adjust (wrong symbol, unmapped address, target
   still running). Only a dead engine surfaces as a transport-level protocol error.

--- a/skills/windbg-debugging/SKILL.md
+++ b/skills/windbg-debugging/SKILL.md
@@ -50,6 +50,13 @@ a bare `execute`, which only sets the run state and doesn't move the target.
   ordered, so a pipelined call can run before `open_dump` establishes a target and fail with
   `0x80040205`, and pipelining stateful debugger commands is unsafe regardless. (Normal MCP
   clients serialize call→result; this only bites custom/batched callers.)
+- **Carry the `session_id`.** The tools that open a target return one; pass it on every later
+  call. The server process is shared, so another caller can replace the target underneath you —
+  with the handle that becomes a clear "stale session handle" error instead of a `read_memory`
+  that quietly returns someone else's memory. Omitting it means "whatever session is current".
+- **A failed debugger operation comes back as a normal tool result**, flagged as an error and
+  carrying the debugger's own text — read it and adjust (wrong symbol, unmapped address, target
+  still running). Only a dead engine surfaces as a transport-level protocol error.
 - **Symbol *names* (`module!func`) need three things together:** (a) `msdia140.dll`
   bundled next to the binary, (b) a symbol path (`execute` →
   `.sympath srv*C:\ProgramData\Dbg\sym*https://msdl.microsoft.com/download/symbols`), and

--- a/skills/windbg-debugging/SKILL.md
+++ b/skills/windbg-debugging/SKILL.md
@@ -54,9 +54,10 @@ a bare `execute`, which only sets the run state and doesn't move the target.
   call. The server process is shared, so another caller can replace the target underneath you —
   with the handle that becomes a clear "stale session handle" error instead of a `read_memory`
   that quietly returns someone else's memory. Omitting it means "whatever session is current".
-  If you never got one back — most likely after an `attach_kernel` that reported a timeout while
-  the engine completed the attach later — call `session_status` to recover it. Do **not** retry
-  the attach or launch; that connects or spawns a second time.
+  If an open **times out**, do not retry it — that connects or spawns a second time. The timeout
+  abandons the wait, not the job, so the open may still land; the message names the `session_id`
+  it would commit. Call `session_status` and adopt the session **only if it reports that same
+  id** — a different id means someone else's open landed and that target is not yours.
 - **A failed debugger operation comes back as a normal tool result**, flagged as an error and
   carrying the debugger's own text — read it and adjust (wrong symbol, unmapped address, target
   still running). Only a dead engine surfaces as a transport-level protocol error.

--- a/skills/windbg-debugging/SKILL.md
+++ b/skills/windbg-debugging/SKILL.md
@@ -80,7 +80,10 @@ a bare `execute`, which only sets the run state and doesn't move the target.
   any thread is live) returns `0x80040205`; `go` to a breakpoint first.
 - **`dx` is the escape hatch for the data model** — any LINQ query beyond the
   `ttd_calls`/`ttd_memory`/`ttd_events` wrappers, e.g.
-  `@$cursession.TTD.Calls("ntdll!NtCreateFile").Where(c => c.ReturnValue != 0)`.
+  `@$cursession.TTD.Calls("ntdll!NtCreateFile").Where(c => c.ReturnValue != 0)`. Note it can also
+  run debugger commands via `Debugger.Utility.Control.ExecuteCommand`, so like `execute` it is
+  annotated destructive and retires your `session_id` when the expression touches command
+  execution. Ordinary TTD queries don't trip it.
 - **TTD is user-mode only** (a Microsoft limitation) — you cannot time-travel a kernel target.
 - **Each tool call is bounded by a per-call timeout** (~60s for load/exec waits); a `go`
   against a long-running live target may hit it.

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -5,16 +5,42 @@
 //! OS thread and marshal every operation onto it over a channel, returning results
 //! to the async (rmcp/tokio) side via oneshot replies.
 
+use std::fmt;
 use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::thread;
 use std::time::{Duration, Instant};
 
-use rmcp::ErrorData;
 use tokio::sync::{mpsc, oneshot};
 use win_kexp::dbgeng::DebugEngine;
 
 /// Result of an engine operation: `Ok(text)` or `Err(message)`.
 type Reply = Result<String, String>;
+
+/// Why an engine call failed, split by who can act on the failure.
+///
+/// The MCP tool spec draws exactly this line: failures the model can see and
+/// self-correct from belong in the tool *result* (`isError: true`), while failures
+/// of the server machinery belong in a JSON-RPC error. Keeping the two apart here
+/// lets [`crate::server`] render each one the right way instead of collapsing every
+/// debugger hiccup into an opaque protocol error the model never really sees.
+#[derive(Debug)]
+pub enum EngineError {
+    /// The debugger ran the operation and it failed — an unresolvable symbol, an
+    /// unreadable address, a command error, a target that never stopped. Actionable:
+    /// the model can adjust its arguments and retry.
+    Debugger(String),
+    /// The engine itself is unusable — the worker thread is gone or dropped the reply.
+    /// Nothing the model can do about it.
+    Unavailable(String),
+}
+
+impl fmt::Display for EngineError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Debugger(m) | Self::Unavailable(m) => f.write_str(m),
+        }
+    }
+}
 
 /// A unit of work to run on the engine thread, plus where to send its result.
 struct Job {
@@ -65,7 +91,7 @@ impl EngineHandle {
     }
 
     /// Runs `f` on the engine thread, awaiting the result with the configured timeout.
-    pub async fn run<F>(&self, f: F) -> Result<String, ErrorData>
+    pub async fn run<F>(&self, f: F) -> Result<String, EngineError>
     where
         F: FnOnce(&DebugEngine) -> Reply + Send + 'static,
     {
@@ -75,14 +101,17 @@ impl EngineHandle {
                 run: Box::new(f),
                 reply: rtx,
             })
-            .map_err(|_| ErrorData::internal_error("engine thread unavailable", None))?;
+            .map_err(|_| EngineError::Unavailable("engine thread unavailable".to_string()))?;
         match tokio::time::timeout(self.call_timeout, rrx).await {
             Ok(Ok(Ok(s))) => Ok(s),
-            Ok(Ok(Err(e))) => Err(ErrorData::internal_error(e, None)),
-            Ok(Err(_)) => Err(ErrorData::internal_error("engine dropped reply", None)),
-            Err(_) => Err(ErrorData::internal_error(
-                "engine call timed out (the target may still be running)",
-                None,
+            // The debugger reached a verdict and it was a failure — including a panic
+            // caught by the worker, which leaves the engine usable for the next call.
+            Ok(Ok(Err(e))) => Err(EngineError::Debugger(e)),
+            Ok(Err(_)) => Err(EngineError::Unavailable("engine dropped reply".to_string())),
+            // A timeout is an operational outcome, not broken plumbing: the target may
+            // simply still be running, and the model can wait, retry, or end the session.
+            Err(_) => Err(EngineError::Debugger(
+                "engine call timed out (the target may still be running)".to_string(),
             )),
         }
     }
@@ -93,7 +122,7 @@ impl EngineHandle {
     /// an unbounded `s` memory search) pinning the single engine thread and wedging every later
     /// call. Use this for command-executing tools (`execute`, `dx`, the `ttd_*` wrappers); the
     /// quick, inherently-bounded operations can keep using [`Self::run`].
-    pub async fn run_command(&self, command: String) -> Result<String, ErrorData> {
+    pub async fn run_command(&self, command: String) -> Result<String, EngineError> {
         // The outer timeout in `run` starts counting at *submission*, but this command may sit
         // in the engine queue behind another job (e.g. a backgrounded `go`) before reaching the
         // worker. Compute the watchdog budget from the time *remaining* until that timeout — not

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -35,6 +35,11 @@ pub enum EngineError {
     /// unreadable address, a command error, a target that never stopped. Actionable:
     /// the model can adjust its arguments and retry.
     Debugger(String),
+    /// The call outlived its budget. Reported to the model exactly like [`Self::Debugger`],
+    /// but kept separate because it means something the caller must know: the job was
+    /// abandoned by the *waiter*, not by the engine, so it may still be running and may
+    /// still succeed. Anything whose retry has side effects has to say so.
+    Timeout(String),
     /// The engine itself is unusable — the worker thread is gone or dropped the reply.
     /// Nothing the model can do about it.
     Unavailable(String),
@@ -43,7 +48,7 @@ pub enum EngineError {
 impl fmt::Display for EngineError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::Debugger(m) | Self::Unavailable(m) => f.write_str(m),
+            Self::Debugger(m) | Self::Timeout(m) | Self::Unavailable(m) => f.write_str(m),
         }
     }
 }
@@ -121,7 +126,8 @@ impl EngineHandle {
             Ok(Err(_)) => Err(EngineError::Unavailable("engine dropped reply".to_string())),
             // A timeout is an operational outcome, not broken plumbing: the target may
             // simply still be running, and the model can wait, retry, or end the session.
-            Err(_) => Err(EngineError::Debugger(
+            // Note the job itself is *not* cancelled — only this wait for it is.
+            Err(_) => Err(EngineError::Timeout(
                 "engine call timed out (the target may still be running)".to_string(),
             )),
         }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -122,7 +122,14 @@ impl EngineHandle {
     /// an unbounded `s` memory search) pinning the single engine thread and wedging every later
     /// call. Use this for command-executing tools (`execute`, `dx`, the `ttd_*` wrappers); the
     /// quick, inherently-bounded operations can keep using [`Self::run`].
-    pub async fn run_command(&self, command: String) -> Result<String, EngineError> {
+    ///
+    /// `precheck` runs **on the engine thread**, immediately before the command and after any
+    /// job queued ahead of it. Callers use it for gates that must not be evaluated while
+    /// earlier work is still in flight — see [`crate::server`]'s session handles.
+    pub async fn run_command<P>(&self, command: String, precheck: P) -> Result<String, EngineError>
+    where
+        P: FnOnce() -> Result<(), String> + Send + 'static,
+    {
         // The outer timeout in `run` starts counting at *submission*, but this command may sit
         // in the engine queue behind another job (e.g. a backgrounded `go`) before reaching the
         // worker. Compute the watchdog budget from the time *remaining* until that timeout — not
@@ -131,6 +138,7 @@ impl EngineHandle {
         let call_timeout = self.call_timeout;
         let submitted = Instant::now();
         self.run(move |e| {
+            precheck()?;
             // Floor the budget so a command dequeued near the deadline still arms the watchdog
             // (a 0 budget disables it) and thus still frees the engine promptly.
             let budget_ms = call_timeout

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -13,8 +13,14 @@ use std::time::{Duration, Instant};
 use tokio::sync::{mpsc, oneshot};
 use win_kexp::dbgeng::DebugEngine;
 
-/// Result of an engine operation: `Ok(text)` or `Err(message)`.
+/// What a job closure returns: `Ok(text)` or `Err(message)`. Jobs describe debugger work,
+/// so a plain message is all they can meaningfully report.
 type Reply = Result<String, String>;
+
+/// What travels back over the reply channel. The worker classifies each outcome at the
+/// point it knows the difference — an operation that failed versus an engine that was
+/// never usable — because that distinction is unrecoverable once it reaches the caller.
+type Classified = Result<String, EngineError>;
 
 /// Why an engine call failed, split by who can act on the failure.
 ///
@@ -45,7 +51,7 @@ impl fmt::Display for EngineError {
 /// A unit of work to run on the engine thread, plus where to send its result.
 struct Job {
     run: Box<dyn FnOnce(&DebugEngine) -> Reply + Send>,
-    reply: oneshot::Sender<Reply>,
+    reply: oneshot::Sender<Classified>,
 }
 
 /// Cloneable handle to the engine thread, shared across all tool calls.
@@ -69,21 +75,27 @@ impl EngineHandle {
                 let engine = match catch_unwind(AssertUnwindSafe(DebugEngine::new)) {
                     Ok(engine) => engine,
                     Err(_) => {
+                        // The engine never came up, and never will for this process. That is
+                        // `Unavailable`, not a failed operation: no argument the model can
+                        // change makes the next call work, so it must not come back as a
+                        // retryable tool error.
                         while let Some(job) = rx.blocking_recv() {
-                            let _ = job.reply.send(Err(
+                            let _ = job.reply.send(Err(EngineError::Unavailable(
                                 "failed to initialize DbgEng (is dbgeng.dll on the search path?)"
                                     .to_string(),
-                            ));
+                            )));
                         }
                         return;
                     }
                 };
                 while let Some(job) = rx.blocking_recv() {
                     // A panic inside a win-kexp method (several use `.expect`) must not
-                    // kill the worker — surface it as an error for this one call.
+                    // kill the worker — surface it as an error for this one call. The engine
+                    // survives, so this stays a debugger-level failure the model can work
+                    // around by trying something else.
                     let result = catch_unwind(AssertUnwindSafe(|| (job.run)(&engine)))
                         .unwrap_or_else(|_| Err("debugger operation panicked".to_string()));
-                    let _ = job.reply.send(result);
+                    let _ = job.reply.send(result.map_err(EngineError::Debugger));
                 }
             })
             .expect("failed to spawn dbgeng thread");
@@ -103,10 +115,9 @@ impl EngineHandle {
             })
             .map_err(|_| EngineError::Unavailable("engine thread unavailable".to_string()))?;
         match tokio::time::timeout(self.call_timeout, rrx).await {
-            Ok(Ok(Ok(s))) => Ok(s),
-            // The debugger reached a verdict and it was a failure — including a panic
-            // caught by the worker, which leaves the engine usable for the next call.
-            Ok(Ok(Err(e))) => Err(EngineError::Debugger(e)),
+            // Already classified by the worker, which is the only place that can tell a
+            // failed operation apart from an engine that never initialized.
+            Ok(Ok(classified)) => classified,
             Ok(Err(_)) => Err(EngineError::Unavailable("engine dropped reply".to_string())),
             // A timeout is an operational outcome, not broken plumbing: the target may
             // simply still be running, and the model can wait, retry, or end the session.

--- a/src/server.rs
+++ b/src/server.rs
@@ -1398,6 +1398,23 @@ fn reject_command_breakers(field: &str, value: &str, quotes: Quotes) -> Result<(
     ))
 }
 
+/// Can this data-model expression run debugger commands?
+///
+/// `dx` evaluates arbitrary data-model expressions, and the data model exposes
+/// `Debugger.Utility.Control.ExecuteCommand`, which runs any command string — `.opendump`
+/// included. So `dx` is a second command hatch beside `execute`, and has to be treated as
+/// one. Where [`changes_debug_target`] can read the command and decide, this cannot: the
+/// command is a runtime string inside an expression. So the trigger is *reaching command
+/// execution at all*, and the handle is retired without knowing what ran.
+///
+/// Best-effort for a stronger reason than [`changes_debug_target`]: the data model is
+/// extensible, so no fixed list can enumerate every route to execution. `dx` and `execute`
+/// are therefore both documented as surfaces where a handle is a strong hint, not a
+/// guarantee — everywhere else in this server it is a guarantee.
+fn dx_executes_commands(expression: &str) -> bool {
+    expression.to_ascii_lowercase().contains("executecommand")
+}
+
 /// Does this raw `execute` command replace or release the debug target?
 ///
 /// The typed tools announce their own transitions, but `execute` is an escape hatch: a
@@ -2043,10 +2060,15 @@ impl WindbgServer {
     }
 
     /// Evaluate a data-model (LINQ) expression with `dx` — ideal for TTD queries.
+    /// The data model can also run debugger commands, so this is a second command hatch
+    /// alongside `execute` and is annotated and handle-checked as one; see
+    /// [`dx_executes_commands`].
     #[rmcp::tool(annotations(
         title = "Evaluate data-model expression",
         read_only_hint = false,
-        destructive_hint = false,
+        // The data model reaches `Debugger.Utility.Control.ExecuteCommand`, so a `dx` can do
+        // anything `execute` can — including replacing the target.
+        destructive_hint = true,
         idempotent_hint = false,
         open_world_hint = true
     ))]
@@ -2055,10 +2077,22 @@ impl WindbgServer {
             return tool_error(e);
         }
         let gate = self.session_gate(args.session_id.as_deref());
+        let session = Arc::clone(&self.session);
+        let retires_session = dx_executes_commands(&args.expression);
+        let precheck = move || {
+            gate()?;
+            if retires_session {
+                // We cannot see *which* command the data model is about to run, so the
+                // conservative reading is the only sound one: assume it replaced the target.
+                // Dropped before the expression evaluates, for the reason `execute` does.
+                *lock(&session) = None;
+            }
+            Ok(())
+        };
         let cmd = format!("dx {}", args.expression);
         // Bounded: a data-model query that runs away (e.g. a heavy LINQ or index build on a
         // huge trace) self-aborts rather than pinning the engine thread.
-        let out = self.engine.run_command(cmd, gate).await;
+        let out = self.engine.run_command(cmd, precheck).await;
         engine_result(out)
     }
 
@@ -3023,6 +3057,37 @@ mod tests {
             reject_command_breakers("function", "kernelbase!CreateFileW", Quotes::Rejected).is_ok()
         );
         assert!(reject_command_breakers("function", "ntdll!Nt*", Quotes::Rejected).is_ok());
+    }
+
+    /// `dx` reaches command execution through the data model, so it retires the handle too
+    /// — conservatively, since the command it runs is a runtime string this server never
+    /// sees. The ordinary TTD queries `dx` exists for must not trip it, or the handle would
+    /// be useless for the workflow it was built for.
+    #[test]
+    fn dx_retires_the_handle_only_when_it_reaches_command_execution() {
+        for expression in [
+            "Debugger.Utility.Control.ExecuteCommand(\".opendump C:\\\\b.dmp\")",
+            "@$curprocess.TTD.Events.Select(e => Debugger.Utility.Control.ExecuteCommand(\"g\"))",
+            // Case is not an escape route.
+            "Debugger.Utility.Control.executecommand(\".detach\")",
+        ] {
+            assert!(
+                dx_executes_commands(expression),
+                "`{expression}` must retire the handle"
+            );
+        }
+
+        for expression in [
+            "@$curprocess.TTD.Lifetime",
+            "@$cursession.TTD.Calls(\"ntdll!Nt*\")",
+            "@$cursession.TTD.Calls(\"kernelbase!CreateFileW\").Where(c => c.ReturnValue != 0)",
+            "@$curprocess.TTD.Memory(0x1000, 0x2000, \"rw\")",
+        ] {
+            assert!(
+                !dx_executes_commands(expression),
+                "`{expression}` is an ordinary query and must keep the handle"
+            );
+        }
     }
 
     /// `execute` is the one path that can swap the target without going through a typed

--- a/src/server.rs
+++ b/src/server.rs
@@ -6,6 +6,7 @@
 //! `win-kexp` methods and then wait for the target to stop.
 
 use std::collections::{HashMap, HashSet, VecDeque};
+use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -1444,7 +1445,15 @@ impl WindbgServer {
                 // The target is ours from here, so a failed diagnostic still has to hand the
                 // caller their handle — otherwise they cannot use the protection this whole
                 // mechanism promises without re-running a side-effecting open.
-                report(e).map_err(|err| {
+                //
+                // Caught here rather than left to the worker's outer guard: a panic in a
+                // win-kexp method (several use `.expect`) would unwind straight past the
+                // `map_err` below and strip the handle off a session that is already
+                // committed. The engine survives a caught panic either way — the thing that
+                // must not be lost is the id.
+                let reported = catch_unwind(AssertUnwindSafe(|| report(e)))
+                    .unwrap_or_else(|_| Err("debugger operation panicked".to_string()));
+                reported.map_err(|err| {
                     format!(
                         "{err}\n\nsession_id: {id_for_report}\nThe target opened; only this \
                          follow-up report failed, so the handle above is valid and usable."

--- a/src/server.rs
+++ b/src/server.rs
@@ -1347,6 +1347,41 @@ fn lock(session: &Mutex<Option<String>>) -> std::sync::MutexGuard<'_, Option<Str
     session.lock().unwrap_or_else(|e| e.into_inner())
 }
 
+/// Rejects a caller-supplied operand that could end the command it is embedded in.
+///
+/// The typed tools build commands by interpolation — `u {address}`, `bp {expression}`,
+/// `!drvobj {name} 7` — and DbgEng reads `;` as a command separator. So an operand of
+/// `rip; .opendump C:\other.dmp` turns `disassemble` into a target swap: it runs a
+/// session-control command from a tool that advertises `readOnlyHint: true`, and it does
+/// it without going through the [`changes_debug_target`] check, leaving every outstanding
+/// handle pointing at a target that is no longer loaded.
+///
+/// These parameters are documented as *operands*, never command lists, so refusing the
+/// separator costs nothing real: `execute` exists for anything that genuinely needs to
+/// chain, and it is annotated and handle-checked accordingly.
+///
+/// `quoted` additionally refuses `"`, for the operands interpolated inside a quoted string
+/// in a data-model expression, where a quote would escape the literal instead.
+fn reject_command_breakers(field: &str, value: &str, quoted: bool) -> Result<(), String> {
+    let bad = value
+        .chars()
+        .find(|c| matches!(c, ';' | '\n' | '\r') || (quoted && *c == '"'));
+    let Some(bad) = bad else {
+        return Ok(());
+    };
+    let what = match bad {
+        ';' => "a `;`",
+        '"' => "a `\"`",
+        _ => "a line break",
+    };
+    Err(format!(
+        "`{field}` contains {what}, which would end the command this tool builds around it \
+         and let the rest run as a separate command. This parameter takes a single operand. \
+         Use `execute` if you meant to run a command list — it is annotated as destructive \
+         and retires the session handle when a command replaces the target."
+    ))
+}
+
 /// Does this raw `execute` command replace or release the debug target?
 ///
 /// The typed tools announce their own transitions, but `execute` is an escape hatch: a
@@ -1971,6 +2006,11 @@ impl WindbgServer {
         &self,
         Parameters(args): Parameters<DisassembleArgs>,
     ) -> Result<CallToolResult, ErrorData> {
+        if let Some(a) = &args.address
+            && let Err(e) = reject_command_breakers("address", a, false)
+        {
+            return tool_error(e);
+        }
         let gate = self.session_gate(args.session_id.as_deref());
         let cmd = match args.address {
             Some(a) => format!("u {a}"),
@@ -1995,6 +2035,9 @@ impl WindbgServer {
         open_world_hint = true
     ))]
     async fn dx(&self, Parameters(args): Parameters<DxArgs>) -> Result<CallToolResult, ErrorData> {
+        if let Err(e) = reject_command_breakers("expression", &args.expression, false) {
+            return tool_error(e);
+        }
         let gate = self.session_gate(args.session_id.as_deref());
         let cmd = format!("dx {}", args.expression);
         // Bounded: a data-model query that runs away (e.g. a heavy LINQ or index build on a
@@ -2016,6 +2059,9 @@ impl WindbgServer {
         &self,
         Parameters(args): Parameters<TtdCallsArgs>,
     ) -> Result<CallToolResult, ErrorData> {
+        if let Err(e) = reject_command_breakers("function", &args.function, true) {
+            return tool_error(e);
+        }
         let gate = self.session_gate(args.session_id.as_deref());
         let cmd = format!("dx @$cursession.TTD.Calls(\"{}\")", args.function);
         let out = self.engine.run_command(cmd, gate).await;
@@ -2035,6 +2081,11 @@ impl WindbgServer {
         Parameters(args): Parameters<TtdMemoryArgs>,
     ) -> Result<CallToolResult, ErrorData> {
         let gate = self.session_gate(args.session_id.as_deref());
+        if let Some(mode) = &args.mode
+            && let Err(e) = reject_command_breakers("mode", mode, true)
+        {
+            return tool_error(e);
+        }
         // A bad address is the model's mistake to fix, so it comes back as a tool error
         // rather than a protocol error the model cannot act on.
         let start = match parse_u64(&args.address) {
@@ -2085,6 +2136,9 @@ impl WindbgServer {
         &self,
         Parameters(args): Parameters<BreakpointArgs>,
     ) -> Result<CallToolResult, ErrorData> {
+        if let Err(e) = reject_command_breakers("expression", &args.expression, false) {
+            return tool_error(e);
+        }
         let gate = self.session_gate(args.session_id.as_deref());
         let cmd = format!("bp {}", args.expression);
         let out = self
@@ -2137,6 +2191,9 @@ impl WindbgServer {
         &self,
         Parameters(args): Parameters<RunToAddressArgs>,
     ) -> Result<CallToolResult, ErrorData> {
+        if let Err(e) = reject_command_breakers("address", &args.address, false) {
+            return tool_error(e);
+        }
         let gate = self.session_gate(args.session_id.as_deref());
         let out = self
             .engine
@@ -2311,6 +2368,9 @@ impl WindbgServer {
         &self,
         Parameters(args): Parameters<PositionArgs>,
     ) -> Result<CallToolResult, ErrorData> {
+        if let Err(e) = reject_command_breakers("position", &args.position, false) {
+            return tool_error(e);
+        }
         let gate = self.session_gate(args.session_id.as_deref());
         let cmd = format!("!tt {}", args.position);
         let out = self
@@ -2436,6 +2496,9 @@ impl WindbgServer {
         &self,
         Parameters(args): Parameters<DriverObjectArgs>,
     ) -> Result<CallToolResult, ErrorData> {
+        if let Err(e) = reject_command_breakers("name", &args.name, false) {
+            return tool_error(e);
+        }
         let gate = self.session_gate(args.session_id.as_deref());
         let cmd = format!("!drvobj {} 7", args.name);
         let out = self
@@ -2461,6 +2524,9 @@ impl WindbgServer {
         &self,
         Parameters(args): Parameters<DeviceObjectArgs>,
     ) -> Result<CallToolResult, ErrorData> {
+        if let Err(e) = reject_command_breakers("device", &args.device, false) {
+            return tool_error(e);
+        }
         let gate = self.session_gate(args.session_id.as_deref());
         let cmd = format!("!devobj {}", args.device);
         let out = self
@@ -2485,6 +2551,11 @@ impl WindbgServer {
         &self,
         Parameters(args): Parameters<IrpStackArgs>,
     ) -> Result<CallToolResult, ErrorData> {
+        if let Some(irp) = &args.irp
+            && let Err(e) = reject_command_breakers("irp", irp, false)
+        {
+            return tool_error(e);
+        }
         let gate = self.session_gate(args.session_id.as_deref());
         let irp = args.irp.unwrap_or_else(|| "@rdx".to_string());
         let cmd = format!("!irp {irp} 1");
@@ -2514,6 +2585,9 @@ impl WindbgServer {
         &self,
         Parameters(args): Parameters<IoctlTraceArgs>,
     ) -> Result<CallToolResult, ErrorData> {
+        if let Err(e) = reject_command_breakers("dispatch", &args.dispatch, false) {
+            return tool_error(e);
+        }
         let gate = self.session_gate(args.session_id.as_deref());
         // IRP in @rdx at dispatch entry (x64). CurrentStackLocation = poi(Irp+0xb8).
         // Within IO_STACK_LOCATION: OutputBufferLength +0x08, InputBufferLength +0x10,
@@ -2549,6 +2623,18 @@ impl WindbgServer {
         &self,
         Parameters(args): Parameters<ReachabilityArgs>,
     ) -> Result<CallToolResult, ErrorData> {
+        for (field, value) in [
+            ("from", Some(&args.from)),
+            ("address", args.address.as_ref()),
+            ("module", args.module.as_ref()),
+            ("rva", args.rva.as_ref()),
+        ] {
+            if let Some(value) = value
+                && let Err(e) = reject_command_breakers(field, value, false)
+            {
+                return tool_error(e);
+            }
+        }
         let gate = self.session_gate(args.session_id.as_deref());
         let out = self
             .engine
@@ -2843,6 +2929,55 @@ mod tests {
         let gate = session_gate_for(Arc::clone(&session), None);
         *lock(&session) = Some("sess-B".to_string());
         assert!(gate().is_ok());
+    }
+
+    /// The typed tools interpolate their operands into commands, and DbgEng chains on `;`.
+    /// Without this, `disassemble { address: "rip; .opendump other.dmp" }` runs a target
+    /// swap from a tool advertising `readOnlyHint: true`, and does it without retiring
+    /// anyone's session handle.
+    #[test]
+    fn operands_may_not_end_the_command_they_are_embedded_in() {
+        for value in [
+            "rip; .opendump C:\\other.dmp",
+            "rip;.detach",
+            "rip\n.detach",
+            "rip\r\n.kill",
+        ] {
+            assert!(
+                reject_command_breakers("address", value, false).is_err(),
+                "`{value}` must be refused"
+            );
+        }
+    }
+
+    /// Operands interpolated inside a quoted data-model string can also escape via `"`.
+    #[test]
+    fn quoted_operands_may_not_escape_their_string() {
+        assert!(reject_command_breakers("function", "nt!*\") ; .detach //", true).is_err());
+        // Only the quoted positions are stricter; a quote is fine where none is implied.
+        assert!(reject_command_breakers("expression", "foo\"bar", false).is_ok());
+    }
+
+    /// The rejection must not swallow the operand forms these tools exist to accept.
+    #[test]
+    fn ordinary_operands_are_accepted() {
+        for value in [
+            "rip",
+            "nt!NtCreateFile",
+            "fffff803`3e254750",
+            "0x1000",
+            "@$curprocess.TTD.Lifetime",
+            "HEVD!DispatchDeviceControl+0x42",
+            "\\Driver\\HEVD",
+            "12:0",
+        ] {
+            assert!(
+                reject_command_breakers("operand", value, false).is_ok(),
+                "`{value}` must be accepted"
+            );
+        }
+        assert!(reject_command_breakers("function", "kernelbase!CreateFileW", true).is_ok());
+        assert!(reject_command_breakers("function", "ntdll!Nt*", true).is_ok());
     }
 
     /// `execute` is the one path that can swap the target without going through a typed

--- a/src/server.rs
+++ b/src/server.rs
@@ -1347,6 +1347,22 @@ fn lock(session: &Mutex<Option<String>>) -> std::sync::MutexGuard<'_, Option<Str
     session.lock().unwrap_or_else(|e| e.into_inner())
 }
 
+/// Whether an operand may legitimately contain a double quote.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum Quotes {
+    /// Only `dx`, whose data-model expressions use quoted string literals as a matter of
+    /// course (`@$cursession.TTD.Calls("ntdll!Nt*")`).
+    Allowed,
+    /// Everywhere else. A quote either escapes a string literal this server wrapped around
+    /// the operand, or — for a `bp` location — opens a *breakpoint command string*, which
+    /// WinDbg runs every time the breakpoint fires. `ioctl_trace` builds exactly that form
+    /// deliberately, so `set_breakpoint { expression: "nt!Foo \".opendump other.dmp\"" }`
+    /// would arm a target swap that happens later: outside any tool call, and outside
+    /// anything that could retire the session handle. A quote has no legitimate meaning in
+    /// an address, a symbol, a device name or a TTD position, so refusing it costs nothing.
+    Rejected,
+}
+
 /// Rejects a caller-supplied operand that could end the command it is embedded in.
 ///
 /// The typed tools build commands by interpolation — `u {address}`, `bp {expression}`,
@@ -1360,12 +1376,12 @@ fn lock(session: &Mutex<Option<String>>) -> std::sync::MutexGuard<'_, Option<Str
 /// separator costs nothing real: `execute` exists for anything that genuinely needs to
 /// chain, and it is annotated and handle-checked accordingly.
 ///
-/// `quoted` additionally refuses `"`, for the operands interpolated inside a quoted string
-/// in a data-model expression, where a quote would escape the literal instead.
-fn reject_command_breakers(field: &str, value: &str, quoted: bool) -> Result<(), String> {
+/// Quotes are refused everywhere except `dx` — see [`Quotes`] for why a quote is never a
+/// legitimate part of an address, symbol, device name or breakpoint location.
+fn reject_command_breakers(field: &str, value: &str, quotes: Quotes) -> Result<(), String> {
     let bad = value
         .chars()
-        .find(|c| matches!(c, ';' | '\n' | '\r') || (quoted && *c == '"'));
+        .find(|c| matches!(c, ';' | '\n' | '\r') || (quotes == Quotes::Rejected && *c == '"'));
     let Some(bad) = bad else {
         return Ok(());
     };
@@ -2007,7 +2023,7 @@ impl WindbgServer {
         Parameters(args): Parameters<DisassembleArgs>,
     ) -> Result<CallToolResult, ErrorData> {
         if let Some(a) = &args.address
-            && let Err(e) = reject_command_breakers("address", a, false)
+            && let Err(e) = reject_command_breakers("address", a, Quotes::Rejected)
         {
             return tool_error(e);
         }
@@ -2035,7 +2051,7 @@ impl WindbgServer {
         open_world_hint = true
     ))]
     async fn dx(&self, Parameters(args): Parameters<DxArgs>) -> Result<CallToolResult, ErrorData> {
-        if let Err(e) = reject_command_breakers("expression", &args.expression, false) {
+        if let Err(e) = reject_command_breakers("expression", &args.expression, Quotes::Allowed) {
             return tool_error(e);
         }
         let gate = self.session_gate(args.session_id.as_deref());
@@ -2059,7 +2075,7 @@ impl WindbgServer {
         &self,
         Parameters(args): Parameters<TtdCallsArgs>,
     ) -> Result<CallToolResult, ErrorData> {
-        if let Err(e) = reject_command_breakers("function", &args.function, true) {
+        if let Err(e) = reject_command_breakers("function", &args.function, Quotes::Rejected) {
             return tool_error(e);
         }
         let gate = self.session_gate(args.session_id.as_deref());
@@ -2082,7 +2098,7 @@ impl WindbgServer {
     ) -> Result<CallToolResult, ErrorData> {
         let gate = self.session_gate(args.session_id.as_deref());
         if let Some(mode) = &args.mode
-            && let Err(e) = reject_command_breakers("mode", mode, true)
+            && let Err(e) = reject_command_breakers("mode", mode, Quotes::Rejected)
         {
             return tool_error(e);
         }
@@ -2136,7 +2152,7 @@ impl WindbgServer {
         &self,
         Parameters(args): Parameters<BreakpointArgs>,
     ) -> Result<CallToolResult, ErrorData> {
-        if let Err(e) = reject_command_breakers("expression", &args.expression, false) {
+        if let Err(e) = reject_command_breakers("expression", &args.expression, Quotes::Rejected) {
             return tool_error(e);
         }
         let gate = self.session_gate(args.session_id.as_deref());
@@ -2191,7 +2207,7 @@ impl WindbgServer {
         &self,
         Parameters(args): Parameters<RunToAddressArgs>,
     ) -> Result<CallToolResult, ErrorData> {
-        if let Err(e) = reject_command_breakers("address", &args.address, false) {
+        if let Err(e) = reject_command_breakers("address", &args.address, Quotes::Rejected) {
             return tool_error(e);
         }
         let gate = self.session_gate(args.session_id.as_deref());
@@ -2368,7 +2384,7 @@ impl WindbgServer {
         &self,
         Parameters(args): Parameters<PositionArgs>,
     ) -> Result<CallToolResult, ErrorData> {
-        if let Err(e) = reject_command_breakers("position", &args.position, false) {
+        if let Err(e) = reject_command_breakers("position", &args.position, Quotes::Rejected) {
             return tool_error(e);
         }
         let gate = self.session_gate(args.session_id.as_deref());
@@ -2496,7 +2512,7 @@ impl WindbgServer {
         &self,
         Parameters(args): Parameters<DriverObjectArgs>,
     ) -> Result<CallToolResult, ErrorData> {
-        if let Err(e) = reject_command_breakers("name", &args.name, false) {
+        if let Err(e) = reject_command_breakers("name", &args.name, Quotes::Rejected) {
             return tool_error(e);
         }
         let gate = self.session_gate(args.session_id.as_deref());
@@ -2524,7 +2540,7 @@ impl WindbgServer {
         &self,
         Parameters(args): Parameters<DeviceObjectArgs>,
     ) -> Result<CallToolResult, ErrorData> {
-        if let Err(e) = reject_command_breakers("device", &args.device, false) {
+        if let Err(e) = reject_command_breakers("device", &args.device, Quotes::Rejected) {
             return tool_error(e);
         }
         let gate = self.session_gate(args.session_id.as_deref());
@@ -2552,7 +2568,7 @@ impl WindbgServer {
         Parameters(args): Parameters<IrpStackArgs>,
     ) -> Result<CallToolResult, ErrorData> {
         if let Some(irp) = &args.irp
-            && let Err(e) = reject_command_breakers("irp", irp, false)
+            && let Err(e) = reject_command_breakers("irp", irp, Quotes::Rejected)
         {
             return tool_error(e);
         }
@@ -2585,7 +2601,7 @@ impl WindbgServer {
         &self,
         Parameters(args): Parameters<IoctlTraceArgs>,
     ) -> Result<CallToolResult, ErrorData> {
-        if let Err(e) = reject_command_breakers("dispatch", &args.dispatch, false) {
+        if let Err(e) = reject_command_breakers("dispatch", &args.dispatch, Quotes::Rejected) {
             return tool_error(e);
         }
         let gate = self.session_gate(args.session_id.as_deref());
@@ -2630,7 +2646,7 @@ impl WindbgServer {
             ("rva", args.rva.as_ref()),
         ] {
             if let Some(value) = value
-                && let Err(e) = reject_command_breakers(field, value, false)
+                && let Err(e) = reject_command_breakers(field, value, Quotes::Rejected)
             {
                 return tool_error(e);
             }
@@ -2944,18 +2960,45 @@ mod tests {
             "rip\r\n.kill",
         ] {
             assert!(
-                reject_command_breakers("address", value, false).is_err(),
+                reject_command_breakers("address", value, Quotes::Rejected).is_err(),
                 "`{value}` must be refused"
             );
         }
     }
 
-    /// Operands interpolated inside a quoted data-model string can also escape via `"`.
+    /// A quote is refused everywhere except `dx`, for two separate reasons.
     #[test]
-    fn quoted_operands_may_not_escape_their_string() {
-        assert!(reject_command_breakers("function", "nt!*\") ; .detach //", true).is_err());
-        // Only the quoted positions are stricter; a quote is fine where none is implied.
-        assert!(reject_command_breakers("expression", "foo\"bar", false).is_ok());
+    fn operands_may_not_carry_quotes_except_in_dx() {
+        // Escaping the string literal this server wrapped around the operand.
+        assert!(
+            reject_command_breakers("function", "nt!*\") ; .detach //", Quotes::Rejected).is_err()
+        );
+
+        // Opening a `bp` command string, which WinDbg runs on every hit — a target swap
+        // armed for later, outside any tool call and outside handle retirement.
+        assert!(
+            reject_command_breakers(
+                "expression",
+                "nt!NtCreateFile \".opendump C:\\\\other.dmp\"",
+                Quotes::Rejected
+            )
+            .is_err()
+        );
+
+        // `dx` is the exception: quoted literals are ordinary data-model syntax.
+        assert!(
+            reject_command_breakers(
+                "expression",
+                "@$cursession.TTD.Calls(\"ntdll!Nt*\")",
+                Quotes::Allowed
+            )
+            .is_ok()
+        );
+        // Even there, a separator still ends the command.
+        assert!(
+            reject_command_breakers("expression", "@$curprocess; .detach", Quotes::Allowed)
+                .is_err()
+        );
     }
 
     /// The rejection must not swallow the operand forms these tools exist to accept.
@@ -2972,12 +3015,14 @@ mod tests {
             "12:0",
         ] {
             assert!(
-                reject_command_breakers("operand", value, false).is_ok(),
+                reject_command_breakers("operand", value, Quotes::Rejected).is_ok(),
                 "`{value}` must be accepted"
             );
         }
-        assert!(reject_command_breakers("function", "kernelbase!CreateFileW", true).is_ok());
-        assert!(reject_command_breakers("function", "ntdll!Nt*", true).is_ok());
+        assert!(
+            reject_command_breakers("function", "kernelbase!CreateFileW", Quotes::Rejected).is_ok()
+        );
+        assert!(reject_command_breakers("function", "ntdll!Nt*", Quotes::Rejected).is_ok());
     }
 
     /// `execute` is the one path that can swap the target without going through a typed

--- a/src/server.rs
+++ b/src/server.rs
@@ -1473,12 +1473,12 @@ impl WindbgServer {
             // the caller would only learn "some session exists" and could adopt a handle
             // belonging to somebody else's open that landed in the meantime.
             Err(EngineError::Timeout(msg)) => tool_error(format!(
-                "{msg}\n\nThis open may still complete on the engine thread. If it does, its \
-                 handle will be exactly `{id}`. Call session_status: treat the session as \
-                 yours only if it reports that same id, and if it reports a different one \
-                 then another caller's target is loaded and yours never landed. Do not re-run \
-                 this open to recover — attaching or launching again would connect to, or \
-                 start, a second target."
+                "{msg}\n\nThe wait was abandoned, but this open was not: it may still be \
+                 queued behind other work, and may still run and commit the handle `{id}`. \
+                 Poll session_status — the session is yours once it reports `{id}`. A \
+                 different id means yours has not landed *yet*, not that it failed; it may \
+                 still be pending. Either way do not re-run this open to recover, which would \
+                 attach to, or start, a second target."
             )),
             Err(e) => engine_result(Err(e)),
         }
@@ -1745,6 +1745,11 @@ impl WindbgServer {
     /// This reports *the current* handle, not *your* handle — the two differ if another
     /// caller's open landed while yours was in flight. A timed-out open names the handle it
     /// would commit, so compare against that: adopt the session only when the two match.
+    ///
+    /// A mismatch means "not yours *yet*", not "yours failed". The timeout abandons the
+    /// wait, not the job, so a timed-out open can still be sitting in the queue and can
+    /// still land later. Poll rather than concluding; re-running the open is the one thing
+    /// that is never the answer.
     #[rmcp::tool(annotations(
         title = "Show current session handle",
         read_only_hint = true,

--- a/src/server.rs
+++ b/src/server.rs
@@ -1403,6 +1403,15 @@ impl WindbgServer {
 }
 
 // ---- Tools ---------------------------------------------------------------
+//
+// On `open_world_hint`: with a symbol server on the symbol path — the documented, and
+// recommended, setup — almost anything here can make DbgEng reach out and download a PDB.
+// It is not just the obvious symbol-pattern queries: `r` symbolizes the current
+// instruction, `k` symbolizes every frame, `bp module!Symbol` resolves a name. So the hint
+// is true for all of them, and false only where it is genuinely, structurally false:
+// `read_memory` (raw bytes to a hex dump), `decode_ioctl` (pure arithmetic, no engine at
+// all), and `end_session` (teardown). Claiming otherwise would tell a client that a tool
+// cannot touch the network and let it skip whatever consent that decision gates.
 
 #[rmcp::tool_router]
 impl WindbgServer {
@@ -1676,7 +1685,7 @@ impl WindbgServer {
     #[rmcp::tool(annotations(
         title = "Show registers",
         read_only_hint = true,
-        open_world_hint = false
+        open_world_hint = true
     ))]
     async fn registers(
         &self,
@@ -1733,7 +1742,7 @@ impl WindbgServer {
     #[rmcp::tool(annotations(
         title = "Show call stack",
         read_only_hint = true,
-        open_world_hint = false
+        open_world_hint = true
     ))]
     async fn backtrace(
         &self,
@@ -1754,7 +1763,7 @@ impl WindbgServer {
     #[rmcp::tool(annotations(
         title = "List modules",
         read_only_hint = true,
-        open_world_hint = false
+        open_world_hint = true
     ))]
     async fn modules(
         &self,
@@ -1775,7 +1784,7 @@ impl WindbgServer {
     #[rmcp::tool(annotations(
         title = "List threads",
         read_only_hint = true,
-        open_world_hint = false
+        open_world_hint = true
     ))]
     async fn threads(
         &self,
@@ -1796,7 +1805,7 @@ impl WindbgServer {
     #[rmcp::tool(annotations(
         title = "Disassemble",
         read_only_hint = true,
-        open_world_hint = false
+        open_world_hint = true
     ))]
     async fn disassemble(
         &self,
@@ -1823,7 +1832,7 @@ impl WindbgServer {
         read_only_hint = false,
         destructive_hint = false,
         idempotent_hint = false,
-        open_world_hint = false
+        open_world_hint = true
     ))]
     async fn dx(&self, Parameters(args): Parameters<DxArgs>) -> Result<CallToolResult, ErrorData> {
         let gate = self.session_gate(args.session_id.as_deref());
@@ -1841,7 +1850,7 @@ impl WindbgServer {
     #[rmcp::tool(annotations(
         title = "TTD: find calls to a function",
         read_only_hint = true,
-        open_world_hint = false
+        open_world_hint = true
     ))]
     async fn ttd_calls(
         &self,
@@ -1859,7 +1868,7 @@ impl WindbgServer {
     #[rmcp::tool(annotations(
         title = "TTD: find accesses to a memory range",
         read_only_hint = true,
-        open_world_hint = false
+        open_world_hint = true
     ))]
     async fn ttd_memory(
         &self,
@@ -1890,7 +1899,7 @@ impl WindbgServer {
     #[rmcp::tool(annotations(
         title = "TTD: list trace events",
         read_only_hint = true,
-        open_world_hint = false
+        open_world_hint = true
     ))]
     async fn ttd_events(
         &self,
@@ -1910,7 +1919,7 @@ impl WindbgServer {
         read_only_hint = false,
         destructive_hint = false,
         idempotent_hint = false,
-        open_world_hint = false
+        open_world_hint = true
     ))]
     async fn set_breakpoint(
         &self,
@@ -1934,7 +1943,7 @@ impl WindbgServer {
         read_only_hint = false,
         destructive_hint = true,
         idempotent_hint = false,
-        open_world_hint = false
+        open_world_hint = true
     ))]
     async fn go(
         &self,
@@ -1962,7 +1971,7 @@ impl WindbgServer {
         read_only_hint = false,
         destructive_hint = true,
         idempotent_hint = false,
-        open_world_hint = false
+        open_world_hint = true
     ))]
     async fn run_to_address(
         &self,
@@ -2019,7 +2028,7 @@ impl WindbgServer {
         read_only_hint = false,
         destructive_hint = true,
         idempotent_hint = false,
-        open_world_hint = false
+        open_world_hint = true
     ))]
     async fn step_over(
         &self,
@@ -2042,7 +2051,7 @@ impl WindbgServer {
         read_only_hint = false,
         destructive_hint = true,
         idempotent_hint = false,
-        open_world_hint = false
+        open_world_hint = true
     ))]
     async fn step_into(
         &self,
@@ -2067,7 +2076,7 @@ impl WindbgServer {
         read_only_hint = false,
         destructive_hint = false,
         idempotent_hint = false,
-        open_world_hint = false
+        open_world_hint = true
     ))]
     async fn step_back(
         &self,
@@ -2090,7 +2099,7 @@ impl WindbgServer {
         read_only_hint = false,
         destructive_hint = false,
         idempotent_hint = false,
-        open_world_hint = false
+        open_world_hint = true
     ))]
     async fn step_over_back(
         &self,
@@ -2113,7 +2122,7 @@ impl WindbgServer {
         read_only_hint = false,
         destructive_hint = false,
         idempotent_hint = false,
-        open_world_hint = false
+        open_world_hint = true
     ))]
     async fn reverse_go(
         &self,
@@ -2136,7 +2145,7 @@ impl WindbgServer {
         read_only_hint = false,
         destructive_hint = false,
         idempotent_hint = true,
-        open_world_hint = false
+        open_world_hint = true
     ))]
     async fn goto_position(
         &self,
@@ -2259,7 +2268,7 @@ impl WindbgServer {
     #[rmcp::tool(annotations(
         title = "Inspect driver object",
         read_only_hint = true,
-        open_world_hint = false
+        open_world_hint = true
     ))]
     async fn driver_object(
         &self,
@@ -2284,7 +2293,7 @@ impl WindbgServer {
     #[rmcp::tool(annotations(
         title = "Inspect device object",
         read_only_hint = true,
-        open_world_hint = false
+        open_world_hint = true
     ))]
     async fn device_object(
         &self,
@@ -2308,7 +2317,7 @@ impl WindbgServer {
     #[rmcp::tool(annotations(
         title = "Dump IRP stack location",
         read_only_hint = true,
-        open_world_hint = false
+        open_world_hint = true
     ))]
     async fn irp_stack(
         &self,
@@ -2337,7 +2346,7 @@ impl WindbgServer {
         read_only_hint = false,
         destructive_hint = false,
         idempotent_hint = false,
-        open_world_hint = false
+        open_world_hint = true
     ))]
     async fn ioctl_trace(
         &self,
@@ -2372,7 +2381,7 @@ impl WindbgServer {
     #[rmcp::tool(annotations(
         title = "Test reachability from IOCTL dispatch",
         read_only_hint = true,
-        open_world_hint = false
+        open_world_hint = true
     ))]
     async fn reachable_from_dispatch(
         &self,
@@ -2563,6 +2572,25 @@ mod tests {
                 "`{name}` only inspects and should be marked read-only"
             );
         }
+    }
+
+    /// Only the tools that structurally cannot reach a symbol server may say so. Everything
+    /// else can trigger a PDB download once a symbol server is on the path, and a client may
+    /// be gating network consent on this hint.
+    #[test]
+    fn only_the_tools_that_cannot_reach_the_network_are_closed_world() {
+        let closed: Vec<String> = WindbgServer::tool_router()
+            .list_all()
+            .into_iter()
+            .filter(|t| {
+                t.annotations
+                    .as_ref()
+                    .is_some_and(|a| a.open_world_hint == Some(false))
+            })
+            .map(|t| t.name.to_string())
+            .collect();
+
+        assert_eq!(closed, ["decode_ioctl", "end_session", "read_memory"]);
     }
 
     /// Session-scoped tools take a handle; the two that are genuinely session-independent

--- a/src/server.rs
+++ b/src/server.rs
@@ -1466,15 +1466,16 @@ impl WindbgServer {
 // ---- Tools ---------------------------------------------------------------
 //
 // On `open_world_hint`: everything that touches a debug target is open-world, and only
-// `decode_ioctl` — pure arithmetic on a control code, which never reaches the engine — is
-// not. Two independent reasons put the rest over the line. A symbol server on the symbol
+// `decode_ioctl` (pure arithmetic on a control code) and `session_status` (a read of this
+// server's own state) are not. Two independent reasons put the rest over the line. A symbol server on the symbol
 // path (the documented, recommended setup) means almost any command can make DbgEng
 // download a PDB, and not only the obvious symbol-pattern queries: `r` symbolizes the
 // current instruction, `k` symbolizes every frame, `bp module!Symbol` resolves a name.
 // And a session opened over KDNET puts the *target itself* on the far side of a network
 // link, so even `read_memory` fetching raw bytes, or `end_session` releasing the target,
-// is remote traffic. Claiming otherwise would tell a client the tool cannot touch the
-// network and let it skip whatever consent that decision gates.
+// is remote traffic. That leaves `decode_ioctl` and `session_status`, the two that never
+// reach the engine at all. Claiming otherwise would tell a client the tool cannot touch
+// the network and let it skip whatever consent that decision gates.
 
 #[rmcp::tool_router]
 impl WindbgServer {
@@ -1710,6 +1711,35 @@ impl WindbgServer {
             |e| e.execute_command("r").map_err(es),
         )
         .await
+    }
+
+    /// Report the handle of the debug session this server currently holds, or that none is
+    /// open. Use it to recover a `session_id` you never received — most importantly after an
+    /// `attach_kernel` that reported a timeout: a live kernel attach waits indefinitely, so
+    /// the call can give up while the engine thread stays parked and completes the attach
+    /// later, committing a handle no reply ever carried. Prefer this to retrying the attach,
+    /// which would connect a second time.
+    #[rmcp::tool(annotations(
+        title = "Show current session handle",
+        read_only_hint = true,
+        open_world_hint = false
+    ))]
+    async fn session_status(&self) -> Result<CallToolResult, ErrorData> {
+        // Deliberately *not* queued on the engine thread. The case this exists for is a
+        // parked attach holding that thread, so queueing behind it would make the tool
+        // unavailable exactly when it is needed. The cost is that it can read a moment
+        // behind an open that is still in flight, which is fine for a status query.
+        let current = lock(&self.session).clone();
+        text_result(match current {
+            Some(id) => format!(
+                "session_id: {id}\nPass this as `session_id` on later calls so they fail \
+                 loudly instead of silently acting on a different target if this server's \
+                 session is replaced."
+            ),
+            None => "No debug session is open. Start one with open_dump / open_trace / \
+                     attach_process / attach_kernel / attach_kernel_local / launch."
+                .to_string(),
+        })
     }
 
     /// End the current debug session (detach/close the target) without exiting the server.
@@ -2272,7 +2302,9 @@ impl WindbgServer {
     #[rmcp::tool(annotations(
         title = "Build TTD trace index",
         read_only_hint = false,
-        destructive_hint = false,
+        // `-force` deletes and rebuilds an unloadable `.idx` — that is replacing an
+        // on-disk artifact, whatever the intent behind it.
+        destructive_hint = true,
         idempotent_hint = true,
         open_world_hint = true
     ))]
@@ -2675,7 +2707,7 @@ mod tests {
 
     /// Only a tool that structurally cannot reach the network may say so. Everything that
     /// touches a target can trigger a PDB download, and over KDNET the target itself is
-    /// remote — so `decode_ioctl`, which never reaches the engine, is the only one left.
+    /// remote — leaving the two that never reach the engine at all.
     #[test]
     fn only_the_tools_that_cannot_reach_the_network_are_closed_world() {
         let closed: Vec<String> = WindbgServer::tool_router()
@@ -2689,7 +2721,7 @@ mod tests {
             .map(|t| t.name.to_string())
             .collect();
 
-        assert_eq!(closed, ["decode_ioctl"]);
+        assert_eq!(closed, ["decode_ioctl", "session_status"]);
     }
 
     /// Session-scoped tools take a handle; the two that are genuinely session-independent
@@ -2708,7 +2740,14 @@ mod tests {
         for name in ["read_memory", "execute", "go", "end_session", "modules"] {
             assert!(takes_session(name), "`{name}` should accept session_id");
         }
-        for name in ["decode_ioctl", "record_trace", "open_dump"] {
+        // `session_status` in particular must not require one — it exists to hand back a
+        // handle the caller never received.
+        for name in [
+            "decode_ioctl",
+            "record_trace",
+            "open_dump",
+            "session_status",
+        ] {
             assert!(
                 !takes_session(name),
                 "`{name}` should not accept session_id"

--- a/src/server.rs
+++ b/src/server.rs
@@ -16,7 +16,7 @@ use rmcp::model::{CallToolResult, Content};
 use schemars::JsonSchema;
 use serde::Deserialize;
 
-use win_kexp::dbgeng::RunToOutcome;
+use win_kexp::dbgeng::{DebugEngine, RunToOutcome};
 
 use crate::engine::{EngineError, EngineHandle};
 use crate::ttd;
@@ -1302,7 +1302,16 @@ pub struct RunToAddressArgs {
 // refuses to run when it no longer matches.
 //
 // The handle is optional so existing callers keep working; supplying it is what buys
-// the guarantee that a call can never land on a target it did not open.
+// the guarantee that a call which does supply one can never land on a target it did
+// not open.
+//
+// That guarantee only holds because both the check and the session transition happen
+// **on the engine thread**, inside the same queued job as the debugger call itself.
+// Checking on the async side instead would be a time-of-check/time-of-use bug: with
+// session A current, an `open_dump` for B can already be in flight while `session`
+// still reads A, so an `end_session(session_id=A)` would pass the check, queue behind
+// the open, and then close B. The engine queue is the only serialisation point that
+// orders against DbgEng access, so the gate has to live on it.
 
 /// The session-handle policy, as a pure function so it unit-tests without an engine.
 ///
@@ -1330,42 +1339,64 @@ fn check_session_handle(current: Option<&str>, supplied: Option<&str>) -> Result
     }
 }
 
+/// A poisoned lock only ever means a previous holder panicked mid-update; the value is a
+/// plain `Option<String>` and cannot be left inconsistent, so recovering beats poisoning
+/// every later tool call. The lock is never held across a debugger operation.
+fn lock(session: &Mutex<Option<String>>) -> std::sync::MutexGuard<'_, Option<String>> {
+    session.lock().unwrap_or_else(|e| e.into_inner())
+}
+
+/// Builds the deferred session check.
+///
+/// The returned closure reads the session *when it runs*, not when it is built — that is
+/// the whole point, and it is why the gate must be handed to the engine thread rather than
+/// evaluated by the caller. Free function so it tests without an engine.
+fn session_gate_for(
+    session: Arc<Mutex<Option<String>>>,
+    supplied: Option<&str>,
+) -> impl FnOnce() -> Result<(), String> + Send + 'static + use<> {
+    let supplied = supplied.map(str::to_owned);
+    move || check_session_handle(lock(&session).as_deref(), supplied.as_deref())
+}
+
 impl WindbgServer {
-    /// Records a newly opened target and returns its handle.
-    fn begin_session(&self) -> String {
+    /// Builds the session gate for a caller-supplied handle. The returned closure is run
+    /// *by the engine thread*, immediately before the debugger operation it guards — see
+    /// the module note above for why checking any earlier is unsound.
+    fn session_gate(
+        &self,
+        supplied: Option<&str>,
+    ) -> impl FnOnce() -> Result<(), String> + Send + 'static + use<> {
+        session_gate_for(Arc::clone(&self.session), supplied)
+    }
+
+    /// Runs a session-opening operation and takes ownership of the session in the same
+    /// queued job, so no other call can be ordered across the transition.
+    async fn opened_result<F>(&self, f: F) -> Result<CallToolResult, ErrorData>
+    where
+        F: FnOnce(&DebugEngine) -> Result<String, String> + Send + 'static,
+    {
         let id = mint_session_id();
-        *self.session_lock() = Some(id.clone());
-        id
-    }
-
-    /// Forgets the current target, so handles held by callers now read as stale.
-    fn clear_session(&self) {
-        *self.session_lock() = None;
-    }
-
-    /// A poisoned lock here only ever means a previous holder panicked mid-update; the
-    /// value itself is a plain `Option<String>` and cannot be left inconsistent, so
-    /// recovering beats propagating the panic into every later tool call.
-    fn session_lock(&self) -> std::sync::MutexGuard<'_, Option<String>> {
-        self.session.lock().unwrap_or_else(|e| e.into_inner())
-    }
-
-    /// Validates a caller-supplied handle against the target actually loaded.
-    fn check_session(&self, supplied: Option<&str>) -> Result<(), String> {
-        check_session_handle(self.session_lock().as_deref(), supplied)
-    }
-
-    /// Renders a session-creating tool's outcome, minting a handle on success.
-    fn opened_result(&self, r: Result<String, EngineError>) -> Result<CallToolResult, ErrorData> {
-        match r {
-            Ok(out) => {
-                let id = self.begin_session();
-                text_result(format!(
-                    "{out}\n\nsession_id: {id}\nPass this as `session_id` on later calls so they \
-                     fail loudly instead of silently acting on a different target if this \
-                     server's session is replaced."
-                ))
-            }
+        let session = Arc::clone(&self.session);
+        let new_id = id.clone();
+        let out = self
+            .engine
+            .run(move |e| {
+                // The target is being replaced, so every handle issued so far is stale from
+                // here on — including if the open fails partway and leaves the engine holding
+                // neither the old target nor a usable new one.
+                *lock(&session) = None;
+                let out = f(e)?;
+                *lock(&session) = Some(new_id);
+                Ok(out)
+            })
+            .await;
+        match out {
+            Ok(out) => text_result(format!(
+                "{out}\n\nsession_id: {id}\nPass this as `session_id` on later calls so they \
+                 fail loudly instead of silently acting on a different target if this \
+                 server's session is replaced."
+            )),
             Err(e) => engine_result(Err(e)),
         }
     }
@@ -1395,22 +1426,19 @@ impl WindbgServer {
         &self,
         Parameters(args): Parameters<PathArgs>,
     ) -> Result<CallToolResult, ErrorData> {
-        let out = self
-            .engine
-            .run(move |e| {
-                e.open_dump(&args.path).map_err(es)?;
-                e.wait_for_event(LOAD_WAIT_MS).map_err(es)?;
-                // Load the WinDbg extension DLL so `!`-extension commands resolve — most
-                // importantly `!ext.analyze -v`, the crash-dump triage workhorse. A bare
-                // engine doesn't auto-load it, and even after `.load ext` the unqualified
-                // `!analyze` won't resolve, so callers must use `!ext.analyze`. Best-effort:
-                // a minimal engine without a bundled `winext\` directory simply won't have
-                // ext.dll, which must not fail the open (live/dump state is still usable).
-                let _ = e.execute_command(".load ext");
-                e.execute_command("lm").map_err(es)
-            })
-            .await;
-        self.opened_result(out)
+        self.opened_result(move |e| {
+            e.open_dump(&args.path).map_err(es)?;
+            e.wait_for_event(LOAD_WAIT_MS).map_err(es)?;
+            // Load the WinDbg extension DLL so `!`-extension commands resolve — most
+            // importantly `!ext.analyze -v`, the crash-dump triage workhorse. A bare
+            // engine doesn't auto-load it, and even after `.load ext` the unqualified
+            // `!analyze` won't resolve, so callers must use `!ext.analyze`. Best-effort:
+            // a minimal engine without a bundled `winext\` directory simply won't have
+            // ext.dll, which must not fail the open (live/dump state is still usable).
+            let _ = e.execute_command(".load ext");
+            e.execute_command("lm").map_err(es)
+        })
+        .await
     }
 
     /// Open a TTD trace (.run); alias of open_dump. Enables time-travel navigation and TTD queries.
@@ -1426,9 +1454,7 @@ impl WindbgServer {
         &self,
         Parameters(args): Parameters<PathArgs>,
     ) -> Result<CallToolResult, ErrorData> {
-        let out = self
-            .engine
-            .run(move |e| {
+        self.opened_result(move |e| {
                 e.open_trace(&args.path).map_err(es)?;
                 e.wait_for_event(LOAD_WAIT_MS).map_err(es)?;
                 // Check the index state *before* any data-model query: `!ttdext.index -status`
@@ -1460,9 +1486,8 @@ impl WindbgServer {
                     );
                 }
                 Ok(out)
-            })
-            .await;
-        self.opened_result(out)
+        })
+        .await
     }
 
     /// Attach to the local kernel (live local kernel debugging).
@@ -1475,21 +1500,18 @@ impl WindbgServer {
         open_world_hint = true
     ))]
     async fn attach_kernel_local(&self) -> Result<CallToolResult, ErrorData> {
-        let out = self
-            .engine
-            .run(move |e| {
-                // attach_local_kernel breaks the target in internally (INITIAL_BREAK +
-                // an INFINITE wait, as a live kernel requires).
-                e.attach_local_kernel().map_err(es)?;
-                // The driver_object/device_object/irp_stack tools use kernel-extension
-                // commands (!drvobj/!devobj/!irp) from kdexts.dll, which a bare engine does
-                // not auto-load. Best-effort, like open_dump's `.load ext`; harmless if the
-                // extension isn't bundled (those tools then report a clean "no export").
-                let _ = e.execute_command(".load kdexts");
-                e.execute_command("vertarget").map_err(es)
-            })
-            .await;
-        self.opened_result(out)
+        self.opened_result(move |e| {
+            // attach_local_kernel breaks the target in internally (INITIAL_BREAK +
+            // an INFINITE wait, as a live kernel requires).
+            e.attach_local_kernel().map_err(es)?;
+            // The driver_object/device_object/irp_stack tools use kernel-extension
+            // commands (!drvobj/!devobj/!irp) from kdexts.dll, which a bare engine does
+            // not auto-load. Best-effort, like open_dump's `.load ext`; harmless if the
+            // extension isn't bundled (those tools then report a clean "no export").
+            let _ = e.execute_command(".load kdexts");
+            e.execute_command("vertarget").map_err(es)
+        })
+        .await
     }
 
     /// Attach to a kernel target over a connection string (e.g. KDNET).
@@ -1505,19 +1527,16 @@ impl WindbgServer {
         &self,
         Parameters(args): Parameters<ConnectionArgs>,
     ) -> Result<CallToolResult, ErrorData> {
-        let out = self
-            .engine
-            .run(move |e| {
-                // attach_kernel connects, requests an initial break, and waits (INFINITE,
-                // as a live kernel requires) for the break-in — all internally.
-                e.attach_kernel(&args.connection).map_err(es)?;
-                // Load kdexts.dll so the driver_object/device_object/irp_stack tools'
-                // !drvobj/!devobj/!irp commands resolve (see attach_kernel_local). Best-effort.
-                let _ = e.execute_command(".load kdexts");
-                e.execute_command("vertarget").map_err(es)
-            })
-            .await;
-        self.opened_result(out)
+        self.opened_result(move |e| {
+            // attach_kernel connects, requests an initial break, and waits (INFINITE,
+            // as a live kernel requires) for the break-in — all internally.
+            e.attach_kernel(&args.connection).map_err(es)?;
+            // Load kdexts.dll so the driver_object/device_object/irp_stack tools'
+            // !drvobj/!devobj/!irp commands resolve (see attach_kernel_local). Best-effort.
+            let _ = e.execute_command(".load kdexts");
+            e.execute_command("vertarget").map_err(es)
+        })
+        .await
     }
 
     /// Set or extend the symbol search path, then reload symbols, so `module!Symbol`
@@ -1537,13 +1556,12 @@ impl WindbgServer {
         &self,
         Parameters(args): Parameters<SymbolPathArgs>,
     ) -> Result<CallToolResult, ErrorData> {
-        if let Err(e) = self.check_session(args.session_id.as_deref()) {
-            return tool_error(e);
-        }
+        let gate = self.session_gate(args.session_id.as_deref());
         let append = args.append.unwrap_or(true);
         let out = self
             .engine
             .run(move |e| {
+                gate()?;
                 if append {
                     e.append_symbol_path(&args.path).map_err(es)?;
                 } else {
@@ -1573,15 +1591,12 @@ impl WindbgServer {
         Parameters(args): Parameters<PidArgs>,
     ) -> Result<CallToolResult, ErrorData> {
         let pid = args.pid;
-        let out = self
-            .engine
-            .run(move |e| {
-                // attach_process waits for the break-in internally.
-                e.attach_process(pid).map_err(es)?;
-                e.execute_command("r").map_err(es)
-            })
-            .await;
-        self.opened_result(out)
+        self.opened_result(move |e| {
+            // attach_process waits for the break-in internally.
+            e.attach_process(pid).map_err(es)?;
+            e.execute_command("r").map_err(es)
+        })
+        .await
     }
 
     /// Launch a new user-mode process under the debugger, stopping at the initial breakpoint.
@@ -1597,15 +1612,12 @@ impl WindbgServer {
         &self,
         Parameters(args): Parameters<CommandLineArgs>,
     ) -> Result<CallToolResult, ErrorData> {
-        let out = self
-            .engine
-            .run(move |e| {
-                // launch_process waits for the initial break internally.
-                e.launch_process(&args.command_line).map_err(es)?;
-                e.execute_command("r").map_err(es)
-            })
-            .await;
-        self.opened_result(out)
+        self.opened_result(move |e| {
+            // launch_process waits for the initial break internally.
+            e.launch_process(&args.command_line).map_err(es)?;
+            e.execute_command("r").map_err(es)
+        })
+        .await
     }
 
     /// End the current debug session (detach/close the target) without exiting the server.
@@ -1622,20 +1634,22 @@ impl WindbgServer {
         &self,
         Parameters(args): Parameters<SessionArgs>,
     ) -> Result<CallToolResult, ErrorData> {
-        if let Err(e) = self.check_session(args.session_id.as_deref()) {
-            return tool_error(e);
-        }
+        let gate = self.session_gate(args.session_id.as_deref());
+        let session = Arc::clone(&self.session);
         let out = self
             .engine
             .run(move |e| {
-                e.end_session()
+                gate()?;
+                let out = e
+                    .end_session()
                     .map(|_| "session ended".to_string())
-                    .map_err(es)
+                    .map_err(es)?;
+                // Cleared in the same job as the teardown, so a call queued behind this one
+                // sees "no session open" rather than a handle that outlived its target.
+                *lock(&session) = None;
+                Ok(out)
             })
             .await;
-        if out.is_ok() {
-            self.clear_session();
-        }
         engine_result(out)
     }
 
@@ -1651,12 +1665,10 @@ impl WindbgServer {
         &self,
         Parameters(args): Parameters<ExecuteArgs>,
     ) -> Result<CallToolResult, ErrorData> {
-        if let Err(e) = self.check_session(args.session_id.as_deref()) {
-            return tool_error(e);
-        }
+        let gate = self.session_gate(args.session_id.as_deref());
         // Bounded: a runaway raw command (e.g. an unbounded `s` search) self-aborts instead
         // of pinning the engine thread and wedging every later call.
-        let out = self.engine.run_command(args.command).await;
+        let out = self.engine.run_command(args.command, gate).await;
         engine_result(out)
     }
 
@@ -1670,10 +1682,14 @@ impl WindbgServer {
         &self,
         Parameters(args): Parameters<SessionArgs>,
     ) -> Result<CallToolResult, ErrorData> {
-        if let Err(e) = self.check_session(args.session_id.as_deref()) {
-            return tool_error(e);
-        }
-        let out = self.engine.run(move |e| e.registers().map_err(es)).await;
+        let gate = self.session_gate(args.session_id.as_deref());
+        let out = self
+            .engine
+            .run(move |e| {
+                gate()?;
+                e.registers().map_err(es)
+            })
+            .await;
         // DbgEng prints nothing for `r` when there is no live thread context (e.g. a
         // module-load break, or a bare goto_position to the very start of a trace).
         let out = out.map(|s| {
@@ -1699,13 +1715,12 @@ impl WindbgServer {
         &self,
         Parameters(args): Parameters<ReadMemoryArgs>,
     ) -> Result<CallToolResult, ErrorData> {
-        if let Err(e) = self.check_session(args.session_id.as_deref()) {
-            return tool_error(e);
-        }
+        let gate = self.session_gate(args.session_id.as_deref());
         let size = args.size;
         let out = self
             .engine
             .run(move |e| {
+                gate()?;
                 let addr = parse_u64(&args.address)?;
                 let bytes = e.read_memory(addr, size as usize).map_err(es)?;
                 Ok(hexdump(addr, &bytes))
@@ -1724,12 +1739,13 @@ impl WindbgServer {
         &self,
         Parameters(args): Parameters<SessionArgs>,
     ) -> Result<CallToolResult, ErrorData> {
-        if let Err(e) = self.check_session(args.session_id.as_deref()) {
-            return tool_error(e);
-        }
+        let gate = self.session_gate(args.session_id.as_deref());
         let out = self
             .engine
-            .run(move |e| e.execute_command("k").map_err(es))
+            .run(move |e| {
+                gate()?;
+                e.execute_command("k").map_err(es)
+            })
             .await;
         engine_result(out)
     }
@@ -1744,12 +1760,13 @@ impl WindbgServer {
         &self,
         Parameters(args): Parameters<SessionArgs>,
     ) -> Result<CallToolResult, ErrorData> {
-        if let Err(e) = self.check_session(args.session_id.as_deref()) {
-            return tool_error(e);
-        }
+        let gate = self.session_gate(args.session_id.as_deref());
         let out = self
             .engine
-            .run(move |e| e.execute_command("lm").map_err(es))
+            .run(move |e| {
+                gate()?;
+                e.execute_command("lm").map_err(es)
+            })
             .await;
         engine_result(out)
     }
@@ -1764,12 +1781,13 @@ impl WindbgServer {
         &self,
         Parameters(args): Parameters<SessionArgs>,
     ) -> Result<CallToolResult, ErrorData> {
-        if let Err(e) = self.check_session(args.session_id.as_deref()) {
-            return tool_error(e);
-        }
+        let gate = self.session_gate(args.session_id.as_deref());
         let out = self
             .engine
-            .run(move |e| e.execute_command("~").map_err(es))
+            .run(move |e| {
+                gate()?;
+                e.execute_command("~").map_err(es)
+            })
             .await;
         engine_result(out)
     }
@@ -1784,16 +1802,17 @@ impl WindbgServer {
         &self,
         Parameters(args): Parameters<DisassembleArgs>,
     ) -> Result<CallToolResult, ErrorData> {
-        if let Err(e) = self.check_session(args.session_id.as_deref()) {
-            return tool_error(e);
-        }
+        let gate = self.session_gate(args.session_id.as_deref());
         let cmd = match args.address {
             Some(a) => format!("u {a}"),
             None => "u".to_string(),
         };
         let out = self
             .engine
-            .run(move |e| e.execute_command(&cmd).map_err(es))
+            .run(move |e| {
+                gate()?;
+                e.execute_command(&cmd).map_err(es)
+            })
             .await;
         engine_result(out)
     }
@@ -1807,13 +1826,11 @@ impl WindbgServer {
         open_world_hint = false
     ))]
     async fn dx(&self, Parameters(args): Parameters<DxArgs>) -> Result<CallToolResult, ErrorData> {
-        if let Err(e) = self.check_session(args.session_id.as_deref()) {
-            return tool_error(e);
-        }
+        let gate = self.session_gate(args.session_id.as_deref());
         let cmd = format!("dx {}", args.expression);
         // Bounded: a data-model query that runs away (e.g. a heavy LINQ or index build on a
         // huge trace) self-aborts rather than pinning the engine thread.
-        let out = self.engine.run_command(cmd).await;
+        let out = self.engine.run_command(cmd, gate).await;
         engine_result(out)
     }
 
@@ -1830,11 +1847,9 @@ impl WindbgServer {
         &self,
         Parameters(args): Parameters<TtdCallsArgs>,
     ) -> Result<CallToolResult, ErrorData> {
-        if let Err(e) = self.check_session(args.session_id.as_deref()) {
-            return tool_error(e);
-        }
+        let gate = self.session_gate(args.session_id.as_deref());
         let cmd = format!("dx @$cursession.TTD.Calls(\"{}\")", args.function);
-        let out = self.engine.run_command(cmd).await;
+        let out = self.engine.run_command(cmd, gate).await;
         engine_result(out)
     }
 
@@ -1850,9 +1865,7 @@ impl WindbgServer {
         &self,
         Parameters(args): Parameters<TtdMemoryArgs>,
     ) -> Result<CallToolResult, ErrorData> {
-        if let Err(e) = self.check_session(args.session_id.as_deref()) {
-            return tool_error(e);
-        }
+        let gate = self.session_gate(args.session_id.as_deref());
         // A bad address is the model's mistake to fix, so it comes back as a tool error
         // rather than a protocol error the model cannot act on.
         let start = match parse_u64(&args.address) {
@@ -1867,7 +1880,7 @@ impl WindbgServer {
             ),
             _ => format!("dx @$cursession.TTD.Memory(0x{start:x}, 0x{end:x})"),
         };
-        let out = self.engine.run_command(cmd).await;
+        let out = self.engine.run_command(cmd, gate).await;
         engine_result(out)
     }
 
@@ -1883,12 +1896,10 @@ impl WindbgServer {
         &self,
         Parameters(args): Parameters<SessionArgs>,
     ) -> Result<CallToolResult, ErrorData> {
-        if let Err(e) = self.check_session(args.session_id.as_deref()) {
-            return tool_error(e);
-        }
+        let gate = self.session_gate(args.session_id.as_deref());
         let out = self
             .engine
-            .run_command("dx -r2 @$curprocess.TTD.Events".to_string())
+            .run_command("dx -r2 @$curprocess.TTD.Events".to_string(), gate)
             .await;
         engine_result(out)
     }
@@ -1905,13 +1916,14 @@ impl WindbgServer {
         &self,
         Parameters(args): Parameters<BreakpointArgs>,
     ) -> Result<CallToolResult, ErrorData> {
-        if let Err(e) = self.check_session(args.session_id.as_deref()) {
-            return tool_error(e);
-        }
+        let gate = self.session_gate(args.session_id.as_deref());
         let cmd = format!("bp {}", args.expression);
         let out = self
             .engine
-            .run(move |e| e.execute_command(&cmd).map_err(es))
+            .run(move |e| {
+                gate()?;
+                e.execute_command(&cmd).map_err(es)
+            })
             .await;
         engine_result(out)
     }
@@ -1928,12 +1940,13 @@ impl WindbgServer {
         &self,
         Parameters(args): Parameters<SessionArgs>,
     ) -> Result<CallToolResult, ErrorData> {
-        if let Err(e) = self.check_session(args.session_id.as_deref()) {
-            return tool_error(e);
-        }
+        let gate = self.session_gate(args.session_id.as_deref());
         let out = self
             .engine
-            .run(move |e| e.execute_and_wait("g", EXEC_WAIT_MS).map_err(es))
+            .run(move |e| {
+                gate()?;
+                e.execute_and_wait("g", EXEC_WAIT_MS).map_err(es)
+            })
             .await;
         engine_result(out)
     }
@@ -1955,12 +1968,11 @@ impl WindbgServer {
         &self,
         Parameters(args): Parameters<RunToAddressArgs>,
     ) -> Result<CallToolResult, ErrorData> {
-        if let Err(e) = self.check_session(args.session_id.as_deref()) {
-            return tool_error(e);
-        }
+        let gate = self.session_gate(args.session_id.as_deref());
         let out = self
             .engine
             .run(move |e| {
+                gate()?;
                 // Resolve the target the same WinDbg-aware way as `reachable_from_dispatch`.
                 let resolve = |expr: &str| -> Option<u64> {
                     e.execute_command(&format!("? {expr}"))
@@ -2013,12 +2025,13 @@ impl WindbgServer {
         &self,
         Parameters(args): Parameters<SessionArgs>,
     ) -> Result<CallToolResult, ErrorData> {
-        if let Err(e) = self.check_session(args.session_id.as_deref()) {
-            return tool_error(e);
-        }
+        let gate = self.session_gate(args.session_id.as_deref());
         let out = self
             .engine
-            .run(move |e| e.execute_and_wait("p", EXEC_WAIT_MS).map_err(es))
+            .run(move |e| {
+                gate()?;
+                e.execute_and_wait("p", EXEC_WAIT_MS).map_err(es)
+            })
             .await;
         engine_result(out)
     }
@@ -2035,12 +2048,13 @@ impl WindbgServer {
         &self,
         Parameters(args): Parameters<SessionArgs>,
     ) -> Result<CallToolResult, ErrorData> {
-        if let Err(e) = self.check_session(args.session_id.as_deref()) {
-            return tool_error(e);
-        }
+        let gate = self.session_gate(args.session_id.as_deref());
         let out = self
             .engine
-            .run(move |e| e.execute_and_wait("t", EXEC_WAIT_MS).map_err(es))
+            .run(move |e| {
+                gate()?;
+                e.execute_and_wait("t", EXEC_WAIT_MS).map_err(es)
+            })
             .await;
         engine_result(out)
     }
@@ -2059,12 +2073,13 @@ impl WindbgServer {
         &self,
         Parameters(args): Parameters<SessionArgs>,
     ) -> Result<CallToolResult, ErrorData> {
-        if let Err(e) = self.check_session(args.session_id.as_deref()) {
-            return tool_error(e);
-        }
+        let gate = self.session_gate(args.session_id.as_deref());
         let out = self
             .engine
-            .run(move |e| e.execute_and_wait("t-", EXEC_WAIT_MS).map_err(es))
+            .run(move |e| {
+                gate()?;
+                e.execute_and_wait("t-", EXEC_WAIT_MS).map_err(es)
+            })
             .await;
         engine_result(out)
     }
@@ -2081,12 +2096,13 @@ impl WindbgServer {
         &self,
         Parameters(args): Parameters<SessionArgs>,
     ) -> Result<CallToolResult, ErrorData> {
-        if let Err(e) = self.check_session(args.session_id.as_deref()) {
-            return tool_error(e);
-        }
+        let gate = self.session_gate(args.session_id.as_deref());
         let out = self
             .engine
-            .run(move |e| e.execute_and_wait("p-", EXEC_WAIT_MS).map_err(es))
+            .run(move |e| {
+                gate()?;
+                e.execute_and_wait("p-", EXEC_WAIT_MS).map_err(es)
+            })
             .await;
         engine_result(out)
     }
@@ -2103,12 +2119,13 @@ impl WindbgServer {
         &self,
         Parameters(args): Parameters<SessionArgs>,
     ) -> Result<CallToolResult, ErrorData> {
-        if let Err(e) = self.check_session(args.session_id.as_deref()) {
-            return tool_error(e);
-        }
+        let gate = self.session_gate(args.session_id.as_deref());
         let out = self
             .engine
-            .run(move |e| e.execute_and_wait("g-", EXEC_WAIT_MS).map_err(es))
+            .run(move |e| {
+                gate()?;
+                e.execute_and_wait("g-", EXEC_WAIT_MS).map_err(es)
+            })
             .await;
         engine_result(out)
     }
@@ -2125,13 +2142,14 @@ impl WindbgServer {
         &self,
         Parameters(args): Parameters<PositionArgs>,
     ) -> Result<CallToolResult, ErrorData> {
-        if let Err(e) = self.check_session(args.session_id.as_deref()) {
-            return tool_error(e);
-        }
+        let gate = self.session_gate(args.session_id.as_deref());
         let cmd = format!("!tt {}", args.position);
         let out = self
             .engine
-            .run(move |e| e.execute_command(&cmd).map_err(es))
+            .run(move |e| {
+                gate()?;
+                e.execute_command(&cmd).map_err(es)
+            })
             .await;
         engine_result(out)
     }
@@ -2154,12 +2172,13 @@ impl WindbgServer {
         &self,
         Parameters(args): Parameters<SessionArgs>,
     ) -> Result<CallToolResult, ErrorData> {
-        if let Err(e) = self.check_session(args.session_id.as_deref()) {
-            return tool_error(e);
-        }
+        let gate = self.session_gate(args.session_id.as_deref());
         let out = self
             .engine
-            .run(move |e| e.execute_command("!ttdext.index -force").map_err(es))
+            .run(move |e| {
+                gate()?;
+                e.execute_command("!ttdext.index -force").map_err(es)
+            })
             .await;
         engine_result(out)
     }
@@ -2246,13 +2265,14 @@ impl WindbgServer {
         &self,
         Parameters(args): Parameters<DriverObjectArgs>,
     ) -> Result<CallToolResult, ErrorData> {
-        if let Err(e) = self.check_session(args.session_id.as_deref()) {
-            return tool_error(e);
-        }
+        let gate = self.session_gate(args.session_id.as_deref());
         let cmd = format!("!drvobj {} 7", args.name);
         let out = self
             .engine
-            .run(move |e| e.execute_command(&cmd).map_err(es))
+            .run(move |e| {
+                gate()?;
+                e.execute_command(&cmd).map_err(es)
+            })
             .await;
         engine_result(out)
     }
@@ -2270,13 +2290,14 @@ impl WindbgServer {
         &self,
         Parameters(args): Parameters<DeviceObjectArgs>,
     ) -> Result<CallToolResult, ErrorData> {
-        if let Err(e) = self.check_session(args.session_id.as_deref()) {
-            return tool_error(e);
-        }
+        let gate = self.session_gate(args.session_id.as_deref());
         let cmd = format!("!devobj {}", args.device);
         let out = self
             .engine
-            .run(move |e| e.execute_command(&cmd).map_err(es))
+            .run(move |e| {
+                gate()?;
+                e.execute_command(&cmd).map_err(es)
+            })
             .await;
         engine_result(out)
     }
@@ -2293,14 +2314,15 @@ impl WindbgServer {
         &self,
         Parameters(args): Parameters<IrpStackArgs>,
     ) -> Result<CallToolResult, ErrorData> {
-        if let Err(e) = self.check_session(args.session_id.as_deref()) {
-            return tool_error(e);
-        }
+        let gate = self.session_gate(args.session_id.as_deref());
         let irp = args.irp.unwrap_or_else(|| "@rdx".to_string());
         let cmd = format!("!irp {irp} 1");
         let out = self
             .engine
-            .run(move |e| e.execute_command(&cmd).map_err(es))
+            .run(move |e| {
+                gate()?;
+                e.execute_command(&cmd).map_err(es)
+            })
             .await;
         engine_result(out)
     }
@@ -2321,9 +2343,7 @@ impl WindbgServer {
         &self,
         Parameters(args): Parameters<IoctlTraceArgs>,
     ) -> Result<CallToolResult, ErrorData> {
-        if let Err(e) = self.check_session(args.session_id.as_deref()) {
-            return tool_error(e);
-        }
+        let gate = self.session_gate(args.session_id.as_deref());
         // IRP in @rdx at dispatch entry (x64). CurrentStackLocation = poi(Irp+0xb8).
         // Within IO_STACK_LOCATION: OutputBufferLength +0x08, InputBufferLength +0x10,
         // IoControlCode +0x18 (Parameters union begins at +0x08).
@@ -2334,7 +2354,10 @@ impl WindbgServer {
         );
         let out = self
             .engine
-            .run(move |e| e.execute_command(&cmd).map_err(es))
+            .run(move |e| {
+                gate()?;
+                e.execute_command(&cmd).map_err(es)
+            })
             .await;
         engine_result(out)
     }
@@ -2355,12 +2378,11 @@ impl WindbgServer {
         &self,
         Parameters(args): Parameters<ReachabilityArgs>,
     ) -> Result<CallToolResult, ErrorData> {
-        if let Err(e) = self.check_session(args.session_id.as_deref()) {
-            return tool_error(e);
-        }
+        let gate = self.session_gate(args.session_id.as_deref());
         let out = self
             .engine
             .run(move |e| {
+                gate()?;
                 // Resolve an address/offset expression the way `uf`/WinDbg read it:
                 // evaluate `? <expr>` first (the MASM evaluator's default base is hex, so
                 // a bare `00401234` is 0x00401234 and `module!Dispatch+0x123` resolves),
@@ -2591,6 +2613,39 @@ mod tests {
     fn handle_is_refused_once_the_session_is_ended() {
         let err = check_session_handle(None, Some("sess-1")).unwrap_err();
         assert!(err.contains("no debug session open"), "{err}");
+    }
+
+    /// The gate must read the session at execution time. Building it and evaluating it at
+    /// submission time — the obvious-looking caller-side check — leaves a window in which a
+    /// concurrent `open_*` replaces the target between the check and the debugger call, so
+    /// a call that passed validation still runs against the wrong session.
+    #[test]
+    fn the_gate_reads_the_session_when_it_runs_not_when_it_is_built() {
+        let session = Arc::new(Mutex::new(Some("sess-A".to_string())));
+        let gate = session_gate_for(Arc::clone(&session), Some("sess-A"));
+
+        // A concurrent open lands after the gate was built but before it runs.
+        *lock(&session) = Some("sess-B".to_string());
+
+        let err = gate().unwrap_err();
+        assert!(err.contains("sess-B"), "{err}");
+    }
+
+    #[test]
+    fn the_gate_passes_when_the_session_is_unchanged_at_execution_time() {
+        let session = Arc::new(Mutex::new(Some("sess-A".to_string())));
+        let gate = session_gate_for(Arc::clone(&session), Some("sess-A"));
+        assert!(gate().is_ok());
+    }
+
+    /// A target replaced while the caller held no handle is still their problem to opt into,
+    /// so an absent handle keeps passing whatever the session did in the meantime.
+    #[test]
+    fn an_absent_handle_still_passes_after_a_replacement() {
+        let session = Arc::new(Mutex::new(Some("sess-A".to_string())));
+        let gate = session_gate_for(Arc::clone(&session), None);
+        *lock(&session) = Some("sess-B".to_string());
+        assert!(gate().is_ok());
     }
 
     #[test]

--- a/src/server.rs
+++ b/src/server.rs
@@ -35,9 +35,12 @@ static SESSION_SEQ: AtomicU64 = AtomicU64::new(1);
 pub struct WindbgServer {
     engine: EngineHandle,
     /// Handle identifying the debug session the engine is currently attached to, or
-    /// `None` when no target is open. See [`WindbgServer::check_session`] for why this
-    /// exists rather than letting the connection stand in for the session.
+    /// `None` when no target is open. See [`check_session_handle`] for why this exists
+    /// rather than letting the connection stand in for the session.
     session: Arc<Mutex<Option<String>>>,
+    /// Recent opener outcomes, so a caller whose open timed out can find out whether it is
+    /// still pending, landed, or failed. See [`OpenOutcome`].
+    opens: Arc<Mutex<VecDeque<(String, OpenOutcome)>>>,
 }
 
 /// Maps any error to a `String` for the engine `Reply` channel.
@@ -1398,6 +1401,47 @@ fn reject_command_breakers(field: &str, value: &str, quotes: Quotes) -> Result<(
     ))
 }
 
+/// How far a session-opening job got.
+///
+/// Recorded because the per-call timeout abandons the *waiter*, not the job: a caller can
+/// stop hearing about an open that is still queued, still running, or already finished. The
+/// current session handle alone cannot tell those apart — a handle that is not yours means
+/// only "not yours", which is equally true while you wait and after you have failed. So the
+/// outcome is tracked per opener, and [`WindbgServer::session_status`] can be asked about a
+/// specific one.
+///
+/// The distinction matters because it changes what the caller should do: a `Pending` open
+/// must not be re-run (that attaches or launches a second time), while a `Failed` one has to
+/// be, since nothing else will produce a target.
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum OpenOutcome {
+    /// Queued or running. The handle may still be committed.
+    Pending,
+    /// The target was opened and the handle committed. It may since have been replaced by a
+    /// later open — that is what the handle check is for — but this open did land.
+    Landed,
+    /// The open failed. This handle will never be committed; opening again is the only way
+    /// forward.
+    Failed(String),
+}
+
+/// How many opener outcomes to remember. Opens are rare and a caller only ever asks about a
+/// recent one, so a short window keeps this from growing without bound.
+const OPEN_HISTORY: usize = 8;
+
+/// Records an opener's outcome, evicting the oldest once [`OPEN_HISTORY`] is reached.
+fn record_open(opens: &Mutex<VecDeque<(String, OpenOutcome)>>, id: &str, outcome: OpenOutcome) {
+    let mut opens = opens.lock().unwrap_or_else(|e| e.into_inner());
+    if let Some(slot) = opens.iter_mut().find(|(known, _)| known == id) {
+        slot.1 = outcome;
+        return;
+    }
+    if opens.len() == OPEN_HISTORY {
+        opens.pop_front();
+    }
+    opens.push_back((id.to_string(), outcome));
+}
+
 /// Can this data-model expression run debugger commands?
 ///
 /// `dx` evaluates arbitrary data-model expressions, and the data model exposes
@@ -1499,8 +1543,12 @@ impl WindbgServer {
     {
         let id = mint_session_id();
         let session = Arc::clone(&self.session);
+        let opens = Arc::clone(&self.opens);
         let new_id = id.clone();
         let id_for_report = id.clone();
+        // Recorded before the job is queued, so a caller who never hears back can still ask
+        // about it — the whole point is that the reply may never arrive.
+        record_open(&self.opens, &id, OpenOutcome::Pending);
         let out = self
             .engine
             .run(move |e| {
@@ -1508,8 +1556,18 @@ impl WindbgServer {
                 // here on — including if the transition fails partway and leaves the engine
                 // holding neither the old target nor a usable new one.
                 *lock(&session) = None;
-                transition(e)?;
-                *lock(&session) = Some(new_id);
+                // Under `catch_unwind` for the same reason the report is: an unwind here
+                // would leave the outcome recorded as `Pending` forever, and a caller
+                // following the documented recovery would poll for a handle that is never
+                // coming.
+                let transitioned = catch_unwind(AssertUnwindSafe(|| transition(e)))
+                    .unwrap_or_else(|_| Err("debugger operation panicked".to_string()));
+                if let Err(err) = transitioned {
+                    record_open(&opens, &new_id, OpenOutcome::Failed(err.clone()));
+                    return Err(err);
+                }
+                *lock(&session) = Some(new_id.clone());
+                record_open(&opens, &new_id, OpenOutcome::Landed);
                 // The target is ours from here, so a failed diagnostic still has to hand the
                 // caller their handle — otherwise they cannot use the protection this whole
                 // mechanism promises without re-running a side-effecting open.
@@ -1543,12 +1601,19 @@ impl WindbgServer {
             Err(EngineError::Timeout(msg)) => tool_error(format!(
                 "{msg}\n\nThe wait was abandoned, but this open was not: it may still be \
                  queued behind other work, and may still run and commit the handle `{id}`. \
-                 Poll session_status — the session is yours once it reports `{id}`. A \
-                 different id means yours has not landed *yet*, not that it failed; it may \
-                 still be pending. Either way do not re-run this open to recover, which would \
-                 attach to, or start, a second target."
+                 Ask `session_status {{ \"session_id\": \"{id}\" }}` — it reports whether this \
+                 open is still pending, has landed, or has failed. Do not re-run the open \
+                 while it is pending, which would attach to, or start, a second target; once \
+                 it reports failed, re-running is the only way forward."
             )),
-            Err(e) => engine_result(Err(e)),
+            Err(e) => {
+                // The job never reached the engine (the worker is gone), so nothing on that
+                // side will ever record an outcome for it.
+                if matches!(e, EngineError::Unavailable(_)) {
+                    record_open(&self.opens, &id, OpenOutcome::Failed(e.to_string()));
+                }
+                engine_result(Err(e))
+            }
         }
     }
 }
@@ -1573,6 +1638,7 @@ impl WindbgServer {
         Self {
             engine,
             session: Arc::new(Mutex::new(None)),
+            opens: Arc::new(Mutex::new(VecDeque::new())),
         }
     }
 
@@ -1803,42 +1869,85 @@ impl WindbgServer {
         .await
     }
 
-    /// Report the handle of the debug session this server currently holds, or that none is
-    /// open. Use it to recover a `session_id` you never received — most importantly after an
-    /// `attach_kernel` that reported a timeout: a live kernel attach waits indefinitely, so
-    /// the call can give up while the engine thread stays parked and completes the attach
-    /// later, committing a handle no reply ever carried. Prefer this to retrying the attach,
-    /// which would connect a second time.
+    /// Report the handle of the debug session this server currently holds, and — when asked
+    /// about a specific `session_id` — what became of the open that would have committed it.
     ///
-    /// This reports *the current* handle, not *your* handle — the two differ if another
-    /// caller's open landed while yours was in flight. A timed-out open names the handle it
-    /// would commit, so compare against that: adopt the session only when the two match.
+    /// This exists because a per-call timeout abandons the *waiter*, not the job. A live
+    /// `attach_kernel` waits indefinitely by design, so an open reporting a timeout while it
+    /// completes moments later is normal, not exceptional; the handle it commits is one no
+    /// reply ever carried. Pass the `session_id` the timeout named and this reports whether
+    /// that open is still pending, has landed, or has failed — which is the difference
+    /// between "wait" and "open again", and re-running an attach or launch on a guess
+    /// connects or spawns a second time.
     ///
-    /// A mismatch means "not yours *yet*", not "yours failed". The timeout abandons the
-    /// wait, not the job, so a timed-out open can still be sitting in the queue and can
-    /// still land later. Poll rather than concluding; re-running the open is the one thing
-    /// that is never the answer.
+    /// Called with no argument it reports only the current handle, which answers "what is
+    /// loaded" but deliberately not "is it mine": another caller's open landing while yours
+    /// was in flight produces exactly the same answer.
     #[rmcp::tool(annotations(
         title = "Show current session handle",
         read_only_hint = true,
         open_world_hint = false
     ))]
-    async fn session_status(&self) -> Result<CallToolResult, ErrorData> {
+    async fn session_status(
+        &self,
+        Parameters(args): Parameters<SessionArgs>,
+    ) -> Result<CallToolResult, ErrorData> {
         // Deliberately *not* queued on the engine thread. The case this exists for is a
         // parked attach holding that thread, so queueing behind it would make the tool
         // unavailable exactly when it is needed. The cost is that it can read a moment
         // behind an open that is still in flight, which is fine for a status query.
         let current = lock(&self.session).clone();
-        text_result(match current {
-            Some(id) => format!(
-                "session_id: {id}\nPass this as `session_id` on later calls so they fail \
-                 loudly instead of silently acting on a different target if this server's \
-                 session is replaced."
+        let mut out = match &current {
+            Some(id) => format!("Current session: {id}"),
+            None => "No debug session is open.".to_string(),
+        };
+
+        let Some(asked) = args.session_id.as_deref() else {
+            out.push_str(match current {
+                Some(_) => {
+                    "\nPass a `session_id` here to ask what became of a specific open — this \
+                     line says what is loaded, not whether it is yours."
+                }
+                None => {
+                    "\nStart one with open_dump / open_trace / attach_process / attach_kernel \
+                     / attach_kernel_local / launch."
+                }
+            });
+            return text_result(out);
+        };
+
+        let known = self
+            .opens
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .iter()
+            .find(|(id, _)| id == asked)
+            .map(|(_, outcome)| outcome.clone());
+
+        out.push_str(&match known {
+            Some(OpenOutcome::Landed) if current.as_deref() == Some(asked) => format!(
+                "\n\n`{asked}` landed and is the session now loaded. It is yours: pass it as \
+                 `session_id` on later calls."
             ),
-            None => "No debug session is open. Start one with open_dump / open_trace / \
-                     attach_process / attach_kernel / attach_kernel_local / launch."
-                .to_string(),
-        })
+            Some(OpenOutcome::Landed) => format!(
+                "\n\n`{asked}` landed, but has since been replaced by a later open. That \
+                 target is gone; calls carrying this handle will be refused. Open again."
+            ),
+            Some(OpenOutcome::Pending) => format!(
+                "\n\n`{asked}` is still pending — queued or running. Do not re-run the open, \
+                 which would attach to, or start, a second target. Ask again shortly."
+            ),
+            Some(OpenOutcome::Failed(why)) => format!(
+                "\n\n`{asked}` failed and will never be committed:\n  {why}\nOpening again is \
+                 the only way forward."
+            ),
+            None => format!(
+                "\n\n`{asked}` is not a handle this server issued recently. Only the last \
+                 {OPEN_HISTORY} opens are remembered, so an older one has been forgotten — \
+                 treat it as gone and open again."
+            ),
+        });
+        text_result(out)
     }
 
     /// End the current debug session (detach/close the target) without exiting the server.
@@ -2904,22 +3013,41 @@ mod tests {
                 .is_some()
         };
 
-        for name in ["read_memory", "execute", "go", "end_session", "modules"] {
-            assert!(takes_session(name), "`{name}` should accept session_id");
-        }
-        // `session_status` in particular must not require one — it exists to hand back a
-        // handle the caller never received.
         for name in [
-            "decode_ioctl",
-            "record_trace",
-            "open_dump",
+            "read_memory",
+            "execute",
+            "go",
+            "end_session",
+            "modules",
+            // Takes one to ask *about*, not to be checked against.
             "session_status",
         ] {
+            assert!(takes_session(name), "`{name}` should accept session_id");
+        }
+        for name in ["decode_ioctl", "record_trace", "open_dump"] {
             assert!(
                 !takes_session(name),
                 "`{name}` should not accept session_id"
             );
         }
+
+        // `session_status` must never *require* one: its whole purpose is answering for a
+        // caller who did not receive a handle, and requiring the thing you are asking for
+        // would defeat that.
+        let required = tools
+            .iter()
+            .find(|t| t.name == "session_status")
+            .unwrap()
+            .input_schema
+            .get("required")
+            .cloned();
+        let requires_nothing = required
+            .as_ref()
+            .is_none_or(|r| r.as_array().is_none_or(|r| r.is_empty()));
+        assert!(
+            requires_nothing,
+            "`session_status` must not require any argument, got {required:?}"
+        );
     }
 
     // ---- Session handles -----------------------------------------------
@@ -3130,6 +3258,54 @@ mod tests {
         ] {
             assert!(!changes_debug_target(cmd), "`{cmd}` should keep the handle");
         }
+    }
+
+    /// An opener whose wait timed out has to remain answerable, because the outcome is what
+    /// tells the caller whether to keep waiting or open again — and re-opening on a guess
+    /// attaches or launches a second time.
+    #[test]
+    fn opener_outcomes_are_recorded_and_answerable() {
+        let opens = Mutex::new(VecDeque::new());
+
+        record_open(&opens, "sess-A", OpenOutcome::Pending);
+        record_open(&opens, "sess-B", OpenOutcome::Pending);
+        let read = |id: &str| {
+            opens
+                .lock()
+                .unwrap()
+                .iter()
+                .find(|(known, _)| known == id)
+                .map(|(_, o)| o.clone())
+        };
+        assert_eq!(read("sess-A"), Some(OpenOutcome::Pending));
+
+        // An outcome replaces the pending entry in place rather than appending a second one.
+        record_open(&opens, "sess-A", OpenOutcome::Landed);
+        assert_eq!(read("sess-A"), Some(OpenOutcome::Landed));
+        assert_eq!(opens.lock().unwrap().len(), 2);
+
+        // A terminal failure is recorded too — the case that made "keep polling" wrong.
+        record_open(&opens, "sess-B", OpenOutcome::Failed("no such dump".into()));
+        assert_eq!(
+            read("sess-B"),
+            Some(OpenOutcome::Failed("no such dump".into()))
+        );
+    }
+
+    /// The history is bounded, so a long-lived server cannot accumulate outcomes forever.
+    #[test]
+    fn opener_history_is_bounded_and_evicts_oldest_first() {
+        let opens = Mutex::new(VecDeque::new());
+        for n in 0..OPEN_HISTORY + 3 {
+            record_open(&opens, &format!("sess-{n}"), OpenOutcome::Landed);
+        }
+        let opens = opens.lock().unwrap();
+        assert_eq!(opens.len(), OPEN_HISTORY);
+        assert_eq!(opens.front().unwrap().0, "sess-3");
+        assert_eq!(
+            opens.back().unwrap().0,
+            format!("sess-{}", OPEN_HISTORY + 2)
+        );
     }
 
     #[test]

--- a/src/server.rs
+++ b/src/server.rs
@@ -1346,6 +1346,41 @@ fn lock(session: &Mutex<Option<String>>) -> std::sync::MutexGuard<'_, Option<Str
     session.lock().unwrap_or_else(|e| e.into_inner())
 }
 
+/// Does this raw `execute` command replace or release the debug target?
+///
+/// The typed tools announce their own transitions, but `execute` is an escape hatch: a
+/// caller can `.opendump` a different file, or `.detach`, and every handle issued for the
+/// old target is then meaningless. Matching the first token of each `;`-separated segment
+/// catches the session-control commands by name.
+///
+/// This is deliberately **best-effort, biased toward retiring the handle**. Over-matching
+/// costs a caller one re-open; under-matching would let a stale handle pass, which is the
+/// failure this mechanism exists to prevent. It cannot be exhaustive — DbgEng has more ways
+/// to reach the target than a name list can enumerate — so `execute` remains the one place
+/// where a handle is a strong hint rather than a guarantee.
+fn changes_debug_target(command: &str) -> bool {
+    /// Session-control commands: open, attach to, release, or terminate a target.
+    const RETIRES_SESSION: &[&str] = &[
+        ".opendump",
+        ".attach",
+        ".detach",
+        ".kill",
+        ".restart",
+        ".create",
+        ".abandon",
+        ".remote",
+        "q",
+        "qd",
+        "qq",
+    ];
+    command.split(';').any(|segment| {
+        segment
+            .split_whitespace()
+            .next()
+            .is_some_and(|first| RETIRES_SESSION.contains(&first.to_ascii_lowercase().as_str()))
+    })
+}
+
 /// Builds the deferred session check.
 ///
 /// The returned closure reads the session *when it runs*, not when it is built — that is
@@ -1404,14 +1439,16 @@ impl WindbgServer {
 
 // ---- Tools ---------------------------------------------------------------
 //
-// On `open_world_hint`: with a symbol server on the symbol path — the documented, and
-// recommended, setup — almost anything here can make DbgEng reach out and download a PDB.
-// It is not just the obvious symbol-pattern queries: `r` symbolizes the current
-// instruction, `k` symbolizes every frame, `bp module!Symbol` resolves a name. So the hint
-// is true for all of them, and false only where it is genuinely, structurally false:
-// `read_memory` (raw bytes to a hex dump), `decode_ioctl` (pure arithmetic, no engine at
-// all), and `end_session` (teardown). Claiming otherwise would tell a client that a tool
-// cannot touch the network and let it skip whatever consent that decision gates.
+// On `open_world_hint`: everything that touches a debug target is open-world, and only
+// `decode_ioctl` — pure arithmetic on a control code, which never reaches the engine — is
+// not. Two independent reasons put the rest over the line. A symbol server on the symbol
+// path (the documented, recommended setup) means almost any command can make DbgEng
+// download a PDB, and not only the obvious symbol-pattern queries: `r` symbolizes the
+// current instruction, `k` symbolizes every frame, `bp module!Symbol` resolves a name.
+// And a session opened over KDNET puts the *target itself* on the far side of a network
+// link, so even `read_memory` fetching raw bytes, or `end_session` releasing the target,
+// is remote traffic. Claiming otherwise would tell a client the tool cannot touch the
+// network and let it skip whatever consent that decision gates.
 
 #[rmcp::tool_router]
 impl WindbgServer {
@@ -1637,7 +1674,7 @@ impl WindbgServer {
         read_only_hint = false,
         destructive_hint = true,
         idempotent_hint = true,
-        open_world_hint = false
+        open_world_hint = true
     ))]
     async fn end_session(
         &self,
@@ -1663,6 +1700,8 @@ impl WindbgServer {
     }
 
     /// Run a raw debugger command and return its full output. The universal escape hatch.
+    /// A command that replaces or releases the target (`.opendump`, `.attach`, `.detach`, …)
+    /// retires the current `session_id`; see [`changes_debug_target`].
     #[rmcp::tool(annotations(
         title = "Run raw debugger command",
         read_only_hint = false,
@@ -1675,9 +1714,23 @@ impl WindbgServer {
         Parameters(args): Parameters<ExecuteArgs>,
     ) -> Result<CallToolResult, ErrorData> {
         let gate = self.session_gate(args.session_id.as_deref());
+        let session = Arc::clone(&self.session);
+        let retires_session = changes_debug_target(&args.command);
+        // Both steps run on the engine thread, immediately before the command, for the same
+        // ordering reason the gate does.
+        let precheck = move || {
+            gate()?;
+            if retires_session {
+                // Dropped *before* the command runs, not after: a `.detach` that reports an
+                // error may still have detached, and a handle that outlives its target is
+                // the failure mode this whole mechanism exists to prevent.
+                *lock(&session) = None;
+            }
+            Ok(())
+        };
         // Bounded: a runaway raw command (e.g. an unbounded `s` search) self-aborts instead
         // of pinning the engine thread and wedging every later call.
-        let out = self.engine.run_command(args.command, gate).await;
+        let out = self.engine.run_command(args.command, precheck).await;
         engine_result(out)
     }
 
@@ -1718,7 +1771,7 @@ impl WindbgServer {
     #[rmcp::tool(annotations(
         title = "Read memory",
         read_only_hint = true,
-        open_world_hint = false
+        open_world_hint = true
     ))]
     async fn read_memory(
         &self,
@@ -2574,9 +2627,9 @@ mod tests {
         }
     }
 
-    /// Only the tools that structurally cannot reach a symbol server may say so. Everything
-    /// else can trigger a PDB download once a symbol server is on the path, and a client may
-    /// be gating network consent on this hint.
+    /// Only a tool that structurally cannot reach the network may say so. Everything that
+    /// touches a target can trigger a PDB download, and over KDNET the target itself is
+    /// remote — so `decode_ioctl`, which never reaches the engine, is the only one left.
     #[test]
     fn only_the_tools_that_cannot_reach_the_network_are_closed_world() {
         let closed: Vec<String> = WindbgServer::tool_router()
@@ -2590,7 +2643,7 @@ mod tests {
             .map(|t| t.name.to_string())
             .collect();
 
-        assert_eq!(closed, ["decode_ioctl", "end_session", "read_memory"]);
+        assert_eq!(closed, ["decode_ioctl"]);
     }
 
     /// Session-scoped tools take a handle; the two that are genuinely session-independent
@@ -2674,6 +2727,48 @@ mod tests {
         let gate = session_gate_for(Arc::clone(&session), None);
         *lock(&session) = Some("sess-B".to_string());
         assert!(gate().is_ok());
+    }
+
+    /// `execute` is the one path that can swap the target without going through a typed
+    /// tool, so the session-control commands have to retire the handle — otherwise a
+    /// `.detach` followed by `read_memory(session_id=A)` reads a target A never opened.
+    #[test]
+    fn session_control_commands_retire_the_handle() {
+        for cmd in [
+            ".detach",
+            ".opendump c:\\crash.dmp",
+            ".attach 0n4242",
+            ".kill",
+            ".restart",
+            ".abandon",
+            "qd",
+            // Case and chaining must not be an escape route.
+            ".DETACH",
+            "db @rip; .detach",
+        ] {
+            assert!(
+                changes_debug_target(cmd),
+                "`{cmd}` should retire the handle"
+            );
+        }
+    }
+
+    /// Over-matching only costs a re-open, but it should still not fire on ordinary
+    /// inspection commands, or the handle would be useless in practice.
+    #[test]
+    fn ordinary_commands_keep_the_handle() {
+        for cmd in [
+            "db @rip",
+            "dt nt!_EPROCESS",
+            "!ext.analyze -v",
+            "u rip",
+            "lm m HEVD",
+            // Starts with a token that merely contains a listed command as a substring.
+            ".sympath+ c:\\symbols\\qd",
+            ".reload /f",
+        ] {
+            assert!(!changes_debug_target(cmd), "`{cmd}` should keep the handle");
+        }
     }
 
     #[test]

--- a/src/server.rs
+++ b/src/server.rs
@@ -1401,6 +1401,40 @@ fn reject_command_breakers(field: &str, value: &str, quotes: Quotes) -> Result<(
     ))
 }
 
+/// What a *failed* transition may nonetheless have already done.
+///
+/// win-kexp bundles the wait for the initial break into `launch_process`, `attach_process`
+/// and the kernel attaches, so a single call both creates the side effect and waits for it.
+/// From here those are one operation: a failure can mean "nothing happened" or "the process
+/// was started / the debugger attached, and then the wait failed", and this server cannot
+/// tell which. Splitting them properly means splitting the win-kexp methods, which is a
+/// change in that crate rather than this one; until then the recovery advice must not claim
+/// more than is known, because "just open again" is how a caller ends up with two processes.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum OpenSideEffect {
+    /// Loading a dump or trace. A failure leaves no target behind, so re-opening is clean.
+    None,
+    /// Attaching or launching. A failure may still have attached to, or started, a target.
+    MayHaveStartedTarget,
+}
+
+impl OpenSideEffect {
+    /// The caveat to append to a failed transition, so the failure says what is actually
+    /// known rather than asserting a clean slate.
+    fn failure_caveat(self) -> &'static str {
+        match self {
+            Self::None => "",
+            Self::MayHaveStartedTarget => {
+                "\n\nNote: this operation attaches or launches and waits for the initial break \
+                 in one step, so this failure may have left a target behind — the wait can \
+                 fail after the process was started or the attach succeeded. Check with \
+                 `execute { \"command\": \"vertarget\" }` before opening again; re-running \
+                 blindly can start a second process or attach twice."
+            }
+        }
+    }
+}
+
 /// How far a session-opening job got.
 ///
 /// Recorded because the per-call timeout abandons the *waiter*, not the job: a caller can
@@ -1564,6 +1598,7 @@ impl WindbgServer {
     /// `wait_for_event` that times out very much included — belongs in `report`.
     async fn opened_result<T, R>(
         &self,
+        side_effect: OpenSideEffect,
         transition: T,
         report: R,
     ) -> Result<CallToolResult, ErrorData>
@@ -1593,6 +1628,7 @@ impl WindbgServer {
                 let transitioned = catch_unwind(AssertUnwindSafe(|| transition(e)))
                     .unwrap_or_else(|_| Err("debugger operation panicked".to_string()));
                 if let Err(err) = transitioned {
+                    let err = format!("{err}{}", side_effect.failure_caveat());
                     record_open(&opens, &new_id, OpenOutcome::Failed(err.clone()));
                     return Err(err);
                 }
@@ -1686,6 +1722,7 @@ impl WindbgServer {
         Parameters(args): Parameters<PathArgs>,
     ) -> Result<CallToolResult, ErrorData> {
         self.opened_result(
+            OpenSideEffect::None,
             // `open_dump` is the call that replaces the target; the load wait belongs after
             // the commit, since a wait that times out still leaves DbgEng holding the dump.
             move |e| e.open_dump(&args.path).map_err(es),
@@ -1718,6 +1755,7 @@ impl WindbgServer {
         Parameters(args): Parameters<PathArgs>,
     ) -> Result<CallToolResult, ErrorData> {
         self.opened_result(
+            OpenSideEffect::None,
             // As in `open_dump`: the load wait sits after the commit, because a wait that
             // times out still leaves DbgEng holding the trace.
             move |e| e.open_trace(&args.path).map_err(es),
@@ -1768,6 +1806,7 @@ impl WindbgServer {
     ))]
     async fn attach_kernel_local(&self) -> Result<CallToolResult, ErrorData> {
         self.opened_result(
+            OpenSideEffect::MayHaveStartedTarget,
             |e| {
                 // attach_local_kernel breaks the target in internally (INITIAL_BREAK +
                 // an INFINITE wait, as a live kernel requires).
@@ -1799,6 +1838,7 @@ impl WindbgServer {
         Parameters(args): Parameters<ConnectionArgs>,
     ) -> Result<CallToolResult, ErrorData> {
         self.opened_result(
+            OpenSideEffect::MayHaveStartedTarget,
             move |e| {
                 // attach_kernel connects, requests an initial break, and waits (INFINITE,
                 // as a live kernel requires) for the break-in — all internally.
@@ -1867,6 +1907,7 @@ impl WindbgServer {
     ) -> Result<CallToolResult, ErrorData> {
         let pid = args.pid;
         self.opened_result(
+            OpenSideEffect::MayHaveStartedTarget,
             move |e| {
                 // attach_process waits for the break-in internally.
                 e.attach_process(pid).map_err(es)
@@ -1890,6 +1931,7 @@ impl WindbgServer {
         Parameters(args): Parameters<CommandLineArgs>,
     ) -> Result<CallToolResult, ErrorData> {
         self.opened_result(
+            OpenSideEffect::MayHaveStartedTarget,
             move |e| {
                 // launch_process waits for the initial break internally.
                 e.launch_process(&args.command_line).map_err(es)
@@ -1946,6 +1988,20 @@ impl WindbgServer {
             return text_result(out);
         };
 
+        // The live session is authoritative and answered first, before the bounded history
+        // is consulted at all. The ledger can evict a settled entry while its handle is
+        // still the loaded one — a burst of pending opens pushes the oldest settled entry
+        // out — and falling through to the history would then contradict the line above:
+        // "Current session: A" followed by "A is not held, opening again is safe", which
+        // during timeout recovery is advice that duplicates an attach or a launch.
+        if current.as_deref() == Some(asked) {
+            out.push_str(&format!(
+                "\n\n`{asked}` is the session now loaded. It is yours: pass it as \
+                 `session_id` on later calls."
+            ));
+            return text_result(out);
+        }
+
         let known = self
             .opens
             .lock()
@@ -1955,10 +2011,6 @@ impl WindbgServer {
             .map(|(_, outcome)| outcome.clone());
 
         out.push_str(&match known {
-            Some(OpenOutcome::Landed) if current.as_deref() == Some(asked) => format!(
-                "\n\n`{asked}` landed and is the session now loaded. It is yours: pass it as \
-                 `session_id` on later calls."
-            ),
             Some(OpenOutcome::Landed) => format!(
                 "\n\n`{asked}` landed, but has since been replaced by a later open. That \
                  target is gone; calls carrying this handle will be refused. Open again."
@@ -1968,8 +2020,9 @@ impl WindbgServer {
                  which would attach to, or start, a second target. Ask again shortly."
             ),
             Some(OpenOutcome::Failed(why)) => format!(
-                "\n\n`{asked}` failed and will never be committed:\n  {why}\nOpening again is \
-                 the only way forward."
+                "\n\n`{asked}` failed and will never be committed:\n  {why}\n\nOpening again is \
+                 how you get a target — but read the reason first, since some failures leave \
+                 one behind."
             ),
             // Pending opens are never evicted, so an id this server has forgotten is
             // necessarily one that finished and aged out — never one still in flight.
@@ -3358,6 +3411,22 @@ mod tests {
         let opens = opens.lock().unwrap();
         assert_eq!(opens.len(), OPEN_HISTORY);
         assert!(!opens.iter().any(|(id, _)| id == "sess-slow"));
+    }
+
+    /// A failed transition must not claim a clean slate for the operations that create the
+    /// target and wait for it in one win-kexp call. "Just open again" is how a caller ends
+    /// up with two processes.
+    #[test]
+    fn side_effecting_opens_warn_that_a_failure_may_leave_a_target() {
+        let caveat = OpenSideEffect::MayHaveStartedTarget.failure_caveat();
+        assert!(caveat.contains("vertarget"), "must say how to check");
+        assert!(
+            caveat.contains("second process") || caveat.contains("attach twice"),
+            "must name the cost of re-running blindly"
+        );
+
+        // Loading a dump leaves nothing behind, so it says nothing extra.
+        assert!(OpenSideEffect::None.failure_caveat().is_empty());
     }
 
     /// A burst of concurrent opens legitimately exceeds the bound while all of them are

--- a/src/server.rs
+++ b/src/server.rs
@@ -63,7 +63,7 @@ fn tool_error(s: String) -> Result<CallToolResult, ErrorData> {
 fn engine_result(r: Result<String, EngineError>) -> Result<CallToolResult, ErrorData> {
     match r {
         Ok(out) => text_result(out),
-        Err(EngineError::Debugger(m)) => tool_error(m),
+        Err(EngineError::Debugger(m) | EngineError::Timeout(m)) => tool_error(m),
         Err(EngineError::Unavailable(m)) => Err(ErrorData::internal_error(m, None)),
     }
 }
@@ -1458,6 +1458,19 @@ impl WindbgServer {
                  fail loudly instead of silently acting on a different target if this \
                  server's session is replaced."
             )),
+            // A timeout abandons the *wait*, not the job: this open may still be running and
+            // may still commit. The handle was minted before the job was queued, so it can be
+            // named now — which is what makes recovery via `session_status` sound. Without it
+            // the caller would only learn "some session exists" and could adopt a handle
+            // belonging to somebody else's open that landed in the meantime.
+            Err(EngineError::Timeout(msg)) => tool_error(format!(
+                "{msg}\n\nThis open may still complete on the engine thread. If it does, its \
+                 handle will be exactly `{id}`. Call session_status: treat the session as \
+                 yours only if it reports that same id, and if it reports a different one \
+                 then another caller's target is loaded and yours never landed. Do not re-run \
+                 this open to recover — attaching or launching again would connect to, or \
+                 start, a second target."
+            )),
             Err(e) => engine_result(Err(e)),
         }
     }
@@ -1719,6 +1732,10 @@ impl WindbgServer {
     /// the call can give up while the engine thread stays parked and completes the attach
     /// later, committing a handle no reply ever carried. Prefer this to retrying the attach,
     /// which would connect a second time.
+    ///
+    /// This reports *the current* handle, not *your* handle — the two differ if another
+    /// caller's open landed while yours was in flight. A timed-out open names the handle it
+    /// would commit, so compare against that: adopt the session only when the two match.
     #[rmcp::tool(annotations(
         title = "Show current session handle",
         read_only_hint = true,
@@ -2876,6 +2893,15 @@ mod tests {
         let err = engine_result(Err(EngineError::Unavailable("engine gone".into())))
             .expect_err("a dead engine must surface as a protocol error");
         assert!(err.message.contains("engine gone"));
+    }
+
+    /// A timeout is still something the model can act on (wait, retry, end the session), so
+    /// it renders like any other debugger failure rather than as a protocol error.
+    #[test]
+    fn timeouts_are_tool_errors_too() {
+        let r = engine_result(Err(EngineError::Timeout("timed out".into())))
+            .expect("a timeout must not surface as a protocol error");
+        assert_eq!(r.is_error, Some(true));
     }
 
     #[test]

--- a/src/server.rs
+++ b/src/server.rs
@@ -1429,15 +1429,29 @@ enum OpenOutcome {
 /// recent one, so a short window keeps this from growing without bound.
 const OPEN_HISTORY: usize = 8;
 
-/// Records an opener's outcome, evicting the oldest once [`OPEN_HISTORY`] is reached.
+/// Records an opener's outcome, evicting the oldest *settled* entry once [`OPEN_HISTORY`]
+/// is reached.
+///
+/// Settled is the important word. A `Pending` entry is an open that is still queued or
+/// running, and forgetting one is worse than remembering it forever: `session_status` would
+/// report the handle as unknown, which tells the caller to open again — and that duplicates
+/// an attach or a launch, then lets the original job land afterwards and replace the target
+/// underneath them. Avoiding exactly that is why this ledger exists.
+///
+/// So the history can exceed [`OPEN_HISTORY`] while opens are in flight. That is
+/// self-limiting rather than unbounded: the engine runs jobs one at a time and every job
+/// settles, including the ones that never reach it, which settle as `Failed` on the caller
+/// side.
 fn record_open(opens: &Mutex<VecDeque<(String, OpenOutcome)>>, id: &str, outcome: OpenOutcome) {
     let mut opens = opens.lock().unwrap_or_else(|e| e.into_inner());
     if let Some(slot) = opens.iter_mut().find(|(known, _)| known == id) {
         slot.1 = outcome;
         return;
     }
-    if opens.len() == OPEN_HISTORY {
-        opens.pop_front();
+    if opens.len() >= OPEN_HISTORY
+        && let Some(oldest_settled) = opens.iter().position(|(_, o)| *o != OpenOutcome::Pending)
+    {
+        opens.remove(oldest_settled);
     }
     opens.push_back((id.to_string(), outcome));
 }
@@ -1941,10 +1955,13 @@ impl WindbgServer {
                 "\n\n`{asked}` failed and will never be committed:\n  {why}\nOpening again is \
                  the only way forward."
             ),
+            // Pending opens are never evicted, so an id this server has forgotten is
+            // necessarily one that finished and aged out — never one still in flight.
             None => format!(
-                "\n\n`{asked}` is not a handle this server issued recently. Only the last \
-                 {OPEN_HISTORY} opens are remembered, so an older one has been forgotten — \
-                 treat it as gone and open again."
+                "\n\n`{asked}` is not a handle this server is holding. Either it was never \
+                 issued here, or it settled a while ago and has aged out of the recent-open \
+                 history. It is not still in flight — those are never forgotten — so opening \
+                 again is safe."
             ),
         });
         text_result(out)
@@ -3292,9 +3309,39 @@ mod tests {
         );
     }
 
-    /// The history is bounded, so a long-lived server cannot accumulate outcomes forever.
+    /// A pending open must survive any amount of later traffic. Forgetting one makes
+    /// `session_status` report it as unknown, which tells the caller to open again — and
+    /// that duplicates an attach or a launch, then lets the original land afterwards and
+    /// replace the target underneath them.
     #[test]
-    fn opener_history_is_bounded_and_evicts_oldest_first() {
+    fn a_pending_open_is_never_evicted() {
+        let opens = Mutex::new(VecDeque::new());
+        record_open(&opens, "sess-slow", OpenOutcome::Pending);
+        for n in 0..OPEN_HISTORY * 2 {
+            record_open(&opens, &format!("sess-{n}"), OpenOutcome::Landed);
+        }
+
+        let still_there = opens
+            .lock()
+            .unwrap()
+            .iter()
+            .any(|(id, outcome)| id == "sess-slow" && *outcome == OpenOutcome::Pending);
+        assert!(still_there, "a pending open must outlive the history bound");
+
+        // Once it settles it becomes evictable like any other, so the history returns to
+        // its bound rather than growing forever.
+        record_open(&opens, "sess-slow", OpenOutcome::Landed);
+        for n in 0..OPEN_HISTORY {
+            record_open(&opens, &format!("later-{n}"), OpenOutcome::Landed);
+        }
+        let opens = opens.lock().unwrap();
+        assert_eq!(opens.len(), OPEN_HISTORY);
+        assert!(!opens.iter().any(|(id, _)| id == "sess-slow"));
+    }
+
+    /// Settled history is bounded, so a long-lived server cannot accumulate outcomes forever.
+    #[test]
+    fn settled_opener_history_is_bounded_and_evicts_oldest_first() {
         let opens = Mutex::new(VecDeque::new());
         for n in 0..OPEN_HISTORY + 3 {
             record_open(&opens, &format!("sess-{n}"), OpenOutcome::Landed);

--- a/src/server.rs
+++ b/src/server.rs
@@ -1444,16 +1444,27 @@ const OPEN_HISTORY: usize = 8;
 /// side.
 fn record_open(opens: &Mutex<VecDeque<(String, OpenOutcome)>>, id: &str, outcome: OpenOutcome) {
     let mut opens = opens.lock().unwrap_or_else(|e| e.into_inner());
-    if let Some(slot) = opens.iter_mut().find(|(known, _)| known == id) {
-        slot.1 = outcome;
-        return;
+    match opens.iter_mut().find(|(known, _)| known == id) {
+        Some(slot) => slot.1 = outcome,
+        None => opens.push_back((id.to_string(), outcome)),
     }
-    if opens.len() >= OPEN_HISTORY
-        && let Some(oldest_settled) = opens.iter().position(|(_, o)| *o != OpenOutcome::Pending)
-    {
+    // Trimmed after an update as well as an insertion. A burst of concurrent opens is all
+    // `Pending` at first and legitimately exceeds the bound; if only insertions trimmed,
+    // the ledger would stay over it forever once that burst settled in place, holding every
+    // handle and failure string for the life of the process.
+    trim_settled_opens(&mut opens);
+}
+
+/// Evicts oldest-settled entries until the ledger is back within [`OPEN_HISTORY`], or until
+/// only pending entries are left — those are never evicted, whatever the bound says.
+fn trim_settled_opens(opens: &mut VecDeque<(String, OpenOutcome)>) {
+    while opens.len() > OPEN_HISTORY {
+        let Some(oldest_settled) = opens.iter().position(|(_, o)| *o != OpenOutcome::Pending)
+        else {
+            return;
+        };
         opens.remove(oldest_settled);
     }
-    opens.push_back((id.to_string(), outcome));
 }
 
 /// Can this data-model expression run debugger commands?
@@ -1477,8 +1488,13 @@ fn dx_executes_commands(expression: &str) -> bool {
 ///
 /// The typed tools announce their own transitions, but `execute` is an escape hatch: a
 /// caller can `.opendump` a different file, or `.detach`, and every handle issued for the
-/// old target is then meaningless. Matching the first token of each `;`-separated segment
-/// catches the session-control commands by name.
+/// old target is then meaningless. Matching the first token of each segment catches the
+/// session-control commands by name.
+///
+/// Segments are split on `;` **and line breaks**, because DbgEng treats both as command
+/// boundaries — [`reject_command_breakers`] refuses both in typed operands for exactly that
+/// reason, and a scanner that honoured only `;` would let `r\n.opendump other.dmp` through
+/// while seeing nothing but `r`.
 ///
 /// This is deliberately **best-effort, biased toward retiring the handle**. Over-matching
 /// costs a caller one re-open; under-matching would let a stale handle pass, which is the
@@ -1500,7 +1516,7 @@ fn changes_debug_target(command: &str) -> bool {
         "qd",
         "qq",
     ];
-    command.split(';').any(|segment| {
+    command.split([';', '\n', '\r']).any(|segment| {
         segment
             .split_whitespace()
             .next()
@@ -3251,6 +3267,11 @@ mod tests {
             // Case and chaining must not be an escape route.
             ".DETACH",
             "db @rip; .detach",
+            // DbgEng ends a command at a line break too, and `reject_command_breakers`
+            // already refuses them in typed operands for that reason. `execute` accepts
+            // them, so the scanner has to split on them.
+            "r\n.opendump C:\\other.dmp",
+            "r\r\n.detach",
         ] {
             assert!(
                 changes_debug_target(cmd),
@@ -3337,6 +3358,29 @@ mod tests {
         let opens = opens.lock().unwrap();
         assert_eq!(opens.len(), OPEN_HISTORY);
         assert!(!opens.iter().any(|(id, _)| id == "sess-slow"));
+    }
+
+    /// A burst of concurrent opens legitimately exceeds the bound while all of them are
+    /// pending. Once they settle, the ledger has to come back down — otherwise it stays over
+    /// the bound for the life of the process, holding every handle and failure string.
+    #[test]
+    fn a_settled_burst_returns_the_ledger_to_its_bound() {
+        let opens = Mutex::new(VecDeque::new());
+        let burst = OPEN_HISTORY * 2;
+        for n in 0..burst {
+            record_open(&opens, &format!("sess-{n}"), OpenOutcome::Pending);
+        }
+        assert_eq!(
+            opens.lock().unwrap().len(),
+            burst,
+            "pending opens must all be kept, even past the bound"
+        );
+
+        // They settle in place, which is the path that previously skipped trimming.
+        for n in 0..burst {
+            record_open(&opens, &format!("sess-{n}"), OpenOutcome::Landed);
+        }
+        assert_eq!(opens.lock().unwrap().len(), OPEN_HISTORY);
     }
 
     /// Settled history is bounded, so a long-lived server cannot accumulate outcomes forever.

--- a/src/server.rs
+++ b/src/server.rs
@@ -1409,12 +1409,16 @@ impl WindbgServer {
     /// queued job, so no other call can be ordered across the transition.
     ///
     /// The work is split in two because the split is where correctness lives. `transition`
-    /// is the DbgEng call that actually changes the target; `report` is the follow-up
-    /// diagnostic (`lm`, `vertarget`, `r`, the TTD lifetime query) whose output the caller
-    /// reads. The handle is committed *between* them, so a failing diagnostic cannot cost
-    /// the caller a handle for a target that is genuinely open — which matters because the
-    /// only way to get one back is to open again, and for `launch` that spawns a second
-    /// process.
+    /// is the DbgEng call that actually changes the target; `report` is everything after it
+    /// — the load wait, and the diagnostic (`lm`, `vertarget`, `r`, the TTD lifetime query)
+    /// whose output the caller reads. The handle is committed *between* them, so a failure
+    /// after the target has already changed cannot cost the caller a handle for a target
+    /// that is genuinely open — which matters because the only way to get one back is to
+    /// open again, and for `launch` that spawns a second process.
+    ///
+    /// So `transition` must be **exactly the one call that replaces the target**, and
+    /// nothing else. Anything that can fail once the target is already replaced — a
+    /// `wait_for_event` that times out very much included — belongs in `report`.
     async fn opened_result<T, R>(
         &self,
         transition: T,
@@ -1495,11 +1499,11 @@ impl WindbgServer {
         Parameters(args): Parameters<PathArgs>,
     ) -> Result<CallToolResult, ErrorData> {
         self.opened_result(
-            move |e| {
-                e.open_dump(&args.path).map_err(es)?;
-                e.wait_for_event(LOAD_WAIT_MS).map_err(es)
-            },
+            // `open_dump` is the call that replaces the target; the load wait belongs after
+            // the commit, since a wait that times out still leaves DbgEng holding the dump.
+            move |e| e.open_dump(&args.path).map_err(es),
             |e| {
+                e.wait_for_event(LOAD_WAIT_MS).map_err(es)?;
                 // Load the WinDbg extension DLL so `!`-extension commands resolve — most
                 // importantly `!ext.analyze -v`, the crash-dump triage workhorse. A bare
                 // engine doesn't auto-load it, and even after `.load ext` the unqualified
@@ -1527,11 +1531,11 @@ impl WindbgServer {
         Parameters(args): Parameters<PathArgs>,
     ) -> Result<CallToolResult, ErrorData> {
         self.opened_result(
-            move |e| {
-                e.open_trace(&args.path).map_err(es)?;
-                e.wait_for_event(LOAD_WAIT_MS).map_err(es)
-            },
+            // As in `open_dump`: the load wait sits after the commit, because a wait that
+            // times out still leaves DbgEng holding the trace.
+            move |e| e.open_trace(&args.path).map_err(es),
             |e| {
+                e.wait_for_event(LOAD_WAIT_MS).map_err(es)?;
                 // Check the index state *before* any data-model query: `!ttdext.index -status`
                 // only reads the on-disk .idx (never builds), whereas a `dx` on an unindexed
                 // trace can itself trigger the long in-memory index build. TtdExt reports a

--- a/src/server.rs
+++ b/src/server.rs
@@ -6,6 +6,9 @@
 //! `win-kexp` methods and then wait for the target to stop.
 
 use std::collections::{HashMap, HashSet, VecDeque};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use rmcp::ErrorData;
 use rmcp::handler::server::wrapper::Parameters;
@@ -15,7 +18,7 @@ use serde::Deserialize;
 
 use win_kexp::dbgeng::RunToOutcome;
 
-use crate::engine::EngineHandle;
+use crate::engine::{EngineError, EngineHandle};
 use crate::ttd;
 
 /// How long to wait for a target to stop after open/attach/launch (ms).
@@ -24,9 +27,16 @@ const LOAD_WAIT_MS: u32 = 60_000;
 /// next stop (ms).
 const EXEC_WAIT_MS: u32 = 60_000;
 
+/// Counter behind [`mint_session_id`]. Only needs to be unique within this process.
+static SESSION_SEQ: AtomicU64 = AtomicU64::new(1);
+
 #[derive(Clone)]
 pub struct WindbgServer {
     engine: EngineHandle,
+    /// Handle identifying the debug session the engine is currently attached to, or
+    /// `None` when no target is open. See [`WindbgServer::check_session`] for why this
+    /// exists rather than letting the connection stand in for the session.
+    session: Arc<Mutex<Option<String>>>,
 }
 
 /// Maps any error to a `String` for the engine `Reply` channel.
@@ -36,6 +46,37 @@ fn es<E: ToString>(e: E) -> String {
 
 fn text_result(s: String) -> Result<CallToolResult, ErrorData> {
     Ok(CallToolResult::success(vec![Content::text(s)]))
+}
+
+/// A tool-execution error: something the model should see in the result and can act on,
+/// as opposed to a JSON-RPC protocol error it cannot.
+fn tool_error(s: String) -> Result<CallToolResult, ErrorData> {
+    Ok(CallToolResult::error(vec![Content::text(s)]))
+}
+
+/// Renders an engine outcome using the MCP error model.
+///
+/// A failed *debugger operation* (bad symbol, unreadable address, target that never
+/// stopped) is feedback the model can act on, so it comes back as a tool-execution
+/// error with the text intact. Only a broken engine — the one thing no amount of
+/// retrying will fix — becomes a JSON-RPC protocol error.
+fn engine_result(r: Result<String, EngineError>) -> Result<CallToolResult, ErrorData> {
+    match r {
+        Ok(out) => text_result(out),
+        Err(EngineError::Debugger(m)) => tool_error(m),
+        Err(EngineError::Unavailable(m)) => Err(ErrorData::internal_error(m, None)),
+    }
+}
+
+/// Mints a fresh session handle. Unique per process, which is all the guard needs:
+/// the handle exists to detect *replacement* of the target, not to authenticate.
+fn mint_session_id() -> String {
+    let n = SESSION_SEQ.fetch_add(1, Ordering::Relaxed);
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos() as u64)
+        .unwrap_or(0);
+    format!("sess-{nanos:x}-{n}")
 }
 
 /// Parses a decimal or `0x`-prefixed hex integer.
@@ -979,6 +1020,21 @@ fn format_recipe(recipes: &[SegmentRecipe]) -> String {
 }
 
 // ---- Tool parameter types ------------------------------------------------
+//
+// Every tool that touches the debug target carries an optional `session_id` (see the
+// "Session handles" section below). The field is repeated per struct rather than
+// flattened from a shared type so each tool's input schema stays a plain, self-contained
+// object — flattening renders as a schema composition that clients handle unevenly.
+
+/// Parameters for tools that take no arguments beyond the session handle.
+#[derive(Deserialize, JsonSchema)]
+pub struct SessionArgs {
+    /// Session handle returned by open_dump/open_trace/attach_*/launch. Optional: omit it
+    /// to act on whatever session is current, or pass it to have the call refuse to run if
+    /// this server's debug target has been replaced since you opened it.
+    #[serde(default)]
+    pub session_id: Option<String>,
+}
 
 #[derive(Deserialize, JsonSchema)]
 pub struct PathArgs {
@@ -1008,6 +1064,10 @@ pub struct CommandLineArgs {
 pub struct ExecuteArgs {
     /// Raw debugger command to run (e.g. "!analyze -v", "u rip", "dt nt!_EPROCESS").
     pub command: String,
+    /// Session handle from open_dump/open_trace/attach_*/launch. Optional; pass it to
+    /// refuse the call if this server's debug target has been replaced since you opened it.
+    #[serde(default)]
+    pub session_id: Option<String>,
 }
 
 #[derive(Deserialize, JsonSchema)]
@@ -1016,6 +1076,10 @@ pub struct ReadMemoryArgs {
     pub address: String,
     /// Number of bytes to read.
     pub size: u32,
+    /// Session handle from open_dump/open_trace/attach_*/launch. Optional; pass it to
+    /// refuse the call if this server's debug target has been replaced since you opened it.
+    #[serde(default)]
+    pub session_id: Option<String>,
 }
 
 #[derive(Deserialize, JsonSchema)]
@@ -1023,24 +1087,40 @@ pub struct DisassembleArgs {
     /// Address or symbol to disassemble at; uses the current instruction pointer if omitted.
     #[serde(default)]
     pub address: Option<String>,
+    /// Session handle from open_dump/open_trace/attach_*/launch. Optional; pass it to
+    /// refuse the call if this server's debug target has been replaced since you opened it.
+    #[serde(default)]
+    pub session_id: Option<String>,
 }
 
 #[derive(Deserialize, JsonSchema)]
 pub struct DxArgs {
     /// Data-model (LINQ) expression, e.g. "@$cursession.TTD.Calls(\"ntdll!*\")".
     pub expression: String,
+    /// Session handle from open_dump/open_trace/attach_*/launch. Optional; pass it to
+    /// refuse the call if this server's debug target has been replaced since you opened it.
+    #[serde(default)]
+    pub session_id: Option<String>,
 }
 
 #[derive(Deserialize, JsonSchema)]
 pub struct BreakpointArgs {
     /// Breakpoint location: symbol, address, or expression (e.g. "nt!NtCreateFile").
     pub expression: String,
+    /// Session handle from open_dump/open_trace/attach_*/launch. Optional; pass it to
+    /// refuse the call if this server's debug target has been replaced since you opened it.
+    #[serde(default)]
+    pub session_id: Option<String>,
 }
 
 #[derive(Deserialize, JsonSchema)]
 pub struct PositionArgs {
     /// TTD position to travel to, e.g. "12:0" or "0" for the start of the trace.
     pub position: String,
+    /// Session handle from open_dump/open_trace/attach_*/launch. Optional; pass it to
+    /// refuse the call if this server's debug target has been replaced since you opened it.
+    #[serde(default)]
+    pub session_id: Option<String>,
 }
 
 #[derive(Deserialize, JsonSchema)]
@@ -1065,6 +1145,10 @@ pub struct TtdCallsArgs {
     /// Function symbol or wildcard pattern to find calls to, e.g.
     /// "kernelbase!CreateFileW" or "ntdll!Nt*".
     pub function: String,
+    /// Session handle from open_dump/open_trace/attach_*/launch. Optional; pass it to
+    /// refuse the call if this server's debug target has been replaced since you opened it.
+    #[serde(default)]
+    pub session_id: Option<String>,
 }
 
 #[derive(Deserialize, JsonSchema)]
@@ -1077,6 +1161,10 @@ pub struct TtdMemoryArgs {
     /// Omit to report every access.
     #[serde(default)]
     pub mode: Option<String>,
+    /// Session handle from open_dump/open_trace/attach_*/launch. Optional; pass it to
+    /// refuse the call if this server's debug target has been replaced since you opened it.
+    #[serde(default)]
+    pub session_id: Option<String>,
 }
 
 #[derive(Deserialize, JsonSchema)]
@@ -1101,18 +1189,30 @@ pub struct SymbolPathArgs {
     /// force-load one module's symbols. Omit to reload all deferred modules.
     #[serde(default)]
     pub reload: Option<String>,
+    /// Session handle from open_dump/open_trace/attach_*/launch. Optional; pass it to
+    /// refuse the call if this server's debug target has been replaced since you opened it.
+    #[serde(default)]
+    pub session_id: Option<String>,
 }
 
 #[derive(Deserialize, JsonSchema)]
 pub struct DriverObjectArgs {
     /// Driver object name, e.g. "mydriver" or "\\Driver\\mydriver".
     pub name: String,
+    /// Session handle from open_dump/open_trace/attach_*/launch. Optional; pass it to
+    /// refuse the call if this server's debug target has been replaced since you opened it.
+    #[serde(default)]
+    pub session_id: Option<String>,
 }
 
 #[derive(Deserialize, JsonSchema)]
 pub struct DeviceObjectArgs {
     /// Device object: a name (e.g. "\\Device\\MyDevice") or an address (0x-hex).
     pub device: String,
+    /// Session handle from open_dump/open_trace/attach_*/launch. Optional; pass it to
+    /// refuse the call if this server's debug target has been replaced since you opened it.
+    #[serde(default)]
+    pub session_id: Option<String>,
 }
 
 #[derive(Deserialize, JsonSchema)]
@@ -1122,6 +1222,10 @@ pub struct IrpStackArgs {
     /// clobbers the register.
     #[serde(default)]
     pub irp: Option<String>,
+    /// Session handle from open_dump/open_trace/attach_*/launch. Optional; pass it to
+    /// refuse the call if this server's debug target has been replaced since you opened it.
+    #[serde(default)]
+    pub session_id: Option<String>,
 }
 
 #[derive(Deserialize, JsonSchema)]
@@ -1129,6 +1233,10 @@ pub struct IoctlTraceArgs {
     /// Virtual address of the IRP_MJ_DEVICE_CONTROL dispatch routine, rebased to the
     /// live load base. Recover it via `driver_object` (MajorFunction[0x0e]).
     pub dispatch: String,
+    /// Session handle from open_dump/open_trace/attach_*/launch. Optional; pass it to
+    /// refuse the call if this server's debug target has been replaced since you opened it.
+    #[serde(default)]
+    pub session_id: Option<String>,
 }
 
 #[derive(Deserialize, JsonSchema)]
@@ -1162,6 +1270,10 @@ pub struct ReachabilityArgs {
     /// the bare verdict + call path.
     #[serde(default)]
     pub recipe: Option<bool>,
+    /// Session handle from open_dump/open_trace/attach_*/launch. Optional; pass it to
+    /// refuse the call if this server's debug target has been replaced since you opened it.
+    #[serde(default)]
+    pub session_id: Option<String>,
 }
 
 /// Address to run the target to, for `run_to_address`.
@@ -1174,6 +1286,89 @@ pub struct RunToAddressArgs {
     /// (milliseconds). Defaults to the standard execution wait.
     #[serde(default)]
     pub timeout_ms: Option<u32>,
+    /// Session handle from open_dump/open_trace/attach_*/launch. Optional; pass it to
+    /// refuse the call if this server's debug target has been replaced since you opened it.
+    #[serde(default)]
+    pub session_id: Option<String>,
+}
+
+// ---- Session handles -----------------------------------------------------
+//
+// One process drives one DbgEng session, but an MCP connection is explicitly *not*
+// a session: clients may interleave unrelated requests over the same stdio process,
+// so "the target the last open_* call attached to" is not a safe thing for a tool to
+// assume. Rather than silently operating on whatever target happens to be loaded,
+// the session-creating tools mint a handle and every other tool accepts it and
+// refuses to run when it no longer matches.
+//
+// The handle is optional so existing callers keep working; supplying it is what buys
+// the guarantee that a call can never land on a target it did not open.
+
+/// The session-handle policy, as a pure function so it unit-tests without an engine.
+///
+/// `supplied == None` means the caller opted out of the check and accepts whatever
+/// session is current — the behaviour from before handles existed. A handle that does
+/// not match is refused rather than silently honoured, because honouring it means
+/// reading memory from, or setting breakpoints on, a target the caller never opened.
+fn check_session_handle(current: Option<&str>, supplied: Option<&str>) -> Result<(), String> {
+    let Some(want) = supplied else {
+        return Ok(());
+    };
+    match current {
+        Some(cur) if cur == want => Ok(()),
+        Some(cur) => Err(format!(
+            "stale session handle `{want}`: this server is now debugging session `{cur}`. \
+             The debug target was replaced after you opened yours — this stdio process is \
+             shared, not per-conversation. Re-open your target, or omit `session_id` to \
+             operate on whatever session is current."
+        )),
+        None => Err(format!(
+            "stale session handle `{want}`: this server has no debug session open — it was \
+             ended, or never started. Re-open your target with open_dump / open_trace / \
+             attach_process / attach_kernel / attach_kernel_local / launch."
+        )),
+    }
+}
+
+impl WindbgServer {
+    /// Records a newly opened target and returns its handle.
+    fn begin_session(&self) -> String {
+        let id = mint_session_id();
+        *self.session_lock() = Some(id.clone());
+        id
+    }
+
+    /// Forgets the current target, so handles held by callers now read as stale.
+    fn clear_session(&self) {
+        *self.session_lock() = None;
+    }
+
+    /// A poisoned lock here only ever means a previous holder panicked mid-update; the
+    /// value itself is a plain `Option<String>` and cannot be left inconsistent, so
+    /// recovering beats propagating the panic into every later tool call.
+    fn session_lock(&self) -> std::sync::MutexGuard<'_, Option<String>> {
+        self.session.lock().unwrap_or_else(|e| e.into_inner())
+    }
+
+    /// Validates a caller-supplied handle against the target actually loaded.
+    fn check_session(&self, supplied: Option<&str>) -> Result<(), String> {
+        check_session_handle(self.session_lock().as_deref(), supplied)
+    }
+
+    /// Renders a session-creating tool's outcome, minting a handle on success.
+    fn opened_result(&self, r: Result<String, EngineError>) -> Result<CallToolResult, ErrorData> {
+        match r {
+            Ok(out) => {
+                let id = self.begin_session();
+                text_result(format!(
+                    "{out}\n\nsession_id: {id}\nPass this as `session_id` on later calls so they \
+                     fail loudly instead of silently acting on a different target if this \
+                     server's session is replaced."
+                ))
+            }
+            Err(e) => engine_result(Err(e)),
+        }
+    }
 }
 
 // ---- Tools ---------------------------------------------------------------
@@ -1181,11 +1376,21 @@ pub struct RunToAddressArgs {
 #[rmcp::tool_router]
 impl WindbgServer {
     pub fn new(engine: EngineHandle) -> Self {
-        Self { engine }
+        Self {
+            engine,
+            session: Arc::new(Mutex::new(None)),
+        }
     }
 
     /// Open a crash dump (.dmp) or a Time Travel Debugging trace (.run) and wait for it to load.
-    #[rmcp::tool]
+    /// Replaces any session already open, and returns a `session_id` for later calls.
+    #[rmcp::tool(annotations(
+        title = "Open crash dump or TTD trace",
+        read_only_hint = false,
+        destructive_hint = true,
+        idempotent_hint = false,
+        open_world_hint = true
+    ))]
     async fn open_dump(
         &self,
         Parameters(args): Parameters<PathArgs>,
@@ -1204,12 +1409,19 @@ impl WindbgServer {
                 let _ = e.execute_command(".load ext");
                 e.execute_command("lm").map_err(es)
             })
-            .await?;
-        text_result(out)
+            .await;
+        self.opened_result(out)
     }
 
     /// Open a TTD trace (.run); alias of open_dump. Enables time-travel navigation and TTD queries.
-    #[rmcp::tool]
+    /// Replaces any session already open, and returns a `session_id` for later calls.
+    #[rmcp::tool(annotations(
+        title = "Open TTD trace",
+        read_only_hint = false,
+        destructive_hint = true,
+        idempotent_hint = false,
+        open_world_hint = true
+    ))]
     async fn open_trace(
         &self,
         Parameters(args): Parameters<PathArgs>,
@@ -1249,12 +1461,19 @@ impl WindbgServer {
                 }
                 Ok(out)
             })
-            .await?;
-        text_result(out)
+            .await;
+        self.opened_result(out)
     }
 
     /// Attach to the local kernel (live local kernel debugging).
-    #[rmcp::tool]
+    /// Replaces any session already open, and returns a `session_id` for later calls.
+    #[rmcp::tool(annotations(
+        title = "Attach to local kernel",
+        read_only_hint = false,
+        destructive_hint = true,
+        idempotent_hint = false,
+        open_world_hint = true
+    ))]
     async fn attach_kernel_local(&self) -> Result<CallToolResult, ErrorData> {
         let out = self
             .engine
@@ -1269,12 +1488,19 @@ impl WindbgServer {
                 let _ = e.execute_command(".load kdexts");
                 e.execute_command("vertarget").map_err(es)
             })
-            .await?;
-        text_result(out)
+            .await;
+        self.opened_result(out)
     }
 
     /// Attach to a kernel target over a connection string (e.g. KDNET).
-    #[rmcp::tool]
+    /// Replaces any session already open, and returns a `session_id` for later calls.
+    #[rmcp::tool(annotations(
+        title = "Attach to kernel target",
+        read_only_hint = false,
+        destructive_hint = true,
+        idempotent_hint = false,
+        open_world_hint = true
+    ))]
     async fn attach_kernel(
         &self,
         Parameters(args): Parameters<ConnectionArgs>,
@@ -1290,8 +1516,8 @@ impl WindbgServer {
                 let _ = e.execute_command(".load kdexts");
                 e.execute_command("vertarget").map_err(es)
             })
-            .await?;
-        text_result(out)
+            .await;
+        self.opened_result(out)
     }
 
     /// Set or extend the symbol search path, then reload symbols, so `module!Symbol`
@@ -1300,11 +1526,20 @@ impl WindbgServer {
     /// be reachable from THIS (debugger) host — symbols are not fetched from the target
     /// over the KD wire. Goes through the DbgEng API, so it avoids the `.sympath` command
     /// quirk of swallowing the rest of the command line.
-    #[rmcp::tool]
+    #[rmcp::tool(annotations(
+        title = "Set symbol search path",
+        read_only_hint = false,
+        destructive_hint = false,
+        idempotent_hint = false,
+        open_world_hint = true
+    ))]
     async fn set_symbol_path(
         &self,
         Parameters(args): Parameters<SymbolPathArgs>,
     ) -> Result<CallToolResult, ErrorData> {
+        if let Err(e) = self.check_session(args.session_id.as_deref()) {
+            return tool_error(e);
+        }
         let append = args.append.unwrap_or(true);
         let out = self
             .engine
@@ -1320,12 +1555,19 @@ impl WindbgServer {
                 // Echo the effective path so the caller can confirm what resolved.
                 e.execute_command(".sympath").map_err(es)
             })
-            .await?;
-        text_result(out)
+            .await;
+        engine_result(out)
     }
 
     /// Attach to an existing user-mode process by PID and break in.
-    #[rmcp::tool]
+    /// Replaces any session already open, and returns a `session_id` for later calls.
+    #[rmcp::tool(annotations(
+        title = "Attach to process",
+        read_only_hint = false,
+        destructive_hint = true,
+        idempotent_hint = false,
+        open_world_hint = true
+    ))]
     async fn attach_process(
         &self,
         Parameters(args): Parameters<PidArgs>,
@@ -1338,12 +1580,19 @@ impl WindbgServer {
                 e.attach_process(pid).map_err(es)?;
                 e.execute_command("r").map_err(es)
             })
-            .await?;
-        text_result(out)
+            .await;
+        self.opened_result(out)
     }
 
     /// Launch a new user-mode process under the debugger, stopping at the initial breakpoint.
-    #[rmcp::tool]
+    /// Replaces any session already open, and returns a `session_id` for later calls.
+    #[rmcp::tool(annotations(
+        title = "Launch process under debugger",
+        read_only_hint = false,
+        destructive_hint = true,
+        idempotent_hint = false,
+        open_world_hint = true
+    ))]
     async fn launch(
         &self,
         Parameters(args): Parameters<CommandLineArgs>,
@@ -1355,13 +1604,27 @@ impl WindbgServer {
                 e.launch_process(&args.command_line).map_err(es)?;
                 e.execute_command("r").map_err(es)
             })
-            .await?;
-        text_result(out)
+            .await;
+        self.opened_result(out)
     }
 
     /// End the current debug session (detach/close the target) without exiting the server.
-    #[rmcp::tool]
-    async fn end_session(&self) -> Result<CallToolResult, ErrorData> {
+    /// Pass `session_id` to be sure you are ending your own session and not one another
+    /// caller opened in the meantime.
+    #[rmcp::tool(annotations(
+        title = "End debug session",
+        read_only_hint = false,
+        destructive_hint = true,
+        idempotent_hint = true,
+        open_world_hint = false
+    ))]
+    async fn end_session(
+        &self,
+        Parameters(args): Parameters<SessionArgs>,
+    ) -> Result<CallToolResult, ErrorData> {
+        if let Err(e) = self.check_session(args.session_id.as_deref()) {
+            return tool_error(e);
+        }
         let out = self
             .engine
             .run(move |e| {
@@ -1369,45 +1632,76 @@ impl WindbgServer {
                     .map(|_| "session ended".to_string())
                     .map_err(es)
             })
-            .await?;
-        text_result(out)
+            .await;
+        if out.is_ok() {
+            self.clear_session();
+        }
+        engine_result(out)
     }
 
     /// Run a raw debugger command and return its full output. The universal escape hatch.
-    #[rmcp::tool]
+    #[rmcp::tool(annotations(
+        title = "Run raw debugger command",
+        read_only_hint = false,
+        destructive_hint = true,
+        idempotent_hint = false,
+        open_world_hint = true
+    ))]
     async fn execute(
         &self,
         Parameters(args): Parameters<ExecuteArgs>,
     ) -> Result<CallToolResult, ErrorData> {
+        if let Err(e) = self.check_session(args.session_id.as_deref()) {
+            return tool_error(e);
+        }
         // Bounded: a runaway raw command (e.g. an unbounded `s` search) self-aborts instead
         // of pinning the engine thread and wedging every later call.
-        let out = self.engine.run_command(args.command).await?;
-        text_result(out)
+        let out = self.engine.run_command(args.command).await;
+        engine_result(out)
     }
 
     /// Show the current register set.
-    #[rmcp::tool]
-    async fn registers(&self) -> Result<CallToolResult, ErrorData> {
-        let out = self.engine.run(move |e| e.registers().map_err(es)).await?;
-        if out.trim().is_empty() {
-            // DbgEng prints nothing for `r` when there is no live thread context (e.g. a
-            // module-load break, or a bare goto_position to the very start of a trace).
-            return text_result(
+    #[rmcp::tool(annotations(
+        title = "Show registers",
+        read_only_hint = true,
+        open_world_hint = false
+    ))]
+    async fn registers(
+        &self,
+        Parameters(args): Parameters<SessionArgs>,
+    ) -> Result<CallToolResult, ErrorData> {
+        if let Err(e) = self.check_session(args.session_id.as_deref()) {
+            return tool_error(e);
+        }
+        let out = self.engine.run(move |e| e.registers().map_err(es)).await;
+        // DbgEng prints nothing for `r` when there is no live thread context (e.g. a
+        // module-load break, or a bare goto_position to the very start of a trace).
+        let out = out.map(|s| {
+            if s.trim().is_empty() {
                 "(no thread register context at this position — e.g. a module-load break or \
                  the start of a trace. Travel to a settled position after a go/breakpoint, or \
                  read a specific register with execute { \"command\": \"r rip\" }.)"
-                    .to_string(),
-            );
-        }
-        text_result(out)
+                    .to_string()
+            } else {
+                s
+            }
+        });
+        engine_result(out)
     }
 
     /// Read process/kernel virtual memory and return a hex dump.
-    #[rmcp::tool]
+    #[rmcp::tool(annotations(
+        title = "Read memory",
+        read_only_hint = true,
+        open_world_hint = false
+    ))]
     async fn read_memory(
         &self,
         Parameters(args): Parameters<ReadMemoryArgs>,
     ) -> Result<CallToolResult, ErrorData> {
+        if let Err(e) = self.check_session(args.session_id.as_deref()) {
+            return tool_error(e);
+        }
         let size = args.size;
         let out = self
             .engine
@@ -1416,46 +1710,83 @@ impl WindbgServer {
                 let bytes = e.read_memory(addr, size as usize).map_err(es)?;
                 Ok(hexdump(addr, &bytes))
             })
-            .await?;
-        text_result(out)
+            .await;
+        engine_result(out)
     }
 
     /// Show the call stack of the current thread (`k`).
-    #[rmcp::tool]
-    async fn backtrace(&self) -> Result<CallToolResult, ErrorData> {
+    #[rmcp::tool(annotations(
+        title = "Show call stack",
+        read_only_hint = true,
+        open_world_hint = false
+    ))]
+    async fn backtrace(
+        &self,
+        Parameters(args): Parameters<SessionArgs>,
+    ) -> Result<CallToolResult, ErrorData> {
+        if let Err(e) = self.check_session(args.session_id.as_deref()) {
+            return tool_error(e);
+        }
         let out = self
             .engine
             .run(move |e| e.execute_command("k").map_err(es))
-            .await?;
-        text_result(out)
+            .await;
+        engine_result(out)
     }
 
     /// List loaded modules (`lm`).
-    #[rmcp::tool]
-    async fn modules(&self) -> Result<CallToolResult, ErrorData> {
+    #[rmcp::tool(annotations(
+        title = "List modules",
+        read_only_hint = true,
+        open_world_hint = false
+    ))]
+    async fn modules(
+        &self,
+        Parameters(args): Parameters<SessionArgs>,
+    ) -> Result<CallToolResult, ErrorData> {
+        if let Err(e) = self.check_session(args.session_id.as_deref()) {
+            return tool_error(e);
+        }
         let out = self
             .engine
             .run(move |e| e.execute_command("lm").map_err(es))
-            .await?;
-        text_result(out)
+            .await;
+        engine_result(out)
     }
 
     /// List threads (`~`).
-    #[rmcp::tool]
-    async fn threads(&self) -> Result<CallToolResult, ErrorData> {
+    #[rmcp::tool(annotations(
+        title = "List threads",
+        read_only_hint = true,
+        open_world_hint = false
+    ))]
+    async fn threads(
+        &self,
+        Parameters(args): Parameters<SessionArgs>,
+    ) -> Result<CallToolResult, ErrorData> {
+        if let Err(e) = self.check_session(args.session_id.as_deref()) {
+            return tool_error(e);
+        }
         let out = self
             .engine
             .run(move |e| e.execute_command("~").map_err(es))
-            .await?;
-        text_result(out)
+            .await;
+        engine_result(out)
     }
 
     /// Disassemble at an address/symbol (or the current IP).
-    #[rmcp::tool]
+    #[rmcp::tool(annotations(
+        title = "Disassemble",
+        read_only_hint = true,
+        open_world_hint = false
+    ))]
     async fn disassemble(
         &self,
         Parameters(args): Parameters<DisassembleArgs>,
     ) -> Result<CallToolResult, ErrorData> {
+        if let Err(e) = self.check_session(args.session_id.as_deref()) {
+            return tool_error(e);
+        }
         let cmd = match args.address {
             Some(a) => format!("u {a}"),
             None => "u".to_string(),
@@ -1463,43 +1794,71 @@ impl WindbgServer {
         let out = self
             .engine
             .run(move |e| e.execute_command(&cmd).map_err(es))
-            .await?;
-        text_result(out)
+            .await;
+        engine_result(out)
     }
 
     /// Evaluate a data-model (LINQ) expression with `dx` — ideal for TTD queries.
-    #[rmcp::tool]
+    #[rmcp::tool(annotations(
+        title = "Evaluate data-model expression",
+        read_only_hint = false,
+        destructive_hint = false,
+        idempotent_hint = false,
+        open_world_hint = false
+    ))]
     async fn dx(&self, Parameters(args): Parameters<DxArgs>) -> Result<CallToolResult, ErrorData> {
+        if let Err(e) = self.check_session(args.session_id.as_deref()) {
+            return tool_error(e);
+        }
         let cmd = format!("dx {}", args.expression);
         // Bounded: a data-model query that runs away (e.g. a heavy LINQ or index build on a
         // huge trace) self-aborts rather than pinning the engine thread.
-        let out = self.engine.run_command(cmd).await?;
-        text_result(out)
+        let out = self.engine.run_command(cmd).await;
+        engine_result(out)
     }
 
     /// TTD: find every call to a function across the whole trace
     /// (`dx @$cursession.TTD.Calls(...)`). Each result carries the time, thread,
     /// parameters, and return value. Append LINQ in a follow-up `dx`/`execute` to
     /// filter (e.g. `.Where(c => c.ReturnValue != 0)`).
-    #[rmcp::tool]
+    #[rmcp::tool(annotations(
+        title = "TTD: find calls to a function",
+        read_only_hint = true,
+        open_world_hint = false
+    ))]
     async fn ttd_calls(
         &self,
         Parameters(args): Parameters<TtdCallsArgs>,
     ) -> Result<CallToolResult, ErrorData> {
+        if let Err(e) = self.check_session(args.session_id.as_deref()) {
+            return tool_error(e);
+        }
         let cmd = format!("dx @$cursession.TTD.Calls(\"{}\")", args.function);
-        let out = self.engine.run_command(cmd).await?;
-        text_result(out)
+        let out = self.engine.run_command(cmd).await;
+        engine_result(out)
     }
 
     /// TTD: find every access to a memory range across the trace
     /// (`dx @$cursession.TTD.Memory(start, end, mode)`) — when and from where it was
     /// read, written, or executed.
-    #[rmcp::tool]
+    #[rmcp::tool(annotations(
+        title = "TTD: find accesses to a memory range",
+        read_only_hint = true,
+        open_world_hint = false
+    ))]
     async fn ttd_memory(
         &self,
         Parameters(args): Parameters<TtdMemoryArgs>,
     ) -> Result<CallToolResult, ErrorData> {
-        let start = parse_u64(&args.address).map_err(|e| ErrorData::internal_error(e, None))?;
+        if let Err(e) = self.check_session(args.session_id.as_deref()) {
+            return tool_error(e);
+        }
+        // A bad address is the model's mistake to fix, so it comes back as a tool error
+        // rather than a protocol error the model cannot act on.
+        let start = match parse_u64(&args.address) {
+            Ok(v) => v,
+            Err(e) => return tool_error(e),
+        };
         let end = start.saturating_add(args.size as u64);
         let cmd = match args.mode.as_deref() {
             Some(m) if !m.trim().is_empty() => format!(
@@ -1508,44 +1867,75 @@ impl WindbgServer {
             ),
             _ => format!("dx @$cursession.TTD.Memory(0x{start:x}, 0x{end:x})"),
         };
-        let out = self.engine.run_command(cmd).await?;
-        text_result(out)
+        let out = self.engine.run_command(cmd).await;
+        engine_result(out)
     }
 
     /// TTD: list trace events — module loads/unloads, thread create/exit, and
     /// exceptions (`dx @$curprocess.TTD.Events`). Events and Threads hang off
     /// `@$curprocess.TTD`; Calls and Memory hang off `@$cursession.TTD`.
-    #[rmcp::tool]
-    async fn ttd_events(&self) -> Result<CallToolResult, ErrorData> {
+    #[rmcp::tool(annotations(
+        title = "TTD: list trace events",
+        read_only_hint = true,
+        open_world_hint = false
+    ))]
+    async fn ttd_events(
+        &self,
+        Parameters(args): Parameters<SessionArgs>,
+    ) -> Result<CallToolResult, ErrorData> {
+        if let Err(e) = self.check_session(args.session_id.as_deref()) {
+            return tool_error(e);
+        }
         let out = self
             .engine
             .run_command("dx -r2 @$curprocess.TTD.Events".to_string())
-            .await?;
-        text_result(out)
+            .await;
+        engine_result(out)
     }
 
     /// Set a breakpoint at a symbol, address, or expression (`bp`).
-    #[rmcp::tool]
+    #[rmcp::tool(annotations(
+        title = "Set breakpoint",
+        read_only_hint = false,
+        destructive_hint = false,
+        idempotent_hint = false,
+        open_world_hint = false
+    ))]
     async fn set_breakpoint(
         &self,
         Parameters(args): Parameters<BreakpointArgs>,
     ) -> Result<CallToolResult, ErrorData> {
+        if let Err(e) = self.check_session(args.session_id.as_deref()) {
+            return tool_error(e);
+        }
         let cmd = format!("bp {}", args.expression);
         let out = self
             .engine
             .run(move |e| e.execute_command(&cmd).map_err(es))
-            .await?;
-        text_result(out)
+            .await;
+        engine_result(out)
     }
 
     /// Continue execution (`g`). Runs to the next breakpoint, or the end of a TTD trace.
-    #[rmcp::tool]
-    async fn go(&self) -> Result<CallToolResult, ErrorData> {
+    #[rmcp::tool(annotations(
+        title = "Continue execution",
+        read_only_hint = false,
+        destructive_hint = true,
+        idempotent_hint = false,
+        open_world_hint = false
+    ))]
+    async fn go(
+        &self,
+        Parameters(args): Parameters<SessionArgs>,
+    ) -> Result<CallToolResult, ErrorData> {
+        if let Err(e) = self.check_session(args.session_id.as_deref()) {
+            return tool_error(e);
+        }
         let out = self
             .engine
             .run(move |e| e.execute_and_wait("g", EXEC_WAIT_MS).map_err(es))
-            .await?;
-        text_result(out)
+            .await;
+        engine_result(out)
     }
 
     /// Run the target until it reaches `address` (a one-shot `g <addr>` that doesn't
@@ -1554,11 +1944,20 @@ impl WindbgServer {
     /// reached in time). Confirms *live* that the current input/state drives execution to
     /// a block — e.g. one from `reachable_from_dispatch`. Needs a real KDNET/VM kernel
     /// target (a local kernel can't set code breakpoints).
-    #[rmcp::tool]
+    #[rmcp::tool(annotations(
+        title = "Run to address",
+        read_only_hint = false,
+        destructive_hint = true,
+        idempotent_hint = false,
+        open_world_hint = false
+    ))]
     async fn run_to_address(
         &self,
         Parameters(args): Parameters<RunToAddressArgs>,
     ) -> Result<CallToolResult, ErrorData> {
+        if let Err(e) = self.check_session(args.session_id.as_deref()) {
+            return tool_error(e);
+        }
         let out = self
             .engine
             .run(move |e| {
@@ -1598,72 +1997,143 @@ impl WindbgServer {
                 }
                 Ok(msg)
             })
-            .await?;
-        text_result(out)
+            .await;
+        engine_result(out)
     }
 
     /// Step over one source/instruction step (`p`).
-    #[rmcp::tool]
-    async fn step_over(&self) -> Result<CallToolResult, ErrorData> {
+    #[rmcp::tool(annotations(
+        title = "Step over",
+        read_only_hint = false,
+        destructive_hint = true,
+        idempotent_hint = false,
+        open_world_hint = false
+    ))]
+    async fn step_over(
+        &self,
+        Parameters(args): Parameters<SessionArgs>,
+    ) -> Result<CallToolResult, ErrorData> {
+        if let Err(e) = self.check_session(args.session_id.as_deref()) {
+            return tool_error(e);
+        }
         let out = self
             .engine
             .run(move |e| e.execute_and_wait("p", EXEC_WAIT_MS).map_err(es))
-            .await?;
-        text_result(out)
+            .await;
+        engine_result(out)
     }
 
     /// Step into one instruction (`t`).
-    #[rmcp::tool]
-    async fn step_into(&self) -> Result<CallToolResult, ErrorData> {
+    #[rmcp::tool(annotations(
+        title = "Step into",
+        read_only_hint = false,
+        destructive_hint = true,
+        idempotent_hint = false,
+        open_world_hint = false
+    ))]
+    async fn step_into(
+        &self,
+        Parameters(args): Parameters<SessionArgs>,
+    ) -> Result<CallToolResult, ErrorData> {
+        if let Err(e) = self.check_session(args.session_id.as_deref()) {
+            return tool_error(e);
+        }
         let out = self
             .engine
             .run(move |e| e.execute_and_wait("t", EXEC_WAIT_MS).map_err(es))
-            .await?;
-        text_result(out)
+            .await;
+        engine_result(out)
     }
 
     /// Step backward one instruction in a TTD trace (`t-`). Reverse of step_into.
-    #[rmcp::tool]
-    async fn step_back(&self) -> Result<CallToolResult, ErrorData> {
+    // The reverse-navigation tools only work on a TTD trace, which is a recorded replay:
+    // moving through it cannot destroy state, unlike stepping a live target.
+    #[rmcp::tool(annotations(
+        title = "Step back (TTD)",
+        read_only_hint = false,
+        destructive_hint = false,
+        idempotent_hint = false,
+        open_world_hint = false
+    ))]
+    async fn step_back(
+        &self,
+        Parameters(args): Parameters<SessionArgs>,
+    ) -> Result<CallToolResult, ErrorData> {
+        if let Err(e) = self.check_session(args.session_id.as_deref()) {
+            return tool_error(e);
+        }
         let out = self
             .engine
             .run(move |e| e.execute_and_wait("t-", EXEC_WAIT_MS).map_err(es))
-            .await?;
-        text_result(out)
+            .await;
+        engine_result(out)
     }
 
     /// Step over one call backward in a TTD trace (`p-`). Reverse of step_over.
-    #[rmcp::tool]
-    async fn step_over_back(&self) -> Result<CallToolResult, ErrorData> {
+    #[rmcp::tool(annotations(
+        title = "Step over back (TTD)",
+        read_only_hint = false,
+        destructive_hint = false,
+        idempotent_hint = false,
+        open_world_hint = false
+    ))]
+    async fn step_over_back(
+        &self,
+        Parameters(args): Parameters<SessionArgs>,
+    ) -> Result<CallToolResult, ErrorData> {
+        if let Err(e) = self.check_session(args.session_id.as_deref()) {
+            return tool_error(e);
+        }
         let out = self
             .engine
             .run(move |e| e.execute_and_wait("p-", EXEC_WAIT_MS).map_err(es))
-            .await?;
-        text_result(out)
+            .await;
+        engine_result(out)
     }
 
     /// Reverse-continue: run the TTD trace backward until a breakpoint or its start (`g-`).
-    #[rmcp::tool]
-    async fn reverse_go(&self) -> Result<CallToolResult, ErrorData> {
+    #[rmcp::tool(annotations(
+        title = "Reverse continue (TTD)",
+        read_only_hint = false,
+        destructive_hint = false,
+        idempotent_hint = false,
+        open_world_hint = false
+    ))]
+    async fn reverse_go(
+        &self,
+        Parameters(args): Parameters<SessionArgs>,
+    ) -> Result<CallToolResult, ErrorData> {
+        if let Err(e) = self.check_session(args.session_id.as_deref()) {
+            return tool_error(e);
+        }
         let out = self
             .engine
             .run(move |e| e.execute_and_wait("g-", EXEC_WAIT_MS).map_err(es))
-            .await?;
-        text_result(out)
+            .await;
+        engine_result(out)
     }
 
     /// Travel to a specific position in a TTD trace (`!tt <position>`).
-    #[rmcp::tool]
+    #[rmcp::tool(annotations(
+        title = "Go to TTD position",
+        read_only_hint = false,
+        destructive_hint = false,
+        idempotent_hint = true,
+        open_world_hint = false
+    ))]
     async fn goto_position(
         &self,
         Parameters(args): Parameters<PositionArgs>,
     ) -> Result<CallToolResult, ErrorData> {
+        if let Err(e) = self.check_session(args.session_id.as_deref()) {
+            return tool_error(e);
+        }
         let cmd = format!("!tt {}", args.position);
         let out = self
             .engine
             .run(move |e| e.execute_command(&cmd).map_err(es))
-            .await?;
-        text_result(out)
+            .await;
+        engine_result(out)
     }
 
     /// Build (or repair) the persistent index of the currently open TTD trace
@@ -1673,13 +2143,25 @@ impl WindbgServer {
     /// is the mode that actually fixes the "index not loaded" state `open_trace` warns about.
     /// (The bundled engine exposes these via `TtdExt.dll`; `!tt.index` fails with
     /// `LoadLibrary(tt)` because there is no `tt` extension.)
-    #[rmcp::tool]
-    async fn index_trace(&self) -> Result<CallToolResult, ErrorData> {
+    #[rmcp::tool(annotations(
+        title = "Build TTD trace index",
+        read_only_hint = false,
+        destructive_hint = false,
+        idempotent_hint = true,
+        open_world_hint = true
+    ))]
+    async fn index_trace(
+        &self,
+        Parameters(args): Parameters<SessionArgs>,
+    ) -> Result<CallToolResult, ErrorData> {
+        if let Err(e) = self.check_session(args.session_id.as_deref()) {
+            return tool_error(e);
+        }
         let out = self
             .engine
             .run(move |e| e.execute_command("!ttdext.index -force").map_err(es))
-            .await?;
-        text_result(out)
+            .await;
+        engine_result(out)
     }
 
     /// Record a new TTD trace by launching a target under TTD.exe (requires elevation).
@@ -1687,7 +2169,14 @@ impl WindbgServer {
     /// Optional `env` (KEY=VALUE entries) and `working_dir` are applied to the recorded
     /// target — use them when it needs a specific environment or cwd to run (e.g. a Qt
     /// app's `QT_QPA_PLATFORM_PLUGIN_PATH`, or an anti-analysis "run me from here" guard).
-    #[rmcp::tool]
+    /// Independent of the debug session, so it takes no `session_id`.
+    #[rmcp::tool(annotations(
+        title = "Record new TTD trace",
+        read_only_hint = false,
+        destructive_hint = true,
+        idempotent_hint = false,
+        open_world_hint = true
+    ))]
     async fn record_trace(
         &self,
         Parameters(args): Parameters<RecordArgs>,
@@ -1710,80 +2199,110 @@ impl WindbgServer {
         .await
         .map_err(|e| ErrorData::internal_error(format!("record task panicked: {e}"), None))?;
 
+        // A recorder that won't start (missing TTD.exe, not elevated, bad target) is
+        // actionable feedback, so it belongs in the result rather than a protocol error.
         match res {
             Ok(msg) => text_result(msg),
-            Err(e) => Err(ErrorData::internal_error(e, None)),
+            Err(e) => tool_error(e),
         }
     }
 
     /// Decode a 32-bit IOCTL control code into its CTL_CODE fields (DeviceType,
     /// FunctionCode, Method, RequiredAccess) and flag METHOD_NEITHER / FILE_ANY_ACCESS.
-    /// Pure — needs no debug session.
-    #[rmcp::tool]
+    /// Pure — needs no debug session, so it takes no `session_id`.
+    #[rmcp::tool(annotations(
+        title = "Decode IOCTL control code",
+        read_only_hint = true,
+        open_world_hint = false
+    ))]
     async fn decode_ioctl(
         &self,
         Parameters(args): Parameters<DecodeIoctlArgs>,
     ) -> Result<CallToolResult, ErrorData> {
-        let code = parse_u64(&args.code).map_err(|e| ErrorData::invalid_params(e, None))?;
+        // Both rejections below are semantic input validation, not a malformed request:
+        // the schema is satisfied either way, so they belong in the result where the
+        // model can read them and correct the code it passed.
+        let code = match parse_u64(&args.code) {
+            Ok(v) => v,
+            Err(e) => return tool_error(e),
+        };
         // An IOCTL is a 32-bit value; reject anything wider rather than silently
         // truncating it to a different code.
-        let code = u32::try_from(code).map_err(|_| {
-            ErrorData::invalid_params(
-                format!("IOCTL must be a 32-bit value (got 0x{code:x})"),
-                None,
-            )
-        })?;
+        let Ok(code) = u32::try_from(code) else {
+            return tool_error(format!("IOCTL must be a 32-bit value (got 0x{code:x})"));
+        };
         text_result(decode_ioctl_text(code))
     }
 
     /// Dump a driver object's dispatch table and devices (`!drvobj <name> 7`).
     /// The MajorFunction table's index 0x0e is the IRP_MJ_DEVICE_CONTROL handler — the
     /// IOCTL dispatch routine. Root of the device-tree walk.
-    #[rmcp::tool]
+    #[rmcp::tool(annotations(
+        title = "Inspect driver object",
+        read_only_hint = true,
+        open_world_hint = false
+    ))]
     async fn driver_object(
         &self,
         Parameters(args): Parameters<DriverObjectArgs>,
     ) -> Result<CallToolResult, ErrorData> {
+        if let Err(e) = self.check_session(args.session_id.as_deref()) {
+            return tool_error(e);
+        }
         let cmd = format!("!drvobj {} 7", args.name);
         let out = self
             .engine
             .run(move |e| e.execute_command(&cmd).map_err(es))
-            .await?;
-        text_result(out)
+            .await;
+        engine_result(out)
     }
 
     /// Inspect a device object (`!devobj <device>`): device type, characteristics
     /// (e.g. FILE_DEVICE_SECURE_OPEN), and the SecurityDescriptor pointer — the inputs to the
     /// *openable* gate. (`!sd <SecurityDescriptor>` decodes the DACL where that extension is
     /// available; it is not in the bundled engine.)
-    #[rmcp::tool]
+    #[rmcp::tool(annotations(
+        title = "Inspect device object",
+        read_only_hint = true,
+        open_world_hint = false
+    ))]
     async fn device_object(
         &self,
         Parameters(args): Parameters<DeviceObjectArgs>,
     ) -> Result<CallToolResult, ErrorData> {
+        if let Err(e) = self.check_session(args.session_id.as_deref()) {
+            return tool_error(e);
+        }
         let cmd = format!("!devobj {}", args.device);
         let out = self
             .engine
             .run(move |e| e.execute_command(&cmd).map_err(es))
-            .await?;
-        text_result(out)
+            .await;
+        engine_result(out)
     }
 
     /// Dump the current IO_STACK_LOCATION of an IRP (`!irp <irp> 1`): major/minor,
     /// IoControlCode, input/output buffer lengths, and buffer pointers. Defaults the IRP
     /// to `@rdx` (the PIRP at the dispatch entry on x64) — valid only before stepping.
-    #[rmcp::tool]
+    #[rmcp::tool(annotations(
+        title = "Dump IRP stack location",
+        read_only_hint = true,
+        open_world_hint = false
+    ))]
     async fn irp_stack(
         &self,
         Parameters(args): Parameters<IrpStackArgs>,
     ) -> Result<CallToolResult, ErrorData> {
+        if let Err(e) = self.check_session(args.session_id.as_deref()) {
+            return tool_error(e);
+        }
         let irp = args.irp.unwrap_or_else(|| "@rdx".to_string());
         let cmd = format!("!irp {irp} 1");
         let out = self
             .engine
             .run(move |e| e.execute_command(&cmd).map_err(es))
-            .await?;
-        text_result(out)
+            .await;
+        engine_result(out)
     }
 
     /// Install a conditional logging breakpoint at the IOCTL dispatch routine that prints
@@ -1791,11 +2310,20 @@ impl WindbgServer {
     /// needs no hand-assembled offsets. Reads the current IO_STACK_LOCATION via
     /// `poi(@rdx+0xb8)` (x64); confirm the offset with `dt nt!_IRP` / `dt nt!_IO_STACK_LOCATION`
     /// on the target. Requires a real KDNET/VM target — a local kernel cannot set code bp's.
-    #[rmcp::tool]
+    #[rmcp::tool(annotations(
+        title = "Trace dispatched IOCTLs",
+        read_only_hint = false,
+        destructive_hint = false,
+        idempotent_hint = false,
+        open_world_hint = false
+    ))]
     async fn ioctl_trace(
         &self,
         Parameters(args): Parameters<IoctlTraceArgs>,
     ) -> Result<CallToolResult, ErrorData> {
+        if let Err(e) = self.check_session(args.session_id.as_deref()) {
+            return tool_error(e);
+        }
         // IRP in @rdx at dispatch entry (x64). CurrentStackLocation = poi(Irp+0xb8).
         // Within IO_STACK_LOCATION: OutputBufferLength +0x08, InputBufferLength +0x10,
         // IoControlCode +0x18 (Parameters union begins at +0x08).
@@ -1807,8 +2335,8 @@ impl WindbgServer {
         let out = self
             .engine
             .run(move |e| e.execute_command(&cmd).map_err(es))
-            .await?;
-        text_result(out)
+            .await;
+        engine_result(out)
     }
 
     /// Static, best-effort control-flow reachability: is the code block at `address`
@@ -1818,11 +2346,18 @@ impl WindbgServer {
     /// concrete static path exists, and the call path is reported); "NOT REACHABLE"
     /// means only that the block was not found within the bounds — indirect calls
     /// through function pointers and unresolved compiler jump tables are NOT followed.
-    #[rmcp::tool]
+    #[rmcp::tool(annotations(
+        title = "Test reachability from IOCTL dispatch",
+        read_only_hint = true,
+        open_world_hint = false
+    ))]
     async fn reachable_from_dispatch(
         &self,
         Parameters(args): Parameters<ReachabilityArgs>,
     ) -> Result<CallToolResult, ErrorData> {
+        if let Err(e) = self.check_session(args.session_id.as_deref()) {
+            return tool_error(e);
+        }
         let out = self
             .engine
             .run(move |e| {
@@ -1909,8 +2444,8 @@ impl WindbgServer {
                 }
                 Ok(out)
             })
-            .await?;
-        text_result(out)
+            .await;
+        engine_result(out)
     }
 }
 
@@ -1934,6 +2469,157 @@ impl rmcp::ServerHandler for WindbgServer {}
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ---- MCP protocol surface ------------------------------------------
+
+    /// `tools/list` must not reorder between calls: clients cache the list, and a
+    /// shuffled order also costs LLM prompt-cache hits. The SDK's router sorts by name
+    /// today — this pins that so an SDK bump can't silently regress it.
+    #[test]
+    fn tool_list_is_deterministically_ordered() {
+        let names: Vec<String> = WindbgServer::tool_router()
+            .list_all()
+            .into_iter()
+            .map(|t| t.name.to_string())
+            .collect();
+
+        let mut expected = names.clone();
+        expected.sort();
+        assert_eq!(
+            names, expected,
+            "tools/list must be in a stable, sorted order"
+        );
+
+        // Guard against the list silently becoming empty if the macro wiring changes.
+        assert!(names.contains(&"open_dump".to_string()));
+    }
+
+    /// Behaviour hints let a client tell "read a register" apart from "run arbitrary
+    /// debugger commands" before prompting the user.
+    #[test]
+    fn every_tool_declares_annotations() {
+        for tool in WindbgServer::tool_router().list_all() {
+            let ann = tool
+                .annotations
+                .unwrap_or_else(|| panic!("tool `{}` declares no annotations", tool.name));
+            assert!(
+                ann.title.is_some(),
+                "tool `{}` has no annotation title",
+                tool.name
+            );
+        }
+    }
+
+    /// The tools that mutate a live target must not claim to be read-only, and the
+    /// pure/inspection tools must not be flagged destructive.
+    #[test]
+    fn annotations_match_tool_behaviour() {
+        let tools = WindbgServer::tool_router().list_all();
+        let ann = |name: &str| {
+            tools
+                .iter()
+                .find(|t| t.name == name)
+                .unwrap_or_else(|| panic!("no tool `{name}`"))
+                .annotations
+                .clone()
+                .unwrap()
+        };
+
+        for name in ["execute", "launch", "record_trace", "end_session", "go"] {
+            assert_eq!(
+                ann(name).read_only_hint,
+                Some(false),
+                "`{name}` changes the target and must not be marked read-only"
+            );
+            assert_eq!(ann(name).destructive_hint, Some(true), "`{name}`");
+        }
+
+        for name in ["read_memory", "backtrace", "modules", "decode_ioctl"] {
+            assert_eq!(
+                ann(name).read_only_hint,
+                Some(true),
+                "`{name}` only inspects and should be marked read-only"
+            );
+        }
+    }
+
+    /// Session-scoped tools take a handle; the two that are genuinely session-independent
+    /// must not, or callers would think they were scoped when they are not.
+    #[test]
+    fn session_scoped_tools_accept_a_session_id() {
+        let tools = WindbgServer::tool_router().list_all();
+        let takes_session = |name: &str| {
+            let tool = tools.iter().find(|t| t.name == name).unwrap();
+            tool.input_schema
+                .get("properties")
+                .and_then(|p| p.get("session_id"))
+                .is_some()
+        };
+
+        for name in ["read_memory", "execute", "go", "end_session", "modules"] {
+            assert!(takes_session(name), "`{name}` should accept session_id");
+        }
+        for name in ["decode_ioctl", "record_trace", "open_dump"] {
+            assert!(
+                !takes_session(name),
+                "`{name}` should not accept session_id"
+            );
+        }
+    }
+
+    // ---- Session handles -----------------------------------------------
+
+    #[test]
+    fn omitted_handle_accepts_whatever_session_is_current() {
+        assert!(check_session_handle(Some("sess-1"), None).is_ok());
+        assert!(check_session_handle(None, None).is_ok());
+    }
+
+    #[test]
+    fn matching_handle_is_accepted() {
+        assert!(check_session_handle(Some("sess-1"), Some("sess-1")).is_ok());
+    }
+
+    #[test]
+    fn handle_from_a_replaced_session_is_refused() {
+        let err = check_session_handle(Some("sess-2"), Some("sess-1")).unwrap_err();
+        assert!(err.contains("sess-1"), "{err}");
+        assert!(err.contains("sess-2"), "{err}");
+    }
+
+    #[test]
+    fn handle_is_refused_once_the_session_is_ended() {
+        let err = check_session_handle(None, Some("sess-1")).unwrap_err();
+        assert!(err.contains("no debug session open"), "{err}");
+    }
+
+    #[test]
+    fn minted_handles_are_unique() {
+        let a = mint_session_id();
+        let b = mint_session_id();
+        assert_ne!(a, b);
+    }
+
+    // ---- Error reporting -----------------------------------------------
+
+    /// A failed debugger operation belongs in the result (`isError: true`) so the model
+    /// can read it and correct itself; only a dead engine is a protocol error.
+    #[test]
+    fn debugger_failures_are_tool_errors_not_protocol_errors() {
+        let r = engine_result(Err(EngineError::Debugger("no such symbol".into())))
+            .expect("debugger failure must not surface as a protocol error");
+        assert_eq!(r.is_error, Some(true));
+
+        let err = engine_result(Err(EngineError::Unavailable("engine gone".into())))
+            .expect_err("a dead engine must surface as a protocol error");
+        assert!(err.message.contains("engine gone"));
+    }
+
+    #[test]
+    fn successful_output_is_not_flagged_as_an_error() {
+        let r = engine_result(Ok("rax=0000000000000000".into())).unwrap();
+        assert_eq!(r.is_error, Some(false));
+    }
 
     #[test]
     fn parse_u64_decimal() {

--- a/src/server.rs
+++ b/src/server.rs
@@ -1407,23 +1407,45 @@ impl WindbgServer {
 
     /// Runs a session-opening operation and takes ownership of the session in the same
     /// queued job, so no other call can be ordered across the transition.
-    async fn opened_result<F>(&self, f: F) -> Result<CallToolResult, ErrorData>
+    ///
+    /// The work is split in two because the split is where correctness lives. `transition`
+    /// is the DbgEng call that actually changes the target; `report` is the follow-up
+    /// diagnostic (`lm`, `vertarget`, `r`, the TTD lifetime query) whose output the caller
+    /// reads. The handle is committed *between* them, so a failing diagnostic cannot cost
+    /// the caller a handle for a target that is genuinely open — which matters because the
+    /// only way to get one back is to open again, and for `launch` that spawns a second
+    /// process.
+    async fn opened_result<T, R>(
+        &self,
+        transition: T,
+        report: R,
+    ) -> Result<CallToolResult, ErrorData>
     where
-        F: FnOnce(&DebugEngine) -> Result<String, String> + Send + 'static,
+        T: FnOnce(&DebugEngine) -> Result<(), String> + Send + 'static,
+        R: FnOnce(&DebugEngine) -> Result<String, String> + Send + 'static,
     {
         let id = mint_session_id();
         let session = Arc::clone(&self.session);
         let new_id = id.clone();
+        let id_for_report = id.clone();
         let out = self
             .engine
             .run(move |e| {
                 // The target is being replaced, so every handle issued so far is stale from
-                // here on — including if the open fails partway and leaves the engine holding
-                // neither the old target nor a usable new one.
+                // here on — including if the transition fails partway and leaves the engine
+                // holding neither the old target nor a usable new one.
                 *lock(&session) = None;
-                let out = f(e)?;
+                transition(e)?;
                 *lock(&session) = Some(new_id);
-                Ok(out)
+                // The target is ours from here, so a failed diagnostic still has to hand the
+                // caller their handle — otherwise they cannot use the protection this whole
+                // mechanism promises without re-running a side-effecting open.
+                report(e).map_err(|err| {
+                    format!(
+                        "{err}\n\nsession_id: {id_for_report}\nThe target opened; only this \
+                         follow-up report failed, so the handle above is valid and usable."
+                    )
+                })
             })
             .await;
         match out {
@@ -1472,18 +1494,22 @@ impl WindbgServer {
         &self,
         Parameters(args): Parameters<PathArgs>,
     ) -> Result<CallToolResult, ErrorData> {
-        self.opened_result(move |e| {
-            e.open_dump(&args.path).map_err(es)?;
-            e.wait_for_event(LOAD_WAIT_MS).map_err(es)?;
-            // Load the WinDbg extension DLL so `!`-extension commands resolve — most
-            // importantly `!ext.analyze -v`, the crash-dump triage workhorse. A bare
-            // engine doesn't auto-load it, and even after `.load ext` the unqualified
-            // `!analyze` won't resolve, so callers must use `!ext.analyze`. Best-effort:
-            // a minimal engine without a bundled `winext\` directory simply won't have
-            // ext.dll, which must not fail the open (live/dump state is still usable).
-            let _ = e.execute_command(".load ext");
-            e.execute_command("lm").map_err(es)
-        })
+        self.opened_result(
+            move |e| {
+                e.open_dump(&args.path).map_err(es)?;
+                e.wait_for_event(LOAD_WAIT_MS).map_err(es)
+            },
+            |e| {
+                // Load the WinDbg extension DLL so `!`-extension commands resolve — most
+                // importantly `!ext.analyze -v`, the crash-dump triage workhorse. A bare
+                // engine doesn't auto-load it, and even after `.load ext` the unqualified
+                // `!analyze` won't resolve, so callers must use `!ext.analyze`. Best-effort:
+                // a minimal engine without a bundled `winext\` directory simply won't have
+                // ext.dll, which must not fail the open (live/dump state is still usable).
+                let _ = e.execute_command(".load ext");
+                e.execute_command("lm").map_err(es)
+            },
+        )
         .await
     }
 
@@ -1500,9 +1526,12 @@ impl WindbgServer {
         &self,
         Parameters(args): Parameters<PathArgs>,
     ) -> Result<CallToolResult, ErrorData> {
-        self.opened_result(move |e| {
+        self.opened_result(
+            move |e| {
                 e.open_trace(&args.path).map_err(es)?;
-                e.wait_for_event(LOAD_WAIT_MS).map_err(es)?;
+                e.wait_for_event(LOAD_WAIT_MS).map_err(es)
+            },
+            |e| {
                 // Check the index state *before* any data-model query: `!ttdext.index -status`
                 // only reads the on-disk .idx (never builds), whereas a `dx` on an unindexed
                 // trace can itself trigger the long in-memory index build. TtdExt reports a
@@ -1532,7 +1561,8 @@ impl WindbgServer {
                     );
                 }
                 Ok(out)
-        })
+            },
+        )
         .await
     }
 
@@ -1546,17 +1576,21 @@ impl WindbgServer {
         open_world_hint = true
     ))]
     async fn attach_kernel_local(&self) -> Result<CallToolResult, ErrorData> {
-        self.opened_result(move |e| {
-            // attach_local_kernel breaks the target in internally (INITIAL_BREAK +
-            // an INFINITE wait, as a live kernel requires).
-            e.attach_local_kernel().map_err(es)?;
-            // The driver_object/device_object/irp_stack tools use kernel-extension
-            // commands (!drvobj/!devobj/!irp) from kdexts.dll, which a bare engine does
-            // not auto-load. Best-effort, like open_dump's `.load ext`; harmless if the
-            // extension isn't bundled (those tools then report a clean "no export").
-            let _ = e.execute_command(".load kdexts");
-            e.execute_command("vertarget").map_err(es)
-        })
+        self.opened_result(
+            |e| {
+                // attach_local_kernel breaks the target in internally (INITIAL_BREAK +
+                // an INFINITE wait, as a live kernel requires).
+                e.attach_local_kernel().map_err(es)
+            },
+            |e| {
+                // The driver_object/device_object/irp_stack tools use kernel-extension
+                // commands (!drvobj/!devobj/!irp) from kdexts.dll, which a bare engine does
+                // not auto-load. Best-effort, like open_dump's `.load ext`; harmless if the
+                // extension isn't bundled (those tools then report a clean "no export").
+                let _ = e.execute_command(".load kdexts");
+                e.execute_command("vertarget").map_err(es)
+            },
+        )
         .await
     }
 
@@ -1573,15 +1607,19 @@ impl WindbgServer {
         &self,
         Parameters(args): Parameters<ConnectionArgs>,
     ) -> Result<CallToolResult, ErrorData> {
-        self.opened_result(move |e| {
-            // attach_kernel connects, requests an initial break, and waits (INFINITE,
-            // as a live kernel requires) for the break-in — all internally.
-            e.attach_kernel(&args.connection).map_err(es)?;
-            // Load kdexts.dll so the driver_object/device_object/irp_stack tools'
-            // !drvobj/!devobj/!irp commands resolve (see attach_kernel_local). Best-effort.
-            let _ = e.execute_command(".load kdexts");
-            e.execute_command("vertarget").map_err(es)
-        })
+        self.opened_result(
+            move |e| {
+                // attach_kernel connects, requests an initial break, and waits (INFINITE,
+                // as a live kernel requires) for the break-in — all internally.
+                e.attach_kernel(&args.connection).map_err(es)
+            },
+            |e| {
+                // Load kdexts.dll so the driver_object/device_object/irp_stack tools'
+                // !drvobj/!devobj/!irp commands resolve (see attach_kernel_local). Best-effort.
+                let _ = e.execute_command(".load kdexts");
+                e.execute_command("vertarget").map_err(es)
+            },
+        )
         .await
     }
 
@@ -1637,11 +1675,13 @@ impl WindbgServer {
         Parameters(args): Parameters<PidArgs>,
     ) -> Result<CallToolResult, ErrorData> {
         let pid = args.pid;
-        self.opened_result(move |e| {
-            // attach_process waits for the break-in internally.
-            e.attach_process(pid).map_err(es)?;
-            e.execute_command("r").map_err(es)
-        })
+        self.opened_result(
+            move |e| {
+                // attach_process waits for the break-in internally.
+                e.attach_process(pid).map_err(es)
+            },
+            |e| e.execute_command("r").map_err(es),
+        )
         .await
     }
 
@@ -1658,11 +1698,13 @@ impl WindbgServer {
         &self,
         Parameters(args): Parameters<CommandLineArgs>,
     ) -> Result<CallToolResult, ErrorData> {
-        self.opened_result(move |e| {
-            // launch_process waits for the initial break internally.
-            e.launch_process(&args.command_line).map_err(es)?;
-            e.execute_command("r").map_err(es)
-        })
+        self.opened_result(
+            move |e| {
+                // launch_process waits for the initial break internally.
+                e.launch_process(&args.command_line).map_err(es)
+            },
+            |e| e.execute_command("r").map_err(es),
+        )
         .await
     }
 


### PR DESCRIPTION
Three MCP conformance fixes that don't depend on an SDK upgrade, found while auditing this repo against the spec — plus fixes for the review findings they attracted.

## Debugger failures are now tool-execution errors

Every debugger failure was a JSON-RPC `-32603`. The tool spec draws the line at whether the model can act on the failure: an unresolvable symbol, an unreadable address, or a target that never stopped is feedback it can self-correct from and belongs in the result with `isError: true`; protocol errors are for unknown tools and malformed requests. Clients surface the latter as a transport fault, so in practice the model never saw *why* a call failed.

`EngineError` splits the outcomes — `Debugger`, `Timeout`, `Unavailable` — and the engine worker classifies each at the point it can tell them apart. A `DebugEngine::new()` failure (missing `dbgeng.dll`) is permanent and reports as a protocol error; a caught panic inside a win-kexp method stays a tool error, since the worker survives it. Semantic input validation moved the same way: the request satisfies the schema, so the complaint belongs in the result.

This is the change with the most day-to-day effect — the difference between the model reading "Couldn't resolve error at 'HEVD!Foo'" and retrying, versus seeing an opaque internal error.

## Explicit session handles

One process drives one DbgEng session, but an MCP connection is *not* a session — a client may interleave unrelated requests over the same stdio process, so "the target the last `open_*` call attached to" was not safe for a tool to assume. A `read_memory` issued after someone else's `open_dump` silently read the wrong target.

The six tools that open a target mint a `session_id`; the 28 target-touching tools accept it and refuse to run when it no longer matches. Getting that right needed five invariants, every one of them surfaced by review rather than designed in up front:

- **The check and the transitions run on the engine thread**, in the same queued job as the debugger call. Validating on the caller side is a TOCTOU bug: an `open_dump` for B can be in flight while the session still reads A, so `end_session(session_id=A)` would pass, queue behind the open, and close B.
- **`transition` is exactly the one call that replaces the target.** The handle is committed immediately after it, before the load wait and the diagnostic — so a failure there returns the error *with* the handle rather than swallowing it. Re-opening to recover means `launch` spawns a second process.
- **Every exit path after the commit carries the handle**, including a panic: the report runs under its own `catch_unwind`, because an unwind would skip straight past the code that attaches the id.
- **A timed-out open names the handle it would commit, and its outcome is recorded.** The timeout abandons the *waiter*, not the job. `session_status` takes an optional `session_id` and reports `pending` / `landed` / `failed`, because those need opposite responses: a pending open must not be re-run (it would attach or launch again), a failed one must be.
- **`execute` and `dx` retire the handle.** `execute` on the session-control commands; `dx` whenever the expression reaches `Debugger.Utility.Control.ExecuteCommand`, since the data model can run any command. Both are best-effort and documented as such — inside those two a handle is a strong hint; everywhere else it is a guarantee.

Otherwise the guarantee is **detection, not exclusion**: the opening tools take no handle, so holding one doesn't prevent a replacement; it makes any later call of yours that supplies the handle fail instead of acting on the wrong target. The argument is optional, so existing callers are unaffected.

## Tool annotations

All 37 tools declare a title and the read-only / destructive / idempotent / open-world hints, so a client can tell `read_memory` apart from `execute` before prompting the user.

`openWorldHint` is true for everything that touches a debug target, false only for `decode_ioctl` and `session_status`, which never reach the engine. Two independent reasons: a symbol server on the path means almost any command can pull a PDB (`r` symbolizes the current instruction, `k` symbolizes every frame), and a KDNET session puts the target itself across a network link, so even a raw `read_memory` is remote traffic.

Typed tools also refuse operands that would end the command they build. They interpolate arguments (`u {address}`, `bp {expression}`), so `;`, line breaks, and `"` are rejected — the last everywhere except `dx`. Without it, `disassemble { address: "rip; .opendump other.dmp" }` swaps the target from a tool advertising `readOnlyHint: true`, and `set_breakpoint { expression: "nt!Foo \".opendump other.dmp\"" }` arms one that fires on the next hit, outside any tool call.

## Not changed

`tools/list` ordering needed no fix — rmcp's router already sorts by name — but a test pins it so an SDK bump can't regress it silently.

The remaining gaps against the current `2026-07-28` revision (`server/discover`, `resultType`, `ttlMs`/`cacheScope`, removal of the `initialize` handshake) are all blocked on the SDK: only `rmcp` 3.0.0-beta implements that revision, and `rust-mcp-sdk` doesn't implement it at all. README now states which revision this server speaks and why.

One review finding (#21) is also left structurally unfixed here. win-kexp bundles the wait for the initial break into `launch_process`, `attach_process` and the kernel attaches, so a single call both creates the side effect and waits for it, and a failure is ambiguous — nothing happened, or the target started and the wait failed. Splitting the transition means splitting those methods, which is a change in that crate. What this PR does instead is stop giving dangerous advice about it.

## Review findings addressed

| # | Finding | Reporter | Outcome |
|---|---|---|---|
| 1 | Session check not serialised with the engine queue (TOCTOU) | Codex + CodeRabbit | `1886eca` |
| 2 | Opening tools accept no `session_id`, so replacement can't be refused | CodeRabbit | Documented as detection-not-exclusion; CAS is a separate feature |
| 3 | `DebugEngine::new()` failure classified as a retryable tool error | Codex | `602e7a2` |
| 4 | `open_world_hint` false on symbol-resolving tools | Codex | `602e7a2` |
| 5 | Raw `execute` could swap the target without retiring the handle | Codex | `96df6ed` |
| 6 | `read_memory`/`end_session` are remote over KDNET, not closed-world | Codex | `96df6ed` |
| 7 | Opener's diagnostic failure discarded a committed handle | Codex | `d4d9149` |
| 8 | Load wait still bundled into the transition — same defect one layer down | Codex | `01717b5` |
| 9 | Call timeout could commit a handle the caller never saw | Codex | `5d6b0b6` (`session_status`) |
| 10 | `index_trace` runs `-force` but claimed non-destructive | Codex | `5d6b0b6` |
| 11 | Recovered handle not correlated with the timed-out opener | Codex | `032578e` |
| 12 | A panic in the report unwound past the handle-preserving path | Codex | `1f561d5` |
| 13 | A mismatched handle meant "not yet", not "failed" | Codex | `49d5f48` |
| 14 | Typed operands could chain commands via `;` | Codex | `c56a98d` |
| 15 | Quotes in a `bp` location arm a deferred command string | Codex | `143a2d8` |
| 16 | `dx` reaches command execution through the data model | Codex | `1e823ef` |
| 17 | No terminal-failure state, so recovery could poll forever | Codex | `c3ebb39` |
| 18 | Eviction could drop a *pending* opener, restoring the duplicate-open hazard | Codex | `69de756` |
| 19 | Command scanner split only on `;`, so a line break hid a target swap | Codex | `88dbc24` |
| 20 | Ledger stayed over its bound once an in-flight burst settled in place | Codex | `88dbc24` |
| 21 | Bundled initial-break wait makes a failed open ambiguous | Codex | `aed7918` — advice only; the split is win-kexp work |
| 22 | `session_status` could contradict itself about the currently loaded handle | Codex | `aed7918` |

Twenty-one fixed in code; #2 resolved by correcting an over-strong claim, which CodeRabbit confirmed.

Two of these (#13→#17, and the transition/report line in #7→#8) were my own bad calls rather than gaps not yet reached — I declined per-opener state on reasoning that turned out to be wrong, and drew the phase split in the wrong place. Both are noted in the commit messages rather than quietly corrected.

Three more (#14→#19, and the eviction/trim pair #17→#18→#20) share a shape worth naming: a rule stated correctly in one place and not applied in another that predated it. The operand sanitizer refused line breaks while the command scanner ignored them; the ledger's no-evict-pending rule was added to the insert path and not the update path. Where two functions now depend on the same rule, each names the other in its doc comment.

## Verification

Windows-only crate, so this was checked by cross-compiling to `x86_64-pc-windows-gnu` and running the suite under wine:

- `cargo test` — 64 passed (27 new)
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean
- `markdownlint-cli2` — clean

Not exercised against a live debug target; CI's Windows runner covers the real build.

Deliberate test gaps, both because the path needs a live engine and the test would assert the environment rather than the behaviour: the `DebugEngine::new()` failure branch, and the transition/report interleaving inside `opened_result`. The pure policy around both — outcome recording, handle checks, operand validation — is covered.

---
_Generated by [Claude Code](https://claude.ai/code/session_01A4DSMEsUEyyN2rDiKZdzV9)_



## Summary by CodeRabbit

* **New Features**
  * Added session handles to target-opening tools, with validation applied to subsequent session-scoped operations.
  * Introduced a `session_status` tool for recovering the active session after timeouts.
  * Enhanced tool metadata with clearer behavioural annotations (including read-only/destructive hints).

* **Bug Fixes**
  * Reclassified debugger-operation failures as normal tool errors (rather than protocol-level JSON-RPC errors), while keeping the debugger output.
  * Improved timeout handling and session recovery flows.

* **Documentation**
  * Updated MCP protocol compatibility, session-handle workflow guidance, typed-operand rules, and error-reporting semantics.
