### PR TITLE
fix: say what happened to each session's target on the way out

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1021,13 +1021,42 @@ impl Sessions {
                 session.set_state(SessionState::Closed(
                     "the server is shutting down".to_string(),
                 ));
-                sessions
+                let outcome = sessions
                     .release(
                         &session,
                         Call::supervisor(EngineOp::EndSession),
                         SHUTDOWN_RELEASE_TIMEOUT,
                     )
                     .await;
+                // `end_session` renders this for its caller. Shutdown has no caller — the client
+                // has already gone — so the log is the only place it can land, and it is exactly
+                // where an operator looks after finding a guest that did not come back.
+                match outcome {
+                    Release::Released(_) => {
+                        tracing::info!("shutting down: session {} released its target", session.id)
+                    }
+                    Release::AlreadyGone => tracing::info!(
+                        "shutting down: session {}'s worker had already exited",
+                        session.id
+                    ),
+                    Release::Parked => tracing::warn!(
+                        "shutting down: session {} did not let go within {SHUTDOWN_RELEASE_TIMEOUT:?} \
+                         and its worker (pid {}) was terminated — a live kernel target may be left \
+                         halted",
+                        session.id,
+                        session.pid
+                    ),
+                    Release::Refused(why) => tracing::warn!(
+                        "shutting down: session {} reported an error releasing its target ({why}); \
+                         its worker (pid {}) was terminated anyway",
+                        session.id,
+                        session.pid
+                    ),
+                    Release::Stale(why) => tracing::info!(
+                        "shutting down: session {} was already settled ({why})",
+                        session.id
+                    ),
+                }
             }));
         }
         for task in releasing {

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -293,6 +293,14 @@ pub struct Session {
     delivered: AtomicBool,
     /// How far the opener got, as [`OpenPhase`]. Separate from the state on purpose.
     phase: AtomicU8,
+    /// Whether *some* teardown got a successful `EndSession` out of this worker.
+    ///
+    /// Exists because two teardowns can race for one session — a reclamation releasing in the
+    /// background and a disconnect arriving mid-flight — and only the winner is told it worked.
+    /// The loser is failed out of its wait with [`EngineError::Lost`], which is indistinguishable
+    /// from the worker having crashed. This is what tells those two apart, and the difference is
+    /// "the target was let go" versus "a live kernel may be sitting halted".
+    released: AtomicBool,
     child: Mutex<Option<Child>>,
 }
 
@@ -972,6 +980,13 @@ impl Sessions {
             Err(EngineError::Stale(why)) => return Release::Stale(why),
             other => other,
         };
+        // Recorded **before** `fail_outstanding`, and the order is the whole point: that call is
+        // what turns another teardown's wait on this same session into `Lost`, so the flag has to
+        // be visible by the time anyone is failed out of it. Reordering these two lines silently
+        // restores a warning that says a target may be halted when it was just released.
+        if out.is_ok() {
+            session.released.store(true, Ordering::SeqCst);
+        }
         session.fail_outstanding(&format!("session `{}` was ended", session.id));
         session.kill();
         match out {
@@ -1035,15 +1050,23 @@ impl Sessions {
                     Release::Released(_) => {
                         tracing::info!("shutting down: session {} released its target", session.id)
                     }
-                    // Not the benign reading it looks like. This walk only covers sessions that
-                    // still *own* a worker handle, and releasing one takes that handle away — so
-                    // a session cannot reach here because it was already released. It reaches
-                    // here because its worker died with nobody having released anything, which
-                    // leaves the target in the same unconfirmed state `Parked` does.
+                    // `AlreadyGone` is two different events wearing one name, and they want
+                    // opposite reactions. A session being reclaimed releases in the background,
+                    // and this walk deliberately collects it mid-flight; if that release lands
+                    // first it fails this one out of its wait with `Lost`, which arrives here
+                    // looking exactly like a worker that crashed. `released` is what separates
+                    // them — see the field.
+                    Release::AlreadyGone if session.released.load(Ordering::SeqCst) => {
+                        tracing::info!(
+                            "shutting down: session {}'s target was released by a teardown already \
+                             in flight",
+                            session.id
+                        )
+                    }
                     Release::AlreadyGone => tracing::warn!(
                         "shutting down: session {}'s worker (pid {}) was gone before it could be \
-                         asked to release — it crashed or was terminated, so nothing detached its \
-                         target and a live kernel may be left halted",
+                         asked to release, and no other teardown reported releasing it — so \
+                         nothing detached its target and a live kernel may be left halted",
                         session.id,
                         session.pid
                     ),
@@ -1317,6 +1340,7 @@ impl Sessions {
             waiters: Arc::clone(&waiters),
             delivered: AtomicBool::new(false),
             phase: AtomicU8::new(OpenPhase::Started as u8),
+            released: AtomicBool::new(false),
             child: Mutex::new(Some(child)),
         });
 
@@ -1746,6 +1770,7 @@ mod tests {
             // Test doubles stand in for sessions their callers already hold.
             delivered: AtomicBool::new(true),
             phase: AtomicU8::new(phase as u8),
+            released: AtomicBool::new(false),
             child: Mutex::new(None),
         })
     }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -570,6 +570,7 @@ impl Drop for Slot {
 }
 
 /// How a worker took being told to let go of its target.
