### PR TITLE
test(engine): prove the bounded-command path, and state its coverage rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **The bounded-command path now has a stated coverage rule, and tests that prove it works.**
+  0.3.0 routed `execute`, `dx` and the `ttd_*` tools through a watchdog that Ctrl+Breaks a
+  runaway command before it can pin the engine thread, but nothing exercised that interrupt
+  end to end, and "why these five?" had no written answer.
+
+  `src/engine.rs` gains both. The queue-aware budget arithmetic is now a pure function with
+  unit tests that ride `cargo test`; three `#[ignore]`d tests drive a real engine, proving a
+  runaway command self-aborts and leaves the engine usable — including from behind a queued
+  job, which is the half win-kexp's own tests cannot cover because the queue belongs to this
+  crate. See [`docs/smoke-test.md`](./docs/smoke-test.md).
+
+  The coverage rule, recorded in [`DECISIONS.md`](./DECISIONS.md): bound a command when its
+  cost scales with the target's size or with an arbitrary caller-supplied expression; leave
+  point queries (`k`, `lm`, `u`, `!irp`, …) unbounded. Arming the watchdog measurably rounds a
+  command's duration up to a multiple of 200ms, so bounding a 30ms query would make it a 200ms
+  one for a runaway case it does not have. `index_trace` is a deliberate exception and
+  now says so: it is O(trace), but `-force` deletes before it rebuilds, so an abort can leave no
+  usable index at all — its tool description now tells callers to wait rather than re-issue it.
+
 ### Fixed
 
 - **Every opener now commits its session handle, including the four that attach or launch.**

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -5,6 +5,68 @@ status. Keep entries short; link to code with `file:line` where it helps a futur
 
 ---
 
+## Which tools run on the bounded-command path (2026-08-02)
+
+**Context.** `EngineHandle::run_command` (`src/engine.rs`) runs a raw command under win-kexp's
+`execute_command_bounded`, whose watchdog `SetInterrupt`s the engine before the caller's timeout so
+a runaway command aborts instead of pinning the single engine thread. It was adopted (#45) for
+`execute`, `dx`, `ttd_calls`, `ttd_memory`, `ttd_events`. Every other command-executing tool —
+`backtrace`, `modules`, `threads`, `disassemble`, `set_breakpoint`, `goto_position`,
+`driver_object`, `device_object`, `irp_stack`, `ioctl_trace`, `index_trace` — still calls
+`execute_command` through plain `run`. #46 asked whether that split is principled or accidental.
+
+**The measurement that decides it.** Arming the watchdog is not free, and its cost is not a small
+constant. win-kexp spawns a thread that polls a `done` flag on a 200ms sleep and joins it after
+`Execute` returns — so the join waits out the rest of that sleep, and a bounded command takes
+`ceil(d / 200ms) * 200ms`. Measured against the sample dump
+(`measure_what_the_bounded_path_costs_a_quick_command`, `src/engine.rs`):
+
+| command | unbounded (median) | bounded (median) |
+| --- | --- | --- |
+| `lm` | 0.22ms | ~0.3ms **or** ~200.7ms — it races the watchdog's first poll |
+| `.for`, short | 127ms | 200.8ms |
+| `.for`, long | 377ms | 401.0ms |
+
+Read as a tax on a point query: **anything taking 1–200ms now takes 200ms** — a 30ms `k` becomes a
+200ms `k`. Only sub-millisecond commands can escape, by finishing before the watchdog thread's
+first poll, and that is a race rather than a guarantee (the `lm` median flips between the two modes
+run to run on one host). An analysis session issues these by the dozen.
+
+**Decision.** Keep the split, on a stated criterion rather than on "these felt slow":
+
+> Bound a command when its cost scales with the **target's size** or with an **arbitrary
+> caller-supplied expression**. Leave point queries against current target state unbounded.
+
+- **Bounded.** `execute` and `dx` are open-ended hatches — the caller supplies the command, so
+  nothing bounds their runtime. The `ttd_*` wrappers are whole-trace scans, i.e. O(trace), and
+  traces are routinely gigabytes. These are where the wedge actually happened.
+- **Unbounded.** `k` walks one stack, `u` decodes a screenful, `lm` lists what is loaded, `!irp`
+  formats one structure, `bp` sets one breakpoint. Their cost is set by a small fixed feature of
+  the target, not by anything the caller says, so the 100ms buys nothing. `!tt` (`goto_position`)
+  looks trace-scaled but is not: a seek replays from the nearest keyframe, so it is bounded by
+  keyframe spacing rather than trace length.
+- **Already bounded elsewhere, so not routed here.** The execution-control tools (`go`, the
+  `step_*` family, `reverse_go`) go through `execute_and_wait`, and `run_to_address` through
+  win-kexp's `run_to_address`; both carry their own watchdog. The openers are bounded by
+  `LOAD_WAIT_MS` on the wait half. A second watchdog would be redundant.
+- **`index_trace` is a deliberate exception.** `!ttdext.index -force` *is* O(trace) and can
+  legitimately run for many minutes, so the criterion above would bound it — but it is the one
+  case where the abort is worse than the wedge. `-force` deletes an unloadable `.idx` and rebuilds
+  it, so interrupting mid-rebuild can leave no usable index at all, and the long run is productive
+  work rather than a runaway. A wedge here is temporary and self-heals when the build finishes.
+
+**What the criterion does not cover.** `reachable_from_dispatch` issues *many* `uf` commands inside
+one job, with `max_functions`/`max_depth` supplied by the caller and uncapped. That is
+caller-controlled unbounded runtime, so by the criterion it should be bounded — but `run_command`
+bounds a single command string and cannot help a multi-command job. It needs a job-level deadline
+instead; see FOLLOWUPS.md item 13.
+
+**Status:** accepted. Revisit if win-kexp's watchdog stops quantizing to 200ms (parking on a condvar
+instead of polling a sleep would make it ~free), at which point "bound everything except
+`index_trace`" becomes the cheaper and simpler rule — FOLLOWUPS.md item 14.
+
+---
+
 ## Dynamic confirmation of static reachability (2026-07-03)
 
 **Context.** `reachable_from_dispatch` (`src/server.rs:1195-1279`) gives a *sound* static verdict

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -1,10 +1,12 @@
 # Follow-ups
 
