### PR TITLE
fix: let a worker shutdown missed release itself instead of killing it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A worker the server never got round to releasing now lets go by itself, rather than being
+  killed with its target still attached** ([#67](https://github.com/glslang/windbg-mcp/issues/67)).
+
+  Workers were spawned with tokio's `kill_on_drop`, so the last act of a supervisor on its way out
+  was to `TerminateProcess` every worker handle it still held. For a session shutdown had already
+  released that is harmless. For one it *missed* it is the whole failure: the worker is killed
+  before it can detach, and a live kernel left attached-but-halted is a target machine stopped
+  until someone reboots it. Belt-and-braces that cut the braces.
+
+  A worker has handled this on its own since 0.4.0 — its stdin reaching EOF means "the supervisor
+  is gone", and it asks its engine to release the target before exiting, bounded at five seconds —
+  so the fix is to stop pre-empting it. `kill_on_drop` is gone; EOF is the teardown on every route
+  out, including a Ctrl+C or a crash where there is no supervisor left to do anything. Killing is
+  now only ever deliberate: after a release was asked for and refused, or on a worker known to
+  hold nothing.
+
+  The way shutdown could miss a worker is closed too. An open that was admitted before the client
+  disconnected, and whose worker finished its handshake after shutdown had walked the registry,
+  used to register anyway and be handed its opener — starting an attach nobody was left to end.
+  Registration now re-checks, under the same lock that closes the gate, so such an open is refused
+  and its (target-less) worker ended. That makes the set of workers to release one that cannot
+  grow behind shutdown's snapshot, so the timed drain that used to approximate the same guarantee
+  is gone with it.
+
 ## [0.4.0] - 2026-08-03
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   now only ever deliberate: after a release was asked for and refused, or on a worker known to
   hold nothing.
 
+  Workers are also spawned into their **own process group**, without which EOF could not be the
+  teardown at all on one route: an interactive Ctrl+C goes to every process sharing the console,
+  and a child inherits its parent's group, so a worker took the default console handler and died
+  where it stood — no stdin close, no release. It is the route where the server can help least,
+  since its own default handler ends it before it can run any shutdown, and it is the one a
+  developer driving this from a terminal hits by reflex.
+
   The way shutdown could miss a worker is closed too. An open that was admitted before the client
   disconnected, and whose worker finished its handshake after shutdown had walked the registry,
   used to register anyway and be handed its opener — starting an attach nobody was left to end.

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -217,6 +217,12 @@ cache, which is correct (sessions are independent) but means a `set_symbol_path`
 session opened later. The fix is a supervisor-held default applied at worker startup, not shared
 state between running workers.
 
+Fixed since, from the same review: [#67](https://github.com/glslang/windbg-mcp/issues/67) — workers
+were spawned with `kill_on_drop`, so a worker shutdown missed was terminated with its target still
+attached. `kill_on_drop` is gone (EOF on the worker's stdin is now the only teardown, which it
+already handled), and registration re-checks the shutdown gate so the missable window is closed
+rather than merely survivable.
+
 Two ordering details the review of #62 raised and that PR deliberately left alone, both filed:
 [#64](https://github.com/glslang/windbg-mcp/issues/64) (`end_session` keeps accepting calls while it
 tears the session down — the fix wants the `Gate` treatment `retires` already has) and

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -76,6 +76,19 @@ const END_SESSION_TIMEOUT: Duration = Duration::from_secs(20);
 /// rather than the cost per session.
 const SHUTDOWN_RELEASE_TIMEOUT: Duration = Duration::from_secs(5);
 
+/// `CREATE_NEW_PROCESS_GROUP`, which every worker is spawned with.
+///
+/// An interactive Ctrl+C is delivered to *every* process attached to the console, and a child
+/// inherits its parent's process group — so without this a worker takes the default console
+/// handler and terminates on the spot, before its stdin closes and before it can release its
+/// target. That is precisely the halted kernel this design exists to avoid, arriving by the one
+/// route where the supervisor cannot help: its own default handler ends it, so it never reaches
+/// [`Sessions::shutdown`].
+///
+/// With the flag, Ctrl+C is disabled for the worker's group. The supervisor still dies, its handles
+/// still close, and the worker meets the EOF path that knows how to let go.
+const CREATE_NEW_PROCESS_GROUP: u32 = 0x0000_0200;
+
 /// Counter behind [`mint_session_id`]. Only needs to be unique within this process.
 static SESSION_SEQ: AtomicU64 = AtomicU64::new(1);
 
@@ -1018,7 +1031,13 @@ impl Sessions {
             }));
         }
         for task in releasing {
-            let _ = task.await;
+            // A panic in here is not a correctness gap — the worker still has its own EOF teardown
+            // to fall back on — but it is the difference between a target released and a target
+            // released by the five-second best effort, and an operator should not have to infer
+            // that from a frozen guest.
+            if let Err(e) = task.await {
+                tracing::error!("shutting down: a session's release task failed: {e}");
+            }
         }
     }
 