+#[derive(Debug)]
 enum Release {
     /// It released the target and said so.
     Released(String),
@@ -1046,44 +1047,28 @@ impl Sessions {
                 // `end_session` renders this for its caller. Shutdown has no caller — the client
                 // has already gone — so the log is the only place it can land, and it is exactly
                 // where an operator looks after finding a guest that did not come back.
-                match outcome {
-                    Release::Released(_) => {
+                match shutdown_note(&outcome, session.released.load(Ordering::SeqCst)) {
+                    ShutdownNote::Released => {
                         tracing::info!("shutting down: session {} released its target", session.id)
                     }
-                    // `AlreadyGone` is two different events wearing one name, and they want
-                    // opposite reactions. A session being reclaimed releases in the background,
-                    // and this walk deliberately collects it mid-flight; if that release lands
-                    // first it fails this one out of its wait with `Lost`, which arrives here
-                    // looking exactly like a worker that crashed. `released` is what separates
-                    // them — see the field.
-                    Release::AlreadyGone if session.released.load(Ordering::SeqCst) => {
-                        tracing::info!(
-                            "shutting down: session {}'s target was released by a teardown already \
-                             in flight",
-                            session.id
-                        )
-                    }
-                    Release::AlreadyGone => tracing::warn!(
-                        "shutting down: session {}'s worker (pid {}) was gone before it could be \
-                         asked to release, and no other teardown reported releasing it — so \
-                         nothing detached its target and a live kernel may be left halted",
-                        session.id,
-                        session.pid
+                    ShutdownNote::ReleasedElsewhere => tracing::info!(
+                        "shutting down: session {}'s target was released by a teardown already in \
+                         flight",
+                        session.id
                     ),
-                    Release::Parked => tracing::warn!(
-                        "shutting down: session {} did not let go within {SHUTDOWN_RELEASE_TIMEOUT:?} \
-                         and its worker (pid {}) was terminated — a live kernel target may be left \
-                         halted",
-                        session.id,
-                        session.pid
-                    ),
-                    Release::Refused(why) => tracing::warn!(
+                    ShutdownNote::Refused(why) => tracing::warn!(
                         "shutting down: session {} reported an error releasing its target ({why}); \
                          its worker (pid {}) was terminated anyway",
                         session.id,
                         session.pid
                     ),
-                    Release::Stale(why) => tracing::info!(
+                    ShutdownNote::Unreleased(what) => tracing::warn!(
+                        "shutting down: session {} (pid {}) {what}, and no teardown reported \
+                         releasing its target — so a live kernel target may be left halted",
+                        session.id,
+                        session.pid
+                    ),
+                    ShutdownNote::Settled(why) => tracing::info!(
                         "shutting down: session {} was already settled ({why})",
                         session.id
                     ),
@@ -1456,6 +1441,58 @@ fn settle_open(session: &Session, result: &Result<String, EngineError>) -> bool 
             .then_some(SessionState::Open)
     });
     settled.is_live()
+}
+
+/// What a session's teardown should be reported as at shutdown.
+///
+/// Separate from [`Release`] because a release attempt reports *its own* fate, and that is not the
+/// same question as what became of the target. Two teardowns can be racing for one session — a
+/// reclamation releasing in the background and a disconnect collecting it mid-flight — and only
+/// the winner is told it worked. The loser sees a timeout, a `Lost`, or a debugger error, none of
+/// which mean the target is still attached.
+#[derive(Debug, PartialEq, Eq)]
+enum ShutdownNote<'a> {
+    /// This attempt released the target.
+    Released,
+    /// Another teardown released it first; this attempt's failure is a consequence, not news.
+    ReleasedElsewhere,
+    /// The engine answered and refused. The worker went anyway.
+    Refused(&'a str),
+    /// Nothing reported releasing the target, so it may still be attached. The string says what
+    /// this attempt saw, since the two ways of getting here need different investigation.
+    Unreleased(&'static str),
+    /// There was nothing to tear down.
+    Settled(&'a str),
+}
+
+/// Reads one session's teardown, given what its own attempt returned and whether *any* teardown
+/// got a successful `EndSession` out of that worker.
+///
+/// The rule is one line: a success anywhere outranks this attempt's failure. Every non-success
+/// outcome says only that *we* did not get a confirmation — `Parked` that our clock ran out,
+/// `AlreadyGone` that another teardown failed us out of our wait, `Refused` that the engine had
+/// nothing left to release and said so — and each of those is exactly what winning teardown
+/// leaves behind.
+///
+/// What this cannot do is close the race, only stop misreading it: `released` is set a moment
+/// before the losing waiter is failed, so a teardown that succeeds *while* this is being read
+/// still logs as unreleased. Fixing that means shutdown waiting on another teardown's clock
+/// rather than its own, which is a trade the five-second grace exists to refuse. A warning that
+/// is occasionally early is the acceptable end of that; one that fires when nothing is wrong is
+/// not, because the next real one gets ignored.
+fn shutdown_note(outcome: &Release, released: bool) -> ShutdownNote<'_> {
+    match outcome {
+        Release::Released(_) => ShutdownNote::Released,
+        Release::Stale(why) => ShutdownNote::Settled(why),
+        _ if released => ShutdownNote::ReleasedElsewhere,
+        Release::Parked => ShutdownNote::Unreleased(
+            "did not let go within the grace and its worker was terminated",
+        ),
+        Release::AlreadyGone => {
+            ShutdownNote::Unreleased("had no worker left to ask — it crashed, or was terminated")
+        }
+        Release::Refused(why) => ShutdownNote::Refused(why),
+    }
 }
 
 /// Why an open is refused once the client has disconnected.
@@ -2047,6 +2084,64 @@ mod tests {
         let landed = dormant("sess-3", SessionState::Attaching);
         settle_open(&landed, &Ok("vertarget".into()));
         assert_eq!(landed.state(), SessionState::Open);
+    }
+
+    /// A teardown that lost the race must not report a halted target.
+    ///
+    /// All three ways this attempt can fail are also what a *winning* concurrent teardown leaves
+    /// behind: it fails our waiter out with `Lost`, or beats our clock, or leaves the engine with
+    /// nothing to release and an error to say so. Warning on any of them would mean warning that
+    /// a live kernel may be halted at the moment another teardown cleanly detached it.
+    #[test]
+    fn a_release_that_landed_elsewhere_outranks_this_attempt_failing() {
+        for outcome in [
+            Release::Parked,
+            Release::AlreadyGone,
+            Release::Refused("the engine said no".to_string()),
+        ] {
+            assert_eq!(
+                shutdown_note(&outcome, true),
+                ShutdownNote::ReleasedElsewhere,
+                "{outcome:?} with the target already released is not a halted-kernel warning"
+            );
+        }
+    }
+
+    /// And with nothing else having released it, those same outcomes are the warning.
+    #[test]
+    fn nothing_having_released_the_target_is_what_deserves_the_warning() {
+        assert!(matches!(
+            shutdown_note(&Release::Parked, false),
+            ShutdownNote::Unreleased(_)
+        ));
+        assert!(matches!(
+            shutdown_note(&Release::AlreadyGone, false),
+            ShutdownNote::Unreleased(_)
+        ));
+        // The two say different things, because they need different investigation.
+        assert_ne!(
+            shutdown_note(&Release::Parked, false),
+            shutdown_note(&Release::AlreadyGone, false)
+        );
+        // A refusal is its own outcome: the engine answered, it just said no, and the reason is
+        // the useful part.
+        assert_eq!(
+            shutdown_note(&Release::Refused("bad handle".to_string()), false),
+            ShutdownNote::Refused("bad handle")
+        );
+    }
+
+    /// The outcomes that are already unambiguous are not touched by the flag.
+    #[test]
+    fn a_release_this_attempt_made_reads_the_same_either_way() {
+        let released = Release::Released("session ended".to_string());
+        // `true` is the normal case here: this very release is what set the flag.
+        assert_eq!(shutdown_note(&released, true), ShutdownNote::Released);
+        assert_eq!(shutdown_note(&released, false), ShutdownNote::Released);
+        assert_eq!(
+            shutdown_note(&Release::Stale("already closed".to_string()), false),
+            ShutdownNote::Settled("already closed")
+        );
     }
 
     /// The gap `admit` exists to close: a worker that finishes its handshake after the client has

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1035,9 +1035,17 @@ impl Sessions {
                     Release::Released(_) => {
                         tracing::info!("shutting down: session {} released its target", session.id)
                     }
-                    Release::AlreadyGone => tracing::info!(
-                        "shutting down: session {}'s worker had already exited",
-                        session.id
+                    // Not the benign reading it looks like. This walk only covers sessions that
+                    // still *own* a worker handle, and releasing one takes that handle away — so
+                    // a session cannot reach here because it was already released. It reaches
+                    // here because its worker died with nobody having released anything, which
+                    // leaves the target in the same unconfirmed state `Parked` does.
+                    Release::AlreadyGone => tracing::warn!(
+                        "shutting down: session {}'s worker (pid {}) was gone before it could be \
+                         asked to release — it crashed or was terminated, so nothing detached its \
+                         target and a live kernel may be left halted",
+                        session.id,
+                        session.pid
                     ),
                     Release::Parked => tracing::warn!(
                         "shutting down: session {} did not let go within {SHUTDOWN_RELEASE_TIMEOUT:?} \

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1058,7 +1058,9 @@ impl Sessions {
                     ),
                     ShutdownNote::Refused(why) => tracing::warn!(
                         "shutting down: session {} reported an error releasing its target ({why}); \
-                         its worker (pid {}) was terminated anyway",
+                         its worker (pid {}) was terminated anyway — and terminating a debugger \
+                         does not resume and detach for it, so a live kernel target may be left \
+                         halted",
                         session.id,
                         session.pid
                     ),
@@ -1456,7 +1458,9 @@ enum ShutdownNote<'a> {
     Released,
     /// Another teardown released it first; this attempt's failure is a consequence, not news.
     ReleasedElsewhere,
-    /// The engine answered and refused. The worker went anyway.
+    /// The engine answered and refused. The worker went anyway — which for a live kernel leaves
+    /// the target no better off than [`Self::Unreleased`], since terminating a debugger does not
+    /// resume and detach for it. Kept separate because the engine's reason is the lead here.
     Refused(&'a str),
     /// Nothing reported releasing the target, so it may still be attached. The string says what
     /// this attempt saw, since the two ways of getting here need different investigation.

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -160,7 +160,14 @@ pub fn run() -> ! {
     // operator looking at a target that came back fine wants to see which path did it.
     tracing::info!("worker: supervisor is gone; releasing the target before exit");
     let (ack, released) = mpsc::channel();
-    if tx.send(Job::Release(ack)).is_ok() {
+    if tx.send(Job::Release(ack)).is_err() {
+        // The engine thread died before this could be asked, so nothing was even attempted --
+        // a different failure from the two below, and the only one where no release was tried
+        // at all.
+        tracing::error!(
+            "worker: the engine thread is gone, so nothing was asked to release the target"
+        );
+    } else {
         // Whichever way this ends the process does, but *which* way is the difference between a
         // target let go and a target still attached to a debugger that no longer exists. Silence
         // here would leave that to be inferred from a guest that never came back.

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -161,7 +161,20 @@ pub fn run() -> ! {
     tracing::info!("worker: supervisor is gone; releasing the target before exit");
     let (ack, released) = mpsc::channel();
     if tx.send(Job::Release(ack)).is_ok() {
-        let _ = released.recv_timeout(ABRUPT_EXIT_RELEASE);
+        // Whichever way this ends the process does, but *which* way is the difference between a
+        // target let go and a target still attached to a debugger that no longer exists. Silence
+        // here would leave that to be inferred from a guest that never came back.
+        match released.recv_timeout(ABRUPT_EXIT_RELEASE) {
+            Ok(()) => {}
+            Err(mpsc::RecvTimeoutError::Timeout) => tracing::warn!(
+                "worker: the engine did not finish releasing within {ABRUPT_EXIT_RELEASE:?} \
+                 (parked in DbgEng, most likely); exiting anyway, so a live kernel target may be \
+                 left halted"
+            ),
+            Err(mpsc::RecvTimeoutError::Disconnected) => {
+                tracing::error!("worker: the engine thread is gone, so nothing released the target")
+            }
+        }
     }
     std::process::exit(0);
 }
@@ -193,7 +206,22 @@ fn engine_thread(rx: mpsc::Receiver<Job>) {
             // stop waiting. Best-effort by nature: if the engine never reaches this, the main
             // thread times out and exits anyway.
             Job::Release(ack) => {
-                let _ = catch_unwind(AssertUnwindSafe(|| engine.end_session()));
+                // Reported here rather than handed back: the main thread's only move is to exit
+                // either way, and this is where the reason still exists. So the ack means
+                // "finished trying", not "succeeded" — what the main thread waits for is
+                // permission to stop waiting.
+                match catch_unwind(AssertUnwindSafe(|| engine.end_session())) {
+                    Ok(Ok(_)) => tracing::info!("worker: target released"),
+                    Ok(Err(e)) => tracing::error!(
+                        "worker: the debugger refused to release the target ({}); a live kernel \
+                         target may be left halted",
+                        es(e)
+                    ),
+                    Err(_) => tracing::error!(
+                        "worker: releasing the target panicked; a live kernel target may be left \
+                         halted"
+                    ),
+                }
                 let _ = ack.send(());
                 continue;
             }


### PR DESCRIPTION
Addresses [CodeRabbit's review comment on #68](https://github.com/glslang/windbg-mcp/pull/68#discussion_r3705022858), which landed just before that PR merged — so it comes as its own change.

Both halves of the teardown discarded an outcome they were the only witness to.

## `Sessions::shutdown` threw away each `Release`

`end_session` renders these for its caller. Shutdown has no caller — the client has already gone — so the log is the only place they can land. `Release::Parked` is exactly the case an operator needs told: the worker did not let go inside `SHUTDOWN_RELEASE_TIMEOUT` and was terminated, which for a live kernel can mean a guest left halted. Each outcome now says so, with the session id, and the pid where it matters.

## The worker discarded two more

- `engine.end_session()`'s own `Result` was dropped, so a debugger that *refused* to detach looked identical to one that did.
- `recv_timeout` was dropped, so "released" and "the engine never got to it, exiting anyway" were indistinguishable.

Both are logged now, including the panic arm.

The ack stays unconditional, and the comment now says why rather than leaving it to be inferred: the main thread's only move is to exit either way, so what it waits for is *permission to stop waiting*, not an outcome. The outcome is logged at the point where the reason still exists — which is also more context than the main thread could have printed.

## Verification

- `cargo test` with `WINDBG_MCP_SMOKE_DUMP=1`: 97 unit + 18 smoke, 0 failed
- `cargo fmt --check`, `cargo clippy --all-targets`: clean

Log-only change — no control flow moves, and the release path itself is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shutdown handling during concurrent session teardown.
  * Prevented shutdown waits from hanging when a worker exits unexpectedly or encounters an error.
  * Release failures and timeouts are now handled gracefully, allowing shutdown to complete.

* **Improvements**
  * Added clearer status reporting for successful releases, disconnected workers, parked workers and refused releases.
  * Improved resilience when cleanup operations encounter unexpected failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->