-Deferred work, in three clusters: items 1–6 come from the reachability-confirmation effort (path
+Deferred work, in four clusters: items 1–6 come from the reachability-confirmation effort (path
 recipe + `run_to_address`, merged 2026-07-04), items 7–11 from surveying this server against the
-MCP `2026-07-28` extensions (tasks, apps), and item 12 from the opener split
-(glslang/win-kexp#71, 2026-08-01). Each item notes its repo, why it was deferred, and where
-it picks up. See [`DECISIONS.md`](./DECISIONS.md) for the design rationale (D1–D5) items 1–6 extend.
+MCP `2026-07-28` extensions (tasks, apps), item 12 from the opener split
+(glslang/win-kexp#71, 2026-08-01), and items 13–14 from the bounded-command coverage review
+(#46, 2026-08-02). Each item notes its repo, why it was deferred, and where
+it picks up. See [`DECISIONS.md`](./DECISIONS.md) for the design rationale (D1–D5) items 1–6 extend,
+and the 2026-08-02 entry for the one items 13–14 extend.
 
 Items are roughly ordered by how soon they're worth doing, within each cluster.
 
@@ -225,3 +227,41 @@ The two **kernel** halves ran on no hardware: `attach_local_kernel_begin`/`wait`
   `attach_kernel_begin` + `wait()` pass beside the existing fused one. Prefer a
   snapshot-restorable VM, per item 1.
 - **Tracked as:** [glslang/win-kexp#73](https://github.com/glslang/win-kexp/issues/73).
+
+## 13. [windbg-mcp] A job-level deadline for `reachable_from_dispatch`
+
+`reachable_from_dispatch` runs its whole breadth-first walk — up to `max_functions` × one `uf`
+command each — inside a *single* engine job. Both `max_functions` (default 256) and `max_depth`
+(default 32) come from the caller and are uncapped, so a large enough pair pins the engine thread
+for as long as the walk takes. That is the same wedge the bounded path fixed, arriving by a
+different route.
+
+- **Why the bounded path doesn't reach it:** `EngineHandle::run_command` bounds *one* command
+  string. Here no individual `uf` is the problem — the aggregate is.
+- **Where it picks up:** the walk already drives every disassembly through one `&mut uf` closure
+  (`src/server.rs`), which is the natural place to check a deadline and stop with a partial,
+  honestly-labelled verdict — "NOT REACHABLE within the budget" is already the tool's contract for
+  an exhausted bound, so a time bound reports as a bound rather than as a new failure mode.
+  A cap on `max_functions` is the cheaper half-measure; it bounds the walk in nodes, not seconds.
+- **Why deferred:** the defaults are safe (a 256-function walk against a loaded dump is seconds),
+  so this is reachable only by a caller asking for it. Recorded by the coverage review in
+  DECISIONS.md (2026-08-02) rather than fixed there, because it needs a different mechanism than
+  the review's subject.
+
+## 14. [win-kexp] Make arming the bounded watchdog ~free
+
+`execute_command_bounded` spawns a watchdog thread that polls a `done` flag on a
+`thread::sleep(200ms)` loop, and joins it once `Execute` returns. Because the flag is set while
+that thread is mid-sleep, the join waits out the remainder — so a bounded command takes
+`ceil(d / 200ms) * 200ms`. Measured (`measure_what_the_bounded_path_costs_a_quick_command`,
+`src/engine.rs`): a 127ms command takes 201ms, a 377ms one takes 401ms, and a 0.2ms `lm` takes
+either ~0.3ms or ~200ms depending on whether it beats the watchdog thread's first poll.
+
+Parking on a condvar (or `thread::park_timeout` + `unpark`) instead of sleeping would let `done`
+wake the watchdog immediately and drop that to ~0.
+
+- **Why it matters here:** the cost is the *only* reason windbg-mcp's cheap point-query tools stay
+  off the bounded path (DECISIONS.md, 2026-08-02). Remove it and the coverage rule simplifies to
+  "bound everything except `index_trace`", with no per-call tax to weigh against a rare wedge.
+- **Why deferred:** it is a win-kexp change with its own review, and the current split is correct
+  as long as the cost stands — this is an improvement to the tradeoff, not a fix to a defect.

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -101,6 +101,39 @@ only watches GitHub Actions here, so cargo bumps arrive by hand.
    revision's `_meta` requirements — that is where per-request metadata rules land.
 4. Update the revision list in `README.md` and this file's list above to match what actually passes.
 
+## The bounded-command tests
+
+`src/engine.rs` carries a second set of `#[ignore]`d tests, separate from this file's tiers because
+they drive `EngineHandle` in-process rather than the binary over stdio — they are about the engine
+thread, not the wire.
+
+```pwsh
+cargo test --bin windbg-mcp -- --ignored --nocapture --test-threads=1 engine::tests
+```
+
+`--test-threads=1` is required: dbgeng holds **one debuggee session per process**, so these cannot
+overlap. They open the checked-in sample dump with an empty symbol path, so they run offline; total
+runtime is about a minute, most of it deliberate waiting.
+
+- `a_runaway_command_self_aborts_and_leaves_the_engine_usable` — a `.for` loop sized to run for
+  hours is cut short by the watchdog, and the engine executes the *next* command normally. This is
+  the wedge that used to need a server restart. Proof of interruption is the loop counter left in
+  `$t0`, not the clock and not the "interrupted after" note (which is appended whenever the watchdog
+  *attempted* an interrupt, even one the engine ignored).
+- `a_runaway_command_queued_behind_another_job_still_beats_its_caller` — the same, from behind a
+  job that already occupies the engine thread for half the call budget. This is the half win-kexp
+  cannot cover, because the queue belongs to this crate: budgeting from the full `call_timeout`
+  instead of what remains passes every other assertion and fails here.
+- `measure_what_the_bounded_path_costs_a_quick_command` — prints what arming the watchdog costs,
+  as a distribution across three command lengths. It asserts nothing; it is the evidence behind
+  which tools take the bounded path ([`DECISIONS.md`](../DECISIONS.md), 2026-08-02), namely that
+  a bounded command is rounded up to a multiple of 200ms. Re-run it after a win-kexp watchdog
+  change — if that cost goes away, so does the reason for the split.
+
+The pure budget arithmetic they exercise is also unit-tested in the same module and rides
+`cargo test` everywhere, so a regression in the common case fails in CI rather than waiting for a
+manual run.
+
 ## Manual checklist
 
 Not automated: no runner has a kernel target, a TTD-capable engine, or elevation. Run these by hand

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -53,6 +53,33 @@ impl fmt::Display for EngineError {
     }
 }
 
+/// How much of the call budget the watchdog leaves for itself: it Ctrl+Breaks the engine this
+/// long before the caller's wait expires, so the interrupt has time to land, `Execute` has time
+/// to unwind, and the *engine thread* is free again before the tool call reports its timeout.
+const WATCHDOG_HEADROOM: Duration = Duration::from_secs(15);
+
+/// The watchdog deadline for a command that waited `queued_wait` in the engine queue, given the
+/// caller's total `call_timeout`.
+///
+/// The outer timeout in [`EngineHandle::run`] starts counting at *submission*, but a command may
+/// sit behind another job (e.g. a backgrounded `go`) before reaching the worker. Budgeting from
+/// the time *remaining* — not the full `call_timeout` — is what makes the interrupt fire before
+/// the caller gives up regardless of queue wait.
+///
+/// Floored at [`WATCHDOG_HEADROOM`] rather than allowed to reach zero, because zero *disables*
+/// win-kexp's watchdog: a command dequeued at or past the deadline would then be the one command
+/// that runs unbounded, which is exactly the wedge case. The floor overruns the caller's timeout
+/// by design — the caller has already given up by then, and freeing the engine 15s late still
+/// beats never.
+fn watchdog_budget_ms(call_timeout: Duration, queued_wait: Duration) -> u32 {
+    call_timeout
+        .saturating_sub(queued_wait)
+        .saturating_sub(WATCHDOG_HEADROOM)
+        .max(WATCHDOG_HEADROOM)
+        .as_millis()
+        .min(u32::MAX as u128) as u32
+}
+
 /// A unit of work to run on the engine thread, plus where to send its result.
 struct Job {
     run: Box<dyn FnOnce(&DebugEngine) -> Reply + Send>,
@@ -137,8 +164,16 @@ impl EngineHandle {
     /// runs longer than the call budget, win-kexp's `execute_command_bounded` Ctrl+Breaks the
     /// engine so it aborts and frees the thread — instead of a runaway command (most importantly
     /// an unbounded `s` memory search) pinning the single engine thread and wedging every later
-    /// call. Use this for command-executing tools (`execute`, `dx`, the `ttd_*` wrappers); the
-    /// quick, inherently-bounded operations can keep using [`Self::run`].
+    /// call.
+    ///
+    /// **Which tools use this** is a deliberate split, not an oversight — see `DECISIONS.md`
+    /// (2026-08-02). Route a tool here when its cost scales with the *target's size* or with an
+    /// *arbitrary caller-supplied expression*: `execute` and `dx` (open-ended hatches) and the
+    /// `ttd_*` wrappers (whole-trace scans). Point queries against current target state — `k`,
+    /// `lm`, `~`, `u`, `!drvobj`, `!devobj`, `!irp`, `bp` — keep [`Self::run`], because arming
+    /// the watchdog rounds a command's duration up to a multiple of 200ms (measured; win-kexp
+    /// joins a 200ms poll loop), so a 30ms query would become a 200ms one for a runaway case
+    /// it does not have.
     ///
     /// `precheck` runs **on the engine thread**, immediately before the command and after any
     /// job queued ahead of it. Callers use it for gates that must not be evaluated while
@@ -147,26 +182,389 @@ impl EngineHandle {
     where
         P: FnOnce() -> Result<(), String> + Send + 'static,
     {
-        // The outer timeout in `run` starts counting at *submission*, but this command may sit
-        // in the engine queue behind another job (e.g. a backgrounded `go`) before reaching the
-        // worker. Compute the watchdog budget from the time *remaining* until that timeout — not
-        // the full `call_timeout` — so it Ctrl+Breaks ~15s before the caller gives up regardless
-        // of queue wait. `submitted.elapsed()` (evaluated on the engine thread) is that wait.
         let call_timeout = self.call_timeout;
         let submitted = Instant::now();
         self.run(move |e| {
             precheck()?;
-            // Floor the budget so a command dequeued near the deadline still arms the watchdog
-            // (a 0 budget disables it) and thus still frees the engine promptly.
-            let budget_ms = call_timeout
-                .saturating_sub(submitted.elapsed())
-                .saturating_sub(Duration::from_secs(15))
-                .max(Duration::from_secs(15))
-                .as_millis()
-                .min(u32::MAX as u128) as u32;
+            // `submitted.elapsed()`, evaluated here on the engine thread, is the queue wait —
+            // see [`watchdog_budget_ms`] for why the budget is computed from what remains.
+            let budget_ms = watchdog_budget_ms(call_timeout, submitted.elapsed());
             e.execute_command_bounded(&command, budget_ms)
                 .map_err(|e| e.to_string())
         })
         .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ---- the watchdog budget (pure) -----------------------------------------------
+
+    /// The everyday case: nothing queued ahead, so the watchdog fires one headroom before the
+    /// caller's wait expires. This is the number that keeps a runaway command from outliving
+    /// the tool call that started it.
+    #[test]
+    fn an_unqueued_command_is_bounded_one_headroom_short_of_the_call_timeout() {
+        let timeout = Duration::from_secs(300);
+        assert_eq!(
+            watchdog_budget_ms(timeout, Duration::ZERO),
+            (300 - 15) * 1000
+        );
+    }
+
+    /// The property the queue-awareness exists for, stated as the invariant rather than as an
+    /// arithmetic identity: **queue wait + watchdog budget must not exceed the caller's
+    /// timeout**, or the caller gives up while the command is still running — the wedge.
+    ///
+    /// Budgeting from the full `call_timeout` (ignoring the wait) breaks this for every
+    /// non-zero wait, which is why it is checked across a spread rather than at one point.
+    #[test]
+    fn a_queued_command_still_aborts_before_its_caller_gives_up() {
+        let timeout = Duration::from_secs(300);
+        for waited in [0, 1, 30, 100, 240, 269] {
+            let waited = Duration::from_secs(waited);
+            let budget = Duration::from_millis(watchdog_budget_ms(timeout, waited) as u64);
+            assert!(
+                waited + budget <= timeout,
+                "a command dequeued after {waited:?} gets a {budget:?} budget — it would still \
+                 be running at the {timeout:?} mark, which is the wedge this bounds"
+            );
+        }
+    }
+
+    /// Past the point where any headroom is left, the budget floors instead of reaching zero —
+    /// because zero *disables* win-kexp's watchdog, which would make a command dequeued near
+    /// the deadline the one command that runs unbounded.
+    ///
+    /// The floor deliberately overruns the caller's timeout: by then the caller has already
+    /// given up, and the remaining job is to free the engine thread for the *next* call.
+    #[test]
+    fn a_command_dequeued_past_the_deadline_is_still_bounded() {
+        let timeout = Duration::from_secs(300);
+        for waited in [290, 300, 600, 86_400] {
+            assert_eq!(
+                watchdog_budget_ms(timeout, Duration::from_secs(waited)),
+                15_000,
+                "a command dequeued after {waited}s must still arm the watchdog"
+            );
+        }
+    }
+
+    /// A `call_timeout` beyond `u32::MAX` milliseconds (~49 days) must saturate, not wrap: a
+    /// wrapped budget could land on 0 and silently disable the watchdog.
+    #[test]
+    fn an_absurd_call_timeout_saturates_rather_than_wrapping() {
+        assert_eq!(
+            watchdog_budget_ms(Duration::from_secs(u32::MAX as u64), Duration::ZERO),
+            u32::MAX
+        );
+    }
+
+    // ---- the interrupt path, against a real engine ---------------------------------
+    //
+    // These need DbgEng and a target, so they are `#[ignore]`d rather than gated by an env
+    // var: they are the manual counterpart to win-kexp's own bounded-command tests, and CI
+    // has no way to provide what they need.
+    //
+    // dbgeng holds **one debuggee session per process**, so they must not run in parallel
+    // with each other:
+    //
+    //     cargo test --bin windbg-mcp -- --ignored --nocapture --test-threads=1 engine::tests
+    //
+    // win-kexp proves the primitive (`execute_command_bounded` aborts a runaway command, and
+    // the next command survives it). What is unproven *here* — and is what these cover — is
+    // this crate's wiring of it: that `run_command`'s budget actually reaches the watchdog,
+    // that the abort beats the caller's timeout (including from behind a queued job), and
+    // that the engine thread is free for the next call afterwards.
+
+    /// The checked-in kernel crash dump, also used by `tests/mcp_smoke.rs`'s target tier.
+    const SAMPLE_DUMP: &str = concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/docs/samples/052126-34312-01.dmp"
+    );
+
+    /// A deliberately runaway command: a tight `.for` in the expression evaluator, which is
+    /// genuinely CPU-bound and polls for Ctrl+Break exactly as a real runaway command does.
+    ///
+    /// A broad `s` memory search — the wedge that motivated all of this — is the wrong probe
+    /// despite being the motivating case: it skips unmapped ranges, so even a whole-address-
+    /// space search returns almost immediately on this dump. The `.for` also leaves its
+    /// progress in `$t0`, which is what proves the interruption below.
+    ///
+    /// Sized to run for hours, so "did not finish" cannot mean "finished early on a fast host".
+    const RUNAWAY_ITERATIONS: u64 = 0x4000_0000;
+
+    fn runaway_command() -> String {
+        format!(".for (r $t0 = 0; @$t0 < 0x{RUNAWAY_ITERATIONS:x}; r $t0 = @$t0 + 1) {{ }}")
+    }
+
+    /// Reads a user pseudo-register (`$t0`, `$t1`) as a number. Returns `None` if the engine
+    /// printed something unexpected, so a caller can tell "unreadable" from "zero".
+    fn pseudo_register(text: &str, name: &str) -> Option<u64> {
+        text.split_whitespace()
+            .find_map(|tok| tok.strip_prefix(&format!("{name}=")))
+            .and_then(|v| u64::from_str_radix(&v.replace('`', ""), 16).ok())
+    }
+
+    /// Opens the sample dump on `engine`, or returns why it could not.
+    ///
+    /// `open_dump` only hands the file to DbgEng — the target is not loaded, and `Execute`
+    /// blocks, until `wait_for_event` drives the load. Both halves therefore have to run in
+    /// **one** job: an engine left between them is not a usable target for anything else.
+    async fn open_sample_dump(engine: &EngineHandle) -> Result<(), String> {
+        engine
+            .run(|e| {
+                // Empty symbol path, deliberately: these tests measure *timing*, and a symbol
+                // server on the ambient `_NT_SYMBOL_PATH` would put an unbounded network fetch
+                // inside the very budget under test. Nothing here needs symbols — the `.for`
+                // probe runs in the expression evaluator.
+                let _ = e.set_symbol_path("");
+                e.open_dump(SAMPLE_DUMP).map_err(|e| e.to_string())?;
+                e.wait_for_event(60_000).map_err(|e| e.to_string())?;
+                Ok(String::new())
+            })
+            .await
+            .map(|_| ())
+            .map_err(|e| e.to_string())
+    }
+
+    /// Whether the engine still *executes* commands. Asserted on an effect rather than on
+    /// returned text: `Execute` echoes the command into the output buffer before running it,
+    /// so any substring check against the command itself passes on the echo alone — even for
+    /// a command that was aborted before it did anything.
+    async fn engine_still_executes(engine: &EngineHandle) -> bool {
+        const SENTINEL: u64 = 0x5A5E;
+        if engine
+            .run(|e| {
+                e.execute_command(&format!("r $t1 = 0x{SENTINEL:x}"))
+                    .map_err(|e| e.to_string())
+            })
+            .await
+            .is_err()
+        {
+            return false;
+        }
+        match engine
+            .run(|e| e.execute_command("r $t1").map_err(|e| e.to_string()))
+            .await
+        {
+            Ok(text) => pseudo_register(&text, "$t1") == Some(SENTINEL),
+            Err(_) => false,
+        }
+    }
+
+    /// The whole point of the bounded path, end to end at this crate's altitude: a command
+    /// that would run for hours comes back to the caller *as a result* (not as a timeout),
+    /// and the engine thread is free for the next call.
+    #[tokio::test]
+    #[ignore = "needs DbgEng and a target; run manually with --ignored --test-threads=1"]
+    async fn a_runaway_command_self_aborts_and_leaves_the_engine_usable() {
+        // 30s of call budget leaves the watchdog the 15s floor, which keeps the test short
+        // while still exercising the real arithmetic rather than a special case.
+        let engine = EngineHandle::spawn(Duration::from_secs(30));
+        open_sample_dump(&engine).await.expect("open sample dump");
+
+        let started = Instant::now();
+        let out = engine
+            .run_command(runaway_command(), || Ok(()))
+            .await
+            .expect("a bounded runaway command must return a result, not a timeout");
+        let elapsed = started.elapsed();
+
+        // Proof of interruption is the loop counter, not the clock and not the note: the note
+        // is appended whenever the watchdog *attempted* an interrupt, so an interrupt the
+        // engine ignored would still produce it.
+        let t0 = engine
+            .run(|e| e.execute_command("r $t0").map_err(|e| e.to_string()))
+            .await
+            .ok()
+            .and_then(|text| pseudo_register(&text, "$t0"))
+            .expect("could not read $t0 back");
+        println!(
+            "bounded command returned after {elapsed:?}, $t0 = {t0:#x} of {RUNAWAY_ITERATIONS:#x}"
+        );
+        assert!(t0 > 0, "the loop never started ($t0 = {t0:#x})");
+        assert!(
+            t0 < RUNAWAY_ITERATIONS,
+            "the loop ran to completion ($t0 = {t0:#x}) — the watchdog did not cut it short, \
+             so the rest of this test would prove nothing"
+        );
+        assert!(
+            out.contains("interrupted after"),
+            "no interruption note despite a loop that stopped short:\n{out}"
+        );
+
+        // The wedge itself. Before the bounded path this is where every later call timed out,
+        // and the only recovery was restarting the server.
+        assert!(
+            engine_still_executes(&engine).await,
+            "the engine thread was not freed by the abort — this is the wedge"
+        );
+
+        let _ = engine
+            .run(|e| {
+                e.end_session()
+                    .map(|_| String::new())
+                    .map_err(|e| e.to_string())
+            })
+            .await;
+    }
+
+    /// The queue-aware half of the budget, which is the part that has no equivalent in
+    /// win-kexp: a bounded command that spent most of the call budget waiting its turn must
+    /// still abort *before* its caller's timeout, not one full budget after it was dequeued.
+    ///
+    /// Budgeting from the full `call_timeout` instead of the remainder passes every assertion
+    /// in the test above and fails here — the command would abort ~30s after the caller had
+    /// already given up, with the engine pinned in between.
+    // Multi-threaded runtime, because this test blocks on the "job started" signal below.
+    // On the default current-thread runtime that block also starves the spawned task that
+    // would send it, and the test deadlocks instead of failing.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[ignore = "needs DbgEng and a target; run manually with --ignored --test-threads=1"]
+    async fn a_runaway_command_queued_behind_another_job_still_beats_its_caller() {
+        const CALL_TIMEOUT: Duration = Duration::from_secs(60);
+        const QUEUE_WAIT: Duration = Duration::from_secs(30);
+
+        let engine = EngineHandle::spawn(CALL_TIMEOUT);
+        open_sample_dump(&engine).await.expect("open sample dump");
+
+        // Occupy the engine thread. The signal is sent from *inside* the job, so the runaway
+        // command below is submitted while this one is provably already running — a plain
+        // spawn would race and might queue the two the other way round.
+        let (running_tx, running_rx) = std::sync::mpsc::channel();
+        let blocker = tokio::spawn({
+            let engine = engine.clone();
+            async move {
+                engine
+                    .run(move |_| {
+                        running_tx.send(()).expect("signal receiver alive");
+                        thread::sleep(QUEUE_WAIT);
+                        Ok(String::new())
+                    })
+                    .await
+            }
+        });
+        running_rx.recv().expect("blocker job started");
+
+        let started = Instant::now();
+        let out = engine
+            .run_command(runaway_command(), || Ok(()))
+            .await
+            .expect("a bounded runaway command must return a result, not a timeout");
+        let elapsed = started.elapsed();
+
+        println!(
+            "queued {QUEUE_WAIT:?}, then returned after {elapsed:?} of a {CALL_TIMEOUT:?} budget"
+        );
+        assert!(
+            out.contains("interrupted after"),
+            "the queued command was not interrupted:\n{out}"
+        );
+        assert!(
+            elapsed < CALL_TIMEOUT,
+            "the abort landed after the caller's {CALL_TIMEOUT:?} timeout ({elapsed:?}) — the \
+             watchdog budget did not account for the {QUEUE_WAIT:?} spent queued"
+        );
+        assert!(
+            engine_still_executes(&engine).await,
+            "the engine thread was not freed by the abort"
+        );
+
+        let _ = blocker.await;
+        let _ = engine
+            .run(|e| {
+                e.end_session()
+                    .map(|_| String::new())
+                    .map_err(|e| e.to_string())
+            })
+            .await;
+    }
+
+    /// What the bounded path *costs* a command that was never going to run away — the evidence
+    /// behind the coverage split in `DECISIONS.md` (2026-08-02), kept as a test so a win-kexp
+    /// change to the watchdog can be re-measured rather than re-argued.
+    ///
+    /// The cost is not a constant overhead but a **quantization**, which is why this reports a
+    /// distribution rather than a mean. win-kexp's watchdog thread checks its `done` flag, then
+    /// sleeps 200ms; `Execute` returning sets the flag, but the join has to wait for the sleep
+    /// to end. A command therefore takes `ceil(d / 200ms) * 200ms` — measured on the sample
+    /// dump: `lm` at 0.2ms and a `.for` at 127ms both come back at ~200ms, and a 377ms `.for`
+    /// at ~401ms.
+    ///
+    /// The one escape is a command that finishes before the watchdog thread's *first* check (a
+    /// thread spawn away), which costs ~nothing. Only sub-millisecond commands are ever in that
+    /// regime and they straddle it — the `lm` median flips between ~0.3ms and ~200ms run to run
+    /// on the same host, so it is a race, not a guarantee.
+    ///
+    /// So the tax on a point query is best read as: anything that takes 1–200ms now takes
+    /// 200ms. A 30ms `k` becomes 200ms.
+    ///
+    /// Prints rather than asserts. The cost belongs to win-kexp's watchdog, not to this crate,
+    /// and a threshold pinned here would fail on an unrelated host difference.
+    #[tokio::test]
+    #[ignore = "needs DbgEng and a target; run manually with --ignored --test-threads=1"]
+    async fn measure_what_the_bounded_path_costs_a_quick_command() {
+        const ROUNDS: usize = 20;
+
+        let engine = EngineHandle::spawn(Duration::from_secs(60));
+        open_sample_dump(&engine).await.expect("open sample dump");
+
+        /// min / median / max, because a mean hides the two modes entirely.
+        fn spread(mut samples: Vec<Duration>) -> String {
+            samples.sort();
+            format!(
+                "min {:?}, median {:?}, max {:?}",
+                samples[0],
+                samples[samples.len() / 2],
+                samples[samples.len() - 1]
+            )
+        }
+
+        // Two probes, either side of the regime boundary:
+        //   `lm`  — the command the `modules` tool issues; sub-millisecond on a warm engine
+        //           with no symbol path, so it lands near the boundary and straddles it.
+        //   `.for`— a calibrated ~10ms command, standing in for any real query on a real
+        //           target (symbols, a live stack walk), which is well past the boundary.
+        let spin = |iterations: u64| {
+            format!(".for (r $t0 = 0; @$t0 < 0x{iterations:x}; r $t0 = @$t0 + 1) {{ }}")
+        };
+        for (label, command) in [
+            ("lm", "lm".to_string()),
+            (".for (short)", spin(20_000)),
+            (".for (long)", spin(60_000)),
+        ] {
+            let mut plain = Vec::with_capacity(ROUNDS);
+            let mut bounded = Vec::with_capacity(ROUNDS);
+            for _ in 0..ROUNDS {
+                let cmd = command.clone();
+                let t = Instant::now();
+                engine
+                    .run(move |e| e.execute_command(&cmd).map_err(|e| e.to_string()))
+                    .await
+                    .expect("unbounded command");
+                plain.push(t.elapsed());
+
+                let t = Instant::now();
+                engine
+                    .run_command(command.clone(), || Ok(()))
+                    .await
+                    .expect("bounded command");
+                bounded.push(t.elapsed());
+            }
+            println!("`{label}` x{ROUNDS}");
+            println!("   unbounded: {}", spread(plain));
+            println!("   bounded:   {}", spread(bounded));
+        }
+
+        let _ = engine
+            .run(|e| {
+                e.end_session()
+                    .map(|_| String::new())
+                    .map_err(|e| e.to_string())
+            })
+            .await;
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -2670,6 +2670,10 @@ impl WindbgServer {
     /// is the mode that actually fixes the "index not loaded" state `open_trace` warns about.
     /// (The bundled engine exposes these via `TtdExt.dll`; `!tt.index` fails with
     /// `LoadLibrary(tt)` because there is no `tt` extension.)
+    /// On a large trace the build can outrun the per-call timeout: the call reports a timeout
+    /// while the build keeps running, and later calls queue behind it until it finishes. That
+    /// is deliberate — aborting a `-force` rebuild can leave no usable index at all. Wait and
+    /// retry rather than re-issuing it.
     #[rmcp::tool(annotations(
         title = "Build TTD trace index",
         read_only_hint = false,
@@ -2684,6 +2688,11 @@ impl WindbgServer {
         Parameters(args): Parameters<SessionArgs>,
     ) -> Result<CallToolResult, ErrorData> {
         let gate = self.session_gate(args.session_id.as_deref());
+        // Deliberately *not* on the bounded path, and the one O(trace) command that isn't —
+        // see DECISIONS.md (2026-08-02). Indexing a large trace can legitimately outrun the
+        // per-call timeout, but `-force` deletes an unloadable `.idx` before rebuilding it, so
+        // a watchdog abort mid-rebuild can leave no usable index at all. Here the long run is
+        // productive work rather than a runaway, and the engine frees itself when it finishes.
         let out = self
             .engine
             .run(move |e| {


### PR DESCRIPTION
Closes #46.

## 1. Test gap

Nothing exercised the interrupt end to end, and the queue-aware budget was inline arithmetic inside a closure.

**Pure, rides `cargo test`.** The budget is now `watchdog_budget_ms(call_timeout, queued_wait)`, with tests for the everyday case, the floor (zero *disables* win-kexp's watchdog, so a command dequeued past the deadline must not get one), `u32` saturation, and the invariant that matters — `queue wait + budget <= call_timeout`.

**Live, `#[ignore]`d.** Three tests in `src/engine.rs` drive a real engine against the checked-in sample dump, offline (empty symbol path, so no network fetch lands inside the budget under test):

| test | what it pins |
| --- | --- |
| `a_runaway_command_self_aborts_and_leaves_the_engine_usable` | a `.for` sized to run for hours is cut short, and the engine executes the **next** command |
| `a_runaway_command_queued_behind_another_job_still_beats_its_caller` | the same from behind a job holding the engine thread for half the budget — the half win-kexp can't cover, since the queue belongs to this crate |
| `measure_what_the_bounded_path_costs_a_quick_command` | what bounding costs; the evidence for part 2 |

```
cargo test --bin windbg-mcp -- --ignored --nocapture --test-threads=1 engine::tests
```

`--test-threads=1` because dbgeng holds one debuggee session per process. ~85s.

Proof of interruption is the loop counter left in `$t0`, not the clock and not the "interrupted after" note — that note is appended whenever the watchdog *attempted* an interrupt, so one the engine ignored would still produce it. (A broad `s` search, the motivating wedge, is the wrong probe: it skips unmapped ranges and returns almost immediately.)

**Both were checked against a mutant.** With the queue-awareness deleted, the pure test fails on the invariant and the live one fails with exactly the wedge symptom: `Timeout("engine call timed out")` — the caller giving up while the command runs on.

## 2. Coverage review

Measured before deciding. win-kexp's watchdog polls a `done` flag on a 200ms sleep and is joined after `Execute` returns, so a bounded command takes `ceil(d / 200ms) * 200ms`:

| command | unbounded (median) | bounded (median) |
| --- | --- | --- |
| `lm` | 0.22ms | ~0.3ms **or** ~200.7ms — it races the watchdog's first poll |
| `.for`, short | 127ms | 200.8ms |
| `.for`, long | 377ms | 401.0ms |

So bounding a point query makes a 30ms `k` a 200ms `k`, for a runaway case it doesn't have. The rule, in `DECISIONS.md`:

> Bound a command when its cost scales with the **target's size** or with an **arbitrary caller-supplied expression**. Leave point queries against current target state unbounded.

That keeps the current five (`execute`/`dx` are open-ended hatches; `ttd_*` are O(trace) whole-trace scans) and explains the rest: `k`/`u`/`lm`/`!irp`/`bp` are point queries; the `step_*`/`go`/`run_to_address`/opener family already carries its own watchdog via `execute_and_wait`, so a second would be redundant; `!tt` looks trace-scaled but replays from the nearest keyframe.

`index_trace` is the deliberate exception in the other direction, now documented at the code and in its tool description: it *is* O(trace), but `-force` deletes an unloadable `.idx` before rebuilding, so an abort can leave no usable index at all — the wedge is temporary and self-heals, the abort isn't.

Two things the review turned up, recorded as follow-ups rather than fixed here:

- **13.** `reachable_from_dispatch` runs up to `max_functions` `uf` commands in **one** job, with caller-supplied uncapped bounds — the same wedge by another route. `run_command` bounds one command string and can't help; it needs a job-level deadline.
- **14.** Making win-kexp's watchdog park on a condvar instead of polling would drop the 200ms quantization to ~0, collapsing the rule to "bound everything except `index_trace`".

## Testing

`cargo fmt --all --check`, `cargo clippy --all-targets`, `cargo test` (69 unit + 13 smoke) — clean. The three live tests pass together in one process; measurements above are from this host, reproduced across runs.

No behaviour change to the server: `run_command`'s arithmetic is identical, only extracted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved time-budget handling for bounded commands, including commands delayed in a queue.
  * Added safeguards to help interrupted commands recover reliably and respect watchdog limits.
  * Clarified behaviour for long-running trace index rebuilds, including guidance to avoid duplicate requests while a rebuild is in progress.

* **Documentation**
  * Added architecture notes, follow-up guidance and smoke-test instructions covering command timeouts, queue handling and recovery scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->