@@ -1208,6 +1227,11 @@ impl Sessions {
             // machine left halted. So EOF is the teardown, on every route out — clean shutdown,
             // Ctrl+C, or a crash — and [`Session::kill`] is the deliberate one, used only once a
             // release has been asked for and refused, or on a worker known to hold nothing.
+            //
+            // Which is why the worker also gets its own process group: see
+            // [`CREATE_NEW_PROCESS_GROUP`]. EOF cannot be the teardown if a console Ctrl+C ends the
+            // worker before its stdin ever closes.
+            .creation_flags(CREATE_NEW_PROCESS_GROUP)
             .spawn()
             .map_err(|e| format!("could not start an engine worker ({}): {e}", exe.display()))?;
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -76,28 +76,6 @@ const END_SESSION_TIMEOUT: Duration = Duration::from_secs(20);
 /// rather than the cost per session.
 const SHUTDOWN_RELEASE_TIMEOUT: Duration = Duration::from_secs(5);
 
-/// How many times shutdown re-checks for workers registered while it was running.
-///
-/// One round can miss an open that was between spawning its worker and registering it when the
-/// client disconnected. Two is one round plus a retry, which is all that reasoning needs — new
-/// opens are refused before the first — and it keeps the worst case (each round waiting out
-/// [`SHUTDOWN_RELEASE_TIMEOUT`]) inside the budget a client allows for the process to exit.
-const SHUTDOWN_ROUNDS: usize = 2;
-
-/// How long shutdown will wait for an open that was *already admitted* to register its worker,
-/// when there is nothing else left to release.
-///
-/// It cannot simply stop: such an open holds no target only until it registers, and it opens one
-/// immediately afterwards. Bounded rather than waiting out the worker handshake in full, because
-/// a client that has disconnected is entitled to see the process go — and a worker that has not
-/// registered by then still holds nothing, so what it costs is an ungraceful kill of an engine
-/// with no target.
-const SHUTDOWN_DRAIN: Duration = Duration::from_secs(2);
-
-/// How often that drain re-checks. Short: registration follows the worker's handshake by
-/// microseconds, so this is nearly always one poll.
-const SHUTDOWN_POLL: Duration = Duration::from_millis(50);
-
 /// Counter behind [`mint_session_id`]. Only needs to be unique within this process.
 static SESSION_SEQ: AtomicU64 = AtomicU64::new(1);
 
@@ -536,7 +514,8 @@ pub struct OpenReport {
 pub enum OpenError {
     /// No worker could be started, so no session exists and none could.
     Unavailable(String),
-    /// Every session slot is taken by work in flight.
+    /// Refused without opening anything: every session slot is taken by work in flight, or the
+    /// connection is going away. The message says which.
     NoRoom(String),
     /// The open failed before anything was created or claimed. The slate is clean and opening
     /// again is the correct recovery.
@@ -632,8 +611,9 @@ impl Registry {
     /// Not the same set as [`Self::live`], and shutdown needs this one. A session claimed for
     /// reclamation is marked `Closed` immediately but its worker is released in the background, so
     /// between those two points it is not live and still owns a process — and a client
-    /// disconnecting in that window would drop the runtime, cancel the release, and take the
-    /// worker down by `kill_on_drop` without the `EndSession` that leaves a kernel target running.
+    /// disconnecting in that window would drop the runtime and cancel that release, leaving the
+    /// worker to fall back on noticing its own stdin close: a bounded best effort, where an
+    /// orderly `EndSession` was there for the asking.
     fn owning_workers(&self) -> Vec<Arc<Session>> {
         self.all
             .iter()
@@ -649,9 +629,10 @@ impl Registry {
     ///
     /// Nor is one that still owns a worker, whatever its state says. A session claimed for
     /// reclamation is `Closed` at once and released in the background, and evicting it in that
-    /// window would take it out of [`Self::owning_workers`] — so a disconnect would no longer
-    /// find it, the release would be cancelled with the runtime, and `kill_on_drop` would finish
-    /// the worker without the `EndSession` a halted kernel needs.
+    /// window would take it out of [`Self::owning_workers`] — so a disconnect would no longer find
+    /// it, the release would be cancelled with the runtime, and the worker would be left to let go
+    /// on its own rather than being asked properly, which is the weaker of the two guarantees a
+    /// halted kernel can be given.
     fn trim(&mut self) {
         while self.all.len() > CLOSED_HISTORY + MAX_SESSIONS {
             let evictable = self.all.iter().position(|s| {
@@ -824,10 +805,12 @@ impl Sessions {
             // start must not cost the caller a target they already had.
             Err(why) => return Err(OpenError::Unavailable(why)),
         };
-        {
-            let mut registry = self.registry();
-            registry.all.push_back(Arc::clone(&session));
-            registry.trim();
+        if let Err(why) = self.admit(&session) {
+            // Refused *before* the opener was written, so this worker is `Ready` and holds
+            // nothing at all — no dump, no trace, no attach. There is no target to release and so
+            // nothing for its stdin closing to accomplish; killing it is the whole teardown.
+            session.kill();
+            return Err(OpenError::NoRoom(why));
         }
         // Released only now: from here the session is counted in `all` instead, and holding both
         // would count this open twice.
@@ -994,63 +977,48 @@ impl Sessions {
     /// kernel outright costs. Sessions are released concurrently because they are independent
     /// processes and the client is waiting.
     pub async fn shutdown(&self) {
-        // Refuse new opens first, so the set being walked stops growing. Without this an open
-        // that was between spawning its worker and registering it when the client disconnected
-        // registers *after* the snapshot below, and its worker is never released — for a live
-        // kernel, that is a target left halted.
-        self.registry().closing = true;
-
-        // Rounds rather than one pass, because an open already past the gate can still register
-        // while the first round runs. It terminates: nothing new can be admitted, so each round
-        // finds only what the previous one raced with, and in practice the second is empty.
-        let drain_by = Instant::now() + SHUTDOWN_DRAIN;
-        for _ in 0..SHUTDOWN_ROUNDS {
-            // Every session that still *owns a worker*, not every live one. A session claimed for
-            // reclamation is already `Closed` while its release runs in the background, and a
-            // disconnect in that window would otherwise drop the runtime, cancel that release,
-            // and let `kill_on_drop` terminate the worker — the same halted target by another
-            // route. Releasing one twice is harmless; missing one is not.
-            let owners = loop {
-                let (owners, opening) = {
-                    let registry = self.registry();
-                    (registry.owning_workers(), registry.opening)
-                };
-                if !owners.is_empty() {
-                    break owners;
-                }
-                // Nothing to release *yet* is not the same as nothing to release. An open
-                // admitted before the gate closed may still be waiting for its worker's
-                // handshake, so it is not in the registry to be found — and it holds no target
-                // only until it registers, at which point it opens one immediately. Returning
-                // here would leave exactly that worker to `kill_on_drop`.
-                if opening == 0 || Instant::now() >= drain_by {
-                    return;
-                }
-                tokio::time::sleep(SHUTDOWN_POLL).await;
-            };
-            tracing::info!("shutting down: releasing {} session(s)", owners.len());
-            let mut releasing = Vec::with_capacity(owners.len());
-            for session in owners {
-                let sessions = self.clone();
-                releasing.push(tokio::spawn(async move {
-                    // Marked first so nothing new is routed to a session on its way out; the
-                    // release runs as the supervisor's own teardown and so passes the gate that
-                    // closes. A session already closed keeps the reason it closed for.
-                    session.set_state(SessionState::Closed(
-                        "the server is shutting down".to_string(),
-                    ));
-                    sessions
-                        .release(
-                            &session,
-                            Call::supervisor(EngineOp::EndSession),
-                            SHUTDOWN_RELEASE_TIMEOUT,
-                        )
-                        .await;
-                }));
-            }
-            for task in releasing {
-                let _ = task.await;
-            }
+        // Closing the gate and taking the snapshot under **one** lock acquisition is what makes
+        // one pass enough. [`Self::admit`] re-checks `closing` under this same lock after its
+        // worker's handshake, so every open is on one side or the other of this moment: either it
+        // registered first and is in `owners`, or it registers never and is refused. The set
+        // cannot grow behind this snapshot, which is what earlier versions used a timed drain to
+        // approximate.
+        //
+        // Every session that still *owns a worker*, not every live one. A session claimed for
+        // reclamation is already `Closed` while its release runs in the background, and a
+        // disconnect in that window would otherwise drop the runtime and cancel that release,
+        // leaving the worker to notice its own stdin close — a five-second best-effort where an
+        // orderly release was available. Releasing one twice is harmless; missing one is not.
+        let owners = {
+            let mut registry = self.registry();
+            registry.closing = true;
+            registry.owning_workers()
+        };
+        if owners.is_empty() {
+            return;
+        }
+        tracing::info!("shutting down: releasing {} session(s)", owners.len());
+        let mut releasing = Vec::with_capacity(owners.len());
+        for session in owners {
+            let sessions = self.clone();
+            releasing.push(tokio::spawn(async move {
+                // Marked first so nothing new is routed to a session on its way out; the release
+                // runs as the supervisor's own teardown and so passes the gate that closes. A
+                // session already closed keeps the reason it closed for.
+                session.set_state(SessionState::Closed(
+                    "the server is shutting down".to_string(),
+                ));
+                sessions
+                    .release(
+                        &session,
+                        Call::supervisor(EngineOp::EndSession),
+                        SHUTDOWN_RELEASE_TIMEOUT,
+                    )
+                    .await;
+            }));
+        }
+        for task in releasing {
+            let _ = task.await;
         }
     }
 
@@ -1069,11 +1037,7 @@ impl Sessions {
     fn take_slot(&self) -> Result<Slot, String> {
         let mut registry = self.registry();
         if registry.closing {
-            return Err(
-                "this server is shutting down — the client disconnected, and every session is \
-                 being released. Nothing more can be opened on this connection."
-                    .to_string(),
-            );
+            return Err(shutting_down());
         }
         let live = registry.live();
         // How many sessions would have to be reclaimed to be back at the limit once this open,
@@ -1197,6 +1161,30 @@ impl Sessions {
         Some(Arc::clone(idle))
     }
 
+    /// Registers a worker that has just come up — or refuses it, because the connection it was
+    /// opened for is gone.
+    ///
+    /// This is a *second* reading of the same gate [`Self::take_slot`] checked, and the gap
+    /// between them is the point: an open spends a whole worker handshake there, up to
+    /// [`WORKER_READY_TIMEOUT`], and the client can disconnect in the middle of it. By then
+    /// [`Self::shutdown`] has walked the registry and will not walk it again, so registering here
+    /// would hand a target to a worker nobody is left to release — and for a live kernel attach
+    /// that commits before the process goes, a target left halted.
+    ///
+    /// Refusing is what makes shutdown's single pass sound. Both take the registry lock, so an
+    /// open is on one side or the other of the moment `closing` is set: it either registers first
+    /// and is found by the snapshot, or is refused here. There is no interleaving in which a
+    /// worker holding a target goes unseen.
+    fn admit(&self, session: &Arc<Session>) -> Result<(), String> {
+        let mut registry = self.registry();
+        if registry.closing {
+            return Err(shutting_down());
+        }
+        registry.all.push_back(Arc::clone(session));
+        registry.trim();
+        Ok(())
+    }
+
     /// Starts a worker process and waits for it to report that its engine came up.
     async fn spawn(
         &self,
@@ -1211,7 +1199,15 @@ impl Sessions {
             .stdout(Stdio::piped())
             // Worker logs join the server's own, which is where an MCP client looks for them.
             .stderr(Stdio::inherit())
-            .kill_on_drop(true)
+            // Deliberately **not** `kill_on_drop`, and the absence is load-bearing. Dropping this
+            // handle — or the whole process exiting — closes the worker's stdin, and a worker
+            // reads that EOF as "the supervisor is gone" and asks its engine to release the target
+            // before it exits, bounded (`worker::run`). Terminating on drop pre-empts exactly
+            // that: a worker this server never got round to releasing would die by
+            // `TerminateProcess` with its target still attached, which for a live kernel means a
+            // machine left halted. So EOF is the teardown, on every route out — clean shutdown,
+            // Ctrl+C, or a crash — and [`Session::kill`] is the deliberate one, used only once a
+            // release has been asked for and refused, or on a worker known to hold nothing.
             .spawn()
             .map_err(|e| format!("could not start an engine worker ({}): {e}", exe.display()))?;
 
@@ -1375,6 +1371,16 @@ fn settle_open(session: &Session, result: &Result<String, EngineError>) -> bool 
             .then_some(SessionState::Open)
     });
     settled.is_live()
+}
+
+/// Why an open is refused once the client has disconnected.
+///
+/// Shared by the two gates that refuse it — before a worker is spawned, and again after it comes
+/// up — so the answer cannot drift depending on which one the caller raced.
+fn shutting_down() -> String {
+    "this server is shutting down — the client disconnected, and every session is being released. \
+     Nothing more can be opened on this connection."
+        .to_string()
 }
 
 fn worker_gone(id: &str) -> String {
@@ -1957,12 +1963,58 @@ mod tests {
         assert_eq!(landed.state(), SessionState::Open);
     }
 
+    /// The gap `admit` exists to close: a worker that finishes its handshake after the client has
+    /// gone must never be registered.
+    ///
+    /// `take_slot` let this open through while the connection was alive, and it then spent a whole
+    /// worker handshake — up to `WORKER_READY_TIMEOUT`, against a `SHUTDOWN_RELEASE_TIMEOUT` of
+    /// five seconds — before reaching this point. Registering now would send it an opener, and for
+    /// a kernel attach that commits, the process would exit with a target halted.
+    #[tokio::test]
+    async fn a_worker_that_comes_up_after_the_client_has_gone_is_not_registered() {
+        let sessions = Sessions::new(Duration::from_secs(1));
+        // Nothing to release, so this is the whole of shutdown: close the gate.
+        sessions.shutdown().await;
+
+        let late = dormant("sess-late", SessionState::Opening);
+        let refused = sessions
+            .admit(&late)
+            .expect_err("a worker that came up after the disconnect must be refused");
+        assert!(
+            refused.contains("shutting down"),
+            "the refusal has to say why: {refused}"
+        );
+        assert!(
+            sessions.registry().all.is_empty(),
+            "a refused worker must leave nothing behind for `owning_workers` to have missed"
+        );
+    }
+
+    /// And the ordinary path still registers, which is what makes the refusal above a gate rather
+    /// than a wall.
+    #[tokio::test]
+    async fn a_worker_that_comes_up_on_a_live_connection_is_registered() {
+        let sessions = Sessions::new(Duration::from_secs(1));
+        let session = dormant("sess-1", SessionState::Opening);
+        sessions.admit(&session).expect("a live connection admits");
+        assert_eq!(
+            sessions
+                .registry()
+                .all
+                .iter()
+                .map(|s| s.id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["sess-1"]
+        );
+    }
+
     /// Shutdown is keyed on owning a worker, not on being live.
     ///
     /// A session claimed for reclamation is `Closed` immediately while its release runs in the
     /// background. A disconnect landing in that window must still collect it: otherwise the
-    /// runtime is dropped, the release is cancelled, and `kill_on_drop` terminates the worker
-    /// without the `EndSession` that leaves a kernel target running.
+    /// runtime is dropped, the release is cancelled, and the worker is left to notice its stdin
+    /// close and let go on its own — best effort, when the orderly `EndSession` a halted kernel
+    /// wants was available.
     #[tokio::test]
     async fn shutdown_collects_a_session_whose_release_is_still_in_flight() {
         let sessions = Sessions::new(Duration::from_secs(1));
@@ -2004,8 +2056,8 @@ mod tests {
     ///
     /// A reclaimed session is `Closed` at once and released in the background. Evicting it in that
     /// window takes it out of `owning_workers`, so a disconnect no longer finds it, the release is
-    /// cancelled with the runtime, and `kill_on_drop` finishes the worker without the
-    /// `EndSession` a halted kernel needs.
+    /// cancelled with the runtime, and the worker is left to let go on its own instead of being
+    /// asked — the weaker guarantee, for the target that can least afford it.
     #[tokio::test]
     async fn history_eviction_keeps_a_session_that_still_owns_a_worker() {
         let sessions = Sessions::new(Duration::from_secs(1));

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -136,6 +136,12 @@ pub fn run() -> ! {
     // stdin closed: the supervisor ended this session, or died. Either way this process has no
     // reason to exist.
     //
+    // This is the *only* thing that ends a worker the supervisor did not explicitly kill — it does
+    // not set `kill_on_drop`, deliberately (`engine::Sessions::spawn`). So the path below has to
+    // be unconditional, and is: whatever the engine thread is doing, and whether or not it ever
+    // picks the release up, this process exits within `ABRUPT_EXIT_RELEASE`. Nothing upstream
+    // needs a backstop for a worker that "does not exit on EOF", because there is no such worker.
+    //
     // On the clean path the supervisor has already had this session release its target, so the
     // engine has nothing left to do. On the other one — Ctrl+C, a crash, anything that kills the
     // supervisor without it running its own shutdown — nobody has, and exiting here would leave a

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -149,8 +149,16 @@ pub fn run() -> ! {
     // bounded: an idle engine obliges in milliseconds, a parked one never will, and either way
     // this process is gone within `ABRUPT_EXIT_RELEASE`.
     //
+    // Ctrl+C only reaches this path because a worker is spawned into its own process group
+    // (`engine::CREATE_NEW_PROCESS_GROUP`). Without that it would be delivered here too, and the
+    // default console handler would end this process where it stands — no EOF, no release.
+    //
     // Bounded and then abandoned, never joined: the engine thread may be blocked in DbgEng
     // forever, and this is precisely the case where that must not hold anything up.
+    //
+    // Logged because it is otherwise invisible: this is the teardown nobody asked for, and an
+    // operator looking at a target that came back fine wants to see which path did it.
+    tracing::info!("worker: supervisor is gone; releasing the target before exit");
     let (ack, released) = mpsc::channel();
     if tx.send(Job::Release(ack)).is_ok() {
         let _ = released.recv_timeout(ABRUPT_EXIT_RELEASE);

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -289,6 +289,16 @@ impl Server {
         text_of(&response["result"])
     }
 
+    /// Terminates the supervisor outright, giving it no chance to run its own shutdown.
+    ///
+    /// Stdin is *not* closed first — that would be the graceful path this is the opposite of. The
+    /// point is to leave the workers with nothing but their own stdin reaching EOF as the dead
+    /// supervisor's handles are closed.
+    fn kill_supervisor(mut self) {
+        self.child.kill().expect("terminate the supervisor");
+        self.child.wait().expect("reap the supervisor");
+    }
+
     /// Closes stdin and waits for exit, returning the exit code.
     fn shutdown(mut self) -> Option<i32> {
         drop(self.stdin.take());
@@ -1191,7 +1201,9 @@ fn engine_workers_do_not_outlive_the_connection() {
         "clean disconnect should be a clean exit"
     );
 
-    // The worker notices its stdin close and exits on its own; give it a moment to.
+    // Two ways it can be gone, and this asserts only the outcome: shutdown asked it to release
+    // and then ended it, or — for a worker shutdown never saw — its own stdin closed as the
+    // supervisor exited. Either way, no process is left behind.
     let deadline = Instant::now() + Duration::from_secs(20);
     while process_alive(worker) && Instant::now() < deadline {
         std::thread::sleep(Duration::from_millis(50));
@@ -1199,6 +1211,43 @@ fn engine_workers_do_not_outlive_the_connection() {
     assert!(
         !process_alive(worker),
         "engine worker pid {worker} outlived the connection — every disconnect would leak one"
+    );
+}
+
+/// A worker whose supervisor died without saying goodbye still lets go and exits.
+///
+/// This is the mechanism the whole teardown story now rests on. The supervisor does not terminate
+/// its workers when it goes — `Sessions::spawn` deliberately does not set `kill_on_drop` — because
+/// killing pre-empts the release: a worker the supervisor never got round to asking (one that
+/// registered after shutdown had walked the registry, say) would die with its target still
+/// attached, and a live kernel left attached-but-halted is a machine that needs rebooting.
+///
+/// So the guarantee is the worker's own: stdin reaching EOF means "the supervisor is gone", and it
+/// asks its engine to release before exiting, bounded. Killed outright here, the supervisor
+/// contributes nothing — no shutdown, no `EndSession`, not even a clean stdin close — which is
+/// exactly the case where nothing else can stand in.
+#[test]
+fn a_worker_lets_go_and_exits_when_its_supervisor_is_killed_outright() {
+    let Some(dump) = target_tier() else { return };
+    let mut server = Server::started();
+    let session =
+        session_id_of(&server.tool_text("open_dump", json!({ "path": dump }), TARGET_STEP));
+    let status = server.tool_text("session_status", json!({}), TARGET_STEP);
+    let worker = engine_pid_of(&status, &session);
+    assert!(process_alive(worker), "the worker should be running");
+
+    server.kill_supervisor();
+
+    // Generous against the worker's own release budget (`ABRUPT_EXIT_RELEASE`, 5s), because what
+    // is under test is that it exits at all without being killed, not how fast.
+    let deadline = Instant::now() + Duration::from_secs(30);
+    while process_alive(worker) && Instant::now() < deadline {
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    assert!(
+        !process_alive(worker),
+        "engine worker pid {worker} outlived a killed supervisor — with nothing terminating it, \
+         EOF on its stdin is the only thing that ends it, and it did not"
     );
 }
 


### PR DESCRIPTION
Closes #67.

The fourth route to the same outcome — a worker killed rather than released, and a live kernel left attached-but-halted. The report suggested extending shutdown's drain; that trades an improbable race for a certain 30s hang, so this takes the other option it named: **make EOF the only teardown**.

## `kill_on_drop` is gone

At exit the chain was `serve` returns → `sessions` drops → each `Child` drops → `TerminateProcess`. For a session shutdown had already released, harmless. For one it *missed*, that kill **is** the failure: the worker dies before it can detach.

It was also redundant. Since a5fc0e6 a worker reads stdin EOF as "the supervisor is gone" and asks its engine to release the target before exiting, bounded at `ABRUPT_EXIT_RELEASE`. Belt-and-braces that cut the braces.

So EOF now ends every worker nobody explicitly killed, on all three routes out — clean shutdown, Ctrl+C, crash — and killing is only ever deliberate: after a release was asked for and refused, or on a worker known to hold nothing.

**No backstop is added** for "a worker that does not exit on EOF", because there is no such worker: the path in `worker::run` is unconditional whatever the engine thread is doing. `worker.rs` now says so where someone would go looking for the guarantee.

## The window shutdown could miss is closed

An open admitted before the client disconnected, whose worker finished its handshake after shutdown had walked the registry, used to register anyway and be handed its opener — starting an attach nobody was left to end.

Registration (`Sessions::admit`) now re-checks the gate **under the same lock that closes it**, so such an open is refused and its target-less worker ended. Every open is then on one side or the other of that moment: registered before it and found by the snapshot, or refused after it. There is no interleaving where a worker holding a target goes unseen.

That makes the set of workers to release one that cannot grow behind the snapshot — so the drain cdcf009 added to approximate the same guarantee comes back out, along with `SHUTDOWN_ROUNDS`, `SHUTDOWN_DRAIN` and `SHUTDOWN_POLL`. One pass, taken under the lock that sets `closing`.

## On the issue's three checks

- **The pre-reader window** is not a real race: EOF is level-triggered, so it is observed whenever the reader gets there, however late.
- **`engine_workers_do_not_outlive_the_connection`** still passes, and now proves the mechanism rather than proving `kill_on_drop`.
- **A bounded backstop** is not wanted, for the reason above.

## Tests

- Two unit tests for the registration gate (refused after the gate closes, registered before it).
- A new smoke test that kills the supervisor **outright** — no shutdown, no `EndSession`, not even a clean stdin close — and requires the worker to let go and exit with nothing standing in for it.
- `cargo test` with `WINDBG_MCP_SMOKE_DUMP=1`: 97 unit + 18 smoke, 0 failed. `fmt` and `clippy --all-targets` clean.

✅ **Verified on hardware.** The live-kernel tier — the only check that a disconnect leaves the guest *running*, which is exactly the property this moves — passes against a real KDNET target:

```
test a_live_kernel_session_attaches_coexists_and_detaches_cleanly ... live kernel session detached cleanly
test disconnecting_releases_a_live_kernel_session_rather_than_killing_it ... target uptime advanced 6.008s across a 4s disconnect
test result: ok. 2 passed; 0 failed
```

The uptime line is the assertion with teeth: a halted kernel takes no clock interrupt, so a guest killed with its worker would show a clock that stood still. It advanced by more than the disconnect lasted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved worker shutdown handling for more reliable and orderly cleanup.
  * Prevented new workers from registering after shutdown has started.
  * Ensured workers release their sessions and exit correctly when the supervisor stops unexpectedly.
  * Removed timed draining in favour of coordinated release handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
