### PR TITLE
fix: commit the session handle for the attaching and launching openers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Every opener now commits its session handle, including the four that attach or launch.**
+  0.3.0 shipped this guarantee for `open_dump` and `open_trace` only, and documented the gap
+  for the rest: win-kexp fused the target-creating call and the wait for the initial break
+  into one `Result`, so a failure could mean "nothing happened" or "the process started /
+  the attach succeeded, then the wait failed" — indistinguishable from here, and needing
+  opposite recovery. Those four tools hedged accordingly, telling callers to check
+  `vertarget` before opening again instead of claiming a retry was safe.
+
+  win-kexp split them (glslang/win-kexp#71): each opener is now a `x_begin()` returning a
+  `PendingTarget` guard, plus a `wait()` on that guard. The guard cannot exist unless the
+  side effect succeeded, so there is finally a seam to commit at. `opened_result` hands its
+  `transition` a `commit` callback to invoke at that seam, and every opener reads the same
+  way — side effect, `commit()`, wait.
+
+  So a failed break-in wait on `attach_process`, `attach_kernel`, `attach_kernel_local` or
+  `launch` now returns the error *with* a usable `session_id`, exactly as a failed load wait
+  on a dump already did. The hedge is gone: the server knows which side of the seam a failure
+  fell on, and says so — re-open when nothing was created, never re-open when the target is
+  already there. For `launch` that is the difference between one process and two.
+
 ## [0.3.0] - 2026-08-01
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -843,7 +843,7 @@ dependencies = [
 [[package]]
 name = "win-kexp"
 version = "0.1.0"
-source = "git+https://github.com/glslang/win-kexp?branch=main#6644f0f2224544deea01b11c46bcf1e14979f696"
+source = "git+https://github.com/glslang/win-kexp?branch=main#47993c41e8d5942a5efec6fc2452538c064951c5"
 dependencies = [
  "byte-strings",
  "goblin",

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -1,8 +1,9 @@
 # Follow-ups
 
-Deferred work, in two clusters: items 1–6 come from the reachability-confirmation effort (path
+Deferred work, in three clusters: items 1–6 come from the reachability-confirmation effort (path
 recipe + `run_to_address`, merged 2026-07-04), items 7–11 from surveying this server against the
-MCP `2026-07-28` extensions (tasks, apps). Each item notes its repo, why it was deferred, and where
+MCP `2026-07-28` extensions (tasks, apps), and item 12 from the opener split
+(glslang/win-kexp#71, 2026-08-01). Each item notes its repo, why it was deferred, and where
 it picks up. See [`DECISIONS.md`](./DECISIONS.md) for the design rationale (D1–D5) items 1–6 extend.
 
 Items are roughly ordered by how soon they're worth doing, within each cluster.
@@ -201,3 +202,26 @@ iframe host.
   (events on a trace-position axis).
 - **Cheaper alternative, if those three ever need it:** `structuredContent` + `outputSchema`. Same
   data, lossless to the model, works in every client, no UI runtime. Do that before any HTML.
+
+## 12. [win-kexp] Validate the opener split against a live KDNET target
+
+The split that made per-opener handle commits possible (glslang/win-kexp#71) was validated on
+user-mode targets only — split launch, fused launch, split attach, via `examples/split_open.rs`.
+The two **kernel** halves ran on no hardware: `attach_local_kernel_begin`/`wait` and
+`attach_kernel_begin`/`wait`.
+
+- **What specifically needs a target:** the connection-string buffer now rides across the seam
+  inside the `PendingTarget` guard, because a KDNET link is only established during the wait and
+  DbgEng may still read the string after `AttachKernel` returns. Before the split that buffer
+  stayed alive by accident of scope, so nothing proves the engine reads it late — only that
+  assuming it doesn't is unsafe. A real attach over `net:port=...,key=...` settles it. Second,
+  `wait_for_kernel_break_in`'s bookkeeping (clear `INITIAL_BREAK`, absorb the spurious re-break,
+  map a watchdog-forced return to `KernelBreakTimeout`) all moved behind the guard and wants a
+  live break-in plus a deliberate timeout against an unreachable target.
+- **Why deferred:** no KDNET target was available. The split cannot change *whether* an attach
+  succeeds — `x_begin` makes the identical `AttachKernel` call — so the buffer lifetime is the
+  only genuinely new failure mode.
+- **Where it picks up:** `examples/kdtest.rs` already drives `attach_kernel` over KDNET; add a
+  `attach_kernel_begin` + `wait()` pass beside the existing fused one. Prefer a
+  snapshot-restorable VM, per item 1.
+- **Tracked as:** [glslang/win-kexp#73](https://github.com/glslang/win-kexp/issues/73).

--- a/src/server.rs
+++ b/src/server.rs
@@ -1958,6 +1958,15 @@ impl WindbgServer {
                 // The commit point is *before* the process actually starts: CreateProcessWide
                 // is deferred into the wait. That is still the right moment — once `_begin`
                 // returns Ok the spawn is committed, so a retry from here means two processes.
+                //
+                // It is also not too early, which is the natural worry: only the *spawn* is
+                // deferred, not validation. CreateProcessWide resolves and checks the image
+                // synchronously, so the ways a launch fails with nothing created all land on
+                // this `?`, before the commit — verified against a live engine for a missing
+                // path (0x80070002), a directory (0x80070005), a non-PE file (0x800700C1) and
+                // an empty command line (0x80070057). A failure from `wait` below therefore
+                // means the process really was created, which is what makes the post-commit
+                // message ("a session exists, do not open again") true rather than a guess.
                 let pending = e.launch_process_begin(&args.command_line).map_err(es)?;
                 commit();
                 pending.wait().map_err(es)

--- a/src/server.rs
+++ b/src/server.rs
@@ -5,6 +5,7 @@
 //! hatch, returning full text); session-management tools call the typed
 //! `win-kexp` methods and then wait for the target to stop.
 
+use std::cell::Cell;
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -1401,38 +1402,22 @@ fn reject_command_breakers(field: &str, value: &str, quotes: Quotes) -> Result<(
     ))
 }
 
-/// What a *failed* transition may nonetheless have already done.
+/// The failure message for a transition that fell *after* its commit: the target is open,
+/// so the error has to carry the handle rather than swallow it.
 ///
-/// win-kexp bundles the wait for the initial break into `launch_process`, `attach_process`
-/// and the kernel attaches, so a single call both creates the side effect and waits for it.
-/// From here those are one operation: a failure can mean "nothing happened" or "the process
-/// was started / the debugger attached, and then the wait failed", and this server cannot
-/// tell which. Splitting them properly means splitting the win-kexp methods, which is a
-/// change in that crate rather than this one; until then the recovery advice must not claim
-/// more than is known, because "just open again" is how a caller ends up with two processes.
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
-enum OpenSideEffect {
-    /// Loading a dump or trace. A failure leaves no target behind, so re-opening is clean.
-    None,
-    /// Attaching or launching. A failure may still have attached to, or started, a target.
-    MayHaveStartedTarget,
-}
-
-impl OpenSideEffect {
-    /// The caveat to append to a failed transition, so the failure says what is actually
-    /// known rather than asserting a clean slate.
-    fn failure_caveat(self) -> &'static str {
-        match self {
-            Self::None => "",
-            Self::MayHaveStartedTarget => {
-                "\n\nNote: this operation attaches or launches and waits for the initial break \
-                 in one step, so this failure may have left a target behind — the wait can \
-                 fail after the process was started or the attach succeeded. Check with \
-                 `execute { \"command\": \"vertarget\" }` before opening again; re-running \
-                 blindly can start a second process or attach twice."
-            }
-        }
-    }
+/// Free function so it tests without an engine, as `OpenSideEffect::failure_caveat` did
+/// before the openers were split (glslang/win-kexp#71). What it encodes is the distinction
+/// that split bought — this text must be unreachable for a failure that created nothing,
+/// because telling a caller "your session exists" when it does not strands them exactly as
+/// badly as the advice it replaced.
+fn post_commit_failure(err: &str, session_id: &str) -> String {
+    format!(
+        "{err}\n\nsession_id: {session_id}\nThis failure came *after* the target was opened, \
+         so the handle above names a session that exists — what failed is the wait for it to \
+         become ready. Do not open again to recover: for launch/attach that starts a second \
+         process or attaches twice. Inspect it (`execute {{ \"command\": \"vertarget\" }}`) or \
+         `end_session` first."
+    )
 }
 
 /// How far a session-opening job got.
@@ -1586,24 +1571,30 @@ impl WindbgServer {
     /// queued job, so no other call can be ordered across the transition.
     ///
     /// The work is split in two because the split is where correctness lives. `transition`
-    /// is the DbgEng call that actually changes the target; `report` is everything after it
-    /// — the load wait, and the diagnostic (`lm`, `vertarget`, `r`, the TTD lifetime query)
-    /// whose output the caller reads. The handle is committed *between* them, so a failure
-    /// after the target has already changed cannot cost the caller a handle for a target
-    /// that is genuinely open — which matters because the only way to get one back is to
-    /// open again, and for `launch` that spawns a second process.
+    /// opens the target; `report` is the diagnostic (`lm`, `vertarget`, `r`, the TTD
+    /// lifetime query) whose output the caller reads. The handle is committed *between*
+    /// them, so a failure after the target has already changed cannot cost the caller a
+    /// handle for a target that is genuinely open — which matters because the only way to
+    /// get one back is to open again, and for `launch` that spawns a second process.
     ///
-    /// So `transition` must be **exactly the one call that replaces the target**, and
-    /// nothing else. Anything that can fail once the target is already replaced — a
-    /// `wait_for_event` that times out very much included — belongs in `report`.
+    /// `transition` receives a `commit` callback and must invoke it **the instant the target
+    /// is created or claimed**, before anything that can still fail. Every opener therefore
+    /// reads the same way: side effect, `commit()`, then the wait. That ordering is what the
+    /// callback buys — a `wait_for_event` that times out, or an initial break that never
+    /// arrives, then fails *with* the handle rather than losing it, because by then the dump
+    /// is loaded or the process is running whatever the wait says.
+    ///
+    /// win-kexp's openers expose that seam as `x_begin()` returning a `PendingTarget` guard,
+    /// which cannot exist unless the side effect succeeded — so `commit()` between the guard
+    /// and its `wait()` is exactly the right moment, enforced by the type rather than by
+    /// convention (glslang/win-kexp#71).
     async fn opened_result<T, R>(
         &self,
-        side_effect: OpenSideEffect,
         transition: T,
         report: R,
     ) -> Result<CallToolResult, ErrorData>
     where
-        T: FnOnce(&DebugEngine) -> Result<(), String> + Send + 'static,
+        T: FnOnce(&DebugEngine, &dyn Fn()) -> Result<(), String> + Send + 'static,
         R: FnOnce(&DebugEngine) -> Result<String, String> + Send + 'static,
     {
         let id = mint_session_id();
@@ -1621,19 +1612,39 @@ impl WindbgServer {
                 // here on — including if the transition fails partway and leaves the engine
                 // holding neither the old target nor a usable new one.
                 *lock(&session) = None;
+                // Set by `commit` below. It is what lets a failure say which side of the
+                // seam it fell on: before the commit nothing was created and re-opening is
+                // correct, after it the target exists and re-opening starts a second one.
+                let committed = Cell::new(false);
+                let commit = || {
+                    *lock(&session) = Some(new_id.clone());
+                    record_open(&opens, &new_id, OpenOutcome::Landed);
+                    committed.set(true);
+                };
                 // Under `catch_unwind` for the same reason the report is: an unwind here
                 // would leave the outcome recorded as `Pending` forever, and a caller
                 // following the documented recovery would poll for a handle that is never
                 // coming.
-                let transitioned = catch_unwind(AssertUnwindSafe(|| transition(e)))
+                let transitioned = catch_unwind(AssertUnwindSafe(|| transition(e, &commit)))
                     .unwrap_or_else(|_| Err("debugger operation panicked".to_string()));
-                if let Err(err) = transitioned {
-                    let err = format!("{err}{}", side_effect.failure_caveat());
-                    record_open(&opens, &new_id, OpenOutcome::Failed(err.clone()));
-                    return Err(err);
+                // A transition that succeeded without committing would leave the caller with
+                // an open target and no handle. None do; commit defensively rather than let
+                // a future opener silently regress the guarantee.
+                if transitioned.is_ok() && !committed.get() {
+                    commit();
                 }
-                *lock(&session) = Some(new_id.clone());
-                record_open(&opens, &new_id, OpenOutcome::Landed);
+                if let Err(err) = transitioned {
+                    if !committed.get() {
+                        // Nothing was created or claimed: the slate is clean, and re-opening
+                        // is the correct recovery.
+                        record_open(&opens, &new_id, OpenOutcome::Failed(err.clone()));
+                        return Err(err);
+                    }
+                    // The target was opened and something after it failed — the wait, most
+                    // likely. The handle names a session that exists, so hand it back; making
+                    // the caller re-open to get one is how they end up with two processes.
+                    return Err(post_commit_failure(&err, &id_for_report));
+                }
                 // The target is ours from here, so a failed diagnostic still has to hand the
                 // caller their handle — otherwise they cannot use the protection this whole
                 // mechanism promises without re-running a side-effecting open.
@@ -1722,12 +1733,14 @@ impl WindbgServer {
         Parameters(args): Parameters<PathArgs>,
     ) -> Result<CallToolResult, ErrorData> {
         self.opened_result(
-            OpenSideEffect::None,
-            // `open_dump` is the call that replaces the target; the load wait belongs after
-            // the commit, since a wait that times out still leaves DbgEng holding the dump.
-            move |e| e.open_dump(&args.path).map_err(es),
+            // `open_dump` is the call that replaces the target, so commit right after it:
+            // a load wait that times out still leaves DbgEng holding the dump.
+            move |e, commit| {
+                e.open_dump(&args.path).map_err(es)?;
+                commit();
+                e.wait_for_event(LOAD_WAIT_MS).map_err(es)
+            },
             |e| {
-                e.wait_for_event(LOAD_WAIT_MS).map_err(es)?;
                 // Load the WinDbg extension DLL so `!`-extension commands resolve — most
                 // importantly `!ext.analyze -v`, the crash-dump triage workhorse. A bare
                 // engine doesn't auto-load it, and even after `.load ext` the unqualified
@@ -1755,12 +1768,14 @@ impl WindbgServer {
         Parameters(args): Parameters<PathArgs>,
     ) -> Result<CallToolResult, ErrorData> {
         self.opened_result(
-            OpenSideEffect::None,
-            // As in `open_dump`: the load wait sits after the commit, because a wait that
-            // times out still leaves DbgEng holding the trace.
-            move |e| e.open_trace(&args.path).map_err(es),
+            // As in `open_dump`: commit before the load wait, because a wait that times out
+            // still leaves DbgEng holding the trace.
+            move |e, commit| {
+                e.open_trace(&args.path).map_err(es)?;
+                commit();
+                e.wait_for_event(LOAD_WAIT_MS).map_err(es)
+            },
             |e| {
-                e.wait_for_event(LOAD_WAIT_MS).map_err(es)?;
                 // Check the index state *before* any data-model query: `!ttdext.index -status`
                 // only reads the on-disk .idx (never builds), whereas a `dx` on an unindexed
                 // trace can itself trigger the long in-memory index build. TtdExt reports a
@@ -1806,11 +1821,13 @@ impl WindbgServer {
     ))]
     async fn attach_kernel_local(&self) -> Result<CallToolResult, ErrorData> {
         self.opened_result(
-            OpenSideEffect::MayHaveStartedTarget,
-            |e| {
-                // attach_local_kernel breaks the target in internally (INITIAL_BREAK +
-                // an INFINITE wait, as a live kernel requires).
-                e.attach_local_kernel().map_err(es)
+            |e, commit| {
+                // The engine has claimed the local kernel once `_begin` returns; the
+                // break-in wait (INITIAL_BREAK + the INFINITE wait a live kernel requires)
+                // happens in `wait`, after the handle is ours.
+                let pending = e.attach_local_kernel_begin().map_err(es)?;
+                commit();
+                pending.wait().map_err(es)
             },
             |e| {
                 // The driver_object/device_object/irp_stack tools use kernel-extension
@@ -1838,11 +1855,14 @@ impl WindbgServer {
         Parameters(args): Parameters<ConnectionArgs>,
     ) -> Result<CallToolResult, ErrorData> {
         self.opened_result(
-            OpenSideEffect::MayHaveStartedTarget,
-            move |e| {
-                // attach_kernel connects, requests an initial break, and waits (INFINITE,
-                // as a live kernel requires) for the break-in — all internally.
-                e.attach_kernel(&args.connection).map_err(es)
+            move |e, commit| {
+                // `_begin` takes the connection; the KD link is dialed and the break-in
+                // awaited in `wait`. Committing between them is what stops a failed wait
+                // from looking like "nothing happened" — re-dialing a live link is not a
+                // clean retry.
+                let pending = e.attach_kernel_begin(&args.connection).map_err(es)?;
+                commit();
+                pending.wait().map_err(es)
             },
             |e| {
                 // Load kdexts.dll so the driver_object/device_object/irp_stack tools'
@@ -1907,10 +1927,13 @@ impl WindbgServer {
     ) -> Result<CallToolResult, ErrorData> {
         let pid = args.pid;
         self.opened_result(
-            OpenSideEffect::MayHaveStartedTarget,
-            move |e| {
-                // attach_process waits for the break-in internally.
-                e.attach_process(pid).map_err(es)
+            move |e, commit| {
+                // Attached once `_begin` returns; the break-in wait follows the commit, so
+                // a wait that fails cannot read as "never attached" and get retried into a
+                // second attach on the same PID.
+                let pending = e.attach_process_begin(pid).map_err(es)?;
+                commit();
+                pending.wait().map_err(es)
             },
             |e| e.execute_command("r").map_err(es),
         )
@@ -1931,10 +1954,13 @@ impl WindbgServer {
         Parameters(args): Parameters<CommandLineArgs>,
     ) -> Result<CallToolResult, ErrorData> {
         self.opened_result(
-            OpenSideEffect::MayHaveStartedTarget,
-            move |e| {
-                // launch_process waits for the initial break internally.
-                e.launch_process(&args.command_line).map_err(es)
+            move |e, commit| {
+                // The commit point is *before* the process actually starts: CreateProcessWide
+                // is deferred into the wait. That is still the right moment — once `_begin`
+                // returns Ok the spawn is committed, so a retry from here means two processes.
+                let pending = e.launch_process_begin(&args.command_line).map_err(es)?;
+                commit();
+                pending.wait().map_err(es)
             },
             |e| e.execute_command("r").map_err(es),
         )
@@ -3539,20 +3565,26 @@ mod tests {
         assert!(!opens.iter().any(|(id, _)| id == "sess-slow"));
     }
 
-    /// A failed transition must not claim a clean slate for the operations that create the
-    /// target and wait for it in one win-kexp call. "Just open again" is how a caller ends
-    /// up with two processes.
+    /// A failure that lands after the target is open must hand the handle back and say not
+    /// to re-open. "Just open again" is how a caller ends up with two processes — before the
+    /// openers were split (glslang/win-kexp#71) this server could not tell that case from a
+    /// clean slate and had to hedge on every attach and launch; now it knows which it is.
     #[test]
-    fn side_effecting_opens_warn_that_a_failure_may_leave_a_target() {
-        let caveat = OpenSideEffect::MayHaveStartedTarget.failure_caveat();
-        assert!(caveat.contains("vertarget"), "must say how to check");
+    fn a_post_commit_failure_returns_the_handle_and_warns_against_reopening() {
+        let msg = post_commit_failure("the target never broke in", "sess-1");
         assert!(
-            caveat.contains("second process") || caveat.contains("attach twice"),
+            msg.contains("the target never broke in"),
+            "must keep the underlying error"
+        );
+        assert!(
+            msg.contains("session_id: sess-1"),
+            "must hand back the handle — re-opening is the only other way to get one"
+        );
+        assert!(
+            msg.contains("second process") || msg.contains("attaches twice"),
             "must name the cost of re-running blindly"
         );
-
-        // Loading a dump leaves nothing behind, so it says nothing extra.
-        assert!(OpenSideEffect::None.failure_caveat().is_empty());
+        assert!(msg.contains("vertarget"), "must say how to inspect it");
     }
 
     /// A burst of concurrent opens legitimately exceeds the bound while all of them are

--- a/src/server.rs
+++ b/src/server.rs
@@ -1414,9 +1414,9 @@ fn post_commit_failure(err: &str, session_id: &str) -> String {
     format!(
         "{err}\n\nsession_id: {session_id}\nThis failure came *after* the target was opened, \
          so the handle above names a session that exists — what failed is the wait for it to \
-         become ready. Do not open again to recover: for launch/attach that starts a second \
-         process or attaches twice. Inspect it (`execute {{ \"command\": \"vertarget\" }}`) or \
-         `end_session` first."
+         become ready. Do not open again to recover: for launch or attach, doing so would \
+         start a second process or attach a second time. Inspect it (`execute \
+         {{ \"command\": \"vertarget\" }}`) or `end_session` first."
     )
 }
 
@@ -3581,8 +3581,8 @@ mod tests {
             "must hand back the handle — re-opening is the only other way to get one"
         );
         assert!(
-            msg.contains("second process") || msg.contains("attaches twice"),
-            "must name the cost of re-running blindly"
+            msg.contains("second process") && msg.contains("attach a second time"),
+            "must name the cost of re-running blindly, for launch and attach alike"
         );
         assert!(msg.contains("vertarget"), "must say how to inspect it");
     }


### PR DESCRIPTION
> [!NOTE]
> **Unblocked.** [glslang/win-kexp#72](https://github.com/glslang/win-kexp/pull/72) is merged, and
> `Cargo.lock` is repinned from `6644f0f` to `47993c4` — without that, CI would resolve a win-kexp
> revision predating the `*_begin` openers and fail on four missing methods. No git rebase was
> needed: this branch is 0 commits behind `main`.

## The gap this closes

0.3.0 shipped per-opener session handles, but only `open_dump` and `open_trace` could actually
commit one. win-kexp fused the target-creating call with the wait for the initial break into a
single `Result`, so for the other four a failure could mean either:

- nothing happened — the slate is clean, re-open; or
- the target *was* created or attached, and only the wait failed — never re-open.

Indistinguishable from here, and needing opposite recovery. `OpenSideEffect` existed solely to
hedge on those four, pointing callers at `vertarget` instead of claiming a retry was safe. That
removed the bad advice without removing the ambiguity — the handle still wasn't committed,
because there was nowhere to commit it.

## The seam

win-kexp#71 splits the openers: `x_begin()` returns a `PendingTarget` guard that cannot exist
unless the side effect succeeded, and `wait()` completes the initial break.

`opened_result`'s `transition` now receives a `commit` callback to invoke there, so all six
openers read identically:

```rust
let pending = e.attach_process_begin(pid).map_err(es)?;
commit();
pending.wait().map_err(es)
```

A failure is then sorted by which side of the seam it fell on — before it, the error stands
alone and the open is recorded `Failed`; after it, the error carries the `session_id` and says
not to open again. Dumps and traces move to the same shape, their load wait crossing from
`report` into `transition`, so all six are uniform rather than two-of-a-kind.

`OpenSideEffect` and its caveat delete entirely.

## Notes for review

- **The defensive commit.** A `transition` that returns `Ok` without committing would leave the
  caller with an open target and no handle. None do; it commits anyway rather than let a future
  opener silently regress the guarantee.
- **`post_commit_failure` is a free function** for the same reason `failure_caveat` was one — so
  the message tests without an engine. The old test is replaced by one over it.
- **The queued-precheck design is untouched.** The gate still runs in the same queued job, so
  the ordering guarantee in the CHANGELOG holds unchanged.

## Validation

| | |
|---|---|
| unit tests | 78 pass |
| clippy | clean (`--all-targets`) |
| smoke, debugger tier | `WINDBG_MCP_SMOKE_DUMP=1` — `a_dump_session_opens_reads_and_closes` passes against the sample dump, exercising the restructured `open_dump` path end to end |

Re-verified against the **merged** win-kexp `main` (`47993c4`), not a local path patch — build,
clippy, tests and smoke all run against the same revision `Cargo.lock` names.

**Not validated:** the two kernel attaches, for want of a KDNET target. Tracked as
[glslang/win-kexp#73](https://github.com/glslang/win-kexp/issues/73) and added to `FOLLOWUPS.md`
as item 12 so it does not rest in a PR body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Session identifiers are now retained and returned even when initial target connection or break-in waits fail.
  * Improved recovery guidance is provided when opening a dump, trace, kernel, process, or launched target encounters a post-connection error.
  * Target reopening now clearly distinguishes safe retries from targets that have already been created.

* **Documentation**
  * Updated the unreleased changelog and follow-up documentation with details on connection handling and validation work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
