### PR TITLE
test(smoke): drive the built binary over stdio for dep and spec changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
   push:
     branches: [main]
   pull_request:
+  # Manual trigger for the smoke test's debugger tier, which reaches real DbgEng and so is
+  # kept out of the PR path. Use it after a `win-kexp` bump — see docs/smoke-test.md.
+  workflow_dispatch:
 
 concurrency:
   group: ci-${{ github.ref }}
@@ -44,6 +47,9 @@ jobs:
       - name: Build
         run: cargo build --release
 
+      # Includes the smoke test's protocol tier (tests/mcp_smoke.rs), which drives the built
+      # binary over stdio. That tier needs no debugger, target, or network; the debugger tier
+      # is gated behind WINDBG_MCP_SMOKE_DUMP and runs in the `smoke-debugger` job below.
       - name: Test
         run: cargo test
 
@@ -56,6 +62,32 @@ jobs:
             Write-Host "Validating $f"
             Get-Content $f -Raw | ConvertFrom-Json | Out-Null
           }
+
+  smoke-debugger:
+    name: Smoke test (debugger tier)
+    # On demand only: this tier opens the sample crash dump through the runner's DbgEng, so a
+    # Windows-image change could break it for reasons unrelated to the PR under review.
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: windows-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
+        with:
+          toolchain: stable
+
+      - name: Cache cargo registry and build
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+
+      - name: Smoke test against the sample dump
+        env:
+          WINDBG_MCP_SMOKE_DUMP: "1"
+        run: cargo test --test mcp_smoke -- --nocapture
 
   docs:
     name: Documentation lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,12 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ci-${{ github.ref }}
+  # A superseded push or PR update should cancel its predecessor — but a manual dispatch should
+  # not take part in that at all. It shares `github.ref` with the branch's own CI (on `main`,
+  # with the push run), so a shared group would have the two cancel each other, and a repeat
+  # dispatch would kill the debugger-tier run someone had just asked for. Keying dispatches by
+  # run id gives each one a group of its own: never cancelled, never cancelling.
+  group: ci-${{ github.ref }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || 'auto' }}
   cancel-in-progress: true
 
 jobs:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,8 @@ Use Rust 2024 idioms and `rustfmt` defaults. Keep DbgEng access behind the engin
 
 Add focused unit tests near the code they cover under `#[cfg(test)]`. Name tests after the behavior, for example `decode_ioctl_rejects_short_input`. Tests should run without a live debugger, kernel target, symbols, or network access unless explicitly documented. Run `cargo test` before opening a PR; run `cargo clippy --all-targets` for shared or tool-surface changes.
 
+`tests/mcp_smoke.rs` is the end-to-end smoke test: it drives the built binary over stdio with hand-written JSON-RPC, covering transport hygiene, protocol-revision negotiation, and a golden snapshot of the `tools/list` wire surface (`tests/golden/tools_list.json`). Its protocol tier runs under plain `cargo test`; the debugger tier is opt-in via `WINDBG_MCP_SMOKE_DUMP=1` and opens the checked-in sample dump. Run it after a dependency bump (`rmcp`, `schemars`, `tokio`, `win-kexp`) or an MCP spec revision — see `docs/smoke-test.md` for the runbook and the manual checklist for live/TTD paths.
+
 ## Commit & Pull Request Guidelines
 
 History uses short imperative subjects, sometimes scoped, such as `docs(hevd): make ...` or `Add set_symbol_path tool`. Keep commits focused and mention affected workflows when relevant. PRs should include a concise description, testing performed, linked issues or follow-ups, and updated docs/examples for user-visible tool changes. Include screenshots only when changing rendered documentation or workflow output.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   symbolizes every frame, `bp module!Symbol` resolves a name), and a KDNET session puts the
   target itself across a network link, so even a raw `read_memory` is remote traffic. A
   client may be gating network consent on that hint.
+- **End-to-end smoke test** (`tests/mcp_smoke.rs`), for the two events the in-process tests
+  cannot see: a dependency moving, and the MCP spec revving. Both change the bytes on the wire
+  while the Rust API this crate compiles against stays identical, so the existing tests keep
+  passing and clients break. It spawns the built binary and speaks hand-written JSON-RPC to it,
+  asserting that stdout carries only JSON-RPC (a dependency logging there corrupts the
+  transport), that closing stdin exits the process, that every protocol revision the README
+  promises is served — including `2026-07-28`'s handshake-free `server/discover` and its rule
+  that *every* request, not just the opener, carries the `_meta` protocol keys — and that no
+  capability is advertised that this server does not implement. A golden snapshot
+  (`tests/golden/tools_list.json`) records the structural `tools/list` surface (schema dialect,
+  hints, parameter types) so a `schemars` or `rmcp` bump lands as a readable diff rather than a
+  silent client-visible change; re-record with `UPDATE_GOLDEN=1`. The protocol tier needs no
+  debugger, target, or network and runs under plain `cargo test`; a second tier
+  (`WINDBG_MCP_SMOKE_DUMP=1`) opens the checked-in sample dump through DbgEng and is the
+  automated check for a `win-kexp` regression, available in CI on manual dispatch. Runbook,
+  including the manual checklist for the live/TTD paths no runner can host, in
+  [`docs/smoke-test.md`](docs/smoke-test.md).
 
 ### Changed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,8 +68,12 @@ build differs only in optimization and is exercised by CI on a fresh runner.
 `cargo test` includes `tests/mcp_smoke.rs`, which spawns the **dev** binary (via
 `CARGO_BIN_EXE_windbg-mcp`) and drives it over stdio — so it is also clear of the release lock.
 After a dependency bump (`rmcp`, `schemars`, `tokio`, `cargo update -p win-kexp`) or an MCP spec
-revision, run it and follow [`docs/smoke-test.md`](./docs/smoke-test.md); add
-`WINDBG_MCP_SMOKE_DUMP=1` to include the tier that opens the sample dump through DbgEng.
+revision, run it and follow [`docs/smoke-test.md`](./docs/smoke-test.md). To include the tier that
+opens the sample dump through DbgEng, set the gate first (PowerShell, not `VAR=1 cmd`):
+
+```pwsh
+$env:WINDBG_MCP_SMOKE_DUMP = "1"; cargo test --test mcp_smoke
+```
 
 ## Live kernel + driver IOCTL gotchas (learned driving HEVD over KDNET)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,12 @@ For a compile/behavior check without touching the locked release exe, use the **
 (writes `target/debug`, never locked): `cargo test` and `cargo clippy --all-targets`. The release
 build differs only in optimization and is exercised by CI on a fresh runner.
 
