### PR TITLE
fix(server): report this server's identity, not the SDK's

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,6 +143,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   lost: `execute` remains available for command lists, and is annotated destructive and
   handle-checked accordingly.
 
+### Fixed
+
+- **The server no longer introduces itself as the SDK.** `serverInfo` reported
+  `{"name": "rmcp", "version": "<sdk version>"}` to every client, on both the `initialize`
+  handshake and the `2026-07-28` `server/discover` response — so anything that names or
+  keys off the connected server (client UIs, logs, per-server config) saw "rmcp" rather
+  than "windbg-mcp", and saw the SDK's version where it wanted this crate's. The
+  `#[tool_handler]` macro defaults to `Implementation::from_build_env()`, whose
+  `env!("CARGO_CRATE_NAME")` / `env!("CARGO_PKG_VERSION")` resolve inside `rmcp` rather
+  than here; naming the server on the attribute takes both from this crate instead. The
+  bug predates the `rmcp` 3.x upgrade — 1.x reported the same — so this is the first
+  release in which clients see the right identity.
+
 ### Documentation
 
 - README now states which MCP protocol revisions the server speaks — `2026-07-28` and the

--- a/src/server.rs
+++ b/src/server.rs
@@ -2973,7 +2973,15 @@ impl WindbgServer {
     }
 }
 
+// `name` is not cosmetic: without it the macro falls back to `Implementation::from_build_env()`,
+// whose `env!` macros expand inside *rmcp*, so the server introduces itself to every client as
+// "rmcp" version 3.0.0 — the SDK's identity, not this server's. Naming it here also fixes the
+// version, because the macro's one-argument path pairs the name with an `env!("CARGO_PKG_VERSION")`
+// that expands in this crate. Pass `name` only: the attribute takes a string literal, so
+// `version = env!(...)` would not even parse, and spelling the version out by hand would just be a
+// second place to forget to bump.
 #[rmcp::tool_handler(
+    name = "windbg-mcp",
     instructions = "Drive WinDbg/DbgEng for live user-mode, kernel, crash-dump, and Time Travel Debugging (TTD) analysis. \
 Open a dump or .run trace, attach to a process or the kernel, inspect registers/memory/stacks/modules, and set breakpoints. \
 Navigate a TTD trace in both directions: go/step_over/step_into forward, and reverse_go/step_over_back/step_back backward, \
@@ -3235,6 +3243,20 @@ mod tests {
         assert!(
             instructions.contains("WinDbg"),
             "instructions should be this server's, got {instructions:?}"
+        );
+
+        // The server has to introduce itself as itself. Left to the macro's default this reads
+        // `rmcp` at the SDK's version, because `Implementation::from_build_env()` resolves its
+        // `env!`s inside rmcp — so this asserts the `name` on `#[tool_handler]` is still there.
+        let server_info = &result["_meta"]["io.modelcontextprotocol/serverInfo"];
+        assert_eq!(
+            server_info["name"], "windbg-mcp",
+            "the server must not report the SDK's identity as its own: {line}"
+        );
+        assert_eq!(
+            server_info["version"],
+            env!("CARGO_PKG_VERSION"),
+            "the reported version must track this crate, not the SDK: {line}"
         );
 
         service.cancel().await.expect("shut the service down");


### PR DESCRIPTION
Fixes the `serverInfo` issue surfaced by the discover-first test in #55.

## The bug

`serverInfo` came back as `{"name": "rmcp", "version": "<sdk version>"}` — the SDK's identity, not this server's. Anything that names or keys off the connected server (client UIs, logs, per-server config) saw "rmcp" instead of "windbg-mcp", and saw rmcp's version where it wanted this crate's.

It affected **both** response paths, since they read the same `get_info()`: the `initialize` handshake (top-level `serverInfo`) and the `2026-07-28` `server/discover` response (under `_meta`). It also predates the rmcp 3.x upgrade — 1.x reported the same — so this is the first release in which clients see the right identity.

## The fix

`#[tool_handler]` with no `name` falls back to `Implementation::from_build_env()`, whose `env!("CARGO_CRATE_NAME")` / `env!("CARGO_PKG_VERSION")` expand while *rmcp itself* is compiled — so they describe rmcp. Naming the server on the attribute switches the macro to its one-argument path, which pairs the literal with an `env!("CARGO_PKG_VERSION")` emitted into *this* crate:

```rust
#[rmcp::tool_handler(name = "windbg-mcp", instructions = "…")]
```

`name` is passed alone deliberately. The attribute is parsed by darling and takes a string literal, so `version = env!(...)` would not parse at all; and hardcoding the version would add a second place to forget to bump. Letting the macro supply it means the reported version follows `Cargo.toml` with nothing further to maintain.

## Verification

The discover test from #55 now asserts both fields, so the fix is pinned where the bug was found. Since both paths read the same `get_info()`, that one assertion covers the mechanism.

As with the previous two PRs, the crate is Windows-only, so `cargo check`/`clippy --all-targets` ran against `x86_64-pc-windows-msvc` (clean), with `cargo fmt --check` and markdownlint also clean — but `cargo test` can't run here. I again confirmed the actual emitted values on Linux using the same throwaway rmcp crate, before and after:

**Before** — `initialize` and `discover` alike:
```json
"serverInfo": {"name": "rmcp", "version": "3.0.0"}
```

**After** — `discover` (in `_meta`):
```json
"_meta": {"io.modelcontextprotocol/serverInfo": {"name": "windbg-mcp", "version": "0.2.1"}}
```

**After** — `initialize` (top level), confirming the one attribute covers both:
```json
"serverInfo": {"name": "windbg-mcp", "version": "0.2.1"}
```

The probe crate's own `Cargo.toml` version was set to 0.2.1 for that run, which is what demonstrates the version is taken from the consuming crate rather than from rmcp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tcy6uzkXEf8T9PHUBqnhiV

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tcy6uzkXEf8T9PHUBqnhiV)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the server identity reported during initialisation and discovery.
  * The server now reports its correct name and version instead of the RMCP SDK identity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->