### PR TITLE
Run each debug session in its own engine process (#61)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,8 @@ on:
   push:
     branches: [main]
   pull_request:
-  # Manual trigger for the smoke test's debugger tier, which reaches real DbgEng and so is
-  # kept out of the PR path. Use it after a `win-kexp` bump — see docs/smoke-test.md.
+  # Kept for re-running a tier by hand — the debugger tier after a flaky runner, say. It is no
+  # longer what gates that tier; see the `smoke-debugger` job.
   workflow_dispatch:
 
 concurrency:
@@ -70,9 +70,18 @@ jobs:
 
   smoke-debugger:
     name: Smoke test (debugger tier)
-    # On demand only: this tier opens the sample crash dump through the runner's DbgEng, so a
-    # Windows-image change could break it for reasons unrelated to the PR under review.
-    if: github.event_name == 'workflow_dispatch'
+    # Runs on every push and PR, not on demand.
+    #
+    # It was on-demand while the risk (a Windows-image change breaking it for reasons unrelated
+    # to the PR under review) outweighed what it covered. Process-per-session changed that side
+    # of the scale: this tier is now the only automated check of the properties the architecture
+    # exists for — two sessions coexisting, a parked attach being reclaimed while another session
+    # works, no engine worker outliving the connection — and none of those depend on the image.
+    # It needs no symbols and no network, and the dump it opens is checked in.
+    #
+    # The risk it was hedging against is still real, and the answer to it is that a runner whose
+    # DbgEng cannot open a checked-in dump is something this repo wants to hear about: it breaks
+    # users the same way. If that happens, pin the failure here rather than in a bug report.
     runs-on: windows-latest
     timeout-minutes: 20
     steps:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Project Structure & Module Organization
 
-`windbg-mcp` is a Rust MCP server for WinDbg/DbgEng. Core code lives in `src/`: `main.rs` wires tokio and stdio transport, `server.rs` defines the MCP tool surface, `engine.rs` owns serialized DbgEng access on a worker thread, and `ttd.rs` handles Time Travel Debugging discovery and launch logic. Operational documentation is in `docs/`, agent playbooks are in `skills/windbg-debugging/`, and PowerShell examples live in `examples/`. Helper tooling such as IOCTL harness scripts is under `tools/`. Build output in `target/` is generated and should not be committed.
+`windbg-mcp` is a Rust MCP server for WinDbg/DbgEng. Core code lives in `src/`: `main.rs` selects the process role (supervisor or engine worker) and wires tokio and stdio transport, `server.rs` defines the MCP tool surface, `engine.rs` is the supervisor (session registry, worker processes, routing), `worker.rs` is the child process that owns serialized DbgEng access on a dedicated thread, `proto.rs` is the protocol between them, and `ttd.rs` handles Time Travel Debugging discovery and launch logic. Operational documentation is in `docs/`, agent playbooks are in `skills/windbg-debugging/`, and PowerShell examples live in `examples/`. Helper tooling such as IOCTL harness scripts is under `tools/`. Build output in `target/` is generated and should not be committed.
 
 ## Build, Test, and Development Commands
 
@@ -15,7 +15,7 @@ For local iteration while an MCP client may have the release executable locked, 
 
 ## Coding Style & Naming Conventions
 
-Use Rust 2024 idioms and `rustfmt` defaults. Keep DbgEng access behind the engine-thread abstraction; do not add ad hoc cross-thread calls. Prefer typed Rust APIs and structured JSON over parsing debugger text unless the command surface only exposes text. Use `snake_case` for functions, modules, fields, and tests; use `PascalCase` for types. Keep comments short and focused on non-obvious debugger behavior.
+Use Rust 2024 idioms and `rustfmt` defaults. Keep DbgEng access inside the worker process and on its engine thread; do not add ad hoc cross-thread or cross-process calls. The supervisor must never touch a `DebugEngine`. Prefer typed Rust APIs and structured JSON over parsing debugger text unless the command surface only exposes text. Use `snake_case` for functions, modules, fields, and tests; use `PascalCase` for types. Keep comments short and focused on non-obvious debugger behavior.
 
 ## Testing Guidelines
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,11 +38,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     still coming up (~25s) and one that will never come up were previously indistinguishable, and
     they need opposite responses. Past the point a healthy attach takes it says so, and names the
     recovery. It still never queues on any worker, so it answers while a session is parked.
-  - **Nothing outlives the connection, and nothing is left halted.** A disconnect ends every
-    session the way `end_session` does — released, then terminated if it will not let go — so it
-    cannot leak a debugger process, a debuggee, or (the one that bites) a *frozen kernel target*:
-    DbgEng leaves a detached-but-halted kernel stopped, so a worker killed outright would take the
-    target machine down with the connection.
+  - **Nothing outlives the connection.** A disconnect ends every session the way `end_session`
+    does: each is asked to release its target, and terminated only if it will not let go within a
+    few seconds. So it cannot leak a debugger process or a debuggee.
+
+    Releasing rather than killing matters most for a live kernel, because DbgEng leaves a
+    detached-but-*halted* kernel stopped — a worker killed outright takes the target machine down
+    with the connection. The graceful path is what a disconnect normally takes, and the live-kernel
+    tier checks against the target's own uptime that it does. The residual risk is a session that
+    cannot let go in time — one busy in a long `go`, say — which is terminated, and for a live
+    kernel that does leave the target halted. Ending such a session with `end_session` first (it
+    allows a longer grace) is the way to avoid it.
   - Failures scoped to a session (a debugger error, a timeout, a refused handle, a worker that
     died) are all tool errors with their text intact. The only JSON-RPC protocol error left is
     "no engine worker could be started at all".

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,11 +44,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
     Releasing rather than killing matters most for a live kernel, because DbgEng leaves a
     detached-but-*halted* kernel stopped — a worker killed outright takes the target machine down
-    with the connection. The graceful path is what a disconnect normally takes, and the live-kernel
-    tier checks against the target's own uptime that it does. The residual risk is a session that
-    cannot let go in time — one busy in a long `go`, say — which is terminated, and for a live
-    kernel that does leave the target halted. Ending such a session with `end_session` first (it
-    allows a longer grace) is the way to avoid it.
+    with the connection. A disconnect asks every session to release concurrently, waits five
+    seconds, and terminates only those that have not finished; the live-kernel tier checks against
+    the target's own uptime that the release is what normally happens. The residual risk is a
+    session that cannot let go inside that grace — one busy in a long `go`, say — which is
+    terminated, and for a live kernel that does leave the target halted. Ending such a session
+    with `end_session` first (it allows considerably longer) is the way to avoid it.
   - Failures scoped to a session (a debugger error, a timeout, a refused handle, a worker that
     died) are all tool errors with their text intact. The only JSON-RPC protocol error left is
     "no engine worker could be started at all".

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,16 +38,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     still coming up (~25s) and one that will never come up were previously indistinguishable, and
     they need opposite responses. Past the point a healthy attach takes it says so, and names the
     recovery. It still never queues on any worker, so it answers while a session is parked.
-  - **Nothing outlives the connection.** Workers are terminated on shutdown and exit on their own
-    when their stdin closes, so a disconnect cannot leak a debugger process — or a debuggee.
+  - **Nothing outlives the connection, and nothing is left halted.** A disconnect ends every
+    session the way `end_session` does — released, then terminated if it will not let go — so it
+    cannot leak a debugger process, a debuggee, or (the one that bites) a *frozen kernel target*:
+    DbgEng leaves a detached-but-halted kernel stopped, so a worker killed outright would take the
+    target machine down with the connection.
   - Failures scoped to a session (a debugger error, a timeout, a refused handle, a worker that
     died) are all tool errors with their text intact. The only JSON-RPC protocol error left is
     "no engine worker could be started at all".
 
   Reasoning, and why the two cheaper mitigations were not the fix, in
-  [`DECISIONS.md`](./DECISIONS.md). The smoke test's debugger tier now covers the reported case end
-  to end: an attach parked on a dead port, another session opened alongside it, and `end_session`
-  reclaiming it.
+  [`DECISIONS.md`](./DECISIONS.md). The smoke test's debugger tier covers the reported case end to
+  end — an attach parked on a dead port, another session opened alongside it, and `end_session`
+  reclaiming it — and a new live-kernel tier drives a real KDNET target through attach, coexistence
+  and detach, checking against the target's own uptime that a disconnect leaves it *running*.
 
 - **The bounded-command path now has a stated coverage rule, and tests that prove it works.**
   0.3.0 routed `execute`, `dx` and the `ttd_*` tools through a watchdog that Ctrl+Breaks a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,16 +9,57 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Each debug session now runs in its own engine process, and a session that cannot be unwound
+  can be reclaimed** ([#61](https://github.com/glslang/windbg-mcp/issues/61)).
+
+  A live kernel attach waits for its target with `WaitForEvent(INFINITE)`, and DbgEng cannot
+  interrupt a wait that has not yet connected. So a guest that is powered off, not booted with
+  debugging enabled, or pointed at the wrong host/port/key parked the attach forever — measured on
+  hardware at 300s with no bound and no cancellation path. With one engine thread that park owned
+  the server: every later tool call queued behind it, `end_session` included, and the only recovery
+  was restarting the process. Since the most common mistake in kernel debugging is exactly "the
+  guest is not in debug mode", an agent driving this server hit it routinely.
+
+  The server now runs MCP in a supervisor process and each open target in its own engine worker
+  child process. The park costs one worker, and **`end_session` terminates it** — asking the worker
+  to let go first, killing it if it will not. That is the in-band recovery that did not exist.
+
+  What this changes for callers:
+
+  - **Sessions are concurrent and no longer replace each other.** Triage a crash dump while a kernel
+    attach is live; keep two traces open at once. Up to four; at the limit a new open reclaims the
+    oldest *idle* session, and refuses with the list if every session is busy. The opener tools no
+    longer say "replaces any session already open", because they do not.
+  - **`session_id` routes rather than merely detects.** It names the worker holding your target, so
+    another caller's open cannot invalidate your handle — the accident the handle was built to
+    report is now largely impossible rather than merely visible.
+  - **`session_status` lists every session**, with what state each is in and how long it has been
+    there. For an attach that has not landed, that duration is the whole signal: a KDNET link
+    still coming up (~25s) and one that will never come up were previously indistinguishable, and
+    they need opposite responses. Past the point a healthy attach takes it says so, and names the
+    recovery. It still never queues on any worker, so it answers while a session is parked.
+  - **Nothing outlives the connection.** Workers are terminated on shutdown and exit on their own
+    when their stdin closes, so a disconnect cannot leak a debugger process — or a debuggee.
+  - Failures scoped to a session (a debugger error, a timeout, a refused handle, a worker that
+    died) are all tool errors with their text intact. The only JSON-RPC protocol error left is
+    "no engine worker could be started at all".
+
+  Reasoning, and why the two cheaper mitigations were not the fix, in
+  [`DECISIONS.md`](./DECISIONS.md). The smoke test's debugger tier now covers the reported case end
+  to end: an attach parked on a dead port, another session opened alongside it, and `end_session`
+  reclaiming it.
+
 - **The bounded-command path now has a stated coverage rule, and tests that prove it works.**
   0.3.0 routed `execute`, `dx` and the `ttd_*` tools through a watchdog that Ctrl+Breaks a
   runaway command before it can pin the engine thread, but nothing exercised that interrupt
   end to end, and "why these five?" had no written answer.
 
-  `src/engine.rs` gains both. The queue-aware budget arithmetic is now a pure function with
-  unit tests that ride `cargo test`; three `#[ignore]`d tests drive a real engine, proving a
-  runaway command self-aborts and leaves the engine usable — including from behind a queued
-  job, which is the half win-kexp's own tests cannot cover because the queue belongs to this
-  crate. See [`docs/smoke-test.md`](./docs/smoke-test.md).
+  It gains both. The queue-aware budget arithmetic is a pure function with unit tests that ride
+  `cargo test` (`src/worker.rs`, next to the watchdog it arms); three `#[ignore]`d tests drive a
+  real engine through the shipped binary, proving a runaway command self-aborts and leaves its
+  session usable — including from behind a queued job, which is the half win-kexp's own tests
+  cannot cover because the queue belongs to this crate. See
+  [`docs/smoke-test.md`](./docs/smoke-test.md).
 
   The coverage rule, recorded in [`DECISIONS.md`](./DECISIONS.md): bound a command when its
   cost scales with the target's size or with an arbitrary caller-supplied expression; leave

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,8 +8,18 @@ surface; this file covers the non-obvious operational workflows.
 `windbg-mcp` is a Rust MCP server (stdio, `rmcp`) exposing **WinDbg/DbgEng** for live user-mode,
 kernel, crash-dump, and Time Travel Debugging (TTD) work. The low-level DbgEng bindings come from
 the sibling crate [`win-kexp`](https://github.com/glslang/win-kexp) (a **path/git dependency we grow
-ourselves** — do not add third-party DbgEng crates). Key source: `src/engine.rs` (single dedicated
-engine thread), `src/server.rs` (the MCP tools), `src/ttd.rs`, `src/main.rs`.
+ourselves** — do not add third-party DbgEng crates).
+
+**The binary has two roles.** Started normally it is the **supervisor**: MCP on stdio, no DbgEng.
+Re-executed with `--engine-worker` it owns exactly one debug session, because dbgeng.dll holds one
+debuggee session per process. Key source: `src/engine.rs` (the supervisor — session registry,
+worker supervision, routing), `src/worker.rs` (the child process and the engine thread inside it),
+`src/proto.rs` (the wire protocol between them), `src/server.rs` (the MCP tools), `src/ttd.rs`,
+`src/main.rs` (role selection).
+
+Practical consequences when debugging this server: a stack trace or log line can come from either
+role (worker logs are untagged by target and inherit the supervisor's stderr), and killing the
+supervisor leaves no workers behind — they exit when their stdin closes.
 
 ## Updating the running windbg MCP after code changes
 
@@ -38,6 +48,11 @@ To rebuild and load the new code without stopping the session:
    Claude Code). Only after this reconnect do the windbg tools run the new code.
 4. Once reconnected (the old process is gone), delete `target/release/windbg-mcp.exe.stale`. Do
    **not** delete it while the old process is still alive — it demand-pages code from that file.
+
+A worker is spawned by re-executing the supervisor's *own* image, so a supervisor running from the
+renamed `.stale` file spawns workers from it too — old code stays consistently old, which is what
+you want. It also means `.stale` can be held by more than one process: reconnecting ends the
+supervisor, and its workers exit with it, so step 4 is still just "after the reconnect".
 
 ## Changing win-kexp (the DbgEng bindings)
 
@@ -75,15 +90,32 @@ opens the sample dump through DbgEng, set the gate first (PowerShell, not `VAR=1
 $env:WINDBG_MCP_SMOKE_DUMP = "1"; cargo test --test mcp_smoke
 ```
 
+That tier now also covers the process-per-session behaviour end to end: two sessions coexisting, a
+kernel attach parked on a dead port being reclaimed by `end_session`, and no worker process
+outliving the connection. A third tier is `#[ignore]`d because it runs commands out to a watchdog
+deadline (minutes, not seconds) — run it by hand after a win-kexp watchdog change:
+
+```pwsh
+$env:WINDBG_MCP_SMOKE_DUMP = "1"
+cargo test --test mcp_smoke -- --ignored --nocapture --test-threads=1 bounded
+```
+
 ## Live kernel + driver IOCTL gotchas (learned driving HEVD over KDNET)
 
 **KDNET attach is a blocking wait, by design.** A live kernel needs `WaitForEvent(INFINITE)` (a finite
 timeout returns `E_NOTIMPL` and never drives the link). So if the target isn't reachable, the
-`attach_kernel` MCP call reports a *timeout* while the engine thread stays **parked** in the wait —
+`attach_kernel` MCP call reports a *timeout* while its **worker process** stays parked in the wait —
 it self-heals and completes the attach the moment the target actually connects. Consequences:
-- When an attach "hangs", **diagnose out-of-band** (PowerShell), never by firing more windbg tools —
-  they queue behind the parked engine thread and also time out. Check the debugger is listening
-  (`Get-NetUDPEndpoint -LocalPort 50000` → owned by `windbg-mcp.exe`) and whether any VM is running.
+- The park costs **that session only**. Other sessions and every other tool keep working, so an
+  attach that is going nowhere is no longer a reason to restart the server. `session_status` says
+  how long it has been waiting and whether that is past the point a healthy link takes;
+  `end_session` reclaims it, terminating the worker process if the wait will not unwind (it won't —
+  `SetInterrupt` cannot reach a wait that has not yet connected).
+- **Do not re-run the attach while it is still waiting.** The connection was already claimed, so a
+  retry dials a second time. End it first, or fix the target and let the original attach land.
+- Diagnosing why nothing dialed in is still out-of-band work (PowerShell): check the debugger is
+  listening (`Get-NetUDPEndpoint -LocalPort 50000` → owned by `windbg-mcp.exe`, which will be the
+  *worker* process) and whether any VM is running.
 - The **target must dial this host**: on the target, `bcdedit /dbgsettings net hostip:<debugger-ip>
   port:50000 key:<key>` — **colons, not `=`**. `hostip` must be the debugger host's current IP.
   Symbols are **not** pulled over the KD wire (see below).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,14 +101,18 @@ cargo test --test mcp_smoke -- --ignored --nocapture --test-threads=1 bounded
 ```
 
 A fourth tier drives a **real KDNET target** through a full session lifecycle — attach, work
-alongside a second session, detach gracefully. It is gated on the connection string (which nobody
-can guess) *and* `#[ignore]`d, so a stale variable can never freeze a VM during an ordinary
-`cargo test`. Run it last, on its own:
+alongside a second session, detach gracefully — and separately checks that a client *disconnect*
+releases a live kernel session rather than killing its worker. It is gated on the connection string
+(which nobody can guess) *and* `#[ignore]`d, so a stale variable can never freeze a VM during an
+ordinary `cargo test`. Run it last, on its own:
 
 ```pwsh
 $env:WINDBG_MCP_SMOKE_KERNEL = "net:port=50000,key=<w.x.y.z>"
-cargo test --test mcp_smoke -- --ignored --nocapture live_kernel
+cargo test --test mcp_smoke -- --ignored --nocapture --test-threads=1 live_kernel
 ```
+
+`--test-threads=1` is not optional: the filter matches **two** tests, and the KD transport is
+single-owner, so in parallel the second attach fails and can leave the target halted.
 
 ## Live kernel + driver IOCTL gotchas (learned driving HEVD over KDNET)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,6 +100,16 @@ $env:WINDBG_MCP_SMOKE_DUMP = "1"
 cargo test --test mcp_smoke -- --ignored --nocapture --test-threads=1 bounded
 ```
 
+A fourth tier drives a **real KDNET target** through a full session lifecycle — attach, work
+alongside a second session, detach gracefully. It is gated on the connection string (which nobody
+can guess) *and* `#[ignore]`d, so a stale variable can never freeze a VM during an ordinary
+`cargo test`. Run it last, on its own:
+
+```pwsh
+$env:WINDBG_MCP_SMOKE_KERNEL = "net:port=50000,key=<w.x.y.z>"
+cargo test --test mcp_smoke -- --ignored --nocapture live_kernel
+```
+
 ## Live kernel + driver IOCTL gotchas (learned driving HEVD over KDNET)
 
 **KDNET attach is a blocking wait, by design.** A live kernel needs `WaitForEvent(INFINITE)` (a finite

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -884,7 +884,7 @@ dependencies = [
 [[package]]
 name = "win-kexp"
 version = "0.1.0"
-source = "git+https://github.com/glslang/win-kexp?branch=main#47993c41e8d5942a5efec6fc2452538c064951c5"
+source = "git+https://github.com/glslang/win-kexp?branch=main#38eeafd36cbd037a7fdda08b9209ad9bf60c1d5d"
 dependencies = [
  "byte-strings",
  "goblin",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,6 +156,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -357,6 +367,17 @@ name = "memchr"
 version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+
+[[package]]
+name = "mio"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys",
+]
 
 [[package]]
 name = "nu-ansi-term"
@@ -619,6 +640,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -683,8 +714,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
+ "libc",
+ "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "tokio-macros",
+ "windows-sys",
 ]
 
 [[package]]
@@ -794,6 +829,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasm-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2024"
 [dependencies]
 win-kexp = { git = "https://github.com/glslang/win-kexp", branch = "main" }
 rmcp = { version = "3", features = ["server", "transport-io", "macros", "schemars"] }
-tokio = { version = "1", features = ["macros", "rt-multi-thread", "io-std", "io-util", "sync", "time"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "io-std", "io-util", "process", "sync", "time"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 schemars = "1"

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -5,7 +5,70 @@ status. Keep entries short; link to code with `file:line` where it helps a futur
 
 ---
 
+## One process per debug session (2026-08-02, issue #61)
+
+**Context.** A live-kernel attach waits for its target with `WaitForEvent(INFINITE)` — a finite
+timeout returns `E_NOTIMPL` and never drives the KD link — and `SetInterrupt`, the one DbgEng call
+safe from another thread, cannot reach a wait that has not yet connected. So a guest that is powered
+off, not booted with debugging enabled, or pointed at the wrong host/port/key parks the attach
+**permanently**: measured on hardware at 300s with no bound and no cancellation path. With a single
+engine thread that park owned the whole server. Every other tool queued behind it, `end_session`
+included, and the only recovery was restarting the process.
+
+**Decision.** Run the MCP protocol in a supervisor process and each open target in its own engine
+worker child process (`src/engine.rs`, `src/worker.rs`, `src/proto.rs`). dbgeng.dll holds one
+debuggee session per process, so the process *is* the natural unit of a session — this is the shape
+the library already imposes, not one invented for the bug.
+
+**Why not the cheaper options.** Three cheaper-looking answers were on the table; none of them is a
+fix, though the second fell out of this one for free:
+
+- *Documenting the park in the tool description* leaves the failure in place. It is the most common
+  mistake in kernel debugging — a guest not booted in debug mode — so an agent will hit it, and
+  "restart the server" is not something an agent can do.
+- *Making the pending state age-aware* turns an indistinguishable state into actionable advice, but
+  the only action it could name was still a restart. Under process-per-session the same reporting
+  names a recovery that works, so `session_status` does it anyway: it distinguishes a KDNET link
+  still coming up (~25s) from one that has been waiting far past any healthy attach.
+- *A worker **thread** is not a substitute.* Detaching a `JoinHandle` frees nothing: the thread, its
+  stack, the `DebugEngine`, its COM objects and the claimed transport endpoint all live on blocked
+  for the life of the process, and each retry leaks another set. Only a process can be reclaimed.
+
+**What it cost.** A closure cannot cross a process boundary, so the closures that were marshalled
+onto the engine thread became serializable operations (`EngineOp`). They are deliberately
+*tool*-shaped rather than DbgEng-shaped: a tool whose work is several engine calls —
+`reachable_from_dispatch`'s call-graph walk, `run_to_address`'s resolve-then-run — must stay one
+indivisible job, or another call for the same session could interleave between the parts and the
+walk would see a target that moved underneath it.
+
+The watchdog budget also split. The supervisor now sends the caller's remaining *patience* and the
+worker derives the deadline from it, because the supervisor writes a request the moment it is
+submitted and the queueing then happens on the far side of the pipe, where only the worker can
+measure it. Computing the deadline on the supervisor's side compiles, passes the unqueued test, and
+is wrong: a command that queued for most of the budget would run a full budget *after* its caller
+gave up. That is not hypothetical — it is the bug the first cut of this change shipped, caught by
+the queue-aware test, and it is why the arithmetic lives next to the thing it arms.
+
+**What it bought beyond the bug.** `session_id` stopped meaning "detect that the target changed
+underneath you" and started meaning "route to the worker that owns this target", which retires a
+whole class of accident rather than reporting it: an `open_dump` cannot disturb a kernel attach, and
+an `end_session` for session A can no longer be ordered against an open of B, because there is
+nothing shared to order. Sessions became concurrent (bounded at `MAX_SESSIONS`, 4). And the one
+protocol-level error class shrank to "no worker could be started at all" — every other failure is
+now scoped to a session and has a next move, so it belongs in the tool result.
+
+**Status:** landed. FOLLOWUPS item 10 records what moved for items 7–9, which were written against
+the design this replaced.
+
+---
+
 ## Which tools run on the bounded-command path (2026-08-02)
+
+> **Since:** process-per-session (above, same day) moved the pieces this entry names. The bounded
+> path is now `EngineOp::BoundedCommand`, the budget arithmetic lives in `src/worker.rs`, and the
+> measurement test moved to `tests/mcp_smoke.rs`'s bounded-command tier. The coverage rule below is
+> unchanged and still the rule; what changed is that a runaway command now pins one session rather
+> than the server.
 
 **Context.** `EngineHandle::run_command` (`src/engine.rs`) runs a raw command under win-kexp's
 `execute_command_bounded`, whose watchdog `SetInterrupt`s the engine before the caller's timeout so

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -57,6 +57,16 @@ nothing shared to order. Sessions became concurrent (bounded at `MAX_SESSIONS`, 
 protocol-level error class shrank to "no worker could be started at all" — every other failure is
 now scoped to a session and has a next move, so it belongs in the tool result.
 
+**Corroborated upstream.** win-kexp reached the same conclusion from the library side while this was
+in review, and now documents it on `attach_kernel` itself: *"Callers that must stay responsive (a
+server, an MCP endpoint) need a **separate process they can kill**. Moving the call to a worker
+thread and abandoning it is not a recovery"* — the thread, its stack, the `DebugEngine`, its COM
+objects and the claimed transport endpoint all live on blocked, and each retry leaks another set.
+The same commits settle a detail this server reports on: a guest that is not booted in debug mode
+**never dials in at all**, so the wait is stuck in the *connect* phase rather than in a break-in
+that failed. That is why `session_status` says a long-parked attach will not end on its own *while
+the target stays unreachable*, and equally that fixing the guest still lands it.
+
 **Status:** landed. FOLLOWUPS item 10 records what moved for items 7–9, which were written against
 the design this replaced.
 

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -6,9 +6,11 @@ MCP `2026-07-28` extensions (tasks, apps), item 12 from the opener split
 (glslang/win-kexp#71, 2026-08-01), and items 13–14 from the bounded-command coverage review
 (#46, 2026-08-02). Each item notes its repo, why it was deferred, and where
 it picks up. See [`DECISIONS.md`](./DECISIONS.md) for the design rationale (D1–D5) items 1–6 extend,
-and the 2026-08-02 entry for the one items 13–14 extend.
+and the 2026-08-02 entries for the ones items 13–14 and item 10 extend.
 
-Items are roughly ordered by how soon they're worth doing, within each cluster.
+Items are roughly ordered by how soon they're worth doing, within each cluster. **Item 10 has
+landed** (process-per-session, 2026-08-02); it is kept here rather than deleted because items 7, 8
+and 9 were all written against the single-engine design it replaced, and each now says what moved.
 
 ## 1. [win-kexp] Managed breakpoint lifecycle for `run_to_address`
 
@@ -69,33 +71,42 @@ than the human/LLM-readable recipe emitted today.
 ## 7. [win-kexp + windbg-mcp] On-demand engine interrupt
 
 Expose `SetInterrupt` as a public win-kexp method (and a `Send` handle obtainable from a
-`&DebugEngine`), then plumb it through `EngineHandle` as `interrupt()`. Today the primitive exists
+`&DebugEngine`), then plumb it through to a per-session `interrupt()`. Today the primitive exists
 but is only ever *timeout-driven*: `execute_command_bounded` (win-kexp `src/dbgeng.rs:607`) and
 `wait_for_event_bounded` (`:716`) each spawn a watchdog thread holding an `InterruptHandle` and
 Ctrl+Break the engine when a deadline passes. There is no way for a caller to ask for that now.
 
 `InterruptHandle` (`src/dbgeng.rs:115-119`) already carries the reasoning: `SetInterrupt` is the one
 DbgEng call documented as safe from another thread, so this needs no new threading model — the
-engine stays confined to its one thread (`src/engine.rs`) and the interrupt arrives from outside it,
+engine stays confined to its one thread (`src/worker.rs`) and the interrupt arrives from outside it,
 exactly as it does today.
 
+**Reshaped by item 10.** The interrupt is now a *per-session* concern: it has to reach one worker's
+engine, and it cannot travel as an ordinary op, because a worker whose engine is wedged is exactly
+the one not draining its request queue — it needs a side channel the worker's reader thread acts on.
+The urgency dropped with the same change: `end_session` already ends any call by terminating the
+session, so an interrupt is no longer the only way out of a runaway command, just the graceful one
+that keeps the target.
+
 - **Why it comes first:** it is what would give item 8's `tasks/cancel` anything to do — the spec's
-  cancellation is cooperative, so acknowledging one conforms, but a server whose engine thread is
-  blocked inside DbgEng cannot act on it at all. It stands alone too: it gives an operator a way to
-  abort a runaway `execute` before `ENGINE_CALL_TIMEOUT` (`src/main.rs:22`, 300s) elapses.
-- **A bare `interrupt()` would hit the wrong job.** `SetInterrupt` addresses the engine, meaning
-  whichever operation is *currently running* — but the job queue is FIFO with one worker
-  (`src/engine.rs`), and item 8 makes several calls in flight at once the normal case rather than
-  the exception. Cancelling a task whose job is still queued would then Ctrl+Break an unrelated
+  cancellation is cooperative, so acknowledging one conforms, but a session blocked inside DbgEng
+  cannot act on it at all *without being thrown away*. It stands alone too: it gives an operator a
+  way to abort a runaway `execute` before `ENGINE_CALL_TIMEOUT` (`src/main.rs`, 300s) elapses,
+  keeping the target that `end_session` would discard.
+- **A bare `interrupt()` would hit the wrong job.** `SetInterrupt` addresses one engine, meaning
+  whichever operation that session is *currently running* — but each session's queue is FIFO with
+  one consumer, and item 8 makes several calls in flight at once the normal case rather than the
+  exception. Cancelling a task whose job is still queued would then Ctrl+Break an unrelated
   task's running operation, and the cancelled job would go on to execute anyway when its turn came:
-  `EngineHandle::run` already documents that a timeout abandons the wait and "the job itself is
-  *not* cancelled". So the interrupt has to be bound to job identity — the engine tracks which job
+  `Sessions::call` already documents that a timeout abandons the wait and that the job itself is
+  *not* cancelled. So the interrupt has to be bound to job identity — the engine tracks which job
   is active, a cancel for a queued job drops it from the queue, and `SetInterrupt` fires only when
   the cancelled job is the running one. That is the substance of this item, not an add-on to it.
 - **Known limit, carried from win-kexp `src/dbgeng.rs:726`:** `SetInterrupt` cannot unblock a
   live-kernel wait until the target is *connected*. So the `attach_kernel` KDNET park documented in
   `CLAUDE.md` — the case that most wants cancelling — is not cancellable this way; only tearing down
-  the client or the process ends it. That limit is what motivates item 10.
+  the process ends it. That limit is what motivated item 10, which has since landed and made that
+  teardown a supported, in-band operation (`end_session`).
 
 ## 8. [windbg-mcp] Tasks extension (`io.modelcontextprotocol/tasks`, SEP-2663)
 
@@ -120,15 +131,15 @@ does not already define them, so hand-writing `call_tool` and `get_info` inside 
 
 Suggested order, chosen so the protocol work is proved before it touches DbgEng:
 
-1. `record_trace` — already off the engine thread (`spawn_blocking`, `src/server.rs:2675`), so
-   converting it is pure protocol work with no debugger risk.
+1. `record_trace` — already off any engine (`spawn_blocking`, `src/server.rs`), so converting it is
+   pure protocol work with no debugger risk.
 2. `open_dump` / `open_trace` / `index_trace` / `attach_kernel` — where the pain actually is, and
-   where the `opens` ring can shrink to a thin adapter over `tasks/get`.
+   where `session_status` can shrink to a thin adapter over `tasks/get`.
 3. `go` / `run_to_address` / `execute` — best held until item 7 lands. `tasks/cancel` is
    *cooperative* by spec: acknowledging it while the work runs on to some terminal state is
    conformant, so these are implementable without an interrupt. But for exactly these three the
-   engine thread is blocked inside DbgEng, so until item 7 there is no effort the server could
-   make — cancel would be a no-op until the operation ends on its own. Conformant, useless.
+   session's engine is blocked inside DbgEng, so until item 7 the only effort the server can make
+   is ending the session outright — a heavier answer than a cancel should be.
 
 Fast, pure tools (`decode_ioctl`, `registers`, `read_memory`, `modules`, `threads`, `disassemble`,
 `backtrace`, `session_status`) should stay synchronous.
@@ -145,7 +156,8 @@ Fast, pure tools (`decode_ioctl`, `registers`, `read_memory`, `modules`, `thread
     swapped underneath a client that believes the operation is over. Cooperative cancellation is the
     escape hatch here rather than the problem: acknowledge the request, decline to transition, and
     leave the task `working` until the engine job actually resolves. A cancel that genuinely ends the
-    wait needs item 10's worker teardown.
+    wait needs item 10's worker teardown, which has landed: `end_session` terminates the session's
+    process, so a client that genuinely wants out has a way — it just is not `tasks/cancel`.
   - **The session-handle contract needs a task-path clause.** The queued-precheck design survives
     untouched (a task's gate still runs in the same queued job, so the ordering guarantee in the
     CHANGELOG holds), but if an opener returns a task then the `session_id` arrives in the task
@@ -165,29 +177,40 @@ client for the duration of a command, so output only lands when the command ends
 - **Why deferred:** worth little before item 8 gives it somewhere to go.
 - **Does not buy concurrency.** A second client joins the *same* session and serializes on the same
   engine lock; while one thread is in `WaitForEvent`/`Execute`, calls from the other block. It would
-  swap `engine.rs`'s queue for DbgEng's internal one and gain nothing. Only item 10 delivers
-  parallelism.
+  swap the worker's queue for DbgEng's internal one and gain nothing. Concurrency *between* targets
+  came from item 10 instead.
 
-## 10. [windbg-mcp] Process-per-session, for actual concurrency
+## 10. [windbg-mcp] Process-per-session — **done** (2026-08-02, issue #61)
 
 dbgeng.dll holds **one debuggee session per process**. That is not a win-kexp limitation — it is why
-`.opendump` *replaces* the target, and why the `session_id` design exists at all (a handle that
-detects the swap, because there is nothing to swap *between*). So analysing a dump while a kernel
-attach sits parked in `WaitForEvent(INFINITE)` requires one engine process per session.
+`.opendump` *replaces* the target, and why the `session_id` design existed at all (a handle that
+detects the swap, because there was nothing to swap *between*).
 
-This is what makes item 8 pay off rather than merely report honestly: with a single engine thread a
-`working` task still owns the engine and every other tool queues behind it — the `submitted.elapsed()`
-budget arithmetic in `EngineHandle::run_command` exists because of exactly that queue. Under
-process-per-session, `session_id` stops meaning "detect that the target changed underneath you" and
-starts meaning "route to the worker that owns this target".
+Landed: the binary now runs the MCP protocol in a supervisor process (`src/engine.rs`) and each open
+target in an engine worker child process (`src/worker.rs`), talking over a line-delimited JSON
+protocol (`src/proto.rs`). `session_id` stopped meaning "detect that the target changed underneath
+you" and started meaning "route to the worker that owns this target". Sessions are concurrent (up to
+`MAX_SESSIONS`), and `end_session` can terminate a worker that will not unwind — which is what
+issue #61 needed, since a kernel attach whose target never dials in cannot be interrupted at all.
 
-- **Why deferred:** large. Needs process supervision, per-worker symbol state (`.sympath`, caches),
-  and moving the `opens` / `session_status` bookkeeping up into a supervisor. DbgEng's own remoting
-  (`.server` / `DebugConnect`) is the same shape with more moving parts — the remote session is still
-  its own engine process.
-- **Watch:** `unsafe impl Send/Sync for DebugEngine` (win-kexp `src/dbgeng.rs:164-165`) is sound
-  *because* `src/engine.rs` confines the engine to one thread. Any design that calls it from several
-  threads turns those impls from bookkeeping into a real, unchecked claim.
+What moved, for anyone picking up the items that referenced this:
+
+- The queue is **per session**, so a busy or parked session no longer blocks any other. The
+  budget arithmetic moved with it: the supervisor sends the caller's remaining *patience* and the
+  worker derives the watchdog deadline, because only the worker can measure the wait on its own
+  side of the pipe.
+- The `opens` ledger became the session registry, and `session_status` reports session *state* —
+  including how long an open has been waiting, which is what distinguishes a KDNET link that is
+  coming up from one that never will.
+- `unsafe impl Send/Sync for DebugEngine` (win-kexp `src/dbgeng.rs:164-165`) is still sound for the
+  same reason as before: `src/worker.rs` confines the engine to one thread *inside* the worker. The
+  supervisor never touches a `DebugEngine` at all, which is a stronger position than the one that
+  claim was written for.
+
+Not done, and no longer blocking anything: **per-worker symbol state**. Each worker has its own
+`.sympath` and symbol cache, which is correct (sessions are independent) but means a `set_symbol_path`
+does not carry to a session opened later. If that becomes annoying, the fix is a supervisor-held
+default applied at worker startup, not shared state.
 
 ## 11. [windbg-mcp] MCP Apps (`ui://` resources) — scoped out
 
@@ -232,12 +255,13 @@ The two **kernel** halves ran on no hardware: `attach_local_kernel_begin`/`wait`
 
 `reachable_from_dispatch` runs its whole breadth-first walk — up to `max_functions` × one `uf`
 command each — inside a *single* engine job. Both `max_functions` (default 256) and `max_depth`
-(default 32) come from the caller and are uncapped, so a large enough pair pins the engine thread
-for as long as the walk takes. That is the same wedge the bounded path fixed, arriving by a
-different route.
+(default 32) come from the caller and are uncapped, so a large enough pair pins that session's
+engine for as long as the walk takes. That is the same wedge the bounded path fixed, arriving by a
+different route — smaller now that it costs one session rather than the server, but still a session
+that answers nothing until the walk ends.
 
-- **Why the bounded path doesn't reach it:** `EngineHandle::run_command` bounds *one* command
-  string. Here no individual `uf` is the problem — the aggregate is.
+- **Why the bounded path doesn't reach it:** the bounded path bounds *one* command string. Here no
+  individual `uf` is the problem — the aggregate is.
 - **Where it picks up:** the walk already drives every disassembly through one `&mut uf` closure
   (`src/server.rs`), which is the natural place to check a deadline and stop with a partial,
   honestly-labelled verdict — "NOT REACHABLE within the budget" is already the tool's contract for

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -211,10 +211,17 @@ What moved, for anyone picking up the items that referenced this:
   supervisor never touches a `DebugEngine` at all, which is a stronger position than the one that
   claim was written for.
 
-Not done, and no longer blocking anything: **per-worker symbol state**. Each worker has its own
-`.sympath` and symbol cache, which is correct (sessions are independent) but means a `set_symbol_path`
-does not carry to a session opened later. If that becomes annoying, the fix is a supervisor-held
-default applied at worker startup, not shared state.
+Not done, and no longer blocking anything: **per-worker symbol state** —
+[#66](https://github.com/glslang/windbg-mcp/issues/66). Each worker has its own `.sympath` and symbol
+cache, which is correct (sessions are independent) but means a `set_symbol_path` does not carry to a
+session opened later. The fix is a supervisor-held default applied at worker startup, not shared
+state between running workers.
+
+Two ordering details the review of #62 raised and that PR deliberately left alone, both filed:
+[#64](https://github.com/glslang/windbg-mcp/issues/64) (`end_session` keeps accepting calls while it
+tears the session down — the fix wants the `Gate` treatment `retires` already has) and
+[#65](https://github.com/glslang/windbg-mcp/issues/65) (the worker protocol shares stdout with
+anything the engine prints; mitigated, not structurally prevented).
 
 ## 11. [windbg-mcp] MCP Apps (`ui://` resources) — scoped out
 

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -6,7 +6,7 @@ MCP `2026-07-28` extensions (tasks, apps), item 12 from the opener split
 (glslang/win-kexp#71, 2026-08-01), and items 13–14 from the bounded-command coverage review
 (#46, 2026-08-02). Each item notes its repo, why it was deferred, and where
 it picks up. See [`DECISIONS.md`](./DECISIONS.md) for the design rationale (D1–D5) items 1–6 extend,
-and the 2026-08-02 entries for the ones items 13–14 and item 10 extend.
+and the 2026-08-02 entries that items 13–14 and item 10 extend.
 
 Items are roughly ordered by how soon they're worth doing, within each cluster. **Item 10 has
 landed** (process-per-session, 2026-08-02); it is kept here rather than deleted because items 7, 8

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -12,20 +12,24 @@ Items are roughly ordered by how soon they're worth doing, within each cluster. 
 landed** (process-per-session, 2026-08-02); it is kept here rather than deleted because items 7, 8
 and 9 were all written against the single-engine design it replaced, and each now says what moved.
 
-## 1. [win-kexp] Managed breakpoint lifecycle for `run_to_address`
+## 1. [win-kexp] Managed breakpoint lifecycle for `run_to_address` — **done upstream**
 
-`run_to_address` uses a one-shot `g <addr>` (WinDbg's temporary breakpoint), which DbgEng does **not**
-hand back a handle for. On a non-live timeout the target is now broken in (SetInterrupt + WaitForEvent),
-but the one-shot breakpoint at `address` can remain armed. Replace `g <addr>` with an explicitly
-managed `AddBreakpoint2` + `RemoveBreakpoint` lifecycle so the breakpoint is cleaned up deterministically
-in **all** exit paths (hit, stopped-elsewhere, timeout, error).
+`run_to_address` used a one-shot `g <addr>` (WinDbg's temporary breakpoint), which DbgEng does **not**
+hand back a handle for, so every exit but a hit could leave it armed.
 
-- **Why deferred:** the interrupt + breakpoint-teardown semantics need a live KDNET/VM kernel target to
-  validate; landing it blind risks a worse regression (hang, or clearing the caller's breakpoints).
-- **Tracked as:** [glslang/win-kexp#63](https://github.com/glslang/win-kexp/issues/63) (picks up from
-  win-kexp PR #62's `src/dbgeng.rs` review thread on the `Timeout` branch). A stale one-shot at
-  `address` is currently harmless to this API's own flow (a later `run_to`/`go` arms its own), so it is
-  low-severity until an explicit rewrite is validated on hardware.
+Fixed in win-kexp (`05df6b7`, closing
+[glslang/win-kexp#63](https://github.com/glslang/win-kexp/issues/63)) and picked up here by the pin
+bump. Building it surfaced two further defects on the same path, both of which mattered more than
+the stale breakpoint this item was filed for: the `Timeout` outcome was **unreachable** (it tested
+`GetExecutionStatus() == DEBUG_STATUS_GO`, but an expired finite wait reports `DEBUG_STATUS_BREAK`),
+so a timed-out `run_to_address` returned `0x8000FFFF` "catastrophic failure" and left the session
+with no current process — and the recovery it would have run does not work either, because a finite
+wait stops the engine pumping events and `SetInterrupt` can no longer be delivered. Every target
+type now uses the watchdog-bounded `WaitForEvent(INFINITE)` the live-kernel path already used.
+
+Nothing changed in this crate: `run_to_address` is a thin wrapper and its `RunToOutcome::Timeout`
+branch simply became reachable. The verdict text it renders was already correct for a target that
+ends up broken in.
 
 ## 2. [win-kexp] Typed write primitives
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,10 @@ process. Two things follow, and they are why it is built this way:
 
 - **`engine.rs`** — the supervisor: the session registry, worker spawn/teardown, and the routing
   that turns a `session_id` into "which worker". Each session has one queue with one consumer, so
-  calls against a session are serialized and ordered even though sessions are not.
+  calls against a session are *serialized* — one runs at a time, and the one running finishes
+  before the next starts. Serialized is not ordered: two calls submitted before either has
+  answered reach that queue in whichever order wins the race, so await each result before sending
+  the next call that depends on it.
 - **`worker.rs`** — the child process. The `DebugEngine` is created on, and confined to, one OS
   thread inside it (DbgEng requires serialized, single-thread access, and `WaitForEvent` must run on
   the session-owning thread). A `catch_unwind` guard turns a panic in one operation into a failed

--- a/README.md
+++ b/README.md
@@ -11,18 +11,41 @@ An [MCP](https://modelcontextprotocol.io) server that exposes **WinDbg/DbgEng** 
 **user-mode**, **kernel-mode**, **crash-dump**, and **Time Travel Debugging (TTD)** workflows.
 
 The low-level engine bindings live in [`win-kexp`](https://github.com/glslang/win-kexp)
-(`src/dbgeng.rs`); this crate adds a dedicated engine thread and the `rmcp` tool surface on top.
+(`src/dbgeng.rs`); this crate adds process-per-session engine supervision and the `rmcp` tool
+surface on top.
 
 ## Architecture
 
-- **`engine.rs`** — DbgEng requires serialized, single-thread access (`WaitForEvent` must run on the
-  session-owning thread), so the `DebugEngine` is created on, and confined to, one OS worker thread.
-  Async tool handlers marshal closures onto it via an `mpsc` channel with `oneshot` replies and a
-  per-call timeout. A `catch_unwind` guard turns a panic in one operation into a failed call rather
-  than a dead thread.
+**One debug session per process.** dbgeng.dll holds a single debuggee session per process — that is
+why `.opendump` *replaces* the target rather than opening a second one — so this server runs the MCP
+protocol in a **supervisor** process and each open target in its own **engine worker** child
+process. Two things follow, and they are why it is built this way:
+
+- **A session that cannot be unwound costs a process, not the server.** A live-kernel attach waits
+  for its target with `WaitForEvent(INFINITE)`, and nothing can interrupt a wait that has not yet
+  connected — so a guest that never dials in blocks forever. That blocks one worker, which
+  `end_session` can terminate. It used to block the server's only engine thread, and the only
+  recovery was restarting the server.
+- **Sessions are concurrent.** Triage a crash dump while a kernel attach is live; keep a TTD trace
+  open while you look at another. Up to four at once.
+
+- **`engine.rs`** — the supervisor: the session registry, worker spawn/teardown, and the routing
+  that turns a `session_id` into "which worker". Each session has one queue with one consumer, so
+  calls against a session are serialized and ordered even though sessions are not.
+- **`worker.rs`** — the child process. The `DebugEngine` is created on, and confined to, one OS
+  thread inside it (DbgEng requires serialized, single-thread access, and `WaitForEvent` must run on
+  the session-owning thread). A `catch_unwind` guard turns a panic in one operation into a failed
+  call rather than a dead session.
+- **`proto.rs`** — the line-delimited JSON protocol between the two. A closure cannot cross a
+  process boundary, so what used to be closures marshalled onto the engine thread are now
+  serializable operations — deliberately *tool*-shaped rather than DbgEng-shaped, so a tool that is
+  several engine calls (`reachable_from_dispatch`'s call-graph walk) stays one indivisible job.
 - **`server.rs`** — the MCP tools (see below), built with `rmcp`'s `#[tool_router]`/`#[tool_handler]`.
 - **`ttd.rs`** — locates `TTD.exe` and launches trace recording.
-- **`main.rs`** — tokio + stdio transport. **Logs go to stderr** (stdout is the JSON-RPC channel).
+- **`main.rs`** — role selection (supervisor or worker), tokio + stdio transport. **Logs go to
+  stderr** (stdout is the JSON-RPC channel); workers inherit the supervisor's stderr, so everything
+  lands in the same place. Workers never outlive the connection: they are terminated on shutdown,
+  and exit on their own when their stdin closes.
 
 **MCP protocol revision:** built on `rmcp` 3.x, this server accepts every revision that SDK knows —
 `2026-07-28` and the `initialize`-handshake ("legacy") era before it (`2025-11-25`, `2025-06-18`,
@@ -212,62 +235,54 @@ gh attestation verify <zip> --repo glslang/windbg-mcp `
 | Driver IOCTL | `decode_ioctl`, `driver_object`, `device_object`, `irp_stack`, `ioctl_trace`, `reachable_from_dispatch` |
 | Raw     | `execute` — run any debugger command, returns full text output |
 
-### Session handles
+### Sessions and session handles
 
 The six Session tools that open a target (`open_dump`, `open_trace`, `attach_kernel_local`,
-`attach_kernel`, `attach_process`, `launch`) return a **`session_id`**. Every tool that touches the
-debug target accepts it as an optional argument and refuses to run if it no longer matches the
-session the engine is attached to.
+`attach_kernel`, `attach_process`, `launch`) each create a **session** — one engine worker process
+holding one target — and return a **`session_id`**. Every tool that touches a target accepts that id
+as an optional argument, and it is what **routes** the call to the right worker.
 
-This matters because one server process drives one DbgEng session, while an MCP connection is *not*
-a session: a client may interleave unrelated requests over the same stdio process. Without a handle,
-a `read_memory` issued after someone else's `open_dump` silently reads the wrong target. Passing
-`session_id` turns that into a visible error instead.
+Sessions are independent. Opening a second target does not disturb the first, a call against one
+does not queue behind work in another, and ending one leaves the rest alone. Up to `4` at once; at
+the limit a new open reclaims the oldest **idle** session, and if every session has a call in flight
+the open is refused with the list rather than picking a victim. Sessions end when you `end_session`
+them or when the client disconnects — nothing is left running afterwards.
 
-The check runs **on the engine thread**, in the same queued job as the debugger call it guards.
-That ordering is what makes it sound: checking on the caller side would leave a window in which a
-concurrently-issued `open_dump` is queued ahead of a call that already passed validation, so the
-call would still execute against the replaced target.
+Omit `session_id` and a call goes to the **current** session: the most recently opened one that will
+still accept work. That is the pre-handle behaviour and it still holds. What supplying the id buys
+is that the call can never land on a target you did not open — it fails loudly instead.
+`decode_ioctl` (pure) and `record_trace` (independent of any debug session) do not take one.
 
-The guarantee is *detection, not exclusion*: the opening tools deliberately take no `session_id`, so
-holding a handle does not stop another caller replacing your target — it guarantees that any later
-call of yours which supplies the handle fails loudly instead of acting on a target you did not open.
+`session_status` lists every session — what it is, what state it is in, how long it has been there,
+and which one is current — or reports on one you name. It never queues on any worker, so it answers
+even while a session is parked.
 
-Two caveats, both in the command hatches. The typed tools announce their own transitions, but
-`execute` can replace the target directly (`.opendump`, `.attach`, `.detach`, `.kill`, `.restart`,
-`.abandon`, `.remote`, `q`/`qd`/`qq`), and those commands retire the current handle. `dx` is the
-second hatch: the data model reaches `Debugger.Utility.Control.ExecuteCommand`, which runs any
-command, so an expression that touches command execution retires the handle too — conservatively,
-since the command it runs is a runtime string this server never sees.
+**Recovering a session that is stuck.** A per-call timeout abandons the *wait*, not the job, so a
+call that reports a timeout may still be running. The case that matters is `attach_kernel`: it waits
+for the target to dial in with no timeout, and DbgEng cannot interrupt a wait that has not yet
+connected — so a guest that is powered off, not booted with debugging enabled, or pointed at the
+wrong host/port/key never arrives, and that wait never ends. `session_status` distinguishes a link
+that is still coming up (normal, ~25s for a KDNET resync) from one that has been waiting far longer
+than a healthy attach ever takes. For the second, `end_session` is the recovery: it asks the worker
+to let go, and terminates the worker process if it will not. Do **not** re-run the open while it is
+still waiting — the target was already claimed, so that would attach a second time.
+
+Two caveats, both in the command hatches, and both now confined to a single session. The typed tools
+announce their own transitions, but `execute` can replace its session's target directly
+(`.opendump`, `.attach`, `.detach`, `.kill`, `.restart`, `.abandon`, `.remote`, `q`/`qd`/`qq`), and
+those commands **retire** that session's handle: calls passing it are refused, while calls that pass
+no id still reach the worker. `dx` is the second hatch — the data model reaches
+`Debugger.Utility.Control.ExecuteCommand`, which runs any command, so an expression that touches
+command execution retires the handle too, conservatively, since the command it runs is a runtime
+string this server never sees.
 
 Both matches are deliberately biased toward retiring: over-matching costs one re-open,
 under-matching would let a stale handle through. Neither can be exhaustive — DbgEng has more ways to
 reach the target than a name list can enumerate, and the data model is extensible — so inside
 `execute` and `dx` a handle is a strong hint rather than a guarantee. Everywhere else it is a
-guarantee.
-
-The argument is optional — omit it and a call operates on whatever session is current, exactly as
-before. `decode_ioctl` (pure) and `record_trace` (independent of the debug session) do not take it.
-
-If an open times out, do not open again — recover instead. The per-call timeout abandons the *wait*,
-not the job, so the open may still be running and may still commit a handle no reply carried. A live
-`attach_kernel` is the case that matters: it waits indefinitely by design, so a call reporting a
-timeout while the attach completes moments later is normal (see *Limitations & notes*).
-
-A timed-out open therefore names the handle it *would* commit, and **`session_status`** answers for
-it: pass that id and it reports whether the open is still **pending**, has **landed**, or has
-**failed**.
-
-That three-way answer is the point. The current handle alone cannot distinguish them — "not yours"
-is equally true while you wait and after you have failed — and the two cases need opposite
-responses. While pending, re-running the open would attach to or start a *second* target. Once
-failed, opening again is the only way forward. Guessing either way is a real mistake, so the server
-tracks the outcome rather than leaving you to infer it.
-
-Only the last few *settled* opens are remembered — an open still in flight is never forgotten, so an
-id `session_status` does not recognise is one that finished a while ago, and re-opening is safe.
-`session_status` does not queue on the engine thread, so it still answers while a parked attach
-holds it.
+guarantee, and it is enforced at the front of that session's queue, after everything queued ahead of
+it: checking on the caller's side would leave a window in which an `execute { ".opendump …" }`
+already queued ahead retires the handle between a caller's check and its call.
 
 ### Typed operands are operands, not commands
 
@@ -287,10 +302,11 @@ command list — it is annotated destructive and retires the handle when a comma
 
 ### Error reporting
 
-A failed *debugger operation* — an unresolvable symbol, an unreadable address, a target that never
-stopped — comes back as a normal tool result with `isError: true` and the debugger's own text, so
-the model can read it and correct itself. Only a dead engine thread is reported as a JSON-RPC
-protocol error.
+Anything scoped to a session comes back as a normal tool result with `isError: true` and the text
+intact, so the model can read it and correct itself: a failed *debugger operation* (an unresolvable
+symbol, an unreadable address, a target that never stopped), a refused handle, a timeout, a session
+whose worker is gone. Each has a next move. The only JSON-RPC protocol error is the one failure that
+is the server's rather than a session's — no engine worker could be started at all.
 
 The forward (`go`/`step_over`/`step_into`) and reverse (`reverse_go`/`step_over_back`/`step_back`)
 control tools mirror a debugger UI's F9/F8/F7 and Shift+F9/F8/F7, so an agent can drive a trace in
@@ -335,14 +351,16 @@ timeline). For anything else, `dx` evaluates arbitrary data-model/LINQ expressio
   (after a `go`/breakpoint, not straight off a `!tt`) so the module's PDB is matched and loaded.
   With those, e.g. `ttd_calls("ucrtbase!__stdio_common_vfprintf")` returns the exact call count.
   Without symbols, the data model, navigation, and memory reads still work — query by address.
-- **One debug session, one command at a time.** A single engine instance runs on a dedicated
-  thread and processes operations serially. Issue tool calls **sequentially — await each result
-  before sending the next**; the server does not order concurrent in-flight requests, so pipelining
-  them (firing several calls before their results return) can run a command before the one that
-  establishes its state (a call racing ahead of `open_dump` fails with `0x80040205`), and is
-  meaningless for stateful, order-dependent debugger commands anyway. Standard MCP clients already
-  serialize call→result, so this is only a concern for custom/batched callers. End a session with
-  `end_session` before opening another target.
+- **One command at a time per session.** Sessions run concurrently, but each one is a single engine
+  processing operations serially, so a call against a busy session waits its turn. Issue tool calls
+  for a given session **sequentially — await each result before sending the next**: the server does
+  not order concurrent in-flight requests against each other, so pipelining them (firing several
+  calls before their results return) can run a command before the one that establishes its state,
+  and is meaningless for stateful, order-dependent debugger commands anyway. Standard MCP clients
+  already serialize call→result, so this is only a concern for custom/batched callers.
+- **Sessions are a bounded resource.** Each is a process holding a dump, a trace, or a live target,
+  and at most `4` are open at once. `end_session` when you are done with one rather than relying on
+  the oldest idle session being reclaimed.
 - TTD **replay** (`open_trace`) needs `TTDReplay.dll` discoverable but **not** elevation; TTD
   **recording** (`record_trace`) needs `TTD.exe` **and** Administrator. `record_trace` captures the
   recorder's startup output to `<out_dir>\ttd_record.log` and watches it briefly, so a fast failure

--- a/README.md
+++ b/README.md
@@ -45,11 +45,13 @@ process. Two things follow, and they are why it is built this way:
 - **`main.rs`** — role selection (supervisor or worker), tokio + stdio transport. **Logs go to
   stderr** (stdout is the JSON-RPC channel); workers inherit the supervisor's stderr, so everything
   lands in the same place. Workers never outlive the connection: a disconnect ends every session
-  the same way `end_session` does — asked to release its target, and terminated only if it will not
-  let go within a few seconds — and a worker exits on its own if its stdin closes. Releasing rather
-  than killing matters for a live kernel, because DbgEng leaves a detached-but-halted kernel
-  *frozen*: a session still busy when the client disconnects is terminated, and that does leave the
-  target stopped, so end a live kernel session explicitly rather than relying on the disconnect.
+  the same way `end_session` does — each worker is asked to release its target, and is terminated
+  only if it does not let go within a few seconds — and a worker exits on its own if its stdin
+  closes. Which of those two happens matters for a live kernel. DbgEng leaves a detached-but-halted
+  kernel *frozen*, so a worker that releases its target leaves the machine running, while a worker
+  that is terminated leaves it stopped. A session still busy at disconnect is the one that gets
+  terminated, so end a live kernel session with `end_session` rather than relying on the
+  disconnect.
 
 **MCP protocol revision:** built on `rmcp` 3.x, this server accepts every revision that SDK knows —
 `2026-07-28` and the `initialize`-handshake ("legacy") era before it (`2025-11-25`, `2025-06-18`,

--- a/README.md
+++ b/README.md
@@ -44,14 +44,15 @@ process. Two things follow, and they are why it is built this way:
 - **`ttd.rs`** — locates `TTD.exe` and launches trace recording.
 - **`main.rs`** — role selection (supervisor or worker), tokio + stdio transport. **Logs go to
   stderr** (stdout is the JSON-RPC channel); workers inherit the supervisor's stderr, so everything
-  lands in the same place. Workers never outlive the connection: a disconnect ends every session
-  the same way `end_session` does — each worker is asked to release its target, and is terminated
-  only if it does not let go within a few seconds — and a worker exits on its own if its stdin
-  closes. Which of those two happens matters for a live kernel. DbgEng leaves a detached-but-halted
-  kernel *frozen*, so a worker that releases its target leaves the machine running, while a worker
-  that is terminated leaves it stopped. A session still busy at disconnect is the one that gets
-  terminated, so end a live kernel session with `end_session` rather than relying on the
-  disconnect.
+  lands in the same place. Workers never outlive the connection: a disconnect asks every session
+  to release its target — all of them concurrently — waits **five seconds**, and terminates only
+  the workers that have not finished by then; a worker also exits on its own if its stdin closes.
+  Which of those two endings a session gets matters for a live kernel. DbgEng leaves a
+  detached-but-halted kernel *frozen*, so a worker that releases its target leaves the machine
+  running, while a worker that is terminated leaves it stopped. Five seconds is enough for an
+  idle session and for most busy ones, but a session in the middle of long work may not make it,
+  so end a live kernel session with `end_session` — which allows considerably longer — rather
+  than relying on the disconnect.
 
 **MCP protocol revision:** built on `rmcp` 3.x, this server accepts every revision that SDK knows —
 `2026-07-28` and the `initialize`-handshake ("legacy") era before it (`2025-11-25`, `2025-06-18`,

--- a/README.md
+++ b/README.md
@@ -44,8 +44,11 @@ process. Two things follow, and they are why it is built this way:
 - **`ttd.rs`** — locates `TTD.exe` and launches trace recording.
 - **`main.rs`** — role selection (supervisor or worker), tokio + stdio transport. **Logs go to
   stderr** (stdout is the JSON-RPC channel); workers inherit the supervisor's stderr, so everything
-  lands in the same place. Workers never outlive the connection: they are terminated on shutdown,
-  and exit on their own when their stdin closes.
+  lands in the same place. Workers never outlive the connection: a disconnect ends every session
+  the same way `end_session` does — released, then terminated if it will not let go — and a worker
+  exits on its own if its stdin closes. Releasing rather than killing matters for a live kernel:
+  DbgEng leaves a detached-but-halted kernel *frozen*, so a worker killed outright would leave the
+  target machine stopped.
 
 **MCP protocol revision:** built on `rmcp` 3.x, this server accepts every revision that SDK knows —
 `2026-07-28` and the `initialize`-handshake ("legacy") era before it (`2025-11-25`, `2025-06-18`,
@@ -246,7 +249,8 @@ Sessions are independent. Opening a second target does not disturb the first, a 
 does not queue behind work in another, and ending one leaves the rest alone. Up to `4` at once; at
 the limit a new open reclaims the oldest **idle** session, and if every session has a call in flight
 the open is refused with the list rather than picking a victim. Sessions end when you `end_session`
-them or when the client disconnects — nothing is left running afterwards.
+them or when the client disconnects — a disconnect is treated as `end_session` on everything, so
+no debugger process is left behind and no target is left halted.
 
 Omit `session_id` and a call goes to the **current** session: the most recently opened one that will
 still accept work. That is the pre-handle behaviour and it still holds. What supplying the id buys

--- a/README.md
+++ b/README.md
@@ -45,10 +45,11 @@ process. Two things follow, and they are why it is built this way:
 - **`main.rs`** — role selection (supervisor or worker), tokio + stdio transport. **Logs go to
   stderr** (stdout is the JSON-RPC channel); workers inherit the supervisor's stderr, so everything
   lands in the same place. Workers never outlive the connection: a disconnect ends every session
-  the same way `end_session` does — released, then terminated if it will not let go — and a worker
-  exits on its own if its stdin closes. Releasing rather than killing matters for a live kernel:
-  DbgEng leaves a detached-but-halted kernel *frozen*, so a worker killed outright would leave the
-  target machine stopped.
+  the same way `end_session` does — asked to release its target, and terminated only if it will not
+  let go within a few seconds — and a worker exits on its own if its stdin closes. Releasing rather
+  than killing matters for a live kernel, because DbgEng leaves a detached-but-halted kernel
+  *frozen*: a session still busy when the client disconnects is terminated, and that does leave the
+  target stopped, so end a live kernel session explicitly rather than relying on the disconnect.
 
 **MCP protocol revision:** built on `rmcp` 3.x, this server accepts every revision that SDK knows —
 `2026-07-28` and the `initialize`-handshake ("legacy") era before it (`2025-11-25`, `2025-06-18`,
@@ -249,8 +250,10 @@ Sessions are independent. Opening a second target does not disturb the first, a 
 does not queue behind work in another, and ending one leaves the rest alone. Up to `4` at once; at
 the limit a new open reclaims the oldest **idle** session, and if every session has a call in flight
 the open is refused with the list rather than picking a victim. Sessions end when you `end_session`
-them or when the client disconnects — a disconnect is treated as `end_session` on everything, so
-no debugger process is left behind and no target is left halted.
+them or when the client disconnects — a disconnect is treated as `end_session` on everything, so no
+debugger process is left behind. It gives each session a shorter grace than `end_session` does,
+though, so end a live kernel session explicitly if you can: one still busy at disconnect is
+terminated, and a terminated kernel session leaves its target halted.
 
 Omit `session_id` and a call goes to the **current** session: the most recently opened one that will
 still accept work. That is the pre-handle behaviour and it still holds. What supplying the id buys

--- a/docs/flareauthenticator-ttd-walkthrough.md
+++ b/docs/flareauthenticator-ttd-walkthrough.md
@@ -180,7 +180,8 @@ any sense" indeed.
 ## Pitfalls (learned the hard way)
 
 - **Never run an unbounded memory search on a TTD trace.** `s -u 0 L?0x400000000000 …` sends the engine
-  into a multi-minute scan, and every later call to that session queues behind it. **Scope every search**
+  into a multi-minute scan, and every later *engine* call for that session queues behind it
+  (`session_status` still answers, and `end_session` still reclaims). **Scope every search**
   to a real region (a module range, a heap segment from the PEB `ProcessHeaps`, a stack window), and
   prefer `ttd_calls`/`ttd_memory` over raw `s`. `execute` is on the bounded path, so a scan that runs
   away self-aborts rather than pinning the session indefinitely, and only that session is affected.

--- a/docs/flareauthenticator-ttd-walkthrough.md
+++ b/docs/flareauthenticator-ttd-walkthrough.md
@@ -180,10 +180,10 @@ any sense" indeed.
 ## Pitfalls (learned the hard way)
 
 - **Never run an unbounded memory search on a TTD trace.** `s -u 0 L?0x400000000000 …` sends the engine
-  into a multi-minute scan that can't be interrupted through the MCP layer — it wedges the engine thread
-  and every later call times out behind it. **Scope every search** to a real region (a module range, a
-  heap segment from the PEB `ProcessHeaps`, a stack window), and prefer `ttd_calls`/`ttd_memory` over raw
-  `s`.
+  into a multi-minute scan, and every later call to that session queues behind it. **Scope every search**
+  to a real region (a module range, a heap segment from the PEB `ProcessHeaps`, a stack window), and
+  prefer `ttd_calls`/`ttd_memory` over raw `s`. `execute` is on the bounded path, so a scan that runs
+  away self-aborts rather than pinning the session indefinitely, and only that session is affected.
 - **`registers` can read empty at a module-load break** — use `execute { "r rip" }` and travel to a
   settled position before relying on context.
 - **The WinDbg `.for` radix bites.** With the default radix `10` means `0x10`; write loop bounds

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -25,12 +25,12 @@ connected MCP client holds a lock on (see [`CLAUDE.md`](../CLAUDE.md)). Whole su
 | **Live kernel** | `--ignored` + `WINDBG_MCP_SMOKE_KERNEL` | a KDNET target you can freeze | that a kernel attach *lands*, coexists, and is let go — by `end_session` and by a disconnect |
 | **Live (other)** | manual | TTD engine, elevation, a test driver | see [Manual checklist](#manual-checklist) |
 
-The protocol tier rides `cargo test`, so CI already runs it. The debugger tier is opt-in: it
-reaches real DbgEng and is available in CI on demand via the **Smoke test (debugger tier)** job
-(Actions → CI → *Run workflow*). The bounded-command and live-kernel tiers are `#[ignore]`d — one
-is measured in minutes, the other touches another machine; see below. Neither is automated, and
-the rest of the live checklist is not either: no runner has a kernel target, a TTD engine, or
-elevation.
+The protocol tier rides `cargo test`, so CI already runs it. The debugger tier is opt-in
+*locally* but runs on every push and PR in CI, as the **Smoke test (debugger tier)** job — it is
+the only automated check of the properties process-per-session exists for, and it needs no symbols
+and no network. The bounded-command and live-kernel tiers are `#[ignore]`d — one is measured in
+minutes, the other touches another machine; see below. Neither is automated, and the rest of the
+live checklist is not either: no runner has a kernel target, a TTD engine, or elevation.
 
 ## What it asserts, and why each one is a dependency tripwire
 
@@ -103,7 +103,8 @@ processes, so they need real ones:
 only watches GitHub Actions here, so cargo bumps arrive by hand.
 
 1. `cargo test` — the protocol tier plus the existing unit tests.
-2. For a `win-kexp` bump, add the debugger tier — the only automated thing that touches DbgEng:
+2. For a `win-kexp` bump, add the debugger tier locally too — CI runs it on the PR, but a local
+   run tells you sooner:
 
    ```pwsh
    $env:WINDBG_MCP_SMOKE_DUMP = "1"; cargo test --test mcp_smoke

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -21,11 +21,13 @@ connected MCP client holds a lock on (see [`CLAUDE.md`](../CLAUDE.md)). Whole su
 | --- | --- | --- | --- |
 | **Protocol** | always | nothing — no debugger, no target, no network | transport, revision negotiation, tool-surface drift |
 | **Debugger** | `WINDBG_MCP_SMOKE_DUMP=1` | `dbgeng.dll`, the checked-in sample dump | `win-kexp` / DbgEng regressions |
+| **Bounded command** | `--ignored` | `dbgeng.dll`, the sample dump, ~1 minute | the watchdog wiring, which now spans two processes |
 | **Live** | manual | KDNET target, TTD engine, elevation | see [Manual checklist](#manual-checklist) |
 
 The protocol tier rides `cargo test`, so CI already runs it. The debugger tier is opt-in: it
 reaches real DbgEng and is available in CI on demand via the **Smoke test (debugger tier)** job
-(Actions → CI → *Run workflow*). The live tier is not automated — no runner has a kernel target.
+(Actions → CI → *Run workflow*). The bounded-command tier is `#[ignore]`d because it is measured in
+minutes; see below. The live tier is not automated — no runner has a kernel target.
 
 ## What it asserts, and why each one is a dependency tripwire
 
@@ -33,7 +35,9 @@ reaches real DbgEng and is available in CI on demand via the **Smoke test (debug
 appears on **stderr**. A dependency that prints a banner or a warning to stdout desynchronizes
 every client, and the client-side symptom is an unreadable parse error. Also: closing stdin exits
 the process within 20s (otherwise each client disconnect leaks a process and a DbgEng session),
-and a malformed input line does not kill the session.
+and a malformed input line does not kill the session. Under process-per-session that last one has
+teeth: a disconnect must also take every **engine worker** process with it, which the debugger tier
+checks by pid.
 
 **Protocol revisions.** Every revision the README promises — `2026-07-28`, `2025-11-25`,
 `2025-06-18`, `2025-03-26`, `2024-11-05` — is offered a handshake, served *that* revision, and can
@@ -70,8 +74,23 @@ codegen dependency can introduce them with no change here.
 session-handle contract on the wire (a stale handle is refused; the handle stops working once
 `end_session` runs). It also pins the `isError` contract against a real engine: `threads` is `~`,
 which DbgEng implements only in user mode, so on a kernel dump it must come back as a **tool error
-carrying the engine's message** — not a JSON-RPC error, and not a dead worker thread. Read-only
+carrying the engine's message** — not a JSON-RPC error, and not a dead session. Read-only
 throughout, and it needs no symbols, so it runs offline.
+
+It also covers process-per-session, which cannot be checked any other way — the claims are about
+processes, so they need real ones:
+
+- *Two sessions coexist.* Two dumps open at once, and the first handle still works after the second
+  open landed. Under the single-engine design this was impossible by construction.
+- *A kernel attach that never connects costs one session.* An `attach_kernel` at a dead port parks
+  exactly as a guest that is not in debug mode would; the test then opens a dump **while it is
+  parked** (the regression test for [#61](https://github.com/glslang/windbg-mcp/issues/61)) and
+  reclaims the parked session with `end_session`, checking by pid that the worker process is gone.
+  It skips itself if the attach fails outright instead of parking (a busy UDP port), because there
+  is nothing to assert about a park that did not happen.
+- *No worker outlives the connection.* Reads the engine pid out of `session_status`, disconnects,
+  and checks the process is gone — otherwise every disconnect leaks a debugger process, and for a
+  launch or an attach, a debuggee with it.
 
 ## When to run it
 
@@ -101,38 +120,46 @@ only watches GitHub Actions here, so cargo bumps arrive by hand.
    revision's `_meta` requirements — that is where per-request metadata rules land.
 4. Update the revision list in `README.md` and this file's list above to match what actually passes.
 
-## The bounded-command tests
+## The bounded-command tier
 
-`src/engine.rs` carries a second set of `#[ignore]`d tests, separate from this file's tiers because
-they drive `EngineHandle` in-process rather than the binary over stdio — they are about the engine
-thread, not the wire.
+A third tier in the same file, `#[ignore]`d rather than env-gated because it deliberately runs
+commands out to a watchdog deadline — minutes, not seconds. It needs the debugger tier's gate too.
 
 ```pwsh
-cargo test --bin windbg-mcp -- --ignored --nocapture --test-threads=1 engine::tests
+$env:WINDBG_MCP_SMOKE_DUMP = "1"
+cargo test --test mcp_smoke -- --ignored --nocapture --test-threads=1 bounded
 ```
 
-`--test-threads=1` is required: dbgeng holds **one debuggee session per process**, so these cannot
-overlap. They open the checked-in sample dump with an empty symbol path, so they run offline; total
-runtime is about a minute, most of it deliberate waiting.
+`--test-threads=1` is required: each test spawns a server that opens the checked-in sample dump, and
+these are timing tests that must not compete for the machine. Total runtime is a bit over a minute,
+most of it deliberate waiting. They shrink the per-call budget with
+`WINDBG_MCP_CALL_TIMEOUT_SECS`, so the arithmetic under test is the real one rather than a special
+case.
 
-- `a_runaway_command_self_aborts_and_leaves_the_engine_usable` — a `.for` loop sized to run for
-  hours is cut short by the watchdog, and the engine executes the *next* command normally. This is
+- `a_bounded_runaway_command_aborts_and_leaves_its_session_usable` — a `.for` loop sized to run for
+  hours is cut short by the watchdog, and the session executes the *next* command normally. This is
   the wedge that used to need a server restart. Proof of interruption is the loop counter left in
   `$t0`, not the clock and not the "interrupted after" note (which is appended whenever the watchdog
   *attempted* an interrupt, even one the engine ignored).
-- `a_runaway_command_queued_behind_another_job_still_beats_its_caller` — the same, from behind a
-  job that already occupies the engine thread for half the call budget. This is the half win-kexp
-  cannot cover, because the queue belongs to this crate: budgeting from the full `call_timeout`
-  instead of what remains passes every other assertion and fails here.
-- `measure_what_the_bounded_path_costs_a_quick_command` — prints what arming the watchdog costs,
-  as a distribution across three command lengths. It asserts nothing; it is the evidence behind
-  which tools take the bounded path ([`DECISIONS.md`](../DECISIONS.md), 2026-08-02), namely that
-  a bounded command is rounded up to a multiple of 200ms. Re-run it after a win-kexp watchdog
-  change — if that cost goes away, so does the reason for the split.
+- `a_bounded_command_queued_behind_another_job_still_beats_its_caller` — the same, from behind a
+  `.sleep` that occupies the session for half the call budget. This is the half win-kexp cannot
+  cover, because the queue belongs to this crate: budgeting from the patience as sent, instead of
+  from what remains after the queue wait, passes every other assertion and fails here. Two details
+  the test documents because both silently void it — `.sleep` needs a `0n` prefix (the MASM
+  evaluator's default base is hex, so a bare `30000` is 0x30000 ms), and the blocker needs a head
+  start, since two tool calls in flight at once reach the session's queue in whichever order wins
+  the race.
+- `measure_what_the_bounded_path_costs_a_quick_command` — prints what arming the watchdog costs, as
+  a distribution. It asserts nothing; it is the evidence behind which tools take the bounded path
+  ([`DECISIONS.md`](../DECISIONS.md), 2026-08-02), namely that a bounded command is rounded up to a
+  multiple of 200ms. Re-run it after a win-kexp watchdog change — if that cost goes away, so does
+  the reason for the split.
 
-The pure budget arithmetic they exercise is also unit-tested in the same module and rides
-`cargo test` everywhere, so a regression in the common case fails in CI rather than waiting for a
-manual run.
+These live with the wire tests rather than beside the arithmetic because the wiring they prove now
+spans two processes: the supervisor sends the caller's remaining patience, the worker derives the
+watchdog deadline from it, and only the shipped binary contains both halves. The arithmetic itself
+is unit-tested in `src/worker.rs` and rides `cargo test` everywhere, so a regression in the common
+case fails in CI rather than waiting for a manual run.
 
 ## Manual checklist
 

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -22,7 +22,7 @@ connected MCP client holds a lock on (see [`CLAUDE.md`](../CLAUDE.md)). Whole su
 | **Protocol** | always | nothing — no debugger, no target, no network | transport, revision negotiation, tool-surface drift |
 | **Debugger** | `WINDBG_MCP_SMOKE_DUMP=1` | `dbgeng.dll`, the checked-in sample dump | `win-kexp` / DbgEng regressions |
 | **Bounded command** | `--ignored` | `dbgeng.dll`, the sample dump, ~1 minute | the watchdog wiring, which now spans two processes |
-| **Live kernel** | `--ignored` + `WINDBG_MCP_SMOKE_KERNEL` | a KDNET target you can freeze | that a kernel attach *lands*, coexists, and detaches cleanly |
+| **Live kernel** | `--ignored` + `WINDBG_MCP_SMOKE_KERNEL` | a KDNET target you can freeze | that a kernel attach *lands*, coexists, and is let go — by `end_session` and by a disconnect |
 | **Live (other)** | manual | TTD engine, elevation, a test driver | see [Manual checklist](#manual-checklist) |
 
 The protocol tier rides `cargo test`, so CI already runs it. The debugger tier is opt-in: it
@@ -172,8 +172,12 @@ see the KDNET gotchas in [`CLAUDE.md`](../CLAUDE.md) before diagnosing a failure
 
 ```pwsh
 $env:WINDBG_MCP_SMOKE_KERNEL = "net:port=50000,key=<w.x.y.z>"
-cargo test --test mcp_smoke -- --ignored --nocapture live_kernel
+cargo test --test mcp_smoke -- --ignored --nocapture --test-threads=1 live_kernel
 ```
+
+`--test-threads=1` is required, not tidiness: the filter matches **two** tests, and the KD
+transport is single-owner, so run in parallel the second attach fails and can leave the target
+halted.
 
 The connection string is the one from `bcdedit /dbgsettings` on the target (or the `kd -k` command
 you would otherwise use). It is **never** guessable, so the tier is gated on it rather than on a

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -161,9 +161,13 @@ case.
 
 These live with the wire tests rather than beside the arithmetic because the wiring they prove now
 spans two processes: the supervisor sends the caller's remaining patience, the worker derives the
-watchdog deadline from it, and only the shipped binary contains both halves. The arithmetic itself
-is unit-tested in `src/worker.rs` and rides `cargo test` everywhere, so a regression in the common
-case fails in CI rather than waiting for a manual run.
+watchdog deadline from it, and only the shipped binary contains both halves.
+
+Each half is unit-tested where it lives, and both ride `cargo test` everywhere — so a regression in
+the common case fails in CI rather than waiting for a manual run. What is sent is
+`remaining_patience_ms` in [`src/engine.rs`](../src/engine.rs); what is derived from it is
+`watchdog_budget_ms` in [`src/worker.rs`](../src/worker.rs). The tests above are what checks that
+the two agree across the pipe, which is the part neither module can prove alone.
 
 ## The live-kernel tier
 

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -22,12 +22,15 @@ connected MCP client holds a lock on (see [`CLAUDE.md`](../CLAUDE.md)). Whole su
 | **Protocol** | always | nothing — no debugger, no target, no network | transport, revision negotiation, tool-surface drift |
 | **Debugger** | `WINDBG_MCP_SMOKE_DUMP=1` | `dbgeng.dll`, the checked-in sample dump | `win-kexp` / DbgEng regressions |
 | **Bounded command** | `--ignored` | `dbgeng.dll`, the sample dump, ~1 minute | the watchdog wiring, which now spans two processes |
-| **Live** | manual | KDNET target, TTD engine, elevation | see [Manual checklist](#manual-checklist) |
+| **Live kernel** | `--ignored` + `WINDBG_MCP_SMOKE_KERNEL` | a KDNET target you can freeze | that a kernel attach *lands*, coexists, and detaches cleanly |
+| **Live (other)** | manual | TTD engine, elevation, a test driver | see [Manual checklist](#manual-checklist) |
 
 The protocol tier rides `cargo test`, so CI already runs it. The debugger tier is opt-in: it
 reaches real DbgEng and is available in CI on demand via the **Smoke test (debugger tier)** job
-(Actions → CI → *Run workflow*). The bounded-command tier is `#[ignore]`d because it is measured in
-minutes; see below. The live tier is not automated — no runner has a kernel target.
+(Actions → CI → *Run workflow*). The bounded-command and live-kernel tiers are `#[ignore]`d — one
+is measured in minutes, the other touches another machine; see below. Neither is automated, and
+the rest of the live checklist is not either: no runner has a kernel target, a TTD engine, or
+elevation.
 
 ## What it asserts, and why each one is a dependency tripwire
 
@@ -161,6 +164,52 @@ watchdog deadline from it, and only the shipped binary contains both halves. The
 is unit-tested in `src/worker.rs` and rides `cargo test` everywhere, so a regression in the common
 case fails in CI rather than waiting for a manual run.
 
+## The live-kernel tier
+
+The only tier that touches another machine, and the last thing to run. It needs a KDNET target you
+are willing to freeze for the duration, booted with debugging enabled and dialling *this* host —
+see the KDNET gotchas in [`CLAUDE.md`](../CLAUDE.md) before diagnosing a failure.
+
+```pwsh
+$env:WINDBG_MCP_SMOKE_KERNEL = "net:port=50000,key=<w.x.y.z>"
+cargo test --test mcp_smoke -- --ignored --nocapture live_kernel
+```
+
+The connection string is the one from `bcdedit /dbgsettings` on the target (or the `kd -k` command
+you would otherwise use). It is **never** guessable, so the tier is gated on it rather than on a
+boolean — and gated on `#[ignore]` as well, so a variable left set from an earlier session cannot
+freeze a VM during an ordinary `cargo test`.
+
+Everything else about kernel attaches is proved against a *dead* port, which is the failure #61 was
+about. This is the other half — an attach that lands:
+
+- **It still lands through a worker process.** The `Committed`/`Opened` milestones cross the pipe
+  and leave the session reporting *open*, not stuck mid-attach.
+- **The KD transport endpoint belongs to the worker**, checked against `netstat -ano`. That is the
+  premise of process-per-session: a thread-based design leaves that endpoint claimed for the life
+  of the server, and every retry claims another. If this assertion ever fails, a parked session is
+  no longer reclaimable and the fix is undone.
+- **A second session works alongside it** — a dump opened and used while the kernel attach is held,
+  with the kernel session unaffected. Impossible by construction before.
+- **`end_session` detaches gracefully rather than killing the worker.** This one has teeth: DbgEng
+  leaves a detached-but-halted kernel *frozen*, so win-kexp resumes and actively detaches. A run
+  that took the kill path instead would leave the guest halted with a wedged KD stub, needing a
+  reboot. For the same reason the test body runs under `catch_unwind` — a failed assertion must
+  still detach, or a test failure costs you the VM.
+- **A disconnect releases a live kernel session rather than killing its worker.** Same hazard by
+  the path nobody watches: closing the connection is an ordinary event, and whatever sessions are
+  open at the time are whatever happened to be open. Checked against the **target's own uptime**
+  read either side of the disconnect — a halted kernel takes no clock interrupt, so its uptime
+  stands still while a released one keeps counting. Re-attaching alone proves nothing here: a
+  frozen target still answers its KD stub.
+
+The first run of this tier found a real bug — shutdown killed workers outright, so a disconnect
+froze the target — which no dump-based tier could have found, because killing a worker that holds
+a *dump* costs nothing. Both tests therefore collect their evidence and assert only after the
+target has been released: an earlier draft asserted as it went, failed at the release check, and
+left the target halted. A test for a bug that freezes a machine must not freeze the machine when
+it fails.
+
 ## Manual checklist
 
 Not automated: no runner has a kernel target, a TTD-capable engine, or elevation. Run these by hand
@@ -171,9 +220,11 @@ before a release, or when a change touches the relevant path. Drivers live in
   read registers/modules, set a breakpoint.
 - **Failure paths** — `examples/verify_fixes.ps1`: execution control with no debuggee returns a
   clean "No active debuggee" error, and a failed kernel attach is a clean error rather than a panic.
-- **Live kernel (KDNET)** — `examples/drive_kernel_test.ps1 -Connection "net:port=<n>,key=<w.x.y.z>"`:
-  attach, `bp nt!NtCreateFile`, `go` to it, resume, detach. See the KDNET gotchas in `CLAUDE.md`
-  before diagnosing a hang.
+- **Live kernel (KDNET)** — the [live-kernel tier](#the-live-kernel-tier) covers the session
+  lifecycle (attach, coexist, detach). For execution control on a real target, additionally run
+  `examples/drive_kernel_test.ps1 -Connection "net:port=<n>,key=<w.x.y.z>"`: attach,
+  `bp nt!NtCreateFile`, `go` to it, resume, detach. See the KDNET gotchas in `CLAUDE.md` before
+  diagnosing a hang.
 - **TTD replay** — needs the WinDbg store engine next to the binary (System32's engine rejects
   `.run` traces with `0x80070057`). Open a trace, then exercise `ttd_calls` / `ttd_memory` /
   `ttd_events` and reverse execution. The worked example is

--- a/skills/windbg-debugging/SKILL.md
+++ b/skills/windbg-debugging/SKILL.md
@@ -44,24 +44,30 @@ a bare `execute`, which only sets the run state and doesn't move the target.
 
 ## Cross-cutting gotchas (apply to every workflow)
 
-- **One debug session, and one command at a time** (single engine instance, run serially on
-  one thread). End a session with `end_session` before opening another target. Issue tool calls
-  **sequentially — await each result before the next**: concurrent in-flight requests aren't
-  ordered, so a pipelined call can run before `open_dump` establishes a target and fail with
+- **One command at a time per session.** Each session is its own engine process, so sessions run
+  independently — but within one, work is serial. Issue tool calls for a session **sequentially —
+  await each result before the next**: concurrent in-flight requests aren't ordered against each
+  other, so a pipelined call can run before `open_dump` establishes a target and fail with
   `0x80040205`, and pipelining stateful debugger commands is unsafe regardless. (Normal MCP
   clients serialize call→result; this only bites custom/batched callers.)
 - **Carry the `session_id`.** The tools that open a target return one; pass it on every later
-  call. The server process is shared, so another caller can replace the target underneath you —
-  with the handle that becomes a clear "stale session handle" error instead of a `read_memory`
-  that quietly returns someone else's memory. Omitting it means "whatever session is current".
-  If an open **times out**, do not retry it — that connects or spawns a second time. The timeout
-  abandons the wait, not the job, so the open may still land; the message names the `session_id`
-  it would commit. Ask `session_status { "session_id": "<that id>" }` — it reports **pending**,
-  **landed**, or **failed**. While pending, do not re-run the open (that attaches or launches a
-  second time); once failed, re-running is the only way forward.
+  call — it routes the call to that target's engine. Omitting it means "whatever session is
+  current" (the newest one still accepting work), which is fine when you only have one and a
+  silent wrong-target read when you have more.
+- **Opening a target does not close the ones you have.** Up to four sessions at once, so you can
+  triage a dump while a kernel attach is live. `end_session` when you are done with one; at the
+  limit a new open reclaims the oldest *idle* session, and refuses if every session is busy.
+- **If an open times out, do not retry it** — that connects or spawns a *second* time. The timeout
+  abandons the wait, not the job, so the open may still land. Ask `session_status
+  { "session_id": "<the id the timeout named>" }`: it says what state the session is in and how
+  long it has been there. For a kernel attach that distinction is the whole thing — a link still
+  coming up (~25s) looks identical to a guest that will never dial in, and only the elapsed time
+  tells them apart. Past that point the report says so, and `end_session` reclaims the session,
+  terminating its engine process if the wait will not unwind. It never affects your other sessions.
 - **A failed debugger operation comes back as a normal tool result**, flagged as an error and
   carrying the debugger's own text — read it and adjust (wrong symbol, unmapped address, target
-  still running). Only a dead engine surfaces as a transport-level protocol error.
+  still running). So do a refused handle and a session whose engine died; all of them are things
+  you can act on. Only "no engine could be started at all" is a transport-level protocol error.
 - **Symbol *names* (`module!func`) need three things together:** (a) `msdia140.dll`
   bundled next to the binary, (b) a symbol path (`execute` →
   `.sympath srv*C:\ProgramData\Dbg\sym*https://msdl.microsoft.com/download/symbols`), and

--- a/skills/windbg-debugging/live-and-kernel.md
+++ b/skills/windbg-debugging/live-and-kernel.md
@@ -52,8 +52,10 @@ four at a time).
   - It costs **only that session**: other sessions and every other tool keep working.
   - **Do not re-attach.** The connection was already claimed, so a retry dials a second time.
   - `session_status` says how long it has been waiting, and whether that is past the point a
-    healthy link takes (~25s for a KDNET resync). Past that it will not return on its own —
-    `end_session { "session_id": "<id>" }` reclaims it, terminating its engine process.
+    healthy link takes (~25s for a KDNET resync). Past that, nothing on this side will end the
+    wait — but the target still can: boot the guest with debugging enabled and the attach lands
+    on its own. Use `end_session { "session_id": "<id>" }` when you choose to give up on it
+    instead; that reclaims the session by terminating its engine process.
 
   A *connected* target that doesn't break in is bounded and returns an error.
 - **TTD is user-mode only** — you cannot time-travel a kernel target. For reverse

--- a/skills/windbg-debugging/live-and-kernel.md
+++ b/skills/windbg-debugging/live-and-kernel.md
@@ -18,7 +18,10 @@ Pick one entry point:
   `bcdedit /dbgsettings` on the target, or the `windbgx -k` / `kd -k` command they use)
   and cannot be guessed — never invent a placeholder key.
 
-End with `end_session {}` before opening another target (one session at a time).
+Each of these opens a session of its own and returns a `session_id` — opening one does not close
+another, so you can keep a kernel attach live while you look at a dump. Pass the id on later calls
+to route them, and `end_session { "session_id": "<id>" }` when you are done with a target (up to
+four at a time).
 
 ## Inspect and control
 
@@ -41,10 +44,18 @@ End with `end_session {}` before opening another target (one session at a time).
   expressions.
 - **`go` is bounded by the per-call timeout** (~60s). A long-running live target may not
   reach a breakpoint within one call; on a live kernel it is force-broken at the cap.
-- **Unreachable kernel target blocks.** `attach_kernel` to a target that never establishes
-  the KDNET link waits like `kd` does (a connecting link can't be cancelled mid-handshake),
-  so confirm the target is up and the port/key are correct. A *connected* target that
-  doesn't break in is bounded and returns an error.
+- **Unreachable kernel target waits forever.** `attach_kernel` to a target that never
+  establishes the KDNET link waits like `kd` does — a connecting link can't be cancelled
+  mid-handshake — so the call reports a timeout while the attach keeps waiting. Confirm the
+  target is up, booted with debugging enabled, and pointed at this host with the right
+  port/key. Three things to know when it happens:
+  - It costs **only that session**: other sessions and every other tool keep working.
+  - **Do not re-attach.** The connection was already claimed, so a retry dials a second time.
+  - `session_status` says how long it has been waiting, and whether that is past the point a
+    healthy link takes (~25s for a KDNET resync). Past that it will not return on its own —
+    `end_session { "session_id": "<id>" }` reclaims it, terminating its engine process.
+
+  A *connected* target that doesn't break in is bounded and returns an error.
 - **TTD is user-mode only** — you cannot time-travel a kernel target. For reverse
   execution, record a user-mode trace instead (see [ttd.md](ttd.md)).
 - Symbol names need the full setup (`msdia140.dll` + `.sympath` + `.reload /f` at a stop) —

--- a/skills/windbg-debugging/ttd.md
+++ b/skills/windbg-debugging/ttd.md
@@ -92,11 +92,12 @@ Then `ttd_calls`/`dx` by name work. To inspect a specific call, travel to it
   is the alias — match the real symbol.
 - **Never run an unbounded memory search on a trace.** A whole-address-space
   `execute { "command": "s -u 0 L?0x400000000000 …" }` sends the engine into a scan that can
-  run for minutes — and it wedges the single engine thread, so every later tool call times
-  out queued behind it. **Scope every search** to a real region: a module range (`lm`), a
-  heap segment from the PEB (`dt ntdll!_PEB @$peb ProcessHeap`), or a stack window — and
-  prefer the indexed data model (`ttd_calls`/`ttd_memory`) over raw `s`. If you do wedge it,
-  the only recovery is to kill `windbg-mcp.exe` and reconnect (`/mcp`), then re-open the trace.
+  run for minutes, and every later call to *that session* queues behind it. **Scope every
+  search** to a real region: a module range (`lm`), a heap segment from the PEB
+  (`dt ntdll!_PEB @$peb ProcessHeap`), or a stack window — and prefer the indexed data model
+  (`ttd_calls`/`ttd_memory`) over raw `s`. If you do launch one, `execute` is on the bounded
+  path so it self-aborts before your call gives up; other sessions are unaffected either way,
+  and `end_session` ends the session outright if you would rather not wait.
 - **`registers {}` empty** → no thread context at this position (a module-load break, or a
   bare `goto_position 0`). Travel to a settled position after a `go`/breakpoint, or read one
   register with `execute { "command": "r rip" }`.

--- a/skills/windbg-debugging/ttd.md
+++ b/skills/windbg-debugging/ttd.md
@@ -92,7 +92,7 @@ Then `ttd_calls`/`dx` by name work. To inspect a specific call, travel to it
   is the alias — match the real symbol.
 - **Never run an unbounded memory search on a trace.** A whole-address-space
   `execute { "command": "s -u 0 L?0x400000000000 …" }` sends the engine into a scan that can
-  run for minutes, and every later call to *that session* queues behind it. **Scope every
+  run for minutes, and every later engine call for that session queues behind it. **Scope every
   search** to a real region: a module range (`lm`), a heap segment from the PEB
   (`dt ntdll!_PEB @$peb ProcessHeap`), or a stack window — and prefer the indexed data model
   (`ttd_calls`/`ttd_memory`) over raw `s`. If you do launch one, `execute` is on the bounded

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -602,6 +602,21 @@ impl Registry {
             .collect()
     }
 
+    /// Sessions that still have a worker process, whatever their state says.
+    ///
+    /// Not the same set as [`Self::live`], and shutdown needs this one. A session claimed for
+    /// reclamation is marked `Closed` immediately but its worker is released in the background, so
+    /// between those two points it is not live and still owns a process — and a client
+    /// disconnecting in that window would drop the runtime, cancel the release, and take the
+    /// worker down by `kill_on_drop` without the `EndSession` that leaves a kernel target running.
+    fn owning_workers(&self) -> Vec<Arc<Session>> {
+        self.all
+            .iter()
+            .filter(|s| s.child.lock().unwrap_or_else(|e| e.into_inner()).is_some())
+            .cloned()
+            .collect()
+    }
+
     /// Drops the oldest settled sessions once the history bound is exceeded. Live sessions are
     /// never evicted — forgetting one would report its handle as unknown, and the advice that
     /// follows from "unknown" is "open again", which for an attach or a launch means a second
@@ -820,10 +835,13 @@ impl Sessions {
                 // an open that created nothing strands the caller exactly as badly as the advice
                 // this seam replaced.
                 if !session.phase().committed() {
-                    settle_uncommitted(&session, &message);
-                    // A retired session is still live: a queued command owns that worker now, so
-                    // it keeps its slot and has to pay for it.
-                    if state.is_live() {
+                    // Whether this still owes a slot is what `settle_uncommitted` reports, not
+                    // what `state` said a moment ago: a session that has just been failed and
+                    // killed owns nothing, and reconciling on its behalf would evict somebody
+                    // else's idle target to pay for a session that no longer exists.
+                    if settle_uncommitted(&session, &message) {
+                        // Retired: a queued command owns that worker now, so it keeps its slot
+                        // and has to pay for it.
                         self.reconcile_capacity(&session);
                     }
                     Err(OpenError::Clean(message))
@@ -942,17 +960,24 @@ impl Sessions {
     /// kernel outright costs. Sessions are released concurrently because they are independent
     /// processes and the client is waiting.
     pub async fn shutdown(&self) {
-        let live = self.registry().live();
-        if live.is_empty() {
+        // Every session that still *owns a worker*, not every live one. A session claimed for
+        // reclamation is already `Closed` while its release runs in the background, and a
+        // disconnect in that window would otherwise drop the runtime, cancel that release, and
+        // let `kill_on_drop` terminate the worker — leaving a kernel target halted, which is the
+        // one outcome this whole path exists to avoid. Releasing one twice is harmless; missing
+        // one is not.
+        let owners = self.registry().owning_workers();
+        if owners.is_empty() {
             return;
         }
-        tracing::info!("shutting down: releasing {} session(s)", live.len());
-        let mut releasing = Vec::with_capacity(live.len());
-        for session in live {
+        tracing::info!("shutting down: releasing {} session(s)", owners.len());
+        let mut releasing = Vec::with_capacity(owners.len());
+        for session in owners {
             let sessions = self.clone();
             releasing.push(tokio::spawn(async move {
                 // Marked first so nothing new is routed to a session on its way out; the release
                 // runs as the supervisor's own teardown and so passes the gate that closes.
+                // A session already closed keeps the reason it closed for.
                 session.set_state(SessionState::Closed(
                     "the server is shutting down".to_string(),
                 ));
@@ -1248,36 +1273,34 @@ fn promote_opened(session: &Session) {
 /// Returns whether the session was left **live** — its worker still holds a target, so it still
 /// owes its slot and capacity has to be reconciled against it.
 /// Settles a session whose opener failed **without creating anything**, and ends its worker
-/// unless something else has claimed it.
+/// unless something else has claimed it. Returns whether the session survived — which is to say,
+/// whether it still owns a worker and therefore still owes its slot.
 ///
 /// The exception is the whole reason this is a function rather than two lines: a target-changing
 /// command queued behind the open retires the handle *and* takes the worker over, and that worker
 /// may be about to hold a target of its own. Killing it because this open failed would discard
 /// something the caller explicitly asked for. So a retired session keeps its worker and its
 /// (retired) handle; only the open's own caller is told the slate is clean, which it is.
-fn settle_uncommitted(session: &Session, why: &str) {
+fn settle_uncommitted(session: &Session, why: &str) -> bool {
     if matches!(session.state(), SessionState::Retired(_)) {
-        return;
+        return true;
     }
     session.set_state(SessionState::Failed(why.to_string()));
     session.kill();
+    false
 }
 
 fn settle_open(session: &Session, result: &Result<String, EngineError>) -> bool {
     // The same discriminator `open` uses, and for the same reason: the *phase* says whether a
     // target was created, while the state may since have been retired by a command queued behind
     // the open.
-    if result.is_err() && !session.phase().committed() {
+    if let Err(e) = result
+        && !session.phase().committed()
+    {
         // Nothing was created, so the handle will never be usable — unless something else has
-        // taken the worker over, which `settle_uncommitted` is the arbiter of.
-        settle_uncommitted(
-            session,
-            &result
-                .as_ref()
-                .err()
-                .map_or(String::new(), |e| e.to_string()),
-        );
-        return session.state().is_live();
+        // taken the worker over, which `settle_uncommitted` is the arbiter of, and which is also
+        // what decides whether a slot is still owed.
+        return settle_uncommitted(session, &e.to_string());
     }
     // Decided and applied under one lock, for the reason `update_state` gives: `pump` can retire
     // this session from another task, and that must outrank a decision taken a moment earlier.
@@ -1861,6 +1884,49 @@ mod tests {
         let landed = dormant("sess-3", SessionState::Attaching);
         settle_open(&landed, &Ok("vertarget".into()));
         assert_eq!(landed.state(), SessionState::Open);
+    }
+
+    /// Shutdown is keyed on owning a worker, not on being live.
+    ///
+    /// A session claimed for reclamation is `Closed` immediately while its release runs in the
+    /// background. A disconnect landing in that window must still collect it: otherwise the
+    /// runtime is dropped, the release is cancelled, and `kill_on_drop` terminates the worker
+    /// without the `EndSession` that leaves a kernel target running.
+    #[tokio::test]
+    async fn shutdown_collects_a_session_whose_release_is_still_in_flight() {
+        let sessions = Sessions::new(Duration::from_secs(1));
+        let reclaimed = dormant("sess-reclaimed", SessionState::Open);
+        // A stand-in for the worker: any child process will do, since what is under test is
+        // which sessions the registry hands to shutdown, not what the process is.
+        let child = Command::new("cmd")
+            .args(["/c", "ping", "-n", "30", "127.0.0.1"])
+            .stdout(Stdio::null())
+            .kill_on_drop(true)
+            .spawn()
+            .expect("spawn a stand-in child");
+        *reclaimed.child.lock().unwrap() = Some(child);
+        // Claimed for reclamation: closed already, release still to come.
+        reclaimed.set_state(SessionState::Closed("reclaimed".to_string()));
+        sessions.registry().all.push_back(Arc::clone(&reclaimed));
+
+        assert!(
+            sessions.registry().live().is_empty(),
+            "a claimed victim is not live, which is why keying shutdown on `live` missed it"
+        );
+        assert_eq!(
+            sessions
+                .registry()
+                .owning_workers()
+                .iter()
+                .map(|s| s.id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["sess-reclaimed"],
+            "it still owns a worker, so shutdown has to collect it"
+        );
+
+        // And once the worker is gone there is nothing left to collect.
+        reclaimed.kill();
+        assert!(sessions.registry().owning_workers().is_empty());
     }
 
     /// A retired handle must not be mistaken for a committed target.

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -26,7 +26,7 @@ use std::collections::{HashMap, VecDeque};
 use std::fmt;
 use std::path::PathBuf;
 use std::process::Stdio;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU8, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, Weak};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
@@ -174,6 +174,43 @@ impl SessionKind {
     }
 }
 
+/// How far a session's opener got, tracked **independently of the session state**.
+///
+/// The state cannot answer this on its own, because it encodes two different things: how the open
+/// is progressing *and* whether the handle still names what it was issued for. A command queued
+/// behind the open retires the handle, and that retirement — correctly — outranks the opener's
+/// own transitions. But it also erases the difference between "nothing was created" and "the
+/// target exists", and those need opposite recovery advice: re-open, versus do not re-open or you
+/// will start a second one.
+///
+/// Monotonic, and only ever advanced by the worker's milestones.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[repr(u8)]
+enum OpenPhase {
+    /// Nothing has been created or claimed. A failure here leaves a clean slate.
+    Started = 0,
+    /// The target exists. Re-running the open would attach a second time, or start a second
+    /// process.
+    Committed = 1,
+    /// The target is loaded and stopped; only the follow-up diagnostic was left.
+    Opened = 2,
+}
+
+impl OpenPhase {
+    fn from_u8(v: u8) -> Self {
+        match v {
+            0 => Self::Started,
+            1 => Self::Committed,
+            _ => Self::Opened,
+        }
+    }
+
+    /// Whether the target exists — the question the recovery advice turns on.
+    fn committed(self) -> bool {
+        self >= Self::Committed
+    }
+}
+
 /// Where a session is in its life.
 ///
 /// The three opening states are the distinction issue #61 could not draw: a `Pending` open looked
@@ -241,6 +278,8 @@ pub struct Session {
     /// Whether `open` has finished with this session and told its caller about it. Until then it
     /// is not reclaimable however idle it looks — see [`Session::busy`].
     delivered: AtomicBool,
+    /// How far the opener got, as [`OpenPhase`]. Separate from the state on purpose.
+    phase: AtomicU8,
     child: Mutex<Option<Child>>,
 }
 
@@ -283,6 +322,16 @@ impl Session {
             *slot = (next, Instant::now());
         }
         slot.0.clone()
+    }
+
+    /// How far the opener got. See [`OpenPhase`] for why this is not read off the state.
+    fn phase(&self) -> OpenPhase {
+        OpenPhase::from_u8(self.phase.load(Ordering::Acquire))
+    }
+
+    /// Advances the opener's phase. Monotonic, so a milestone can never walk it backwards.
+    fn reach(&self, phase: OpenPhase) {
+        self.phase.fetch_max(phase as u8, Ordering::AcqRel);
     }
 
     /// How long the session has been in its current state.
@@ -763,38 +812,43 @@ impl Sessions {
             }
             Err(EngineError::Timeout(message)) => Err(OpenError::Timeout { id, message }),
             Err(e) => {
-                // Which side of the seam the failure fell on is recorded in the state the
-                // worker's milestones left behind — see `SessionState`.
-                match session.state() {
-                    // Nothing was created or claimed, and the worker has nothing to hold.
-                    SessionState::Opening => {
-                        let message = e.to_string();
-                        session.set_state(SessionState::Failed(message.clone()));
-                        session.kill();
-                        Err(OpenError::Clean(message))
+                let message = e.to_string();
+                let state = session.state();
+                // Which side of the seam the failure fell on is the **phase**, never the state.
+                // The state also carries handle validity, so a command queued behind the open can
+                // retire it and erase the distinction — and answering "your session exists" for
+                // an open that created nothing strands the caller exactly as badly as the advice
+                // this seam replaced.
+                if !session.phase().committed() {
+                    settle_uncommitted(&session, &message);
+                    // A retired session is still live: a queued command owns that worker now, so
+                    // it keeps its slot and has to pay for it.
+                    if state.is_live() {
+                        self.reconcile_capacity(&session);
                     }
-                    // The worker died during the open. Whatever it had claimed went with the
+                    Err(OpenError::Clean(message))
+                } else if !state.is_live() {
+                    // The worker died after committing. Whatever it had claimed went with the
                     // process, so there is no session to hand back and no reason to warn against
                     // opening again — that is now the only way forward.
-                    state if !state.is_live() => Err(OpenError::Clean(e.to_string())),
-                    // The target exists and the wait failed; or it opened and only the
-                    // diagnostic failed. Either way the session stays: making the caller
-                    // re-open to get a handle is how they end up with two processes.
-                    state => {
-                        let report_only = matches!(state, SessionState::Open);
-                        // Same rule as the success path: `Retired` outranks this normalisation.
-                        promote_opened(&session);
-                        // It failed, but it left a live session behind, so it still has to pay
-                        // for its slot. Skipping this is how the limit stops being one: the
-                        // sessions retained this way are idle, so they go on satisfying the
-                        // capacity check for the *next* open, and the count climbs.
-                        self.reconcile_capacity(&session);
-                        Err(OpenError::PostCommit {
-                            id,
-                            message: e.to_string(),
-                            report_only,
-                        })
-                    }
+                    Err(OpenError::Clean(message))
+                } else {
+                    // The target exists and the wait failed; or it opened and only the diagnostic
+                    // failed. Either way the session stays: making the caller re-open to get a
+                    // handle is how they end up with two processes.
+                    let report_only = session.phase() == OpenPhase::Opened;
+                    // Same rule as the success path: `Retired` outranks this normalisation.
+                    promote_opened(&session);
+                    // It failed, but it left a live session behind, so it still has to pay for
+                    // its slot. Skipping this is how the limit stops being one: the sessions
+                    // retained this way are idle, so they go on satisfying the capacity check for
+                    // the *next* open, and the count climbs.
+                    self.reconcile_capacity(&session);
+                    Err(OpenError::PostCommit {
+                        id,
+                        message,
+                        report_only,
+                    })
                 }
             }
         };
@@ -1114,6 +1168,7 @@ impl Sessions {
             next_id: AtomicU64::new(OPENER_JOB + 1),
             waiters: Arc::clone(&waiters),
             delivered: AtomicBool::new(false),
+            phase: AtomicU8::new(OpenPhase::Started as u8),
             child: Mutex::new(Some(child)),
         });
 
@@ -1192,28 +1247,48 @@ fn promote_opened(session: &Session) {
 
 /// Returns whether the session was left **live** — its worker still holds a target, so it still
 /// owes its slot and capacity has to be reconciled against it.
+/// Settles a session whose opener failed **without creating anything**, and ends its worker
+/// unless something else has claimed it.
+///
+/// The exception is the whole reason this is a function rather than two lines: a target-changing
+/// command queued behind the open retires the handle *and* takes the worker over, and that worker
+/// may be about to hold a target of its own. Killing it because this open failed would discard
+/// something the caller explicitly asked for. So a retired session keeps its worker and its
+/// (retired) handle; only the open's own caller is told the slate is clean, which it is.
+fn settle_uncommitted(session: &Session, why: &str) {
+    if matches!(session.state(), SessionState::Retired(_)) {
+        return;
+    }
+    session.set_state(SessionState::Failed(why.to_string()));
+    session.kill();
+}
+
 fn settle_open(session: &Session, result: &Result<String, EngineError>) -> bool {
+    // The same discriminator `open` uses, and for the same reason: the *phase* says whether a
+    // target was created, while the state may since have been retired by a command queued behind
+    // the open.
+    if result.is_err() && !session.phase().committed() {
+        // Nothing was created, so the handle will never be usable — unless something else has
+        // taken the worker over, which `settle_uncommitted` is the arbiter of.
+        settle_uncommitted(
+            session,
+            &result
+                .as_ref()
+                .err()
+                .map_or(String::new(), |e| e.to_string()),
+        );
+        return session.state().is_live();
+    }
     // Decided and applied under one lock, for the reason `update_state` gives: `pump` can retire
     // this session from another task, and that must outrank a decision taken a moment earlier.
-    let settled = session.update_state(|state| match (state, result) {
-        (SessionState::Opening | SessionState::Attaching, Ok(_)) => Some(SessionState::Open),
-        // Nothing was created or claimed: this handle will never be usable.
-        (SessionState::Opening, Err(e)) => Some(SessionState::Failed(e.to_string())),
-        // The target exists and something after it failed. The session stays usable — that is
-        // the whole point of committing before the wait.
-        (SessionState::Attaching, Err(_)) => Some(SessionState::Open),
-        // Already settled, by `open` or by a worker that exited — or retired by a command queued
-        // behind the open, which stands.
-        _ => None,
+    let settled = session.update_state(|state| {
+        // The target exists, so the session stays usable whichever way the open ended — that is
+        // the whole point of committing before the wait. Retired and already-settled states are
+        // left exactly as they are.
+        matches!(state, SessionState::Opening | SessionState::Attaching)
+            .then_some(SessionState::Open)
     });
-    let live = settled.is_live();
-    if !live {
-        // The same teardown `open` does on a clean failure. Without it the worker survives
-        // holding DbgEng — and a `Failed` session is excluded from `live()`, so `shutdown` would
-        // not collect it either; it would linger until the whole server exits.
-        session.kill();
-    }
-    live
+    settled.is_live()
 }
 
 fn worker_gone(id: &str) -> String {
@@ -1326,14 +1401,21 @@ async fn reader(
             return;
         };
         match message {
-            // Both milestones are conditional transitions, so both go through `update_state`:
-            // a check-then-set would let a retirement land in the gap and be overwritten.
+            // Each milestone records the opener's phase *and* moves the state. The phase is what
+            // survives a retirement landing in between, and it is what the recovery advice reads.
+            //
+            // Both state moves are conditional transitions, so both go through `update_state`:
+            // a check-then-set would let that retirement be overwritten.
             WorkerMessage::Committed { .. } => {
+                session.reach(OpenPhase::Committed);
                 session.update_state(|state| {
                     matches!(state, SessionState::Opening).then_some(SessionState::Attaching)
                 });
             }
-            WorkerMessage::Opened { .. } => promote_opened(&session),
+            WorkerMessage::Opened { .. } => {
+                session.reach(OpenPhase::Opened);
+                promote_opened(&session);
+            }
             WorkerMessage::Done { id, result } => {
                 let waiter = waiters
                     .lock()
@@ -1483,6 +1565,13 @@ mod tests {
     /// which is all these need: they never submit a call.
     fn dormant(id: &str, state: SessionState) -> Arc<Session> {
         let (tx, _rx) = mpsc::unbounded_channel();
+        // The phase a session in this state would really have reached. They are separate fields
+        // for good reason, but a double whose phase contradicts its state would prove nothing.
+        let phase = match state {
+            SessionState::Opening => OpenPhase::Started,
+            SessionState::Attaching => OpenPhase::Committed,
+            _ => OpenPhase::Opened,
+        };
         Arc::new(Session {
             id: id.to_string(),
             kind: SessionKind::Dump,
@@ -1495,6 +1584,7 @@ mod tests {
             waiters: Arc::new(Mutex::new(HashMap::new())),
             // Test doubles stand in for sessions their callers already hold.
             delivered: AtomicBool::new(true),
+            phase: AtomicU8::new(phase as u8),
             child: Mutex::new(None),
         })
     }
@@ -1771,6 +1861,44 @@ mod tests {
         let landed = dormant("sess-3", SessionState::Attaching);
         settle_open(&landed, &Ok("vertarget".into()));
         assert_eq!(landed.state(), SessionState::Open);
+    }
+
+    /// A retired handle must not be mistaken for a committed target.
+    ///
+    /// When a target-changing command is queued behind an opener that has not created anything
+    /// yet, `pump` retires the session while the phase is still `Started`. `Retired` is live, so
+    /// reading commitment off the state would call that a post-commit failure and tell the caller
+    /// their session exists and not to re-open — for an open that created nothing. That is the
+    /// exact false claim `post_commit_failure` documents as unreachable.
+    ///
+    /// The worker still goes untouched, though: the queued command has taken it over and may be
+    /// about to give it a target of its own.
+    #[test]
+    fn a_retirement_is_not_mistaken_for_a_created_target() {
+        let retired = dormant(
+            "sess-1",
+            SessionState::Retired("`.opendump` queued behind the open".to_string()),
+        );
+        // The state says live, the phase says nothing was created. The phase is the truth.
+        retired
+            .phase
+            .store(OpenPhase::Started as u8, Ordering::Release);
+        assert!(!retired.phase().committed());
+
+        let live = settle_open(&retired, &Err(EngineError::Debugger("no target".into())));
+        assert!(
+            matches!(retired.state(), SessionState::Retired(_)),
+            "the worker belongs to the queued command now, so it is not ours to fail or kill"
+        );
+        assert!(live, "it still holds a worker, so it still owes its slot");
+
+        // Without a retirement in the way, the same failure ends the session and its worker.
+        let plain = dormant("sess-2", SessionState::Opening);
+        assert!(!settle_open(
+            &plain,
+            &Err(EngineError::Debugger("no such file".into()))
+        ));
+        assert_eq!(plain.state(), SessionState::Failed("no such file".into()));
     }
 
     /// Settling is idempotent and never resurrects: a session ended while its opener was still

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -710,8 +710,11 @@ impl Sessions {
                     session.set_state(SessionState::Open);
                 }
                 // Only now, with a target that is genuinely open, is an existing session
-                // reclaimed to pay for it.
-                self.trim_to_cap(&session).await;
+                // reclaimed to pay for it — and not on this caller's clock: reclaiming waits on
+                // *other* sessions' workers, each up to `END_SESSION_TIMEOUT`, and serially when
+                // the overage is more than one. The caller is owed the handle for a target that
+                // is already open.
+                self.reconcile_capacity(&session);
                 Ok(OpenReport { id, report })
             }
             Err(EngineError::Timeout(message)) => Err(OpenError::Timeout { id, message }),
@@ -742,7 +745,7 @@ impl Sessions {
                         // for its slot. Skipping this is how the limit stops being one: the
                         // sessions retained this way are idle, so they go on satisfying the
                         // capacity check for the *next* open, and the count climbs.
-                        self.trim_to_cap(&session).await;
+                        self.reconcile_capacity(&session);
                         Err(OpenError::PostCommit {
                             id,
                             message: e.to_string(),
@@ -960,6 +963,19 @@ impl Sessions {
                 keeping.id
             );
         }
+    }
+
+    /// [`Self::trim_to_cap`], off the caller's clock.
+    ///
+    /// Every path that reconciles capacity does so on behalf of a session that has *already*
+    /// opened, so none of them should make anyone wait for other sessions to be released — a
+    /// release is bounded by [`END_SESSION_TIMEOUT`] each, and serial when more than one is owed.
+    /// The accounting is unaffected: the victim is marked under the registry lock the moment it is
+    /// claimed, so a concurrent open sees it gone immediately either way.
+    fn reconcile_capacity(&self, keeping: &Arc<Session>) {
+        let sessions = self.clone();
+        let keeping = Arc::clone(keeping);
+        tokio::spawn(async move { sessions.trim_to_cap(&keeping).await });
     }
 
     /// Marks and hands back the oldest idle session while the registry is over the cap.
@@ -1270,11 +1286,8 @@ async fn reader(
                     && settle_open(&session, &unreceived)
                 {
                     // It settled *live*, so it owes the slot it took — the same reconciliation
-                    // `open` runs, which nobody is left here to run for it. Spawned rather than
-                    // awaited: reclaiming waits on another session's worker, and this task has
-                    // its own worker's messages to keep draining.
-                    let sessions = sessions.clone();
-                    tokio::spawn(async move { sessions.trim_to_cap(&session).await });
+                    // `open` runs, which nobody is left here to run for it.
+                    sessions.reconcile_capacity(&session);
                 }
             }
             // Both belong to the spawn handshake, which has already happened.

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -79,9 +79,24 @@ const SHUTDOWN_RELEASE_TIMEOUT: Duration = Duration::from_secs(5);
 /// How many times shutdown re-checks for workers registered while it was running.
 ///
 /// One round can miss an open that was between spawning its worker and registering it when the
-/// client disconnected. Two suffice — new opens are refused before the first round — and the
-/// third is only there so a bug in that reasoning costs a bounded wait rather than a hang.
-const SHUTDOWN_ROUNDS: usize = 3;
+/// client disconnected. Two is one round plus a retry, which is all that reasoning needs — new
+/// opens are refused before the first — and it keeps the worst case (each round waiting out
+/// [`SHUTDOWN_RELEASE_TIMEOUT`]) inside the budget a client allows for the process to exit.
+const SHUTDOWN_ROUNDS: usize = 2;
+
+/// How long shutdown will wait for an open that was *already admitted* to register its worker,
+/// when there is nothing else left to release.
+///
+/// It cannot simply stop: such an open holds no target only until it registers, and it opens one
+/// immediately afterwards. Bounded rather than waiting out the worker handshake in full, because
+/// a client that has disconnected is entitled to see the process go — and a worker that has not
+/// registered by then still holds nothing, so what it costs is an ungraceful kill of an engine
+/// with no target.
+const SHUTDOWN_DRAIN: Duration = Duration::from_secs(2);
+
+/// How often that drain re-checks. Short: registration follows the worker's handshake by
+/// microseconds, so this is nearly always one poll.
+const SHUTDOWN_POLL: Duration = Duration::from_millis(50);
 
 /// Counter behind [`mint_session_id`]. Only needs to be unique within this process.
 static SESSION_SEQ: AtomicU64 = AtomicU64::new(1);
@@ -631,9 +646,18 @@ impl Registry {
     /// never evicted — forgetting one would report its handle as unknown, and the advice that
     /// follows from "unknown" is "open again", which for an attach or a launch means a second
     /// target.
+    ///
+    /// Nor is one that still owns a worker, whatever its state says. A session claimed for
+    /// reclamation is `Closed` at once and released in the background, and evicting it in that
+    /// window would take it out of [`Self::owning_workers`] — so a disconnect would no longer
+    /// find it, the release would be cancelled with the runtime, and `kill_on_drop` would finish
+    /// the worker without the `EndSession` a halted kernel needs.
     fn trim(&mut self) {
         while self.all.len() > CLOSED_HISTORY + MAX_SESSIONS {
-            let Some(oldest_settled) = self.all.iter().position(|s| !s.state().is_live()) else {
+            let evictable = self.all.iter().position(|s| {
+                !s.state().is_live() && s.child.lock().unwrap_or_else(|e| e.into_inner()).is_none()
+            });
+            let Some(oldest_settled) = evictable else {
                 return;
             };
             self.all.remove(oldest_settled);
@@ -979,16 +1003,31 @@ impl Sessions {
         // Rounds rather than one pass, because an open already past the gate can still register
         // while the first round runs. It terminates: nothing new can be admitted, so each round
         // finds only what the previous one raced with, and in practice the second is empty.
+        let drain_by = Instant::now() + SHUTDOWN_DRAIN;
         for _ in 0..SHUTDOWN_ROUNDS {
             // Every session that still *owns a worker*, not every live one. A session claimed for
             // reclamation is already `Closed` while its release runs in the background, and a
             // disconnect in that window would otherwise drop the runtime, cancel that release,
             // and let `kill_on_drop` terminate the worker — the same halted target by another
             // route. Releasing one twice is harmless; missing one is not.
-            let owners = self.registry().owning_workers();
-            if owners.is_empty() {
-                return;
-            }
+            let owners = loop {
+                let (owners, opening) = {
+                    let registry = self.registry();
+                    (registry.owning_workers(), registry.opening)
+                };
+                if !owners.is_empty() {
+                    break owners;
+                }
+                // Nothing to release *yet* is not the same as nothing to release. An open
+                // admitted before the gate closed may still be waiting for its worker's
+                // handshake, so it is not in the registry to be found — and it holds no target
+                // only until it registers, at which point it opens one immediately. Returning
+                // here would leave exactly that worker to `kill_on_drop`.
+                if opening == 0 || Instant::now() >= drain_by {
+                    return;
+                }
+                tokio::time::sleep(SHUTDOWN_POLL).await;
+            };
             tracing::info!("shutting down: releasing {} session(s)", owners.len());
             let mut releasing = Vec::with_capacity(owners.len());
             for session in owners {
@@ -1959,6 +1998,49 @@ mod tests {
         // And once the worker is gone there is nothing left to collect.
         reclaimed.kill();
         assert!(sessions.registry().owning_workers().is_empty());
+    }
+
+    /// History eviction must not forget a session whose worker is still being released.
+    ///
+    /// A reclaimed session is `Closed` at once and released in the background. Evicting it in that
+    /// window takes it out of `owning_workers`, so a disconnect no longer finds it, the release is
+    /// cancelled with the runtime, and `kill_on_drop` finishes the worker without the
+    /// `EndSession` a halted kernel needs.
+    #[tokio::test]
+    async fn history_eviction_keeps_a_session_that_still_owns_a_worker() {
+        let sessions = Sessions::new(Duration::from_secs(1));
+        let releasing = dormant(
+            "sess-releasing",
+            SessionState::Closed("reclaimed".to_string()),
+        );
+        let child = Command::new("cmd")
+            .args(["/c", "ping", "-n", "30", "127.0.0.1"])
+            .stdout(Stdio::null())
+            .kill_on_drop(true)
+            .spawn()
+            .expect("spawn a stand-in child");
+        *releasing.child.lock().unwrap() = Some(child);
+        {
+            let mut registry = sessions.registry();
+            registry.all.push_back(Arc::clone(&releasing));
+            // Far past the history bound, so trimming has every reason to take it.
+            for n in 0..(CLOSED_HISTORY + MAX_SESSIONS) * 2 {
+                registry.all.push_back(dormant(
+                    &format!("sess-{n}"),
+                    SessionState::Closed("x".into()),
+                ));
+            }
+            registry.trim();
+        }
+        assert!(
+            sessions
+                .registry()
+                .owning_workers()
+                .iter()
+                .any(|s| s.id == "sess-releasing"),
+            "a session mid-release was evicted, so shutdown could no longer find its worker"
+        );
+        releasing.kill();
     }
 
     /// A retired handle must not be mistaken for a committed target.

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1453,15 +1453,23 @@ async fn reader(
             //
             // Both state moves are conditional transitions, so both go through `update_state`:
             // a check-then-set would let that retirement be overwritten.
-            WorkerMessage::Committed { .. } => {
+            // Matched on the reserved opener id, so the contract that only an opener reports
+            // milestones is enforced here rather than assumed to hold for ever.
+            WorkerMessage::Committed { id } if id == OPENER_JOB => {
                 session.reach(OpenPhase::Committed);
                 session.update_state(|state| {
                     matches!(state, SessionState::Opening).then_some(SessionState::Attaching)
                 });
             }
-            WorkerMessage::Opened { .. } => {
+            WorkerMessage::Opened { id } if id == OPENER_JOB => {
                 session.reach(OpenPhase::Opened);
                 promote_opened(&session);
+            }
+            WorkerMessage::Committed { id } | WorkerMessage::Opened { id } => {
+                tracing::warn!(
+                    "session {}: job {id} reported an opener milestone",
+                    session.id
+                );
             }
             WorkerMessage::Done { id, result } => {
                 let waiter = waiters

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -633,11 +633,20 @@ impl Sessions {
         let (tx, rx) = oneshot::channel();
         // Registered before the job is queued, so the session counts as busy from the moment the
         // call is submitted rather than from the moment it is written to the worker.
-        session
-            .waiters
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
-            .insert(id, tx);
+        //
+        // Under the *registry* lock, which is not this map's lock and is not about this map: it is
+        // what `claim_overage_victim` holds while it decides a session is idle and closes it.
+        // Without taking it here, a call could become in-flight in the gap between that decision
+        // and the close, and reclamation would then end a session the caller had just started
+        // using. Held only across the insert; the send below is outside it.
+        {
+            let _reclamation = self.registry();
+            session
+                .waiters
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .insert(id, tx);
+        }
         let queued = session.tx.send(Job {
             id,
             op: call.op,
@@ -677,7 +686,7 @@ impl Sessions {
     ) -> Result<OpenReport, OpenError> {
         debug_assert!(op.is_opener(), "open() needs an opener op");
         // Take a slot before doing anything expensive, but do **not** reclaim anything yet — see
-        // `take_slot` and `trim_to_cap` for why those are separate.
+        // `take_slot` and `reconcile_capacity` for why those are separate.
         let slot = self.take_slot().map_err(OpenError::NoRoom)?;
 
         let id = mint_session_id();
@@ -706,9 +715,14 @@ impl Sessions {
                 // Defensive: a worker that answered without reporting `Opened` still produced a
                 // usable target, and leaving the session mid-open would make every later call
                 // read as "still attaching".
-                if !matches!(session.state(), SessionState::Open) {
-                    session.set_state(SessionState::Open);
-                }
+                //
+                // Promoted *only* from the opening states, never from `Retired`. A
+                // target-changing `execute` can be queued behind an open — through an unnamed
+                // call, or a handle read from `session_status` — and `pump` retires the session
+                // when it forwards that command. Normalising to `Open` here would undo that
+                // while the command is still on its way to the worker, and the handle would go
+                // on certifying a target it no longer names.
+                promote_opened(&session);
                 // Only now, with a target that is genuinely open, is an existing session
                 // reclaimed to pay for it — and not on this caller's clock: reclaiming waits on
                 // *other* sessions' workers, each up to `END_SESSION_TIMEOUT`, and serially when
@@ -738,9 +752,8 @@ impl Sessions {
                     // re-open to get a handle is how they end up with two processes.
                     state => {
                         let report_only = matches!(state, SessionState::Open);
-                        if !report_only {
-                            session.set_state(SessionState::Open);
-                        }
+                        // Same rule as the success path: `Retired` outranks this normalisation.
+                        promote_opened(&session);
                         // It failed, but it left a live session behind, so it still has to pay
                         // for its slot. Skipping this is how the limit stops being one: the
                         // sessions retained this way are idle, so they go on satisfying the
@@ -871,7 +884,7 @@ impl Sessions {
     /// Takes a slot for a new session, or refuses the open.
     ///
     /// Deliberately **decides** without **doing**: at the limit it only checks that some session
-    /// *could* be reclaimed, and leaves the reclaiming to [`Self::trim_to_cap`] once the
+    /// *could* be reclaimed, and leaves the reclaiming to [`Self::reconcile_capacity`] once the
     /// replacement is real. Evicting here instead would mean a mistyped path, or a worker that
     /// would not start, destroys a perfectly good target the caller still wanted — a failed open
     /// must cost nothing but the attempt.
@@ -935,21 +948,23 @@ impl Sessions {
     ///
     /// `keeping` is excluded because it is idle the instant it opens, and with every other
     /// session busy it would otherwise be the one reclaimed — an open that closes itself.
-    async fn trim_to_cap(&self, keeping: &Arc<Session>) {
+    ///
+    /// **Claims synchronously, releases in the background**, and the split is load-bearing in both
+    /// directions. Claiming is a lock and a state write, so doing it on the caller's thread costs
+    /// nothing and means the *next* `take_slot` sees the victims already gone — deferring it would
+    /// let a concurrent open count them as reclaimable a second time, admit itself on capacity
+    /// that was already spent, and end up reclaimed by the first open's own reconciliation.
+    /// Releasing, by contrast, waits on another session's worker for up to
+    /// [`END_SESSION_TIMEOUT`] each and serially when more than one is owed, and nobody opening a
+    /// target should wait for unrelated sessions to finish ending.
+    fn reconcile_capacity(&self, keeping: &Arc<Session>) {
+        let mut victims = Vec::new();
         while let Some(victim) = self.claim_overage_victim(keeping) {
             tracing::info!(
                 "reclaimed idle session {} (at the {MAX_SESSIONS}-session limit)",
                 victim.id
             );
-            // Released the same way `end_session` releases one, so a live debuggee is let go
-            // cleanly rather than dying with its debugger. As the supervisor's own teardown
-            // rather than a caller's call, it runs past the gate the marking above closed.
-            self.release(
-                &victim,
-                Call::supervisor(EngineOp::EndSession),
-                END_SESSION_TIMEOUT,
-            )
-            .await;
+            victims.push(victim);
         }
         let over = self.registry().live().len();
         if over > MAX_SESSIONS {
@@ -963,26 +978,31 @@ impl Sessions {
                 keeping.id
             );
         }
-    }
-
-    /// [`Self::trim_to_cap`], off the caller's clock.
-    ///
-    /// Every path that reconciles capacity does so on behalf of a session that has *already*
-    /// opened, so none of them should make anyone wait for other sessions to be released — a
-    /// release is bounded by [`END_SESSION_TIMEOUT`] each, and serial when more than one is owed.
-    /// The accounting is unaffected: the victim is marked under the registry lock the moment it is
-    /// claimed, so a concurrent open sees it gone immediately either way.
-    fn reconcile_capacity(&self, keeping: &Arc<Session>) {
+        if victims.is_empty() {
+            return;
+        }
         let sessions = self.clone();
-        let keeping = Arc::clone(keeping);
-        tokio::spawn(async move { sessions.trim_to_cap(&keeping).await });
+        tokio::spawn(async move {
+            for victim in victims {
+                // Released the same way `end_session` releases one, so a live debuggee is let go
+                // cleanly rather than dying with its debugger. As the supervisor's own teardown
+                // rather than a caller's call, it runs past the gate the claim already closed.
+                sessions
+                    .release(
+                        &victim,
+                        Call::supervisor(EngineOp::EndSession),
+                        END_SESSION_TIMEOUT,
+                    )
+                    .await;
+            }
+        });
     }
 
     /// Marks and hands back the oldest idle session while the registry is over the cap.
     ///
-    /// Separate from [`Self::trim_to_cap`] so the registry lock is never held across the release
-    /// that follows. The marking happens *under* the lock, so a second open racing this one
-    /// cannot see the same session as live-and-idle, pick it too, and free nothing.
+    /// Separate from [`Self::reconcile_capacity`] so the registry lock is never held across the
+    /// release that follows. The marking happens *under* the lock, so a second open racing this
+    /// one cannot see the same session as live-and-idle, pick it too, and free nothing.
     fn claim_overage_victim(&self, keeping: &Arc<Session>) -> Option<Arc<Session>> {
         let registry = self.registry();
         let live = registry.live();
@@ -1120,6 +1140,22 @@ const OPENER_JOB: u64 = 1;
 /// taken by [`reader`] when the caller's timeout means no reply was received at all. The states
 /// are the discriminator either way — `Opening` means nothing was created, `Attaching` means the
 /// target exists and the wait failed — so both paths reach the same answer.
+/// Moves a session that is still opening to [`SessionState::Open`], and leaves every other state
+/// alone.
+///
+/// The states it refuses to touch are the point. `Retired` in particular must survive: a
+/// target-changing command queued behind the open retires the session as `pump` forwards it, and
+/// an opener finishing afterwards must not undo that — the handle would then certify a target the
+/// queued command is about to replace.
+fn promote_opened(session: &Session) {
+    if matches!(
+        session.state(),
+        SessionState::Opening | SessionState::Attaching
+    ) {
+        session.set_state(SessionState::Open);
+    }
+}
+
 /// Returns whether the session was left **live** — its worker still holds a target, so it still
 /// owes its slot and capacity has to be reconciled against it.
 fn settle_open(session: &Session, result: &Result<String, EngineError>) -> bool {
@@ -1601,7 +1637,7 @@ mod tests {
         ]);
         let slot = sessions.take_slot().expect("there is room");
         drop(slot);
-        sessions.trim_to_cap(&live).await;
+        sessions.reconcile_capacity(&live);
         assert_eq!(live.state(), SessionState::Open, "it was not reclaimed");
     }
 
@@ -1663,7 +1699,7 @@ mod tests {
             }
             registry.all.push_back(Arc::clone(&newest));
         }
-        sessions.trim_to_cap(&newest).await;
+        sessions.reconcile_capacity(&newest);
         assert_eq!(
             newest.state(),
             SessionState::Open,
@@ -1732,11 +1768,51 @@ mod tests {
 
     // ---- reconciling capacity -----------------------------------------------------
 
-    /// Reclaims *until* the server is back at the limit, not once per call.
+    /// An opener finishing must not undo a retirement that happened while it ran.
+    ///
+    /// A target-changing `execute` can be queued behind an open, and `pump` retires the session
+    /// as it forwards that command — before the worker has run it, and possibly before the opener
+    /// has even answered. Normalising the session back to `Open` afterwards would leave the handle
+    /// certifying a target the queued command is about to replace, which is the one thing the
+    /// handle is supposed to make impossible.
+    #[test]
+    fn an_opener_that_finishes_does_not_un_retire_its_session() {
+        let retired = dormant(
+            "sess-1",
+            SessionState::Retired("`.opendump` queued behind the open".to_string()),
+        );
+        promote_opened(&retired);
+        assert!(
+            matches!(retired.state(), SessionState::Retired(_)),
+            "retirement outranks the opener's normalisation, got {:?}",
+            retired.state()
+        );
+
+        // The states it *is* for.
+        for state in [SessionState::Opening, SessionState::Attaching] {
+            let opening = dormant("sess-2", state.clone());
+            promote_opened(&opening);
+            assert_eq!(opening.state(), SessionState::Open, "from {state:?}");
+        }
+
+        // And it never resurrects a settled one.
+        let closed = dormant("sess-3", SessionState::Closed("ended".to_string()));
+        promote_opened(&closed);
+        assert_eq!(closed.state(), SessionState::Closed("ended".to_string()));
+    }
+
+    /// Reclaims *until* the server is back at the limit, not once per call — and does the
+    /// claiming **synchronously**, which is the half that keeps the accounting honest.
     ///
     /// An overage can outlive the open that caused it — if every candidate was busy at the time,
     /// the debt is still owed once they go idle. Taking one victim per open would carry it
     /// forever: six live sessions would become five on the next open, then six, then five.
+    ///
+    /// That the count is already correct when this returns is the point of claiming before
+    /// spawning the releases: a concurrent open would otherwise still see the victims as live and
+    /// idle, count them as capacity a second time, and admit itself on room that was already
+    /// spent — only to be reclaimed by this reconciliation moments later, handing its caller a
+    /// `session_id` that was stale on arrival.
     #[tokio::test]
     async fn reclaiming_clears_the_whole_overage_not_one_session_per_open() {
         let sessions = Sessions::new(Duration::from_secs(1));
@@ -1752,7 +1828,7 @@ mod tests {
         }
         assert_eq!(sessions.registry().live().len(), MAX_SESSIONS + 3);
 
-        sessions.trim_to_cap(&keeping).await;
+        sessions.reconcile_capacity(&keeping);
 
         assert_eq!(
             sessions.registry().live().len(),
@@ -1781,7 +1857,7 @@ mod tests {
             }
             registry.all.push_back(Arc::clone(&keeping));
         }
-        sessions.trim_to_cap(&keeping).await;
+        sessions.reconcile_capacity(&keeping);
         assert_eq!(
             sessions.registry().live().len(),
             MAX_SESSIONS + 1,

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -618,6 +618,18 @@ impl Sessions {
         budget: Duration,
     ) -> Result<String, EngineError> {
         let id = session.next_id.fetch_add(1, Ordering::Relaxed);
+        self.call_as(session, call, budget, id).await
+    }
+
+    /// [`Self::call_within`] with the job id chosen by the caller, which only the opener does —
+    /// see [`OPENER_JOB`].
+    async fn call_as(
+        &self,
+        session: &Arc<Session>,
+        call: Call,
+        budget: Duration,
+        id: u64,
+    ) -> Result<String, EngineError> {
         let (tx, rx) = oneshot::channel();
         // Registered before the job is queued, so the session counts as busy from the moment the
         // call is submitted rather than from the moment it is written to the worker.
@@ -684,7 +696,11 @@ impl Sessions {
         // would count this open twice.
         drop(slot);
 
-        let out = self.call(&session, Call::new(op)).await;
+        // On the reserved job id, so `reader` can still recognise this open if the caller's
+        // timeout means nobody is left to settle it.
+        let out = self
+            .call_as(&session, Call::new(op), self.call_timeout, OPENER_JOB)
+            .await;
         match out {
             Ok(report) => {
                 // Defensive: a worker that answered without reporting `Opened` still produced a
@@ -722,6 +738,11 @@ impl Sessions {
                         if !report_only {
                             session.set_state(SessionState::Open);
                         }
+                        // It failed, but it left a live session behind, so it still has to pay
+                        // for its slot. Skipping this is how the limit stops being one: the
+                        // sessions retained this way are idle, so they go on satisfying the
+                        // capacity check for the *next* open, and the count climbs.
+                        self.trim_to_cap(&session).await;
                         Err(OpenError::PostCommit {
                             id,
                             message: e.to_string(),
@@ -897,57 +918,67 @@ impl Sessions {
         })
     }
 
-    /// Reclaims the oldest idle session if the server is over [`MAX_SESSIONS`], now that
+    /// Reclaims idle sessions until the server is back within [`MAX_SESSIONS`], now that
     /// `keeping` has actually opened and is worth paying for.
+    ///
+    /// Runs from **every** path that leaves a live session behind — a landed open, and an open
+    /// that failed after committing but kept its target. Only reconciling on success is how the
+    /// limit stops being one: a session retained by a post-commit failure is *idle*, so it goes
+    /// on satisfying [`Self::take_slot`] for the next open, and the count climbs.
+    ///
+    /// Reclaims as many as it takes rather than one per call, because an overage can outlive the
+    /// open that caused it: if every candidate was busy at the time, that debt is still owed once
+    /// they go idle, and taking one victim per open would just carry it forever.
     ///
     /// `keeping` is excluded because it is idle the instant it opens, and with every other
     /// session busy it would otherwise be the one reclaimed — an open that closes itself.
-    ///
-    /// May leave the server one over the limit, when the sessions that would have paid for this
-    /// one all became busy while it was opening. That is the honest outcome: the alternatives are
-    /// ending someone's live target or discarding a target that already opened. The next open
-    /// finds nothing idle and is refused, so it does not compound.
     async fn trim_to_cap(&self, keeping: &Arc<Session>) {
-        let victim = {
-            let registry = self.registry();
-            let live = registry.live();
-            if live.len() <= MAX_SESSIONS {
-                return;
-            }
-            match live.iter().find(|s| s.id != keeping.id && !s.busy()) {
-                // Marked while the registry lock is held, so a second open racing this one cannot
-                // see the same session as live-and-idle, pick it too, and free nothing.
-                Some(idle) => {
-                    idle.set_state(SessionState::Closed(format!(
-                        "reclaimed to make room for a new session — this server holds at most \
-                         {MAX_SESSIONS} at once, and this was the oldest idle one"
-                    )));
-                    Arc::clone(idle)
-                }
-                None => {
-                    tracing::warn!(
-                        "{} sessions are open, one over the {MAX_SESSIONS} limit: nothing was \
-                         idle enough to reclaim when `{}` opened",
-                        live.len(),
-                        keeping.id
-                    );
-                    return;
-                }
-            }
-        };
-        tracing::info!(
-            "reclaimed idle session {} (at the {MAX_SESSIONS}-session limit)",
-            victim.id
-        );
-        // Released the same way `end_session` releases one, so a live debuggee is let go cleanly
-        // rather than dying with its debugger. As the supervisor's own teardown rather than a
-        // caller's call, it runs past the gate the state above would otherwise close.
-        self.release(
-            &victim,
-            Call::supervisor(EngineOp::EndSession),
-            END_SESSION_TIMEOUT,
-        )
-        .await;
+        while let Some(victim) = self.claim_overage_victim(keeping) {
+            tracing::info!(
+                "reclaimed idle session {} (at the {MAX_SESSIONS}-session limit)",
+                victim.id
+            );
+            // Released the same way `end_session` releases one, so a live debuggee is let go
+            // cleanly rather than dying with its debugger. As the supervisor's own teardown
+            // rather than a caller's call, it runs past the gate the marking above closed.
+            self.release(
+                &victim,
+                Call::supervisor(EngineOp::EndSession),
+                END_SESSION_TIMEOUT,
+            )
+            .await;
+        }
+        let over = self.registry().live().len();
+        if over > MAX_SESSIONS {
+            // The honest outcome when nothing is reclaimable: the alternatives are ending
+            // someone's live target or discarding one that already opened. It does not compound —
+            // `take_slot` refuses the next open — and the debt is settled by a later call here
+            // once something goes idle.
+            tracing::warn!(
+                "{over} sessions are open, over the {MAX_SESSIONS} limit: nothing was idle \
+                 enough to reclaim when `{}` opened",
+                keeping.id
+            );
+        }
+    }
+
+    /// Marks and hands back the oldest idle session while the registry is over the cap.
+    ///
+    /// Separate from [`Self::trim_to_cap`] so the registry lock is never held across the release
+    /// that follows. The marking happens *under* the lock, so a second open racing this one
+    /// cannot see the same session as live-and-idle, pick it too, and free nothing.
+    fn claim_overage_victim(&self, keeping: &Arc<Session>) -> Option<Arc<Session>> {
+        let registry = self.registry();
+        let live = registry.live();
+        if live.len() <= MAX_SESSIONS {
+            return None;
+        }
+        let idle = live.iter().find(|s| s.id != keeping.id && !s.busy())?;
+        idle.set_state(SessionState::Closed(format!(
+            "reclaimed to make room for a new session — this server holds at most \
+             {MAX_SESSIONS} at once, and this was the oldest idle one"
+        )));
+        Some(Arc::clone(idle))
     }
 
     /// Starts a worker process and waits for it to report that its engine came up.
@@ -1008,7 +1039,8 @@ impl Sessions {
             created: Instant::now(),
             state: Mutex::new((SessionState::Opening, Instant::now())),
             tx,
-            next_id: AtomicU64::new(1),
+            // Job ids start *past* the opener's, which is reserved — see [`OPENER_JOB`].
+            next_id: AtomicU64::new(OPENER_JOB + 1),
             waiters: Arc::clone(&waiters),
             child: Mutex::new(Some(child)),
         });
@@ -1022,7 +1054,12 @@ impl Sessions {
             Arc::clone(&waiters),
             self.call_timeout,
         ));
-        tokio::spawn(reader(Arc::downgrade(&session), lines, waiters));
+        tokio::spawn(reader(
+            Arc::downgrade(&session),
+            lines,
+            waiters,
+            self.clone(),
+        ));
         Ok(session)
     }
 }
@@ -1049,8 +1086,16 @@ fn stale_handle(want: &str, state: &SessionState) -> String {
     }
 }
 
-/// The job id every opener gets. `open` is the first call made against a freshly spawned session
-/// and ids start at 1, so this identifies the opener without threading it through the protocol.
+/// The job id **reserved** for a session's opener.
+///
+/// It is reserved rather than inferred. Inferring it from "the opener is the first call, and ids
+/// start at 1" looks safe — `open` registers the session and submits the opener with no `await`
+/// between — but it is not: a session is routable the moment it is registered (`Opening` and
+/// `Attaching` both accept calls), so a tool call on another runtime thread can slip in and take
+/// id 1 first. The opener would then get id 2, [`reader`] would stop recognising it, and the
+/// settling that keeps a timed-out open from stranding its session would silently never run.
+///
+/// So `next_id` starts *past* this value and only [`Sessions::open`] ever uses it.
 const OPENER_JOB: u64 = 1;
 
 /// Moves a session out of its opening states once the opener's result is known.
@@ -1059,7 +1104,9 @@ const OPENER_JOB: u64 = 1;
 /// taken by [`reader`] when the caller's timeout means no reply was received at all. The states
 /// are the discriminator either way — `Opening` means nothing was created, `Attaching` means the
 /// target exists and the wait failed — so both paths reach the same answer.
-fn settle_open(session: &Session, result: &Result<String, EngineError>) {
+/// Returns whether the session was left **live** — its worker still holds a target, so it still
+/// owes its slot and capacity has to be reconciled against it.
+fn settle_open(session: &Session, result: &Result<String, EngineError>) -> bool {
     let settled = match (session.state(), result) {
         (SessionState::Opening | SessionState::Attaching, Ok(_)) => SessionState::Open,
         // Nothing was created or claimed: this handle will never be usable.
@@ -1068,9 +1115,17 @@ fn settle_open(session: &Session, result: &Result<String, EngineError>) {
         // the whole point of committing before the wait.
         (SessionState::Attaching, Err(_)) => SessionState::Open,
         // Already settled, by `open` or by a worker that exited.
-        _ => return,
+        _ => return false,
     };
+    let live = settled.is_live();
     session.set_state(settled);
+    if !live {
+        // The same teardown `open` does on a clean failure. Without it the worker survives
+        // holding DbgEng — and a `Failed` session is excluded from `live()`, so `shutdown` would
+        // not collect it either; it would linger until the whole server exits.
+        session.kill();
+    }
+    live
 }
 
 fn worker_gone(id: &str) -> String {
@@ -1176,6 +1231,7 @@ async fn reader(
     session: Weak<Session>,
     mut lines: Lines<BufReader<ChildStdout>>,
     waiters: Waiters,
+    sessions: Sessions,
 ) {
     while let Some(message) = next_message(&mut lines).await {
         let Some(session) = session.upgrade() else {
@@ -1211,8 +1267,14 @@ async fn reader(
                 // worker from ever being reclaimed.
                 if let Err(unreceived) = waiter.send(result.map_err(EngineError::Debugger))
                     && id == OPENER_JOB
+                    && settle_open(&session, &unreceived)
                 {
-                    settle_open(&session, &unreceived);
+                    // It settled *live*, so it owes the slot it took — the same reconciliation
+                    // `open` runs, which nobody is left here to run for it. Spawned rather than
+                    // awaited: reclaiming waits on another session's worker, and this task has
+                    // its own worker's messages to keep draining.
+                    let sessions = sessions.clone();
+                    tokio::spawn(async move { sessions.trim_to_cap(&session).await });
                 }
             }
             // Both belong to the spawn handshake, which has already happened.
@@ -1634,7 +1696,83 @@ mod tests {
     #[test]
     fn settling_never_reopens_a_session_that_is_already_over() {
         let closed = dormant("sess-1", SessionState::Closed("ended".into()));
-        settle_open(&closed, &Ok("vertarget".into()));
+        assert!(!settle_open(&closed, &Ok("vertarget".into())));
         assert_eq!(closed.state(), SessionState::Closed("ended".into()));
+    }
+
+    /// Whether a settled opener still owes its slot is exactly whether it left a live session —
+    /// that is what tells the caller to reconcile capacity, and a wrong answer here either leaks
+    /// a slot or reclaims a session nothing paid for.
+    #[test]
+    fn settling_reports_whether_the_session_survived() {
+        let kept = dormant("sess-1", SessionState::Attaching);
+        assert!(
+            settle_open(&kept, &Err(EngineError::Debugger("never broke in".into()))),
+            "the target exists, so the session lives and owes its slot"
+        );
+        let lost = dormant("sess-2", SessionState::Opening);
+        assert!(
+            !settle_open(&lost, &Err(EngineError::Debugger("no such file".into()))),
+            "nothing was created, so there is no session to pay for"
+        );
+    }
+
+    // ---- reconciling capacity -----------------------------------------------------
+
+    /// Reclaims *until* the server is back at the limit, not once per call.
+    ///
+    /// An overage can outlive the open that caused it — if every candidate was busy at the time,
+    /// the debt is still owed once they go idle. Taking one victim per open would carry it
+    /// forever: six live sessions would become five on the next open, then six, then five.
+    #[tokio::test]
+    async fn reclaiming_clears_the_whole_overage_not_one_session_per_open() {
+        let sessions = Sessions::new(Duration::from_secs(1));
+        let keeping = dormant("sess-keep", SessionState::Open);
+        {
+            let mut registry = sessions.registry();
+            for n in 0..MAX_SESSIONS + 2 {
+                registry
+                    .all
+                    .push_back(dormant(&format!("sess-{n}"), SessionState::Open));
+            }
+            registry.all.push_back(Arc::clone(&keeping));
+        }
+        assert_eq!(sessions.registry().live().len(), MAX_SESSIONS + 3);
+
+        sessions.trim_to_cap(&keeping).await;
+
+        assert_eq!(
+            sessions.registry().live().len(),
+            MAX_SESSIONS,
+            "the whole overage should be cleared in one pass"
+        );
+        assert_eq!(
+            keeping.state(),
+            SessionState::Open,
+            "the session being kept is never a victim"
+        );
+    }
+
+    /// Busy sessions are still never taken, so an overage that cannot be paid for is left
+    /// standing rather than settled by ending someone's live target.
+    #[tokio::test]
+    async fn reclaiming_leaves_an_overage_it_cannot_pay_for() {
+        let sessions = Sessions::new(Duration::from_secs(1));
+        let keeping = dormant("sess-keep", SessionState::Open);
+        {
+            let mut registry = sessions.registry();
+            for n in 0..MAX_SESSIONS {
+                registry
+                    .all
+                    .push_back(dormant(&format!("sess-busy-{n}"), SessionState::Attaching));
+            }
+            registry.all.push_back(Arc::clone(&keeping));
+        }
+        sessions.trim_to_cap(&keeping).await;
+        assert_eq!(
+            sessions.registry().live().len(),
+            MAX_SESSIONS + 1,
+            "nothing was reclaimable, so the overage stands"
+        );
     }
 }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -76,6 +76,13 @@ const END_SESSION_TIMEOUT: Duration = Duration::from_secs(20);
 /// rather than the cost per session.
 const SHUTDOWN_RELEASE_TIMEOUT: Duration = Duration::from_secs(5);
 
+/// How many times shutdown re-checks for workers registered while it was running.
+///
+/// One round can miss an open that was between spawning its worker and registering it when the
+/// client disconnected. Two suffice — new opens are refused before the first round — and the
+/// third is only there so a bug in that reasoning costs a bounded wait rather than a hang.
+const SHUTDOWN_ROUNDS: usize = 3;
+
 /// Counter behind [`mint_session_id`]. Only needs to be unique within this process.
 static SESSION_SEQ: AtomicU64 = AtomicU64::new(1);
 
@@ -575,6 +582,9 @@ struct Registry {
     /// each look at the same four live sessions, each conclude there is room, and each spawn —
     /// so the bound is only enforced against sessions that finished opening.
     opening: usize,
+    /// Set once the client has disconnected. Refuses new opens, so the set of workers to release
+    /// stops growing while shutdown is walking it.
+    closing: bool,
 }
 
 impl Registry {
@@ -960,38 +970,48 @@ impl Sessions {
     /// kernel outright costs. Sessions are released concurrently because they are independent
     /// processes and the client is waiting.
     pub async fn shutdown(&self) {
-        // Every session that still *owns a worker*, not every live one. A session claimed for
-        // reclamation is already `Closed` while its release runs in the background, and a
-        // disconnect in that window would otherwise drop the runtime, cancel that release, and
-        // let `kill_on_drop` terminate the worker — leaving a kernel target halted, which is the
-        // one outcome this whole path exists to avoid. Releasing one twice is harmless; missing
-        // one is not.
-        let owners = self.registry().owning_workers();
-        if owners.is_empty() {
-            return;
-        }
-        tracing::info!("shutting down: releasing {} session(s)", owners.len());
-        let mut releasing = Vec::with_capacity(owners.len());
-        for session in owners {
-            let sessions = self.clone();
-            releasing.push(tokio::spawn(async move {
-                // Marked first so nothing new is routed to a session on its way out; the release
-                // runs as the supervisor's own teardown and so passes the gate that closes.
-                // A session already closed keeps the reason it closed for.
-                session.set_state(SessionState::Closed(
-                    "the server is shutting down".to_string(),
-                ));
-                sessions
-                    .release(
-                        &session,
-                        Call::supervisor(EngineOp::EndSession),
-                        SHUTDOWN_RELEASE_TIMEOUT,
-                    )
-                    .await;
-            }));
-        }
-        for task in releasing {
-            let _ = task.await;
+        // Refuse new opens first, so the set being walked stops growing. Without this an open
+        // that was between spawning its worker and registering it when the client disconnected
+        // registers *after* the snapshot below, and its worker is never released — for a live
+        // kernel, that is a target left halted.
+        self.registry().closing = true;
+
+        // Rounds rather than one pass, because an open already past the gate can still register
+        // while the first round runs. It terminates: nothing new can be admitted, so each round
+        // finds only what the previous one raced with, and in practice the second is empty.
+        for _ in 0..SHUTDOWN_ROUNDS {
+            // Every session that still *owns a worker*, not every live one. A session claimed for
+            // reclamation is already `Closed` while its release runs in the background, and a
+            // disconnect in that window would otherwise drop the runtime, cancel that release,
+            // and let `kill_on_drop` terminate the worker — the same halted target by another
+            // route. Releasing one twice is harmless; missing one is not.
+            let owners = self.registry().owning_workers();
+            if owners.is_empty() {
+                return;
+            }
+            tracing::info!("shutting down: releasing {} session(s)", owners.len());
+            let mut releasing = Vec::with_capacity(owners.len());
+            for session in owners {
+                let sessions = self.clone();
+                releasing.push(tokio::spawn(async move {
+                    // Marked first so nothing new is routed to a session on its way out; the
+                    // release runs as the supervisor's own teardown and so passes the gate that
+                    // closes. A session already closed keeps the reason it closed for.
+                    session.set_state(SessionState::Closed(
+                        "the server is shutting down".to_string(),
+                    ));
+                    sessions
+                        .release(
+                            &session,
+                            Call::supervisor(EngineOp::EndSession),
+                            SHUTDOWN_RELEASE_TIMEOUT,
+                        )
+                        .await;
+                }));
+            }
+            for task in releasing {
+                let _ = task.await;
+            }
         }
     }
 
@@ -1009,6 +1029,13 @@ impl Sessions {
     /// the open is refused with the list, which is a better answer than picking a victim.
     fn take_slot(&self) -> Result<Slot, String> {
         let mut registry = self.registry();
+        if registry.closing {
+            return Err(
+                "this server is shutting down — the client disconnected, and every session is \
+                 being released. Nothing more can be opened on this connection."
+                    .to_string(),
+            );
+        }
         let live = registry.live();
         // How many sessions would have to be reclaimed to be back at the limit once this open,
         // and every open already in flight, has landed — against how many *can* be. Counting the
@@ -1250,12 +1277,6 @@ fn stale_handle(want: &str, state: &SessionState) -> String {
 /// So `next_id` starts *past* this value and only [`Sessions::open`] ever uses it.
 const OPENER_JOB: u64 = 1;
 
-/// Moves a session out of its opening states once the opener's result is known.
-///
-/// Normally [`Sessions::open`] does this from the reply it received; this is the same decision
-/// taken by [`reader`] when the caller's timeout means no reply was received at all. The states
-/// are the discriminator either way — `Opening` means nothing was created, `Attaching` means the
-/// target exists and the wait failed — so both paths reach the same answer.
 /// Moves a session that is still opening to [`SessionState::Open`], and leaves every other state
 /// alone.
 ///
@@ -1270,8 +1291,6 @@ fn promote_opened(session: &Session) {
     });
 }
 
-/// Returns whether the session was left **live** — its worker still holds a target, so it still
-/// owes its slot and capacity has to be reconciled against it.
 /// Settles a session whose opener failed **without creating anything**, and ends its worker
 /// unless something else has claimed it. Returns whether the session survived — which is to say,
 /// whether it still owns a worker and therefore still owes its slot.
@@ -1290,6 +1309,11 @@ fn settle_uncommitted(session: &Session, why: &str) -> bool {
     false
 }
 
+/// Settles a session from its opener's result when nobody is left to do it — the caller's timeout
+/// fired, so [`Sessions::open`] never saw the reply.
+///
+/// Returns whether the session was left **live**: its worker still holds a target, so it still
+/// owes its slot and capacity has to be reconciled against it.
 fn settle_open(session: &Session, result: &Result<String, EngineError>) -> bool {
     // The same discriminator `open` uses, and for the same reason: the *phase* says whether a
     // target was created, while the state may since have been retired by a command queued behind

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -62,6 +62,20 @@ const WORKER_READY_TIMEOUT: Duration = Duration::from_secs(30);
 /// gracefully, short enough that recovering a parked attach is not a wait.
 const END_SESSION_TIMEOUT: Duration = Duration::from_secs(20);
 
+/// The same grace, but at shutdown, where it competes with the client's expectation that closing
+/// stdin ends the process promptly.
+///
+/// Releasing rather than killing is not tidiness here. A live kernel left detached *while halted*
+/// stays frozen — one CPU stopped, the rest spinning — so a worker killed instead of released
+/// leaves the target machine stopped and its KD stub wedged until someone reboots it. That is a
+/// far worse outcome than an extra few seconds on the way out, and a client disconnect is exactly
+/// when nobody is watching.
+///
+/// Shorter than [`END_SESSION_TIMEOUT`] because a session that cannot let go within a few seconds
+/// is one that never will, and sessions are released concurrently, so this is the whole cost
+/// rather than the cost per session.
+const SHUTDOWN_RELEASE_TIMEOUT: Duration = Duration::from_secs(5);
+
 /// Counter behind [`mint_session_id`]. Only needs to be unique within this process.
 static SESSION_SEQ: AtomicU64 = AtomicU64::new(1);
 
@@ -695,7 +709,7 @@ impl Sessions {
     /// under process-per-session it costs nothing else.
     pub async fn end(&self, session: &Arc<Session>, named: bool) -> Result<String, EngineError> {
         let call = Call::new(EngineOp::EndSession).named(named);
-        let (reason, message) = match self.release(session, call).await {
+        let (reason, message) = match self.release(session, call, END_SESSION_TIMEOUT).await {
             // A refused handle is the mechanism working, not a session to tear down.
             Release::Stale(why) => return Err(EngineError::Stale(why)),
             Release::Released(text) => (
@@ -747,8 +761,8 @@ impl Sessions {
     /// Asks a worker to release its target and then terminates it, without deciding *why* the
     /// session is closing — `end_session` and reclamation share the teardown but not the reason,
     /// and the reason is what the caller reads afterwards.
-    async fn release(&self, session: &Arc<Session>, call: Call) -> Release {
-        let out = match self.call_within(session, call, END_SESSION_TIMEOUT).await {
+    async fn release(&self, session: &Arc<Session>, call: Call, grace: Duration) -> Release {
+        let out = match self.call_within(session, call, grace).await {
             Err(EngineError::Stale(why)) => return Release::Stale(why),
             other => other,
         };
@@ -762,15 +776,39 @@ impl Sessions {
         }
     }
 
-    /// Terminates every worker. Called on shutdown so a disconnecting client never leaves a
-    /// debugger process — or a debuggee — behind.
-    pub fn shutdown(&self) {
-        for session in self.registry().live() {
-            session.set_state(SessionState::Closed(
-                "the server is shutting down".to_string(),
-            ));
-            session.fail_outstanding("the server is shutting down");
-            session.kill();
+    /// Ends every session, then terminates any worker that did not let go. Called when the client
+    /// disconnects, so a debugger process — or a debuggee — never outlives the connection.
+    ///
+    /// A disconnect is treated as `end_session` on everything, which is both the simplest rule to
+    /// explain and the only safe one: see [`SHUTDOWN_RELEASE_TIMEOUT`] for what killing a live
+    /// kernel outright costs. Sessions are released concurrently because they are independent
+    /// processes and the client is waiting.
+    pub async fn shutdown(&self) {
+        let live = self.registry().live();
+        if live.is_empty() {
+            return;
+        }
+        tracing::info!("shutting down: releasing {} session(s)", live.len());
+        let mut releasing = Vec::with_capacity(live.len());
+        for session in live {
+            let sessions = self.clone();
+            releasing.push(tokio::spawn(async move {
+                // Marked first so nothing new is routed to a session on its way out; the release
+                // runs as the supervisor's own teardown and so passes the gate that closes.
+                session.set_state(SessionState::Closed(
+                    "the server is shutting down".to_string(),
+                ));
+                sessions
+                    .release(
+                        &session,
+                        Call::supervisor(EngineOp::EndSession),
+                        SHUTDOWN_RELEASE_TIMEOUT,
+                    )
+                    .await;
+            }));
+        }
+        for task in releasing {
+            let _ = task.await;
         }
     }
 
@@ -822,8 +860,12 @@ impl Sessions {
         // Released the same way `end_session` releases one, so a live debuggee is let go cleanly
         // rather than dying with its debugger. As the supervisor's own teardown rather than a
         // caller's call, it runs past the gate the state above would otherwise close.
-        self.release(&victim, Call::supervisor(EngineOp::EndSession))
-            .await;
+        self.release(
+            &victim,
+            Call::supervisor(EngineOp::EndSession),
+            END_SESSION_TIMEOUT,
+        )
+        .await;
         Ok(())
     }
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -26,7 +26,7 @@ use std::collections::{HashMap, VecDeque};
 use std::fmt;
 use std::path::PathBuf;
 use std::process::Stdio;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, Weak};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
@@ -238,6 +238,9 @@ pub struct Session {
     /// for a call whose caller already gave up, which is precisely when a session must not be
     /// reclaimed as idle.
     waiters: Waiters,
+    /// Whether `open` has finished with this session and told its caller about it. Until then it
+    /// is not reclaimable however idle it looks — see [`Session::busy`].
+    delivered: AtomicBool,
     child: Mutex<Option<Child>>,
 }
 
@@ -256,11 +259,30 @@ impl Session {
     /// already stopped owning a worker, so a milestone arriving from a worker being torn down
     /// cannot undo the teardown.
     fn set_state(&self, next: SessionState) {
+        self.update_state(|_| Some(next));
+    }
+
+    /// Recomputes the state *from itself*, under a single lock acquisition, and reports where it
+    /// ended up. `next` returns `None` to leave it alone.
+    ///
+    /// The atomicity is the whole point, and check-then-set through two acquisitions is not good
+    /// enough: `pump` retires a session from another task the instant it forwards a
+    /// target-changing command, so a transition that decided on a state it no longer holds would
+    /// overwrite that retirement — and the handle would go on certifying a target the queued
+    /// command is about to replace. Every conditional transition goes through here for that
+    /// reason, not for tidiness.
+    fn update_state(
+        &self,
+        next: impl FnOnce(&SessionState) -> Option<SessionState>,
+    ) -> SessionState {
         let mut slot = self.state.lock().unwrap_or_else(|e| e.into_inner());
         if !slot.0.is_live() {
-            return;
+            return slot.0.clone();
         }
-        *slot = (next, Instant::now());
+        if let Some(next) = next(&slot.0) {
+            *slot = (next, Instant::now());
+        }
+        slot.0.clone()
     }
 
     /// How long the session has been in its current state.
@@ -272,14 +294,22 @@ impl Session {
             .elapsed()
     }
 
-    /// Whether the worker owes a reply, or is still opening. An idle session is one that can be
-    /// reclaimed to make room without abandoning work in flight.
+    /// Whether the worker owes a reply, is still opening, or has not been handed to its caller
+    /// yet. An idle session is one that can be reclaimed to make room without abandoning work in
+    /// flight.
+    ///
+    /// That last clause covers a window nothing else does. A session goes idle the moment its
+    /// opener's waiter is removed — before `open` has returned the handle — so with two opens
+    /// admitted at the limit, the later one's reconciliation could reclaim the earlier one and
+    /// its caller would be handed a `session_id` that was already `Closed`. Undelivered means
+    /// in flight as far as anyone outside is concerned.
     fn busy(&self) -> bool {
-        !self
-            .waiters
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
-            .is_empty()
+        !self.delivered.load(Ordering::Acquire)
+            || !self
+                .waiters
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .is_empty()
             || matches!(
                 self.state(),
                 SessionState::Opening | SessionState::Attaching
@@ -710,7 +740,7 @@ impl Sessions {
         let out = self
             .call_as(&session, Call::new(op), self.call_timeout, OPENER_JOB)
             .await;
-        match out {
+        let outcome = match out {
             Ok(report) => {
                 // Defensive: a worker that answered without reporting `Opened` still produced a
                 // usable target, and leaving the session mid-open would make every later call
@@ -767,7 +797,12 @@ impl Sessions {
                     }
                 }
             }
-        }
+        };
+        // The caller is about to be told about this session, whatever the outcome. Until that
+        // moment it is not reclaimable however idle it looks — otherwise a concurrent open's
+        // reconciliation can close it in the gap, and this returns a handle that is already dead.
+        session.delivered.store(true, Ordering::Release);
+        outcome
     }
 
     /// Ends a session: asks the worker to release its target, then terminates it.
@@ -1078,6 +1113,7 @@ impl Sessions {
             // Job ids start *past* the opener's, which is reserved — see [`OPENER_JOB`].
             next_id: AtomicU64::new(OPENER_JOB + 1),
             waiters: Arc::clone(&waiters),
+            delivered: AtomicBool::new(false),
             child: Mutex::new(Some(child)),
         });
 
@@ -1148,29 +1184,29 @@ const OPENER_JOB: u64 = 1;
 /// an opener finishing afterwards must not undo that — the handle would then certify a target the
 /// queued command is about to replace.
 fn promote_opened(session: &Session) {
-    if matches!(
-        session.state(),
-        SessionState::Opening | SessionState::Attaching
-    ) {
-        session.set_state(SessionState::Open);
-    }
+    session.update_state(|state| {
+        matches!(state, SessionState::Opening | SessionState::Attaching)
+            .then_some(SessionState::Open)
+    });
 }
 
 /// Returns whether the session was left **live** — its worker still holds a target, so it still
 /// owes its slot and capacity has to be reconciled against it.
 fn settle_open(session: &Session, result: &Result<String, EngineError>) -> bool {
-    let settled = match (session.state(), result) {
-        (SessionState::Opening | SessionState::Attaching, Ok(_)) => SessionState::Open,
+    // Decided and applied under one lock, for the reason `update_state` gives: `pump` can retire
+    // this session from another task, and that must outrank a decision taken a moment earlier.
+    let settled = session.update_state(|state| match (state, result) {
+        (SessionState::Opening | SessionState::Attaching, Ok(_)) => Some(SessionState::Open),
         // Nothing was created or claimed: this handle will never be usable.
-        (SessionState::Opening, Err(e)) => SessionState::Failed(e.to_string()),
+        (SessionState::Opening, Err(e)) => Some(SessionState::Failed(e.to_string())),
         // The target exists and something after it failed. The session stays usable — that is
         // the whole point of committing before the wait.
-        (SessionState::Attaching, Err(_)) => SessionState::Open,
-        // Already settled, by `open` or by a worker that exited.
-        _ => return false,
-    };
+        (SessionState::Attaching, Err(_)) => Some(SessionState::Open),
+        // Already settled, by `open` or by a worker that exited — or retired by a command queued
+        // behind the open, which stands.
+        _ => None,
+    });
     let live = settled.is_live();
-    session.set_state(settled);
     if !live {
         // The same teardown `open` does on a clean failure. Without it the worker survives
         // holding DbgEng — and a `Failed` session is excluded from `live()`, so `shutdown` would
@@ -1290,19 +1326,14 @@ async fn reader(
             return;
         };
         match message {
+            // Both milestones are conditional transitions, so both go through `update_state`:
+            // a check-then-set would let a retirement land in the gap and be overwritten.
             WorkerMessage::Committed { .. } => {
-                if matches!(session.state(), SessionState::Opening) {
-                    session.set_state(SessionState::Attaching);
-                }
+                session.update_state(|state| {
+                    matches!(state, SessionState::Opening).then_some(SessionState::Attaching)
+                });
             }
-            WorkerMessage::Opened { .. } => {
-                if matches!(
-                    session.state(),
-                    SessionState::Opening | SessionState::Attaching
-                ) {
-                    session.set_state(SessionState::Open);
-                }
-            }
+            WorkerMessage::Opened { .. } => promote_opened(&session),
             WorkerMessage::Done { id, result } => {
                 let waiter = waiters
                     .lock()
@@ -1462,6 +1493,8 @@ mod tests {
             tx,
             next_id: AtomicU64::new(1),
             waiters: Arc::new(Mutex::new(HashMap::new())),
+            // Test doubles stand in for sessions their callers already hold.
+            delivered: AtomicBool::new(true),
             child: Mutex::new(None),
         })
     }
@@ -1840,6 +1873,49 @@ mod tests {
             SessionState::Open,
             "the session being kept is never a victim"
         );
+    }
+
+    /// A session that has opened but whose caller has not been told about it yet must not be
+    /// reclaimed, however idle it looks.
+    ///
+    /// It goes idle the moment its opener's waiter is removed, which is *before* `open` returns
+    /// the handle. With two opens admitted at the limit, the later one's reconciliation would
+    /// otherwise pick the earlier one — and that caller would be handed a `session_id` that was
+    /// already `Closed`.
+    #[tokio::test]
+    async fn a_session_not_yet_handed_to_its_caller_is_never_reclaimed() {
+        let sessions = Sessions::new(Duration::from_secs(1));
+        let undelivered = dormant("sess-just-opened", SessionState::Open);
+        undelivered.delivered.store(false, Ordering::Release);
+        let keeping = dormant("sess-keep", SessionState::Open);
+        {
+            let mut registry = sessions.registry();
+            for n in 0..MAX_SESSIONS - 1 {
+                registry
+                    .all
+                    .push_back(dormant(&format!("sess-busy-{n}"), SessionState::Attaching));
+            }
+            registry.all.push_back(Arc::clone(&undelivered));
+            registry.all.push_back(Arc::clone(&keeping));
+        }
+        assert!(
+            undelivered.busy(),
+            "an undelivered session counts as in flight"
+        );
+
+        sessions.reconcile_capacity(&keeping);
+
+        assert_eq!(
+            undelivered.state(),
+            SessionState::Open,
+            "the session whose caller is still waiting for its handle was reclaimed"
+        );
+
+        // Once its caller has it, it is an ordinary idle session and can pay for the next open.
+        undelivered.delivered.store(true, Ordering::Release);
+        assert!(!undelivered.busy());
+        sessions.reconcile_capacity(&keeping);
+        assert!(!undelivered.state().is_live(), "now it is reclaimable");
     }
 
     /// Busy sessions are still never taken, so an overage that cannot be paid for is left

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -452,6 +452,22 @@ pub enum OpenError {
     Timeout { id: String, message: String },
 }
 
+/// A slot taken for an open that has not registered its session yet.
+///
+/// Exists so the capacity check can see opens that are still in flight, and releases the slot on
+/// drop — so an open that fails on the way (no worker, a bad path) gives it back rather than
+/// holding it for the life of the process.
+struct Slot {
+    registry: Arc<Mutex<Registry>>,
+}
+
+impl Drop for Slot {
+    fn drop(&mut self) {
+        let mut registry = self.registry.lock().unwrap_or_else(|e| e.into_inner());
+        registry.opening = registry.opening.saturating_sub(1);
+    }
+}
+
 /// How a worker took being told to let go of its target.
 enum Release {
     /// It released the target and said so.
@@ -474,6 +490,12 @@ struct Registry {
     /// Every session this server has held, oldest first: the live ones plus a bounded tail of
     /// closed ones, kept so a caller can still ask what became of a handle.
     all: VecDeque<Arc<Session>>,
+    /// Opens that have taken a slot but have not registered a session yet.
+    ///
+    /// Without this the capacity check is blind to opens already in flight, and two of them can
+    /// each look at the same four live sessions, each conclude there is room, and each spawn —
+    /// so the bound is only enforced against sessions that finished opening.
+    opening: usize,
 }
 
 impl Registry {
@@ -642,11 +664,15 @@ impl Sessions {
         op: EngineOp,
     ) -> Result<OpenReport, OpenError> {
         debug_assert!(op.is_opener(), "open() needs an opener op");
-        self.make_room().await.map_err(OpenError::NoRoom)?;
+        // Take a slot before doing anything expensive, but do **not** reclaim anything yet — see
+        // `take_slot` and `trim_to_cap` for why those are separate.
+        let slot = self.take_slot().map_err(OpenError::NoRoom)?;
 
         let id = mint_session_id();
         let session = match self.spawn(&id, kind, what).await {
             Ok(session) => session,
+            // The slot goes back and no existing session was touched: a worker that would not
+            // start must not cost the caller a target they already had.
             Err(why) => return Err(OpenError::Unavailable(why)),
         };
         {
@@ -654,6 +680,9 @@ impl Sessions {
             registry.all.push_back(Arc::clone(&session));
             registry.trim();
         }
+        // Released only now: from here the session is counted in `all` instead, and holding both
+        // would count this open twice.
+        drop(slot);
 
         let out = self.call(&session, Call::new(op)).await;
         match out {
@@ -664,6 +693,9 @@ impl Sessions {
                 if !matches!(session.state(), SessionState::Open) {
                     session.set_state(SessionState::Open);
                 }
+                // Only now, with a target that is genuinely open, is an existing session
+                // reclaimed to pay for it.
+                self.trim_to_cap(&session).await;
                 Ok(OpenReport { id, report })
             }
             Err(EngineError::Timeout(message)) => Err(OpenError::Timeout { id, message }),
@@ -812,51 +844,101 @@ impl Sessions {
         }
     }
 
-    /// Ensures a session slot is free, reclaiming the least-recently-opened idle session if the
-    /// server is at [`MAX_SESSIONS`].
+    /// Takes a slot for a new session, or refuses the open.
     ///
-    /// Reclaiming only *idle* sessions is the whole of the policy. A session with a call in
-    /// flight — including one whose caller has already given up waiting, and including a parked
-    /// attach — is never taken, because ending it silently is how a caller loses a target they
-    /// are still using. When nothing is reclaimable the open is refused with the list, which is
-    /// a better answer than picking a victim.
-    async fn make_room(&self) -> Result<(), String> {
+    /// Deliberately **decides** without **doing**: at the limit it only checks that some session
+    /// *could* be reclaimed, and leaves the reclaiming to [`Self::trim_to_cap`] once the
+    /// replacement is real. Evicting here instead would mean a mistyped path, or a worker that
+    /// would not start, destroys a perfectly good target the caller still wanted — a failed open
+    /// must cost nothing but the attempt.
+    ///
+    /// Reclaimable means *idle*. A session with a call in flight — including one whose caller has
+    /// already given up waiting, and including a parked attach — is never taken, because ending it
+    /// silently is how a caller loses a target they are still using. When nothing is reclaimable
+    /// the open is refused with the list, which is a better answer than picking a victim.
+    fn take_slot(&self) -> Result<Slot, String> {
+        let mut registry = self.registry();
+        let live = registry.live();
+        // How many sessions would have to be reclaimed to be back at the limit once this open,
+        // and every open already in flight, has landed — against how many *can* be. Counting the
+        // opens in flight is what stops two of them spending the same idle session: the first
+        // needs one reclaimable, the second needs two.
+        let needed = (live.len() + registry.opening + 1).saturating_sub(MAX_SESSIONS);
+        let reclaimable = live.iter().filter(|s| !s.busy()).count();
+        if needed > reclaimable {
+            let listed: Vec<String> = live
+                .iter()
+                .map(|s| {
+                    let busy = if s.busy() { " — busy" } else { " — idle" };
+                    format!("  {} — {} ({}){busy}", s.id, s.kind.label(), s.what)
+                })
+                .collect();
+            let in_flight = match registry.opening {
+                0 => String::new(),
+                n => format!(
+                    " ({n} more open{} already in flight)",
+                    if n == 1 { "" } else { "s" }
+                ),
+            };
+            return Err(format!(
+                "this server holds {} debug sessions{in_flight} and none of them can be reclaimed \
+                 — a session with a call in flight is never ended to make room, and that includes \
+                 an attach still waiting for its target. So there is no room to open another:\n{}\
+                 \n\nEnd one with `end_session {{ \"session_id\": \"…\" }}` — it terminates that \
+                 session's engine worker process even if the session is parked and cannot unwind \
+                 on its own.",
+                live.len(),
+                listed.join("\n")
+            ));
+        }
+        registry.opening += 1;
+        Ok(Slot {
+            registry: Arc::clone(&self.inner),
+        })
+    }
+
+    /// Reclaims the oldest idle session if the server is over [`MAX_SESSIONS`], now that
+    /// `keeping` has actually opened and is worth paying for.
+    ///
+    /// `keeping` is excluded because it is idle the instant it opens, and with every other
+    /// session busy it would otherwise be the one reclaimed — an open that closes itself.
+    ///
+    /// May leave the server one over the limit, when the sessions that would have paid for this
+    /// one all became busy while it was opening. That is the honest outcome: the alternatives are
+    /// ending someone's live target or discarding a target that already opened. The next open
+    /// finds nothing idle and is refused, so it does not compound.
+    async fn trim_to_cap(&self, keeping: &Arc<Session>) {
         let victim = {
             let registry = self.registry();
             let live = registry.live();
-            if live.len() < MAX_SESSIONS {
-                return Ok(());
+            if live.len() <= MAX_SESSIONS {
+                return;
             }
-            match live.iter().find(|s| !s.busy()) {
-                Some(idle) => Arc::clone(idle),
+            match live.iter().find(|s| s.id != keeping.id && !s.busy()) {
+                // Marked while the registry lock is held, so a second open racing this one cannot
+                // see the same session as live-and-idle, pick it too, and free nothing.
+                Some(idle) => {
+                    idle.set_state(SessionState::Closed(format!(
+                        "reclaimed to make room for a new session — this server holds at most \
+                         {MAX_SESSIONS} at once, and this was the oldest idle one"
+                    )));
+                    Arc::clone(idle)
+                }
                 None => {
-                    let listed: Vec<String> = live
-                        .iter()
-                        .map(|s| format!("  {} — {} ({})", s.id, s.kind.label(), s.what))
-                        .collect();
-                    return Err(format!(
-                        "this server already holds {MAX_SESSIONS} debug sessions and every one \
-                         of them has a call in flight, so there is no room to open another:\n{}\n\n\
-                         End one with `end_session {{ \"session_id\": \"…\" }}` — it terminates \
-                         that session's engine worker process even if the session is parked and \
-                         cannot unwind on its own.",
-                        listed.join("\n")
-                    ));
+                    tracing::warn!(
+                        "{} sessions are open, one over the {MAX_SESSIONS} limit: nothing was \
+                         idle enough to reclaim when `{}` opened",
+                        live.len(),
+                        keeping.id
+                    );
+                    return;
                 }
             }
         };
         tracing::info!(
-            "reclaiming idle session {} to make room (at the {MAX_SESSIONS}-session limit)",
+            "reclaimed idle session {} (at the {MAX_SESSIONS}-session limit)",
             victim.id
         );
-        // Marked *before* the release, not after: the release awaits the worker, and a second
-        // open racing this one would otherwise see the same session still live and idle, pick it
-        // too, and free nothing. Closing it first takes it out of `live()` immediately, which is
-        // also what the caller who held its handle will read.
-        victim.set_state(SessionState::Closed(format!(
-            "reclaimed to make room for a new session — this server holds at most \
-             {MAX_SESSIONS} at once, and this was the oldest idle one"
-        )));
         // Released the same way `end_session` releases one, so a live debuggee is let go cleanly
         // rather than dying with its debugger. As the supervisor's own teardown rather than a
         // caller's call, it runs past the gate the state above would otherwise close.
@@ -866,7 +948,6 @@ impl Sessions {
             END_SESSION_TIMEOUT,
         )
         .await;
-        Ok(())
     }
 
     /// Starts a worker process and waits for it to report that its engine came up.
@@ -966,6 +1047,30 @@ fn stale_handle(want: &str, state: &SessionState) -> String {
         // The accepting states never reach here.
         _ => format!("session `{want}` is not accepting calls"),
     }
+}
+
+/// The job id every opener gets. `open` is the first call made against a freshly spawned session
+/// and ids start at 1, so this identifies the opener without threading it through the protocol.
+const OPENER_JOB: u64 = 1;
+
+/// Moves a session out of its opening states once the opener's result is known.
+///
+/// Normally [`Sessions::open`] does this from the reply it received; this is the same decision
+/// taken by [`reader`] when the caller's timeout means no reply was received at all. The states
+/// are the discriminator either way — `Opening` means nothing was created, `Attaching` means the
+/// target exists and the wait failed — so both paths reach the same answer.
+fn settle_open(session: &Session, result: &Result<String, EngineError>) {
+    let settled = match (session.state(), result) {
+        (SessionState::Opening | SessionState::Attaching, Ok(_)) => SessionState::Open,
+        // Nothing was created or claimed: this handle will never be usable.
+        (SessionState::Opening, Err(e)) => SessionState::Failed(e.to_string()),
+        // The target exists and something after it failed. The session stays usable — that is
+        // the whole point of committing before the wait.
+        (SessionState::Attaching, Err(_)) => SessionState::Open,
+        // Already settled, by `open` or by a worker that exited.
+        _ => return,
+    };
+    session.set_state(settled);
 }
 
 fn worker_gone(id: &str) -> String {
@@ -1095,11 +1200,19 @@ async fn reader(
                     .lock()
                     .unwrap_or_else(|e| e.into_inner())
                     .remove(&id);
-                if let Some(waiter) = waiter {
-                    // The receiver is gone when the caller's timeout fired; the send failing is
-                    // that case, and removing the entry above is what matters — it is how the
-                    // session stops counting as busy.
-                    let _ = waiter.send(result.map_err(EngineError::Debugger));
+                let Some(waiter) = waiter else { continue };
+                // A failed send means the receiver is gone: the caller's timeout fired and
+                // nobody is left to act on this result. For an ordinary call that is fine —
+                // removing the entry above is what mattered, and it is how the session stops
+                // counting as busy. For the *opener* it is not: `open` settles the session's
+                // state from its result, so with no one to run that, the session would sit in
+                // `Opening` or `Attaching` for the life of the process — `session_status` would
+                // keep reporting an open that finished long ago, and `busy()` would keep the
+                // worker from ever being reclaimed.
+                if let Err(unreceived) = waiter.send(result.map_err(EngineError::Debugger))
+                    && id == OPENER_JOB
+                {
+                    settle_open(&session, &unreceived);
                 }
             }
             // Both belong to the spawn handshake, which has already happened.
@@ -1375,22 +1488,31 @@ mod tests {
         assert!(idle.busy(), "an abandoned call still owes a reply");
     }
 
-    /// At the limit with nothing idle, an open is refused with the list rather than picking a
-    /// victim — ending someone's live target silently is the one outcome worse than failing.
-    #[tokio::test]
-    async fn opening_past_the_limit_with_no_idle_session_is_refused_with_the_list() {
+    /// Fills the registry with `count` sessions in `state`.
+    fn registry_full_of(state: SessionState) -> Sessions {
         let sessions = Sessions::new(Duration::from_secs(1));
         {
             let mut registry = sessions.registry();
             for n in 0..MAX_SESSIONS {
                 registry
                     .all
-                    .push_back(dormant(&format!("sess-busy-{n}"), SessionState::Attaching));
+                    .push_back(dormant(&format!("sess-{n}"), state.clone()));
             }
         }
-        let err = sessions.make_room().await.unwrap_err();
-        assert!(err.contains("no room"), "{err}");
-        assert!(err.contains("sess-busy-0"), "{err}");
+        sessions
+    }
+
+    /// At the limit with nothing idle, an open is refused with the list rather than picking a
+    /// victim — ending someone's live target silently is the one outcome worse than failing.
+    #[test]
+    fn opening_past_the_limit_with_no_idle_session_is_refused_with_the_list() {
+        let sessions = registry_full_of(SessionState::Attaching);
+        let err = sessions
+            .take_slot()
+            .err()
+            .expect("no idle session means no room");
+        assert!(err.contains("no room to open another"), "{err}");
+        assert!(err.contains("sess-0"), "{err}");
         assert!(err.contains("end_session"), "{err}");
     }
 
@@ -1402,7 +1524,117 @@ mod tests {
             Arc::clone(&live),
             dormant("sess-0", SessionState::Closed("x".into())),
         ]);
-        assert!(sessions.make_room().await.is_ok());
+        let slot = sessions.take_slot().expect("there is room");
+        drop(slot);
+        sessions.trim_to_cap(&live).await;
         assert_eq!(live.state(), SessionState::Open, "it was not reclaimed");
+    }
+
+    /// **A failed open must cost nothing.** Taking a slot deliberately reclaims nothing, so a
+    /// mistyped path or a worker that will not start cannot destroy a target the caller still
+    /// had — the eviction is deferred until a replacement actually exists.
+    #[test]
+    fn a_slot_that_is_never_used_reclaims_nothing() {
+        let sessions = registry_full_of(SessionState::Open);
+        let before: Vec<_> = sessions.registry().live();
+        let slot = sessions
+            .take_slot()
+            .expect("an idle session means there is room");
+        assert!(
+            before.iter().all(|s| s.state() == SessionState::Open),
+            "no session may be touched before the replacement exists"
+        );
+        // The open failed on the way, so the slot goes back.
+        drop(slot);
+        assert_eq!(sessions.registry().opening, 0);
+        assert_eq!(sessions.registry().live().len(), MAX_SESSIONS);
+    }
+
+    /// Opens already in flight count against the limit. Without that the check only sees
+    /// *finished* opens, so two concurrent ones look at the same sessions, both conclude there is
+    /// room, and the bound is enforced against neither.
+    #[test]
+    fn an_open_in_flight_takes_a_slot_from_the_next_one() {
+        let sessions = registry_full_of(SessionState::Open);
+        // One idle session, so exactly one slot can be paid for.
+        for session in sessions.registry().live().iter().skip(1) {
+            session.set_state(SessionState::Attaching);
+        }
+        let _first = sessions
+            .take_slot()
+            .expect("the idle session pays for this one");
+        assert_eq!(sessions.registry().opening, 1);
+        // Hmm — the same idle session cannot pay twice, but it is still idle, so the check has to
+        // reason about the open already in flight rather than about the sessions alone.
+        let second = sessions.take_slot();
+        assert!(
+            second.is_err(),
+            "a second concurrent open must not spend the same slot"
+        );
+    }
+
+    /// The session that just opened is never the one reclaimed to pay for itself, even when it is
+    /// the only idle one — which it always is for a moment.
+    #[tokio::test]
+    async fn a_new_session_is_not_reclaimed_to_make_room_for_itself() {
+        let sessions = Sessions::new(Duration::from_secs(1));
+        let newest = dormant("sess-new", SessionState::Open);
+        {
+            let mut registry = sessions.registry();
+            for n in 0..MAX_SESSIONS {
+                registry
+                    .all
+                    .push_back(dormant(&format!("sess-busy-{n}"), SessionState::Attaching));
+            }
+            registry.all.push_back(Arc::clone(&newest));
+        }
+        sessions.trim_to_cap(&newest).await;
+        assert_eq!(
+            newest.state(),
+            SessionState::Open,
+            "the new session reclaimed itself"
+        );
+        assert_eq!(
+            sessions.registry().live().len(),
+            MAX_SESSIONS + 1,
+            "nothing was reclaimable, so the server sits one over the limit rather than \
+             discarding a target that already opened"
+        );
+    }
+
+    // ---- settling an opener whose caller stopped waiting --------------------------
+
+    /// An opener that finishes after its caller gave up must still settle the session. Left in
+    /// `Opening`/`Attaching` it would report an open that finished long ago, and `busy()` would
+    /// keep the worker from ever being reclaimed.
+    #[test]
+    fn an_abandoned_opener_still_settles_the_session() {
+        // Nothing was created, so the handle is dead and re-opening is the way forward.
+        let clean = dormant("sess-1", SessionState::Opening);
+        settle_open(&clean, &Err(EngineError::Debugger("no such file".into())));
+        assert_eq!(clean.state(), SessionState::Failed("no such file".into()));
+        assert!(!clean.busy(), "a settled session is reclaimable");
+
+        // The target exists and the wait failed: the session stays usable, which is the whole
+        // point of committing before the wait.
+        let committed = dormant("sess-2", SessionState::Attaching);
+        settle_open(
+            &committed,
+            &Err(EngineError::Debugger("never broke in".into())),
+        );
+        assert_eq!(committed.state(), SessionState::Open);
+
+        let landed = dormant("sess-3", SessionState::Attaching);
+        settle_open(&landed, &Ok("vertarget".into()));
+        assert_eq!(landed.state(), SessionState::Open);
+    }
+
+    /// Settling is idempotent and never resurrects: a session ended while its opener was still
+    /// running stays ended.
+    #[test]
+    fn settling_never_reopens_a_session_that_is_already_over() {
+        let closed = dormant("sess-1", SessionState::Closed("ended".into()));
+        settle_open(&closed, &Ok("vertarget".into()));
+        assert_eq!(closed.state(), SessionState::Closed("ended".into()));
     }
 }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1,570 +1,1366 @@
-//! The dedicated DbgEng worker thread.
+//! The supervisor: session registry and worker-process supervision.
 //!
-//! DbgEng requires single-threaded, serialized access (and `WaitForEvent` must run
-//! on the session-owning thread). We therefore confine the [`DebugEngine`] to one
-//! OS thread and marshal every operation onto it over a channel, returning results
-//! to the async (rmcp/tokio) side via oneshot replies.
+//! dbgeng.dll holds **one debuggee session per process**. That is not a binding limitation — it
+//! is why `.opendump` *replaces* the target rather than opening a second one. So a server that
+//! wants more than one session at a time, or that wants to be able to *abandon* one, needs more
+//! than one process. Each open target here gets its own [`crate::worker`] child process, and
+//! this module routes tool calls to them.
+//!
+//! Two things fall out of that, and they are the point:
+//!
+//! * **A session that cannot be unwound costs a process, not the server.** A live-kernel attach
+//!   whose target never dials in blocks in `WaitForEvent(INFINITE)` with no cancellation path
+//!   (win-kexp's `SetInterrupt` watchdog cannot reach a wait that is still establishing the
+//!   link). Confined to its own process, that is one worker the supervisor can kill —
+//!   `end_session` does exactly that — instead of the one engine thread every tool queued on.
+//! * **`session_id` routes rather than merely detects.** The old handle existed to notice that
+//!   the single target had been *replaced* underneath a caller. Here it names a worker, so an
+//!   `open_dump` cannot disturb a kernel attach at all, and an `end_session` for session A can
+//!   no longer be ordered against an open of B — there is nothing shared to order.
+//!
+//! What has *not* changed is the per-session ordering guarantee. Each session has one queue with
+//! one consumer ([`pump`]), and a job's gate runs there, immediately before the request is
+//! written — the same slot the engine thread used to provide, for the same reason.
 
+use std::collections::{HashMap, VecDeque};
 use std::fmt;
-use std::panic::{AssertUnwindSafe, catch_unwind};
-use std::thread;
-use std::time::{Duration, Instant};
+use std::path::PathBuf;
+use std::process::Stdio;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex, Weak};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader, Lines};
+use tokio::process::{Child, ChildStdin, ChildStdout, Command};
 use tokio::sync::{mpsc, oneshot};
-use win_kexp::dbgeng::DebugEngine;
 
-/// What a job closure returns: `Ok(text)` or `Err(message)`. Jobs describe debugger work,
-/// so a plain message is all they can meaningfully report.
-type Reply = Result<String, String>;
+use crate::proto::{EngineOp, WorkerMessage, WorkerRequest};
+use crate::worker::WORKER_FLAG;
 
-/// What travels back over the reply channel. The worker classifies each outcome at the
-/// point it knows the difference — an operation that failed versus an engine that was
-/// never usable — because that distinction is unrecoverable once it reaches the caller.
-type Classified = Result<String, EngineError>;
+/// How many sessions may be open at once.
+///
+/// Each is a process holding a dump, a trace, or a live target, so this is a real resource
+/// bound, not a policy. Four is enough for the workflows that motivated concurrency at all
+/// (triage a crash dump while a kernel attach is live; compare two traces) and small enough that
+/// a client leaking sessions notices.
+pub const MAX_SESSIONS: usize = 4;
+
+/// How many *closed* sessions to remember, so `session_status` can still answer for a handle
+/// after its target is gone. Live sessions are never evicted, whatever this says.
+const CLOSED_HISTORY: usize = 8;
+
+/// How long to wait for a freshly spawned worker to report [`WorkerMessage::Ready`]. This covers
+/// process creation and `DebugCreate`, nothing else — a worker that is slower than this is not
+/// going to become usable.
+const WORKER_READY_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// How long `end_session` gives the worker to release its target cleanly before the process is
+/// killed instead.
+///
+/// It is a bound on *politeness*, not on the teardown: the session ends either way. Long enough
+/// that a live target with real teardown work (a detach that has to resume threads) finishes
+/// gracefully, short enough that recovering a parked attach is not a wait.
+const END_SESSION_TIMEOUT: Duration = Duration::from_secs(20);
+
+/// Counter behind [`mint_session_id`]. Only needs to be unique within this process.
+static SESSION_SEQ: AtomicU64 = AtomicU64::new(1);
+
+/// Mints a fresh session handle. Unique per process, which is all the routing needs: the handle
+/// exists to name a worker, not to authenticate.
+fn mint_session_id() -> String {
+    let n = SESSION_SEQ.fetch_add(1, Ordering::Relaxed);
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos() as u64)
+        .unwrap_or(0);
+    format!("sess-{nanos:x}-{n}")
+}
 
 /// Why an engine call failed, split by who can act on the failure.
 ///
-/// The MCP tool spec draws exactly this line: failures the model can see and
-/// self-correct from belong in the tool *result* (`isError: true`), while failures
-/// of the server machinery belong in a JSON-RPC error. Keeping the two apart here
-/// lets [`crate::server`] render each one the right way instead of collapsing every
-/// debugger hiccup into an opaque protocol error the model never really sees.
+/// The MCP tool spec draws exactly this line: failures the model can see and self-correct from
+/// belong in the tool *result* (`isError: true`), while failures of the server machinery belong
+/// in a JSON-RPC error. Keeping the two apart here lets [`crate::server`] render each one the
+/// right way instead of collapsing every debugger hiccup into an opaque protocol error the model
+/// never really sees.
 #[derive(Debug)]
 pub enum EngineError {
-    /// The debugger ran the operation and it failed — an unresolvable symbol, an
-    /// unreadable address, a command error, a target that never stopped. Actionable:
-    /// the model can adjust its arguments and retry.
+    /// The debugger ran the operation and it failed — an unresolvable symbol, an unreadable
+    /// address, a command error, a target that never stopped. Actionable: the model can adjust
+    /// its arguments and retry.
     Debugger(String),
-    /// The call outlived its budget. Reported to the model exactly like [`Self::Debugger`],
-    /// but kept separate because it means something the caller must know: the job was
-    /// abandoned by the *waiter*, not by the engine, so it may still be running and may
-    /// still succeed. Anything whose retry has side effects has to say so.
+    /// The call outlived its budget. Reported to the model exactly like [`Self::Debugger`], but
+    /// kept separate because it means something the caller must know: the job was abandoned by
+    /// the *waiter*, not by the worker, so it may still be running and may still succeed.
+    /// Anything whose retry has side effects has to say so.
     Timeout(String),
-    /// The engine itself is unusable — the worker thread is gone or dropped the reply.
-    /// Nothing the model can do about it.
-    Unavailable(String),
+    /// The handle named a session this server will not run the call against — it was ended, its
+    /// target was replaced out from under it, or it never existed. Not an engine failure at all:
+    /// the refusal is the feature.
+    Stale(String),
+    /// The worker holding this session is gone — it crashed, or it was terminated to reclaim it.
+    /// The session is unrecoverable, but the server is not: opening again gets a fresh worker.
+    Lost(String),
 }
+
+// Note what is *not* here any more: an "engine is unusable" variant. Under process-per-session
+// every one of these failures is scoped to one session and every one of them has a next move —
+// fix the arguments, name a different session, or open again — so all of them belong in the tool
+// result where the model can read them. The only failure that is genuinely the server's rather
+// than a session's is "no worker process could be started at all", which only an opener can hit;
+// it is `OpenError::Unavailable`, and it is the one thing this server reports as a JSON-RPC error.
 
 impl fmt::Display for EngineError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::Debugger(m) | Self::Timeout(m) | Self::Unavailable(m) => f.write_str(m),
+            Self::Debugger(m) | Self::Timeout(m) | Self::Stale(m) | Self::Lost(m) => f.write_str(m),
         }
     }
 }
 
-/// How much of the call budget the watchdog leaves for itself: it Ctrl+Breaks the engine this
-/// long before the caller's wait expires, so the interrupt has time to land, `Execute` has time
-/// to unwind, and the *engine thread* is free again before the tool call reports its timeout.
-const WATCHDOG_HEADROOM: Duration = Duration::from_secs(15);
-
-/// The watchdog deadline for a command that waited `queued_wait` in the engine queue, given the
-/// caller's total `call_timeout`.
-///
-/// The outer timeout in [`EngineHandle::run`] starts counting at *submission*, but a command may
-/// sit behind another job (e.g. a backgrounded `go`) before reaching the worker. Budgeting from
-/// the time *remaining* — not the full `call_timeout` — is what makes the interrupt fire before
-/// the caller gives up regardless of queue wait.
-///
-/// Floored at [`WATCHDOG_HEADROOM`] rather than allowed to reach zero, because zero *disables*
-/// win-kexp's watchdog: a command dequeued at or past the deadline would then be the one command
-/// that runs unbounded, which is exactly the wedge case. The floor overruns the caller's timeout
-/// by design — the caller has already given up by then, and freeing the engine 15s late still
-/// beats never.
-fn watchdog_budget_ms(call_timeout: Duration, queued_wait: Duration) -> u32 {
+/// How much of the caller's budget is left, from the moment this is called until the tool call
+/// gives up. Sent to the worker so it can size the watchdog on a bounded command — see
+/// [`EngineOp::BoundedCommand`] for why the worker rather than here.
+fn remaining_patience_ms(call_timeout: Duration, submitted: Instant) -> u32 {
     call_timeout
-        .saturating_sub(queued_wait)
-        .saturating_sub(WATCHDOG_HEADROOM)
-        .max(WATCHDOG_HEADROOM)
+        .saturating_sub(submitted.elapsed())
         .as_millis()
         .min(u32::MAX as u128) as u32
 }
 
-/// A unit of work to run on the engine thread, plus where to send its result.
-struct Job {
-    run: Box<dyn FnOnce(&DebugEngine) -> Reply + Send>,
-    reply: oneshot::Sender<Classified>,
+// ---- session state -------------------------------------------------------
+
+/// What kind of target a session holds, for reporting.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SessionKind {
+    Dump,
+    Trace,
+    KernelLocal,
+    Kernel,
+    Process,
+    Launch,
 }
 
-/// Cloneable handle to the engine thread, shared across all tool calls.
-#[derive(Clone)]
-pub struct EngineHandle {
-    tx: mpsc::UnboundedSender<Job>,
-    call_timeout: Duration,
-}
-
-impl EngineHandle {
-    /// Spawns the worker thread. The [`DebugEngine`] is created on, and never leaves,
-    /// that thread.
-    pub fn spawn(call_timeout: Duration) -> Self {
-        let (tx, mut rx) = mpsc::unbounded_channel::<Job>();
-        thread::Builder::new()
-            .name("dbgeng".into())
-            .spawn(move || {
-                // `DebugEngine::new()` panics if the engine can't be created (e.g.
-                // dbgeng.dll is not discoverable); convert that into failed calls
-                // instead of tearing down the process.
-                let engine = match catch_unwind(AssertUnwindSafe(DebugEngine::new)) {
-                    Ok(engine) => engine,
-                    Err(_) => {
-                        // The engine never came up, and never will for this process. That is
-                        // `Unavailable`, not a failed operation: no argument the model can
-                        // change makes the next call work, so it must not come back as a
-                        // retryable tool error.
-                        while let Some(job) = rx.blocking_recv() {
-                            let _ = job.reply.send(Err(EngineError::Unavailable(
-                                "failed to initialize DbgEng (is dbgeng.dll on the search path?)"
-                                    .to_string(),
-                            )));
-                        }
-                        return;
-                    }
-                };
-                while let Some(job) = rx.blocking_recv() {
-                    // A panic inside a win-kexp method (several use `.expect`) must not
-                    // kill the worker — surface it as an error for this one call. The engine
-                    // survives, so this stays a debugger-level failure the model can work
-                    // around by trying something else.
-                    let result = catch_unwind(AssertUnwindSafe(|| (job.run)(&engine)))
-                        .unwrap_or_else(|_| Err("debugger operation panicked".to_string()));
-                    let _ = job.reply.send(result.map_err(EngineError::Debugger));
-                }
-            })
-            .expect("failed to spawn dbgeng thread");
-        Self { tx, call_timeout }
-    }
-
-    /// Runs `f` on the engine thread, awaiting the result with the configured timeout.
-    pub async fn run<F>(&self, f: F) -> Result<String, EngineError>
-    where
-        F: FnOnce(&DebugEngine) -> Reply + Send + 'static,
-    {
-        let (rtx, rrx) = oneshot::channel();
-        self.tx
-            .send(Job {
-                run: Box::new(f),
-                reply: rtx,
-            })
-            .map_err(|_| EngineError::Unavailable("engine thread unavailable".to_string()))?;
-        match tokio::time::timeout(self.call_timeout, rrx).await {
-            // Already classified by the worker, which is the only place that can tell a
-            // failed operation apart from an engine that never initialized.
-            Ok(Ok(classified)) => classified,
-            Ok(Err(_)) => Err(EngineError::Unavailable("engine dropped reply".to_string())),
-            // A timeout is an operational outcome, not broken plumbing: the target may
-            // simply still be running, and the model can wait, retry, or end the session.
-            // Note the job itself is *not* cancelled — only this wait for it is.
-            Err(_) => Err(EngineError::Timeout(
-                "engine call timed out (the target may still be running)".to_string(),
-            )),
+impl SessionKind {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Dump => "crash dump",
+            Self::Trace => "TTD trace",
+            Self::KernelLocal => "local kernel",
+            Self::Kernel => "kernel target",
+            Self::Process => "attached process",
+            Self::Launch => "launched process",
         }
     }
 
-    /// Runs a raw debugger command **bounded** by an engine-side watchdog. If the command
-    /// runs longer than the call budget, win-kexp's `execute_command_bounded` Ctrl+Breaks the
-    /// engine so it aborts and frees the thread — instead of a runaway command (most importantly
-    /// an unbounded `s` memory search) pinning the single engine thread and wedging every later
-    /// call.
-    ///
-    /// **Which tools use this** is a deliberate split, not an oversight — see `DECISIONS.md`
-    /// (2026-08-02). Route a tool here when its cost scales with the *target's size* or with an
-    /// *arbitrary caller-supplied expression*: `execute` and `dx` (open-ended hatches) and the
-    /// `ttd_*` wrappers (whole-trace scans). Point queries against current target state — `k`,
-    /// `lm`, `~`, `u`, `!drvobj`, `!devobj`, `!irp`, `bp` — keep [`Self::run`], because arming
-    /// the watchdog rounds a command's duration up to a multiple of 200ms (measured; win-kexp
-    /// joins a 200ms poll loop), so a 30ms query would become a 200ms one for a runaway case
-    /// it does not have.
-    ///
-    /// `precheck` runs **on the engine thread**, immediately before the command and after any
-    /// job queued ahead of it. Callers use it for gates that must not be evaluated while
-    /// earlier work is still in flight — see [`crate::server`]'s session handles.
-    pub async fn run_command<P>(&self, command: String, precheck: P) -> Result<String, EngineError>
-    where
-        P: FnOnce() -> Result<(), String> + Send + 'static,
-    {
-        let call_timeout = self.call_timeout;
-        let submitted = Instant::now();
-        self.run(move |e| {
-            precheck()?;
-            // `submitted.elapsed()`, evaluated here on the engine thread, is the queue wait —
-            // see [`watchdog_budget_ms`] for why the budget is computed from what remains.
-            let budget_ms = watchdog_budget_ms(call_timeout, submitted.elapsed());
-            e.execute_command_bounded(&command, budget_ms)
-                .map_err(|e| e.to_string())
-        })
-        .await
+    /// Whether an open of this kind can wait forever. Only a live kernel does: it needs
+    /// `WaitForEvent(INFINITE)` and nothing can interrupt a wait that has not yet connected.
+    pub fn waits_indefinitely(self) -> bool {
+        matches!(self, Self::Kernel | Self::KernelLocal)
     }
+}
+
+/// Where a session is in its life.
+///
+/// The three opening states are the distinction issue #61 could not draw: a `Pending` open looked
+/// identical whether the link was five seconds from coming up or would never come up, and those
+/// need opposite advice. [`Self::Attaching`] is reached only once the target has been *claimed*,
+/// so a session sitting in it is one whose transport is up or never will be — and how long it has
+/// sat there is the signal.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum SessionState {
+    /// The opener is running and has not created or claimed anything yet. Opening again is the
+    /// correct recovery from a failure here.
+    Opening,
+    /// The target has been created or claimed, and the opener is waiting for it to stop. The
+    /// target exists from here on, so re-running the open would attach a second time or start a
+    /// second process.
+    Attaching,
+    /// The open completed. Ready for work.
+    Open,
+    /// The open failed without creating anything. This handle will never be usable.
+    Failed(String),
+    /// The worker still holds a target, but a raw command replaced it, so this handle no longer
+    /// names what it was issued for. Calls that *supply* the handle are refused; calls that
+    /// supply none still reach the worker, exactly as they did before handles existed.
+    Retired(String),
+    /// The session is over: ended, reclaimed, or its worker died.
+    Closed(String),
+}
+
+impl SessionState {
+    /// May a call that names this session by handle run against it?
+    fn accepts_handle(&self) -> bool {
+        matches!(self, Self::Opening | Self::Attaching | Self::Open)
+    }
+
+    /// May a call that named no session be routed here? Broader than [`Self::accepts_handle`] by
+    /// exactly one state: a retired handle is refused, but the worker behind it is still the
+    /// server's current target and a caller who asked for no guarantee still gets it.
+    fn accepts_default(&self) -> bool {
+        self.accepts_handle() || matches!(self, Self::Retired(_))
+    }
+
+    /// Whether the session still owns a worker process.
+    pub fn is_live(&self) -> bool {
+        !matches!(self, Self::Failed(_) | Self::Closed(_))
+    }
+}
+
+/// One session: a worker process, its queue, and the outstanding calls against it.
+#[derive(Debug)]
+pub struct Session {
+    pub id: String,
+    pub kind: SessionKind,
+    /// What was opened — the path, connection string, pid, or command line. Reported so a
+    /// caller looking at several sessions can tell them apart.
+    pub what: String,
+    pub pid: u32,
+    created: Instant,
+    state: Mutex<(SessionState, Instant)>,
+    tx: mpsc::UnboundedSender<Job>,
+    next_id: AtomicU64,
+    /// Calls submitted and not yet answered. Non-empty means the worker owes a reply — including
+    /// for a call whose caller already gave up, which is precisely when a session must not be
+    /// reclaimed as idle.
+    waiters: Waiters,
+    child: Mutex<Option<Child>>,
+}
+
+type Waiters = Arc<Mutex<HashMap<u64, oneshot::Sender<Result<String, EngineError>>>>>;
+
+impl Session {
+    fn state(&self) -> SessionState {
+        self.state
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .0
+            .clone()
+    }
+
+    /// Moves the session to `next` and restamps it. Refuses to resurrect a session that has
+    /// already stopped owning a worker, so a milestone arriving from a worker being torn down
+    /// cannot undo the teardown.
+    fn set_state(&self, next: SessionState) {
+        let mut slot = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        if !slot.0.is_live() {
+            return;
+        }
+        *slot = (next, Instant::now());
+    }
+
+    /// How long the session has been in its current state.
+    fn in_state_for(&self) -> Duration {
+        self.state
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .1
+            .elapsed()
+    }
+
+    /// Whether the worker owes a reply, or is still opening. An idle session is one that can be
+    /// reclaimed to make room without abandoning work in flight.
+    fn busy(&self) -> bool {
+        !self
+            .waiters
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .is_empty()
+            || matches!(
+                self.state(),
+                SessionState::Opening | SessionState::Attaching
+            )
+    }
+
+    /// Answers every outstanding call with `why`. Used when the worker dies or is killed: those
+    /// callers are waiting on a reply that is never coming.
+    fn fail_outstanding(&self, why: &str) {
+        let waiters: Vec<_> = self
+            .waiters
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .drain()
+            .map(|(_, tx)| tx)
+            .collect();
+        for tx in waiters {
+            let _ = tx.send(Err(EngineError::Lost(why.to_string())));
+        }
+    }
+
+    /// Kills the worker process. Idempotent.
+    fn kill(&self) {
+        let child = self.child.lock().unwrap_or_else(|e| e.into_inner()).take();
+        if let Some(mut child) = child {
+            // `start_kill` is enough: tokio's process driver reaps the child once it is dropped,
+            // and waiting here would block the caller on a process that is already condemned.
+            let _ = child.start_kill();
+        }
+    }
+}
+
+/// A queued call, waiting for its turn on the session's worker.
+struct Job {
+    id: u64,
+    op: EngineOp,
+    submitted: Instant,
+    gate: Gate,
+}
+
+/// On whose behalf a call runs, which is what decides whether the session may still accept it.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum On {
+    /// A caller who supplied `session_id`. They get the guarantee: refused unless the session
+    /// still stands behind the handle it issued.
+    Handle,
+    /// A caller who supplied none, and so accepts whatever the current session holds — the
+    /// behaviour from before handles existed.
+    Default,
+    /// The supervisor's own teardown. There is no handle to honour and no caller to protect, so
+    /// it runs against a session already marked closed. Reclamation needs this: it has to mark
+    /// its victim before releasing it, or two opens racing at the session limit both pick the
+    /// same one and only one of them frees anything.
+    Supervisor,
+}
+
+/// What has to hold at the moment a call reaches the front of its session's queue.
+///
+/// This runs in [`pump`], immediately before the request is written and after everything queued
+/// ahead of it — the slot the engine thread used to occupy, kept for the same reason. Checking on
+/// the caller side instead would be a time-of-check/time-of-use bug: an `execute { ".opendump
+/// other.dmp" }` already queued ahead can retire the handle between a caller's check and its
+/// call, so the call would run against a target it never opened.
+#[derive(Clone)]
+struct Gate {
+    on: On,
+    /// Set when the call itself can replace the target, so the handle is retired *before* the
+    /// command runs. A `.detach` that reports an error may still have detached, and a handle
+    /// that outlives its target is the failure this ordering exists to prevent.
+    retires: Option<String>,
+}
+
+impl Gate {
+    /// Whether the session in `state` may still run this call.
+    fn admits(&self, state: &SessionState) -> bool {
+        match self.on {
+            On::Handle => state.accepts_handle(),
+            On::Default => state.accepts_default(),
+            On::Supervisor => true,
+        }
+    }
+}
+
+/// A call to run against a session.
+pub struct Call {
+    op: EngineOp,
+    gate: Gate,
+}
+
+impl Call {
+    /// A call the caller did not attach a handle to.
+    pub fn new(op: EngineOp) -> Self {
+        Self {
+            op,
+            gate: Gate {
+                on: On::Default,
+                retires: None,
+            },
+        }
+    }
+
+    /// Records whether the caller supplied `session_id`; see [`On`].
+    pub fn named(mut self, named: bool) -> Self {
+        self.gate.on = if named { On::Handle } else { On::Default };
+        self
+    }
+
+    /// Marks this call as one that can replace or release the target, retiring the handle before
+    /// it runs.
+    pub fn retiring(mut self, why: impl Into<String>) -> Self {
+        self.gate.retires = Some(why.into());
+        self
+    }
+
+    /// The supervisor's own teardown; see [`On::Supervisor`].
+    fn supervisor(op: EngineOp) -> Self {
+        Self {
+            op,
+            gate: Gate {
+                on: On::Supervisor,
+                retires: None,
+            },
+        }
+    }
+}
+
+// ---- what `session_status` reads ------------------------------------------
+
+/// A session as reported by `session_status`, taken without touching any worker.
+#[derive(Clone, Debug)]
+pub struct SessionSnapshot {
+    pub id: String,
+    pub kind: SessionKind,
+    pub what: String,
+    pub pid: u32,
+    pub state: SessionState,
+    /// How long the session has been in `state`.
+    pub in_state_for: Duration,
+    pub age: Duration,
+    /// Whether a call that names no session is routed here.
+    pub current: bool,
+}
+
+// ---- outcomes of an open --------------------------------------------------
+
+pub struct OpenReport {
+    pub id: String,
+    pub report: String,
+}
+
+/// How an open failed. The variants exist because they need different recovery advice, and
+/// getting that wrong costs a second attach or a second process.
+pub enum OpenError {
+    /// No worker could be started, so no session exists and none could.
+    Unavailable(String),
+    /// Every session slot is taken by work in flight.
+    NoRoom(String),
+    /// The open failed before anything was created or claimed. The slate is clean and opening
+    /// again is the correct recovery.
+    Clean(String),
+    /// The target was created or claimed and something after it failed. The handle names a
+    /// session that exists, so it is handed back rather than lost.
+    PostCommit {
+        id: String,
+        message: String,
+        /// The target opened and only the follow-up diagnostic failed — the session is fine.
+        report_only: bool,
+    },
+    /// The wait was abandoned. The open may still be running and may still land.
+    Timeout { id: String, message: String },
+}
+
+/// How a worker took being told to let go of its target.
+enum Release {
+    /// It released the target and said so.
+    Released(String),
+    /// It never answered inside [`END_SESSION_TIMEOUT`] and was killed. The case this whole
+    /// design is for.
+    Parked,
+    /// It had already exited.
+    AlreadyGone,
+    /// The engine reported an error releasing the target. The worker was killed anyway.
+    Refused(String),
+    /// The handle did not name a session that would accept the call. Nothing was torn down.
+    Stale(String),
+}
+
+// ---- the registry ---------------------------------------------------------
+
+#[derive(Default)]
+struct Registry {
+    /// Every session this server has held, oldest first: the live ones plus a bounded tail of
+    /// closed ones, kept so a caller can still ask what became of a handle.
+    all: VecDeque<Arc<Session>>,
+}
+
+impl Registry {
+    /// The session a call that names none is routed to: the newest that still accepts one.
+    ///
+    /// Computed rather than stored, so ending the newest session falls back to the one before it
+    /// instead of leaving the server with no default while a perfectly good target is loaded.
+    fn current(&self) -> Option<Arc<Session>> {
+        self.all
+            .iter()
+            .rev()
+            .find(|s| s.state().accepts_default())
+            .cloned()
+    }
+
+    fn find(&self, id: &str) -> Option<Arc<Session>> {
+        self.all.iter().find(|s| s.id == id).cloned()
+    }
+
+    fn live(&self) -> Vec<Arc<Session>> {
+        self.all
+            .iter()
+            .filter(|s| s.state().is_live())
+            .cloned()
+            .collect()
+    }
+
+    /// Drops the oldest settled sessions once the history bound is exceeded. Live sessions are
+    /// never evicted — forgetting one would report its handle as unknown, and the advice that
+    /// follows from "unknown" is "open again", which for an attach or a launch means a second
+    /// target.
+    fn trim(&mut self) {
+        while self.all.len() > CLOSED_HISTORY + MAX_SESSIONS {
+            let Some(oldest_settled) = self.all.iter().position(|s| !s.state().is_live()) else {
+                return;
+            };
+            self.all.remove(oldest_settled);
+        }
+    }
+}
+
+/// The session registry: what [`crate::server`] holds instead of an engine handle.
+#[derive(Clone)]
+pub struct Sessions {
+    inner: Arc<Mutex<Registry>>,
+    call_timeout: Duration,
+}
+
+impl Sessions {
+    /// Creates an empty registry. No process is started until something is opened, so a server
+    /// that is only ever asked for `tools/list` never loads DbgEng at all.
+    pub fn new(call_timeout: Duration) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(Registry::default())),
+            call_timeout,
+        }
+    }
+
+    fn registry(&self) -> std::sync::MutexGuard<'_, Registry> {
+        self.inner.lock().unwrap_or_else(|e| e.into_inner())
+    }
+
+    /// Routes a call to the session the caller named, or to the current one.
+    ///
+    /// This is where a stale handle is refused. It is *not* the whole check — the session can
+    /// still be retired between here and the worker — which is why [`Gate`] repeats it at the
+    /// front of the queue.
+    pub fn resolve(&self, supplied: Option<&str>) -> Result<Arc<Session>, EngineError> {
+        let registry = self.registry();
+        let Some(want) = supplied else {
+            return registry.current().ok_or_else(|| {
+                EngineError::Stale(
+                    "no debug session is open. Start one with open_dump / open_trace / \
+                     attach_process / attach_kernel / attach_kernel_local / launch."
+                        .to_string(),
+                )
+            });
+        };
+        match registry.find(want) {
+            Some(session) if session.state().accepts_handle() => Ok(session),
+            Some(session) => Err(EngineError::Stale(stale_handle(want, &session.state()))),
+            None => Err(EngineError::Stale(format!(
+                "unknown session handle `{want}`: this server is not holding it. Either it was \
+                 never issued here, or it closed a while ago and has aged out of the session \
+                 history. A session still in flight is never forgotten, so opening again is safe."
+            ))),
+        }
+    }
+
+    /// Every session, newest first, as `session_status` reports them.
+    pub fn snapshot(&self) -> Vec<SessionSnapshot> {
+        let registry = self.registry();
+        let current = registry.current().map(|s| s.id.clone());
+        registry
+            .all
+            .iter()
+            .rev()
+            .map(|s| SessionSnapshot {
+                id: s.id.clone(),
+                kind: s.kind,
+                what: s.what.clone(),
+                pid: s.pid,
+                state: s.state(),
+                in_state_for: s.in_state_for(),
+                age: s.created.elapsed(),
+                current: current.as_deref() == Some(s.id.as_str()),
+            })
+            .collect()
+    }
+
+    /// Runs `call` against `session`, awaiting the result with the configured timeout.
+    pub async fn call(&self, session: &Arc<Session>, call: Call) -> Result<String, EngineError> {
+        self.call_within(session, call, self.call_timeout).await
+    }
+
+    async fn call_within(
+        &self,
+        session: &Arc<Session>,
+        call: Call,
+        budget: Duration,
+    ) -> Result<String, EngineError> {
+        let id = session.next_id.fetch_add(1, Ordering::Relaxed);
+        let (tx, rx) = oneshot::channel();
+        // Registered before the job is queued, so the session counts as busy from the moment the
+        // call is submitted rather than from the moment it is written to the worker.
+        session
+            .waiters
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .insert(id, tx);
+        let queued = session.tx.send(Job {
+            id,
+            op: call.op,
+            submitted: Instant::now(),
+            gate: call.gate,
+        });
+        if queued.is_err() {
+            session
+                .waiters
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .remove(&id);
+            return Err(EngineError::Lost(worker_gone(&session.id)));
+        }
+        match tokio::time::timeout(budget, rx).await {
+            Ok(Ok(result)) => result,
+            // The sender is dropped only when the worker's reader gives up on it, which it does
+            // by answering first — so this is the residual case, not the normal one.
+            Ok(Err(_)) => Err(EngineError::Lost(worker_gone(&session.id))),
+            // A timeout is an operational outcome, not broken plumbing: the target may simply
+            // still be running. Note the job itself is *not* cancelled — only this wait for it.
+            Err(_) => Err(EngineError::Timeout(format!(
+                "engine call timed out (the target may still be running). The session `{}` is \
+                 still holding this call; `session_status` reports it, and `end_session` ends it \
+                 outright — including by terminating the worker process if it will not unwind.",
+                session.id
+            ))),
+        }
+    }
+
+    /// Opens a target in a fresh worker process.
+    pub async fn open(
+        &self,
+        kind: SessionKind,
+        what: String,
+        op: EngineOp,
+    ) -> Result<OpenReport, OpenError> {
+        debug_assert!(op.is_opener(), "open() needs an opener op");
+        self.make_room().await.map_err(OpenError::NoRoom)?;
+
+        let id = mint_session_id();
+        let session = match self.spawn(&id, kind, what).await {
+            Ok(session) => session,
+            Err(why) => return Err(OpenError::Unavailable(why)),
+        };
+        {
+            let mut registry = self.registry();
+            registry.all.push_back(Arc::clone(&session));
+            registry.trim();
+        }
+
+        let out = self.call(&session, Call::new(op)).await;
+        match out {
+            Ok(report) => {
+                // Defensive: a worker that answered without reporting `Opened` still produced a
+                // usable target, and leaving the session mid-open would make every later call
+                // read as "still attaching".
+                if !matches!(session.state(), SessionState::Open) {
+                    session.set_state(SessionState::Open);
+                }
+                Ok(OpenReport { id, report })
+            }
+            Err(EngineError::Timeout(message)) => Err(OpenError::Timeout { id, message }),
+            Err(e) => {
+                // Which side of the seam the failure fell on is recorded in the state the
+                // worker's milestones left behind — see `SessionState`.
+                match session.state() {
+                    // Nothing was created or claimed, and the worker has nothing to hold.
+                    SessionState::Opening => {
+                        let message = e.to_string();
+                        session.set_state(SessionState::Failed(message.clone()));
+                        session.kill();
+                        Err(OpenError::Clean(message))
+                    }
+                    // The worker died during the open. Whatever it had claimed went with the
+                    // process, so there is no session to hand back and no reason to warn against
+                    // opening again — that is now the only way forward.
+                    state if !state.is_live() => Err(OpenError::Clean(e.to_string())),
+                    // The target exists and the wait failed; or it opened and only the
+                    // diagnostic failed. Either way the session stays: making the caller
+                    // re-open to get a handle is how they end up with two processes.
+                    state => {
+                        let report_only = matches!(state, SessionState::Open);
+                        if !report_only {
+                            session.set_state(SessionState::Open);
+                        }
+                        Err(OpenError::PostCommit {
+                            id,
+                            message: e.to_string(),
+                            report_only,
+                        })
+                    }
+                }
+            }
+        }
+    }
+
+    /// Ends a session: asks the worker to release its target, then terminates it.
+    ///
+    /// The kill is not a fallback for tidiness — it is the recovery path. A worker parked in a
+    /// kernel attach that will never connect cannot answer, cannot be interrupted, and would
+    /// otherwise hold its session forever; killing it is the only thing that ends that wait, and
+    /// under process-per-session it costs nothing else.
+    pub async fn end(&self, session: &Arc<Session>, named: bool) -> Result<String, EngineError> {
+        let call = Call::new(EngineOp::EndSession).named(named);
+        let (reason, message) = match self.release(session, call).await {
+            // A refused handle is the mechanism working, not a session to tear down.
+            Release::Stale(why) => return Err(EngineError::Stale(why)),
+            Release::Released(text) => (
+                "ended by end_session".to_string(),
+                format!(
+                    "{text}\n\nSession `{}` is closed and its engine worker process (pid {}) has \
+                     been shut down.",
+                    session.id, session.pid
+                ),
+            ),
+            Release::Parked => (
+                format!(
+                    "terminated by end_session after {END_SESSION_TIMEOUT:?} without unwinding"
+                ),
+                format!(
+                    "Session `{}` did not release its target within {END_SESSION_TIMEOUT:?}, so \
+                     its engine worker process (pid {}) was terminated.\n\nThat is the expected \
+                     outcome for a session parked in a wait DbgEng cannot be interrupted out of — \
+                     a live-kernel attach whose target never connected is the usual one. The \
+                     session is gone and the server is unaffected; no other session was touched.",
+                    session.id, session.pid
+                ),
+            ),
+            Release::AlreadyGone => (
+                "the worker process was already gone".to_string(),
+                format!(
+                    "Session `{}` was already gone — its engine worker process had exited. The \
+                     session is closed.",
+                    session.id
+                ),
+            ),
+            // The engine refused to release the target. Under process-per-session the worker has
+            // no other purpose, so it still goes; reporting both is more use than leaving a
+            // session the caller believes they ended.
+            Release::Refused(why) => (
+                format!("ended after an error: {why}"),
+                format!(
+                    "The debugger reported an error releasing the target:\n  {why}\n\nSession \
+                     `{}` is closed anyway and its engine worker process (pid {}) has been \
+                     terminated, so nothing is left attached.",
+                    session.id, session.pid
+                ),
+            ),
+        };
+        session.set_state(SessionState::Closed(reason));
+        Ok(message)
+    }
+
+    /// Asks a worker to release its target and then terminates it, without deciding *why* the
+    /// session is closing — `end_session` and reclamation share the teardown but not the reason,
+    /// and the reason is what the caller reads afterwards.
+    async fn release(&self, session: &Arc<Session>, call: Call) -> Release {
+        let out = match self.call_within(session, call, END_SESSION_TIMEOUT).await {
+            Err(EngineError::Stale(why)) => return Release::Stale(why),
+            other => other,
+        };
+        session.fail_outstanding(&format!("session `{}` was ended", session.id));
+        session.kill();
+        match out {
+            Ok(text) => Release::Released(text),
+            Err(EngineError::Timeout(_)) => Release::Parked,
+            Err(EngineError::Lost(_)) => Release::AlreadyGone,
+            Err(e) => Release::Refused(e.to_string()),
+        }
+    }
+
+    /// Terminates every worker. Called on shutdown so a disconnecting client never leaves a
+    /// debugger process — or a debuggee — behind.
+    pub fn shutdown(&self) {
+        for session in self.registry().live() {
+            session.set_state(SessionState::Closed(
+                "the server is shutting down".to_string(),
+            ));
+            session.fail_outstanding("the server is shutting down");
+            session.kill();
+        }
+    }
+
+    /// Ensures a session slot is free, reclaiming the least-recently-opened idle session if the
+    /// server is at [`MAX_SESSIONS`].
+    ///
+    /// Reclaiming only *idle* sessions is the whole of the policy. A session with a call in
+    /// flight — including one whose caller has already given up waiting, and including a parked
+    /// attach — is never taken, because ending it silently is how a caller loses a target they
+    /// are still using. When nothing is reclaimable the open is refused with the list, which is
+    /// a better answer than picking a victim.
+    async fn make_room(&self) -> Result<(), String> {
+        let victim = {
+            let registry = self.registry();
+            let live = registry.live();
+            if live.len() < MAX_SESSIONS {
+                return Ok(());
+            }
+            match live.iter().find(|s| !s.busy()) {
+                Some(idle) => Arc::clone(idle),
+                None => {
+                    let listed: Vec<String> = live
+                        .iter()
+                        .map(|s| format!("  {} — {} ({})", s.id, s.kind.label(), s.what))
+                        .collect();
+                    return Err(format!(
+                        "this server already holds {MAX_SESSIONS} debug sessions and every one \
+                         of them has a call in flight, so there is no room to open another:\n{}\n\n\
+                         End one with `end_session {{ \"session_id\": \"…\" }}` — it terminates \
+                         that session's engine worker process even if the session is parked and \
+                         cannot unwind on its own.",
+                        listed.join("\n")
+                    ));
+                }
+            }
+        };
+        tracing::info!(
+            "reclaiming idle session {} to make room (at the {MAX_SESSIONS}-session limit)",
+            victim.id
+        );
+        // Marked *before* the release, not after: the release awaits the worker, and a second
+        // open racing this one would otherwise see the same session still live and idle, pick it
+        // too, and free nothing. Closing it first takes it out of `live()` immediately, which is
+        // also what the caller who held its handle will read.
+        victim.set_state(SessionState::Closed(format!(
+            "reclaimed to make room for a new session — this server holds at most \
+             {MAX_SESSIONS} at once, and this was the oldest idle one"
+        )));
+        // Released the same way `end_session` releases one, so a live debuggee is let go cleanly
+        // rather than dying with its debugger. As the supervisor's own teardown rather than a
+        // caller's call, it runs past the gate the state above would otherwise close.
+        self.release(&victim, Call::supervisor(EngineOp::EndSession))
+            .await;
+        Ok(())
+    }
+
+    /// Starts a worker process and waits for it to report that its engine came up.
+    async fn spawn(
+        &self,
+        id: &str,
+        kind: SessionKind,
+        what: String,
+    ) -> Result<Arc<Session>, String> {
+        let exe = worker_exe()?;
+        let mut child = Command::new(&exe)
+            .arg(WORKER_FLAG)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            // Worker logs join the server's own, which is where an MCP client looks for them.
+            .stderr(Stdio::inherit())
+            .kill_on_drop(true)
+            .spawn()
+            .map_err(|e| format!("could not start an engine worker ({}): {e}", exe.display()))?;
+
+        let stdin = child.stdin.take().ok_or("engine worker has no stdin")?;
+        let stdout = child.stdout.take().ok_or("engine worker has no stdout")?;
+        let pid = child.id().unwrap_or(0);
+        let mut lines = BufReader::new(stdout).lines();
+
+        // Nothing is registered until the worker says its engine exists. A session that cannot
+        // debug is worse than no session: it would accept calls and fail every one.
+        match tokio::time::timeout(WORKER_READY_TIMEOUT, next_message(&mut lines)).await {
+            Ok(Some(WorkerMessage::Ready)) => {}
+            Ok(Some(WorkerMessage::Fatal { message })) => {
+                let _ = child.start_kill();
+                return Err(message);
+            }
+            Ok(Some(other)) => {
+                let _ = child.start_kill();
+                return Err(format!("engine worker said {other:?} before it was ready"));
+            }
+            Ok(None) => {
+                let _ = child.start_kill();
+                return Err("the engine worker exited before it was ready".to_string());
+            }
+            Err(_) => {
+                let _ = child.start_kill();
+                return Err(format!(
+                    "the engine worker did not come up within {WORKER_READY_TIMEOUT:?}"
+                ));
+            }
+        }
+        tracing::info!("session {id}: engine worker pid {pid} ready");
+
+        let (tx, rx) = mpsc::unbounded_channel();
+        let waiters: Waiters = Arc::new(Mutex::new(HashMap::new()));
+        let session = Arc::new(Session {
+            id: id.to_string(),
+            kind,
+            what,
+            pid,
+            created: Instant::now(),
+            state: Mutex::new((SessionState::Opening, Instant::now())),
+            tx,
+            next_id: AtomicU64::new(1),
+            waiters: Arc::clone(&waiters),
+            child: Mutex::new(Some(child)),
+        });
+
+        // Both tasks hold a `Weak`, so a session dropped from the registry takes its worker's
+        // plumbing with it rather than keeping the Arc alive forever.
+        tokio::spawn(pump(
+            Arc::downgrade(&session),
+            rx,
+            stdin,
+            Arc::clone(&waiters),
+            self.call_timeout,
+        ));
+        tokio::spawn(reader(Arc::downgrade(&session), lines, waiters));
+        Ok(session)
+    }
+}
+
+/// The message for a handle whose session will not accept it.
+fn stale_handle(want: &str, state: &SessionState) -> String {
+    match state {
+        SessionState::Failed(why) => format!(
+            "session `{want}` never opened:\n  {why}\n\nOpening again is how you get a target — \
+             but read the reason first, since some failures leave one behind."
+        ),
+        SessionState::Retired(why) => format!(
+            "session handle `{want}` has been retired: {why}. The worker still holds a target, \
+             but it is not the one this handle names, so the guarantee the handle buys no longer \
+             applies. Omit `session_id` to operate on it anyway, or open again for a handle that \
+             means something."
+        ),
+        SessionState::Closed(why) => format!(
+            "session `{want}` is closed: {why}. Open a target again with open_dump / open_trace \
+             / attach_process / attach_kernel / attach_kernel_local / launch."
+        ),
+        // The accepting states never reach here.
+        _ => format!("session `{want}` is not accepting calls"),
+    }
+}
+
+fn worker_gone(id: &str) -> String {
+    format!(
+        "the engine worker process holding session `{id}` is gone — it exited, crashed, or was \
+         terminated. That session's target is lost; the server is unaffected, so opening again \
+         starts a fresh one."
+    )
+}
+
+/// Locates the executable to spawn workers from.
+///
+/// The supervisor re-executes *itself*, so worker and server can never drift apart in version or
+/// in protocol. The override exists for tests, which run from a harness binary rather than from
+/// the server.
+fn worker_exe() -> Result<PathBuf, String> {
+    if let Some(path) = std::env::var_os("WINDBG_MCP_WORKER_EXE") {
+        return Ok(PathBuf::from(path));
+    }
+    std::env::current_exe()
+        .map_err(|e| format!("cannot locate this executable to spawn an engine worker: {e}"))
+}
+
+/// Reads the next well-formed message, skipping anything else on the worker's stdout.
+///
+/// Skipping rather than failing is deliberate: DbgEng output reaches this server through
+/// `IDebugOutputCallbacks`, but an extension that writes to the console directly would otherwise
+/// desynchronize the stream permanently. A logged line costs nothing; a dead session costs a
+/// target.
+async fn next_message(lines: &mut Lines<BufReader<ChildStdout>>) -> Option<WorkerMessage> {
+    loop {
+        let line = lines.next_line().await.ok().flatten()?;
+        if line.trim().is_empty() {
+            continue;
+        }
+        match serde_json::from_str::<WorkerMessage>(&line) {
+            Ok(message) => return Some(message),
+            Err(_) => tracing::warn!("engine worker wrote a line that is not a message: {line}"),
+        }
+    }
+}
+
+/// Feeds one session's queue to its worker, one job at a time.
+///
+/// This is the session's single serialization point, and the only place a [`Gate`] runs. Jobs are
+/// written as they arrive rather than one-per-reply on purpose: a job whose caller has given up
+/// is still running in the worker, and blocking the queue behind it would stop `end_session` from
+/// ever reaching the worker at all.
+async fn pump(
+    session: Weak<Session>,
+    mut rx: mpsc::UnboundedReceiver<Job>,
+    mut stdin: ChildStdin,
+    waiters: Waiters,
+    call_timeout: Duration,
+) {
+    while let Some(job) = rx.recv().await {
+        let Some(session) = session.upgrade() else {
+            return;
+        };
+        let answer = |result: Result<String, EngineError>| {
+            let waiter = waiters
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .remove(&job.id);
+            if let Some(waiter) = waiter {
+                let _ = waiter.send(result);
+            }
+        };
+
+        // The gate, at the front of the queue. See `Gate`.
+        let state = session.state();
+        if !job.gate.admits(&state) {
+            answer(Err(EngineError::Stale(stale_handle(&session.id, &state))));
+            continue;
+        }
+        if let Some(why) = &job.gate.retires {
+            session.set_state(SessionState::Retired(why.clone()));
+        }
+
+        let mut op = job.op;
+        if let EngineOp::BoundedCommand { patience_ms, .. } = &mut op {
+            *patience_ms = remaining_patience_ms(call_timeout, job.submitted);
+        }
+        let request = WorkerRequest { id: job.id, op };
+        let Ok(mut line) = serde_json::to_string(&request) else {
+            answer(Err(EngineError::Debugger(
+                "could not encode this operation for the engine worker".to_string(),
+            )));
+            continue;
+        };
+        line.push('\n');
+        if stdin.write_all(line.as_bytes()).await.is_err() || stdin.flush().await.is_err() {
+            // The worker is gone. The reader task sees the same thing and settles the session;
+            // this job is simply the first to notice.
+            answer(Err(EngineError::Lost(worker_gone(&session.id))));
+            return;
+        }
+    }
+}
+
+/// Consumes one worker's messages: milestones move the session's state, results answer callers.
+async fn reader(
+    session: Weak<Session>,
+    mut lines: Lines<BufReader<ChildStdout>>,
+    waiters: Waiters,
+) {
+    while let Some(message) = next_message(&mut lines).await {
+        let Some(session) = session.upgrade() else {
+            return;
+        };
+        match message {
+            WorkerMessage::Committed { .. } => {
+                if matches!(session.state(), SessionState::Opening) {
+                    session.set_state(SessionState::Attaching);
+                }
+            }
+            WorkerMessage::Opened { .. } => {
+                if matches!(
+                    session.state(),
+                    SessionState::Opening | SessionState::Attaching
+                ) {
+                    session.set_state(SessionState::Open);
+                }
+            }
+            WorkerMessage::Done { id, result } => {
+                let waiter = waiters
+                    .lock()
+                    .unwrap_or_else(|e| e.into_inner())
+                    .remove(&id);
+                if let Some(waiter) = waiter {
+                    // The receiver is gone when the caller's timeout fired; the send failing is
+                    // that case, and removing the entry above is what matters — it is how the
+                    // session stops counting as busy.
+                    let _ = waiter.send(result.map_err(EngineError::Debugger));
+                }
+            }
+            // Both belong to the spawn handshake, which has already happened.
+            WorkerMessage::Ready | WorkerMessage::Fatal { .. } => {}
+        }
+    }
+    // stdout closed: the worker exited, for whatever reason.
+    let Some(session) = session.upgrade() else {
+        return;
+    };
+    if session.state().is_live() {
+        session.set_state(SessionState::Closed(
+            "the engine worker process exited".to_string(),
+        ));
+    }
+    session.fail_outstanding(&worker_gone(&session.id));
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    // ---- the watchdog budget (pure) -----------------------------------------------
+    // ---- what the worker is told about the caller's deadline ----------------------
 
-    /// The everyday case: nothing queued ahead, so the watchdog fires one headroom before the
-    /// caller's wait expires. This is the number that keeps a runaway command from outliving
-    /// the tool call that started it.
+    /// A request written immediately carries the whole call budget: nothing has been spent yet,
+    /// so the worker gets the full picture and subtracts its own queue wait from it.
     #[test]
-    fn an_unqueued_command_is_bounded_one_headroom_short_of_the_call_timeout() {
-        let timeout = Duration::from_secs(300);
+    fn a_request_written_at_once_carries_the_whole_call_budget() {
+        let sent = remaining_patience_ms(Duration::from_secs(300), Instant::now());
+        assert!(
+            (299_000..=300_000).contains(&sent),
+            "expected ~300s of patience, got {sent}ms"
+        );
+    }
+
+    /// Time already spent — in the supervisor's own queue, or waiting for a worker to spawn —
+    /// is time the caller will not wait again, so it comes off before the request is written.
+    #[test]
+    fn time_already_spent_comes_off_the_patience_sent() {
+        let submitted = Instant::now() - Duration::from_secs(100);
+        let sent = remaining_patience_ms(Duration::from_secs(300), submitted);
+        assert!(
+            (199_000..=200_000).contains(&sent),
+            "expected ~200s of patience left, got {sent}ms"
+        );
+    }
+
+    /// A caller that has already given up leaves no patience rather than an underflowed one.
+    /// The worker floors it into a real watchdog budget; what must not happen is a wrap into a
+    /// huge number, which would arm the watchdog for weeks.
+    #[test]
+    fn an_exhausted_budget_saturates_at_zero() {
+        let submitted = Instant::now() - Duration::from_secs(600);
         assert_eq!(
-            watchdog_budget_ms(timeout, Duration::ZERO),
-            (300 - 15) * 1000
+            remaining_patience_ms(Duration::from_secs(300), submitted),
+            0
         );
     }
 
-    /// The property the queue-awareness exists for, stated as the invariant rather than as an
-    /// arithmetic identity: **queue wait + watchdog budget must not exceed the caller's
-    /// timeout**, or the caller gives up while the command is still running — the wedge.
-    ///
-    /// Budgeting from the full `call_timeout` (ignoring the wait) breaks this for every
-    /// non-zero wait, which is why it is checked across a spread rather than at one point.
+    // ---- session handles ----------------------------------------------------------
+
     #[test]
-    fn a_queued_command_still_aborts_before_its_caller_gives_up() {
-        let timeout = Duration::from_secs(300);
-        for waited in [0, 1, 30, 100, 240, 269] {
-            let waited = Duration::from_secs(waited);
-            let budget = Duration::from_millis(watchdog_budget_ms(timeout, waited) as u64);
-            assert!(
-                waited + budget <= timeout,
-                "a command dequeued after {waited:?} gets a {budget:?} budget — it would still \
-                 be running at the {timeout:?} mark, which is the wedge this bounds"
-            );
-        }
+    fn minted_handles_are_unique() {
+        let a = mint_session_id();
+        let b = mint_session_id();
+        assert_ne!(a, b);
+        assert!(a.starts_with("sess-"));
     }
 
-    /// Past the point where any headroom is left, the budget floors instead of reaching zero —
-    /// because zero *disables* win-kexp's watchdog, which would make a command dequeued near
-    /// the deadline the one command that runs unbounded.
-    ///
-    /// The floor deliberately overruns the caller's timeout: by then the caller has already
-    /// given up, and the remaining job is to free the engine thread for the *next* call.
+    /// The routing rules, stated as the states rather than as a table: a handle is honoured
+    /// only while its session can still make good on it, and the one state that parts company
+    /// with that is `Retired` — the worker is alive, so a caller who asked for no guarantee
+    /// still reaches it.
     #[test]
-    fn a_command_dequeued_past_the_deadline_is_still_bounded() {
-        let timeout = Duration::from_secs(300);
-        for waited in [290, 300, 600, 86_400] {
-            assert_eq!(
-                watchdog_budget_ms(timeout, Duration::from_secs(waited)),
-                15_000,
-                "a command dequeued after {waited}s must still arm the watchdog"
-            );
-        }
+    fn a_retired_handle_is_refused_but_still_the_default_target() {
+        let retired = SessionState::Retired("a raw command replaced the target".to_string());
+        assert!(!retired.accepts_handle());
+        assert!(retired.accepts_default());
+        assert!(retired.is_live());
     }
 
-    /// A `call_timeout` beyond `u32::MAX` milliseconds (~49 days) must saturate, not wrap: a
-    /// wrapped budget could land on 0 and silently disable the watchdog.
     #[test]
-    fn an_absurd_call_timeout_saturates_rather_than_wrapping() {
-        assert_eq!(
-            watchdog_budget_ms(Duration::from_secs(u32::MAX as u64), Duration::ZERO),
-            u32::MAX
-        );
-    }
-
-    // ---- the interrupt path, against a real engine ---------------------------------
-    //
-    // These need DbgEng and a target, so they are `#[ignore]`d rather than gated by an env
-    // var: they are the manual counterpart to win-kexp's own bounded-command tests, and CI
-    // has no way to provide what they need.
-    //
-    // dbgeng holds **one debuggee session per process**, so they must not run in parallel
-    // with each other:
-    //
-    //     cargo test --bin windbg-mcp -- --ignored --nocapture --test-threads=1 engine::tests
-    //
-    // win-kexp proves the primitive (`execute_command_bounded` aborts a runaway command, and
-    // the next command survives it). What is unproven *here* — and is what these cover — is
-    // this crate's wiring of it: that `run_command`'s budget actually reaches the watchdog,
-    // that the abort beats the caller's timeout (including from behind a queued job), and
-    // that the engine thread is free for the next call afterwards.
-
-    /// The checked-in kernel crash dump, also used by `tests/mcp_smoke.rs`'s target tier.
-    const SAMPLE_DUMP: &str = concat!(
-        env!("CARGO_MANIFEST_DIR"),
-        "/docs/samples/052126-34312-01.dmp"
-    );
-
-    /// A deliberately runaway command: a tight `.for` in the expression evaluator, which is
-    /// genuinely CPU-bound and polls for Ctrl+Break exactly as a real runaway command does.
-    ///
-    /// A broad `s` memory search — the wedge that motivated all of this — is the wrong probe
-    /// despite being the motivating case: it skips unmapped ranges, so even a whole-address-
-    /// space search returns almost immediately on this dump. The `.for` also leaves its
-    /// progress in `$t0`, which is what proves the interruption below.
-    ///
-    /// Sized to run for hours, so "did not finish" cannot mean "finished early on a fast host".
-    const RUNAWAY_ITERATIONS: u64 = 0x4000_0000;
-
-    fn runaway_command() -> String {
-        format!(".for (r $t0 = 0; @$t0 < 0x{RUNAWAY_ITERATIONS:x}; r $t0 = @$t0 + 1) {{ }}")
-    }
-
-    /// Reads a user pseudo-register (`$t0`, `$t1`) as a number. Returns `None` if the engine
-    /// printed something unexpected, so a caller can tell "unreadable" from "zero".
-    fn pseudo_register(text: &str, name: &str) -> Option<u64> {
-        text.split_whitespace()
-            .find_map(|tok| tok.strip_prefix(&format!("{name}=")))
-            .and_then(|v| u64::from_str_radix(&v.replace('`', ""), 16).ok())
-    }
-
-    /// Opens the sample dump on `engine`, or returns why it could not.
-    ///
-    /// `open_dump` only hands the file to DbgEng — the target is not loaded, and `Execute`
-    /// blocks, until `wait_for_event` drives the load. Both halves therefore have to run in
-    /// **one** job: an engine left between them is not a usable target for anything else.
-    async fn open_sample_dump(engine: &EngineHandle) -> Result<(), String> {
-        engine
-            .run(|e| {
-                // Empty symbol path, deliberately: these tests measure *timing*, and a symbol
-                // server on the ambient `_NT_SYMBOL_PATH` would put an unbounded network fetch
-                // inside the very budget under test. Nothing here needs symbols — the `.for`
-                // probe runs in the expression evaluator.
-                let _ = e.set_symbol_path("");
-                e.open_dump(SAMPLE_DUMP).map_err(|e| e.to_string())?;
-                e.wait_for_event(60_000).map_err(|e| e.to_string())?;
-                Ok(String::new())
-            })
-            .await
-            .map(|_| ())
-            .map_err(|e| e.to_string())
-    }
-
-    /// Whether the engine still *executes* commands. Asserted on an effect rather than on
-    /// returned text: `Execute` echoes the command into the output buffer before running it,
-    /// so any substring check against the command itself passes on the echo alone — even for
-    /// a command that was aborted before it did anything.
-    async fn engine_still_executes(engine: &EngineHandle) -> bool {
-        const SENTINEL: u64 = 0x5A5E;
-        if engine
-            .run(|e| {
-                e.execute_command(&format!("r $t1 = 0x{SENTINEL:x}"))
-                    .map_err(|e| e.to_string())
-            })
-            .await
-            .is_err()
-        {
-            return false;
-        }
-        match engine
-            .run(|e| e.execute_command("r $t1").map_err(|e| e.to_string()))
-            .await
-        {
-            Ok(text) => pseudo_register(&text, "$t1") == Some(SENTINEL),
-            Err(_) => false,
-        }
-    }
-
-    /// The whole point of the bounded path, end to end at this crate's altitude: a command
-    /// that would run for hours comes back to the caller *as a result* (not as a timeout),
-    /// and the engine thread is free for the next call.
-    #[tokio::test]
-    #[ignore = "needs DbgEng and a target; run manually with --ignored --test-threads=1"]
-    async fn a_runaway_command_self_aborts_and_leaves_the_engine_usable() {
-        // 30s of call budget leaves the watchdog the 15s floor, which keeps the test short
-        // while still exercising the real arithmetic rather than a special case.
-        let engine = EngineHandle::spawn(Duration::from_secs(30));
-        open_sample_dump(&engine).await.expect("open sample dump");
-
-        let started = Instant::now();
-        let out = engine
-            .run_command(runaway_command(), || Ok(()))
-            .await
-            .expect("a bounded runaway command must return a result, not a timeout");
-        let elapsed = started.elapsed();
-
-        // Proof of interruption is the loop counter, not the clock and not the note: the note
-        // is appended whenever the watchdog *attempted* an interrupt, so an interrupt the
-        // engine ignored would still produce it.
-        let t0 = engine
-            .run(|e| e.execute_command("r $t0").map_err(|e| e.to_string()))
-            .await
-            .ok()
-            .and_then(|text| pseudo_register(&text, "$t0"))
-            .expect("could not read $t0 back");
-        println!(
-            "bounded command returned after {elapsed:?}, $t0 = {t0:#x} of {RUNAWAY_ITERATIONS:#x}"
-        );
-        assert!(t0 > 0, "the loop never started ($t0 = {t0:#x})");
-        assert!(
-            t0 < RUNAWAY_ITERATIONS,
-            "the loop ran to completion ($t0 = {t0:#x}) — the watchdog did not cut it short, \
-             so the rest of this test would prove nothing"
-        );
-        assert!(
-            out.contains("interrupted after"),
-            "no interruption note despite a loop that stopped short:\n{out}"
-        );
-
-        // The wedge itself. Before the bounded path this is where every later call timed out,
-        // and the only recovery was restarting the server.
-        assert!(
-            engine_still_executes(&engine).await,
-            "the engine thread was not freed by the abort — this is the wedge"
-        );
-
-        let _ = engine
-            .run(|e| {
-                e.end_session()
-                    .map(|_| String::new())
-                    .map_err(|e| e.to_string())
-            })
-            .await;
-    }
-
-    /// The queue-aware half of the budget, which is the part that has no equivalent in
-    /// win-kexp: a bounded command that spent most of the call budget waiting its turn must
-    /// still abort *before* its caller's timeout, not one full budget after it was dequeued.
-    ///
-    /// Budgeting from the full `call_timeout` instead of the remainder passes every assertion
-    /// in the test above and fails here — the command would abort ~30s after the caller had
-    /// already given up, with the engine pinned in between.
-    // Multi-threaded runtime, because this test blocks on the "job started" signal below.
-    // On the default current-thread runtime that block also starves the spawned task that
-    // would send it, and the test deadlocks instead of failing.
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    #[ignore = "needs DbgEng and a target; run manually with --ignored --test-threads=1"]
-    async fn a_runaway_command_queued_behind_another_job_still_beats_its_caller() {
-        const CALL_TIMEOUT: Duration = Duration::from_secs(60);
-        const QUEUE_WAIT: Duration = Duration::from_secs(30);
-
-        let engine = EngineHandle::spawn(CALL_TIMEOUT);
-        open_sample_dump(&engine).await.expect("open sample dump");
-
-        // Occupy the engine thread. The signal is sent from *inside* the job, so the runaway
-        // command below is submitted while this one is provably already running — a plain
-        // spawn would race and might queue the two the other way round.
-        let (running_tx, running_rx) = std::sync::mpsc::channel();
-        let blocker = tokio::spawn({
-            let engine = engine.clone();
-            async move {
-                engine
-                    .run(move |_| {
-                        running_tx.send(()).expect("signal receiver alive");
-                        thread::sleep(QUEUE_WAIT);
-                        Ok(String::new())
-                    })
-                    .await
-            }
-        });
-        running_rx.recv().expect("blocker job started");
-
-        let started = Instant::now();
-        let out = engine
-            .run_command(runaway_command(), || Ok(()))
-            .await
-            .expect("a bounded runaway command must return a result, not a timeout");
-        let elapsed = started.elapsed();
-
-        println!(
-            "queued {QUEUE_WAIT:?}, then returned after {elapsed:?} of a {CALL_TIMEOUT:?} budget"
-        );
-        assert!(
-            out.contains("interrupted after"),
-            "the queued command was not interrupted:\n{out}"
-        );
-        assert!(
-            elapsed < CALL_TIMEOUT,
-            "the abort landed after the caller's {CALL_TIMEOUT:?} timeout ({elapsed:?}) — the \
-             watchdog budget did not account for the {QUEUE_WAIT:?} spent queued"
-        );
-        assert!(
-            engine_still_executes(&engine).await,
-            "the engine thread was not freed by the abort"
-        );
-
-        let _ = blocker.await;
-        let _ = engine
-            .run(|e| {
-                e.end_session()
-                    .map(|_| String::new())
-                    .map_err(|e| e.to_string())
-            })
-            .await;
-    }
-
-    /// What the bounded path *costs* a command that was never going to run away — the evidence
-    /// behind the coverage split in `DECISIONS.md` (2026-08-02), kept as a test so a win-kexp
-    /// change to the watchdog can be re-measured rather than re-argued.
-    ///
-    /// The cost is not a constant overhead but a **quantization**, which is why this reports a
-    /// distribution rather than a mean. win-kexp's watchdog thread checks its `done` flag, then
-    /// sleeps 200ms; `Execute` returning sets the flag, but the join has to wait for the sleep
-    /// to end. A command therefore takes `ceil(d / 200ms) * 200ms` — measured on the sample
-    /// dump: `lm` at 0.2ms and a `.for` at 127ms both come back at ~200ms, and a 377ms `.for`
-    /// at ~401ms.
-    ///
-    /// The one escape is a command that finishes before the watchdog thread's *first* check (a
-    /// thread spawn away), which costs ~nothing. Only sub-millisecond commands are ever in that
-    /// regime and they straddle it — the `lm` median flips between ~0.3ms and ~200ms run to run
-    /// on the same host, so it is a race, not a guarantee.
-    ///
-    /// So the tax on a point query is best read as: anything that takes 1–200ms now takes
-    /// 200ms. A 30ms `k` becomes 200ms.
-    ///
-    /// Prints rather than asserts. The cost belongs to win-kexp's watchdog, not to this crate,
-    /// and a threshold pinned here would fail on an unrelated host difference.
-    #[tokio::test]
-    #[ignore = "needs DbgEng and a target; run manually with --ignored --test-threads=1"]
-    async fn measure_what_the_bounded_path_costs_a_quick_command() {
-        const ROUNDS: usize = 20;
-
-        let engine = EngineHandle::spawn(Duration::from_secs(60));
-        open_sample_dump(&engine).await.expect("open sample dump");
-
-        /// min / median / max, because a mean hides the two modes entirely.
-        fn spread(mut samples: Vec<Duration>) -> String {
-            samples.sort();
-            format!(
-                "min {:?}, median {:?}, max {:?}",
-                samples[0],
-                samples[samples.len() / 2],
-                samples[samples.len() - 1]
-            )
-        }
-
-        // Two probes, either side of the regime boundary:
-        //   `lm`  — the command the `modules` tool issues; sub-millisecond on a warm engine
-        //           with no symbol path, so it lands near the boundary and straddles it.
-        //   `.for`— a calibrated ~10ms command, standing in for any real query on a real
-        //           target (symbols, a live stack walk), which is well past the boundary.
-        let spin = |iterations: u64| {
-            format!(".for (r $t0 = 0; @$t0 < 0x{iterations:x}; r $t0 = @$t0 + 1) {{ }}")
-        };
-        for (label, command) in [
-            ("lm", "lm".to_string()),
-            (".for (short)", spin(20_000)),
-            (".for (long)", spin(60_000)),
+    fn an_opening_session_accepts_calls_that_then_queue_behind_the_open() {
+        for state in [
+            SessionState::Opening,
+            SessionState::Attaching,
+            SessionState::Open,
         ] {
-            let mut plain = Vec::with_capacity(ROUNDS);
-            let mut bounded = Vec::with_capacity(ROUNDS);
-            for _ in 0..ROUNDS {
-                let cmd = command.clone();
-                let t = Instant::now();
-                engine
-                    .run(move |e| e.execute_command(&cmd).map_err(|e| e.to_string()))
-                    .await
-                    .expect("unbounded command");
-                plain.push(t.elapsed());
-
-                let t = Instant::now();
-                engine
-                    .run_command(command.clone(), || Ok(()))
-                    .await
-                    .expect("bounded command");
-                bounded.push(t.elapsed());
-            }
-            println!("`{label}` x{ROUNDS}");
-            println!("   unbounded: {}", spread(plain));
-            println!("   bounded:   {}", spread(bounded));
+            assert!(state.accepts_handle(), "{state:?} should accept its handle");
+            assert!(state.accepts_default());
         }
+    }
 
-        let _ = engine
-            .run(|e| {
-                e.end_session()
-                    .map(|_| String::new())
-                    .map_err(|e| e.to_string())
-            })
-            .await;
+    #[test]
+    fn a_settled_session_accepts_nothing_and_owns_no_worker() {
+        for state in [
+            SessionState::Failed("boom".to_string()),
+            SessionState::Closed("ended".to_string()),
+        ] {
+            assert!(!state.accepts_handle(), "{state:?}");
+            assert!(!state.accepts_default(), "{state:?}");
+            assert!(!state.is_live(), "{state:?}");
+        }
+    }
+
+    /// A stale-handle message has to say which of the three ways it went stale, because the
+    /// recovery differs: re-open, drop the handle, or read the failure first.
+    #[test]
+    fn a_stale_handle_explains_which_way_it_went_stale() {
+        let failed = stale_handle("sess-1", &SessionState::Failed("no such file".to_string()));
+        assert!(failed.contains("never opened"), "{failed}");
+        assert!(failed.contains("no such file"), "{failed}");
+
+        let retired = stale_handle("sess-1", &SessionState::Retired("`.opendump`".to_string()));
+        assert!(retired.contains("retired"), "{retired}");
+        assert!(retired.contains("Omit `session_id`"), "{retired}");
+
+        let closed = stale_handle("sess-1", &SessionState::Closed("ended".to_string()));
+        assert!(closed.contains("closed"), "{closed}");
+        assert!(closed.contains("open_dump"), "{closed}");
+    }
+
+    // ---- the registry (no workers involved) ---------------------------------------
+
+    /// A `Session` with no worker behind it, for the routing tests. Its queue has no consumer,
+    /// which is all these need: they never submit a call.
+    fn dormant(id: &str, state: SessionState) -> Arc<Session> {
+        let (tx, _rx) = mpsc::unbounded_channel();
+        Arc::new(Session {
+            id: id.to_string(),
+            kind: SessionKind::Dump,
+            what: "test".to_string(),
+            pid: 0,
+            created: Instant::now(),
+            state: Mutex::new((state, Instant::now())),
+            tx,
+            next_id: AtomicU64::new(1),
+            waiters: Arc::new(Mutex::new(HashMap::new())),
+            child: Mutex::new(None),
+        })
+    }
+
+    fn registry_of(sessions: &[Arc<Session>]) -> Sessions {
+        let s = Sessions::new(Duration::from_secs(1));
+        s.registry().all.extend(sessions.iter().cloned());
+        s
+    }
+
+    #[test]
+    fn an_unnamed_call_goes_to_the_newest_usable_session() {
+        let older = dormant("sess-1", SessionState::Open);
+        let newer = dormant("sess-2", SessionState::Open);
+        let sessions = registry_of(&[older, newer]);
+        assert_eq!(sessions.resolve(None).unwrap().id, "sess-2");
+    }
+
+    /// Ending the newest session must not leave the server with no default while another target
+    /// is still loaded — the old design had exactly one session, so "ended" and "none" were the
+    /// same thing; here they are not.
+    #[test]
+    fn ending_the_newest_session_falls_back_to_the_one_before_it() {
+        let older = dormant("sess-1", SessionState::Open);
+        let newer = dormant("sess-2", SessionState::Closed("ended".to_string()));
+        let sessions = registry_of(&[older, newer]);
+        assert_eq!(sessions.resolve(None).unwrap().id, "sess-1");
+    }
+
+    #[test]
+    fn a_named_session_is_routed_to_regardless_of_which_is_current() {
+        let mine = dormant("sess-1", SessionState::Open);
+        let newer = dormant("sess-2", SessionState::Open);
+        let sessions = registry_of(&[mine, newer]);
+        assert_eq!(sessions.resolve(Some("sess-1")).unwrap().id, "sess-1");
+    }
+
+    /// The property process-per-session buys that the single-engine design could not: opening a
+    /// second target does not disturb the first, so a handle stays good across someone else's
+    /// open instead of being invalidated by it.
+    #[test]
+    fn a_handle_survives_another_callers_open() {
+        let mine = dormant("sess-1", SessionState::Open);
+        let sessions = registry_of(&[Arc::clone(&mine)]);
+        assert!(sessions.resolve(Some("sess-1")).is_ok());
+
+        sessions
+            .registry()
+            .all
+            .push_back(dormant("sess-2", SessionState::Attaching));
+        assert!(
+            sessions.resolve(Some("sess-1")).is_ok(),
+            "another session opening must not retire this one"
+        );
+    }
+
+    #[test]
+    fn an_unknown_handle_is_refused_rather_than_answered_by_the_current_session() {
+        let sessions = registry_of(&[dormant("sess-1", SessionState::Open)]);
+        let err = sessions.resolve(Some("sess-nope")).unwrap_err().to_string();
+        assert!(err.contains("unknown session handle"), "{err}");
+    }
+
+    #[test]
+    fn with_nothing_open_a_call_is_told_how_to_open_something() {
+        let sessions = Sessions::new(Duration::from_secs(1));
+        let err = sessions.resolve(None).unwrap_err().to_string();
+        assert!(err.contains("no debug session is open"), "{err}");
+        assert!(err.contains("open_dump"), "{err}");
+    }
+
+    /// Closed sessions age out; live ones never do. Forgetting a live session would report its
+    /// handle as unknown, and "unknown" tells a caller to open again — which for an attach or a
+    /// launch means a second target.
+    #[test]
+    fn closed_sessions_age_out_and_live_ones_do_not() {
+        let sessions = Sessions::new(Duration::from_secs(1));
+        {
+            let mut registry = sessions.registry();
+            registry
+                .all
+                .push_back(dormant("sess-live", SessionState::Attaching));
+            for n in 0..(CLOSED_HISTORY + MAX_SESSIONS + 4) {
+                registry.all.push_back(dormant(
+                    &format!("sess-{n}"),
+                    SessionState::Closed("x".into()),
+                ));
+            }
+            registry.trim();
+        }
+        assert!(
+            sessions.resolve(Some("sess-live")).is_ok(),
+            "a live session must never be evicted"
+        );
+        assert!(
+            sessions.registry().all.len() <= CLOSED_HISTORY + MAX_SESSIONS,
+            "settled sessions should have been trimmed to the bound"
+        );
+    }
+
+    /// The bound is on *settled* sessions only: a server at the session limit with every session
+    /// live keeps all of them, because there is nothing evictable.
+    #[test]
+    fn a_registry_of_only_live_sessions_is_never_trimmed() {
+        let sessions = Sessions::new(Duration::from_secs(1));
+        {
+            let mut registry = sessions.registry();
+            for n in 0..MAX_SESSIONS {
+                registry
+                    .all
+                    .push_back(dormant(&format!("sess-{n}"), SessionState::Open));
+            }
+            registry.trim();
+        }
+        assert_eq!(sessions.registry().live().len(), MAX_SESSIONS);
+    }
+
+    /// A parked attach is *busy*, so it is never the session reclaimed to make room — and a
+    /// caller who gave up waiting does not make it idle either, because the worker still owes a
+    /// reply.
+    #[tokio::test]
+    async fn a_parked_session_is_never_reclaimed_to_make_room() {
+        let parked = dormant("sess-parked", SessionState::Attaching);
+        let idle = dormant("sess-idle", SessionState::Open);
+        assert!(parked.busy(), "an attaching session is busy");
+        assert!(!idle.busy(), "an open session with no calls is idle");
+
+        // A call whose caller has given up leaves its waiter registered, which is what keeps the
+        // session busy after the timeout.
+        let (tx, _rx) = oneshot::channel();
+        idle.waiters
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .insert(1, tx);
+        assert!(idle.busy(), "an abandoned call still owes a reply");
+    }
+
+    /// At the limit with nothing idle, an open is refused with the list rather than picking a
+    /// victim — ending someone's live target silently is the one outcome worse than failing.
+    #[tokio::test]
+    async fn opening_past_the_limit_with_no_idle_session_is_refused_with_the_list() {
+        let sessions = Sessions::new(Duration::from_secs(1));
+        {
+            let mut registry = sessions.registry();
+            for n in 0..MAX_SESSIONS {
+                registry
+                    .all
+                    .push_back(dormant(&format!("sess-busy-{n}"), SessionState::Attaching));
+            }
+        }
+        let err = sessions.make_room().await.unwrap_err();
+        assert!(err.contains("no room"), "{err}");
+        assert!(err.contains("sess-busy-0"), "{err}");
+        assert!(err.contains("end_session"), "{err}");
+    }
+
+    /// Below the limit nothing is reclaimed, however many settled sessions are remembered.
+    #[tokio::test]
+    async fn opening_below_the_limit_reclaims_nothing() {
+        let live = dormant("sess-1", SessionState::Open);
+        let sessions = registry_of(&[
+            Arc::clone(&live),
+            dormant("sess-0", SessionState::Closed("x".into())),
+        ]);
+        assert!(sessions.make_room().await.is_ok());
+        assert_eq!(live.state(), SessionState::Open, "it was not reclaimed");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,7 +49,7 @@ fn main() -> Result<()> {
     // Read the role before anything else: a worker has no use for a tokio runtime, and its
     // engine thread must be free to block in DbgEng indefinitely.
     let is_worker = std::env::args().any(|arg| arg == worker::WORKER_FLAG);
-    init_logging(is_worker);
+    init_logging();
     if is_worker {
         worker::run();
     }
@@ -62,18 +62,19 @@ fn main() -> Result<()> {
 
 /// stdout is the JSON-RPC transport, so all logging must go to stderr. A worker's stderr is
 /// inherited from the supervisor, so both roles' logs land in the same place an MCP client
-/// already reads — tagged, so they can be told apart.
-fn init_logging(is_worker: bool) {
-    let builder = tracing_subscriber::fmt()
+/// already reads.
+///
+/// Targets stay on for both, which is what tells them apart: a worker's records carry
+/// `windbg_mcp::worker`, the supervisor's `windbg_mcp::engine` and friends. Suppressing them for
+/// workers — the first cut here — identified a worker only by the *absence* of a field, which is
+/// no help at all when two processes are interleaving lines in one stream.
+fn init_logging() {
+    tracing_subscriber::fmt()
         .with_writer(std::io::stderr)
         .with_env_filter(
             EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
-        );
-    if is_worker {
-        builder.with_target(false).init();
-    } else {
-        builder.init();
-    }
+        )
+        .init();
 }
 
 async fn serve() -> Result<()> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,17 @@
-//! windbg-mcp — an MCP server exposing WinDbg/DbgEng (live user-mode, kernel,
-//! crash dumps, and Time Travel Debugging) to MCP clients over stdio.
+//! windbg-mcp — an MCP server exposing WinDbg/DbgEng (live user-mode, kernel, crash dumps,
+//! and Time Travel Debugging) to MCP clients over stdio.
 //!
-//! The DbgEng engine is driven through win-kexp's `dbgeng` bindings on a dedicated
-//! worker thread; tools are exposed via the official `rmcp` SDK.
+//! The process runs in one of two roles. Started normally it is the **supervisor**: it speaks
+//! MCP on stdio, holds the tool surface, and never loads DbgEng. Re-executed with
+//! [`worker::WORKER_FLAG`] it is an **engine worker**, owning exactly one debug session — which
+//! is what dbgeng.dll's one-session-per-process rule makes the natural unit, and what lets a
+//! session that cannot be unwound be killed without taking the server with it.
 
 mod engine;
+mod proto;
 mod server;
 mod ttd;
+mod worker;
 
 use std::time::Duration;
 
@@ -15,27 +20,74 @@ use rmcp::ServiceExt;
 use rmcp::transport::stdio;
 use tracing_subscriber::EnvFilter;
 
-use crate::engine::EngineHandle;
+use crate::engine::Sessions;
 use crate::server::WindbgServer;
 
 /// Upper bound for any single debugger operation before the tool call reports a timeout.
 const ENGINE_CALL_TIMEOUT: Duration = Duration::from_secs(300);
 
-#[tokio::main]
-async fn main() -> Result<()> {
-    // stdout is the JSON-RPC transport, so all logging must go to stderr.
-    tracing_subscriber::fmt()
+/// Overrides [`ENGINE_CALL_TIMEOUT`], in whole seconds.
+///
+/// Exists because the budget is also what arms win-kexp's watchdog on the bounded-command path,
+/// so the only honest way to exercise that arithmetic end to end is to shrink it — a test that
+/// waits out the 300s default is a test nobody runs. Operationally it is the knob for a host
+/// where the default is wrong in either direction (a slow symbol server, or an operator who
+/// wants to hear about a stuck call sooner).
+const CALL_TIMEOUT_ENV: &str = "WINDBG_MCP_CALL_TIMEOUT_SECS";
+
+fn call_timeout() -> Duration {
+    match std::env::var(CALL_TIMEOUT_ENV)
+        .ok()
+        .and_then(|v| v.parse().ok())
+    {
+        Some(secs) if secs > 0 => Duration::from_secs(secs),
+        _ => ENGINE_CALL_TIMEOUT,
+    }
+}
+
+fn main() -> Result<()> {
+    // Read the role before anything else: a worker has no use for a tokio runtime, and its
+    // engine thread must be free to block in DbgEng indefinitely.
+    let is_worker = std::env::args().any(|arg| arg == worker::WORKER_FLAG);
+    init_logging(is_worker);
+    if is_worker {
+        worker::run();
+    }
+
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()?
+        .block_on(serve())
+}
+
+/// stdout is the JSON-RPC transport, so all logging must go to stderr. A worker's stderr is
+/// inherited from the supervisor, so both roles' logs land in the same place an MCP client
+/// already reads — tagged, so they can be told apart.
+fn init_logging(is_worker: bool) {
+    let builder = tracing_subscriber::fmt()
         .with_writer(std::io::stderr)
         .with_env_filter(
             EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
-        )
-        .init();
+        );
+    if is_worker {
+        builder.with_target(false).init();
+    } else {
+        builder.init();
+    }
+}
 
-    let engine = EngineHandle::spawn(ENGINE_CALL_TIMEOUT);
-    let server = WindbgServer::new(engine);
+async fn serve() -> Result<()> {
+    let sessions = Sessions::new(call_timeout());
+    let server = WindbgServer::new(sessions.clone());
 
     tracing::info!("windbg-mcp starting on stdio");
     let service = server.serve(stdio()).await?;
-    service.waiting().await?;
+    let outcome = service.waiting().await;
+
+    // The client disconnected. Every worker is a process holding a debug session — and, for a
+    // launch or an attach, a debuggee whose fate is tied to its debugger — so none may outlive
+    // the connection that opened it.
+    sessions.shutdown();
+    outcome?;
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -86,8 +86,9 @@ async fn serve() -> Result<()> {
 
     // The client disconnected. Every worker is a process holding a debug session — and, for a
     // launch or an attach, a debuggee whose fate is tied to its debugger — so none may outlive
-    // the connection that opened it.
-    sessions.shutdown();
+    // the connection that opened it. Released rather than killed: a live kernel that is merely
+    // killed is left *frozen*, which outlives the connection in the worst possible way.
+    sessions.shutdown().await;
     outcome?;
     Ok(())
 }

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -1,0 +1,151 @@
+//! The supervisor↔worker wire protocol.
+//!
+//! A debug session lives in its own child process (see [`crate::worker`]), so the work a tool
+//! wants done has to survive being *serialized* — which is the one real constraint this
+//! architecture imposes. The old in-process design marshalled a closure onto the engine thread;
+//! a closure cannot cross a process boundary, so the closures became the variants of
+//! [`EngineOp`].
+//!
+//! One line of JSON per message in each direction: requests down the worker's stdin, messages
+//! up its stdout. Line-delimited rather than length-prefixed so that a stray write to the
+//! worker's stdout — DbgEng output is captured through `IDebugOutputCallbacks`, but nothing
+//! *guarantees* every extension behaves — corrupts one line the supervisor can log and skip,
+//! rather than desynchronizing the stream permanently.
+
+use serde::{Deserialize, Serialize};
+
+/// One unit of debugger work, as it crosses the process boundary.
+///
+/// The variants are deliberately **tool-shaped, not DbgEng-shaped**. Several tools are more than
+/// one engine call — `reachable_from_dispatch` disassembles a whole call graph, `run_to_address`
+/// resolves an expression and then runs — and splitting those into per-primitive round trips
+/// would let another call for the same session interleave between the parts, so the walk could
+/// see a target that moved underneath it. One op is one indivisible job on the worker's engine
+/// thread, which is exactly the guarantee the single queued closure used to provide.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum EngineOp {
+    // ---- openers: the first op sent to a freshly spawned worker ----
+    OpenDump {
+        path: String,
+    },
+    OpenTrace {
+        path: String,
+    },
+    AttachKernelLocal,
+    AttachKernel {
+        connection: String,
+    },
+    AttachProcess {
+        pid: u32,
+    },
+    Launch {
+        command_line: String,
+    },
+
+    // ---- ordinary work ----
+    /// A raw command, run to completion (`IDebugControl::Execute`).
+    Command {
+        command: String,
+    },
+    /// A raw command bounded by win-kexp's watchdog, which Ctrl+Breaks the engine before the
+    /// caller gives up rather than letting a runaway command pin the session.
+    ///
+    /// What crosses the boundary is **the caller's remaining patience**, not the watchdog
+    /// deadline: how much of the tool call's budget was left when the supervisor wrote this
+    /// request. The watchdog deadline is derived from it in the worker, because only the worker
+    /// knows the other half — how long the request then sat in *its* queue behind a command
+    /// already running. Deriving it on the supervisor's side (where a request is written the
+    /// moment it is submitted, and waits on the far side of the pipe) would credit that wait to
+    /// nobody, and a command that queued for most of the budget would then run a full budget
+    /// *after* its caller had already given up. Filled in by the supervisor's pump; the value
+    /// callers construct is ignored.
+    BoundedCommand {
+        command: String,
+        patience_ms: u32,
+    },
+    /// A command plus the `WaitForEvent` pump that actually moves the target (`g`, `p`, `t`,
+    /// and their TTD reverses).
+    CommandAndWait {
+        command: String,
+        timeout_ms: u32,
+    },
+    Registers,
+    ReadMemory {
+        address: String,
+        size: u32,
+    },
+    SymbolPath {
+        path: String,
+        append: bool,
+        reload: String,
+    },
+    RunToAddress {
+        address: String,
+        timeout_ms: u32,
+    },
+    Reachability(ReachabilityOp),
+    /// Release the target. The supervisor tears the worker down afterwards — under
+    /// process-per-session a worker outlives its target for no reason.
+    EndSession,
+}
+
+impl EngineOp {
+    /// Whether this op creates the worker's target, and so reports the `Committed`/`Opened`
+    /// milestones below.
+    pub fn is_opener(&self) -> bool {
+        matches!(
+            self,
+            Self::OpenDump { .. }
+                | Self::OpenTrace { .. }
+                | Self::AttachKernelLocal
+                | Self::AttachKernel { .. }
+                | Self::AttachProcess { .. }
+                | Self::Launch { .. }
+        )
+    }
+}
+
+/// `reachable_from_dispatch`'s arguments, after the supervisor has applied its defaults.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReachabilityOp {
+    pub from: String,
+    pub address: Option<String>,
+    pub module: Option<String>,
+    pub rva: Option<String>,
+    pub max_functions: usize,
+    pub max_depth: usize,
+    pub recipe: bool,
+}
+
+/// A request down the worker's stdin. `id` is echoed on every message the op produces.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct WorkerRequest {
+    pub id: u64,
+    pub op: EngineOp,
+}
+
+/// A message up the worker's stdout.
+#[derive(Debug, Serialize, Deserialize)]
+pub enum WorkerMessage {
+    /// The engine was created; the worker will accept requests. Sent once, before anything
+    /// else, so the supervisor never registers a session behind a worker that cannot debug.
+    Ready,
+    /// The engine could not be created and this worker is exiting. Distinct from a failed
+    /// operation: no argument the caller can change makes the next attempt work.
+    Fatal { message: String },
+    /// The opener's target was **created or claimed** — the dump is loaded, the process is
+    /// spawned, the KD connection is taken. Everything after this point can fail without the
+    /// target ceasing to exist, which is the difference between "open again" and "do not open
+    /// again, you would start a second one".
+    Committed { id: u64 },
+    /// The opener's wait returned: the target is loaded and stopped. Only the follow-up
+    /// diagnostic (`lm`, `vertarget`, …) is left, so a failure from here on costs nothing but
+    /// that report. This is also what moves a kernel attach out of the state it can park in
+    /// forever.
+    Opened { id: u64 },
+    /// The op finished. `Err` is a debugger-level failure with the engine's own text.
+    Done {
+        id: u64,
+        result: Result<String, String>,
+    },
+}

--- a/src/server.rs
+++ b/src/server.rs
@@ -1561,9 +1561,12 @@ impl WindbgServer {
             // A timeout abandons the *wait*, not the job: this open may still be running and may
             // still land. The handle exists from the moment the session is registered, so it can
             // be named now — which is what makes recovery via `session_status` sound.
+            // The `session_id:` line is the same one a successful open emits, deliberately: this
+            // is the result a caller most needs to get a handle *out* of, and prose alone would
+            // make it the one opener outcome they cannot parse the id from.
             Err(OpenError::Timeout { id, message }) => tool_error(format!(
-                "{message}\n\nThe wait was abandoned, but this open was not: it is still running \
-                 in session `{id}`, and may still land. Ask `session_status \
+                "{message}\n\nsession_id: {id}\nThe wait was abandoned, but this open was not: it \
+                 is still running in the session above, and may still land. Ask `session_status \
                  {{ \"session_id\": \"{id}\" }}` — it reports whether the open is still going, \
                  how long it has been going, and whether that is longer than a healthy one takes. \
                  Do not re-run the open while it is still going, which would attach to, or start, \

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,16 +1,12 @@
 //! The MCP server: a curated set of debugger tools plus a raw command passthrough.
 //!
-//! Every tool marshals its work onto the engine thread via [`EngineHandle`]. Most
-//! tools are thin wrappers over `execute_command` (the universal DbgEng escape
-//! hatch, returning full text); session-management tools call the typed
-//! `win-kexp` methods and then wait for the target to stop.
+//! Every tool routes its work to a session's worker process via [`Sessions`] — the tool decides
+//! *what* to run ([`EngineOp`]) and *which* session runs it, and [`crate::engine`] does the rest.
+//! Most tools are thin wrappers over `execute_command` (the universal DbgEng escape hatch,
+//! returning full text); session-management tools drive the typed `win-kexp` openers.
 
-use std::cell::Cell;
 use std::collections::{HashMap, HashSet, VecDeque};
-use std::panic::{AssertUnwindSafe, catch_unwind};
-use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{Arc, Mutex};
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::Duration;
 
 use rmcp::ErrorData;
 use rmcp::handler::server::wrapper::Parameters;
@@ -18,35 +14,28 @@ use rmcp::model::{CallToolResult, ContentBlock};
 use schemars::JsonSchema;
 use serde::Deserialize;
 
-use win_kexp::dbgeng::{DebugEngine, RunToOutcome};
-
-use crate::engine::{EngineError, EngineHandle};
+use crate::engine::{
+    Call, EngineError, MAX_SESSIONS, OpenError, OpenReport, SessionKind, SessionSnapshot,
+    SessionState, Sessions,
+};
+use crate::proto::{EngineOp, ReachabilityOp};
 use crate::ttd;
 
-/// How long to wait for a target to stop after open/attach/launch (ms).
-const LOAD_WAIT_MS: u32 = 60_000;
 /// How long to wait for an execution-control command (go/step/reverse) to reach its
 /// next stop (ms).
 const EXEC_WAIT_MS: u32 = 60_000;
 
-/// Counter behind [`mint_session_id`]. Only needs to be unique within this process.
-static SESSION_SEQ: AtomicU64 = AtomicU64::new(1);
+/// How long an open may sit un-landed before `session_status` stops calling it normal.
+///
+/// A KDNET link that is coming up resyncs in ~25s; a guest that is not booted in debug mode
+/// never dials at all, and the two look identical from here except for how long they have taken.
+/// Past this the report says so, because the advice diverges completely — "wait" versus "this
+/// will not return; `end_session` reclaims it".
+const OPEN_TAKING_TOO_LONG: Duration = Duration::from_secs(120);
 
 #[derive(Clone)]
 pub struct WindbgServer {
-    engine: EngineHandle,
-    /// Handle identifying the debug session the engine is currently attached to, or
-    /// `None` when no target is open. See [`check_session_handle`] for why this exists
-    /// rather than letting the connection stand in for the session.
-    session: Arc<Mutex<Option<String>>>,
-    /// Recent opener outcomes, so a caller whose open timed out can find out whether it is
-    /// still pending, landed, or failed. See [`OpenOutcome`].
-    opens: Arc<Mutex<VecDeque<(String, OpenOutcome)>>>,
-}
-
-/// Maps any error to a `String` for the engine `Reply` channel.
-fn es<E: ToString>(e: E) -> String {
-    e.to_string()
+    sessions: Sessions,
 }
 
 fn text_result(s: String) -> Result<CallToolResult, ErrorData> {
@@ -59,33 +48,23 @@ fn tool_error(s: String) -> Result<CallToolResult, ErrorData> {
     Ok(CallToolResult::error(vec![ContentBlock::text(s)]))
 }
 
-/// Renders an engine outcome using the MCP error model.
+/// Renders a session-scoped engine outcome using the MCP error model.
 ///
-/// A failed *debugger operation* (bad symbol, unreadable address, target that never
-/// stopped) is feedback the model can act on, so it comes back as a tool-execution
-/// error with the text intact. Only a broken engine — the one thing no amount of
-/// retrying will fix — becomes a JSON-RPC protocol error.
+/// Everything that can go wrong here is feedback the model can act on — a failed debugger
+/// operation (bad symbol, unreadable address, a target that never stopped), a refused handle, a
+/// session whose worker is gone — so all of it comes back as a tool-execution error with the text
+/// intact, never as a JSON-RPC error the model never really sees. The one failure that is the
+/// *server's* rather than a session's is "no engine worker could be started", and only an opener
+/// can hit it; [`WindbgServer::opened`] renders that one.
 fn engine_result(r: Result<String, EngineError>) -> Result<CallToolResult, ErrorData> {
     match r {
         Ok(out) => text_result(out),
-        Err(EngineError::Debugger(m) | EngineError::Timeout(m)) => tool_error(m),
-        Err(EngineError::Unavailable(m)) => Err(ErrorData::internal_error(m, None)),
+        Err(e) => tool_error(e.to_string()),
     }
 }
 
-/// Mints a fresh session handle. Unique per process, which is all the guard needs:
-/// the handle exists to detect *replacement* of the target, not to authenticate.
-fn mint_session_id() -> String {
-    let n = SESSION_SEQ.fetch_add(1, Ordering::Relaxed);
-    let nanos = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_nanos() as u64)
-        .unwrap_or(0);
-    format!("sess-{nanos:x}-{n}")
-}
-
 /// Parses a decimal or `0x`-prefixed hex integer.
-fn parse_u64(s: &str) -> Result<u64, String> {
+pub(crate) fn parse_u64(s: &str) -> Result<u64, String> {
     let t = s.trim();
     let parsed = if let Some(h) = t.strip_prefix("0x").or_else(|| t.strip_prefix("0X")) {
         u64::from_str_radix(h, 16)
@@ -95,7 +74,7 @@ fn parse_u64(s: &str) -> Result<u64, String> {
     parsed.map_err(|_| format!("invalid number: {s}"))
 }
 
-fn hexdump(base: u64, bytes: &[u8]) -> String {
+pub(crate) fn hexdump(base: u64, bytes: &[u8]) -> String {
     let mut out = String::new();
     for (i, chunk) in bytes.chunks(16).enumerate() {
         let addr = base + (i * 16) as u64;
@@ -179,7 +158,7 @@ fn decode_ioctl_text(c: u32) -> String {
 /// trailed by parens/commas ("(fffff803`3e2547f0)"). Requires >= 8 hex digits so
 /// it never mistakes a mnemonic, a short immediate, or a "module!Symbol:" label
 /// for an address.
-fn parse_windbg_addr(tok: &str) -> Option<u64> {
+pub(crate) fn parse_windbg_addr(tok: &str) -> Option<u64> {
     let cleaned: String = tok
         .trim_matches(|c| c == '(' || c == ')' || c == ',')
         .chars()
@@ -361,7 +340,7 @@ fn walk_function(block: &UfBlock, start: u64) -> Option<FnWalk> {
 /// The first address token in `lm m <module>` output is the module's live start
 /// (its base). Header lines ("Browse full module list", the "start end module"
 /// legend) have no leading address and are skipped by the >= 8 hex-digit rule.
-fn parse_lm_base(text: &str) -> Option<u64> {
+pub(crate) fn parse_lm_base(text: &str) -> Option<u64> {
     text.lines()
         .find_map(|l| l.split_whitespace().next().and_then(parse_windbg_addr))
 }
@@ -370,17 +349,17 @@ fn parse_lm_base(text: &str) -> Option<u64> {
 /// "Evaluate expression: 18446735277667370832 = fffff803`3e254750" — the address
 /// is the hex token after the `=`. Used to resolve a symbolic/backtick `from` (like
 /// `mydriver!Dispatch+0x123`) to the numeric VA the intra-function walk starts at.
-fn parse_eval(text: &str) -> Option<u64> {
+pub(crate) fn parse_eval(text: &str) -> Option<u64> {
     let rhs = text.split('=').nth(1)?;
     parse_windbg_addr(rhs.split_whitespace().next()?)
 }
 
 /// Outcome of a reachability walk. `verdict_reachable` is sound (a concrete static
 /// path exists); a false verdict is best-effort within the explored bounds.
-struct Report {
-    verdict_reachable: bool,
+pub(crate) struct Report {
+    pub(crate) verdict_reachable: bool,
     /// Resolved entry of the `from` function (None if `from` didn't disassemble).
-    from_entry: Option<u64>,
+    pub(crate) from_entry: Option<u64>,
     target: u64,
     /// Entry of the function containing `target`, when reachable.
     containing_fn: Option<u64>,
@@ -405,7 +384,7 @@ struct Report {
 /// handler scoped past a switch — the intra-function walk begins there, not at the
 /// entry, so sibling switch cases aren't spuriously reachable. `None` (unresolvable)
 /// falls back to the function entry.
-fn reachability(
+pub(crate) fn reachability(
     from: &str,
     seed_start: Option<u64>,
     target: u64,
@@ -505,12 +484,12 @@ fn reconstruct(
 }
 
 /// Formats a WinDbg-style `hi`lo` address.
-fn fmt_addr(a: u64) -> String {
+pub(crate) fn fmt_addr(a: u64) -> String {
     format!("{:08x}`{:08x}", a >> 32, a & 0xffff_ffff)
 }
 
 /// Renders a [`Report`] as the tool's text output.
-fn format_report(r: &Report) -> String {
+pub(crate) fn format_report(r: &Report) -> String {
     let mut out = String::new();
     out.push_str("IOCTL dispatch reachability\n");
     match r.from_entry {
@@ -638,7 +617,7 @@ struct BranchStep {
 /// The recipe for one function on the call path: the branch decisions between where the
 /// function is entered and where control leaves it toward the target.
 #[derive(Debug, Clone, PartialEq)]
-struct SegmentRecipe {
+pub(crate) struct SegmentRecipe {
     /// Entry (or mid-function start) the segment's walk begins at.
     start: u64,
     /// Address the segment routes to: the call/jmp site to the next hop, or the target.
@@ -885,7 +864,7 @@ fn decode_predicate(
 /// recording the on-path branch decisions. `from` disassembles the seed function (a symbol
 /// still resolves); later functions enter their callee by address. `seed_start` scopes the
 /// seed segment to a mid-function start when set.
-fn path_recipe(
+pub(crate) fn path_recipe(
     from: &str,
     seed_start: Option<u64>,
     rpt: &Report,
@@ -980,7 +959,7 @@ fn render_predicate(p: &Predicate) -> String {
 }
 
 /// Renders the path recipe, appended after [`format_report`] on a REACHABLE verdict.
-fn format_recipe(recipes: &[SegmentRecipe]) -> String {
+pub(crate) fn format_recipe(recipes: &[SegmentRecipe]) -> String {
     let mut out = String::new();
     out.push_str("\nPath recipe (input that keeps control on the path to the target)\n");
     out.push_str(
@@ -1299,57 +1278,25 @@ pub struct RunToAddressArgs {
 
 // ---- Session handles -----------------------------------------------------
 //
-// One process drives one DbgEng session, but an MCP connection is explicitly *not*
-// a session: clients may interleave unrelated requests over the same stdio process,
-// so "the target the last open_* call attached to" is not a safe thing for a tool to
-// assume. Rather than silently operating on whatever target happens to be loaded,
-// the session-creating tools mint a handle and every other tool accepts it and
-// refuses to run when it no longer matches.
+// An MCP connection is explicitly *not* a session: clients may interleave unrelated requests
+// over the same stdio process, so "the target the last open_* call attached to" is not a safe
+// thing for a tool to assume. The session-creating tools therefore mint a handle, and every tool
+// that touches a target accepts it.
 //
-// The handle is optional so existing callers keep working; supplying it is what buys
-// the guarantee that a call which does supply one can never land on a target it did
-// not open.
+// What the handle *does* changed with process-per-session. It used to be a tripwire: one engine,
+// one target, and the handle existed so a call could notice that the target had been replaced
+// underneath it. Now it **routes** — it names the worker process that holds that target — and the
+// class of accident it guarded against mostly cannot happen any more, because opening a second
+// target no longer disturbs the first. See [`crate::engine`].
 //
-// That guarantee only holds because both the check and the session transition happen
-// **on the engine thread**, inside the same queued job as the debugger call itself.
-// Checking on the async side instead would be a time-of-check/time-of-use bug: with
-// session A current, an `open_dump` for B can already be in flight while `session`
-// still reads A, so an `end_session(session_id=A)` would pass the check, queue behind
-// the open, and then close B. The engine queue is the only serialisation point that
-// orders against DbgEng access, so the gate has to live on it.
-
-/// The session-handle policy, as a pure function so it unit-tests without an engine.
-///
-/// `supplied == None` means the caller opted out of the check and accepts whatever
-/// session is current — the behaviour from before handles existed. A handle that does
-/// not match is refused rather than silently honoured, because honouring it means
-/// reading memory from, or setting breakpoints on, a target the caller never opened.
-fn check_session_handle(current: Option<&str>, supplied: Option<&str>) -> Result<(), String> {
-    let Some(want) = supplied else {
-        return Ok(());
-    };
-    match current {
-        Some(cur) if cur == want => Ok(()),
-        Some(cur) => Err(format!(
-            "stale session handle `{want}`: this server is now debugging session `{cur}`. \
-             The debug target was replaced after you opened yours — this stdio process is \
-             shared, not per-conversation. Re-open your target, or omit `session_id` to \
-             operate on whatever session is current."
-        )),
-        None => Err(format!(
-            "stale session handle `{want}`: this server has no debug session open — it was \
-             ended, or never started. Re-open your target with open_dump / open_trace / \
-             attach_process / attach_kernel / attach_kernel_local / launch."
-        )),
-    }
-}
-
-/// A poisoned lock only ever means a previous holder panicked mid-update; the value is a
-/// plain `Option<String>` and cannot be left inconsistent, so recovering beats poisoning
-/// every later tool call. The lock is never held across a debugger operation.
-fn lock(session: &Mutex<Option<String>>) -> std::sync::MutexGuard<'_, Option<String>> {
-    session.lock().unwrap_or_else(|e| e.into_inner())
-}
+// It is still optional, and omitting it still means "whatever session is current" (the newest one
+// that will still accept work). What supplying it buys is unchanged: a call that names a session
+// can never land on a target the caller did not open.
+//
+// Two seams remain, and both are inside one worker rather than across the server: `execute` and
+// `dx` can replace a session's target from underneath its own handle. That retirement is ordered
+// against the session's queue — see `engine::Gate` — for the same time-of-check/time-of-use
+// reason the old design put the check on the engine thread.
 
 /// Whether an operand may legitimately contain a double quote.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -1420,70 +1367,85 @@ fn post_commit_failure(err: &str, session_id: &str) -> String {
     )
 }
 
-/// How far a session-opening job got.
-///
-/// Recorded because the per-call timeout abandons the *waiter*, not the job: a caller can
-/// stop hearing about an open that is still queued, still running, or already finished. The
-/// current session handle alone cannot tell those apart — a handle that is not yours means
-/// only "not yours", which is equally true while you wait and after you have failed. So the
-/// outcome is tracked per opener, and [`WindbgServer::session_status`] can be asked about a
-/// specific one.
-///
-/// The distinction matters because it changes what the caller should do: a `Pending` open
-/// must not be re-run (that attaches or launches a second time), while a `Failed` one has to
-/// be, since nothing else will produce a target.
-#[derive(Clone, Debug, PartialEq, Eq)]
-enum OpenOutcome {
-    /// Queued or running. The handle may still be committed.
-    Pending,
-    /// The target was opened and the handle committed. It may since have been replaced by a
-    /// later open — that is what the handle check is for — but this open did land.
-    Landed,
-    /// The open failed. This handle will never be committed; opening again is the only way
-    /// forward.
-    Failed(String),
+/// Renders a duration the way a person reads one: "8.4s", "3m12s", "1h05m".
+fn fmt_duration(d: Duration) -> String {
+    let secs = d.as_secs();
+    match secs {
+        0..=59 => format!("{:.1}s", d.as_secs_f64()),
+        60..=3599 => format!("{}m{:02}s", secs / 60, secs % 60),
+        _ => format!("{}h{:02}m", secs / 3600, (secs % 3600) / 60),
+    }
 }
 
-/// How many opener outcomes to remember. Opens are rare and a caller only ever asks about a
-/// recent one, so a short window keeps this from growing without bound.
-const OPEN_HISTORY: usize = 8;
-
-/// Records an opener's outcome, evicting the oldest *settled* entry once [`OPEN_HISTORY`]
-/// is reached.
+/// One session, as `session_status` reports it.
 ///
-/// Settled is the important word. A `Pending` entry is an open that is still queued or
-/// running, and forgetting one is worse than remembering it forever: `session_status` would
-/// report the handle as unknown, which tells the caller to open again — and that duplicates
-/// an attach or a launch, then lets the original job land afterwards and replace the target
-/// underneath them. Avoiding exactly that is why this ledger exists.
+/// The interesting line is the one for an open that has not landed. `Attaching` means the target
+/// has been *claimed* — the dump handed over, the connection taken — and the debugger is waiting
+/// for it to break in. For a live kernel that wait is `WaitForEvent(INFINITE)` and nothing can
+/// interrupt it, so the state itself cannot say whether the link is about to come up or the guest
+/// was never booted in debug mode. **How long it has been waiting can**, which is why the
+/// duration is not decoration here: past [`OPEN_TAKING_TOO_LONG`] the report stops calling it
+/// normal and names the recovery, because the two cases need opposite responses.
 ///
-/// So the history can exceed [`OPEN_HISTORY`] while opens are in flight. That is
-/// self-limiting rather than unbounded: the engine runs jobs one at a time and every job
-/// settles, including the ones that never reach it, which settle as `Failed` on the caller
-/// side.
-fn record_open(opens: &Mutex<VecDeque<(String, OpenOutcome)>>, id: &str, outcome: OpenOutcome) {
-    let mut opens = opens.lock().unwrap_or_else(|e| e.into_inner());
-    match opens.iter_mut().find(|(known, _)| known == id) {
-        Some(slot) => slot.1 = outcome,
-        None => opens.push_back((id.to_string(), outcome)),
+/// Free function so the wording tests without a debugger.
+fn describe_session(s: &SessionSnapshot) -> String {
+    let current = if s.current { " (current)" } else { "" };
+    let mut out = format!(
+        "{}{current} — {}: {}  [engine pid {}, opened {} ago]\n",
+        s.id,
+        s.kind.label(),
+        s.what,
+        s.pid,
+        fmt_duration(s.age)
+    );
+    let waited = fmt_duration(s.in_state_for);
+    match &s.state {
+        SessionState::Opening => {
+            out.push_str(&format!(
+                "  opening for {waited}. Nothing has been created or claimed yet, so a failure \
+                 from here would leave a clean slate.\n"
+            ));
+        }
+        SessionState::Attaching => {
+            out.push_str(&format!(
+                "  the target has been created or claimed, and the debugger has been waiting \
+                 {waited} for it to break in. Do not re-run the open — that would attach to, or \
+                 start, a second target.\n"
+            ));
+            if s.kind.waits_indefinitely() {
+                if s.in_state_for >= OPEN_TAKING_TOO_LONG {
+                    out.push_str(&format!(
+                        "  [!] That is far longer than a healthy kernel attach takes (a KDNET \
+                         link that is coming up resyncs in ~25s), and this wait has no timeout \
+                         and cannot be interrupted — it will not return on its own. The usual \
+                         causes are a guest that is powered off, not booted with debugging \
+                         enabled, or pointed at a different host/port/key. Fix the target and it \
+                         will still connect; otherwise reclaim the session with `end_session \
+                         {{ \"session_id\": \"{}\" }}`, which terminates its engine process. \
+                         Nothing else on this server is affected in the meantime.\n",
+                        s.id
+                    ));
+                } else {
+                    out.push_str(
+                        "  A kernel attach waits for the target to dial in, so this is normal \
+                         while the link comes up (~25s for a KDNET resync). Ask again shortly.\n",
+                    );
+                }
+            }
+        }
+        SessionState::Open => out.push_str(&format!("  open for {waited}; ready for work.\n")),
+        SessionState::Failed(why) => out.push_str(&format!(
+            "  failed {waited} ago and never opened:\n    {why}\n  Nothing was created, so \
+             opening again is the way forward.\n"
+        )),
+        SessionState::Retired(why) => out.push_str(&format!(
+            "  the handle was retired {waited} ago: {why}. The engine process still holds a \
+             target, but not the one this handle names — calls that pass `session_id` are \
+             refused, calls that omit it still reach it.\n"
+        )),
+        SessionState::Closed(why) => out.push_str(&format!("  closed {waited} ago: {why}\n")),
     }
-    // Trimmed after an update as well as an insertion. A burst of concurrent opens is all
-    // `Pending` at first and legitimately exceeds the bound; if only insertions trimmed,
-    // the ledger would stay over it forever once that burst settled in place, holding every
-    // handle and failure string for the life of the process.
-    trim_settled_opens(&mut opens);
-}
-
-/// Evicts oldest-settled entries until the ledger is back within [`OPEN_HISTORY`], or until
-/// only pending entries are left — those are never evicted, whatever the bound says.
-fn trim_settled_opens(opens: &mut VecDeque<(String, OpenOutcome)>) {
-    while opens.len() > OPEN_HISTORY {
-        let Some(oldest_settled) = opens.iter().position(|(_, o)| *o != OpenOutcome::Pending)
-        else {
-            return;
-        };
-        opens.remove(oldest_settled);
-    }
+    out
 }
 
 /// Can this data-model expression run debugger commands?
@@ -1543,154 +1505,71 @@ fn changes_debug_target(command: &str) -> bool {
     })
 }
 
-/// Builds the deferred session check.
-///
-/// The returned closure reads the session *when it runs*, not when it is built — that is
-/// the whole point, and it is why the gate must be handed to the engine thread rather than
-/// evaluated by the caller. Free function so it tests without an engine.
-fn session_gate_for(
-    session: Arc<Mutex<Option<String>>>,
-    supplied: Option<&str>,
-) -> impl FnOnce() -> Result<(), String> + Send + 'static + use<> {
-    let supplied = supplied.map(str::to_owned);
-    move || check_session_handle(lock(&session).as_deref(), supplied.as_deref())
-}
-
 impl WindbgServer {
-    /// Builds the session gate for a caller-supplied handle. The returned closure is run
-    /// *by the engine thread*, immediately before the debugger operation it guards — see
-    /// the module note above for why checking any earlier is unsound.
-    fn session_gate(
-        &self,
-        supplied: Option<&str>,
-    ) -> impl FnOnce() -> Result<(), String> + Send + 'static + use<> {
-        session_gate_for(Arc::clone(&self.session), supplied)
+    /// Routes a call to the session the caller named — or to the current one — and runs it.
+    ///
+    /// Resolution happens here, on the async side, because under process-per-session it is a
+    /// *routing* decision and routing cannot race: an open for another target creates its own
+    /// worker and cannot be ordered against this call at all. What still has to be re-checked
+    /// at the front of the session's own queue is whether the handle survived work queued ahead
+    /// of it, and that is `engine::Gate`'s job.
+    async fn run_call(&self, session_id: Option<&str>, call: Call) -> Result<String, EngineError> {
+        let session = self.sessions.resolve(session_id)?;
+        self.sessions
+            .call(&session, call.named(session_id.is_some()))
+            .await
     }
 
-    /// Runs a session-opening operation and takes ownership of the session in the same
-    /// queued job, so no other call can be ordered across the transition.
+    /// The common case: one op, no handle retirement.
+    async fn run(&self, session_id: Option<&str>, op: EngineOp) -> Result<String, EngineError> {
+        self.run_call(session_id, Call::new(op)).await
+    }
+
+    /// Opens a target in a session of its own and renders the outcome.
     ///
-    /// The work is split in two because the split is where correctness lives. `transition`
-    /// opens the target; `report` is the diagnostic (`lm`, `vertarget`, `r`, the TTD
-    /// lifetime query) whose output the caller reads. The handle is committed *between*
-    /// them, so a failure after the target has already changed cannot cost the caller a
-    /// handle for a target that is genuinely open — which matters because the only way to
-    /// get one back is to open again, and for `launch` that spawns a second process.
-    ///
-    /// `transition` receives a `commit` callback and must invoke it **the instant the target
-    /// is created or claimed**, before anything that can still fail. Every opener therefore
-    /// reads the same way: side effect, `commit()`, then the wait. That ordering is what the
-    /// callback buys — a `wait_for_event` that times out, or an initial break that never
-    /// arrives, then fails *with* the handle rather than losing it, because by then the dump
-    /// is loaded or the process is running whatever the wait says.
-    ///
-    /// win-kexp's openers expose that seam as `x_begin()` returning a `PendingTarget` guard,
-    /// which cannot exist unless the side effect succeeded — so `commit()` between the guard
-    /// and its `wait()` is exactly the right moment, enforced by the type rather than by
-    /// convention (glslang/win-kexp#71).
-    async fn opened_result<T, R>(
+    /// Every failure mode here needs different advice, and getting it wrong is expensive — "open
+    /// again" after a launch that already spawned means two processes. [`OpenError`] carries
+    /// which one happened; the worker's milestones are what let the supervisor tell them apart
+    /// (see [`crate::proto::WorkerMessage`]).
+    async fn opened(
         &self,
-        transition: T,
-        report: R,
-    ) -> Result<CallToolResult, ErrorData>
-    where
-        T: FnOnce(&DebugEngine, &dyn Fn()) -> Result<(), String> + Send + 'static,
-        R: FnOnce(&DebugEngine) -> Result<String, String> + Send + 'static,
-    {
-        let id = mint_session_id();
-        let session = Arc::clone(&self.session);
-        let opens = Arc::clone(&self.opens);
-        let new_id = id.clone();
-        let id_for_report = id.clone();
-        // Recorded before the job is queued, so a caller who never hears back can still ask
-        // about it — the whole point is that the reply may never arrive.
-        record_open(&self.opens, &id, OpenOutcome::Pending);
-        let out = self
-            .engine
-            .run(move |e| {
-                // The target is being replaced, so every handle issued so far is stale from
-                // here on — including if the transition fails partway and leaves the engine
-                // holding neither the old target nor a usable new one.
-                *lock(&session) = None;
-                // Set by `commit` below. It is what lets a failure say which side of the
-                // seam it fell on: before the commit nothing was created and re-opening is
-                // correct, after it the target exists and re-opening starts a second one.
-                let committed = Cell::new(false);
-                let commit = || {
-                    *lock(&session) = Some(new_id.clone());
-                    record_open(&opens, &new_id, OpenOutcome::Landed);
-                    committed.set(true);
-                };
-                // Under `catch_unwind` for the same reason the report is: an unwind here
-                // would leave the outcome recorded as `Pending` forever, and a caller
-                // following the documented recovery would poll for a handle that is never
-                // coming.
-                let transitioned = catch_unwind(AssertUnwindSafe(|| transition(e, &commit)))
-                    .unwrap_or_else(|_| Err("debugger operation panicked".to_string()));
-                // A transition that succeeded without committing would leave the caller with
-                // an open target and no handle. None do; commit defensively rather than let
-                // a future opener silently regress the guarantee.
-                if transitioned.is_ok() && !committed.get() {
-                    commit();
-                }
-                if let Err(err) = transitioned {
-                    if !committed.get() {
-                        // Nothing was created or claimed: the slate is clean, and re-opening
-                        // is the correct recovery.
-                        record_open(&opens, &new_id, OpenOutcome::Failed(err.clone()));
-                        return Err(err);
-                    }
-                    // The target was opened and something after it failed — the wait, most
-                    // likely. The handle names a session that exists, so hand it back; making
-                    // the caller re-open to get one is how they end up with two processes.
-                    return Err(post_commit_failure(&err, &id_for_report));
-                }
-                // The target is ours from here, so a failed diagnostic still has to hand the
-                // caller their handle — otherwise they cannot use the protection this whole
-                // mechanism promises without re-running a side-effecting open.
-                //
-                // Caught here rather than left to the worker's outer guard: a panic in a
-                // win-kexp method (several use `.expect`) would unwind straight past the
-                // `map_err` below and strip the handle off a session that is already
-                // committed. The engine survives a caught panic either way — the thing that
-                // must not be lost is the id.
-                let reported = catch_unwind(AssertUnwindSafe(|| report(e)))
-                    .unwrap_or_else(|_| Err("debugger operation panicked".to_string()));
-                reported.map_err(|err| {
-                    format!(
-                        "{err}\n\nsession_id: {id_for_report}\nThe target opened; only this \
-                         follow-up report failed, so the handle above is valid and usable."
-                    )
-                })
-            })
-            .await;
-        match out {
-            Ok(out) => text_result(format!(
-                "{out}\n\nsession_id: {id}\nPass this as `session_id` on later calls so they \
-                 fail loudly instead of silently acting on a different target if this \
-                 server's session is replaced."
+        kind: SessionKind,
+        what: String,
+        op: EngineOp,
+    ) -> Result<CallToolResult, ErrorData> {
+        match self.sessions.open(kind, what, op).await {
+            Ok(OpenReport { id, report }) => text_result(format!(
+                "{report}
+
+session_id: {id}
+Pass this as `session_id` on later calls to route                  them to this session and to fail loudly rather than act on a different target."
             )),
-            // A timeout abandons the *wait*, not the job: this open may still be running and
-            // may still commit. The handle was minted before the job was queued, so it can be
-            // named now — which is what makes recovery via `session_status` sound. Without it
-            // the caller would only learn "some session exists" and could adopt a handle
-            // belonging to somebody else's open that landed in the meantime.
-            Err(EngineError::Timeout(msg)) => tool_error(format!(
-                "{msg}\n\nThe wait was abandoned, but this open was not: it may still be \
-                 queued behind other work, and may still run and commit the handle `{id}`. \
-                 Ask `session_status {{ \"session_id\": \"{id}\" }}` — it reports whether this \
-                 open is still pending, has landed, or has failed. Do not re-run the open \
-                 while it is pending, which would attach to, or start, a second target; once \
-                 it reports failed, re-running is the only way forward."
+            // No worker, so no session — and no argument the model can change fixes that.
+            Err(OpenError::Unavailable(m)) => Err(ErrorData::internal_error(m, None)),
+            Err(OpenError::NoRoom(m)) => tool_error(m),
+            Err(OpenError::Clean(m)) => tool_error(m),
+            Err(OpenError::PostCommit {
+                id,
+                message,
+                report_only,
+            }) => tool_error(if report_only {
+                format!(
+                    "{message}
+
+session_id: {id}
+The target opened; only this follow-up report                      failed, so the handle above is valid and usable."
+                )
+            } else {
+                post_commit_failure(&message, &id)
+            }),
+            // A timeout abandons the *wait*, not the job: this open may still be running and may
+            // still land. The handle exists from the moment the session is registered, so it can
+            // be named now — which is what makes recovery via `session_status` sound.
+            Err(OpenError::Timeout { id, message }) => tool_error(format!(
+                "{message}
+
+The wait was abandoned, but this open was not: it is still running                  in session `{id}`, and may still land. Ask `session_status                  {{ \"session_id\": \"{id}\" }}` — it reports whether the open is still going, how                  long it has been going, and whether that is longer than a healthy one takes. Do                  not re-run the open while it is still going, which would attach to, or start, a                  second target; `end_session {{ \"session_id\": \"{id}\" }}` ends it outright,                  terminating the worker process if it will not unwind."
             )),
-            Err(e) => {
-                // The job never reached the engine (the worker is gone), so nothing on that
-                // side will ever record an outcome for it.
-                if matches!(e, EngineError::Unavailable(_)) {
-                    record_open(&self.opens, &id, OpenOutcome::Failed(e.to_string()));
-                }
-                engine_result(Err(e))
-            }
         }
     }
 }
@@ -1711,16 +1590,13 @@ impl WindbgServer {
 
 #[rmcp::tool_router]
 impl WindbgServer {
-    pub fn new(engine: EngineHandle) -> Self {
-        Self {
-            engine,
-            session: Arc::new(Mutex::new(None)),
-            opens: Arc::new(Mutex::new(VecDeque::new())),
-        }
+    pub fn new(sessions: Sessions) -> Self {
+        Self { sessions }
     }
 
     /// Open a crash dump (.dmp) or a Time Travel Debugging trace (.run) and wait for it to load.
-    /// Replaces any session already open, and returns a `session_id` for later calls.
+    /// Opens a new session in its own engine process — sessions already open are left alone —
+    /// and returns a `session_id` that routes later calls to it. End it with `end_session`.
     #[rmcp::tool(annotations(
         title = "Open crash dump or TTD trace",
         read_only_hint = false,
@@ -1732,30 +1608,17 @@ impl WindbgServer {
         &self,
         Parameters(args): Parameters<PathArgs>,
     ) -> Result<CallToolResult, ErrorData> {
-        self.opened_result(
-            // `open_dump` is the call that replaces the target, so commit right after it:
-            // a load wait that times out still leaves DbgEng holding the dump.
-            move |e, commit| {
-                e.open_dump(&args.path).map_err(es)?;
-                commit();
-                e.wait_for_event(LOAD_WAIT_MS).map_err(es)
-            },
-            |e| {
-                // Load the WinDbg extension DLL so `!`-extension commands resolve — most
-                // importantly `!ext.analyze -v`, the crash-dump triage workhorse. A bare
-                // engine doesn't auto-load it, and even after `.load ext` the unqualified
-                // `!analyze` won't resolve, so callers must use `!ext.analyze`. Best-effort:
-                // a minimal engine without a bundled `winext\` directory simply won't have
-                // ext.dll, which must not fail the open (live/dump state is still usable).
-                let _ = e.execute_command(".load ext");
-                e.execute_command("lm").map_err(es)
-            },
+        self.opened(
+            SessionKind::Dump,
+            args.path.clone(),
+            EngineOp::OpenDump { path: args.path },
         )
         .await
     }
 
     /// Open a TTD trace (.run); alias of open_dump. Enables time-travel navigation and TTD queries.
-    /// Replaces any session already open, and returns a `session_id` for later calls.
+    /// Opens a new session in its own engine process — sessions already open are left alone —
+    /// and returns a `session_id` that routes later calls to it. End it with `end_session`.
     #[rmcp::tool(annotations(
         title = "Open TTD trace",
         read_only_hint = false,
@@ -1767,51 +1630,17 @@ impl WindbgServer {
         &self,
         Parameters(args): Parameters<PathArgs>,
     ) -> Result<CallToolResult, ErrorData> {
-        self.opened_result(
-            // As in `open_dump`: commit before the load wait, because a wait that times out
-            // still leaves DbgEng holding the trace.
-            move |e, commit| {
-                e.open_trace(&args.path).map_err(es)?;
-                commit();
-                e.wait_for_event(LOAD_WAIT_MS).map_err(es)
-            },
-            |e| {
-                // Check the index state *before* any data-model query: `!ttdext.index -status`
-                // only reads the on-disk .idx (never builds), whereas a `dx` on an unindexed
-                // trace can itself trigger the long in-memory index build. TtdExt reports a
-                // healthy, ready index as exactly "Index file loaded."; per MS guidance treat
-                // anything else (missing, out of date, corrupt, unloadable) as needing an index.
-                // A blank result means the status query itself failed — don't warn then.
-                let needs_index = {
-                    let status = e
-                        .execute_command("!ttdext.index -status")
-                        .unwrap_or_default();
-                    !status.trim().is_empty()
-                        && !status.to_ascii_lowercase().contains("index file loaded")
-                };
-                // Confirm TTD replay is active and report the trace's position span. Lifetime
-                // is cheap metadata (min/max position); the expensive indexing is triggered by
-                // Calls/Memory/Events queries, which is what the note below warns about.
-                let mut out = e
-                    .execute_command("dx @$curprocess.TTD.Lifetime")
-                    .map_err(es)?;
-                if needs_index {
-                    out.push_str(
-                        "\nNote: this trace's index is not loaded (missing, out of date, or \
-                         unusable). The first data-model query (ttd_calls/ttd_memory/ttd_events/dx) \
-                         then builds an in-memory index and can run long — let it finish before \
-                         issuing more queries. Run index_trace to (re)build a persistent .idx \
-                         (fast queries and re-opens).",
-                    );
-                }
-                Ok(out)
-            },
+        self.opened(
+            SessionKind::Trace,
+            args.path.clone(),
+            EngineOp::OpenTrace { path: args.path },
         )
         .await
     }
 
     /// Attach to the local kernel (live local kernel debugging).
-    /// Replaces any session already open, and returns a `session_id` for later calls.
+    /// Opens a new session in its own engine process — sessions already open are left alone —
+    /// and returns a `session_id` that routes later calls to it. End it with `end_session`.
     #[rmcp::tool(annotations(
         title = "Attach to local kernel",
         read_only_hint = false,
@@ -1820,29 +1649,24 @@ impl WindbgServer {
         open_world_hint = true
     ))]
     async fn attach_kernel_local(&self) -> Result<CallToolResult, ErrorData> {
-        self.opened_result(
-            |e, commit| {
-                // The engine has claimed the local kernel once `_begin` returns; the
-                // break-in wait (INITIAL_BREAK + the INFINITE wait a live kernel requires)
-                // happens in `wait`, after the handle is ours.
-                let pending = e.attach_local_kernel_begin().map_err(es)?;
-                commit();
-                pending.wait().map_err(es)
-            },
-            |e| {
-                // The driver_object/device_object/irp_stack tools use kernel-extension
-                // commands (!drvobj/!devobj/!irp) from kdexts.dll, which a bare engine does
-                // not auto-load. Best-effort, like open_dump's `.load ext`; harmless if the
-                // extension isn't bundled (those tools then report a clean "no export").
-                let _ = e.execute_command(".load kdexts");
-                e.execute_command("vertarget").map_err(es)
-            },
+        self.opened(
+            SessionKind::KernelLocal,
+            "local kernel".to_string(),
+            EngineOp::AttachKernelLocal,
         )
         .await
     }
 
     /// Attach to a kernel target over a connection string (e.g. KDNET).
-    /// Replaces any session already open, and returns a `session_id` for later calls.
+    /// Opens a new session in its own engine process — sessions already open are left alone —
+    /// and returns a `session_id` that routes later calls to it.
+    /// A live kernel attach waits for the target to dial in, and that wait has no timeout and
+    /// cannot be interrupted: if the guest is powered off, not booted with `/debug on`, or
+    /// pointed at the wrong host/port/key, this call reports a timeout and the attach keeps
+    /// waiting forever. That costs only this session — other sessions and the server are
+    /// unaffected — and `session_status` says how long it has been waiting. Recover with
+    /// `end_session`, which terminates the session's engine process; do NOT re-attach while it
+    /// is still waiting.
     #[rmcp::tool(annotations(
         title = "Attach to kernel target",
         read_only_hint = false,
@@ -1854,21 +1678,11 @@ impl WindbgServer {
         &self,
         Parameters(args): Parameters<ConnectionArgs>,
     ) -> Result<CallToolResult, ErrorData> {
-        self.opened_result(
-            move |e, commit| {
-                // `_begin` takes the connection; the KD link is dialed and the break-in
-                // awaited in `wait`. Committing between them is what stops a failed wait
-                // from looking like "nothing happened" — re-dialing a live link is not a
-                // clean retry.
-                let pending = e.attach_kernel_begin(&args.connection).map_err(es)?;
-                commit();
-                pending.wait().map_err(es)
-            },
-            |e| {
-                // Load kdexts.dll so the driver_object/device_object/irp_stack tools'
-                // !drvobj/!devobj/!irp commands resolve (see attach_kernel_local). Best-effort.
-                let _ = e.execute_command(".load kdexts");
-                e.execute_command("vertarget").map_err(es)
+        self.opened(
+            SessionKind::Kernel,
+            args.connection.clone(),
+            EngineOp::AttachKernel {
+                connection: args.connection,
             },
         )
         .await
@@ -1891,29 +1705,22 @@ impl WindbgServer {
         &self,
         Parameters(args): Parameters<SymbolPathArgs>,
     ) -> Result<CallToolResult, ErrorData> {
-        let gate = self.session_gate(args.session_id.as_deref());
-        let append = args.append.unwrap_or(true);
         let out = self
-            .engine
-            .run(move |e| {
-                gate()?;
-                if append {
-                    e.append_symbol_path(&args.path).map_err(es)?;
-                } else {
-                    e.set_symbol_path(&args.path).map_err(es)?;
-                }
-                // Reload so the new path takes effect (default: all deferred modules).
-                e.reload_symbols(args.reload.as_deref().unwrap_or(""))
-                    .map_err(es)?;
-                // Echo the effective path so the caller can confirm what resolved.
-                e.execute_command(".sympath").map_err(es)
-            })
+            .run(
+                args.session_id.as_deref(),
+                EngineOp::SymbolPath {
+                    path: args.path,
+                    append: args.append.unwrap_or(true),
+                    reload: args.reload.unwrap_or_default(),
+                },
+            )
             .await;
         engine_result(out)
     }
 
     /// Attach to an existing user-mode process by PID and break in.
-    /// Replaces any session already open, and returns a `session_id` for later calls.
+    /// Opens a new session in its own engine process — sessions already open are left alone —
+    /// and returns a `session_id` that routes later calls to it. End it with `end_session`.
     #[rmcp::tool(annotations(
         title = "Attach to process",
         read_only_hint = false,
@@ -1925,23 +1732,17 @@ impl WindbgServer {
         &self,
         Parameters(args): Parameters<PidArgs>,
     ) -> Result<CallToolResult, ErrorData> {
-        let pid = args.pid;
-        self.opened_result(
-            move |e, commit| {
-                // Attached once `_begin` returns; the break-in wait follows the commit, so
-                // a wait that fails cannot read as "never attached" and get retried into a
-                // second attach on the same PID.
-                let pending = e.attach_process_begin(pid).map_err(es)?;
-                commit();
-                pending.wait().map_err(es)
-            },
-            |e| e.execute_command("r").map_err(es),
+        self.opened(
+            SessionKind::Process,
+            format!("pid {}", args.pid),
+            EngineOp::AttachProcess { pid: args.pid },
         )
         .await
     }
 
     /// Launch a new user-mode process under the debugger, stopping at the initial breakpoint.
-    /// Replaces any session already open, and returns a `session_id` for later calls.
+    /// Opens a new session in its own engine process — sessions already open are left alone —
+    /// and returns a `session_id` that routes later calls to it. End it with `end_session`.
     #[rmcp::tool(annotations(
         title = "Launch process under debugger",
         read_only_hint = false,
@@ -1953,45 +1754,33 @@ impl WindbgServer {
         &self,
         Parameters(args): Parameters<CommandLineArgs>,
     ) -> Result<CallToolResult, ErrorData> {
-        self.opened_result(
-            move |e, commit| {
-                // The commit point is *before* the process actually starts: CreateProcessWide
-                // is deferred into the wait. That is still the right moment — once `_begin`
-                // returns Ok the spawn is committed, so a retry from here means two processes.
-                //
-                // It is also not too early, which is the natural worry: only the *spawn* is
-                // deferred, not validation. CreateProcessWide resolves and checks the image
-                // synchronously, so the ways a launch fails with nothing created all land on
-                // this `?`, before the commit — verified against a live engine for a missing
-                // path (0x80070002), a directory (0x80070005), a non-PE file (0x800700C1) and
-                // an empty command line (0x80070057). A failure from `wait` below therefore
-                // means the process really was created, which is what makes the post-commit
-                // message ("a session exists, do not open again") true rather than a guess.
-                let pending = e.launch_process_begin(&args.command_line).map_err(es)?;
-                commit();
-                pending.wait().map_err(es)
+        self.opened(
+            SessionKind::Launch,
+            args.command_line.clone(),
+            EngineOp::Launch {
+                command_line: args.command_line,
             },
-            |e| e.execute_command("r").map_err(es),
         )
         .await
     }
 
-    /// Report the handle of the debug session this server currently holds, and — when asked
-    /// about a specific `session_id` — what became of the open that would have committed it.
+    /// List the debug sessions this server holds — what each one is, how long it has been in
+    /// its current state, and which one a call that names no session is routed to. Pass a
+    /// `session_id` to ask about one in particular.
     ///
-    /// This exists because a per-call timeout abandons the *waiter*, not the job. A live
-    /// `attach_kernel` waits indefinitely by design, so an open reporting a timeout while it
-    /// completes moments later is normal, not exceptional; the handle it commits is one no
-    /// reply ever carried. Pass the `session_id` the timeout named and this reports whether
-    /// that open is still pending, has landed, or has failed — which is the difference
-    /// between "wait" and "open again", and re-running an attach or launch on a guess
-    /// connects or spawns a second time.
+    /// This is how you find out what happened to an open that reported a timeout. A per-call
+    /// timeout abandons the *waiter*, not the job, so an open can still be running with no reply
+    /// on its way — a live `attach_kernel` waits for its target indefinitely by design, and that
+    /// wait cannot be interrupted. The state here separates the two cases that look identical
+    /// from the outside: an open that is progressing normally, and one that has been waiting far
+    /// longer than a healthy one ever takes and is not going to finish. They need opposite
+    /// responses — wait, versus `end_session` to reclaim it — and re-running an attach or a
+    /// launch on a guess connects or spawns a second time.
     ///
-    /// Called with no argument it reports only the current handle, which answers "what is
-    /// loaded" but deliberately not "is it mine": another caller's open landing while yours
-    /// was in flight produces exactly the same answer.
+    /// Answers even while a session is parked: it reads this server's own bookkeeping and never
+    /// queues on any session's engine.
     #[rmcp::tool(annotations(
-        title = "Show current session handle",
+        title = "List debug sessions",
         read_only_hint = true,
         open_world_hint = false
     ))]
@@ -1999,81 +1788,50 @@ impl WindbgServer {
         &self,
         Parameters(args): Parameters<SessionArgs>,
     ) -> Result<CallToolResult, ErrorData> {
-        // Deliberately *not* queued on the engine thread. The case this exists for is a
-        // parked attach holding that thread, so queueing behind it would make the tool
-        // unavailable exactly when it is needed. The cost is that it can read a moment
-        // behind an open that is still in flight, which is fine for a status query.
-        let current = lock(&self.session).clone();
-        let mut out = match &current {
-            Some(id) => format!("Current session: {id}"),
-            None => "No debug session is open.".to_string(),
-        };
+        // Deliberately never routed to a worker. The case this exists for is a session parked in
+        // an attach, so asking that worker anything would make the tool unavailable exactly when
+        // it is needed.
+        let sessions = self.sessions.snapshot();
 
         let Some(asked) = args.session_id.as_deref() else {
-            out.push_str(match current {
-                Some(_) => {
-                    "\nPass a `session_id` here to ask what became of a specific open — this \
-                     line says what is loaded, not whether it is yours."
-                }
-                None => {
-                    "\nStart one with open_dump / open_trace / attach_process / attach_kernel \
-                     / attach_kernel_local / launch."
-                }
-            });
+            if sessions.iter().all(|s| !s.state.is_live()) {
+                return text_result(
+                    "No debug session is open. Start one with open_dump / open_trace / \
+                     attach_process / attach_kernel / attach_kernel_local / launch."
+                        .to_string(),
+                );
+            }
+            let mut out = String::new();
+            for s in sessions.iter().filter(|s| s.state.is_live()) {
+                out.push_str(&describe_session(s));
+                out.push('\n');
+            }
+            out.push_str(&format!(
+                "\nEach session is its own engine process, so they do not interfere: work on one \
+                 while another is busy or parked. Up to {MAX_SESSIONS} at a time. Pass \
+                 `session_id` on a call to route it to a specific session; omit it and the \
+                 session marked (current) is used.",
+            ));
             return text_result(out);
         };
 
-        // The live session is authoritative and answered first, before the bounded history
-        // is consulted at all. The ledger can evict a settled entry while its handle is
-        // still the loaded one — a burst of pending opens pushes the oldest settled entry
-        // out — and falling through to the history would then contradict the line above:
-        // "Current session: A" followed by "A is not held, opening again is safe", which
-        // during timeout recovery is advice that duplicates an attach or a launch.
-        if current.as_deref() == Some(asked) {
-            out.push_str(&format!(
-                "\n\n`{asked}` is the session now loaded. It is yours: pass it as \
-                 `session_id` on later calls."
+        let Some(session) = sessions.iter().find(|s| s.id == asked) else {
+            return text_result(format!(
+                "`{asked}` is not a handle this server is holding. Either it was never issued \
+                 here, or it closed a while ago and has aged out of the session history. A \
+                 session that still exists is never forgotten, so opening again is safe."
             ));
-            return text_result(out);
-        }
-
-        let known = self
-            .opens
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
-            .iter()
-            .find(|(id, _)| id == asked)
-            .map(|(_, outcome)| outcome.clone());
-
-        out.push_str(&match known {
-            Some(OpenOutcome::Landed) => format!(
-                "\n\n`{asked}` landed, but has since been replaced by a later open. That \
-                 target is gone; calls carrying this handle will be refused. Open again."
-            ),
-            Some(OpenOutcome::Pending) => format!(
-                "\n\n`{asked}` is still pending — queued or running. Do not re-run the open, \
-                 which would attach to, or start, a second target. Ask again shortly."
-            ),
-            Some(OpenOutcome::Failed(why)) => format!(
-                "\n\n`{asked}` failed and will never be committed:\n  {why}\n\nOpening again is \
-                 how you get a target — but read the reason first, since some failures leave \
-                 one behind."
-            ),
-            // Pending opens are never evicted, so an id this server has forgotten is
-            // necessarily one that finished and aged out — never one still in flight.
-            None => format!(
-                "\n\n`{asked}` is not a handle this server is holding. Either it was never \
-                 issued here, or it settled a while ago and has aged out of the recent-open \
-                 history. It is not still in flight — those are never forgotten — so opening \
-                 again is safe."
-            ),
-        });
-        text_result(out)
+        };
+        text_result(describe_session(session))
     }
 
-    /// End the current debug session (detach/close the target) without exiting the server.
-    /// Pass `session_id` to be sure you are ending your own session and not one another
-    /// caller opened in the meantime.
+    /// End a debug session: release its target and shut down its engine process. Pass
+    /// `session_id` to be sure you are ending your own session and not another one.
+    ///
+    /// This is also the recovery for a session that is stuck. If the session does not let go
+    /// within a short grace period — a live-kernel attach whose target never dialed in cannot,
+    /// since nothing can interrupt that wait — its engine process is terminated outright. The
+    /// session ends either way, and no other session is affected.
     #[rmcp::tool(annotations(
         title = "End debug session",
         read_only_hint = false,
@@ -2085,23 +1843,12 @@ impl WindbgServer {
         &self,
         Parameters(args): Parameters<SessionArgs>,
     ) -> Result<CallToolResult, ErrorData> {
-        let gate = self.session_gate(args.session_id.as_deref());
-        let session = Arc::clone(&self.session);
-        let out = self
-            .engine
-            .run(move |e| {
-                gate()?;
-                let out = e
-                    .end_session()
-                    .map(|_| "session ended".to_string())
-                    .map_err(es)?;
-                // Cleared in the same job as the teardown, so a call queued behind this one
-                // sees "no session open" rather than a handle that outlived its target.
-                *lock(&session) = None;
-                Ok(out)
-            })
-            .await;
-        engine_result(out)
+        let session_id = args.session_id.as_deref();
+        let session = match self.sessions.resolve(session_id) {
+            Ok(session) => session,
+            Err(e) => return engine_result(Err(e)),
+        };
+        engine_result(self.sessions.end(&session, session_id.is_some()).await)
     }
 
     /// Run a raw debugger command and return its full output. The universal escape hatch.
@@ -2118,25 +1865,19 @@ impl WindbgServer {
         &self,
         Parameters(args): Parameters<ExecuteArgs>,
     ) -> Result<CallToolResult, ErrorData> {
-        let gate = self.session_gate(args.session_id.as_deref());
-        let session = Arc::clone(&self.session);
-        let retires_session = changes_debug_target(&args.command);
-        // Both steps run on the engine thread, immediately before the command, for the same
-        // ordering reason the gate does.
-        let precheck = move || {
-            gate()?;
-            if retires_session {
-                // Dropped *before* the command runs, not after: a `.detach` that reports an
-                // error may still have detached, and a handle that outlives its target is
-                // the failure mode this whole mechanism exists to prevent.
-                *lock(&session) = None;
-            }
-            Ok(())
-        };
-        // Bounded: a runaway raw command (e.g. an unbounded `s` search) self-aborts instead
-        // of pinning the engine thread and wedging every later call.
-        let out = self.engine.run_command(args.command, precheck).await;
-        engine_result(out)
+        // Bounded: a runaway raw command (e.g. an unbounded `s` search) self-aborts instead of
+        // pinning its session's engine and wedging every later call to it.
+        let mut call = Call::new(EngineOp::BoundedCommand {
+            command: args.command.clone(),
+            patience_ms: 0,
+        });
+        if changes_debug_target(&args.command) {
+            // Retired *before* the command runs, not after: a `.detach` that reports an error
+            // may still have detached, and a handle that outlives its target is the failure
+            // mode this whole mechanism exists to prevent.
+            call = call.retiring("a raw `execute` command replaced or released the target");
+        }
+        engine_result(self.run_call(args.session_id.as_deref(), call).await)
     }
 
     /// Show the current register set.
@@ -2149,13 +1890,8 @@ impl WindbgServer {
         &self,
         Parameters(args): Parameters<SessionArgs>,
     ) -> Result<CallToolResult, ErrorData> {
-        let gate = self.session_gate(args.session_id.as_deref());
         let out = self
-            .engine
-            .run(move |e| {
-                gate()?;
-                e.registers().map_err(es)
-            })
+            .run(args.session_id.as_deref(), EngineOp::Registers)
             .await;
         // DbgEng prints nothing for `r` when there is no live thread context (e.g. a
         // module-load break, or a bare goto_position to the very start of a trace).
@@ -2182,16 +1918,14 @@ impl WindbgServer {
         &self,
         Parameters(args): Parameters<ReadMemoryArgs>,
     ) -> Result<CallToolResult, ErrorData> {
-        let gate = self.session_gate(args.session_id.as_deref());
-        let size = args.size;
         let out = self
-            .engine
-            .run(move |e| {
-                gate()?;
-                let addr = parse_u64(&args.address)?;
-                let bytes = e.read_memory(addr, size as usize).map_err(es)?;
-                Ok(hexdump(addr, &bytes))
-            })
+            .run(
+                args.session_id.as_deref(),
+                EngineOp::ReadMemory {
+                    address: args.address,
+                    size: args.size,
+                },
+            )
             .await;
         engine_result(out)
     }
@@ -2206,13 +1940,13 @@ impl WindbgServer {
         &self,
         Parameters(args): Parameters<SessionArgs>,
     ) -> Result<CallToolResult, ErrorData> {
-        let gate = self.session_gate(args.session_id.as_deref());
         let out = self
-            .engine
-            .run(move |e| {
-                gate()?;
-                e.execute_command("k").map_err(es)
-            })
+            .run(
+                args.session_id.as_deref(),
+                EngineOp::Command {
+                    command: "k".to_string(),
+                },
+            )
             .await;
         engine_result(out)
     }
@@ -2227,13 +1961,13 @@ impl WindbgServer {
         &self,
         Parameters(args): Parameters<SessionArgs>,
     ) -> Result<CallToolResult, ErrorData> {
-        let gate = self.session_gate(args.session_id.as_deref());
         let out = self
-            .engine
-            .run(move |e| {
-                gate()?;
-                e.execute_command("lm").map_err(es)
-            })
+            .run(
+                args.session_id.as_deref(),
+                EngineOp::Command {
+                    command: "lm".to_string(),
+                },
+            )
             .await;
         engine_result(out)
     }
@@ -2248,13 +1982,13 @@ impl WindbgServer {
         &self,
         Parameters(args): Parameters<SessionArgs>,
     ) -> Result<CallToolResult, ErrorData> {
-        let gate = self.session_gate(args.session_id.as_deref());
         let out = self
-            .engine
-            .run(move |e| {
-                gate()?;
-                e.execute_command("~").map_err(es)
-            })
+            .run(
+                args.session_id.as_deref(),
+                EngineOp::Command {
+                    command: "~".to_string(),
+                },
+            )
             .await;
         engine_result(out)
     }
@@ -2274,17 +2008,15 @@ impl WindbgServer {
         {
             return tool_error(e);
         }
-        let gate = self.session_gate(args.session_id.as_deref());
         let cmd = match args.address {
             Some(a) => format!("u {a}"),
             None => "u".to_string(),
         };
         let out = self
-            .engine
-            .run(move |e| {
-                gate()?;
-                e.execute_command(&cmd).map_err(es)
-            })
+            .run(
+                args.session_id.as_deref(),
+                EngineOp::Command { command: cmd },
+            )
             .await;
         engine_result(out)
     }
@@ -2306,24 +2038,19 @@ impl WindbgServer {
         if let Err(e) = reject_command_breakers("expression", &args.expression, Quotes::Allowed) {
             return tool_error(e);
         }
-        let gate = self.session_gate(args.session_id.as_deref());
-        let session = Arc::clone(&self.session);
-        let retires_session = dx_executes_commands(&args.expression);
-        let precheck = move || {
-            gate()?;
-            if retires_session {
-                // We cannot see *which* command the data model is about to run, so the
-                // conservative reading is the only sound one: assume it replaced the target.
-                // Dropped before the expression evaluates, for the reason `execute` does.
-                *lock(&session) = None;
-            }
-            Ok(())
-        };
-        let cmd = format!("dx {}", args.expression);
         // Bounded: a data-model query that runs away (e.g. a heavy LINQ or index build on a
-        // huge trace) self-aborts rather than pinning the engine thread.
-        let out = self.engine.run_command(cmd, precheck).await;
-        engine_result(out)
+        // huge trace) self-aborts rather than pinning its session's engine.
+        let mut call = Call::new(EngineOp::BoundedCommand {
+            command: format!("dx {}", args.expression),
+            patience_ms: 0,
+        });
+        if dx_executes_commands(&args.expression) {
+            // We cannot see *which* command the data model is about to run, so the conservative
+            // reading is the only sound one: assume it replaced the target. Retired before the
+            // expression evaluates, for the reason `execute` does.
+            call = call.retiring("a `dx` expression reached debugger command execution");
+        }
+        engine_result(self.run_call(args.session_id.as_deref(), call).await)
     }
 
     /// TTD: find every call to a function across the whole trace
@@ -2342,9 +2069,15 @@ impl WindbgServer {
         if let Err(e) = reject_command_breakers("function", &args.function, Quotes::Rejected) {
             return tool_error(e);
         }
-        let gate = self.session_gate(args.session_id.as_deref());
-        let cmd = format!("dx @$cursession.TTD.Calls(\"{}\")", args.function);
-        let out = self.engine.run_command(cmd, gate).await;
+        let out = self
+            .run(
+                args.session_id.as_deref(),
+                EngineOp::BoundedCommand {
+                    command: format!("dx @$cursession.TTD.Calls(\"{}\")", args.function),
+                    patience_ms: 0,
+                },
+            )
+            .await;
         engine_result(out)
     }
 
@@ -2360,7 +2093,6 @@ impl WindbgServer {
         &self,
         Parameters(args): Parameters<TtdMemoryArgs>,
     ) -> Result<CallToolResult, ErrorData> {
-        let gate = self.session_gate(args.session_id.as_deref());
         if let Some(mode) = &args.mode
             && let Err(e) = reject_command_breakers("mode", mode, Quotes::Rejected)
         {
@@ -2380,7 +2112,15 @@ impl WindbgServer {
             ),
             _ => format!("dx @$cursession.TTD.Memory(0x{start:x}, 0x{end:x})"),
         };
-        let out = self.engine.run_command(cmd, gate).await;
+        let out = self
+            .run(
+                args.session_id.as_deref(),
+                EngineOp::BoundedCommand {
+                    command: cmd,
+                    patience_ms: 0,
+                },
+            )
+            .await;
         engine_result(out)
     }
 
@@ -2396,10 +2136,14 @@ impl WindbgServer {
         &self,
         Parameters(args): Parameters<SessionArgs>,
     ) -> Result<CallToolResult, ErrorData> {
-        let gate = self.session_gate(args.session_id.as_deref());
         let out = self
-            .engine
-            .run_command("dx -r2 @$curprocess.TTD.Events".to_string(), gate)
+            .run(
+                args.session_id.as_deref(),
+                EngineOp::BoundedCommand {
+                    command: "dx -r2 @$curprocess.TTD.Events".to_string(),
+                    patience_ms: 0,
+                },
+            )
             .await;
         engine_result(out)
     }
@@ -2419,14 +2163,12 @@ impl WindbgServer {
         if let Err(e) = reject_command_breakers("expression", &args.expression, Quotes::Rejected) {
             return tool_error(e);
         }
-        let gate = self.session_gate(args.session_id.as_deref());
         let cmd = format!("bp {}", args.expression);
         let out = self
-            .engine
-            .run(move |e| {
-                gate()?;
-                e.execute_command(&cmd).map_err(es)
-            })
+            .run(
+                args.session_id.as_deref(),
+                EngineOp::Command { command: cmd },
+            )
             .await;
         engine_result(out)
     }
@@ -2443,13 +2185,14 @@ impl WindbgServer {
         &self,
         Parameters(args): Parameters<SessionArgs>,
     ) -> Result<CallToolResult, ErrorData> {
-        let gate = self.session_gate(args.session_id.as_deref());
         let out = self
-            .engine
-            .run(move |e| {
-                gate()?;
-                e.execute_and_wait("g", EXEC_WAIT_MS).map_err(es)
-            })
+            .run(
+                args.session_id.as_deref(),
+                EngineOp::CommandAndWait {
+                    command: "g".to_string(),
+                    timeout_ms: EXEC_WAIT_MS,
+                },
+            )
             .await;
         engine_result(out)
     }
@@ -2474,47 +2217,14 @@ impl WindbgServer {
         if let Err(e) = reject_command_breakers("address", &args.address, Quotes::Rejected) {
             return tool_error(e);
         }
-        let gate = self.session_gate(args.session_id.as_deref());
         let out = self
-            .engine
-            .run(move |e| {
-                gate()?;
-                // Resolve the target the same WinDbg-aware way as `reachable_from_dispatch`.
-                let resolve = |expr: &str| -> Option<u64> {
-                    e.execute_command(&format!("? {expr}"))
-                        .ok()
-                        .as_deref()
-                        .and_then(parse_eval)
-                        .or_else(|| parse_windbg_addr(expr))
-                        .or_else(|| parse_u64(expr).ok())
-                };
-                let target = resolve(&args.address)
-                    .ok_or_else(|| format!("could not resolve address `{}`", args.address))?;
-                let wait = args.timeout_ms.unwrap_or(EXEC_WAIT_MS);
-
-                let res = e.run_to_address(target, wait).map_err(es)?;
-                let mut msg = match res.outcome {
-                    RunToOutcome::Hit => {
-                        format!("VERDICT: HIT — execution reached {}\n", fmt_addr(target))
-                    }
-                    RunToOutcome::StoppedElsewhere { stopped_at } => format!(
-                        "VERDICT: STOPPED ELSEWHERE — stopped at {} before reaching {}\n  \
-                         (another breakpoint or exception fired first)\n",
-                        fmt_addr(stopped_at),
-                        fmt_addr(target)
-                    ),
-                    RunToOutcome::Timeout => format!(
-                        "VERDICT: TIMEOUT — did not reach {} within {wait} ms\n  \
-                         (the current input/state likely does not drive execution to this block)\n",
-                        fmt_addr(target)
-                    ),
-                };
-                if !res.output.trim().is_empty() {
-                    msg.push_str("---- debugger output ----\n");
-                    msg.push_str(&res.output);
-                }
-                Ok(msg)
-            })
+            .run(
+                args.session_id.as_deref(),
+                EngineOp::RunToAddress {
+                    address: args.address,
+                    timeout_ms: args.timeout_ms.unwrap_or(EXEC_WAIT_MS),
+                },
+            )
             .await;
         engine_result(out)
     }
@@ -2531,13 +2241,14 @@ impl WindbgServer {
         &self,
         Parameters(args): Parameters<SessionArgs>,
     ) -> Result<CallToolResult, ErrorData> {
-        let gate = self.session_gate(args.session_id.as_deref());
         let out = self
-            .engine
-            .run(move |e| {
-                gate()?;
-                e.execute_and_wait("p", EXEC_WAIT_MS).map_err(es)
-            })
+            .run(
+                args.session_id.as_deref(),
+                EngineOp::CommandAndWait {
+                    command: "p".to_string(),
+                    timeout_ms: EXEC_WAIT_MS,
+                },
+            )
             .await;
         engine_result(out)
     }
@@ -2554,13 +2265,14 @@ impl WindbgServer {
         &self,
         Parameters(args): Parameters<SessionArgs>,
     ) -> Result<CallToolResult, ErrorData> {
-        let gate = self.session_gate(args.session_id.as_deref());
         let out = self
-            .engine
-            .run(move |e| {
-                gate()?;
-                e.execute_and_wait("t", EXEC_WAIT_MS).map_err(es)
-            })
+            .run(
+                args.session_id.as_deref(),
+                EngineOp::CommandAndWait {
+                    command: "t".to_string(),
+                    timeout_ms: EXEC_WAIT_MS,
+                },
+            )
             .await;
         engine_result(out)
     }
@@ -2579,13 +2291,14 @@ impl WindbgServer {
         &self,
         Parameters(args): Parameters<SessionArgs>,
     ) -> Result<CallToolResult, ErrorData> {
-        let gate = self.session_gate(args.session_id.as_deref());
         let out = self
-            .engine
-            .run(move |e| {
-                gate()?;
-                e.execute_and_wait("t-", EXEC_WAIT_MS).map_err(es)
-            })
+            .run(
+                args.session_id.as_deref(),
+                EngineOp::CommandAndWait {
+                    command: "t-".to_string(),
+                    timeout_ms: EXEC_WAIT_MS,
+                },
+            )
             .await;
         engine_result(out)
     }
@@ -2602,13 +2315,14 @@ impl WindbgServer {
         &self,
         Parameters(args): Parameters<SessionArgs>,
     ) -> Result<CallToolResult, ErrorData> {
-        let gate = self.session_gate(args.session_id.as_deref());
         let out = self
-            .engine
-            .run(move |e| {
-                gate()?;
-                e.execute_and_wait("p-", EXEC_WAIT_MS).map_err(es)
-            })
+            .run(
+                args.session_id.as_deref(),
+                EngineOp::CommandAndWait {
+                    command: "p-".to_string(),
+                    timeout_ms: EXEC_WAIT_MS,
+                },
+            )
             .await;
         engine_result(out)
     }
@@ -2625,13 +2339,14 @@ impl WindbgServer {
         &self,
         Parameters(args): Parameters<SessionArgs>,
     ) -> Result<CallToolResult, ErrorData> {
-        let gate = self.session_gate(args.session_id.as_deref());
         let out = self
-            .engine
-            .run(move |e| {
-                gate()?;
-                e.execute_and_wait("g-", EXEC_WAIT_MS).map_err(es)
-            })
+            .run(
+                args.session_id.as_deref(),
+                EngineOp::CommandAndWait {
+                    command: "g-".to_string(),
+                    timeout_ms: EXEC_WAIT_MS,
+                },
+            )
             .await;
         engine_result(out)
     }
@@ -2651,14 +2366,12 @@ impl WindbgServer {
         if let Err(e) = reject_command_breakers("position", &args.position, Quotes::Rejected) {
             return tool_error(e);
         }
-        let gate = self.session_gate(args.session_id.as_deref());
         let cmd = format!("!tt {}", args.position);
         let out = self
-            .engine
-            .run(move |e| {
-                gate()?;
-                e.execute_command(&cmd).map_err(es)
-            })
+            .run(
+                args.session_id.as_deref(),
+                EngineOp::Command { command: cmd },
+            )
             .await;
         engine_result(out)
     }
@@ -2687,18 +2400,18 @@ impl WindbgServer {
         &self,
         Parameters(args): Parameters<SessionArgs>,
     ) -> Result<CallToolResult, ErrorData> {
-        let gate = self.session_gate(args.session_id.as_deref());
         // Deliberately *not* on the bounded path, and the one O(trace) command that isn't —
         // see DECISIONS.md (2026-08-02). Indexing a large trace can legitimately outrun the
         // per-call timeout, but `-force` deletes an unloadable `.idx` before rebuilding it, so
         // a watchdog abort mid-rebuild can leave no usable index at all. Here the long run is
         // productive work rather than a runaway, and the engine frees itself when it finishes.
         let out = self
-            .engine
-            .run(move |e| {
-                gate()?;
-                e.execute_command("!ttdext.index -force").map_err(es)
-            })
+            .run(
+                args.session_id.as_deref(),
+                EngineOp::Command {
+                    command: "!ttdext.index -force".to_string(),
+                },
+            )
             .await;
         engine_result(out)
     }
@@ -2788,14 +2501,12 @@ impl WindbgServer {
         if let Err(e) = reject_command_breakers("name", &args.name, Quotes::Rejected) {
             return tool_error(e);
         }
-        let gate = self.session_gate(args.session_id.as_deref());
         let cmd = format!("!drvobj {} 7", args.name);
         let out = self
-            .engine
-            .run(move |e| {
-                gate()?;
-                e.execute_command(&cmd).map_err(es)
-            })
+            .run(
+                args.session_id.as_deref(),
+                EngineOp::Command { command: cmd },
+            )
             .await;
         engine_result(out)
     }
@@ -2816,14 +2527,12 @@ impl WindbgServer {
         if let Err(e) = reject_command_breakers("device", &args.device, Quotes::Rejected) {
             return tool_error(e);
         }
-        let gate = self.session_gate(args.session_id.as_deref());
         let cmd = format!("!devobj {}", args.device);
         let out = self
-            .engine
-            .run(move |e| {
-                gate()?;
-                e.execute_command(&cmd).map_err(es)
-            })
+            .run(
+                args.session_id.as_deref(),
+                EngineOp::Command { command: cmd },
+            )
             .await;
         engine_result(out)
     }
@@ -2845,15 +2554,13 @@ impl WindbgServer {
         {
             return tool_error(e);
         }
-        let gate = self.session_gate(args.session_id.as_deref());
         let irp = args.irp.unwrap_or_else(|| "@rdx".to_string());
         let cmd = format!("!irp {irp} 1");
         let out = self
-            .engine
-            .run(move |e| {
-                gate()?;
-                e.execute_command(&cmd).map_err(es)
-            })
+            .run(
+                args.session_id.as_deref(),
+                EngineOp::Command { command: cmd },
+            )
             .await;
         engine_result(out)
     }
@@ -2877,7 +2584,6 @@ impl WindbgServer {
         if let Err(e) = reject_command_breakers("dispatch", &args.dispatch, Quotes::Rejected) {
             return tool_error(e);
         }
-        let gate = self.session_gate(args.session_id.as_deref());
         // IRP in @rdx at dispatch entry (x64). CurrentStackLocation = poi(Irp+0xb8).
         // Within IO_STACK_LOCATION: OutputBufferLength +0x08, InputBufferLength +0x10,
         // IoControlCode +0x18 (Parameters union begins at +0x08).
@@ -2887,11 +2593,10 @@ impl WindbgServer {
             args.dispatch
         );
         let out = self
-            .engine
-            .run(move |e| {
-                gate()?;
-                e.execute_command(&cmd).map_err(es)
-            })
+            .run(
+                args.session_id.as_deref(),
+                EngineOp::Command { command: cmd },
+            )
             .await;
         engine_result(out)
     }
@@ -2924,94 +2629,19 @@ impl WindbgServer {
                 return tool_error(e);
             }
         }
-        let gate = self.session_gate(args.session_id.as_deref());
         let out = self
-            .engine
-            .run(move |e| {
-                gate()?;
-                // Resolve an address/offset expression the way `uf`/WinDbg read it:
-                // evaluate `? <expr>` first (the MASM evaluator's default base is hex, so
-                // a bare `00401234` is 0x00401234 and `module!Dispatch+0x123` resolves),
-                // then fall back to pure parsing (backtick / bare-hex, then `0x`/decimal).
-                // Applied to both the target VA and the `from` seed so a value pasted from
-                // WinDbg — a `hi`lo` backtick address or a digit-only 32-bit address — is
-                // read consistently on both sides.
-                let resolve = |expr: &str| -> Option<u64> {
-                    e.execute_command(&format!("? {expr}"))
-                        .ok()
-                        .as_deref()
-                        .and_then(parse_eval)
-                        .or_else(|| parse_windbg_addr(expr))
-                        .or_else(|| parse_u64(expr).ok())
-                };
-
-                // Resolve the target VA: an absolute address, or module+RVA rebased
-                // against the module's live base from `lm m <module>`.
-                let target = match (&args.address, &args.module, &args.rva) {
-                    // Reject conflicting target forms rather than silently ignoring one —
-                    // analysing the wrong target would give a misleading verdict.
-                    (Some(_), Some(_), _) | (Some(_), _, Some(_)) => {
-                        return Err("provide `address` OR `module`+`rva`, not both".to_string());
-                    }
-                    (Some(a), None, None) => resolve(a)
-                        .ok_or_else(|| format!("could not resolve target address `{a}`"))?,
-                    (None, Some(m), Some(r)) => {
-                        let rva =
-                            resolve(r).ok_or_else(|| format!("could not resolve rva `{r}`"))?;
-                        let lm = e.execute_command(&format!("lm m {m}")).map_err(es)?;
-                        let base = parse_lm_base(&lm).ok_or_else(|| {
-                            format!("module `{m}` not found (`lm m {m}` returned):\n{lm}")
-                        })?;
-                        base.checked_add(rva)
-                            .ok_or_else(|| "module base + rva overflowed u64".to_string())?
-                    }
-                    _ => {
-                        return Err("provide `address`, or both `module` and `rva`".to_string());
-                    }
-                };
-
-                let max_functions = args.max_functions.unwrap_or(256);
-                let max_depth = args.max_depth.unwrap_or(32);
-
-                // Resolve `from` to a numeric VA so a mid-function start (a handler scoped
-                // past a switch) is honored; `None` (unresolvable) starts at the entry.
-                let seed_start = resolve(&args.from);
-
-                // A real `uf` lists backtick addresses or at least a "module!Func:" label;
-                // error text ("Couldn't resolve...", "no code") lacks both and prunes the
-                // branch. parse_uf then discards any non-disassembly. Held in a `&mut`
-                // binding so the same disassembler drives both the walk and the recipe.
-                let mut uf = |arg: &str| match e.execute_command(&format!("uf {arg}")) {
-                    Ok(t) if t.contains('`') || t.contains(':') => Some(t),
-                    _ => None,
-                };
-
-                let rpt = reachability(
-                    &args.from,
-                    seed_start,
-                    target,
-                    max_functions,
-                    max_depth,
-                    &mut uf,
-                );
-
-                if rpt.from_entry.is_none() {
-                    return Err(format!(
-                        "could not disassemble `from` ({}): `uf` returned no function. \
-                         Check the symbol/address and that the module is loaded.",
-                        args.from
-                    ));
-                }
-
-                // On a REACHABLE verdict, re-walk the path functions to emit the directional
-                // recipe (which branch each on-path `jcc` must take, and what it tests).
-                let mut out = format_report(&rpt);
-                if rpt.verdict_reachable && args.recipe.unwrap_or(true) {
-                    let recipes = path_recipe(&args.from, seed_start, &rpt, &mut uf);
-                    out.push_str(&format_recipe(&recipes));
-                }
-                Ok(out)
-            })
+            .run(
+                args.session_id.as_deref(),
+                EngineOp::Reachability(ReachabilityOp {
+                    from: args.from,
+                    address: args.address,
+                    module: args.module,
+                    rva: args.rva,
+                    max_functions: args.max_functions.unwrap_or(256),
+                    max_depth: args.max_depth.unwrap_or(32),
+                    recipe: args.recipe.unwrap_or(true),
+                }),
+            )
             .await;
         engine_result(out)
     }
@@ -3028,6 +2658,12 @@ impl WindbgServer {
     name = "windbg-mcp",
     instructions = "Drive WinDbg/DbgEng for live user-mode, kernel, crash-dump, and Time Travel Debugging (TTD) analysis. \
 Open a dump or .run trace, attach to a process or the kernel, inspect registers/memory/stacks/modules, and set breakpoints. \
+Each open target is a separate session in its own engine process, so several can be open at once (up to 4) without \
+disturbing each other; pass the `session_id` an opener returns on later calls to route them to that target, and \
+`end_session` when done. `session_status` lists what is open and what state each session is in — ask it when an open \
+reports a timeout rather than re-running the open, which would attach or launch a second time. A live kernel attach \
+waits for its target indefinitely and cannot be interrupted; if it has been waiting far longer than a healthy link \
+takes, `end_session` reclaims that session (and only that session) by terminating its engine process. \
 Navigate a TTD trace in both directions: go/step_over/step_into forward, and reverse_go/step_over_back/step_back backward, \
 or jump with goto_position. Analyze a trace with the data-model tools ttd_calls (calls to a function), ttd_memory (accesses \
 to an address range), and ttd_events (module/thread/exception events), or run any data-model query with dx. Record new traces \
@@ -3230,11 +2866,11 @@ mod tests {
             .await
             .expect("write the discover request");
 
-        // The engine thread is never reached — discover is answered from `get_info` alone —
-        // which is what lets this run on a machine with no debugger.
+        // No session is ever opened, so no engine worker is spawned — discover is answered
+        // from `get_info` alone, which is what lets this run on a machine with no debugger.
         let service = tokio::time::timeout(
             STEP,
-            WindbgServer::new(EngineHandle::spawn(STEP)).serve(server_io),
+            WindbgServer::new(Sessions::new(STEP)).serve(server_io),
         )
         .await
         .expect("serve must not block waiting for an `initialize` that never comes")
@@ -3306,63 +2942,114 @@ mod tests {
         service.cancel().await.expect("shut the service down");
     }
 
-    // ---- Session handles -----------------------------------------------
+    // ---- What `session_status` says ------------------------------------
+    //
+    // The routing rules themselves live in `engine.rs`, with the registry that enforces them.
+    // What is checked here is the reporting: an agent acts on this text, and for a session that
+    // has not landed the right action flips entirely on how long it has been waiting.
 
+    fn snapshot(kind: SessionKind, state: SessionState, waited: Duration) -> SessionSnapshot {
+        SessionSnapshot {
+            id: "sess-1".to_string(),
+            kind,
+            what: "net:port=50000,key=1.2.3.4".to_string(),
+            pid: 4242,
+            state,
+            in_state_for: waited,
+            age: waited,
+            current: true,
+        }
+    }
+
+    /// A kernel attach that is still settling is *normal*, and saying otherwise would send an
+    /// agent off to reclaim a session that is about to come up.
     #[test]
-    fn omitted_handle_accepts_whatever_session_is_current() {
-        assert!(check_session_handle(Some("sess-1"), None).is_ok());
-        assert!(check_session_handle(None, None).is_ok());
+    fn a_young_kernel_attach_is_reported_as_normal() {
+        let out = describe_session(&snapshot(
+            SessionKind::Kernel,
+            SessionState::Attaching,
+            Duration::from_secs(10),
+        ));
+        assert!(out.contains("waiting 10.0s"), "{out}");
+        assert!(out.contains("normal"), "{out}");
+        assert!(
+            !out.contains("end_session"),
+            "a healthy attach must not be advised to reclaim itself:\n{out}"
+        );
+        // The one thing that must be said whatever the age: the target exists.
+        assert!(out.contains("Do not re-run the open"), "{out}");
+    }
+
+    /// The report issue #61 asked for. Past the point a healthy link takes, "pending" stops
+    /// being an honest answer: this wait cannot be interrupted and will not return, and the
+    /// caller needs to be told that *and* told the recovery — which now exists.
+    #[test]
+    fn a_long_parked_kernel_attach_is_reported_as_never_returning() {
+        let out = describe_session(&snapshot(
+            SessionKind::Kernel,
+            SessionState::Attaching,
+            Duration::from_secs(400),
+        ));
+        assert!(out.contains("6m40s"), "the wait must be quantified:\n{out}");
+        assert!(
+            out.contains("will not return on its own"),
+            "the caller must not be left waiting on it:\n{out}"
+        );
+        assert!(
+            out.contains("end_session") && out.contains("terminates its engine process"),
+            "the recovery must be named, and it is a process kill:\n{out}"
+        );
+        assert!(
+            out.contains("debug"),
+            "the usual cause (a guest not booted in debug mode) should be named:\n{out}"
+        );
+    }
+
+    /// The age advice is specific to a wait that cannot be interrupted. A dump load has a
+    /// finite timeout, so telling its caller the same thing would be wrong.
+    #[test]
+    fn a_slow_dump_load_is_not_told_it_will_never_return() {
+        let out = describe_session(&snapshot(
+            SessionKind::Dump,
+            SessionState::Attaching,
+            Duration::from_secs(400),
+        ));
+        assert!(!out.contains("will not return on its own"), "{out}");
+        assert!(!out.contains("KDNET"), "{out}");
+    }
+
+    /// A retired handle is the one state where "refused" and "unusable" part company, so the
+    /// report has to say both halves or the caller writes the session off.
+    #[test]
+    fn a_retired_session_is_reported_as_reachable_without_the_handle() {
+        let out = describe_session(&snapshot(
+            SessionKind::Dump,
+            SessionState::Retired("`.opendump` replaced the target".to_string()),
+            Duration::from_secs(3),
+        ));
+        assert!(out.contains("retired"), "{out}");
+        assert!(out.contains("`.opendump` replaced the target"), "{out}");
+        assert!(out.contains("calls that omit it still reach it"), "{out}");
+    }
+
+    /// A failed open must say the slate is clean — that is what makes "open again" safe advice
+    /// rather than the thing that starts a second process.
+    #[test]
+    fn a_failed_open_says_nothing_was_created() {
+        let out = describe_session(&snapshot(
+            SessionKind::Launch,
+            SessionState::Failed("0x80070002".to_string()),
+            Duration::from_secs(1),
+        ));
+        assert!(out.contains("0x80070002"), "{out}");
+        assert!(out.contains("Nothing was created"), "{out}");
     }
 
     #[test]
-    fn matching_handle_is_accepted() {
-        assert!(check_session_handle(Some("sess-1"), Some("sess-1")).is_ok());
-    }
-
-    #[test]
-    fn handle_from_a_replaced_session_is_refused() {
-        let err = check_session_handle(Some("sess-2"), Some("sess-1")).unwrap_err();
-        assert!(err.contains("sess-1"), "{err}");
-        assert!(err.contains("sess-2"), "{err}");
-    }
-
-    #[test]
-    fn handle_is_refused_once_the_session_is_ended() {
-        let err = check_session_handle(None, Some("sess-1")).unwrap_err();
-        assert!(err.contains("no debug session open"), "{err}");
-    }
-
-    /// The gate must read the session at execution time. Building it and evaluating it at
-    /// submission time — the obvious-looking caller-side check — leaves a window in which a
-    /// concurrent `open_*` replaces the target between the check and the debugger call, so
-    /// a call that passed validation still runs against the wrong session.
-    #[test]
-    fn the_gate_reads_the_session_when_it_runs_not_when_it_is_built() {
-        let session = Arc::new(Mutex::new(Some("sess-A".to_string())));
-        let gate = session_gate_for(Arc::clone(&session), Some("sess-A"));
-
-        // A concurrent open lands after the gate was built but before it runs.
-        *lock(&session) = Some("sess-B".to_string());
-
-        let err = gate().unwrap_err();
-        assert!(err.contains("sess-B"), "{err}");
-    }
-
-    #[test]
-    fn the_gate_passes_when_the_session_is_unchanged_at_execution_time() {
-        let session = Arc::new(Mutex::new(Some("sess-A".to_string())));
-        let gate = session_gate_for(Arc::clone(&session), Some("sess-A"));
-        assert!(gate().is_ok());
-    }
-
-    /// A target replaced while the caller held no handle is still their problem to opt into,
-    /// so an absent handle keeps passing whatever the session did in the meantime.
-    #[test]
-    fn an_absent_handle_still_passes_after_a_replacement() {
-        let session = Arc::new(Mutex::new(Some("sess-A".to_string())));
-        let gate = session_gate_for(Arc::clone(&session), None);
-        *lock(&session) = Some("sess-B".to_string());
-        assert!(gate().is_ok());
+    fn durations_are_rendered_at_human_scale() {
+        assert_eq!(fmt_duration(Duration::from_millis(8400)), "8.4s");
+        assert_eq!(fmt_duration(Duration::from_secs(192)), "3m12s");
+        assert_eq!(fmt_duration(Duration::from_secs(3900)), "1h05m");
     }
 
     /// The typed tools interpolate their operands into commands, and DbgEng chains on `;`.
@@ -3521,68 +3208,6 @@ mod tests {
         }
     }
 
-    /// An opener whose wait timed out has to remain answerable, because the outcome is what
-    /// tells the caller whether to keep waiting or open again — and re-opening on a guess
-    /// attaches or launches a second time.
-    #[test]
-    fn opener_outcomes_are_recorded_and_answerable() {
-        let opens = Mutex::new(VecDeque::new());
-
-        record_open(&opens, "sess-A", OpenOutcome::Pending);
-        record_open(&opens, "sess-B", OpenOutcome::Pending);
-        let read = |id: &str| {
-            opens
-                .lock()
-                .unwrap()
-                .iter()
-                .find(|(known, _)| known == id)
-                .map(|(_, o)| o.clone())
-        };
-        assert_eq!(read("sess-A"), Some(OpenOutcome::Pending));
-
-        // An outcome replaces the pending entry in place rather than appending a second one.
-        record_open(&opens, "sess-A", OpenOutcome::Landed);
-        assert_eq!(read("sess-A"), Some(OpenOutcome::Landed));
-        assert_eq!(opens.lock().unwrap().len(), 2);
-
-        // A terminal failure is recorded too — the case that made "keep polling" wrong.
-        record_open(&opens, "sess-B", OpenOutcome::Failed("no such dump".into()));
-        assert_eq!(
-            read("sess-B"),
-            Some(OpenOutcome::Failed("no such dump".into()))
-        );
-    }
-
-    /// A pending open must survive any amount of later traffic. Forgetting one makes
-    /// `session_status` report it as unknown, which tells the caller to open again — and
-    /// that duplicates an attach or a launch, then lets the original land afterwards and
-    /// replace the target underneath them.
-    #[test]
-    fn a_pending_open_is_never_evicted() {
-        let opens = Mutex::new(VecDeque::new());
-        record_open(&opens, "sess-slow", OpenOutcome::Pending);
-        for n in 0..OPEN_HISTORY * 2 {
-            record_open(&opens, &format!("sess-{n}"), OpenOutcome::Landed);
-        }
-
-        let still_there = opens
-            .lock()
-            .unwrap()
-            .iter()
-            .any(|(id, outcome)| id == "sess-slow" && *outcome == OpenOutcome::Pending);
-        assert!(still_there, "a pending open must outlive the history bound");
-
-        // Once it settles it becomes evictable like any other, so the history returns to
-        // its bound rather than growing forever.
-        record_open(&opens, "sess-slow", OpenOutcome::Landed);
-        for n in 0..OPEN_HISTORY {
-            record_open(&opens, &format!("later-{n}"), OpenOutcome::Landed);
-        }
-        let opens = opens.lock().unwrap();
-        assert_eq!(opens.len(), OPEN_HISTORY);
-        assert!(!opens.iter().any(|(id, _)| id == "sess-slow"));
-    }
-
     /// A failure that lands after the target is open must hand the handle back and say not
     /// to re-open. "Just open again" is how a caller ends up with two processes — before the
     /// openers were split (glslang/win-kexp#71) this server could not tell that case from a
@@ -3605,74 +3230,30 @@ mod tests {
         assert!(msg.contains("vertarget"), "must say how to inspect it");
     }
 
-    /// A burst of concurrent opens legitimately exceeds the bound while all of them are
-    /// pending. Once they settle, the ledger has to come back down — otherwise it stays over
-    /// the bound for the life of the process, holding every handle and failure string.
-    #[test]
-    fn a_settled_burst_returns_the_ledger_to_its_bound() {
-        let opens = Mutex::new(VecDeque::new());
-        let burst = OPEN_HISTORY * 2;
-        for n in 0..burst {
-            record_open(&opens, &format!("sess-{n}"), OpenOutcome::Pending);
-        }
-        assert_eq!(
-            opens.lock().unwrap().len(),
-            burst,
-            "pending opens must all be kept, even past the bound"
-        );
-
-        // They settle in place, which is the path that previously skipped trimming.
-        for n in 0..burst {
-            record_open(&opens, &format!("sess-{n}"), OpenOutcome::Landed);
-        }
-        assert_eq!(opens.lock().unwrap().len(), OPEN_HISTORY);
-    }
-
-    /// Settled history is bounded, so a long-lived server cannot accumulate outcomes forever.
-    #[test]
-    fn settled_opener_history_is_bounded_and_evicts_oldest_first() {
-        let opens = Mutex::new(VecDeque::new());
-        for n in 0..OPEN_HISTORY + 3 {
-            record_open(&opens, &format!("sess-{n}"), OpenOutcome::Landed);
-        }
-        let opens = opens.lock().unwrap();
-        assert_eq!(opens.len(), OPEN_HISTORY);
-        assert_eq!(opens.front().unwrap().0, "sess-3");
-        assert_eq!(
-            opens.back().unwrap().0,
-            format!("sess-{}", OPEN_HISTORY + 2)
-        );
-    }
-
-    #[test]
-    fn minted_handles_are_unique() {
-        let a = mint_session_id();
-        let b = mint_session_id();
-        assert_ne!(a, b);
-    }
-
     // ---- Error reporting -----------------------------------------------
 
-    /// A failed debugger operation belongs in the result (`isError: true`) so the model
-    /// can read it and correct itself; only a dead engine is a protocol error.
+    /// Every session-scoped failure belongs in the result (`isError: true`) so the model can
+    /// read it and correct itself: a bad symbol (fix the arguments), a timeout (wait, retry, or
+    /// end the session), a refused handle (name a different session, or open one), a session
+    /// whose worker is gone (open again). A JSON-RPC error would hide the text that says which.
     #[test]
-    fn debugger_failures_are_tool_errors_not_protocol_errors() {
-        let r = engine_result(Err(EngineError::Debugger("no such symbol".into())))
-            .expect("debugger failure must not surface as a protocol error");
-        assert_eq!(r.is_error, Some(true));
-
-        let err = engine_result(Err(EngineError::Unavailable("engine gone".into())))
-            .expect_err("a dead engine must surface as a protocol error");
-        assert!(err.message.contains("engine gone"));
-    }
-
-    /// A timeout is still something the model can act on (wait, retry, end the session), so
-    /// it renders like any other debugger failure rather than as a protocol error.
-    #[test]
-    fn timeouts_are_tool_errors_too() {
-        let r = engine_result(Err(EngineError::Timeout("timed out".into())))
-            .expect("a timeout must not surface as a protocol error");
-        assert_eq!(r.is_error, Some(true));
+    fn session_scoped_failures_are_tool_errors_not_protocol_errors() {
+        for e in [
+            EngineError::Debugger("no such symbol".into()),
+            EngineError::Timeout("timed out".into()),
+            EngineError::Stale("that session is closed".into()),
+            EngineError::Lost("the worker exited".into()),
+        ] {
+            let rendered = e.to_string();
+            let r = engine_result(Err(e)).expect("must not surface as a protocol error");
+            assert_eq!(r.is_error, Some(true), "{rendered}");
+            assert!(
+                r.content
+                    .iter()
+                    .any(|b| b.as_text().is_some_and(|t| t.text == rendered)),
+                "the explanation must survive: {rendered}"
+            );
+        }
     }
 
     #[test]

--- a/src/server.rs
+++ b/src/server.rs
@@ -1539,10 +1539,8 @@ impl WindbgServer {
     ) -> Result<CallToolResult, ErrorData> {
         match self.sessions.open(kind, what, op).await {
             Ok(OpenReport { id, report }) => text_result(format!(
-                "{report}
-
-session_id: {id}
-Pass this as `session_id` on later calls to route                  them to this session and to fail loudly rather than act on a different target."
+                "{report}\n\nsession_id: {id}\nPass this as `session_id` on later calls to route \
+                 them to this session and to fail loudly rather than act on a different target."
             )),
             // No worker, so no session — and no argument the model can change fixes that.
             Err(OpenError::Unavailable(m)) => Err(ErrorData::internal_error(m, None)),
@@ -1554,10 +1552,8 @@ Pass this as `session_id` on later calls to route                  them to this 
                 report_only,
             }) => tool_error(if report_only {
                 format!(
-                    "{message}
-
-session_id: {id}
-The target opened; only this follow-up report                      failed, so the handle above is valid and usable."
+                    "{message}\n\nsession_id: {id}\nThe target opened; only this follow-up report \
+                     failed, so the handle above is valid and usable."
                 )
             } else {
                 post_commit_failure(&message, &id)
@@ -1566,9 +1562,13 @@ The target opened; only this follow-up report                      failed, so th
             // still land. The handle exists from the moment the session is registered, so it can
             // be named now — which is what makes recovery via `session_status` sound.
             Err(OpenError::Timeout { id, message }) => tool_error(format!(
-                "{message}
-
-The wait was abandoned, but this open was not: it is still running                  in session `{id}`, and may still land. Ask `session_status                  {{ \"session_id\": \"{id}\" }}` — it reports whether the open is still going, how                  long it has been going, and whether that is longer than a healthy one takes. Do                  not re-run the open while it is still going, which would attach to, or start, a                  second target; `end_session {{ \"session_id\": \"{id}\" }}` ends it outright,                  terminating the worker process if it will not unwind."
+                "{message}\n\nThe wait was abandoned, but this open was not: it is still running \
+                 in session `{id}`, and may still land. Ask `session_status \
+                 {{ \"session_id\": \"{id}\" }}` — it reports whether the open is still going, \
+                 how long it has been going, and whether that is longer than a healthy one takes. \
+                 Do not re-run the open while it is still going, which would attach to, or start, \
+                 a second target; `end_session {{ \"session_id\": \"{id}\" }}` ends it outright, \
+                 terminating the worker process if it will not unwind."
             )),
         }
     }

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -42,6 +42,14 @@ pub const WORKER_FLAG: &str = "--engine-worker";
 /// sessions live in their own process.
 const LOAD_WAIT_MS: u32 = 60_000;
 
+/// Most bytes a single `read_memory` will fetch.
+///
+/// A guard against exhausting the worker, not a judgement about what is useful: the buffer costs
+/// this much and the hexdump built from it costs roughly four times more, so an unbounded `size`
+/// is an out-of-memory away from losing the session. 1 MiB is far past any real inspection —
+/// which renders as some 65,000 lines of hex — while leaving no plausible caller short.
+const MAX_READ_BYTES: usize = 1024 * 1024;
+
 /// How much of the caller's remaining patience the watchdog keeps for itself: it Ctrl+Breaks the
 /// engine this long before the caller's wait expires, so the interrupt has time to land, `Execute`
 /// has time to unwind, and this worker is free again before the tool call reports its timeout.
@@ -74,10 +82,18 @@ pub fn run() -> ! {
     // Each request is stamped when it is *read*, so the engine thread can tell how long it then
     // waited its turn — the half of the watchdog budget only this process can measure.
     let (tx, rx) = mpsc::channel::<(Instant, WorkerRequest)>();
-    thread::Builder::new()
+    // Reported rather than panicked: the supervisor is waiting for `Ready` or `Fatal`, and a
+    // panic here would give it neither — it would see only "the worker exited before it was
+    // ready" and lose the reason.
+    if let Err(e) = thread::Builder::new()
         .name("dbgeng".into())
         .spawn(move || engine_thread(rx))
-        .expect("failed to spawn dbgeng thread");
+    {
+        emit(&WorkerMessage::Fatal {
+            message: format!("could not start the engine thread: {e}"),
+        });
+        std::process::exit(1);
+    }
 
     let stdin = std::io::stdin();
     for line in stdin.lock().lines() {
@@ -91,7 +107,13 @@ pub fn run() -> ! {
                     break; // the engine thread is gone; nothing can run any more
                 }
             }
-            Err(e) => tracing::error!("worker: unreadable request ({e}): {line}"),
+            // The line itself is never logged. An `AttachKernel` request carries the KD
+            // connection string, key and all, and this worker's stderr is the supervisor's —
+            // which is to say, the MCP client's log.
+            Err(e) => tracing::error!(
+                "worker: unreadable request ({e}); {} bytes, discarded",
+                line.len()
+            ),
         }
     }
 
@@ -306,6 +328,17 @@ fn execute(e: &DebugEngine, id: u64, op: EngineOp, queued: Duration) -> Result<S
         EngineOp::Registers => e.registers().map_err(es),
         EngineOp::ReadMemory { address, size } => {
             let addr = parse_u64(&address)?;
+            // Bounded before the allocation, not after. `size` arrives from the caller as a bare
+            // `u32`, and a large one costs that many bytes here plus a hexdump several times
+            // larger — enough to take the worker down with an OOM, which costs the caller their
+            // whole session for a number a model can produce by accident.
+            if size as usize > MAX_READ_BYTES {
+                return Err(format!(
+                    "`size` is {size} bytes; this tool reads at most {MAX_READ_BYTES}. Read the \
+                     range you need in pieces, or use `execute` with a `db`/`dd` command if you \
+                     want the debugger's own paging."
+                ));
+            }
             let bytes = e.read_memory(addr, size as usize).map_err(es)?;
             Ok(hexdump(addr, &bytes))
         }

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -213,7 +213,14 @@ fn emit(message: &WorkerMessage) {
     };
     let stdout = std::io::stdout();
     let mut stdout = stdout.lock();
-    let _ = writeln!(stdout, "{line}");
+    // Leading newline, not just a trailing one. DbgEng's own output reaches the supervisor through
+    // `IDebugOutputCallbacks` and never comes this way, but an extension DLL that writes to the
+    // console directly does — and if it left its last line *unterminated*, a trailing-newline-only
+    // message would be appended to that text and arrive as one unparseable line. The supervisor
+    // skips what it cannot parse, so the reply would be lost outright: the caller times out, its
+    // waiter is never removed, and the session stays busy and unreclaimable for good. Opening with
+    // a newline terminates whatever came before, so a message always starts its own line.
+    let _ = write!(stdout, "\n{line}\n");
     let _ = stdout.flush();
 }
 

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -77,11 +77,27 @@ fn watchdog_budget_ms(patience: Duration, queued: Duration) -> u32 {
         .min(u32::MAX as u128) as u32
 }
 
+/// How long the worker gives its engine to let go of the target when the supervisor disappears
+/// without saying goodbye — a Ctrl+C, a crash, anything that is not a clean disconnect.
+///
+/// Short, because this is a process on its way out and the engine may be parked in a wait that
+/// will never end. Long enough for an idle engine to resume and detach a live kernel, which is
+/// the case that matters: exiting without it leaves the target machine halted.
+const ABRUPT_EXIT_RELEASE: Duration = Duration::from_secs(5);
+
+/// What the stdin reader hands to the engine thread.
+enum Job {
+    /// A request from the supervisor, stamped when it was read.
+    Run(Instant, WorkerRequest),
+    /// The supervisor is gone: release the target and acknowledge.
+    Release(mpsc::Sender<()>),
+}
+
 /// Runs this process as an engine worker. Never returns.
 pub fn run() -> ! {
     // Each request is stamped when it is *read*, so the engine thread can tell how long it then
     // waited its turn — the half of the watchdog budget only this process can measure.
-    let (tx, rx) = mpsc::channel::<(Instant, WorkerRequest)>();
+    let (tx, rx) = mpsc::channel::<Job>();
     // Reported rather than panicked: the supervisor is waiting for `Ready` or `Fatal`, and a
     // panic here would give it neither — it would see only "the worker exited before it was
     // ready" and lose the reason.
@@ -103,7 +119,7 @@ pub fn run() -> ! {
         }
         match serde_json::from_str::<WorkerRequest>(&line) {
             Ok(request) => {
-                if tx.send((Instant::now(), request)).is_err() {
+                if tx.send(Job::Run(Instant::now(), request)).is_err() {
                     break; // the engine thread is gone; nothing can run any more
                 }
             }
@@ -118,13 +134,26 @@ pub fn run() -> ! {
     }
 
     // stdin closed: the supervisor ended this session, or died. Either way this process has no
-    // reason to exist. Exit rather than join — the engine thread may be parked in DbgEng
+    // reason to exist.
+    //
+    // On the clean path the supervisor has already had this session release its target, so the
+    // engine has nothing left to do. On the other one — Ctrl+C, a crash, anything that kills the
+    // supervisor without it running its own shutdown — nobody has, and exiting here would leave a
+    // live kernel *halted*, because DbgEng needs an explicit resume-and-detach. So ask for one,
+    // bounded: an idle engine obliges in milliseconds, a parked one never will, and either way
+    // this process is gone within `ABRUPT_EXIT_RELEASE`.
+    //
+    // Bounded and then abandoned, never joined: the engine thread may be blocked in DbgEng
     // forever, and this is precisely the case where that must not hold anything up.
+    let (ack, released) = mpsc::channel();
+    if tx.send(Job::Release(ack)).is_ok() {
+        let _ = released.recv_timeout(ABRUPT_EXIT_RELEASE);
+    }
     std::process::exit(0);
 }
 
 /// Owns the [`DebugEngine`] for the life of the process and runs one op at a time.
-fn engine_thread(rx: mpsc::Receiver<(Instant, WorkerRequest)>) {
+fn engine_thread(rx: mpsc::Receiver<Job>) {
     // `DebugEngine::new()` panics if the engine can't be created (dbgeng.dll not discoverable,
     // most likely). Report it and exit instead of accepting requests that can only fail: the
     // supervisor is waiting for exactly one of these two messages before it registers a
@@ -142,7 +171,19 @@ fn engine_thread(rx: mpsc::Receiver<(Instant, WorkerRequest)>) {
     };
     emit(&WorkerMessage::Ready);
 
-    while let Ok((arrived, request)) = rx.recv() {
+    while let Ok(job) = rx.recv() {
+        let (arrived, request) = match job {
+            Job::Run(arrived, request) => (arrived, request),
+            // The supervisor is gone. Let go of the target before this process does, so a live
+            // kernel is left running rather than halted, then acknowledge so the main thread can
+            // stop waiting. Best-effort by nature: if the engine never reaches this, the main
+            // thread times out and exits anyway.
+            Job::Release(ack) => {
+                let _ = catch_unwind(AssertUnwindSafe(|| engine.end_session()));
+                let _ = ack.send(());
+                continue;
+            }
+        };
         // Measured here, at the front of the queue: this is the wait only this process can see,
         // and the bounded path needs it to size the watchdog.
         let queued = arrived.elapsed();

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -1,0 +1,561 @@
+//! The engine worker process: one child process, one DbgEng session.
+//!
+//! dbgeng.dll holds **one debuggee session per process**, so a session is a process here rather
+//! than a thread. The supervisor ([`crate::engine`]) spawns one of these per open target and
+//! talks to it over stdin/stdout ([`crate::proto`]).
+//!
+//! Inside the worker the old confinement rules still apply — DbgEng wants serialized,
+//! single-threaded access, and `WaitForEvent` must run on the session-owning thread — so the
+//! [`DebugEngine`] is created on, and never leaves, one dedicated thread. What changed is what
+//! happens when that thread cannot be freed: a live-kernel attach whose target never dials in
+//! blocks in `WaitForEvent(INFINITE)` with no cancellation path (win-kexp's `SetInterrupt`
+//! watchdog cannot reach a wait that is still establishing the link). That used to park the
+//! server's only engine thread; here it parks this process, which the supervisor can kill.
+//!
+//! Which is why the stdin reader lives on the *main* thread and exits the process outright on
+//! EOF instead of joining the engine thread: at EOF the engine thread may be parked forever,
+//! and waiting for it would recreate the very wedge this design removes.
+
+use std::io::{BufRead, Write};
+use std::panic::{AssertUnwindSafe, catch_unwind};
+use std::sync::mpsc;
+use std::thread;
+use std::time::{Duration, Instant};
+
+use win_kexp::dbgeng::{DebugEngine, RunToOutcome};
+
+use crate::proto::{EngineOp, ReachabilityOp, WorkerMessage, WorkerRequest};
+use crate::server::{
+    fmt_addr, format_recipe, format_report, hexdump, parse_eval, parse_lm_base, parse_u64,
+    parse_windbg_addr, path_recipe, reachability,
+};
+
+/// The argument that turns this executable into a worker. Not a documented CLI: the supervisor
+/// re-executes itself with it, and nothing else should.
+pub const WORKER_FLAG: &str = "--engine-worker";
+
+/// How long to wait for a target to stop after open/attach/launch (ms).
+///
+/// Advisory for everything but a live kernel: `attach_kernel` needs `WaitForEvent(INFINITE)`
+/// (a finite timeout returns `E_NOTIMPL` and never drives the KD link), so win-kexp's
+/// `PendingTarget::wait` ignores this for that one case. That unbounded wait is the reason
+/// sessions live in their own process.
+const LOAD_WAIT_MS: u32 = 60_000;
+
+/// How much of the caller's remaining patience the watchdog keeps for itself: it Ctrl+Breaks the
+/// engine this long before the caller's wait expires, so the interrupt has time to land, `Execute`
+/// has time to unwind, and this worker is free again before the tool call reports its timeout.
+const WATCHDOG_HEADROOM: Duration = Duration::from_secs(15);
+
+/// The watchdog deadline for a command that waited `queued` in this worker's queue, given the
+/// `patience` its caller had left when the supervisor sent it.
+///
+/// The caller's timeout starts at submission, but a command may sit behind another job for the
+/// same session (a backgrounded `go`, a long `!ttdext.index`) before the engine reaches it.
+/// Budgeting from what *remains* — not from the patience as sent — is what makes the interrupt
+/// fire before the caller gives up regardless of queue wait.
+///
+/// Floored at [`WATCHDOG_HEADROOM`] rather than allowed to reach zero, because zero *disables*
+/// win-kexp's watchdog: a command dequeued at or past the deadline would then be the one command
+/// that runs unbounded, which is exactly the wedge case. The floor overruns the caller's timeout
+/// by design — the caller has already given up by then, and freeing the worker 15s late still
+/// beats never.
+fn watchdog_budget_ms(patience: Duration, queued: Duration) -> u32 {
+    patience
+        .saturating_sub(queued)
+        .saturating_sub(WATCHDOG_HEADROOM)
+        .max(WATCHDOG_HEADROOM)
+        .as_millis()
+        .min(u32::MAX as u128) as u32
+}
+
+/// Runs this process as an engine worker. Never returns.
+pub fn run() -> ! {
+    // Each request is stamped when it is *read*, so the engine thread can tell how long it then
+    // waited its turn — the half of the watchdog budget only this process can measure.
+    let (tx, rx) = mpsc::channel::<(Instant, WorkerRequest)>();
+    thread::Builder::new()
+        .name("dbgeng".into())
+        .spawn(move || engine_thread(rx))
+        .expect("failed to spawn dbgeng thread");
+
+    let stdin = std::io::stdin();
+    for line in stdin.lock().lines() {
+        let Ok(line) = line else { break };
+        if line.trim().is_empty() {
+            continue;
+        }
+        match serde_json::from_str::<WorkerRequest>(&line) {
+            Ok(request) => {
+                if tx.send((Instant::now(), request)).is_err() {
+                    break; // the engine thread is gone; nothing can run any more
+                }
+            }
+            Err(e) => tracing::error!("worker: unreadable request ({e}): {line}"),
+        }
+    }
+
+    // stdin closed: the supervisor ended this session, or died. Either way this process has no
+    // reason to exist. Exit rather than join — the engine thread may be parked in DbgEng
+    // forever, and this is precisely the case where that must not hold anything up.
+    std::process::exit(0);
+}
+
+/// Owns the [`DebugEngine`] for the life of the process and runs one op at a time.
+fn engine_thread(rx: mpsc::Receiver<(Instant, WorkerRequest)>) {
+    // `DebugEngine::new()` panics if the engine can't be created (dbgeng.dll not discoverable,
+    // most likely). Report it and exit instead of accepting requests that can only fail: the
+    // supervisor is waiting for exactly one of these two messages before it registers a
+    // session, so it can report a dead engine as server machinery rather than as a debugger
+    // error the model would pointlessly retry.
+    let engine = match catch_unwind(AssertUnwindSafe(DebugEngine::new)) {
+        Ok(engine) => engine,
+        Err(_) => {
+            emit(&WorkerMessage::Fatal {
+                message: "failed to initialize DbgEng (is dbgeng.dll on the search path?)"
+                    .to_string(),
+            });
+            std::process::exit(1);
+        }
+    };
+    emit(&WorkerMessage::Ready);
+
+    while let Ok((arrived, request)) = rx.recv() {
+        // Measured here, at the front of the queue: this is the wait only this process can see,
+        // and the bounded path needs it to size the watchdog.
+        let queued = arrived.elapsed();
+        // A panic inside a win-kexp method (several use `.expect`) must not kill the session —
+        // surface it as an error for this one op. The engine survives, so this stays a
+        // debugger-level failure the model can work around by trying something else.
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            execute(&engine, request.id, request.op, queued)
+        }))
+        .unwrap_or_else(|_| Err("debugger operation panicked".to_string()));
+        emit(&WorkerMessage::Done {
+            id: request.id,
+            result,
+        });
+    }
+}
+
+/// Writes one message to stdout. Only the engine thread writes, so the lock is uncontended;
+/// it is taken anyway because `Stdout` is shared and a torn line would desynchronize the
+/// supervisor's reader.
+fn emit(message: &WorkerMessage) {
+    let Ok(line) = serde_json::to_string(message) else {
+        // Every variant is plain data, so this cannot happen — but a worker that dies silently
+        // here would look to the supervisor like an engine crash.
+        tracing::error!("worker: could not encode {message:?}");
+        return;
+    };
+    let stdout = std::io::stdout();
+    let mut stdout = stdout.lock();
+    let _ = writeln!(stdout, "{line}");
+    let _ = stdout.flush();
+}
+
+/// Runs one op against this worker's engine. `queued` is how long it waited its turn here, which
+/// only the bounded-command path cares about.
+fn execute(e: &DebugEngine, id: u64, op: EngineOp, queued: Duration) -> Result<String, String> {
+    match op {
+        // ---- openers ----
+        //
+        // Each reads the same way: side effect, `commit`, wait, `opened`, report. That order is
+        // the contract the milestones exist to express — see [`open`].
+        EngineOp::OpenDump { path } => open(
+            id,
+            |commit| {
+                // `open_dump` is the call that claims the target, so commit right after it: a
+                // load wait that times out still leaves DbgEng holding the dump.
+                e.open_dump(&path).map_err(es)?;
+                commit();
+                e.wait_for_event(LOAD_WAIT_MS).map_err(es)
+            },
+            || {
+                // Load the WinDbg extension DLL so `!`-extension commands resolve — most
+                // importantly `!ext.analyze -v`, the crash-dump triage workhorse. A bare engine
+                // doesn't auto-load it, and even after `.load ext` the unqualified `!analyze`
+                // won't resolve, so callers must use `!ext.analyze`. Best-effort: a minimal
+                // engine without a bundled `winext\` directory simply won't have ext.dll, which
+                // must not fail the open (live/dump state is still usable).
+                let _ = e.execute_command(".load ext");
+                e.execute_command("lm").map_err(es)
+            },
+        ),
+
+        EngineOp::OpenTrace { path } => open(
+            id,
+            |commit| {
+                // As in `OpenDump`: commit before the load wait, because a wait that times out
+                // still leaves DbgEng holding the trace.
+                e.open_trace(&path).map_err(es)?;
+                commit();
+                e.wait_for_event(LOAD_WAIT_MS).map_err(es)
+            },
+            || {
+                // Check the index state *before* any data-model query: `!ttdext.index -status`
+                // only reads the on-disk .idx (never builds), whereas a `dx` on an unindexed
+                // trace can itself trigger the long in-memory index build. TtdExt reports a
+                // healthy, ready index as exactly "Index file loaded."; per MS guidance treat
+                // anything else (missing, out of date, corrupt, unloadable) as needing an index.
+                // A blank result means the status query itself failed — don't warn then.
+                let needs_index = {
+                    let status = e
+                        .execute_command("!ttdext.index -status")
+                        .unwrap_or_default();
+                    !status.trim().is_empty()
+                        && !status.to_ascii_lowercase().contains("index file loaded")
+                };
+                // Confirm TTD replay is active and report the trace's position span. Lifetime
+                // is cheap metadata (min/max position); the expensive indexing is triggered by
+                // Calls/Memory/Events queries, which is what the note below warns about.
+                let mut out = e
+                    .execute_command("dx @$curprocess.TTD.Lifetime")
+                    .map_err(es)?;
+                if needs_index {
+                    out.push_str(
+                        "\nNote: this trace's index is not loaded (missing, out of date, or \
+                         unusable). The first data-model query (ttd_calls/ttd_memory/ttd_events/dx) \
+                         then builds an in-memory index and can run long — let it finish before \
+                         issuing more queries. Run index_trace to (re)build a persistent .idx \
+                         (fast queries and re-opens).",
+                    );
+                }
+                Ok(out)
+            },
+        ),
+
+        EngineOp::AttachKernelLocal => open(
+            id,
+            |commit| {
+                // The engine has claimed the local kernel once `_begin` returns; the break-in
+                // wait (INITIAL_BREAK + the INFINITE wait a live kernel requires) happens in
+                // `wait`, after the target is ours.
+                let pending = e.attach_local_kernel_begin().map_err(es)?;
+                commit();
+                pending.wait().map_err(es)
+            },
+            || kernel_report(e),
+        ),
+
+        EngineOp::AttachKernel { connection } => open(
+            id,
+            |commit| {
+                // `_begin` takes the connection; the KD link is dialed and the break-in awaited
+                // in `wait`. Committing between them is what stops a failed wait from looking
+                // like "nothing happened" — re-dialing a live link is not a clean retry.
+                //
+                // This `wait` is the one that can never return: `SetInterrupt` cannot reach a
+                // wait still establishing the link, so a guest that never dials in parks here
+                // for good. It parks *this process*, which the supervisor can kill.
+                let pending = e.attach_kernel_begin(&connection).map_err(es)?;
+                commit();
+                pending.wait().map_err(es)
+            },
+            || kernel_report(e),
+        ),
+
+        EngineOp::AttachProcess { pid } => open(
+            id,
+            |commit| {
+                // Attached once `_begin` returns; the break-in wait follows the commit, so a
+                // wait that fails cannot read as "never attached" and get retried into a second
+                // attach on the same PID.
+                let pending = e.attach_process_begin(pid).map_err(es)?;
+                commit();
+                pending.wait().map_err(es)
+            },
+            || e.execute_command("r").map_err(es),
+        ),
+
+        EngineOp::Launch { command_line } => open(
+            id,
+            |commit| {
+                // The commit point is *before* the process actually starts: CreateProcessWide is
+                // deferred into the wait. That is still the right moment — once `_begin` returns
+                // Ok the spawn is committed, so a retry from here means two processes.
+                //
+                // It is also not too early, which is the natural worry: only the *spawn* is
+                // deferred, not validation. CreateProcessWide resolves and checks the image
+                // synchronously, so the ways a launch fails with nothing created all land on
+                // this `?`, before the commit — verified against a live engine for a missing
+                // path (0x80070002), a directory (0x80070005), a non-PE file (0x800700C1) and
+                // an empty command line (0x80070057). A failure from `wait` below therefore
+                // means the process really was created, which is what makes the post-commit
+                // message ("a session exists, do not open again") true rather than a guess.
+                let pending = e.launch_process_begin(&command_line).map_err(es)?;
+                commit();
+                pending.wait().map_err(es)
+            },
+            || e.execute_command("r").map_err(es),
+        ),
+
+        // ---- ordinary work ----
+        EngineOp::Command { command } => e.execute_command(&command).map_err(es),
+        EngineOp::BoundedCommand {
+            command,
+            patience_ms,
+        } => {
+            let budget = watchdog_budget_ms(Duration::from_millis(u64::from(patience_ms)), queued);
+            e.execute_command_bounded(&command, budget).map_err(es)
+        }
+        EngineOp::CommandAndWait {
+            command,
+            timeout_ms,
+        } => e.execute_and_wait(&command, timeout_ms).map_err(es),
+        EngineOp::Registers => e.registers().map_err(es),
+        EngineOp::ReadMemory { address, size } => {
+            let addr = parse_u64(&address)?;
+            let bytes = e.read_memory(addr, size as usize).map_err(es)?;
+            Ok(hexdump(addr, &bytes))
+        }
+        EngineOp::SymbolPath {
+            path,
+            append,
+            reload,
+        } => {
+            if append {
+                e.append_symbol_path(&path).map_err(es)?;
+            } else {
+                e.set_symbol_path(&path).map_err(es)?;
+            }
+            // Reload so the new path takes effect (default: all deferred modules).
+            e.reload_symbols(&reload).map_err(es)?;
+            // Echo the effective path so the caller can confirm what resolved.
+            e.execute_command(".sympath").map_err(es)
+        }
+        EngineOp::RunToAddress {
+            address,
+            timeout_ms,
+        } => run_to_address(e, &address, timeout_ms),
+        EngineOp::Reachability(args) => reachable(e, args),
+        EngineOp::EndSession => e
+            .end_session()
+            .map(|_| "session ended".to_string())
+            .map_err(es),
+    }
+}
+
+/// Maps any error to a `String` for the wire.
+fn es<E: ToString>(e: E) -> String {
+    e.to_string()
+}
+
+/// Runs an opener as **transition, then report**, announcing the two milestones the supervisor
+/// needs to tell the failure modes apart.
+///
+/// The split is where correctness lives. `transition` claims the target; `report` is the
+/// diagnostic (`lm`, `vertarget`, `r`, the TTD lifetime query) whose output the caller reads. A
+/// failure is one of three things, and they need different advice:
+///
+/// * before `commit` — nothing was created, and opening again is the correct recovery;
+/// * after `commit` — the target exists and the *wait* failed, so opening again would attach a
+///   second time or start a second process;
+/// * after `Opened` — only the diagnostic failed; the session is fine.
+///
+/// The supervisor infers which from the milestones that arrived before the `Done`, so the error
+/// text lives there, with the session handle it has to quote.
+///
+/// win-kexp's openers expose the first seam as `x_begin()` returning a `PendingTarget` guard,
+/// which cannot exist unless the side effect succeeded — so `commit()` between the guard and its
+/// `wait()` is enforced by the type rather than by convention (glslang/win-kexp#71).
+fn open<T, R>(id: u64, transition: T, report: R) -> Result<String, String>
+where
+    T: FnOnce(&dyn Fn()) -> Result<(), String>,
+    R: FnOnce() -> Result<String, String>,
+{
+    transition(&|| emit(&WorkerMessage::Committed { id }))?;
+    emit(&WorkerMessage::Opened { id });
+    report()
+}
+
+/// The post-attach diagnostic shared by both kernel openers.
+fn kernel_report(e: &DebugEngine) -> Result<String, String> {
+    // The driver_object/device_object/irp_stack tools use kernel-extension commands
+    // (!drvobj/!devobj/!irp) from kdexts.dll, which a bare engine does not auto-load.
+    // Best-effort, like open_dump's `.load ext`; harmless if the extension isn't bundled
+    // (those tools then report a clean "no export").
+    let _ = e.execute_command(".load kdexts");
+    e.execute_command("vertarget").map_err(es)
+}
+
+/// Resolve an address/offset expression the way `uf`/WinDbg read it: evaluate `? <expr>` first
+/// (the MASM evaluator's default base is hex, so a bare `00401234` is 0x00401234 and
+/// `module!Dispatch+0x123` resolves), then fall back to pure parsing (backtick / bare-hex, then
+/// `0x`/decimal).
+fn resolve(e: &DebugEngine, expr: &str) -> Option<u64> {
+    e.execute_command(&format!("? {expr}"))
+        .ok()
+        .as_deref()
+        .and_then(parse_eval)
+        .or_else(|| parse_windbg_addr(expr))
+        .or_else(|| parse_u64(expr).ok())
+}
+
+fn run_to_address(e: &DebugEngine, address: &str, wait: u32) -> Result<String, String> {
+    let target =
+        resolve(e, address).ok_or_else(|| format!("could not resolve address `{address}`"))?;
+    let res = e.run_to_address(target, wait).map_err(es)?;
+    let mut msg = match res.outcome {
+        RunToOutcome::Hit => format!("VERDICT: HIT — execution reached {}\n", fmt_addr(target)),
+        RunToOutcome::StoppedElsewhere { stopped_at } => format!(
+            "VERDICT: STOPPED ELSEWHERE — stopped at {} before reaching {}\n  \
+             (another breakpoint or exception fired first)\n",
+            fmt_addr(stopped_at),
+            fmt_addr(target)
+        ),
+        RunToOutcome::Timeout => format!(
+            "VERDICT: TIMEOUT — did not reach {} within {wait} ms\n  \
+             (the current input/state likely does not drive execution to this block)\n",
+            fmt_addr(target)
+        ),
+    };
+    if !res.output.trim().is_empty() {
+        msg.push_str("---- debugger output ----\n");
+        msg.push_str(&res.output);
+    }
+    Ok(msg)
+}
+
+fn reachable(e: &DebugEngine, args: ReachabilityOp) -> Result<String, String> {
+    // Resolve the target VA: an absolute address, or module+RVA rebased against the module's
+    // live base from `lm m <module>`. Both sides go through `resolve`, so a value pasted from
+    // WinDbg — a `hi`lo` backtick address or a digit-only 32-bit address — reads consistently.
+    let target = match (&args.address, &args.module, &args.rva) {
+        // Reject conflicting target forms rather than silently ignoring one — analysing the
+        // wrong target would give a misleading verdict.
+        (Some(_), Some(_), _) | (Some(_), _, Some(_)) => {
+            return Err("provide `address` OR `module`+`rva`, not both".to_string());
+        }
+        (Some(a), None, None) => {
+            resolve(e, a).ok_or_else(|| format!("could not resolve target address `{a}`"))?
+        }
+        (None, Some(m), Some(r)) => {
+            let rva = resolve(e, r).ok_or_else(|| format!("could not resolve rva `{r}`"))?;
+            let lm = e.execute_command(&format!("lm m {m}")).map_err(es)?;
+            let base = parse_lm_base(&lm)
+                .ok_or_else(|| format!("module `{m}` not found (`lm m {m}` returned):\n{lm}"))?;
+            base.checked_add(rva)
+                .ok_or_else(|| "module base + rva overflowed u64".to_string())?
+        }
+        _ => return Err("provide `address`, or both `module` and `rva`".to_string()),
+    };
+
+    // Resolve `from` to a numeric VA so a mid-function start (a handler scoped past a switch)
+    // is honored; `None` (unresolvable) starts at the entry.
+    let seed_start = resolve(e, &args.from);
+
+    // A real `uf` lists backtick addresses or at least a "module!Func:" label; error text
+    // ("Couldn't resolve...", "no code") lacks both and prunes the branch. parse_uf then
+    // discards any non-disassembly. Held in a `&mut` binding so the same disassembler drives
+    // both the walk and the recipe.
+    let mut uf = |arg: &str| match e.execute_command(&format!("uf {arg}")) {
+        Ok(t) if t.contains('`') || t.contains(':') => Some(t),
+        _ => None,
+    };
+
+    let rpt = reachability(
+        &args.from,
+        seed_start,
+        target,
+        args.max_functions,
+        args.max_depth,
+        &mut uf,
+    );
+
+    if rpt.from_entry.is_none() {
+        return Err(format!(
+            "could not disassemble `from` ({}): `uf` returned no function. Check the \
+             symbol/address and that the module is loaded.",
+            args.from
+        ));
+    }
+
+    // On a REACHABLE verdict, re-walk the path functions to emit the directional recipe (which
+    // branch each on-path `jcc` must take, and what it tests).
+    let mut out = format_report(&rpt);
+    if rpt.verdict_reachable && args.recipe {
+        let recipes = path_recipe(&args.from, seed_start, &rpt, &mut uf);
+        out.push_str(&format_recipe(&recipes));
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // The watchdog budget, as arithmetic. What it is *wired to* needs a real engine and a real
+    // target, and lives in `tests/mcp_smoke.rs`'s bounded-command tier — the wiring now spans two
+    // processes, so the shipped binary is the only place it exists whole.
+
+    /// The everyday case: nothing queued ahead, so the watchdog fires one headroom before the
+    /// caller's wait expires. This is the number that keeps a runaway command from outliving the
+    /// tool call that started it.
+    #[test]
+    fn an_unqueued_command_is_bounded_one_headroom_short_of_the_callers_patience() {
+        let patience = Duration::from_secs(300);
+        assert_eq!(
+            watchdog_budget_ms(patience, Duration::ZERO),
+            (300 - 15) * 1000
+        );
+    }
+
+    /// The property the queue-awareness exists for, stated as the invariant rather than as an
+    /// arithmetic identity: **queue wait + watchdog budget must not exceed the caller's
+    /// patience**, or the caller gives up while the command is still running — the wedge.
+    ///
+    /// Budgeting from the patience as sent (ignoring the wait) breaks this for every non-zero
+    /// wait, which is why it is checked across a spread rather than at one point. That is not a
+    /// hypothetical: it is the bug the first cut of the process split shipped, because the
+    /// supervisor writes a request the moment it is submitted and the waiting then happens on
+    /// the far side of the pipe, where only this process can see it.
+    #[test]
+    fn a_queued_command_still_aborts_before_its_caller_gives_up() {
+        let patience = Duration::from_secs(300);
+        for waited in [0, 1, 30, 100, 240, 269] {
+            let waited = Duration::from_secs(waited);
+            let budget = Duration::from_millis(watchdog_budget_ms(patience, waited) as u64);
+            assert!(
+                waited + budget <= patience,
+                "a command dequeued after {waited:?} gets a {budget:?} budget — it would still \
+                 be running at the {patience:?} mark, which is the wedge this bounds"
+            );
+        }
+    }
+
+    /// Past the point where any headroom is left, the budget floors instead of reaching zero —
+    /// because zero *disables* win-kexp's watchdog, which would make a command dequeued near the
+    /// deadline the one command that runs unbounded.
+    ///
+    /// The floor deliberately overruns the caller's timeout: by then the caller has already given
+    /// up, and the remaining job is to free this worker for the *next* call.
+    #[test]
+    fn a_command_dequeued_past_the_deadline_is_still_bounded() {
+        let patience = Duration::from_secs(300);
+        for waited in [290, 300, 600, 86_400] {
+            assert_eq!(
+                watchdog_budget_ms(patience, Duration::from_secs(waited)),
+                15_000,
+                "a command dequeued after {waited}s must still arm the watchdog"
+            );
+        }
+    }
+
+    /// A caller whose patience was already exhausted when the request was written (the
+    /// supervisor sends 0) must still arm the watchdog, not disable it.
+    #[test]
+    fn no_patience_left_still_arms_the_watchdog() {
+        assert_eq!(watchdog_budget_ms(Duration::ZERO, Duration::ZERO), 15_000);
+    }
+
+    /// A patience beyond `u32::MAX` milliseconds (~49 days) must saturate, not wrap: a wrapped
+    /// budget could land on 0 and silently disable the watchdog.
+    #[test]
+    fn an_absurd_patience_saturates_rather_than_wrapping() {
+        assert_eq!(
+            watchdog_budget_ms(Duration::from_secs(u32::MAX as u64), Duration::ZERO),
+            u32::MAX
+        );
+    }
+}

--- a/tests/golden/tools_list.json
+++ b/tests/golden/tools_list.json
@@ -435,7 +435,7 @@
         "session_id: string|null"
       ],
       "required": [],
-      "title": "Show current session handle"
+      "title": "List debug sessions"
     },
     {
       "hints": {

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -964,17 +964,25 @@ fn a_dump_session_opens_reads_and_closes() {
     );
 }
 
-/// The `session_id` a tool result carries, or a panic naming what it said instead.
+/// The `session_id` a tool result carries, if it carries one.
 ///
 /// Anchored to the line the openers actually emit (`session_id: sess-…`) rather than to the
 /// substring anywhere in the text: the tool prose mentions `session_id` several times, and a
 /// loose match would yield a plausible-looking wrong handle whose failure surfaces later as an
 /// unrelated mismatch.
-fn session_id_of(text: &str) -> String {
+///
+/// A **failed** opener can carry one too, and that is the case worth remembering: an open that
+/// fails *after* claiming its target hands the handle back deliberately, because the session
+/// exists and needs cleaning up. So cleanup must key on this, never on `isError`.
+fn maybe_session_id(text: &str) -> Option<String> {
     text.lines()
         .find_map(|line| line.trim().strip_prefix("session_id:"))
         .map(|id| id.trim().to_string())
-        .unwrap_or_else(|| panic!("expected a session_id in:\n{text}"))
+}
+
+/// [`maybe_session_id`], for a call that must have opened something.
+fn session_id_of(text: &str) -> String {
+    maybe_session_id(text).unwrap_or_else(|| panic!("expected a session_id in:\n{text}"))
 }
 
 /// Whether a process is still running. Windows-only, like everything else here.
@@ -1629,20 +1637,30 @@ fn a_live_kernel_session_attaches_coexists_and_detaches_cleanly() {
         json!({ "connection": connection }),
         TARGET_STEP,
     );
-    assert_no_error(&attached, "attach_kernel");
     let report = text_of(&attached["result"]);
-    assert!(
-        !is_tool_error(&attached),
-        "the attach did not land. The target must be booted with debugging enabled and dialling \
-         this host, and the KD transport is single-owner — if WinDbg's EngHost already holds the \
-         port, nothing else can attach:\n{report}"
-    );
-    let session = session_id_of(&report);
+    // Whether there is anything to clean up is decided by the *handle*, not by `isError`: an
+    // attach that claims its target and then fails the wait comes back as a tool error carrying a
+    // valid `session_id`, and that session is live, halted, and needs detaching just as much as a
+    // successful one. Nothing below panics until that has happened.
+    let Some(session) = maybe_session_id(&report) else {
+        assert_no_error(&attached, "attach_kernel");
+        panic!(
+            "the attach did not land, and left no session behind. The target must be booted with \
+             debugging enabled and dialling this host, and the KD transport is single-owner — if \
+             WinDbg's EngHost already holds the port, nothing else can attach:\n{report}"
+        );
+    };
 
     // Everything from here runs under `catch_unwind`, because the target is now broken in and
     // stays that way until the detach below — including the `vertarget` check, which has no
     // business being the one assertion that can leave a machine frozen.
     let outcome = catch_unwind(AssertUnwindSafe(|| {
+        assert_no_error(&attached, "attach_kernel");
+        assert!(
+            !is_tool_error(&attached),
+            "the attach reported a failure but left a session behind, so it claimed the target \
+             and then failed — the detach below still has to run:\n{report}"
+        );
         // `vertarget`, run by the opener inside the worker.
         assert!(
             report.contains("Kernel"),
@@ -1760,14 +1778,18 @@ fn disconnecting_releases_a_live_kernel_session_rather_than_killing_it() {
         json!({ "connection": connection }),
         TARGET_STEP,
     );
+    let report = text_of(&attached["result"]);
+    // As above: a tool error can still carry a live session, so refuse to bail before there is
+    // something to bail on. From here the disconnect is the release, so nothing needs a detach —
+    // but the assertion order still has to survive an attach that half-failed.
     assert_no_error(&attached, "attach_kernel");
+    let session = maybe_session_id(&report)
+        .unwrap_or_else(|| panic!("the attach left no session behind:\n{report}"));
     assert!(
         !is_tool_error(&attached),
-        "the attach did not land:\n{}",
-        text_of(&attached["result"])
+        "the attach claimed its target and then failed; this test needs one that landed:\n{report}"
     );
     let status = server.tool_text("session_status", json!({}), STEP);
-    let session = session_id_of(&text_of(&attached["result"]));
     let worker = engine_pid_of(&status, &session);
     let before = system_uptime(&server.tool_text(
         "execute",
@@ -1821,18 +1843,22 @@ fn disconnecting_releases_a_live_kernel_session_rather_than_killing_it() {
     );
     let report = text_of(&reattached["result"]);
     let landed = reattached["error"].is_null() && !is_tool_error(&reattached);
-    let (after, ended) = if landed {
-        let session = session_id_of(&report);
-        let after = system_uptime(&again.tool_text(
-            "execute",
-            json!({ "command": ".time", "session_id": session }),
-            TARGET_STEP,
-        ));
-        // The release. From here the target is running again whatever the assertions say.
-        let ended = again.tool_text("end_session", json!({ "session_id": session }), TARGET_STEP);
-        (after, ended)
-    } else {
-        (None, String::new())
+    // Keyed on the handle, not on `landed`: a re-attach that claimed the target and then failed
+    // its wait comes back as a tool error *with* a session, and skipping the release for it would
+    // leave the target halted — the one thing this test exists to catch.
+    let (after, ended) = match maybe_session_id(&report) {
+        Some(session) => {
+            let after = system_uptime(&again.tool_text(
+                "execute",
+                json!({ "command": ".time", "session_id": session }),
+                TARGET_STEP,
+            ));
+            // The release. From here the target is running again whatever the assertions say.
+            let ended =
+                again.tool_text("end_session", json!({ "session_id": session }), TARGET_STEP);
+            (after, ended)
+        }
+        None => (None, String::new()),
     };
 
     // --- now assert ----------------------------------------------------------------------

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -22,11 +22,16 @@
 //!   beside the budget arithmetic in `src/engine.rs` because the two halves it proves are now
 //!   in *different processes* — the budget is computed by the supervisor and armed by the
 //!   worker — so the only place the wiring exists as a whole is the shipped binary.
+//! * **Live kernel** (`#[ignore]`d **and** `WINDBG_MCP_SMOKE_KERNEL=<connection string>`) — a
+//!   real KDNET target. The only tier that touches another machine, and the only one that can
+//!   prove a kernel attach still *lands* and lets go cleanly rather than merely parks. Run it
+//!   last, on its own.
 //!
 //! See `docs/smoke-test.md` for the runbook.
 
 use std::collections::VecDeque;
 use std::io::{BufRead, BufReader, Write};
+use std::panic::{AssertUnwindSafe, catch_unwind, resume_unwind};
 use std::process::{Child, ChildStdin, Command, Stdio};
 use std::sync::mpsc::{Receiver, RecvTimeoutError, channel};
 use std::sync::{Arc, Mutex};
@@ -1484,4 +1489,361 @@ fn measure_what_the_bounded_path_costs_a_quick_command() {
     }
 
     server.tool_text("end_session", json!({ "session_id": session }), TARGET_STEP);
+}
+
+// ---- tier 4: a live KDNET kernel target ---------------------------------------
+//
+// The only tier that touches another machine. Everything above proves the *parked* half of a
+// kernel attach — a connection nothing answers — which is the failure #61 was about, but says
+// nothing about the half that has to keep working: an attach that actually lands, drives a real
+// target through a worker process, and lets go of it cleanly.
+//
+// Doubly gated, because running it by accident has consequences on a machine that is not this
+// one. `#[ignore]` keeps it out of every default run, and it needs a connection string only the
+// operator has:
+//
+//     $env:WINDBG_MCP_SMOKE_KERNEL = "net:port=50000,key=<w.x.y.z>"
+//     cargo test --test mcp_smoke -- --ignored --nocapture live_kernel
+//
+// Run it **last**, on its own, as the final step of the manual checklist: it is the only tier
+// whose blast radius includes a VM you care about.
+//
+// Remote (KDNET) only. `attach_kernel_local` is a different code path with a different failure
+// mode, it needs Secure Boot off to be attachable at all, and a frozen local kernel is the host
+// you are testing from.
+
+/// The connection string for the live-kernel tier, or `None` when it is off.
+fn kernel_tier() -> Option<String> {
+    match std::env::var("WINDBG_MCP_SMOKE_KERNEL") {
+        Ok(connection) if !connection.trim().is_empty() => Some(connection.trim().to_string()),
+        _ => {
+            skip(
+                "set WINDBG_MCP_SMOKE_KERNEL=\"net:port=<n>,key=<w.x.y.z>\" to run the \
+                 live-kernel tier",
+            );
+            None
+        }
+    }
+}
+
+/// The `port=` field of a KDNET connection string.
+fn kdnet_port(connection: &str) -> Option<u16> {
+    connection
+        .split(',')
+        .find_map(|field| field.trim().strip_prefix("port="))
+        .and_then(|port| port.trim().parse().ok())
+}
+
+/// `System Uptime` out of `.time` output, e.g. `0 days 0:05:31.599`.
+///
+/// A halted kernel's uptime does not advance — no CPU is running to take the clock interrupt — so
+/// this is the one signal that distinguishes a target that was *left running* from one that was
+/// merely left reachable. Returns `None` if the shape is not what this expects, so a caller can
+/// tell "did not advance" from "could not tell".
+fn system_uptime(time_output: &str) -> Option<Duration> {
+    let value = time_output
+        .lines()
+        .find_map(|line| line.split_once("System Uptime:"))?
+        .1
+        .trim();
+    let (days, hms) = match value.split_once("day") {
+        Some((days, rest)) => (
+            days.trim().parse::<u64>().ok()?,
+            rest.trim_start_matches('s').trim(),
+        ),
+        None => (0, value),
+    };
+    let mut parts = hms.split(':');
+    let hours: u64 = parts.next()?.trim().parse().ok()?;
+    let minutes: u64 = parts.next()?.trim().parse().ok()?;
+    let seconds: f64 = parts.next()?.trim().parse().ok()?;
+    Some(Duration::from_secs_f64(
+        (days * 86_400 + hours * 3_600 + minutes * 60) as f64 + seconds,
+    ))
+}
+
+/// Whether `pid` owns a UDP endpoint on `port`, per `netstat -ano`.
+fn owns_udp_port(pid: u32, port: u16) -> bool {
+    let out = Command::new("netstat")
+        .args(["-ano", "-p", "UDP"])
+        .output()
+        .expect("run netstat");
+    // `  UDP    0.0.0.0:50000    *:*    1234` — local address second, owning pid last.
+    String::from_utf8_lossy(&out.stdout).lines().any(|line| {
+        let local = line.split_whitespace().nth(1).unwrap_or_default();
+        let owner = line.split_whitespace().last().unwrap_or_default();
+        local.ends_with(&format!(":{port}")) && owner == pid.to_string()
+    })
+}
+
+/// A live KDNET session, end to end: attach, work, coexist with another session, detach cleanly.
+///
+/// The claims that need a real target, and that the dead-port test cannot make:
+///
+/// * an attach that **lands** still works through a worker process — the `Committed`/`Opened`
+///   milestones cross the pipe and leave the session `Open` rather than stuck mid-attach;
+/// * the KD transport endpoint belongs to the **worker**, which is the premise of the whole fix.
+///   A thread-based design leaves that endpoint claimed for the life of the server, and each
+///   retry claims another;
+/// * a second session works *alongside* a live kernel attach — impossible by construction before
+///   — checked here on the target it matters most for;
+/// * `end_session` takes the **graceful** path on a live kernel. That is not tidiness: DbgEng
+///   leaves a detached-but-halted kernel frozen, so win-kexp resumes and *actively* detaches. A
+///   session that fell through to the worker kill instead would leave the guest halted — one CPU
+///   stopped, the rest spinning — and its KD stub wedged until a reboot.
+///
+/// Which is also why the body runs under `catch_unwind`: from the attach onward the target is
+/// broken in and stays that way until the session ends, so a panic that skipped the detach would
+/// leave someone's VM frozen because a test failed.
+#[test]
+#[ignore = "needs a live KDNET target and its connection string; run manually, last"]
+fn a_live_kernel_session_attaches_coexists_and_detaches_cleanly() {
+    let Some(connection) = kernel_tier() else {
+        return;
+    };
+    let mut server = Server::started();
+
+    let attached = server.call_tool(
+        "attach_kernel",
+        json!({ "connection": connection }),
+        TARGET_STEP,
+    );
+    assert_no_error(&attached, "attach_kernel");
+    let report = text_of(&attached["result"]);
+    assert!(
+        !is_tool_error(&attached),
+        "the attach did not land. The target must be booted with debugging enabled and dialling \
+         this host, and the KD transport is single-owner — if WinDbg's EngHost already holds the \
+         port, nothing else can attach:\n{report}"
+    );
+    let session = session_id_of(&report);
+    // `vertarget`, run by the opener inside the worker.
+    assert!(
+        report.contains("Kernel"),
+        "the post-attach report should be `vertarget` output naming the kernel:\n{report}"
+    );
+
+    let outcome = catch_unwind(AssertUnwindSafe(|| {
+        // The milestones made it across: not still "attaching", which is where a parked one sits.
+        let status = server.tool_text("session_status", json!({ "session_id": session }), STEP);
+        assert!(
+            status.contains("ready for work"),
+            "a landed attach must report as open, not mid-attach:\n{status}"
+        );
+
+        // The transport lives in the worker — the process `end_session` can terminate.
+        if let Some(port) = kdnet_port(&connection) {
+            let worker = engine_pid_of(&status, &session);
+            assert!(
+                owns_udp_port(worker, port),
+                "UDP {port} is not owned by the engine worker (pid {worker}) — if the KD endpoint \
+                 belonged to the server instead, a session that cannot unwind could not be \
+                 reclaimed, which is the whole premise of running sessions in their own processes"
+            );
+        }
+
+        // A routed call reaches the right worker, and the target is real.
+        let modules = server.tool_text("modules", json!({ "session_id": session }), TARGET_STEP);
+        let listed: Vec<&str> = modules
+            .lines()
+            .filter_map(|line| line.split_whitespace().nth(2))
+            .collect();
+        assert!(
+            listed.contains(&"nt"),
+            "the kernel image should be in the module list:\n{modules}"
+        );
+        let registers =
+            server.tool_text("registers", json!({ "session_id": session }), TARGET_STEP);
+        assert!(
+            registers.contains("rip="),
+            "a broken-in kernel should have a thread context:\n{registers}"
+        );
+
+        // The payoff, on the target it matters most for: another session opened and used while a
+        // live kernel attach is held, and the kernel session untouched by it.
+        if std::path::Path::new(SAMPLE_DUMP).exists() {
+            let opened = server.call_tool("open_dump", json!({ "path": SAMPLE_DUMP }), TARGET_STEP);
+            assert_no_error(&opened, "open_dump alongside a live kernel session");
+            assert!(
+                !is_tool_error(&opened),
+                "opening a dump must not be blocked by a live kernel session:\n{}",
+                text_of(&opened["result"])
+            );
+            let dump_session = session_id_of(&text_of(&opened["result"]));
+            let after = server.call_tool("modules", json!({ "session_id": session }), TARGET_STEP);
+            assert!(
+                !is_tool_error(&after),
+                "the kernel session must survive another session being opened:\n{}",
+                text_of(&after["result"])
+            );
+            server.tool_text(
+                "end_session",
+                json!({ "session_id": dump_session }),
+                TARGET_STEP,
+            );
+        } else {
+            eprintln!("NOTE: sample dump missing, skipping the second-session check");
+        }
+    }));
+
+    // Always, whatever happened above — the target is frozen until this runs.
+    let ended = server.call_tool("end_session", json!({ "session_id": session }), TARGET_STEP);
+    let ended_text = text_of(&ended["result"]);
+    if let Err(panic) = outcome {
+        eprintln!("detached after the failure below:\n{ended_text}");
+        resume_unwind(panic);
+    }
+
+    assert_no_error(&ended, "end_session on a live kernel");
+    assert!(
+        !ended_text.contains("terminated"),
+        "the worker was killed instead of detaching — DbgEng leaves a detached-but-halted kernel \
+         frozen, so this would have left the target stopped and its KD stub wedged:\n{ended_text}"
+    );
+    assert!(
+        ended_text.contains("closed"),
+        "end_session should report the session closed:\n{ended_text}"
+    );
+    println!("live kernel session detached cleanly:\n{ended_text}");
+}
+
+/// Disconnecting with a live kernel session open must **release** it, not kill its worker.
+///
+/// This is the same hazard as the detach above, arriving by the path nobody is watching. A client
+/// disconnect is an ordinary event — closing a laptop lid ends one — and the sessions it finds are
+/// whatever happened to be open. Killing a worker that holds a broken-in kernel leaves the target
+/// halted: DbgEng needs the resume-and-active-detach that only a real teardown performs.
+///
+/// Caught by running this tier for the first time: shutdown killed workers outright, so a
+/// disconnect froze the target machine. The dump-based tier could never have found it — killing a
+/// worker that holds a *dump* costs nothing at all.
+///
+/// The proof is the target's own **uptime**, read either side of the disconnect. A halted kernel
+/// takes no clock interrupt, so its uptime stands still; a released one keeps counting. Re-attaching
+/// alone would not show this — a frozen target still answers its KD stub — which is exactly the
+/// trap that made the bug survive a first round of manual checking.
+#[test]
+#[ignore = "needs a live KDNET target and its connection string; run manually, last"]
+fn disconnecting_releases_a_live_kernel_session_rather_than_killing_it() {
+    let Some(connection) = kernel_tier() else {
+        return;
+    };
+
+    let mut server = Server::started();
+    let attached = server.call_tool(
+        "attach_kernel",
+        json!({ "connection": connection }),
+        TARGET_STEP,
+    );
+    assert_no_error(&attached, "attach_kernel");
+    assert!(
+        !is_tool_error(&attached),
+        "the attach did not land:\n{}",
+        text_of(&attached["result"])
+    );
+    let status = server.tool_text("session_status", json!({}), STEP);
+    let session = session_id_of(&text_of(&attached["result"]));
+    let worker = engine_pid_of(&status, &session);
+    let before = system_uptime(&server.tool_text(
+        "execute",
+        json!({ "command": ".time", "session_id": session }),
+        TARGET_STEP,
+    ));
+
+    // --- act, and *collect* rather than assert -------------------------------------------
+    //
+    // Nothing below panics until the target has been re-attached and detached again. Asserting
+    // as it goes reads better and is wrong here: the first version of this test failed at the
+    // release check and left the target halted, because the recovery came after the assertion.
+    // A test for a bug that freezes a machine must not freeze the machine when it fails.
+
+    // Disconnect the way a client does: close stdin and let the server wind itself up. No
+    // `end_session` — that is the whole point. The log is captured before `shutdown` consumes
+    // the harness, since what it says is half the evidence.
+    let log = Arc::clone(&server.stderr_log);
+    let exit = server.shutdown();
+
+    // The stderr reader is a separate thread draining a pipe the process just closed, so poll
+    // rather than snapshot — a bare read races the drain and fails intermittently.
+    let deadline = Instant::now() + Duration::from_secs(5);
+    let stderr = loop {
+        let stderr = log.lock().unwrap().join("\n");
+        if stderr.contains("releasing 1 session") || Instant::now() >= deadline {
+            break stderr;
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    };
+
+    let deadline = Instant::now() + Duration::from_secs(20);
+    while process_alive(worker) && Instant::now() < deadline {
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    let worker_gone = !process_alive(worker);
+
+    // Give the target time to visibly run, if it is running at all.
+    const RUNNING_FOR: Duration = Duration::from_secs(4);
+    std::thread::sleep(RUNNING_FOR);
+
+    // Re-attach: needed to read the uptime again, and it is also how the target gets left
+    // detached and running rather than broken in.
+    let mut again = Server::started();
+    let reattached = again.call_tool(
+        "attach_kernel",
+        json!({ "connection": connection }),
+        TARGET_STEP,
+    );
+    let report = text_of(&reattached["result"]);
+    let landed = reattached["error"].is_null() && !is_tool_error(&reattached);
+    let (after, ended) = if landed {
+        let session = session_id_of(&report);
+        let after = system_uptime(&again.tool_text(
+            "execute",
+            json!({ "command": ".time", "session_id": session }),
+            TARGET_STEP,
+        ));
+        // The release. From here the target is running again whatever the assertions say.
+        let ended = again.tool_text("end_session", json!({ "session_id": session }), TARGET_STEP);
+        (after, ended)
+    } else {
+        (None, String::new())
+    };
+
+    // --- now assert ----------------------------------------------------------------------
+    assert_eq!(exit, Some(0), "a disconnect should still be a clean exit");
+    assert!(
+        stderr.contains("releasing 1 session"),
+        "the disconnect should have *released* the kernel session, not killed its worker — a \
+         killed worker leaves the target halted:\n{stderr}"
+    );
+    assert!(
+        worker_gone,
+        "engine worker pid {worker} outlived the connection"
+    );
+    assert!(
+        landed,
+        "the target was not reattachable after a disconnect — the previous session did not let go \
+         of it cleanly, and this run could not put it back:\n{report}"
+    );
+    assert!(
+        !ended.contains("terminated"),
+        "the final detach must be graceful, or the target is left frozen:\n{ended}"
+    );
+    match (before, after) {
+        (Some(before), Some(after)) => {
+            let ran_for = after.saturating_sub(before);
+            println!("target uptime advanced {ran_for:?} across a {RUNNING_FOR:?} disconnect");
+            assert!(
+                ran_for >= RUNNING_FOR / 2,
+                "the target's uptime barely moved across the disconnect ({ran_for:?} over \
+                 {RUNNING_FOR:?}) — it was left halted, which is what killing a worker that holds \
+                 a broken-in kernel does instead of releasing it"
+            );
+        }
+        // Not a failure: the check is only as good as `.time`'s shape, and the release itself is
+        // asserted above. Say so loudly rather than pass quietly on the weaker claim.
+        _ => eprintln!(
+            "NOTE: could not read System Uptime either side of the disconnect, so this run \
+             proved only that the session was released and the target stayed reachable"
+        ),
+    }
 }

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -10,13 +10,18 @@
 //! * **The MCP spec revved.** New revision, new required field, a capability the SDK now
 //!   advertises on our behalf that this server does not actually implement.
 //!
-//! Two tiers, so the cheap half can ride `cargo test` everywhere:
+//! Three tiers, so the cheap one can ride `cargo test` everywhere:
 //!
 //! * **Protocol** (default) — spawns the server, speaks JSON-RPC. No debugger target, no
 //!   symbols, no network.
 //! * **Target** (`WINDBG_MCP_SMOKE_DUMP=1`) — opens the sample crash dump through DbgEng, so
 //!   it needs `dbgeng.dll` and may reach a symbol server. Off by default; this is the tier
 //!   that catches a `win-kexp` regression.
+//! * **Bounded command** (`#[ignore]`d, run by hand) — deliberately runs away and waits out a
+//!   watchdog, so it is measured in minutes rather than seconds. It lives here rather than
+//!   beside the budget arithmetic in `src/engine.rs` because the two halves it proves are now
+//!   in *different processes* — the budget is computed by the supervisor and armed by the
+//!   worker — so the only place the wiring exists as a whole is the shipped binary.
 //!
 //! See `docs/smoke-test.md` for the runbook.
 
@@ -75,12 +80,23 @@ struct Server {
 
 impl Server {
     fn spawn() -> Self {
-        let mut child = Command::new(EXE)
+        Self::spawn_with(&[])
+    }
+
+    /// `env` is extra environment for the server process — the bounded-command tier uses it to
+    /// shrink the per-call budget so a runaway command aborts in seconds rather than minutes.
+    fn spawn_with(env: &[(&str, &str)]) -> Self {
+        let mut command = Command::new(EXE);
+        command
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             // Deterministic logging regardless of the developer's shell.
-            .env("RUST_LOG", "info")
+            .env("RUST_LOG", "info");
+        for (key, value) in env {
+            command.env(key, value);
+        }
+        let mut child = command
             .spawn()
             .unwrap_or_else(|e| panic!("failed to spawn {EXE}: {e}"));
 
@@ -168,11 +184,19 @@ impl Server {
 
     /// Sends a request and returns the response with the matching id.
     fn request(&mut self, method: &str, params: Value, budget: Duration) -> Value {
+        let id = self.send_request(method, params);
+        self.await_id(id, method, budget)
+    }
+
+    /// Sends a request and returns its id **without waiting for the answer**, so a test can keep
+    /// driving the server while a call is still outstanding. That is the whole point of one of
+    /// the tests below: a session that will never answer must not stop the others.
+    fn send_request(&mut self, method: &str, params: Value) -> i64 {
         let id = self.next_id;
         self.next_id += 1;
         let msg = json!({ "jsonrpc": "2.0", "id": id, "method": method, "params": params });
         self.send_line(&msg);
-        self.await_id(id, method, budget)
+        id
     }
 
     fn await_id(&mut self, id: i64, what: &str, budget: Duration) -> Value {
@@ -226,7 +250,11 @@ impl Server {
 
     /// A ready-to-use session on the newest revision, for tests that are not about the opener.
     fn started() -> Self {
-        let mut server = Self::spawn();
+        Self::started_with(&[])
+    }
+
+    fn started_with(env: &[(&str, &str)]) -> Self {
+        let mut server = Self::spawn_with(env);
         server.initialize(SUPPORTED_REVISIONS[0]);
         server
     }
@@ -846,21 +874,12 @@ fn a_dump_session_opens_reads_and_closes() {
         "opening the sample dump failed — DbgEng may be missing or the dump unreadable:\n{opened}"
     );
 
-    // The handle is what every later call is checked against, so the open has to mint one.
-    // Anchored to the line `open_dump` actually emits (`session_id: sess-…`) rather than to the
-    // substring anywhere in the text — the tool's prose mentions `session_id` several times, and
-    // a loose match would yield a plausible-looking wrong handle whose failure surfaces later as
-    // an unrelated mismatch.
-    let session_id = opened
-        .lines()
-        .find_map(|line| line.trim().strip_prefix("session_id:"))
-        .map(str::trim)
-        .unwrap_or_else(|| panic!("open_dump must return a session_id, got:\n{opened}"));
+    // The handle is what routes every later call, so the open has to mint one.
+    let session_id = session_id_of(&opened);
     assert!(
         session_id.starts_with("sess-"),
         "session handles are minted as `sess-…`, got `{session_id}` in:\n{opened}"
     );
-    let session_id = session_id.to_string();
 
     let status = server.tool_text("session_status", json!({}), TARGET_STEP);
     assert!(
@@ -913,8 +932,8 @@ fn a_dump_session_opens_reads_and_closes() {
         "the failure must explain itself: {unsupported}"
     );
 
-    // A handle from a session that is not current must be refused rather than silently
-    // answered against whatever happens to be open — the contract `check_session_handle` owns.
+    // A handle this server never issued must be refused rather than silently answered against
+    // whatever happens to be open — the contract `Sessions::resolve` owns.
     let stale = server.call_tool(
         "modules",
         json!({ "session_id": "sess-not-a-real-handle" }),
@@ -940,29 +959,529 @@ fn a_dump_session_opens_reads_and_closes() {
     );
 }
 
-/// The `isError` contract, on the wire. `engine.rs` splits debugger failures (the model can
-/// retry) from engine failures (it cannot); the first kind must arrive as a *result* flagged
-/// `isError`, never as a JSON-RPC error the model never really sees.
+/// The `session_id` a tool result carries, or a panic naming what it said instead.
+///
+/// Anchored to the line the openers actually emit (`session_id: sess-…`) rather than to the
+/// substring anywhere in the text: the tool prose mentions `session_id` several times, and a
+/// loose match would yield a plausible-looking wrong handle whose failure surfaces later as an
+/// unrelated mismatch.
+fn session_id_of(text: &str) -> String {
+    text.lines()
+        .find_map(|line| line.trim().strip_prefix("session_id:"))
+        .map(|id| id.trim().to_string())
+        .unwrap_or_else(|| panic!("expected a session_id in:\n{text}"))
+}
+
+/// Whether a process is still running. Windows-only, like everything else here.
+fn process_alive(pid: u32) -> bool {
+    let out = Command::new("tasklist")
+        .args(["/FI", &format!("PID eq {pid}"), "/NH"])
+        .output()
+        .expect("run tasklist");
+    // No match prints "INFO: No tasks are running which match…", which never contains the pid.
+    String::from_utf8_lossy(&out.stdout).contains(&pid.to_string())
+}
+
+/// The `pid` `session_status` reports for a session, from its `[engine pid N, …]` line.
+fn engine_pid_of(status: &str, session_id: &str) -> u32 {
+    let line = status
+        .lines()
+        .find(|l| l.contains(session_id) && l.contains("engine pid"))
+        .unwrap_or_else(|| panic!("no engine pid reported for `{session_id}` in:\n{status}"));
+    let after = line.split("engine pid ").nth(1).expect("checked above");
+    after
+        .chars()
+        .take_while(char::is_ascii_digit)
+        .collect::<String>()
+        .parse()
+        .unwrap_or_else(|e| panic!("unreadable engine pid in {line:?}: {e}"))
+}
+
+/// Sessions are independent processes, so opening a second target must not disturb the first.
+///
+/// Under the single-engine design this was impossible by construction — one process, one DbgEng
+/// session, so the second open *replaced* the first and every handle to it went stale. The whole
+/// reason sessions became processes is that a target you cannot unwind must not cost you the
+/// server; this is the same property seen from the other side.
 #[test]
-fn a_failed_debugger_operation_is_a_tool_error_not_a_protocol_error() {
-    if target_tier().is_none() {
-        return;
-    }
+fn two_sessions_coexist_and_do_not_disturb_each_other() {
+    let Some(dump) = target_tier() else { return };
     let mut server = Server::started();
 
-    // No target is open, so execution control has nothing to run.
+    let first = session_id_of(&server.tool_text("open_dump", json!({ "path": dump }), TARGET_STEP));
+    let second =
+        session_id_of(&server.tool_text("open_dump", json!({ "path": dump }), TARGET_STEP));
+    assert_ne!(first, second, "each open must get its own session");
+
+    // The claim: the first handle still names a live target after the second open landed.
+    let response = server.call_tool("modules", json!({ "session_id": first }), TARGET_STEP);
+    assert_no_error(&response, "modules on the first session");
+    assert!(
+        !is_tool_error(&response),
+        "the first session must survive a later open:\n{}",
+        text_of(&response["result"])
+    );
+
+    // Both are listed, and the newest is the one an omitted handle routes to.
+    let status = server.tool_text("session_status", json!({}), TARGET_STEP);
+    for id in [&first, &second] {
+        assert!(
+            status.contains(id.as_str()),
+            "`{id}` should be listed:\n{status}"
+        );
+    }
+    let current_line = status
+        .lines()
+        .find(|l| l.contains("(current)"))
+        .unwrap_or_else(|| panic!("some session must be current:\n{status}"));
+    assert!(
+        current_line.contains(&second),
+        "the newest session should be current, got:\n{current_line}"
+    );
+
+    // Ending one leaves the other alone — the failure mode that made `end_session` unusable as a
+    // recovery before, since there was only ever one session to end.
+    server.tool_text("end_session", json!({ "session_id": second }), TARGET_STEP);
+    let still_there = server.call_tool("modules", json!({ "session_id": first }), TARGET_STEP);
+    assert!(
+        !is_tool_error(&still_there),
+        "ending one session must not touch another:\n{}",
+        text_of(&still_there["result"])
+    );
+    let gone = server.call_tool("modules", json!({ "session_id": second }), TARGET_STEP);
+    assert!(
+        is_tool_error(&gone),
+        "the ended handle must be refused: {gone}"
+    );
+
+    server.tool_text("end_session", json!({ "session_id": first }), TARGET_STEP);
+}
+
+/// Issue #61, end to end: a kernel attach whose target never dials in waits forever, and that
+/// must cost exactly one session.
+///
+/// The wait is `WaitForEvent(INFINITE)` and nothing can interrupt it — `SetInterrupt` cannot
+/// reach a wait that is still establishing the KD link — so the only way it ends is the process
+/// ending. Before process-per-session that process was the server: every later tool call queued
+/// behind the parked wait, `end_session` included, and the only recovery was restarting the
+/// server. This asserts the two things that changed: other sessions still work, and
+/// `end_session` actually ends it.
+#[test]
+fn a_kernel_attach_that_never_connects_costs_one_session_and_can_be_ended() {
+    let Some(dump) = target_tier() else { return };
+    let mut server = Server::started();
+
+    // A KDNET connection nothing is listening on. The attach itself succeeds in milliseconds —
+    // it is the wait for the target to dial *this* host that never returns.
+    let attaching = server.send_request(
+        "tools/call",
+        json!({
+            "name": "attach_kernel",
+            "arguments": { "connection": "net:port=50007,key=1.1.1.1" },
+        }),
+    );
+
+    // Wait for it to reach the parked state rather than assuming a timing.
+    let deadline = Instant::now() + Duration::from_secs(30);
+    let parked = loop {
+        let status = server.tool_text("session_status", json!({}), STEP);
+        if status.contains("waiting") && status.contains("kernel target") {
+            break Some(status);
+        }
+        if Instant::now() >= deadline {
+            break None;
+        }
+        std::thread::sleep(Duration::from_millis(200));
+    };
+    let Some(status) = parked else {
+        // The attach failed outright instead of parking — most likely the UDP port was already
+        // taken on this host. Nothing to assert about a park that did not happen.
+        skip("attach_kernel did not reach the parked state (port 50007 busy?)");
+        return;
+    };
+    let kernel_session = status
+        .lines()
+        .find(|l| l.contains("kernel target"))
+        .map(|l| l.split_whitespace().next().unwrap_or_default().to_string())
+        .expect("the kernel session should be listed");
+
+    // The point. A parked session used to be the *server's* engine thread; now it is one worker,
+    // and everything else carries on.
+    let opened = server.call_tool("open_dump", json!({ "path": dump }), TARGET_STEP);
+    assert_no_error(&opened, "open_dump while a kernel attach is parked");
+    assert!(
+        !is_tool_error(&opened),
+        "a parked kernel attach must not block another session:\n{}",
+        text_of(&opened["result"])
+    );
+    let dump_session = session_id_of(&text_of(&opened["result"]));
+
+    // …and the parked session reports itself honestly rather than as an ordinary pending open.
+    let asked = server.tool_text(
+        "session_status",
+        json!({ "session_id": kernel_session }),
+        STEP,
+    );
+    assert!(
+        asked.contains("Do not re-run the open"),
+        "the target exists, so re-attaching would be a second attach:\n{asked}"
+    );
+
+    // The recovery that did not exist before: `end_session` cannot be answered by a worker that
+    // is parked, so the worker is killed. It has to come back, and the process has to be gone.
+    let worker = engine_pid_of(&status, &kernel_session);
+    let ended = server.tool_text(
+        "end_session",
+        json!({ "session_id": kernel_session }),
+        Duration::from_secs(120),
+    );
+    assert!(
+        ended.contains("terminated"),
+        "a parked session ends by terminating its worker:\n{ended}"
+    );
+    assert!(
+        !process_alive(worker),
+        "the parked engine worker (pid {worker}) is still running after end_session"
+    );
+
+    // The abandoned attach call is still outstanding; its session is gone, so it must come back
+    // rather than hang forever.
+    let answer = server.await_id(attaching, "attach_kernel", Duration::from_secs(60));
+    assert_no_error(
+        &answer,
+        "the abandoned attach must be answered, not dropped",
+    );
+
+    server.tool_text(
+        "end_session",
+        json!({ "session_id": dump_session }),
+        TARGET_STEP,
+    );
+}
+
+/// A worker is a process holding a debug session — and, for a launch or an attach, a debuggee
+/// whose fate is tied to its debugger. None may outlive the client connection that opened it, or
+/// every disconnect leaks a debugger process.
+#[test]
+fn engine_workers_do_not_outlive_the_connection() {
+    let Some(dump) = target_tier() else { return };
+    let mut server = Server::started();
+    let session =
+        session_id_of(&server.tool_text("open_dump", json!({ "path": dump }), TARGET_STEP));
+    let status = server.tool_text("session_status", json!({}), TARGET_STEP);
+    let worker = engine_pid_of(&status, &session);
+    assert!(process_alive(worker), "the worker should be running");
+
+    assert_eq!(
+        server.shutdown(),
+        Some(0),
+        "clean disconnect should be a clean exit"
+    );
+
+    // The worker notices its stdin close and exits on its own; give it a moment to.
+    let deadline = Instant::now() + Duration::from_secs(20);
+    while process_alive(worker) && Instant::now() < deadline {
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    assert!(
+        !process_alive(worker),
+        "engine worker pid {worker} outlived the connection — every disconnect would leak one"
+    );
+}
+
+/// The `isError` contract, on the wire. A failure the model can act on must arrive as a *result*
+/// flagged `isError`, never as a JSON-RPC error the model never really sees.
+///
+/// Both halves are exercised: a call with no session at all (refused by the supervisor, which now
+/// knows there is nowhere to route it) and a command a real engine rejects.
+#[test]
+fn a_failed_debugger_operation_is_a_tool_error_not_a_protocol_error() {
+    let Some(dump) = target_tier() else { return };
+    let mut server = Server::started();
+
+    // Nothing is open, so there is no session to route to. That is the model's to fix — by
+    // opening one — so it belongs in the result, with the list of tools that would.
     let response = server.call_tool("go", json!({}), TARGET_STEP);
     assert_no_error(
         &response,
-        "go with no debuggee (a debugger failure is a tool result, not a protocol error)",
+        "go with no session (a routing failure is a tool result, not a protocol error)",
     );
     assert!(
         is_tool_error(&response),
-        "a failed debugger operation must set isError, got {response}"
+        "a call with no session must set isError, got {response}"
     );
     let text = text_of(&response["result"]);
     assert!(
-        !text.trim().is_empty(),
+        text.contains("open_dump"),
         "a tool error must explain itself so the model can correct: {response}"
     );
+
+    // And the other half: a real engine failure, carrying the engine's own text. `~` is
+    // user-mode-only, so DbgEng rejects it against this kernel dump.
+    let session_id =
+        session_id_of(&server.tool_text("open_dump", json!({ "path": dump }), TARGET_STEP));
+    let unsupported = server.call_tool("threads", json!({ "session_id": session_id }), TARGET_STEP);
+    assert_no_error(&unsupported, "threads on a kernel dump");
+    assert!(
+        is_tool_error(&unsupported),
+        "a command DbgEng cannot run must set isError, got {unsupported}"
+    );
+    assert!(
+        !text_of(&unsupported["result"]).trim().is_empty(),
+        "the failure must explain itself: {unsupported}"
+    );
+
+    // The session survives its own failed command — a worker that died on a bad command would
+    // turn every tool error into a lost target.
+    let after = server.call_tool("modules", json!({ "session_id": session_id }), TARGET_STEP);
+    assert!(
+        !is_tool_error(&after),
+        "the session must survive a failed command:\n{}",
+        text_of(&after["result"])
+    );
+}
+
+// ---- tier 3: the bounded-command path -----------------------------------------
+//
+// These deliberately run a command that would take hours and wait for a watchdog to cut it short,
+// so they are `#[ignore]`d rather than gated by an env var — they cost minutes, and no CI runner
+// should pay that on every push:
+//
+//     $env:WINDBG_MCP_SMOKE_DUMP = "1"
+//     cargo test --test mcp_smoke -- --ignored --nocapture --test-threads=1 bounded
+//
+// win-kexp proves the primitive (`execute_command_bounded` aborts a runaway command, and the next
+// command survives it). What is unproven *there* is this server's wiring of it, and that wiring is
+// now split across two processes: the supervisor computes the budget from what is left of the
+// caller's timeout after queue wait, and the worker arms the watchdog with it. Only the shipped
+// binary contains both halves, which is why these moved out of `src/engine.rs`.
+
+/// A deliberately runaway command: a tight `.for` in the expression evaluator, which is genuinely
+/// CPU-bound and polls for Ctrl+Break exactly as a real runaway command does.
+///
+/// A broad `s` memory search — the wedge that motivated all of this — is the wrong probe despite
+/// being the motivating case: it skips unmapped ranges, so even a whole-address-space search
+/// returns almost immediately on this dump. The `.for` also leaves its progress in `$t0`, which is
+/// what proves the interruption.
+///
+/// Sized to run for hours, so "did not finish" cannot mean "finished early on a fast host".
+const RUNAWAY_ITERATIONS: u64 = 0x4000_0000;
+
+fn runaway_command(counter: &str) -> String {
+    format!(
+        ".for (r {counter} = 0; @{counter} < 0x{RUNAWAY_ITERATIONS:x}; r {counter} = @{counter} + 1) {{ }}"
+    )
+}
+
+/// Reads a user pseudo-register (`$t0`, `$t1`) as a number from `r $tN` output. `None` if the
+/// engine printed something unexpected, so a caller can tell "unreadable" from "zero".
+fn pseudo_register(text: &str, name: &str) -> Option<u64> {
+    text.split_whitespace()
+        .find_map(|tok| tok.strip_prefix(&format!("{name}=")))
+        .and_then(|v| u64::from_str_radix(&v.replace('`', ""), 16).ok())
+}
+
+/// The whole point of the bounded path, end to end through the shipped binary: a command that
+/// would run for hours comes back to the caller *as a result* (not as a timeout), and the session
+/// is usable afterwards.
+#[test]
+#[ignore = "runs a command out to the watchdog deadline; run manually with --ignored"]
+fn a_bounded_runaway_command_aborts_and_leaves_its_session_usable() {
+    let Some(dump) = target_tier() else { return };
+    // 30s of call budget leaves the watchdog its 15s floor, which keeps the test short while
+    // still exercising the real arithmetic rather than a special case.
+    let mut server = Server::started_with(&[("WINDBG_MCP_CALL_TIMEOUT_SECS", "30")]);
+    let session =
+        session_id_of(&server.tool_text("open_dump", json!({ "path": dump }), TARGET_STEP));
+
+    let started = Instant::now();
+    let response = server.call_tool(
+        "execute",
+        json!({ "command": runaway_command("$t0"), "session_id": session }),
+        Duration::from_secs(120),
+    );
+    let elapsed = started.elapsed();
+    assert_no_error(&response, "a bounded runaway command");
+    let out = text_of(&response["result"]);
+    assert!(
+        !is_tool_error(&response),
+        "a bounded runaway command must return a result, not a timeout ({elapsed:?}):\n{out}"
+    );
+
+    // Proof of interruption is the loop counter, not the clock and not the note: the note is
+    // appended whenever the watchdog *attempted* an interrupt, so an interrupt the engine ignored
+    // would still produce it.
+    let counter = server.tool_text(
+        "execute",
+        json!({ "command": "r $t0", "session_id": session }),
+        TARGET_STEP,
+    );
+    let t0 = pseudo_register(&counter, "$t0")
+        .unwrap_or_else(|| panic!("could not read $t0 back from:\n{counter}"));
+    println!(
+        "bounded command returned after {elapsed:?}, $t0 = {t0:#x} of {RUNAWAY_ITERATIONS:#x}"
+    );
+    assert!(t0 > 0, "the loop never started ($t0 = {t0:#x})");
+    assert!(
+        t0 < RUNAWAY_ITERATIONS,
+        "the loop ran to completion ($t0 = {t0:#x}) — the watchdog did not cut it short, so the \
+         rest of this test would prove nothing"
+    );
+    assert!(
+        out.contains("interrupted after"),
+        "no interruption note despite a loop that stopped short:\n{out}"
+    );
+
+    // The wedge itself. Before the bounded path this is where every later call timed out, and
+    // the only recovery was restarting the server.
+    let after = server.call_tool("modules", json!({ "session_id": session }), TARGET_STEP);
+    assert!(
+        !is_tool_error(&after),
+        "the session was not freed by the abort — this is the wedge:\n{}",
+        text_of(&after["result"])
+    );
+    server.tool_text("end_session", json!({ "session_id": session }), TARGET_STEP);
+}
+
+/// The queue-aware half of the budget, which is the part that has no equivalent in win-kexp: a
+/// bounded command that spent most of the call budget waiting its turn must still abort *before*
+/// its caller's timeout, not one full budget after it was dequeued.
+///
+/// Budgeting from the full call timeout instead of the remainder passes every assertion in the
+/// test above and fails here — the command would abort well after the caller had already given
+/// up, with the session pinned in between.
+///
+/// The queue is per-session now, so the blocker has to be sent to the *same* session. A job in
+/// another session would not queue behind anything, which is the whole point of the change.
+#[test]
+#[ignore = "runs a command out to the watchdog deadline; run manually with --ignored"]
+fn a_bounded_command_queued_behind_another_job_still_beats_its_caller() {
+    let Some(dump) = target_tier() else { return };
+    const CALL_TIMEOUT: Duration = Duration::from_secs(60);
+
+    const QUEUE_WAIT: Duration = Duration::from_secs(30);
+
+    let mut server = Server::started_with(&[("WINDBG_MCP_CALL_TIMEOUT_SECS", "60")]);
+    let session =
+        session_id_of(&server.tool_text("open_dump", json!({ "path": dump }), TARGET_STEP));
+
+    // Occupy the session for a known time, then queue the runaway behind it. `.sleep` blocks the
+    // engine exactly the way a long command does, and unlike a calibrated spin its duration does
+    // not depend on the host — which matters, because the arithmetic under test is about *how
+    // long* the wait was.
+    //
+    // `0n` is not decoration: the MASM evaluator's default base is **hex**, so a bare `.sleep
+    // 30000` sleeps for 0x30000 ms — three and a half minutes, not thirty seconds.
+    let blocker = server.send_request(
+        "tools/call",
+        json!({
+            "name": "execute",
+            "arguments": {
+                "command": format!(".sleep 0n{}", QUEUE_WAIT.as_millis()),
+                "session_id": session,
+            },
+        }),
+    );
+
+    // Two tool calls in flight at once are dispatched concurrently and reach the session's queue
+    // in whichever order wins the race, so "sent first" is not "queued first". This test needs
+    // the blocker to be the one holding the engine — with the order reversed it silently becomes
+    // the unqueued case and proves nothing — so give it a head start it cannot lose.
+    std::thread::sleep(Duration::from_secs(3));
+
+    let started = Instant::now();
+    let response = server.call_tool(
+        "execute",
+        json!({ "command": runaway_command("$t0"), "session_id": session }),
+        Duration::from_secs(240),
+    );
+    let elapsed = started.elapsed();
+    let out = text_of(&response["result"]);
+    assert_no_error(&response, "a queued bounded runaway command");
+    assert!(
+        out.contains("interrupted after"),
+        "the queued command was not interrupted after {elapsed:?}:\n{out}"
+    );
+    // The premise: it really did wait behind the blocker. Without this the test would quietly
+    // degrade into the unqueued case — which passes the assertion below for the wrong reason —
+    // if `.sleep` ever stopped blocking or the head start stopped being enough.
+    assert!(
+        elapsed > QUEUE_WAIT.mul_f32(0.6),
+        "the runaway did not queue behind the blocker ({elapsed:?}) — this run proves nothing \
+         about the queue-aware budget"
+    );
+    // And the claim.
+    assert!(
+        elapsed < CALL_TIMEOUT,
+        "the abort landed after the caller's {CALL_TIMEOUT:?} timeout ({elapsed:?}) — the \
+         watchdog budget did not account for the {QUEUE_WAIT:?} spent queued"
+    );
+
+    let _ = server.await_id(blocker, "the blocking command", Duration::from_secs(120));
+    server.tool_text("end_session", json!({ "session_id": session }), TARGET_STEP);
+}
+
+/// What the bounded path *costs* a command that was never going to run away — the evidence behind
+/// the coverage split in `DECISIONS.md` (2026-08-02), kept as a test so a win-kexp change to the
+/// watchdog can be re-measured rather than re-argued.
+///
+/// The cost is not a constant overhead but a **quantization**: win-kexp's watchdog thread checks
+/// its `done` flag, then sleeps 200ms, so a command takes `ceil(d / 200ms) * 200ms`. The tax on a
+/// point query is best read as: anything that takes 1–200ms now takes 200ms.
+///
+/// Prints rather than asserts. The cost belongs to win-kexp's watchdog, not to this crate, and a
+/// threshold pinned here would fail on an unrelated host difference. Measured through the tool
+/// surface, so the numbers now include this server's own per-call overhead — one IPC round trip
+/// on top of what the in-process version measured, which is the number a caller actually sees.
+#[test]
+#[ignore = "a measurement, not an assertion; run manually with --ignored --nocapture"]
+fn measure_what_the_bounded_path_costs_a_quick_command() {
+    let Some(dump) = target_tier() else { return };
+    const ROUNDS: usize = 20;
+
+    let mut server = Server::started();
+    let session =
+        session_id_of(&server.tool_text("open_dump", json!({ "path": dump }), TARGET_STEP));
+
+    /// min / median / max, because a mean hides the two modes entirely.
+    fn spread(mut samples: Vec<Duration>) -> String {
+        samples.sort();
+        format!(
+            "min {:?}, median {:?}, max {:?}",
+            samples[0],
+            samples[samples.len() / 2],
+            samples[samples.len() - 1]
+        )
+    }
+
+    // `modules` is `lm` on the unbounded path; `execute` runs whatever it is given on the bounded
+    // one. Same engine, same session, one difference: the watchdog.
+    for (label, command) in [
+        ("lm", "lm".to_string()),
+        (
+            ".for (short)",
+            ".for (r $t0 = 0; @$t0 < 0x4e20; r $t0 = @$t0 + 1) { }".to_string(),
+        ),
+    ] {
+        let mut unbounded = Vec::with_capacity(ROUNDS);
+        let mut bounded = Vec::with_capacity(ROUNDS);
+        for _ in 0..ROUNDS {
+            let t = Instant::now();
+            server.tool_text("modules", json!({ "session_id": session }), TARGET_STEP);
+            unbounded.push(t.elapsed());
+
+            let t = Instant::now();
+            server.tool_text(
+                "execute",
+                json!({ "command": command.clone(), "session_id": session }),
+                TARGET_STEP,
+            );
+            bounded.push(t.elapsed());
+        }
+        println!("`{label}` x{ROUNDS}");
+        println!("   unbounded (`modules` / lm): {}", spread(unbounded));
+        println!("   bounded   (`execute`):      {}", spread(bounded));
+    }
+
+    server.tool_text("end_session", json!({ "session_id": session }), TARGET_STEP);
 }

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -1503,7 +1503,7 @@ fn measure_what_the_bounded_path_costs_a_quick_command() {
 // operator has:
 //
 //     $env:WINDBG_MCP_SMOKE_KERNEL = "net:port=50000,key=<w.x.y.z>"
-//     cargo test --test mcp_smoke -- --ignored --nocapture live_kernel
+//     cargo test --test mcp_smoke -- --ignored --nocapture --test-threads=1 live_kernel
 //
 // Run it **last**, on its own, as the final step of the manual checklist: it is the only tier
 // whose blast radius includes a VM you care about.
@@ -1526,12 +1526,33 @@ fn kernel_tier() -> Option<String> {
     }
 }
 
-/// The `port=` field of a KDNET connection string.
+/// The `port=` field of a KDNET connection string such as `net:port=50000,key=w.x.y.z`.
+///
+/// The transport prefix sits on the *first* field (`net:port=50000`), not in front of the whole
+/// string, so matching `port=` against the raw field silently misses — and a `None` here skips the
+/// UDP-ownership assertion rather than failing it, which is how the first version of this went
+/// unnoticed through several runs.
 fn kdnet_port(connection: &str) -> Option<u16> {
     connection
         .split(',')
+        .filter_map(|field| field.rsplit(':').next())
         .find_map(|field| field.trim().strip_prefix("port="))
         .and_then(|port| port.trim().parse().ok())
+}
+
+/// Pinned in the default tier, because the failure it guards against is a *silent skip*: the
+/// assertion it feeds is conditional on `Some`, so a parser that stops matching takes the proof
+/// with it and every run still passes.
+#[test]
+fn a_kdnet_connection_string_yields_its_port() {
+    assert_eq!(kdnet_port("net:port=50000,key=1.1.1.1"), Some(50000));
+    assert_eq!(kdnet_port("net:port=50005,key=a.b.c.d,foo=1"), Some(50005));
+    // Spacing and field order are the caller's business, not ours.
+    assert_eq!(kdnet_port("net: port=50000 , key=x"), Some(50000));
+    assert_eq!(kdnet_port("net:key=1.1.1.1,port=50000"), Some(50000));
+    // Transports with no port at all must not produce a bogus one.
+    assert_eq!(kdnet_port("com:pipe,port=\\\\.\\pipe\\kd"), None);
+    assert_eq!(kdnet_port("net:key=1.1.1.1"), None);
 }
 
 /// `System Uptime` out of `.time` output, e.g. `0 days 0:05:31.599`.
@@ -1617,13 +1638,17 @@ fn a_live_kernel_session_attaches_coexists_and_detaches_cleanly() {
          port, nothing else can attach:\n{report}"
     );
     let session = session_id_of(&report);
-    // `vertarget`, run by the opener inside the worker.
-    assert!(
-        report.contains("Kernel"),
-        "the post-attach report should be `vertarget` output naming the kernel:\n{report}"
-    );
 
+    // Everything from here runs under `catch_unwind`, because the target is now broken in and
+    // stays that way until the detach below — including the `vertarget` check, which has no
+    // business being the one assertion that can leave a machine frozen.
     let outcome = catch_unwind(AssertUnwindSafe(|| {
+        // `vertarget`, run by the opener inside the worker.
+        assert!(
+            report.contains("Kernel"),
+            "the post-attach report should be `vertarget` output naming the kernel:\n{report}"
+        );
+
         // The milestones made it across: not still "attaching", which is where a parked one sits.
         let status = server.tool_text("session_status", json!({ "session_id": session }), STEP);
         assert!(
@@ -1761,7 +1786,9 @@ fn disconnecting_releases_a_live_kernel_session_rather_than_killing_it() {
     // `end_session` — that is the whole point. The log is captured before `shutdown` consumes
     // the harness, since what it says is half the evidence.
     let log = Arc::clone(&server.stderr_log);
-    let exit = server.shutdown();
+    // `shutdown` panics if the server does not exit in 20s, and the kernel is broken in right
+    // now — so even this is collected rather than allowed to propagate.
+    let exit = catch_unwind(AssertUnwindSafe(|| server.shutdown()));
 
     // The stderr reader is a separate thread draining a pipe the process just closed, so poll
     // rather than snapshot — a bare read races the drain and fails intermittently.
@@ -1809,7 +1836,10 @@ fn disconnecting_releases_a_live_kernel_session_rather_than_killing_it() {
     };
 
     // --- now assert ----------------------------------------------------------------------
-    assert_eq!(exit, Some(0), "a disconnect should still be a clean exit");
+    match exit {
+        Ok(code) => assert_eq!(code, Some(0), "a disconnect should still be a clean exit"),
+        Err(panic) => resume_unwind(panic),
+    }
     assert!(
         stderr.contains("releasing 1 session"),
         "the disconnect should have *released* the kernel session, not killed its worker — a \


### PR DESCRIPTION
Closes #61. Takes the structural fix (FOLLOWUPS item 10) rather than the two mitigations the issue offered — both are subsumed by it, the second for free.

## What was wrong

A live kernel attach waits with `WaitForEvent(INFINITE)`, and `SetInterrupt` cannot reach a wait that has not yet connected. A guest that is powered off, not booted with debugging enabled, or pointed at the wrong host/port/key therefore parks the attach **permanently** — measured on hardware at 300s with no bound and no cancellation path.

With one engine thread that park owned the whole server: every later tool call queued behind it, `end_session` included, and the only recovery was restarting the process. The trigger is the most common mistake in kernel debugging, so an agent hit it routinely and had no way out.

## What this does

Runs the MCP protocol in a **supervisor** process and each open target in its own **engine worker** child process (`--engine-worker`). dbgeng.dll holds one debuggee session per process, so the process is the natural unit of a session — this is the shape the library already imposes, not one invented for the bug.

The park now costs one worker, and **`end_session` terminates it**: it asks the worker to let go, and kills the process if it will not. That is the in-band recovery that did not exist.

- `src/engine.rs` — rewritten as the supervisor: session registry, worker supervision, routing.
- `src/worker.rs` (new) — the child process; the `DebugEngine` is still confined to one thread inside it.
- `src/proto.rs` (new) — line-delimited JSON between the two.

## What callers will notice

- **Openers no longer replace each other.** Up to 4 sessions at once; at the limit the oldest *idle* session is reclaimed, and if every session is busy the open is refused with the list rather than picking a victim. Every opener's description dropped "replaces any session already open", because it does not.
- **`session_id` routes rather than merely detects.** An `open_dump` cannot disturb a kernel attach, and an `end_session` for session A can no longer be ordered against an open of B — there is nothing shared to order.
- **`session_status` lists every session** with its state and how long it has been in it. That is the issue's mitigation (2), but the advice it gives now works: past the point a healthy attach takes, it says the wait will not return and names `end_session`.
- Omitting `session_id` falls back to the newest session still accepting work, so ending the newest lands on the one before it rather than "no session open".
- Failures scoped to a session (debugger error, timeout, refused handle, dead worker) are all tool errors. The only JSON-RPC protocol error left is "no engine worker could be started at all".

## The non-obvious part

A closure cannot cross a process boundary, so the closures marshalled onto the engine thread became serializable ops — deliberately *tool*-shaped, not DbgEng-shaped, so a tool that is several engine calls (`reachable_from_dispatch`'s call-graph walk, `run_to_address`'s resolve-then-run) stays one indivisible job. Split into per-primitive round trips, another call for the same session could interleave between the parts and the walk would see a target that moved underneath it.

The watchdog budget split with it, and this is where I got it wrong first. The supervisor now sends the caller's remaining *patience* and the worker derives the deadline, because the supervisor writes a request the moment it is submitted and the queueing then happens on the far side of the pipe, where only the worker can measure it. Deriving it supervisor-side compiles, passes the unqueued test, and is wrong: a command that queued for most of the budget runs a full budget *after* its caller gave up. The queue-aware test caught it; both `DECISIONS.md` and `docs/smoke-test.md` record it so the arithmetic does not drift back.

## Verification

`cargo test` with `WINDBG_MCP_SMOKE_DUMP=1`: 82 unit + 16 wire tests green. New coverage, all against a real engine:

- **`a_kernel_attach_that_never_connects_costs_one_session_and_can_be_ended`** — the reported case end to end: an `attach_kernel` parked on a dead port, a dump opened *while it is parked*, then `end_session` reclaiming it, checking by pid that the worker process is gone. It skips itself if the attach fails outright instead of parking, so it never passes for the wrong reason.
- **`two_sessions_coexist_and_do_not_disturb_each_other`** — impossible by construction under the old design.
- **`engine_workers_do_not_outlive_the_connection`** — otherwise every disconnect leaks a debugger process, and for a launch or attach, a debuggee with it.

The three bounded-command hardware tests moved to the binary level (`#[ignore]`d, third tier) since the wiring they prove now spans two processes; all three pass. The session cap, reclamation and handle-retirement paths were driven by hand.

## Not done

**Per-worker symbol state.** Each session has its own `.sympath` and cache, which is correct — sessions are independent — but means `set_symbol_path` does not carry to a session opened later. Recorded in FOLLOWUPS item 10; the fix if it becomes annoying is a supervisor-held default applied at worker startup, not shared state.

**No release build run locally** — `target/release/windbg-mcp.exe` is held by a connected MCP client (see `CLAUDE.md`), so this was verified on the dev profile; CI covers release on a fresh runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for up to four concurrent, independently managed debug sessions.
  - Added session listing, status reporting, isolated routing, cleanup, and recovery guidance.
  - Added bounded command handling to interrupt long-running operations without affecting other sessions.
  - Added worker recovery and clearer diagnostics for stalled or disconnected sessions.

- **Bug Fixes**
  - Debugger and session failures are now reported as actionable tool errors.

- **Documentation**
  - Updated usage, troubleshooting, smoke-test, and debugging guidance for multi-session workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->