### PR TITLE
test(server): pin the discover-first connection path

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2024"
 [dependencies]
 win-kexp = { git = "https://github.com/glslang/win-kexp", branch = "main" }
 rmcp = { version = "3", features = ["server", "transport-io", "macros", "schemars"] }
-tokio = { version = "1", features = ["macros", "rt-multi-thread", "io-std", "sync", "time"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "io-std", "io-util", "sync", "time"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 schemars = "1"

--- a/src/server.rs
+++ b/src/server.rs
@@ -3136,6 +3136,110 @@ mod tests {
         );
     }
 
+    /// A `2026-07-28` client may skip the handshake entirely and open the connection with
+    /// `server/discover`. Nothing in this crate implements that path — it falls out of the
+    /// SDK's defaults — which is exactly why it is worth pinning: an SDK bump could take it
+    /// away silently, and the failure mode is a whole class of client that cannot connect at
+    /// all rather than a tool that misbehaves.
+    ///
+    /// Driven over a real duplex with hand-written JSON-RPC, because the claim is about the
+    /// bytes on the wire: calling `discover()` directly would prove only that the default
+    /// method exists, not that `serve` accepts it as the *opening* message.
+    #[tokio::test]
+    async fn discover_opens_a_session_without_initialize() {
+        use std::time::Duration;
+
+        use rmcp::ServiceExt;
+        use tokio::io::{AsyncBufReadExt, AsyncWriteExt};
+
+        // Generous enough that a loaded CI runner never trips it, bounded so a regression
+        // fails this test instead of hanging the suite.
+        const STEP: Duration = Duration::from_secs(30);
+
+        let (mut client_io, server_io) = tokio::io::duplex(64 * 1024);
+
+        // Per-request metadata is what replaces the handshake, so a discover opener has to
+        // carry the two keys 2026-07-28 makes mandatory; without them the SDK is entitled to
+        // reject the request and demand `initialize`. Buffered before the server starts, so
+        // the opening message is already waiting when `serve` reads.
+        let discover = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "server/discover",
+            "params": {
+                "_meta": {
+                    "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+                    "io.modelcontextprotocol/clientCapabilities": {},
+                }
+            }
+        });
+        client_io
+            .write_all(format!("{discover}\n").as_bytes())
+            .await
+            .expect("write the discover request");
+
+        // The engine thread is never reached — discover is answered from `get_info` alone —
+        // which is what lets this run on a machine with no debugger.
+        let service = tokio::time::timeout(
+            STEP,
+            WindbgServer::new(EngineHandle::spawn(STEP)).serve(server_io),
+        )
+        .await
+        .expect("serve must not block waiting for an `initialize` that never comes")
+        .expect("`server/discover` must open a session on its own");
+
+        let mut line = String::new();
+        tokio::time::timeout(
+            STEP,
+            tokio::io::BufReader::new(&mut client_io).read_line(&mut line),
+        )
+        .await
+        .expect("the discover response should arrive")
+        .expect("read the discover response");
+
+        let response: serde_json::Value = serde_json::from_str(&line)
+            .unwrap_or_else(|e| panic!("malformed response {line:?}: {e}"));
+        assert_eq!(
+            response["error"],
+            serde_json::Value::Null,
+            "discover must not be answered with a JSON-RPC error: {line}"
+        );
+        let result = &response["result"];
+
+        // SEP-2322: 2026-07-28 requires the discriminator, and a client that parses results
+        // by it cannot read a response that omits it.
+        assert_eq!(result["resultType"], "complete");
+
+        // The point of the whole exercise: the revision that permits this opener is one the
+        // server actually offers, alongside the handshake era it still serves.
+        let versions = result["supportedVersions"]
+            .as_array()
+            .unwrap_or_else(|| panic!("discover must advertise supportedVersions: {line}"));
+        for expected in ["2026-07-28", "2025-11-25"] {
+            assert!(
+                versions.iter().any(|v| v == expected),
+                "discover must advertise `{expected}`, got {versions:?}"
+            );
+        }
+
+        // A discover-first client learns the server only from this one response, so the tool
+        // capability and the usage instructions have to reach it here — not only via
+        // `initialize`, which such a client never sends.
+        assert!(
+            !result["capabilities"]["tools"].is_null(),
+            "discover must advertise the tools capability: {line}"
+        );
+        let instructions = result["instructions"]
+            .as_str()
+            .unwrap_or_else(|| panic!("discover must carry the server instructions: {line}"));
+        assert!(
+            instructions.contains("WinDbg"),
+            "instructions should be this server's, got {instructions:?}"
+        );
+
+        service.cancel().await.expect("shut the service down");
+    }
+
     // ---- Session handles -----------------------------------------------
 
     #[test]


