### PR TITLE
fix: stop telling a caller nothing is attached after a refused release

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -959,12 +959,19 @@ impl Sessions {
             // The engine refused to release the target. Under process-per-session the worker has
             // no other purpose, so it still goes; reporting both is more use than leaving a
             // session the caller believes they ended.
+            //
+            // What it must not do is call that clean. Terminating a debugger is not a detach —
+            // DbgEng resumes and detaches a live kernel as part of releasing it, which is the step
+            // that just failed — so the one caller who most needs to check their target was
+            // previously told there was nothing to check.
             Release::Refused(why) => (
                 format!("ended after an error: {why}"),
                 format!(
                     "The debugger reported an error releasing the target:\n  {why}\n\nSession \
-                     `{}` is closed anyway and its engine worker process (pid {}) has been \
-                     terminated, so nothing is left attached.",
+                     `{}` is closed and its engine worker process (pid {}) has been terminated. \
+                     Terminating the debugger does not resume and detach for it, so a live kernel \
+                     target may be left halted — check the target before treating this as a clean \
+                     end. For a dump or a trace there is nothing left to clean up.",
                     session.id, session.pid
                 ),
             ),


### PR DESCRIPTION
Found while reviewing [#70](https://github.com/glslang/windbg-mcp/pull/70) — [this thread](https://github.com/glslang/windbg-mcp/pull/70#discussion_r3705642434) — on a path that PR does not touch, so it comes on its own.

## The claim that is backwards

`end_session` renders `Release::Refused` as:

> Session `sess-…` is closed anyway and its engine worker process (pid N) has been terminated, **so nothing is left attached.**

For a live kernel that is exactly wrong, and wrong in the direction that costs a machine. DbgEng resumes and detaches the target *as part of* releasing it — and releasing is the step that just failed. Terminating the worker afterwards is not a detach: it leaves the guest attached-but-halted, one CPU stopped and the rest spinning, until someone reboots it.

So the one caller who most needs to go and look at their target was being told there was nothing to look at.

## What it says now

That the debugger was terminated, that terminating is not a detach, and that a live kernel target may therefore be left halted — with the recovery framed as "check the target before treating this as a clean end".

It also names the dump and trace case explicitly, because for those the original sentence was *true*: nothing is attached, nothing to check. Warning everyone equally would be its own kind of noise.

## Relationship to #70

#70 makes the same correction to the shutdown **log**, for the same `Release::Refused`. This is the other half: same outcome, different reader. Neither depends on the other, and they touch different functions, so they can merge in either order.

## Verification

- `cargo test` with `WINDBG_MCP_SMOKE_DUMP=1`: 97 unit + 18 smoke, 0 failed
- `cargo fmt --check`, `cargo clippy --all-targets`: clean
- No test asserted the old phrasing (it appeared exactly once in the tree, at the site itself)

Text-only change — no control flow moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
