### PR TITLE
deps(rmcp): upgrade the MCP SDK from 1.x to 3.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,18 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
-
-- **Upgraded the `rmcp` SDK from 1.x to 3.x**, now that the 3.x line is released rather than beta.
-  The practical gain is protocol coverage: 3.x knows the `2026-07-28` revision, so the server now
-  answers `server/discover` and the stateless per-request lifecycle in addition to the
-  `initialize` handshake, and a client that speaks *only* `2026-07-28` can now talk to it. Both
-  come from the SDK's defaults (`supported_protocol_versions` covers every known revision, and
-  `serve` dispatches a non-`initialize` opening request through the inline lifecycle), so no
-  handler code was needed. The only source change the bump required is the `Content` →
-  `ContentBlock` rename in `rmcp::model`; the tool surface, its schemas, and the tool-call wire
-  format are unchanged.
-
 ### Added
 
 - **Explicit session handles.** The tools that open a target (`open_dump`, `open_trace`,
@@ -114,6 +102,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   client may be gating network consent on that hint.
 
 ### Changed
+
+- **Upgraded the `rmcp` SDK from 1.x to 3.x**, now that the 3.x line is released rather than beta.
+  The practical gain is protocol coverage: 3.x knows the `2026-07-28` revision, so the server now
+  answers `server/discover` and the stateless per-request lifecycle in addition to the
+  `initialize` handshake, and a client that speaks *only* `2026-07-28` can now talk to it. Both
+  come from the SDK's defaults (`supported_protocol_versions` covers every known revision, and
+  `serve` dispatches a non-`initialize` opening request through the inline lifecycle), so no
+  handler code was needed. The only source change the bump required is the `Content` →
+  `ContentBlock` rename in `rmcp::model`; the tool surface, its schemas, and the tool-call wire
+  format are unchanged.
 
 - **Debugger failures are now tool-execution errors, not protocol errors.** An unresolvable
   symbol, an unreadable address, a target that never stopped, or a recorder that won't

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Upgraded the `rmcp` SDK from 1.x to 3.x**, now that the 3.x line is released rather than beta.
+  The practical gain is protocol coverage: 3.x knows the `2026-07-28` revision, so the server now
+  answers `server/discover` and the stateless per-request lifecycle in addition to the
+  `initialize` handshake, and a client that speaks *only* `2026-07-28` can now talk to it. Both
+  come from the SDK's defaults (`supported_protocol_versions` covers every known revision, and
+  `serve` dispatches a non-`initialize` opening request through the inline lifecycle), so no
+  handler code was needed. The only source change the bump required is the `Content` →
+  `ContentBlock` rename in `rmcp::model`; the tool surface, its schemas, and the tool-call wire
+  format are unchanged.
+
 ### Added
 
 - **Explicit session handles.** The tools that open a target (`open_dump`, `open_trace`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -145,8 +145,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation
 
-- README now states which MCP protocol revision the server speaks (the `initialize`-handshake
-  era: `2025-11-25` / `2025-06-18`) and why `2026-07-28` is not supported yet.
+- README now states which MCP protocol revisions the server speaks — `2026-07-28` and the
+  `initialize`-handshake era before it — and what a client gets from each.
 
 ## [0.2.1] - 2026-07-23
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,9 +45,9 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "base64"
-version = "0.22.1"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+checksum = "b25655df2c3cdd83c5e5b293b88acd880332b2ddadd7c30ac43144fdc0033da9"
 
 [[package]]
 name = "bumpalo"
@@ -250,6 +250,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+]
+
+[[package]]
 name = "goblin"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -408,6 +419,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "ref-cast"
 version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -446,9 +463,9 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rmcp"
-version = "1.7.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0810a9f717d9828f475fe1f629f4c305c8464b7f496c3a854b58d29e65f4058e"
+checksum = "fcd2b6dd3b18129368955f32661a7718969e8c152c7d8866434c09cf15a512e0"
 dependencies = [
  "async-trait",
  "base64",
@@ -464,13 +481,14 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+ "uuid",
 ]
 
 [[package]]
 name = "rmcp-macros"