+`cargo test` includes `tests/mcp_smoke.rs`, which spawns the **dev** binary (via
+`CARGO_BIN_EXE_windbg-mcp`) and drives it over stdio — so it is also clear of the release lock.
+After a dependency bump (`rmcp`, `schemars`, `tokio`, `cargo update -p win-kexp`) or an MCP spec
+revision, run it and follow [`docs/smoke-test.md`](./docs/smoke-test.md); add
+`WINDBG_MCP_SMOKE_DUMP=1` to include the tier that opens the sample dump through DbgEng.
+
 ## Live kernel + driver IOCTL gotchas (learned driving HEVD over KDNET)
 
 **KDNET attach is a blocking wait, by design.** A live kernel needs `WaitForEvent(INFINITE)` (a finite

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,9 @@ schemars = "1"
 anyhow = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+
+# The end-to-end smoke test (`tests/mcp_smoke.rs`) drives the built binary over stdio with
+# hand-written JSON-RPC, so it needs a JSON parser and nothing else — deliberately no new
+# crates, since it is the test you reach for when a dependency has just broken something.
+[dev-dependencies]
+serde_json = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,3 @@ schemars = "1"
 anyhow = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-
-# The end-to-end smoke test (`tests/mcp_smoke.rs`) drives the built binary over stdio with
-# hand-written JSON-RPC, so it needs a JSON parser and nothing else — deliberately no new
-# crates, since it is the test you reach for when a dependency has just broken something.
-[dev-dependencies]
-serde_json = "1"

--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ cargo build --release
 
 `win-kexp` is fetched automatically as a git dependency from [`glslang/win-kexp`](https://github.com/glslang/win-kexp) — no sibling checkout needed.
 
+`cargo test` covers the unit tests plus an end-to-end smoke test that drives the built binary over
+stdio. Run it after a dependency bump or an MCP spec revision — see
+[`docs/smoke-test.md`](docs/smoke-test.md).
+
 ### Bundling the WinDbg engine
 
 Needed for two things: TTD `.run` replay (System32's engine rejects traces with `0x80070057`) and

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -1,0 +1,119 @@
+# Smoke test
+
+`tests/mcp_smoke.rs` drives the **built binary** over stdio with hand-written JSON-RPC. It exists
+for the two moments the in-process unit tests in `src/server.rs` cannot cover: **a dependency
+moved**, and **the MCP spec revved**. Both change the bytes on the wire while the Rust API this
+crate compiles against stays identical — so the unit tests keep passing and clients break.
+
+## Running it
+
+```pwsh
+cargo test --test mcp_smoke              # protocol tier (default)
+$env:WINDBG_MCP_SMOKE_DUMP = "1"; cargo test --test mcp_smoke   # + the debugger tier
+```
+
+It builds and runs against `target/debug`, so it never touches the `target/release` exe a
+connected MCP client holds a lock on (see [`CLAUDE.md`](../CLAUDE.md)). Whole suite is ~1s.
+
+### Tiers
+
+| Tier | Gate | Needs | Catches |
+| --- | --- | --- | --- |
+| **Protocol** | always | nothing — no debugger, no target, no network | transport, revision negotiation, tool-surface drift |
+| **Debugger** | `WINDBG_MCP_SMOKE_DUMP=1` | `dbgeng.dll`, the checked-in sample dump | `win-kexp` / DbgEng regressions |
+| **Live** | manual | KDNET target, TTD engine, elevation | see [Manual checklist](#manual-checklist) |
+
+The protocol tier rides `cargo test`, so CI already runs it. The debugger tier is opt-in: it
+reaches real DbgEng and is available in CI on demand via the **Smoke test (debugger tier)** job
+(Actions → CI → *Run workflow*). The live tier is not automated — no runner has a kernel target.
+
+## What it asserts, and why each one is a dependency tripwire
+
+**Transport.** Every line the server writes to stdout parses as JSON-RPC, and the startup log
+appears on **stderr**. A dependency that prints a banner or a warning to stdout desynchronizes
+every client, and the client-side symptom is an unreadable parse error. Also: closing stdin exits
+the process within 20s (otherwise each client disconnect leaks a process and a DbgEng session),
+and a malformed input line does not kill the session.
+
+**Protocol revisions.** Every revision the README promises — `2026-07-28`, `2025-11-25`,
+`2025-06-18`, `2025-03-26`, `2024-11-05` — is offered a handshake, served *that* revision, and can
+reach `tools/list`. An unknown revision negotiates down to `2025-11-25`. `server/discover` opens a
+session with no handshake at all, and — the rule that is easy to get wrong — in that stateless mode
+**every** request must carry the `_meta` protocol keys, not just the opener; a request without them
+is refused with `-32602`.
+
+**Capability honesty.** `tools` is advertised; `resources`, `prompts`, `completions`, `logging` and
+`extensions` are not, because none are implemented. `tasks/get` answers `method_not_found`
+(deliberate — [`FOLLOWUPS.md`](../FOLLOWUPS.md) item 8). If an SDK bump starts advertising something
+on this server's behalf, this test is where you find out, and the choice is implement it or
+suppress it — not ship an advertisement clients will call into a dead end.
+
+**Tool surface golden.** `tests/golden/tools_list.json` records the *structural* `tools/list`
+surface as it appears on the wire: JSON Schema dialect, `$defs` usage, tool count, and per tool its
+name, title, four behaviour hints, required arguments, and each parameter's type/format/enum. It
+deliberately excludes descriptions, so prose edits do not churn it while a `schemars` dialect
+switch, an `rmcp` annotation-casing change, or an accidental tool rename all land as a readable
+line diff.
+
+Re-record after an *intended* change, and read the diff before committing:
+
+```pwsh
+$env:UPDATE_GOLDEN = "1"; cargo test --test mcp_smoke tools_list_matches
+```
+
+**Schema resolvability.** Every tool's input schema is an object schema whose `$ref`s all resolve
+inside the same document. External or dangling refs break strict client-side validators, and a
+codegen dependency can introduce them with no change here.
+
+**Debugger tier.** Opens the checked-in kernel crash dump, confirms it mints a `session_id` that
+`session_status` reports, reads it through `modules` / `registers` / `backtrace`, then checks the
+session-handle contract on the wire (a stale handle is refused; the handle stops working once
+`end_session` runs). It also pins the `isError` contract against a real engine: `threads` is `~`,
+which DbgEng implements only in user mode, so on a kernel dump it must come back as a **tool error
+carrying the engine's message** — not a JSON-RPC error, and not a dead worker thread. Read-only
+throughout, and it needs no symbols, so it runs offline.
+
+## When to run it
+
+### A dependency moved
+
+`rmcp`, `schemars`, `tokio`, or a `win-kexp` pin bump (`cargo update -p win-kexp`). Note Dependabot
+only watches GitHub Actions here, so cargo bumps arrive by hand.
+
+1. `cargo test` — the protocol tier plus the existing unit tests.
+2. `WINDBG_MCP_SMOKE_DUMP=1 cargo test --test mcp_smoke` for a `win-kexp` bump, since that tier is
+   the only automated thing that touches DbgEng.
+3. If the golden diff fires, read it before re-recording. A changed dialect or nullable encoding is
+   a **client-visible** change and belongs in `CHANGELOG.md`, not in a silent re-record.
+
+### The MCP spec revved
+
+1. Add the new revision to the front of `SUPPORTED_REVISIONS` in `tests/mcp_smoke.rs` and run it.
+   A failure means the SDK does not speak it yet — that is the answer to "do we need an `rmcp`
+   bump", and until then the README's revision list must not claim it.
+2. Check `capabilities_advertise_only_what_is_implemented`. New spec revisions add capabilities and
+   extensions; this test fails the moment the SDK advertises one this server does not implement.
+3. Re-read the stateless assertions in `discover_opens_a_session_without_initialize` against the new
+   revision's `_meta` requirements — that is where per-request metadata rules land.
+4. Update the revision list in `README.md` and this file's list above to match what actually passes.
+
+## Manual checklist
+
+Not automated: no runner has a kernel target, a TTD-capable engine, or elevation. Run these by hand
+before a release, or when a change touches the relevant path. Drivers live in
+[`examples/`](../examples/README.md) and need `cargo build --release` first.
+
+- **Live user-mode** — `examples/test_usermode.ps1`: launch `cmd.exe` under the debugger, break in,
+  read registers/modules, set a breakpoint.
+- **Failure paths** — `examples/verify_fixes.ps1`: execution control with no debuggee returns a
+  clean "No active debuggee" error, and a failed kernel attach is a clean error rather than a panic.
+- **Live kernel (KDNET)** — `examples/drive_kernel_test.ps1 -Connection "net:port=<n>,key=<w.x.y.z>"`:
+  attach, `bp nt!NtCreateFile`, `go` to it, resume, detach. See the KDNET gotchas in `CLAUDE.md`
+  before diagnosing a hang.
+- **TTD replay** — needs the WinDbg store engine next to the binary (System32's engine rejects
+  `.run` traces with `0x80070057`). Open a trace, then exercise `ttd_calls` / `ttd_memory` /
+  `ttd_events` and reverse execution. The worked example is
+  [`docs/flareauthenticator-ttd-walkthrough.md`](flareauthenticator-ttd-walkthrough.md).
+- **TTD recording** — `record_trace` needs elevation and `TTD.exe` on `PATH`.
+- **Driver IOCTL sweep** — `examples/sweep_ioctls.ps1` plus the target-side
+  `examples/send_ioctls_target.ps1`; needs a benign test driver on a KDNET target.

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -81,8 +81,11 @@ throughout, and it needs no symbols, so it runs offline.
 only watches GitHub Actions here, so cargo bumps arrive by hand.
 
 1. `cargo test` — the protocol tier plus the existing unit tests.
-2. `WINDBG_MCP_SMOKE_DUMP=1 cargo test --test mcp_smoke` for a `win-kexp` bump, since that tier is
-   the only automated thing that touches DbgEng.
+2. For a `win-kexp` bump, add the debugger tier — the only automated thing that touches DbgEng:
+
+   ```pwsh
+   $env:WINDBG_MCP_SMOKE_DUMP = "1"; cargo test --test mcp_smoke
+   ```
 3. If the golden diff fires, read it before re-recording. A changed dialect or nullable encoding is
    a **client-visible** change and belongs in `CHANGELOG.md`, not in a silent re-record.
 

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -86,6 +86,7 @@ only watches GitHub Actions here, so cargo bumps arrive by hand.
    ```pwsh
    $env:WINDBG_MCP_SMOKE_DUMP = "1"; cargo test --test mcp_smoke
    ```
+
 3. If the golden diff fires, read it before re-recording. A changed dialect or nullable encoding is
    a **client-visible** change and belongs in `CHANGELOG.md`, not in a silent re-record.
 

--- a/tests/golden/tools_list.json
+++ b/tests/golden/tools_list.json
@@ -1,0 +1,599 @@
+{
+  "schemaDialects": [
+    "(none)",
+    "https://json-schema.org/draft/2020-12/schema"
+  ],
+  "toolCount": 37,
+  "tools": [
+    {
+      "hints": {
+        "destructive": true,
+        "idempotent": false,
+        "openWorld": true,
+        "readOnly": false
+      },
+      "name": "attach_kernel",
+      "params": [
+        "connection: string"
+      ],
+      "required": [
+        "connection"
+      ],
+      "title": "Attach to kernel target"
+    },
+    {
+      "hints": {
+        "destructive": true,
+        "idempotent": false,
+        "openWorld": true,
+        "readOnly": false
+      },
+      "name": "attach_kernel_local",
+      "params": [],
+      "required": [],
+      "title": "Attach to local kernel"
+    },
+    {
+      "hints": {
+        "destructive": true,
+        "idempotent": false,
+        "openWorld": true,
+        "readOnly": false
+      },
+      "name": "attach_process",
+      "params": [
+        "pid: integer/uint32"
+      ],
+      "required": [
+        "pid"
+      ],
+      "title": "Attach to process"
+    },
+    {
+      "hints": {
+        "destructive": null,
+        "idempotent": null,
+        "openWorld": true,
+        "readOnly": true
+      },
+      "name": "backtrace",
+      "params": [
+        "session_id: string|null"
+      ],
+      "required": [],
+      "title": "Show call stack"
+    },
+    {
+      "hints": {
+        "destructive": null,
+        "idempotent": null,
+        "openWorld": false,
+        "readOnly": true
+      },
+      "name": "decode_ioctl",
+      "params": [
+        "code: string"
+      ],
+      "required": [
+        "code"
+      ],
+      "title": "Decode IOCTL control code"
+    },
+    {
+      "hints": {
+        "destructive": null,
+        "idempotent": null,
+        "openWorld": true,
+        "readOnly": true
+      },
+      "name": "device_object",
+      "params": [
+        "device: string",
+        "session_id: string|null"
+      ],
+      "required": [
+        "device"
+      ],
+      "title": "Inspect device object"
+    },
+    {
+      "hints": {
+        "destructive": null,
+        "idempotent": null,
+        "openWorld": true,
+        "readOnly": true
+      },
+      "name": "disassemble",
+      "params": [
+        "address: string|null",
+        "session_id: string|null"
+      ],
+      "required": [],
+      "title": "Disassemble"
+    },
+    {
+      "hints": {
+        "destructive": null,
+        "idempotent": null,
+        "openWorld": true,
+        "readOnly": true
+      },
+      "name": "driver_object",
+      "params": [
+        "name: string",
+        "session_id: string|null"
+      ],
+      "required": [
+        "name"
+      ],
+      "title": "Inspect driver object"
+    },
+    {
+      "hints": {
+        "destructive": true,
+        "idempotent": false,
+        "openWorld": true,
+        "readOnly": false
+      },
+      "name": "dx",
+      "params": [
+        "expression: string",
+        "session_id: string|null"
+      ],
+      "required": [
+        "expression"
+      ],
+      "title": "Evaluate data-model expression"
+    },
+    {
+      "hints": {
+        "destructive": true,
+        "idempotent": true,
+        "openWorld": true,
+        "readOnly": false
+      },
+      "name": "end_session",
+      "params": [
+        "session_id: string|null"
+      ],
+      "required": [],
+      "title": "End debug session"
+    },
+    {
+      "hints": {
+        "destructive": true,
+        "idempotent": false,
+        "openWorld": true,
+        "readOnly": false
+      },
+      "name": "execute",
+      "params": [
+        "command: string",
+        "session_id: string|null"
+      ],
+      "required": [
+        "command"
+      ],
+      "title": "Run raw debugger command"
+    },
+    {
+      "hints": {
+        "destructive": true,
+        "idempotent": false,
+        "openWorld": true,
+        "readOnly": false
+      },
+      "name": "go",
+      "params": [
+        "session_id: string|null"
+      ],
+      "required": [],
+      "title": "Continue execution"
+    },
+    {
+      "hints": {
+        "destructive": false,
+        "idempotent": true,
+        "openWorld": true,
+        "readOnly": false
+      },
+      "name": "goto_position",
+      "params": [
+        "position: string",
+        "session_id: string|null"
+      ],
+      "required": [
+        "position"
+      ],
+      "title": "Go to TTD position"
+    },
+    {
+      "hints": {
+        "destructive": true,
+        "idempotent": true,
+        "openWorld": true,
+        "readOnly": false
+      },
+      "name": "index_trace",
+      "params": [
+        "session_id: string|null"
+      ],
+      "required": [],
+      "title": "Build TTD trace index"
+    },
+    {
+      "hints": {
+        "destructive": false,
+        "idempotent": false,
+        "openWorld": true,
+        "readOnly": false
+      },
+      "name": "ioctl_trace",
+      "params": [
+        "dispatch: string",
+        "session_id: string|null"
+      ],
+      "required": [
+        "dispatch"
+      ],
+      "title": "Trace dispatched IOCTLs"
+    },
+    {
+      "hints": {
+        "destructive": null,
+        "idempotent": null,
+        "openWorld": true,
+        "readOnly": true
+      },
+      "name": "irp_stack",
+      "params": [
+        "irp: string|null",
+        "session_id: string|null"
+      ],
+      "required": [],
+      "title": "Dump IRP stack location"
+    },
+    {
+      "hints": {
+        "destructive": true,
+        "idempotent": false,
+        "openWorld": true,
+        "readOnly": false
+      },
+      "name": "launch",
+      "params": [
+        "command_line: string"
+      ],
+      "required": [
+        "command_line"
+      ],
+      "title": "Launch process under debugger"
+    },
+    {
+      "hints": {
+        "destructive": null,
+        "idempotent": null,
+        "openWorld": true,
+        "readOnly": true
+      },
+      "name": "modules",
+      "params": [
+        "session_id: string|null"
+      ],
+      "required": [],
+      "title": "List modules"
+    },
+    {
+      "hints": {
+        "destructive": true,
+        "idempotent": false,
+        "openWorld": true,
+        "readOnly": false
+      },
+      "name": "open_dump",
+      "params": [
+        "path: string"
+      ],
+      "required": [
+        "path"
+      ],
+      "title": "Open crash dump or TTD trace"
+    },
+    {
+      "hints": {
+        "destructive": true,
+        "idempotent": false,
+        "openWorld": true,
+        "readOnly": false
+      },
+      "name": "open_trace",
+      "params": [
+        "path: string"
+      ],
+      "required": [
+        "path"
+      ],
+      "title": "Open TTD trace"
+    },
+    {
+      "hints": {
+        "destructive": null,
+        "idempotent": null,
+        "openWorld": true,
+        "readOnly": true
+      },
+      "name": "reachable_from_dispatch",
+      "params": [
+        "address: string|null",
+        "from: string",
+        "max_depth: integer|null/uint",
+        "max_functions: integer|null/uint",
+        "module: string|null",
+        "recipe: boolean|null",
+        "rva: string|null",
+        "session_id: string|null"
+      ],
+      "required": [
+        "from"
+      ],
+      "title": "Test reachability from IOCTL dispatch"
+    },
+    {
+      "hints": {
+        "destructive": null,
+        "idempotent": null,
+        "openWorld": true,
+        "readOnly": true
+      },
+      "name": "read_memory",
+      "params": [
+        "address: string",
+        "session_id: string|null",
+        "size: integer/uint32"
+      ],
+      "required": [
+        "address",
+        "size"
+      ],
+      "title": "Read memory"
+    },
+    {
+      "hints": {
+        "destructive": true,
+        "idempotent": false,
+        "openWorld": true,
+        "readOnly": false
+      },
+      "name": "record_trace",
+      "params": [
+        "env: array<string>",
+        "out_dir: string",
+        "target: string",
+        "working_dir: string|null"
+      ],
+      "required": [
+        "out_dir",
+        "target"
+      ],
+      "title": "Record new TTD trace"
+    },
+    {
+      "hints": {
+        "destructive": null,
+        "idempotent": null,
+        "openWorld": true,
+        "readOnly": true
+      },
+      "name": "registers",
+      "params": [
+        "session_id: string|null"
+      ],
+      "required": [],
+      "title": "Show registers"
+    },
+    {
+      "hints": {
+        "destructive": false,
+        "idempotent": false,
+        "openWorld": true,
+        "readOnly": false
+      },
+      "name": "reverse_go",
+      "params": [
+        "session_id: string|null"
+      ],
+      "required": [],
+      "title": "Reverse continue (TTD)"
+    },
+    {
+      "hints": {
+        "destructive": true,
+        "idempotent": false,
+        "openWorld": true,
+        "readOnly": false
+      },
+      "name": "run_to_address",
+      "params": [
+        "address: string",
+        "session_id: string|null",
+        "timeout_ms: integer|null/uint32"
+      ],
+      "required": [
+        "address"
+      ],
+      "title": "Run to address"
+    },
+    {
+      "hints": {
+        "destructive": null,
+        "idempotent": null,
+        "openWorld": false,
+        "readOnly": true
+      },
+      "name": "session_status",
+      "params": [
+        "session_id: string|null"
+      ],
+      "required": [],
+      "title": "Show current session handle"
+    },
+    {
+      "hints": {
+        "destructive": false,
+        "idempotent": false,
+        "openWorld": true,
+        "readOnly": false
+      },
+      "name": "set_breakpoint",
+      "params": [
+        "expression: string",
+        "session_id: string|null"
+      ],
+      "required": [
+        "expression"
+      ],
+      "title": "Set breakpoint"
+    },
+    {
+      "hints": {
+        "destructive": false,
+        "idempotent": false,
+        "openWorld": true,
+        "readOnly": false
+      },
+      "name": "set_symbol_path",
+      "params": [
+        "append: boolean|null",
+        "path: string",
+        "reload: string|null",
+        "session_id: string|null"
+      ],
+      "required": [
+        "path"
+      ],
+      "title": "Set symbol search path"
+    },
+    {
+      "hints": {
+        "destructive": false,
+        "idempotent": false,
+        "openWorld": true,
+        "readOnly": false
+      },
+      "name": "step_back",
+      "params": [
+        "session_id: string|null"
+      ],
+      "required": [],
+      "title": "Step back (TTD)"
+    },
+    {
+      "hints": {
+        "destructive": true,
+        "idempotent": false,
+        "openWorld": true,
+        "readOnly": false
+      },
+      "name": "step_into",
+      "params": [
+        "session_id: string|null"
+      ],
+      "required": [],
+      "title": "Step into"
+    },
+    {
+      "hints": {
+        "destructive": true,
+        "idempotent": false,
+        "openWorld": true,
+        "readOnly": false
+      },
+      "name": "step_over",
+      "params": [
+        "session_id: string|null"
+      ],
+      "required": [],
+      "title": "Step over"
+    },
+    {
+      "hints": {
+        "destructive": false,
+        "idempotent": false,
+        "openWorld": true,
+        "readOnly": false
+      },
+      "name": "step_over_back",
+      "params": [
+        "session_id: string|null"
+      ],
+      "required": [],
+      "title": "Step over back (TTD)"
+    },
+    {
+      "hints": {
+        "destructive": null,
+        "idempotent": null,
+        "openWorld": true,
+        "readOnly": true
+      },
+      "name": "threads",
+      "params": [
+        "session_id: string|null"
+      ],
+      "required": [],
+      "title": "List threads"
+    },
+    {
+      "hints": {
+        "destructive": null,
+        "idempotent": null,
+        "openWorld": true,
+        "readOnly": true
+      },
+      "name": "ttd_calls",
+      "params": [
+        "function: string",
+        "session_id: string|null"
+      ],
+      "required": [
+        "function"
+      ],
+      "title": "TTD: find calls to a function"
+    },
+    {
+      "hints": {
+        "destructive": null,
+        "idempotent": null,
+        "openWorld": true,
+        "readOnly": true
+      },
+      "name": "ttd_events",
+      "params": [
+        "session_id: string|null"
+      ],
+      "required": [],
+      "title": "TTD: list trace events"
+    },
+    {
+      "hints": {
+        "destructive": null,
+        "idempotent": null,
+        "openWorld": true,
+        "readOnly": true
+      },
+      "name": "ttd_memory",
+      "params": [
+        "address: string",
+        "mode: string|null",
+        "session_id: string|null",
+        "size: integer/uint32"
+      ],
+      "required": [
+        "address",
+        "size"
+      ],
+      "title": "TTD: find accesses to a memory range"
+    }
+  ],
+  "usesDefs": false
+}

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -134,6 +134,23 @@ impl Server {
         self.stderr_log.lock().unwrap().join("\n")
     }
 
+    /// Waits for a line on stderr. stdout and stderr are drained by independent threads with
+    /// no ordering between them, so a bare snapshot can miss a line the server has already
+    /// written — and that race would surface as an intermittent failure on a loaded runner,
+    /// which is the worst kind of test to own.
+    fn wait_for_stderr(&self, needle: &str, budget: Duration) -> bool {
+        let deadline = Instant::now() + budget;
+        loop {
+            if self.stderr().contains(needle) {
+                return true;
+            }
+            if Instant::now() >= deadline {
+                return false;
+            }
+            std::thread::sleep(Duration::from_millis(20));
+        }
+    }
+
     fn stdout_lines(&self) -> Vec<String> {
         self.stdout_log.lock().unwrap().clone()
     }
@@ -319,10 +336,10 @@ fn stdout_carries_only_json_rpc_and_logging_goes_to_stderr() {
     }
 
     // The counterpart: the startup log has to be somewhere, and that somewhere is stderr.
-    let stderr = server.stderr();
     assert!(
-        stderr.contains("windbg-mcp starting on stdio"),
-        "expected the startup log on stderr, got:\n{stderr}"
+        server.wait_for_stderr("windbg-mcp starting on stdio", STEP),
+        "expected the startup log on stderr, got:\n{}",
+        server.stderr()
     );
 }
 
@@ -674,10 +691,17 @@ fn tools_list_matches_the_recorded_wire_surface() {
 }
 
 /// Clients validate arguments against these schemas before ever calling. A `$ref` that points
-/// outside the document, or a mix of dialects, breaks strict validators — and both are things
-/// a codegen dependency can introduce without any change here.
+/// outside the document, or two dialects across one tool list, breaks strict validators — and
+/// both are things a codegen dependency can introduce without any change here.
+///
+/// On the dialect: every tool that has parameters declares `2020-12`; the one tool with no
+/// parameters at all (`attach_kernel_local`) emits a bare empty object schema with no `$schema`
+/// at all. That is schemars' emission, not something this crate chooses, and it is harmless —
+/// an empty schema constrains nothing, so there is no keyword whose meaning a dialect could
+/// change. What would *not* be harmless is two different declared dialects, so that is what is
+/// pinned here.
 #[test]
-fn tool_schemas_are_self_contained() {
+fn tool_schemas_declare_one_dialect_and_are_self_contained() {
     let mut server = Server::started();
     let response = server.request("tools/list", json!({}), STEP);
     let tools = response["result"]["tools"]
@@ -686,6 +710,7 @@ fn tool_schemas_are_self_contained() {
         .clone();
     assert!(!tools.is_empty(), "tools/list must not be empty");
 
+    let mut declared: Vec<(String, String)> = Vec::new();
     for tool in &tools {
         let name = tool["name"].as_str().unwrap_or("<unnamed>");
         let schema = &tool["inputSchema"];
@@ -693,6 +718,17 @@ fn tool_schemas_are_self_contained() {
             schema["type"], "object",
             "`{name}` input schema must be an object schema: {schema}"
         );
+
+        match schema["$schema"].as_str() {
+            Some(dialect) => declared.push((name.to_string(), dialect.to_string())),
+            // Only the constraint-free case may skip the declaration.
+            None => assert!(
+                schema["properties"]
+                    .as_object()
+                    .is_none_or(|props| props.is_empty()),
+                "`{name}` constrains arguments but declares no $schema dialect: {schema}"
+            ),
+        }
 
         let mut refs = Vec::new();
         collect_refs(schema, &mut refs);
@@ -707,6 +743,16 @@ fn tool_schemas_are_self_contained() {
                 "`{name}` has a dangling $ref `{reference}`"
             );
         }
+    }
+
+    // One dialect across the whole list. A client picks a validator per dialect; two of them
+    // in one `tools/list` means some tools validate under rules the client did not select.
+    let (first_tool, first_dialect) = declared.first().expect("some tool declares a dialect");
+    if let Some((other_tool, other)) = declared.iter().find(|(_, d)| d != first_dialect) {
+        panic!(
+            "tools/list mixes JSON Schema dialects: `{first_tool}` declares {first_dialect}, \
+             `{other_tool}` declares {other}"
+        );
     }
 }
 
@@ -801,20 +847,20 @@ fn a_dump_session_opens_reads_and_closes() {
     );
 
     // The handle is what every later call is checked against, so the open has to mint one.
+    // Anchored to the line `open_dump` actually emits (`session_id: sess-…`) rather than to the
+    // substring anywhere in the text — the tool's prose mentions `session_id` several times, and
+    // a loose match would yield a plausible-looking wrong handle whose failure surfaces later as
+    // an unrelated mismatch.
     let session_id = opened
         .lines()
-        .find_map(|l| l.split("session_id").nth(1))
-        .map(|rest| {
-            rest.trim_start_matches([':', ' ', '=', '"'])
-                .trim_end_matches(['"', ',', '.'])
-                .split_whitespace()
-                .next()
-                .unwrap_or_default()
-                .trim_end_matches(['"', ',', '.'])
-                .to_string()
-        })
+        .find_map(|line| line.trim().strip_prefix("session_id:"))
+        .map(str::trim)
         .unwrap_or_else(|| panic!("open_dump must return a session_id, got:\n{opened}"));
-    assert!(!session_id.is_empty(), "empty session_id in:\n{opened}");
+    assert!(
+        session_id.starts_with("sess-"),
+        "session handles are minted as `sess-…`, got `{session_id}` in:\n{opened}"
+    );
+    let session_id = session_id.to_string();
 
     let status = server.tool_text("session_status", json!({}), TARGET_STEP);
     assert!(
@@ -827,12 +873,20 @@ fn a_dump_session_opens_reads_and_closes() {
     // The checked-in sample is a *kernel* crash dump, so the kernel image and HAL are the
     // anchors — not `ntdll`. Symbols are not needed: the rows come from the dump's own module
     // list, which keeps this tier runnable offline.
+    //
+    // Matched as whitespace-separated tokens rather than by column position: `lm` lays out its
+    // columns from the address width and the longest module name, so a layout shift would
+    // otherwise fail here and name the wrong cause.
     let modules = server.tool_text("modules", json!({ "session_id": session_id }), TARGET_STEP);
-    for expected in ["   nt ", "   hal "] {
+    let listed: Vec<&str> = modules
+        .lines()
+        // `start end name [flags]` — the module name is the third token on a row.
+        .filter_map(|line| line.split_whitespace().nth(2))
+        .collect();
+    for expected in ["nt", "hal"] {
         assert!(
-            modules.contains(expected),
-            "the module list should include `{}`, got:\n{modules}",
-            expected.trim()
+            listed.contains(&expected),
+            "the module list should include `{expected}`, got:\n{modules}"
         );
     }
     for tool in ["registers", "backtrace"] {

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -1,0 +1,914 @@
+//! End-to-end smoke test: drives the **real binary** over stdio with hand-written JSON-RPC.
+//!
+//! The unit tests in `src/server.rs` check the tool surface in-process, through the SDK's
+//! Rust API. That is the wrong altitude for the two events this file exists for:
+//!
+//! * **A dependency moved** (`rmcp`, `win-kexp`, `schemars`, `tokio`). The in-process tests
+//!   still compile and pass while the bytes on the wire change underneath them — a schema
+//!   dialect switch, a crate that starts writing to stdout and corrupts the transport, a
+//!   shutdown path that leaves the process alive.
+//! * **The MCP spec revved.** New revision, new required field, a capability the SDK now
+//!   advertises on our behalf that this server does not actually implement.
+//!
+//! Two tiers, so the cheap half can ride `cargo test` everywhere:
+//!
+//! * **Protocol** (default) — spawns the server, speaks JSON-RPC. No debugger target, no
+//!   symbols, no network.
+//! * **Target** (`WINDBG_MCP_SMOKE_DUMP=1`) — opens the sample crash dump through DbgEng, so
+//!   it needs `dbgeng.dll` and may reach a symbol server. Off by default; this is the tier
+//!   that catches a `win-kexp` regression.
+//!
+//! See `docs/smoke-test.md` for the runbook.
+
+use std::collections::VecDeque;
+use std::io::{BufRead, BufReader, Write};
+use std::process::{Child, ChildStdin, Command, Stdio};
+use std::sync::mpsc::{Receiver, RecvTimeoutError, channel};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use serde_json::{Value, json};
+
+/// The binary built for the current profile. Using Cargo's path (rather than
+/// `target/release/windbg-mcp.exe`) keeps the smoke test clear of the release exe that a
+/// connected MCP client holds a lock on — see `CLAUDE.md`.
+const EXE: &str = env!("CARGO_BIN_EXE_windbg-mcp");
+
+/// Per-request budget for protocol-tier calls. Generous enough that a loaded CI runner never
+/// trips it, bounded so a regression fails instead of hanging the suite.
+const STEP: Duration = Duration::from_secs(60);
+
+/// Debugger work gets its own budget: opening a dump can pull symbols over the network.
+const TARGET_STEP: Duration = Duration::from_secs(240);
+
+/// Revisions the README promises this server speaks, newest first.
+const SUPPORTED_REVISIONS: &[&str] = &[
+    "2026-07-28",
+    "2025-11-25",
+    "2025-06-18",
+    "2025-03-26",
+    "2024-11-05",
+];
+
+/// What a client offering something the SDK does not know gets answered with.
+const FALLBACK_REVISION: &str = "2025-11-25";
+
+const GOLDEN: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/golden/tools_list.json");
+const SAMPLE_DUMP: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/docs/samples/052126-34312-01.dmp"
+);
+
+// ---- harness ------------------------------------------------------------------
+
+/// A spawned server plus a line-oriented JSON-RPC client for it.
+struct Server {
+    child: Child,
+    stdin: Option<ChildStdin>,
+    rx: Receiver<Option<String>>,
+    stdout_log: Arc<Mutex<Vec<String>>>,
+    stderr_log: Arc<Mutex<Vec<String>>>,
+    /// Messages read while waiting for some other id (notifications, out-of-order replies).
+    pending: VecDeque<Value>,
+    next_id: i64,
+}
+
+impl Server {
+    fn spawn() -> Self {
+        let mut child = Command::new(EXE)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            // Deterministic logging regardless of the developer's shell.
+            .env("RUST_LOG", "info")
+            .spawn()
+            .unwrap_or_else(|e| panic!("failed to spawn {EXE}: {e}"));
+
+        let stdout_log = Arc::new(Mutex::new(Vec::new()));
+        let stderr_log = Arc::new(Mutex::new(Vec::new()));
+        let (tx, rx) = channel();
+
+        // stdout is the transport: every line is forwarded to the client loop *and* kept, so
+        // a test can afterwards assert nothing else was written there.
+        let out = BufReader::new(child.stdout.take().expect("piped stdout"));
+        let log = Arc::clone(&stdout_log);
+        std::thread::spawn(move || {
+            for line in out.lines() {
+                match line {
+                    Ok(line) => {
+                        log.lock().unwrap().push(line.clone());
+                        if tx.send(Some(line)).is_err() {
+                            return;
+                        }
+                    }
+                    Err(_) => break,
+                }
+            }
+            let _ = tx.send(None);
+        });
+
+        // stderr is drained continuously: left unread it fills the pipe buffer and deadlocks
+        // the server mid-test, which would look like a protocol hang.
+        let err = BufReader::new(child.stderr.take().expect("piped stderr"));
+        let log = Arc::clone(&stderr_log);
+        std::thread::spawn(move || {
+            for line in err.lines().map_while(Result::ok) {
+                log.lock().unwrap().push(line);
+            }
+        });
+
+        Self {
+            stdin: child.stdin.take(),
+            child,
+            rx,
+            stdout_log,
+            stderr_log,
+            pending: VecDeque::new(),
+            next_id: 1,
+        }
+    }
+
+    /// Everything the server has written to stderr so far, for failure messages. A dep that
+    /// breaks the handshake usually says why here.
+    fn stderr(&self) -> String {
+        self.stderr_log.lock().unwrap().join("\n")
+    }
+
+    fn stdout_lines(&self) -> Vec<String> {
+        self.stdout_log.lock().unwrap().clone()
+    }
+
+    fn send_line(&mut self, msg: &Value) {
+        let stdin = self.stdin.as_mut().expect("stdin still open");
+        writeln!(stdin, "{msg}").expect("write request");
+        stdin.flush().expect("flush request");
+    }
+
+    fn notify(&mut self, method: &str, params: Value) {
+        let msg = json!({ "jsonrpc": "2.0", "method": method, "params": params });
+        self.send_line(&msg);
+    }
+
+    /// Sends a request and returns the response with the matching id.
+    fn request(&mut self, method: &str, params: Value, budget: Duration) -> Value {
+        let id = self.next_id;
+        self.next_id += 1;
+        let msg = json!({ "jsonrpc": "2.0", "id": id, "method": method, "params": params });
+        self.send_line(&msg);
+        self.await_id(id, method, budget)
+    }
+
+    fn await_id(&mut self, id: i64, what: &str, budget: Duration) -> Value {
+        let deadline = Instant::now() + budget;
+        loop {
+            if let Some(pos) = self.pending.iter().position(|m| m["id"] == json!(id)) {
+                return self.pending.remove(pos).expect("checked position");
+            }
+            let left = deadline.saturating_duration_since(Instant::now());
+            if left.is_zero() {
+                panic!(
+                    "timed out after {budget:?} waiting for `{what}` (id {id})\n--- stderr ---\n{}",
+                    self.stderr()
+                );
+            }
+            match self.rx.recv_timeout(left) {
+                Ok(Some(line)) => match serde_json::from_str::<Value>(&line) {
+                    Ok(msg) => self.pending.push_back(msg),
+                    Err(e) => panic!(
+                        "server wrote a non-JSON line to stdout while answering `{what}`: {line:?} ({e})\n\
+                         stdout is the JSON-RPC transport — a dependency logging there breaks every client.\n\
+                         --- stderr ---\n{}",
+                        self.stderr()
+                    ),
+                },
+                Ok(None) | Err(RecvTimeoutError::Disconnected) => panic!(
+                    "server closed stdout while answering `{what}` (id {id}) — it crashed or exited\n\
+                     --- stderr ---\n{}",
+                    self.stderr()
+                ),
+                Err(RecvTimeoutError::Timeout) => continue,
+            }
+        }
+    }
+
+    /// `initialize` + `notifications/initialized`, the pre-`2026-07-28` opener.
+    fn initialize(&mut self, revision: &str) -> Value {
+        let response = self.request(
+            "initialize",
+            json!({
+                "protocolVersion": revision,
+                "capabilities": {},
+                "clientInfo": { "name": "windbg-mcp-smoke", "version": "1" },
+            }),
+            STEP,
+        );
+        assert_no_error(&response, &format!("initialize({revision})"));
+        self.notify("notifications/initialized", json!({}));
+        response["result"].clone()
+    }
+
+    /// A ready-to-use session on the newest revision, for tests that are not about the opener.
+    fn started() -> Self {
+        let mut server = Self::spawn();
+        server.initialize(SUPPORTED_REVISIONS[0]);
+        server
+    }
+
+    /// A request in `2026-07-28`'s stateless mode, where there is no handshake to remember the
+    /// negotiated revision — so *every* request, not only the opener, has to carry it.
+    fn stateless_request(&mut self, method: &str, mut params: Value, budget: Duration) -> Value {
+        params["_meta"] = json!({
+            "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+            "io.modelcontextprotocol/clientCapabilities": {},
+        });
+        self.request(method, params, budget)
+    }
+
+    fn call_tool(&mut self, name: &str, args: Value, budget: Duration) -> Value {
+        self.request(
+            "tools/call",
+            json!({ "name": name, "arguments": args }),
+            budget,
+        )
+    }
+
+    /// The text a tool call produced, whether it succeeded or reported a tool error.
+    fn tool_text(&mut self, name: &str, args: Value, budget: Duration) -> String {
+        let response = self.call_tool(name, args, budget);
+        assert_no_error(&response, &format!("tools/call {name}"));
+        text_of(&response["result"])
+    }
+
+    /// Closes stdin and waits for exit, returning the exit code.
+    fn shutdown(mut self) -> Option<i32> {
+        drop(self.stdin.take());
+        let deadline = Instant::now() + Duration::from_secs(20);
+        loop {
+            match self.child.try_wait().expect("poll child") {
+                Some(status) => return status.code(),
+                None if Instant::now() >= deadline => {
+                    let _ = self.child.kill();
+                    panic!(
+                        "server did not exit within 20s of stdin closing — an MCP client would \
+                         leave this process behind on every disconnect\n--- stderr ---\n{}",
+                        self.stderr()
+                    );
+                }
+                None => std::thread::sleep(Duration::from_millis(50)),
+            }
+        }
+    }
+}
+
+impl Drop for Server {
+    fn drop(&mut self) {
+        drop(self.stdin.take());
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+fn assert_no_error(response: &Value, what: &str) {
+    assert!(
+        response["error"].is_null(),
+        "`{what}` was answered with a JSON-RPC error: {}",
+        response["error"]
+    );
+}
+
+/// Concatenates the text blocks of a `tools/call` result.
+fn text_of(result: &Value) -> String {
+    result["content"]
+        .as_array()
+        .map(|blocks| {
+            blocks
+                .iter()
+                .filter_map(|b| b["text"].as_str())
+                .collect::<Vec<_>>()
+                .join("\n")
+        })
+        .unwrap_or_default()
+}
+
+/// Whether a tool call came back flagged as a *tool* error (`isError: true`), which is the
+/// only way a debugger failure is allowed to surface.
+fn is_tool_error(response: &Value) -> bool {
+    response["result"]["isError"] == json!(true)
+}
+
+fn skip(reason: &str) {
+    eprintln!("SKIPPED: {reason}");
+}
+
+// ---- tier 1: transport --------------------------------------------------------
+
+/// stdout is the JSON-RPC channel. Anything else written there — a dependency's banner, a
+/// `println!` that slipped in, a panic message — desynchronizes every client, and the client
+/// side of that failure is unreadable ("unexpected token"). Cheapest possible dep tripwire.
+#[test]
+fn stdout_carries_only_json_rpc_and_logging_goes_to_stderr() {
+    let mut server = Server::started();
+    server.request("tools/list", json!({}), STEP);
+    let text = server.tool_text("decode_ioctl", json!({ "code": "0x70000" }), STEP);
+    assert!(!text.is_empty(), "expected decoded output");
+
+    for line in server.stdout_lines() {
+        let msg: Value = serde_json::from_str(&line)
+            .unwrap_or_else(|e| panic!("non-JSON line on stdout: {line:?} ({e})"));
+        assert_eq!(msg["jsonrpc"], "2.0", "non-JSON-RPC line on stdout: {line}");
+    }
+
+    // The counterpart: the startup log has to be somewhere, and that somewhere is stderr.
+    let stderr = server.stderr();
+    assert!(
+        stderr.contains("windbg-mcp starting on stdio"),
+        "expected the startup log on stderr, got:\n{stderr}"
+    );
+}
+
+/// Closing stdin is how every MCP client disconnects. A server that does not notice leaks a
+/// process (and, here, a DbgEng session) per connection.
+#[test]
+fn server_exits_when_its_stdin_closes() {
+    let mut server = Server::started();
+    server.request("tools/list", json!({}), STEP);
+    assert_eq!(
+        server.shutdown(),
+        Some(0),
+        "clean disconnect should be a clean exit"
+    );
+}
+
+/// A client that sends garbage — or a framing bug in a client library — must not take the
+/// server down with it; the next well-formed request still has to be answered.
+#[test]
+fn a_malformed_line_does_not_kill_the_server() {
+    let mut server = Server::started();
+    server.send_line(&json!("this is not a JSON-RPC message"));
+    server
+        .stdin
+        .as_mut()
+        .map(|s| writeln!(s, "{{ not even json"))
+        .transpose()
+        .expect("write malformed line");
+
+    let response = server.request("tools/list", json!({}), STEP);
+    assert_no_error(&response, "tools/list after malformed input");
+    assert!(
+        response["result"]["tools"].is_array(),
+        "server should still serve tools after malformed input"
+    );
+}
+
+// ---- tier 1: protocol revisions -----------------------------------------------
+
+/// The README names the revisions this server speaks. When the spec revs, this is the list to
+/// extend — and the test that says whether the SDK bump actually delivered it.
+#[test]
+fn every_documented_protocol_revision_is_served() {
+    for revision in SUPPORTED_REVISIONS {
+        let mut server = Server::spawn();
+        let result = server.initialize(revision);
+
+        let served = result["protocolVersion"]
+            .as_str()
+            .unwrap_or_else(|| panic!("initialize({revision}) returned no protocolVersion"));
+        assert_eq!(
+            served, *revision,
+            "a client offering `{revision}` must be served that revision, not `{served}`"
+        );
+        assert!(
+            !result["capabilities"]["tools"].is_null(),
+            "initialize({revision}) must advertise the tools capability: {result}"
+        );
+
+        // The server has to introduce itself as itself on every revision — left to the SDK's
+        // default this reads `rmcp` at the SDK's version.
+        assert_eq!(result["serverInfo"]["name"], "windbg-mcp", "on {revision}");
+        assert_eq!(
+            result["serverInfo"]["version"],
+            env!("CARGO_PKG_VERSION"),
+            "the reported version must track this crate, not the SDK (on {revision})"
+        );
+
+        // Tools must be reachable on every revision, not just the newest.
+        let tools = server.request("tools/list", json!({}), STEP);
+        assert_no_error(&tools, &format!("tools/list on {revision}"));
+        assert!(
+            tools["result"]["tools"]
+                .as_array()
+                .is_some_and(|t| !t.is_empty()),
+            "tools/list must be non-empty on {revision}"
+        );
+    }
+}
+
+/// An unknown revision must be negotiated down, not refused: a newer client than the SDK
+/// knows about should still get a usable session.
+#[test]
+fn an_unknown_protocol_revision_is_negotiated_down() {
+    let mut server = Server::spawn();
+    let response = server.request(
+        "initialize",
+        json!({
+            "protocolVersion": "2999-01-01",
+            "capabilities": {},
+            "clientInfo": { "name": "windbg-mcp-smoke", "version": "1" },
+        }),
+        STEP,
+    );
+    assert_no_error(&response, "initialize(unknown revision)");
+    assert_eq!(
+        response["result"]["protocolVersion"], FALLBACK_REVISION,
+        "an unknown revision should be answered with the documented fallback"
+    );
+}
+
+/// `2026-07-28` lets a client skip the handshake entirely. `src/server.rs` pins this over an
+/// in-process duplex; here it is the shipped executable, because "can this client connect at
+/// all" is a property of the process, not of `get_info`.
+#[test]
+fn discover_opens_a_session_without_initialize() {
+    let mut server = Server::spawn();
+    let response = server.stateless_request("server/discover", json!({}), STEP);
+    assert_no_error(&response, "server/discover");
+    let result = &response["result"];
+
+    // SEP-2322: the discriminator is mandatory, and a client that parses by it cannot read a
+    // response without one.
+    assert_eq!(result["resultType"], "complete");
+
+    let versions = result["supportedVersions"]
+        .as_array()
+        .unwrap_or_else(|| panic!("discover must advertise supportedVersions: {result}"));
+    for expected in SUPPORTED_REVISIONS {
+        assert!(
+            versions.iter().any(|v| v == expected),
+            "discover must advertise `{expected}`, got {versions:?}"
+        );
+    }
+
+    // A discover-first client learns the server from this one response and nothing else.
+    assert!(
+        !result["capabilities"]["tools"].is_null(),
+        "discover must advertise the tools capability: {result}"
+    );
+    let instructions = result["instructions"]
+        .as_str()
+        .unwrap_or_else(|| panic!("discover must carry the server instructions: {result}"));
+    assert!(
+        instructions.contains("WinDbg"),
+        "instructions should be this server's, got {instructions:?}"
+    );
+
+    // Tools have to be reachable on a session opened this way, not merely listed by discover.
+    let tools = server.stateless_request("tools/list", json!({}), STEP);
+    assert_no_error(&tools, "tools/list after discover");
+    assert!(
+        tools["result"]["tools"]
+            .as_array()
+            .is_some_and(|t| !t.is_empty()),
+        "tools/list must be non-empty for a discover-first client: {tools}"
+    );
+
+    // The stateless rule itself: with no handshake to remember the revision, a request that
+    // omits the per-request `_meta` is refused. Pinned because a client library that sends it
+    // only on the opener would fail here and nowhere else.
+    let bare = server.request("tools/list", json!({}), STEP);
+    assert_eq!(
+        bare["error"]["code"], -32602,
+        "a stateless request without `_meta` must be an invalid-params error, got {bare}"
+    );
+}
+
+/// Advertising a capability the server does not implement is worse than not advertising it:
+/// clients route real calls into a `method_not_found`. This asserts the honest surface — if an
+/// SDK bump switches something on for us, this test is where you find out and decide whether
+/// to implement it or suppress it.
+#[test]
+fn capabilities_advertise_only_what_is_implemented() {
+    let mut server = Server::spawn();
+    let result = server.initialize(SUPPORTED_REVISIONS[0]);
+    let capabilities = &result["capabilities"];
+
+    assert!(
+        !capabilities["tools"].is_null(),
+        "tools must be advertised: {capabilities}"
+    );
+    for unimplemented in ["resources", "prompts", "completions", "logging"] {
+        assert!(
+            capabilities[unimplemented].is_null(),
+            "`{unimplemented}` is advertised but this server implements no such handler — \
+             clients will call it and get method_not_found: {capabilities}"
+        );
+    }
+
+    // Tasks (`io.modelcontextprotocol/tasks`, SEP-2663) are deliberately not implemented —
+    // see FOLLOWUPS.md item 8. The advertisement and the behaviour have to agree.
+    assert!(
+        capabilities["extensions"].is_null(),
+        "no protocol extension is implemented yet, so none may be advertised: {capabilities}"
+    );
+    let tasks = server.request("tasks/get", json!({ "taskId": "nope" }), STEP);
+    assert_eq!(
+        tasks["error"]["code"], -32601,
+        "an unimplemented extension method must be method_not_found, got {tasks}"
+    );
+}
+
+// ---- tier 1: tool surface -----------------------------------------------------
+
+/// Describes a schema node tightly enough that a dialect or codegen change shows up, without
+/// churning on prose edits.
+fn describe_type(node: &Value) -> String {
+    if let Some(variants) = node.get("enum").and_then(|e| e.as_array()) {
+        let names: Vec<String> = variants.iter().map(|v| v.to_string()).collect();
+        return format!("enum[{}]", names.join("|"));
+    }
+    if let Some(reference) = node.get("$ref").and_then(|r| r.as_str()) {
+        return format!("ref({reference})");
+    }
+    let base = match &node["type"] {
+        Value::String(t) => t.clone(),
+        Value::Array(ts) => ts
+            .iter()
+            .filter_map(|t| t.as_str())
+            .collect::<Vec<_>>()
+            .join("|"),
+        _ => "any".to_string(),
+    };
+    let base = match node.get("items") {
+        Some(items) if base.starts_with("array") => format!("array<{}>", describe_type(items)),
+        _ => base,
+    };
+    match node.get("format").and_then(|f| f.as_str()) {
+        Some(format) => format!("{base}/{format}"),
+        None => base,
+    }
+}
+
+/// The structural contract of one tool: everything a client binds against, minus the prose.
+fn digest_tool(tool: &Value) -> Value {
+    let schema = &tool["inputSchema"];
+    let mut params: Vec<String> = schema["properties"]
+        .as_object()
+        .map(|props| {
+            props
+                .iter()
+                .map(|(name, node)| format!("{name}: {}", describe_type(node)))
+                .collect()
+        })
+        .unwrap_or_default();
+    params.sort();
+
+    let mut required: Vec<String> = schema["required"]
+        .as_array()
+        .map(|r| {
+            r.iter()
+                .filter_map(|v| v.as_str().map(String::from))
+                .collect()
+        })
+        .unwrap_or_default();
+    required.sort();
+
+    let annotations = &tool["annotations"];
+    json!({
+        "name": tool["name"],
+        "title": annotations["title"],
+        "hints": {
+            "readOnly": annotations["readOnlyHint"],
+            "destructive": annotations["destructiveHint"],
+            "idempotent": annotations["idempotentHint"],
+            "openWorld": annotations["openWorldHint"],
+        },
+        "required": required,
+        "params": params,
+    })
+}
+
+/// The whole `tools/list` surface, normalized: JSON Schema dialect, then one digest per tool.
+fn digest_tool_list(tools: &[Value]) -> Value {
+    let dialects: Vec<String> = {
+        let mut seen: Vec<String> = tools
+            .iter()
+            .map(|t| match t["inputSchema"]["$schema"].as_str() {
+                Some(s) => s.to_string(),
+                None => "(none)".to_string(),
+            })
+            .collect();
+        seen.sort();
+        seen.dedup();
+        seen
+    };
+    let uses_defs = tools.iter().any(|t| {
+        !t["inputSchema"]["$defs"].is_null() || !t["inputSchema"]["definitions"].is_null()
+    });
+
+    json!({
+        "schemaDialects": dialects,
+        "usesDefs": uses_defs,
+        "toolCount": tools.len(),
+        "tools": tools.iter().map(digest_tool).collect::<Vec<_>>(),
+    })
+}
+
+/// A golden snapshot of the tool surface as it appears **on the wire**. This is the highest-
+/// signal dependency tripwire in the file: a `schemars` bump changing dialect or nullable
+/// encoding, an `rmcp` bump changing annotation casing, or an accidental tool rename all land
+/// here as a readable diff.
+///
+/// Intentional changes: re-record with `UPDATE_GOLDEN=1 cargo test --test mcp_smoke` and read
+/// the resulting diff before committing it.
+#[test]
+fn tools_list_matches_the_recorded_wire_surface() {
+    let mut server = Server::started();
+    let response = server.request("tools/list", json!({}), STEP);
+    assert_no_error(&response, "tools/list");
+    let tools = response["result"]["tools"]
+        .as_array()
+        .expect("tools/list returns an array")
+        .clone();
+
+    let actual = digest_tool_list(&tools);
+    let rendered = format!("{}\n", serde_json::to_string_pretty(&actual).unwrap());
+
+    if std::env::var_os("UPDATE_GOLDEN").is_some() {
+        std::fs::create_dir_all(std::path::Path::new(GOLDEN).parent().unwrap())
+            .expect("create golden dir");
+        std::fs::write(GOLDEN, &rendered).expect("write golden");
+        eprintln!("re-recorded {GOLDEN}");
+        return;
+    }
+
+    let expected = std::fs::read_to_string(GOLDEN).unwrap_or_else(|e| {
+        panic!("cannot read {GOLDEN}: {e}\nrecord it with `UPDATE_GOLDEN=1 cargo test --test mcp_smoke`")
+    });
+    if rendered.replace("\r\n", "\n") == expected.replace("\r\n", "\n") {
+        return;
+    }
+
+    // Line diff, so the failure names what moved instead of dumping two large blobs.
+    let expected_lines: Vec<&str> = expected.lines().collect();
+    let actual_lines: Vec<&str> = rendered.lines().collect();
+    let mut diff = String::new();
+    for i in 0..expected_lines.len().max(actual_lines.len()) {
+        let (was, now) = (expected_lines.get(i), actual_lines.get(i));
+        if was != now {
+            diff.push_str(&format!(
+                "line {}:\n  recorded: {}\n  actual:   {}\n",
+                i + 1,
+                was.unwrap_or(&"(absent)"),
+                now.unwrap_or(&"(absent)")
+            ));
+            if diff.lines().count() > 60 {
+                diff.push_str("  ... (truncated)\n");
+                break;
+            }
+        }
+    }
+    panic!(
+        "the tools/list wire surface changed:\n{diff}\n\
+         If this is intended, re-record with `UPDATE_GOLDEN=1 cargo test --test mcp_smoke` \
+         and review the diff."
+    );
+}
+
+/// Clients validate arguments against these schemas before ever calling. A `$ref` that points
+/// outside the document, or a mix of dialects, breaks strict validators — and both are things
+/// a codegen dependency can introduce without any change here.
+#[test]
+fn tool_schemas_are_self_contained() {
+    let mut server = Server::started();
+    let response = server.request("tools/list", json!({}), STEP);
+    let tools = response["result"]["tools"]
+        .as_array()
+        .expect("tools/list returns an array")
+        .clone();
+    assert!(!tools.is_empty(), "tools/list must not be empty");
+
+    for tool in &tools {
+        let name = tool["name"].as_str().unwrap_or("<unnamed>");
+        let schema = &tool["inputSchema"];
+        assert_eq!(
+            schema["type"], "object",
+            "`{name}` input schema must be an object schema: {schema}"
+        );
+
+        let mut refs = Vec::new();
+        collect_refs(schema, &mut refs);
+        for reference in refs {
+            assert!(
+                reference.starts_with("#/"),
+                "`{name}` has an external $ref `{reference}` — clients cannot resolve it"
+            );
+            let pointer = reference.trim_start_matches('#');
+            assert!(
+                schema.pointer(pointer).is_some(),
+                "`{name}` has a dangling $ref `{reference}`"
+            );
+        }
+    }
+}
+
+fn collect_refs(node: &Value, out: &mut Vec<String>) {
+    match node {
+        Value::Object(map) => {
+            for (key, value) in map {
+                if key == "$ref" {
+                    if let Some(reference) = value.as_str() {
+                        out.push(reference.to_string());
+                    }
+                } else {
+                    collect_refs(value, out);
+                }
+            }
+        }
+        Value::Array(items) => items.iter().for_each(|i| collect_refs(i, out)),
+        _ => {}
+    }
+}
+
+/// One tool executed end to end, chosen because it is pure: `decode_ioctl` never reaches the
+/// engine, so this proves the call path — arguments in, content blocks out — on any machine.
+#[test]
+fn a_tool_call_round_trips_over_the_wire() {
+    let mut server = Server::started();
+    // IOCTL_DISK_GET_DRIVE_GEOMETRY: device 0x7 (DISK), function 0x0, METHOD_BUFFERED, FILE_ANY_ACCESS.
+    let text = server.tool_text("decode_ioctl", json!({ "code": "0x70000" }), STEP);
+    for expected in ["0x00070000", "METHOD_BUFFERED", "FILE_ANY_ACCESS"] {
+        assert!(
+            text.contains(expected),
+            "decoded output should mention `{expected}`, got:\n{text}"
+        );
+    }
+}
+
+/// Bad calls have to fail as *protocol* errors, and — the part that matters — the connection
+/// has to survive them. A client that gets its own bug back as a dead session cannot recover.
+#[test]
+fn bad_calls_are_rejected_without_killing_the_session() {
+    let mut server = Server::started();
+
+    let unknown = server.call_tool("no_such_tool", json!({}), STEP);
+    assert!(
+        !unknown["error"].is_null() || is_tool_error(&unknown),
+        "an unknown tool must be refused, got {unknown}"
+    );
+
+    // `decode_ioctl` requires `code`; omitting it is the everyday client mistake.
+    let missing = server.call_tool("decode_ioctl", json!({}), STEP);
+    assert!(
+        !missing["error"].is_null() || is_tool_error(&missing),
+        "a missing required argument must be refused, got {missing}"
+    );
+
+    let text = server.tool_text("decode_ioctl", json!({ "code": "0x70000" }), STEP);
+    assert!(
+        text.contains("METHOD_BUFFERED"),
+        "the session must still work after bad calls, got:\n{text}"
+    );
+}
+
+// ---- tier 2: a real debugger target -------------------------------------------
+
+/// Gate for the tier that needs DbgEng. Returns the dump path, or `None` when the tier is off.
+fn target_tier() -> Option<&'static str> {
+    if std::env::var_os("WINDBG_MCP_SMOKE_DUMP").is_none() {
+        skip("set WINDBG_MCP_SMOKE_DUMP=1 to run the debugger tier");
+        return None;
+    }
+    if !std::path::Path::new(SAMPLE_DUMP).exists() {
+        skip(&format!("sample dump not found at {SAMPLE_DUMP}"));
+        return None;
+    }
+    Some(SAMPLE_DUMP)
+}
+
+/// The end-to-end debugger path, which is what a `win-kexp` or DbgEng change actually moves:
+/// open a real dump, read state out of it through several tools, then close it. Everything
+/// here is read-only against a checked-in dump — no live target, no writes.
+#[test]
+fn a_dump_session_opens_reads_and_closes() {
+    let Some(dump) = target_tier() else { return };
+    let mut server = Server::started();
+
+    let response = server.call_tool("open_dump", json!({ "path": dump }), TARGET_STEP);
+    assert_no_error(&response, "open_dump");
+    let opened = text_of(&response["result"]);
+    assert!(
+        !is_tool_error(&response),
+        "opening the sample dump failed — DbgEng may be missing or the dump unreadable:\n{opened}"
+    );
+
+    // The handle is what every later call is checked against, so the open has to mint one.
+    let session_id = opened
+        .lines()
+        .find_map(|l| l.split("session_id").nth(1))
+        .map(|rest| {
+            rest.trim_start_matches([':', ' ', '=', '"'])
+                .trim_end_matches(['"', ',', '.'])
+                .split_whitespace()
+                .next()
+                .unwrap_or_default()
+                .trim_end_matches(['"', ',', '.'])
+                .to_string()
+        })
+        .unwrap_or_else(|| panic!("open_dump must return a session_id, got:\n{opened}"));
+    assert!(!session_id.is_empty(), "empty session_id in:\n{opened}");
+
+    let status = server.tool_text("session_status", json!({}), TARGET_STEP);
+    assert!(
+        status.contains(&session_id),
+        "session_status should report the open session `{session_id}`, got:\n{status}"
+    );
+
+    // Read-only inspection through the engine thread. These are the calls that break when a
+    // DbgEng binding changes shape.
+    // The checked-in sample is a *kernel* crash dump, so the kernel image and HAL are the
+    // anchors — not `ntdll`. Symbols are not needed: the rows come from the dump's own module
+    // list, which keeps this tier runnable offline.
+    let modules = server.tool_text("modules", json!({ "session_id": session_id }), TARGET_STEP);
+    for expected in ["   nt ", "   hal "] {
+        assert!(
+            modules.contains(expected),
+            "the module list should include `{}`, got:\n{modules}",
+            expected.trim()
+        );
+    }
+    for tool in ["registers", "backtrace"] {
+        let response = server.call_tool(tool, json!({ "session_id": session_id }), TARGET_STEP);
+        assert_no_error(&response, tool);
+        let text = text_of(&response["result"]);
+        assert!(
+            !is_tool_error(&response) && !text.trim().is_empty(),
+            "`{tool}` failed against the sample dump:\n{text}"
+        );
+    }
+
+    // `threads` is `~`, which DbgEng only implements in user mode — against this kernel dump
+    // it fails, and that is the point: a real engine failure has to come back as a *tool*
+    // error carrying the engine's message, not as a protocol error or a killed worker thread.
+    let unsupported = server.call_tool("threads", json!({ "session_id": session_id }), TARGET_STEP);
+    assert_no_error(&unsupported, "threads on a kernel dump");
+    assert!(
+        is_tool_error(&unsupported),
+        "a command DbgEng cannot run here must set isError, got {unsupported}"
+    );
+    assert!(
+        !text_of(&unsupported["result"]).trim().is_empty(),
+        "the failure must explain itself: {unsupported}"
+    );
+
+    // A handle from a session that is not current must be refused rather than silently
+    // answered against whatever happens to be open — the contract `check_session_handle` owns.
+    let stale = server.call_tool(
+        "modules",
+        json!({ "session_id": "sess-not-a-real-handle" }),
+        TARGET_STEP,
+    );
+    assert!(
+        is_tool_error(&stale) || !stale["error"].is_null(),
+        "a stale session handle must be refused, got {stale}"
+    );
+
+    let ended = server.tool_text(
+        "end_session",
+        json!({ "session_id": session_id }),
+        TARGET_STEP,
+    );
+    assert!(!ended.trim().is_empty(), "end_session said nothing");
+
+    // After the session is gone, the old handle must not be honoured.
+    let after = server.call_tool("modules", json!({ "session_id": session_id }), TARGET_STEP);
+    assert!(
+        is_tool_error(&after) || !after["error"].is_null(),
+        "a handle from an ended session must be refused, got {after}"
+    );
+}
+
+/// The `isError` contract, on the wire. `engine.rs` splits debugger failures (the model can
+/// retry) from engine failures (it cannot); the first kind must arrive as a *result* flagged
+/// `isError`, never as a JSON-RPC error the model never really sees.
+#[test]
+fn a_failed_debugger_operation_is_a_tool_error_not_a_protocol_error() {
+    if target_tier().is_none() {
+        return;
+    }
+    let mut server = Server::started();
+
+    // No target is open, so execution control has nothing to run.
+    let response = server.call_tool("go", json!({}), TARGET_STEP);
+    assert_no_error(
+        &response,
+        "go with no debuggee (a debugger failure is a tool result, not a protocol error)",
+    );
+    assert!(
+        is_tool_error(&response),
+        "a failed debugger operation must set isError, got {response}"
+    );
+    let text = text_of(&response["result"]);
+    assert!(
+        !text.trim().is_empty(),
+        "a tool error must explain itself so the model can correct: {response}"
+    );
+}


### PR DESCRIPTION
## Why

The unit tests in `src/server.rs` check the tool surface **in-process**, through the SDK's Rust API. That is the wrong altitude for the two events where this server actually breaks:

- **A dependency moved** — `rmcp`, `schemars`, `tokio`, or a `win-kexp` pin bump.
- **The MCP spec revved** — new revision, new required field, a capability the SDK starts advertising on our behalf.

Both change the bytes on the wire while the Rust API this crate compiles against stays identical. The existing tests keep passing and clients break.

## What

`tests/mcp_smoke.rs` spawns the **built binary** and speaks hand-written JSON-RPC to it over stdio. Whole suite runs in ~0.2s.

| Tier | Gate | Needs | Catches |
| --- | --- | --- | --- |
| Protocol | always (rides `cargo test`) | nothing | transport, revision negotiation, tool-surface drift |
| Debugger | `WINDBG_MCP_SMOKE_DUMP=1` | dbgeng + the checked-in sample dump | `win-kexp`/DbgEng regressions |
| Live | manual | KDNET / TTD / elevation | documented checklist, not automated |

It runs the **dev** binary via `CARGO_BIN_EXE_windbg-mcp`, so it stays clear of the release exe a connected MCP client holds a lock on.

### The assertions that earn their place

- **stdout carries only JSON-RPC**, startup log on stderr. A dependency that prints a banner there corrupts the transport for every client, and the client-side symptom is an unreadable parse error.
- **Every revision the README promises** is served — and each can reach `tools/list`, not merely handshake. An unknown revision negotiates down to `2025-11-25`.
- **Capability honesty** — `resources`/`prompts`/`completions`/`logging`/`extensions` must stay unadvertised while unimplemented, and `tasks/get` must stay `method_not_found` (FOLLOWUPS #8). This is the tripwire for an SDK bump advertising something we do not implement.
- **Process exits when stdin closes** — otherwise every client disconnect leaks a process and a DbgEng session.
- **Schemas are self-contained** — all `$ref`s resolve inside the document, since external or dangling refs break strict client-side validators.

### Golden snapshot

`tests/golden/tools_list.json` records the **structural** `tools/list` surface: schema dialect, `$defs` usage, tool count, and per tool its name, title, four behaviour hints, required arguments, and each parameter's type/format/enum. Descriptions are deliberately excluded, so prose edits do not churn it while a `schemars` dialect switch or an `rmcp` annotation-casing change lands as a readable line diff. Re-record with `UPDATE_GOLDEN=1 cargo test --test mcp_smoke`.

### Two findings, now pinned as tests

1. In `2026-07-28`'s stateless mode, **every** request must carry the `_meta` protocol keys — not just the opener. A client library that sends them only on `server/discover` fails on the next call and nowhere else.
2. `threads` is `~`, which DbgEng implements only in user mode, so it fails against the kernel sample dump. Rather than drop it, the test asserts it returns a **tool error carrying the engine's message** — an end-to-end check of the `isError` split in `engine.rs` against a real engine.

## CI

The protocol tier rides the existing `cargo test` step. The debugger tier is a `workflow_dispatch`-only job (`Smoke test (debugger tier)`), so a Windows-image change cannot block an unrelated PR.

## Docs

`docs/smoke-test.md` is the runbook, split by trigger — "a dependency moved" and "the MCP spec revved" each get an ordered procedure. The spec one starts with *add the revision to `SUPPORTED_REVISIONS` and run it; a failure is your answer on whether an `rmcp` bump is needed*. It also carries the manual checklist for the live kernel and TTD paths no runner can host, pointing at the existing `examples/` drivers. Pointers added to `README.md`, `CLAUDE.md`, `AGENTS.md`, plus a `CHANGELOG.md` entry.

## Testing

- `cargo fmt --all --check` — clean
- `cargo clippy --all-targets` — clean
- `cargo test` — 65 unit + 13 smoke, all passing
- `WINDBG_MCP_SMOKE_DUMP=1 cargo test` — same, with the debugger tier against `docs/samples/052126-34312-01.dmp`
- Golden diff output verified by perturbing the snapshot: the failure names the exact lines that moved

One known blind spot: Dependabot only watches GitHub Actions here, so cargo/`win-kexp` bumps arrive by hand — the debugger tier only helps if it is remembered, which is why the runbook leads with it.

## Note on one dependency

Adds a single `[dev-dependencies]` entry, `serde_json`, which is already a normal dependency. Deliberately no new crates: this is the test you reach for when a dependency has just broken something.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added end-to-end MCP smoke testing over stdio, covering protocol negotiation, capabilities, tool discovery and validation.
  * Added optional Windows debugger smoke tests for sample-dump sessions and inspection workflows.
  * Added a golden catalogue for the supported debugger tool surface.

* **Documentation**
  * Added smoke-test guidance, runbook procedures and local verification instructions.
  * Updated the README and project guidance with test commands and optional debugger coverage.

* **CI**
  * Added manual smoke-test dispatch and Windows debugger validation in continuous integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->