### PR DESCRIPTION
Follow-up to #54, which made the server speak `2026-07-28`. Nothing in this crate implements the discover-first path — it falls out of rmcp's defaults — so nothing here would notice if an SDK bump took it away. This adds the test.

## What's covered

A `2026-07-28` client may skip the handshake and open the connection with `server/discover`. The test drives that over a `tokio::io::duplex` with hand-written JSON-RPC rather than calling `discover()` directly, because the claim is about the bytes on the wire: a direct call would only prove the default method exists, not that `serve` accepts it as the **opening** message. The request carries the two `_meta` keys the revision makes mandatory (`io.modelcontextprotocol/protocolVersion` and `.../clientCapabilities`) — without them the SDK is entitled to reject it and demand `initialize`.

It asserts what a discover-first client actually needs out of that single response:

- no JSON-RPC error (the path works at all)
- `resultType: "complete"` — the SEP-2322 discriminator 2026-07-28 requires
- `supportedVersions` offers both `2026-07-28` and `2025-11-25`
- `capabilities.tools` and this server's `instructions` — which such a client can *only* learn here, never having sent `initialize`

The engine thread is never reached (discover is answered from `get_info` alone), so this satisfies the AGENTS.md rule that tests run without a live debugger, symbols, or network.

`io-util` joins tokio's feature list because the test now uses `duplex`/`BufReader` directly rather than inheriting them transitively from rmcp's `transport-async-rw`.

## Verification

This crate is Windows-only via win-kexp, so as with #54: `cargo check --all-targets`, `cargo clippy --all-targets` (both `--target x86_64-pc-windows-msvc`) and `cargo fmt --check` are clean, but `cargo test` can't run here.

Rather than let CI discover whether the assertions were right, I stood up a throwaway crate on Linux with the same rmcp 3.0.0 wiring (`#[tool_router]` / `#[tool_handler(instructions = …)]`) and ran this exact exchange against it. It passes, and the real response confirms every field name and value asserted above:

```json
{"jsonrpc":"2.0","id":1,"result":{"resultType":"complete","supportedVersions":["2024-11-05","2025-03-26","2025-06-18","2025-11-25","2026-07-28"],"capabilities":{"tools":{}},"instructions":"Drive WinDbg/DbgEng for …","ttlMs":0,"cacheScope":"private","_meta":{"io.modelcontextprotocol/serverInfo":{"name":"rmcp","version":"3.0.0"}}}}
```

## Separate issue this surfaced (not fixed here)

Look at the last field: `serverInfo` reports **`{"name":"rmcp","version":"3.0.0"}`** — the SDK's own identity, not this server's. The `#[tool_handler]` macro defaults to `Implementation::from_build_env()`, whose `env!("CARGO_CRATE_NAME")` / `env!("CARGO_PKG_VERSION")` expand inside *rmcp*, not inside this crate.

This is pre-existing and not caused by #54 — rmcp 1.x did the same, and it affects `initialize` identically, since both read the same `get_info()`. So every client that has ever connected has been told this server is called "rmcp". The fix is one attribute:

```rust
#[rmcp::tool_handler(name = "windbg-mcp", version = env!("CARGO_PKG_VERSION"), instructions = "…")]
```

I left it out because it changes what the server reports over the wire, which is beyond "add a test" — happy to do it in a follow-up if you want it. The test deliberately does not assert on `serverInfo`, so it neither cements the current value nor blocks the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tcy6uzkXEf8T9PHUBqnhiV

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tcy6uzkXEf8T9PHUBqnhiV)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server discovery so clients can receive supported protocol versions and tool capabilities without first sending an initialise request.
  * Confirmed discovery responses include complete results and WinDbg instructions.

* **Tests**
  * Added coverage for discovery over a JSON-RPC connection, including protocol version negotiation and capability reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->