-version = "1.7.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aefac48c364756e97f04c0401ba3231e8607882c7c1d92da0437dc16307904d"
+checksum = "e1aa4b9345795260a43fc23d6d05e096407c8b953903f673af7c4404b49fb2d6"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -759,6 +777,17 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "uuid"
+version = "1.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
+dependencies = [
+ "getrandom",
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "valuable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 
 [dependencies]
 win-kexp = { git = "https://github.com/glslang/win-kexp", branch = "main" }
-rmcp = { version = "1", features = ["server", "transport-io", "macros", "schemars"] }
+rmcp = { version = "3", features = ["server", "transport-io", "macros", "schemars"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "io-std", "sync", "time"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ The low-level engine bindings live in [`win-kexp`](https://github.com/glslang/wi
 - **`ttd.rs`** — locates `TTD.exe` and launches trace recording.
 - **`main.rs`** — tokio + stdio transport. **Logs go to stderr** (stdout is the JSON-RPC channel).
 
-**MCP protocol revision:** this server speaks the `initialize`-handshake ("legacy") era of MCP —
-`2025-11-25` and `2025-06-18`, whichever the client negotiates — because that is what `rmcp` 1.x
-implements. The `2026-07-28` revision replaces the handshake with a stateless, per-request model
-(`server/discover`, `resultType`, per-request `_meta`); clients that speak *only* `2026-07-28` cannot
-talk to this server. Support for it waits on a stable `rmcp` 3.x (`2026-07-28` support currently
-exists only in its beta line).
+**MCP protocol revision:** built on `rmcp` 3.x, this server accepts every revision that SDK knows —
+`2026-07-28` and the `initialize`-handshake ("legacy") era before it (`2025-11-25`, `2025-06-18`,
+`2025-03-26`, `2024-11-05`) — and serves whichever the client selects. A `2026-07-28` client gets the
+stateless, per-request model (`server/discover`, `resultType`, per-request `_meta`) and may open with
+`server/discover` instead of `initialize`; older clients keep the handshake, and a client that offers
+an unknown revision is answered with `2025-11-25`.
 
 ## Requirements
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -13,7 +13,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use rmcp::ErrorData;
 use rmcp::handler::server::wrapper::Parameters;
-use rmcp::model::{CallToolResult, Content};
+use rmcp::model::{CallToolResult, ContentBlock};
 use schemars::JsonSchema;
 use serde::Deserialize;
 
@@ -49,13 +49,13 @@ fn es<E: ToString>(e: E) -> String {
 }
 
 fn text_result(s: String) -> Result<CallToolResult, ErrorData> {
-    Ok(CallToolResult::success(vec![Content::text(s)]))
+    Ok(CallToolResult::success(vec![ContentBlock::text(s)]))
 }
 
 /// A tool-execution error: something the model should see in the result and can act on,
 /// as opposed to a JSON-RPC protocol error it cannot.
 fn tool_error(s: String) -> Result<CallToolResult, ErrorData> {
-    Ok(CallToolResult::error(vec![Content::text(s)]))
+    Ok(CallToolResult::error(vec![ContentBlock::text(s)]))
 }
 
 /// Renders an engine outcome using the MCP error model.


### PR DESCRIPTION
`rmcp` 3.x is released rather than beta, so the pin can move off 1.x.

## What this buys

Protocol coverage. rmcp 3 knows the `2026-07-28` revision, which replaces the `initialize` handshake with a stateless, per-request model (`server/discover`, `resultType`, per-request `_meta`). Both halves of supporting it come from the SDK's own defaults, so **no handler code was needed**:

- `ServerHandler::supported_protocol_versions` defaults to `ProtocolVersion::KNOWN_VERSIONS`, which now includes `2026-07-28`, and the default `discover` derives its result from `get_info` — so the `#[tool_handler]`-generated impl already answers `server/discover` with this server's capabilities and instructions.
- `serve()` routes an opening request that *isn't* `initialize` through the inline lifecycle instead of erroring, so a discover-first client works over stdio.

A client that speaks *only* `2026-07-28` can now talk to this server. Legacy clients keep the handshake exactly as before — `negotiate_protocol_version` still honours whatever known revision the client asks for, falling back to `2025-11-25`.

## Source change

Exactly one: `rmcp::model::Content` → `ContentBlock`. It is a rename, not a reshape — `CallToolResult::success`/`error` still take a `Vec` of them and the text variant still serialises the same way — so the tool surface, the generated input schemas, and the `tools/call` wire format are all unchanged.

The `Cargo.lock` diff is correspondingly small: `rmcp`/`rmcp-macros` 1.7.0 → 3.0.0, plus `uuid` (now pulled in by the `server` feature) and its `getrandom`/`r-efi` deps, and a `base64` 0.22 → 0.23 bump.

Docs updated: the README paragraph that said `2026-07-28` support "waits on a stable `rmcp` 3.x" now describes what the server actually accepts, and there's a CHANGELOG entry under Unreleased.

## Verification

This crate is Windows-only (via `win-kexp`), so it was verified by cross-checking to `x86_64-pc-windows-msvc`:

- `cargo check --all-targets --target x86_64-pc-windows-msvc` — clean
- `cargo clippy --all-targets --target x86_64-pc-windows-msvc` — clean
- `cargo fmt --all --check` — clean

The unit tests compile but can't be *run* off Windows; CI on `windows-latest` covers that. The router behaviour the protocol-surface tests pin is unchanged in 3.0 — `ToolRouter::list_all` still sorts by name, and `Tool` still carries `annotations` and a JSON-object `input_schema` — so those assertions should hold, but CI is the real check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tcy6uzkXEf8T9PHUBqnhiV

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tcy6uzkXEf8T9PHUBqnhiV)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the `2026-07-28` MCP protocol revision.
  * Supports stateless per-request interactions, including `server/discover` and per-request metadata.
  * Clients can begin communication with `server/discover` when using the newer protocol model.
  * Supports both legacy and newer handshake styles.

* **Bug Fixes**
  * Added a fallback response for clients offering an unknown protocol revision.

* **Documentation**
  * Updated the README and changelog to describe supported protocol revisions and connection behaviours.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->