### PR TITLE
Give the worker protocol a channel nothing else can write on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **The supervisor↔worker protocol has a channel of its own, so nothing a worker prints can cost a
+  session** ([#65](https://github.com/glslang/windbg-mcp/issues/65)).
+
+  The protocol used to ride the worker's stdin and stdout — the same stdout any code in that
+  process can write to. DbgEng's own output never lands there (it is captured through
+  `IDebugOutputCallbacks`), but an extension DLL that prints to the console directly does, and an
+  *unterminated* stray line swallowed the message written after it. The supervisor drops what it
+  cannot parse, and only a `Done` removes a waiter, so the cost of one stray `printf` was not a
+  lost line but a lost session: the call timed out, its waiter stayed, and the session counted as
+  busy — and so could never be reclaimed — for the life of the server. 0.4.1 mitigated this by
+  opening each message with a newline; the property was still a convention about who prints where.
+
+  Each worker now gets a pair of anonymous pipes, created by the supervisor and inherited across
+  the spawn: requests down one, messages up the other. An anonymous pipe has no name to open and
+  is reachable only through an inherited handle, so nothing outside that pair of processes can
+  write on it — "stray output cannot corrupt a reply" is a property of the plumbing rather than of
+  what happens to be loaded. The worker's stdout is now only a log: it is drained into the
+  server's stderr with the session it came from, which is also the first time an extension's
+  console output has been visible at all. Its stdin is `NUL` — never inherited, since the
+  supervisor's stdin is the MCP transport.
+
+  What the channel cannot make impossible is a `Done` that is never written, and that is the half
+  that strands a waiter, so it is answered directly: a result that cannot be encoded is replaced
+  by one that says so, and a channel that cannot be written to means the supervisor is gone — its
+  exit fails every outstanding call out. Teardown is unchanged in substance: EOF on the request
+  channel now means what EOF on stdin meant, and a worker still releases its target before it
+  exits.
+
 ## [0.4.1] - 2026-08-04
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,9 @@ worker supervision, routing), `src/worker.rs` (the child process and the engine 
 
 Practical consequences when debugging this server: a stack trace or log line can come from either
 role (worker logs are untagged by target and inherit the supervisor's stderr), and killing the
-supervisor leaves no workers behind — they exit when their stdin closes.
+supervisor leaves no workers behind — they exit when their request channel closes. That channel is
+a pair of inherited anonymous pipes, *not* the worker's stdio: anything a worker prints to stdout
+is drained into the log and cannot reach the protocol.
 
 ## Updating the running windbg MCP after code changes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -908,6 +908,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "win-kexp",
+ "windows-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,6 @@ schemars = "1"
 anyhow = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+# Only for the handle plumbing behind the supervisor↔worker channel (see `engine::spawn_worker`):
+# marking a pipe end inheritable is the one thing std cannot express.
+windows-sys = { version = "0.61", features = ["Win32_Foundation"] }

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -1,11 +1,11 @@
 # Follow-ups
 
-Deferred work, in four clusters: items 1–6 come from the reachability-confirmation effort (path
+Deferred work, in five clusters: items 1–6 come from the reachability-confirmation effort (path
 recipe + `run_to_address`, merged 2026-07-04), items 7–11 from surveying this server against the
 MCP `2026-07-28` extensions (tasks, apps), item 12 from the opener split
-(glslang/win-kexp#71, 2026-08-01), and items 13–14 from the bounded-command coverage review
-(#46, 2026-08-02). Each item notes its repo, why it was deferred, and where
-it picks up. See [`DECISIONS.md`](./DECISIONS.md) for the design rationale (D1–D5) items 1–6 extend,
+(glslang/win-kexp#71, 2026-08-01), items 13–14 from the bounded-command coverage review
+(#46, 2026-08-02), and item 15 from the private worker channel (#65 / #72, 2026-08-04). Each item
+notes its repo, why it was deferred, and where it picks up. See [`DECISIONS.md`](./DECISIONS.md) for the design rationale (D1–D5) items 1–6 extend,
 and the 2026-08-02 entries that items 13–14 and item 10 extend.
 
 Items are roughly ordered by how soon they're worth doing, within each cluster. **Item 10 has
@@ -306,3 +306,35 @@ wake the watchdog immediately and drop that to ~0.
   "bound everything except `index_trace`", with no per-call tax to weigh against a rare wedge.
 - **Why deferred:** it is a win-kexp change with its own review, and the current split is correct
   as long as the cost stands — this is an improvement to the tradeoff, not a fix to a defect.
+
+## 15. [windbg-mcp] Make handle inheritance a property of the spawn, not of the process
+
+The worker protocol channel (#65, landed in #72) is a pair of anonymous pipes whose child ends are
+marked inheritable across the spawn. Marking is **process-wide for as long as it lasts**:
+`CreateProcess` inherits every inheritable handle, and cannot be told "only these" without a
+`STARTUPINFOEX` handle list (`PROC_THREAD_ATTRIBUTE_HANDLE_LIST`). So "only this worker gets these
+handles" is currently kept by serializing *every* process this server creates — `spawn_worker`, the
+TTD recorder, the test stand-ins — through `engine::spawn_guard`.
+
+A handle list would make it structural: the spawn names what it passes, nothing else is inherited,
+and no other spawn site needs to know the rule exists.
+
+- **What it costs today:** the rule is conventional. A spawn added anywhere — a new tool that shells
+  out, another recorder — silently reopens the hole, and the failure is quiet and expensive: a
+  process holding a worker's *message write end* keeps that pipe from ever reporting EOF, so the
+  supervisor never learns the worker exited, `reader`'s tail never runs, the calls it owed replies
+  to wait for ever, and the session can never be reclaimed. The first cut of #72 missed two existing
+  spawn sites, which is how much the convention is worth unaided.
+- **Why deferred:** doing it now means leaving `std::process::Command` for a raw `CreateProcessW`,
+  and with it tokio's `Child` — process reaping, `start_kill`, `id()` — all of which
+  `Session::kill` and shutdown depend on. That is a large, risk-bearing rewrite for a hazard the
+  lock already covers.
+- **Where it picks up:** std already has the API, unstable — `CommandExt::raw_attribute` +
+  `ProcThreadAttributeList` ([rust-lang/rust#114854](https://github.com/rust-lang/rust/issues/114854))
+  — and tokio exposes the inner command through `Command::as_std_mut()`, so on stabilization this
+  is a handful of lines in `spawn_worker` with tokio's `Child` intact. **That stabilization is the
+  trigger**; there is no reason to hand-roll it first.
+- **Meanwhile:** `every_process_spawn_in_this_crate_takes_the_spawn_lock` (`src/engine.rs`) reads
+  the crate's own source and fails if a `.spawn()` appears without `spawn_guard` held in the same
+  function. The convention is pinned rather than merely documented, which is what makes this an
+  improvement to *how* the property is held rather than a fix to a live hole.

--- a/README.md
+++ b/README.md
@@ -42,14 +42,18 @@ process. Two things follow, and they are why it is built this way:
 - **`proto.rs`** — the line-delimited JSON protocol between the two. A closure cannot cross a
   process boundary, so what used to be closures marshalled onto the engine thread are now
   serializable operations — deliberately *tool*-shaped rather than DbgEng-shaped, so a tool that is
-  several engine calls (`reachable_from_dispatch`'s call-graph walk) stays one indivisible job.
+  several engine calls (`reachable_from_dispatch`'s call-graph walk) stays one indivisible job. It
+  travels on a pair of anonymous pipes the worker inherits, not on its standard handles: an
+  extension DLL that prints to the console writes to the worker's stdout, which is drained into the
+  log and carries nothing else.
 - **`server.rs`** — the MCP tools (see below), built with `rmcp`'s `#[tool_router]`/`#[tool_handler]`.
 - **`ttd.rs`** — locates `TTD.exe` and launches trace recording.
 - **`main.rs`** — role selection (supervisor or worker), tokio + stdio transport. **Logs go to
   stderr** (stdout is the JSON-RPC channel); workers inherit the supervisor's stderr, so everything
   lands in the same place. Workers never outlive the connection: a disconnect asks every session
   to release its target — all of them concurrently — waits **five seconds**, and terminates only
-  the workers that have not finished by then; a worker also exits on its own if its stdin closes.
+  the workers that have not finished by then; a worker also exits on its own once its request
+  channel closes.
   Which of those two endings a session gets matters for a live kernel. DbgEng leaves a
   detached-but-halted kernel *frozen*, so a worker that releases its target leaves the machine
   running, while a worker that is terminated leaves it stopped. Five seconds is enough for an

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -95,6 +95,12 @@ processes, so they need real ones:
   and checks the process is gone — otherwise every disconnect leaks a debugger process, and for a
   launch or an attach, a debuggee with it.
 
+This tier is also the only end-to-end check of the **protocol channel** — the inherited pipe pair a
+worker speaks on ([`proto.rs`](../src/proto.rs)). Handles are passed on the worker's command line
+and inherited across the spawn, so a mistake there is not a compile error: the worker simply never
+answers, and every test here that opens a target fails at once. Run it after touching
+`engine::spawn_worker` or `worker::run`.
+
 ## When to run it
 
 ### A dependency moved

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -97,9 +97,9 @@ processes, so they need real ones:
 
 This tier is also the only end-to-end check of the **protocol channel** — the inherited pipe pair a
 worker speaks on ([`proto.rs`](../src/proto.rs)). Handles are passed on the worker's command line
-and inherited across the spawn, so a mistake there is not a compile error: the worker simply never
-answers, and every test here that opens a target fails at once. Run it after touching
-`engine::spawn_worker` or `worker::run`.
+and inherited across the spawn, so a mistake there is not a compile error: the worker exits without
+a usable channel, or comes up and is never heard from, and either way every test here that opens a
+target fails on the open. Run it after touching `engine::spawn_worker` or `worker::run`.
 
 ## When to run it
 

--- a/examples/ctrl_c_teardown.ps1
+++ b/examples/ctrl_c_teardown.ps1
@@ -5,12 +5,13 @@
 .DESCRIPTION
     The supervisor does not terminate its workers when it goes: killing pre-empts the release,
     and a live kernel left attached-but-halted is a machine that needs rebooting. Instead a
-    worker treats stdin EOF as "the supervisor is gone" and asks its engine to let go first.
+    worker treats EOF on its request channel as "the supervisor is gone" and asks its engine to
+    let go first.
 
     Ctrl+C is the route where that guarantee is hardest to keep. It is delivered to every process
     attached to the console, and a child inherits its parent's process group -- so without
     CREATE_NEW_PROCESS_GROUP the worker takes the default console handler and dies where it
-    stands, before its stdin ever closes. It is also the route where the supervisor can help
+    stands, before that channel ever closes. It is also the route where the supervisor can help
     least: its *own* default handler ends it, so it never runs its shutdown.
 
     This script reproduces exactly that and checks the worker still let go.

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1994,6 +1994,77 @@ mod tests {
         let _ = child.wait().await;
     }
 
+    /// The rule [`SPAWN_LOCK`] rests on, checked against the source rather than asserted in a doc
+    /// comment: **no process is created in this crate without [`spawn_guard`] held**.
+    ///
+    /// It is checked this way because the rule is the kind that decays silently and expensively.
+    /// A handle is inheritable process-wide from the moment it is marked, so a spawn added
+    /// anywhere — a new tool that shells out, another recorder — can hand a worker's channel end
+    /// to a process that outlives it, and the pipe then never reports EOF: the session never
+    /// settles, its callers never hear back, and nothing about the new code looks wrong. The
+    /// first cut of this very change missed two existing spawn sites (`ttd::record`, the
+    /// stand-ins below), which is the evidence that a comment is not enough.
+    ///
+    /// `.spawn()` with empty parentheses is a reliable marker for a *process* spawn here: a
+    /// thread spawn always takes a closure, and `tokio::spawn` a future. The count is asserted
+    /// too, so a refactor that stops matching fails loudly instead of quietly checking nothing.
+    #[test]
+    fn every_process_spawn_in_this_crate_takes_the_spawn_lock() {
+        let mut sites = 0;
+        let mut unguarded = Vec::new();
+        for file in rust_sources(&PathBuf::from(concat!(env!("CARGO_MANIFEST_DIR"), "/src"))) {
+            let text = std::fs::read_to_string(&file).expect("read a source file");
+            // Reset at each function, so "guarded" means guarded *here* rather than anywhere
+            // earlier in the file. Comments are skipped: prose about a `fn` is not one.
+            let mut guarded = false;
+            for (n, line) in text.lines().enumerate() {
+                let code = line.trim_start();
+                if code.starts_with("//") {
+                    continue;
+                }
+                if code.starts_with("fn ") || code.contains(" fn ") {
+                    guarded = false;
+                }
+                if code.contains("spawn_guard()") {
+                    guarded = true;
+                }
+                if code.contains(".spawn()") {
+                    sites += 1;
+                    if !guarded {
+                        unguarded.push(format!("{}:{}", file.display(), n + 1));
+                    }
+                }
+            }
+        }
+        assert!(
+            unguarded.is_empty(),
+            "these spawn a process without holding `engine::spawn_guard()` in the same function, \
+             so a child started there can inherit a worker's protocol channel and keep it from \
+             ever reporting EOF: {unguarded:?}"
+        );
+        assert!(
+            sites >= 3,
+            "expected to find the known process spawns (the worker, the TTD recorder, the test \
+             stand-in) and found {sites} — the marker no longer matches, so this test is checking \
+             nothing"
+        );
+    }
+
+    /// Every `.rs` file under a directory, recursively — so a spawn added in a new submodule is
+    /// checked rather than silently skipped.
+    fn rust_sources(dir: &PathBuf) -> Vec<PathBuf> {
+        let mut found = Vec::new();
+        for entry in std::fs::read_dir(dir).expect("read the source directory") {
+            let path = entry.expect("read a directory entry").path();
+            if path.is_dir() {
+                found.extend(rust_sources(&path));
+            } else if path.extension().is_some_and(|e| e == "rs") {
+                found.push(path);
+            }
+        }
+        found
+    }
+
     /// Draining a worker's stdout moves runaway output off the worker, where a full pipe blocked
     /// the engine thread, and onto the supervisor — which is only an improvement if what arrives
     /// is bounded. So the cap is applied to what is *buffered*, not just to what is logged: a

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -24,18 +24,21 @@
 
 use std::collections::{HashMap, VecDeque};
 use std::fmt;
-use std::path::PathBuf;
+use std::io::{BufRead, PipeReader, PipeWriter, Write};
+use std::os::windows::io::AsRawHandle;
+use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::sync::atomic::{AtomicBool, AtomicU8, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, Weak};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader, Lines};
-use tokio::process::{Child, ChildStdin, ChildStdout, Command};
+use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::process::{Child, ChildStdout, Command};
 use tokio::sync::{mpsc, oneshot};
+use windows_sys::Win32::Foundation::{HANDLE_FLAG_INHERIT, SetHandleInformation};
 
 use crate::proto::{EngineOp, WorkerMessage, WorkerRequest};
-use crate::worker::WORKER_FLAG;
+use crate::worker::{MESSAGES_FLAG, REQUESTS_FLAG, WORKER_FLAG};
 
 /// How many sessions may be open at once.
 ///
@@ -80,10 +83,10 @@ const SHUTDOWN_RELEASE_TIMEOUT: Duration = Duration::from_secs(5);
 ///
 /// An interactive Ctrl+C is delivered to *every* process attached to the console, and a child
 /// inherits its parent's process group — so without this a worker takes the default console
-/// handler and terminates on the spot, before its stdin closes and before it can release its
-/// target. That is precisely the halted kernel this design exists to avoid, arriving by the one
-/// route where the supervisor cannot help: its own default handler ends it, so it never reaches
-/// [`Sessions::shutdown`].
+/// handler and terminates on the spot, before its request channel closes and before it can
+/// release its target. That is precisely the halted kernel this design exists to avoid, arriving
+/// by the one route where the supervisor cannot help: its own default handler ends it, so it never
+/// reaches [`Sessions::shutdown`].
 ///
 /// With the flag, Ctrl+C is disabled for the worker's group. The supervisor still dies, its handles
 /// still close, and the worker meets the EOF path that knows how to let go.
@@ -634,8 +637,8 @@ impl Registry {
     /// reclamation is marked `Closed` immediately but its worker is released in the background, so
     /// between those two points it is not live and still owns a process — and a client
     /// disconnecting in that window would drop the runtime and cancel that release, leaving the
-    /// worker to fall back on noticing its own stdin close: a bounded best effort, where an
-    /// orderly `EndSession` was there for the asking.
+    /// worker to fall back on noticing its own request channel close: a bounded best effort,
+    /// where an orderly `EndSession` was there for the asking.
     fn owning_workers(&self) -> Vec<Arc<Session>> {
         self.all
             .iter()
@@ -830,7 +833,7 @@ impl Sessions {
         if let Err(why) = self.admit(&session) {
             // Refused *before* the opener was written, so this worker is `Ready` and holds
             // nothing at all — no dump, no trace, no attach. There is no target to release and so
-            // nothing for its stdin closing to accomplish; killing it is the whole teardown.
+            // nothing for its channel closing to accomplish; killing it is the whole teardown.
             session.kill();
             return Err(OpenError::NoRoom(why));
         }
@@ -1023,8 +1026,9 @@ impl Sessions {
         // Every session that still *owns a worker*, not every live one. A session claimed for
         // reclamation is already `Closed` while its release runs in the background, and a
         // disconnect in that window would otherwise drop the runtime and cancel that release,
-        // leaving the worker to notice its own stdin close — a five-second best-effort where an
-        // orderly release was available. Releasing one twice is harmless; missing one is not.
+        // leaving the worker to notice its own request channel close — a five-second best-effort
+        // where an orderly release was available. Releasing one twice is harmless; missing one is
+        // not.
         let owners = {
             let mut registry = self.registry();
             registry.closing = true;
@@ -1266,37 +1270,29 @@ impl Sessions {
         what: String,
     ) -> Result<Arc<Session>, String> {
         let exe = worker_exe()?;
-        let mut child = Command::new(&exe)
-            .arg(WORKER_FLAG)
-            .stdin(Stdio::piped())
-            .stdout(Stdio::piped())
-            // Worker logs join the server's own, which is where an MCP client looks for them.
-            .stderr(Stdio::inherit())
-            // Deliberately **not** `kill_on_drop`, and the absence is load-bearing. Dropping this
-            // handle — or the whole process exiting — closes the worker's stdin, and a worker
-            // reads that EOF as "the supervisor is gone" and asks its engine to release the target
-            // before it exits, bounded (`worker::run`). Terminating on drop pre-empts exactly
-            // that: a worker this server never got round to releasing would die by
-            // `TerminateProcess` with its target still attached, which for a live kernel means a
-            // machine left halted. So EOF is the teardown, on every route out — clean shutdown,
-            // Ctrl+C, or a crash — and [`Session::kill`] is the deliberate one, used only once a
-            // release has been asked for and refused, or on a worker known to hold nothing.
-            //
-            // Which is why the worker also gets its own process group: see
-            // [`CREATE_NEW_PROCESS_GROUP`]. EOF cannot be the teardown if a console Ctrl+C ends the
-            // worker before its stdin ever closes.
-            .creation_flags(CREATE_NEW_PROCESS_GROUP)
-            .spawn()
+        let (mut child, channel) = spawn_worker(&exe)
             .map_err(|e| format!("could not start an engine worker ({}): {e}", exe.display()))?;
 
-        let stdin = child.stdin.take().ok_or("engine worker has no stdin")?;
         let stdout = child.stdout.take().ok_or("engine worker has no stdout")?;
         let pid = child.id().unwrap_or(0);
-        let mut lines = BufReader::new(stdout).lines();
+        // Drained from the start, before the handshake: a worker that prints during startup must
+        // not be able to block on a full pipe on its way to `Ready`.
+        tokio::spawn(log_stray_output(id.to_string(), stdout));
+        let mut messages = match read_messages(id.to_string(), channel.messages) {
+            Ok(messages) => messages,
+            Err(e) => {
+                // Nothing has been asked of this worker yet, so it holds no target: killing it is
+                // the whole teardown.
+                let _ = child.start_kill();
+                return Err(format!(
+                    "could not start a reader for an engine worker's messages: {e}"
+                ));
+            }
+        };
 
         // Nothing is registered until the worker says its engine exists. A session that cannot
         // debug is worse than no session: it would accept calls and fail every one.
-        match tokio::time::timeout(WORKER_READY_TIMEOUT, next_message(&mut lines)).await {
+        match tokio::time::timeout(WORKER_READY_TIMEOUT, messages.recv()).await {
             Ok(Some(WorkerMessage::Ready)) => {}
             Ok(Some(WorkerMessage::Fatal { message })) => {
                 let _ = child.start_kill();
@@ -1338,18 +1334,31 @@ impl Sessions {
             child: Mutex::new(Some(child)),
         });
 
-        // Both tasks hold a `Weak`, so a session dropped from the registry takes its worker's
+        // Both halves hold a `Weak`, so a session dropped from the registry takes its worker's
         // plumbing with it rather than keeping the Arc alive forever.
-        tokio::spawn(pump(
-            Arc::downgrade(&session),
-            rx,
-            stdin,
-            Arc::clone(&waiters),
-            self.call_timeout,
-        ));
+        let pumping = std::thread::Builder::new()
+            .name(format!("reqs-{id}"))
+            // A pump parks on its queue, and a session keeps its queue for as long as the registry
+            // remembers it — a dozen at the outside — so keep the stack small. The loop serializes
+            // one request and writes it; there is no deep call graph to leave room for.
+            .stack_size(256 * 1024)
+            .spawn({
+                let session = Arc::downgrade(&session);
+                let waiters = Arc::clone(&waiters);
+                let call_timeout = self.call_timeout;
+                move || pump(session, rx, channel.requests, waiters, call_timeout)
+            });
+        if let Err(e) = pumping {
+            // Nothing has been submitted yet, so this worker holds no target either. Killing it
+            // also frees the reader thread, whose pipe closes with the process.
+            session.kill();
+            return Err(format!(
+                "could not start a writer for an engine worker's requests: {e}"
+            ));
+        }
         tokio::spawn(reader(
             Arc::downgrade(&session),
-            lines,
+            messages,
             waiters,
             self.clone(),
         ));
@@ -1537,22 +1546,200 @@ fn worker_exe() -> Result<PathBuf, String> {
         .map_err(|e| format!("cannot locate this executable to spawn an engine worker: {e}"))
 }
 
-/// Reads the next well-formed message, skipping anything else on the worker's stdout.
+/// The supervisor's ends of one worker's protocol channel.
 ///
-/// Skipping rather than failing is deliberate: DbgEng output reaches this server through
-/// `IDebugOutputCallbacks`, but an extension that writes to the console directly would otherwise
-/// desynchronize the stream permanently. A logged line costs nothing; a dead session costs a
-/// target.
-async fn next_message(lines: &mut Lines<BufReader<ChildStdout>>) -> Option<WorkerMessage> {
+/// Two anonymous pipes rather than the worker's standard handles, because those are shared with
+/// everything else loaded into that process — see [`crate::proto`] for what a stray `printf` used
+/// to cost. Anonymous, so there is no name for anything outside this pair of processes to open:
+/// the only way to reach either pipe is the handle the child inherited.
+struct Channel {
+    /// Requests down to the worker.
+    requests: PipeWriter,
+    /// Messages up from it.
+    messages: PipeReader,
+}
+
+/// Serializes worker spawns, so an inheritable handle reaches only the child it was made for.
+///
+/// A handle marked inheritable is inherited by **every** process created while it is marked, and
+/// `CreateProcess` cannot narrow that without a full `STARTUPINFOEX` handle list. Two overlapping
+/// opens would therefore cross-inherit each other's channel ends, and the damage is concrete: a
+/// worker holding another worker's *write* end keeps that pipe from ever reporting EOF, so the
+/// supervisor would never learn that the other worker had exited — [`reader`]'s tail would not
+/// run, and the calls that worker owed replies to would wait for ever.
+///
+/// std holds a lock of its own across the same window for the stdio handles it prepares, which is
+/// the same reasoning applied to the same hazard; this one covers the handles std knows nothing
+/// about. Nothing else in this process spawns children, so between them the window is closed.
+static SPAWN_LOCK: Mutex<()> = Mutex::new(());
+
+/// Marks a handle inheritable, so the child gets a copy of it.
+fn inheritable(handle: &impl AsRawHandle) -> std::io::Result<()> {
+    // SAFETY: the handle is borrowed from an owner that outlives the call, and this only changes
+    // a flag on it.
+    let ok = unsafe {
+        SetHandleInformation(
+            handle.as_raw_handle(),
+            HANDLE_FLAG_INHERIT,
+            HANDLE_FLAG_INHERIT,
+        )
+    };
+    if ok == 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+/// Starts a worker process with a protocol channel of its own.
+///
+/// Marking, spawning and closing all happen under [`SPAWN_LOCK`], which is the whole of what
+/// keeps this channel private: a handle is inheritable from the moment it is marked until it is
+/// closed, and every process created in between gets a copy. The supervisor's copies of the
+/// child's ends go at the end of that window for a second reason too — one left open on the
+/// request side would mean the worker never sees the EOF that tells it the supervisor is gone,
+/// and one left open on the message side would mean the supervisor never sees the EOF that tells
+/// it the worker exited.
+fn spawn_worker(exe: &Path) -> std::io::Result<(Child, Channel)> {
+    let (their_requests, our_requests) = std::io::pipe()?;
+    let (our_messages, their_messages) = std::io::pipe()?;
+
+    let _one_spawn_at_a_time = SPAWN_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    inheritable(&their_requests)?;
+    inheritable(&their_messages)?;
+    let child = Command::new(exe)
+        .arg(WORKER_FLAG)
+        .arg(format!(
+            "{REQUESTS_FLAG}{}",
+            their_requests.as_raw_handle() as usize
+        ))
+        .arg(format!(
+            "{MESSAGES_FLAG}{}",
+            their_messages.as_raw_handle() as usize
+        ))
+        // Emphatically **not** inherited: this server's stdin is the MCP transport, and a worker
+        // holding it could consume the client's requests. Nothing of ours is read from it either
+        // — the protocol has its own channel — so there is nothing for it to be.
+        .stdin(Stdio::null())
+        // Piped and drained into the log (`log_stray_output`). This is where an extension DLL
+        // that prints to the console lands, and it is now only a log: nothing of the protocol
+        // comes this way.
+        .stdout(Stdio::piped())
+        // Worker logs join the server's own, which is where an MCP client looks for them.
+        .stderr(Stdio::inherit())
+        // Deliberately **not** `kill_on_drop`, and the absence is load-bearing. Dropping the
+        // request channel — or the whole process exiting — closes the worker's end of it, and a
+        // worker reads that EOF as "the supervisor is gone" and asks its engine to release the
+        // target before it exits, bounded (`worker::run`). Terminating on drop pre-empts exactly
+        // that: a worker this server never got round to releasing would die by `TerminateProcess`
+        // with its target still attached, which for a live kernel means a machine left halted. So
+        // EOF is the teardown, on every route out — clean shutdown, Ctrl+C, or a crash — and
+        // [`Session::kill`] is the deliberate one, used only once a release has been asked for
+        // and refused, or on a worker known to hold nothing.
+        //
+        // Which is why the worker also gets its own process group: see
+        // [`CREATE_NEW_PROCESS_GROUP`]. EOF cannot be the teardown if a console Ctrl+C ends the
+        // worker before its channel ever closes.
+        .creation_flags(CREATE_NEW_PROCESS_GROUP)
+        .spawn()?;
+    // Explicitly, and before the lock is released rather than at the end of the function: the
+    // child has its copies, and these are the ones that would otherwise stay inheritable — and
+    // hold both pipes open — for as long as this scope lasted.
+    drop(their_requests);
+    drop(their_messages);
+    drop(_one_spawn_at_a_time);
+
+    Ok((
+        child,
+        Channel {
+            requests: our_requests,
+            messages: our_messages,
+        },
+    ))
+}
+
+/// Reads one worker's messages off the channel, on a thread of its own.
+///
+/// A thread rather than a task because an anonymous pipe cannot be read asynchronously on Windows
+/// — it is not an overlapped handle, so there is nothing to register with the runtime's poller.
+/// Detached rather than joined, for the same reason `kill_on_drop` is not set: this thread is
+/// parked in a read that ends when the worker exits, and the supervisor must never wait on that.
+///
+/// Parsing happens here so the task side only ever sees well-formed messages. A line that does
+/// not parse is a bug in this program now, not a stray `printf` from an extension — those go to
+/// the worker's stdout, which no longer carries protocol.
+fn read_messages(
+    id: String,
+    pipe: PipeReader,
+) -> std::io::Result<mpsc::UnboundedReceiver<WorkerMessage>> {
+    let (tx, rx) = mpsc::unbounded_channel();
+    std::thread::Builder::new()
+        .name(format!("msgs-{id}"))
+        .spawn(move || {
+            for line in std::io::BufReader::new(pipe).lines() {
+                let Ok(line) = line else { break };
+                if line.trim().is_empty() {
+                    continue;
+                }
+                match serde_json::from_str::<WorkerMessage>(&line) {
+                    Ok(message) => {
+                        if tx.send(message).is_err() {
+                            break; // nobody is left to route it to
+                        }
+                    }
+                    Err(e) => tracing::error!(
+                        "session {id}: unreadable message from its engine worker ({e}): {}",
+                        clipped(&line)
+                    ),
+                }
+            }
+        })?;
+    Ok(rx)
+}
+
+/// How much of a line from a worker to put in the log before clipping it. Generous enough for a
+/// real diagnostic, small enough that a runaway extension cannot bury the log in one line.
+const LOGGED_LINE_LIMIT: usize = 2048;
+
+/// One line as it should appear in the log: clipped, and honest about what was clipped.
+fn clipped(line: &str) -> String {
+    let mut out: String = line.chars().take(LOGGED_LINE_LIMIT).collect();
+    if out.len() < line.len() {
+        out.push_str(&format!("… ({} bytes in all)", line.len()));
+    }
+    out
+}
+
+/// Drains a worker's stdout into the log.
+///
+/// Nothing of ours writes there — the protocol has its own channel — so anything that arrives was
+/// printed by something else inside that process: an extension DLL writing to the console is the
+/// case that motivated all of this. Logged rather than discarded because it is the only place
+/// that output can now be seen, and drained rather than left because an unread pipe fills at a
+/// few dozen KiB and the *next* write blocks the engine thread inside DbgEng.
+async fn log_stray_output(id: String, stdout: ChildStdout) {
+    let mut stdout = BufReader::new(stdout);
+    let mut line = Vec::new();
     loop {
-        let line = lines.next_line().await.ok().flatten()?;
-        if line.trim().is_empty() {
+        line.clear();
+        // Bytes and then a lossy decode, not `lines()`. Whatever prints here is not ours and owes
+        // us no encoding — an extension writing in the console's code page is not UTF-8 — and a
+        // decode error must not be able to end this loop. Stopping the drain is the one outcome
+        // that matters: the pipe would fill, and the next write would block the engine thread
+        // inside DbgEng, which is a session lost to output nobody even wanted.
+        match stdout.read_until(b'\n', &mut line).await {
+            // EOF, or a broken pipe: the worker is gone and there is nothing left to drain.
+            Ok(0) | Err(_) => return,
+            Ok(_) => {}
+        }
+        let text = String::from_utf8_lossy(&line);
+        let text = text.trim_end_matches(['\r', '\n']);
+        if text.trim().is_empty() {
             continue;
         }
-        match serde_json::from_str::<WorkerMessage>(&line) {
-            Ok(message) => return Some(message),
-            Err(_) => tracing::warn!("engine worker wrote a line that is not a message: {line}"),
-        }
+        tracing::info!(
+            "session {id}: its engine worker wrote to stdout: {}",
+            clipped(text)
+        );
     }
 }
 
@@ -1562,14 +1749,21 @@ async fn next_message(lines: &mut Lines<BufReader<ChildStdout>>) -> Option<Worke
 /// written as they arrive rather than one-per-reply on purpose: a job whose caller has given up
 /// is still running in the worker, and blocking the queue behind it would stop `end_session` from
 /// ever reaching the worker at all.
-async fn pump(
+///
+/// Runs on a thread rather than as a task, because the request channel is an anonymous pipe and
+/// those cannot be written asynchronously on Windows. A blocking write on a runtime thread is the
+/// one thing that could not be allowed here: the whole design is about a stuck session costing a
+/// process, not the server.
+fn pump(
     session: Weak<Session>,
     mut rx: mpsc::UnboundedReceiver<Job>,
-    mut stdin: ChildStdin,
+    mut requests: PipeWriter,
     waiters: Waiters,
     call_timeout: Duration,
 ) {
-    while let Some(job) = rx.recv().await {
+    // No runtime on this thread, so this really blocks — which is what lets the write below do
+    // the same without stalling anything else.
+    while let Some(job) = rx.blocking_recv() {
         let Some(session) = session.upgrade() else {
             return;
         };
@@ -1605,7 +1799,11 @@ async fn pump(
             continue;
         };
         line.push('\n');
-        if stdin.write_all(line.as_bytes()).await.is_err() || stdin.flush().await.is_err() {
+        if requests
+            .write_all(line.as_bytes())
+            .and_then(|()| requests.flush())
+            .is_err()
+        {
             // The worker is gone. The reader task sees the same thing and settles the session;
             // this job is simply the first to notice.
             answer(Err(EngineError::Lost(worker_gone(&session.id))));
@@ -1615,13 +1813,16 @@ async fn pump(
 }
 
 /// Consumes one worker's messages: milestones move the session's state, results answer callers.
+///
+/// Fed by [`read_messages`]'s thread, so this side stays on the runtime — settling a session
+/// touches the registry and the worker's process handle, which is where both belong.
 async fn reader(
     session: Weak<Session>,
-    mut lines: Lines<BufReader<ChildStdout>>,
+    mut messages: mpsc::UnboundedReceiver<WorkerMessage>,
     waiters: Waiters,
     sessions: Sessions,
 ) {
-    while let Some(message) = next_message(&mut lines).await {
+    while let Some(message) = messages.recv().await {
         let Some(session) = session.upgrade() else {
             return;
         };
@@ -1676,7 +1877,9 @@ async fn reader(
             WorkerMessage::Ready | WorkerMessage::Fatal { .. } => {}
         }
     }
-    // stdout closed: the worker exited, for whatever reason.
+    // The channel closed: the worker exited, for whatever reason. Nothing else can close it —
+    // the worker's end of it is held by nobody but that process, and the reader thread runs until
+    // it reads EOF — so this is the worker's death, not a message that failed to parse.
     let Some(session) = session.upgrade() else {
         return;
     };
@@ -1691,6 +1894,67 @@ async fn reader(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ---- the worker's protocol channel --------------------------------------------
+
+    /// The property the private channel exists for: a worker's stdout is not the protocol.
+    ///
+    /// `cmd.exe` is the stand-in, and a good one. Handed a worker's command line it makes nothing
+    /// of it, prints its banner and a promptless line to stdout, reads EOF on the null stdin and
+    /// exits — a process that writes to its standard handles, leaves the last line unterminated,
+    /// and never says a word on the channel. That is the exact shape of the hazard: it used to be
+    /// an extension's `printf` swallowing the reply written after it.
+    ///
+    /// What the supervisor has to conclude is "this worker said nothing, then exited", because
+    /// that is what settles the session and fails its callers out ([`reader`]'s tail). Reading
+    /// the banner as a message would be the old corruption; never reaching EOF would be the
+    /// supervisor holding a copy of the child's end open, and either one leaves a session waiting
+    /// for a reply that is not coming.
+    #[tokio::test]
+    async fn a_workers_stdout_is_not_its_protocol_channel() {
+        use tokio::io::AsyncReadExt;
+
+        let (mut child, channel) =
+            spawn_worker(Path::new("cmd.exe")).expect("spawn a stand-in worker");
+        let mut stdout = child.stdout.take().expect("a worker's stdout is piped");
+        let mut printed = String::new();
+        tokio::time::timeout(Duration::from_secs(10), stdout.read_to_string(&mut printed))
+            .await
+            .expect("the stand-in's stdout closed within 10s")
+            .expect("read the stand-in's stdout");
+        assert!(
+            !printed.trim().is_empty(),
+            "the stand-in printed nothing to stdout, so this test would pass whatever the \
+             channel did with it"
+        );
+
+        let mut messages =
+            read_messages("sess-stand-in".to_string(), channel.messages).expect("read messages");
+        let heard = tokio::time::timeout(Duration::from_secs(10), messages.recv()).await;
+        assert!(
+            matches!(heard, Ok(None)),
+            "expected silence and then EOF on the channel, got {heard:?} — either stdout reached \
+             the protocol, or the channel never reported the worker's exit, which is what a \
+             supervisor's own copy of the child's end left open looks like"
+        );
+        let _ = child.wait().await;
+    }
+
+    /// A worker line reaches the log clipped, and says how much was left out. An extension in a
+    /// loop must not be able to bury the log under one line.
+    #[test]
+    fn a_long_line_from_a_worker_is_clipped_before_it_is_logged() {
+        let short = "a stray printf";
+        assert_eq!(clipped(short), short);
+
+        let long = "x".repeat(LOGGED_LINE_LIMIT * 3);
+        let clipped = clipped(&long);
+        assert!(clipped.len() < long.len(), "a long line was logged whole");
+        assert!(
+            clipped.contains(&format!("{} bytes in all", long.len())),
+            "the clipped line does not say how much there was: {clipped}"
+        );
+    }
 
     // ---- what the worker is told about the caller's deadline ----------------------
 
@@ -2204,9 +2468,9 @@ mod tests {
     ///
     /// A session claimed for reclamation is `Closed` immediately while its release runs in the
     /// background. A disconnect landing in that window must still collect it: otherwise the
-    /// runtime is dropped, the release is cancelled, and the worker is left to notice its stdin
-    /// close and let go on its own — best effort, when the orderly `EndSession` a halted kernel
-    /// wants was available.
+    /// runtime is dropped, the release is cancelled, and the worker is left to notice its request
+    /// channel close and let go on its own — best effort, when the orderly `EndSession` a halted
+    /// kernel wants was available.
     #[tokio::test]
     async fn shutdown_collects_a_session_whose_release_is_still_in_flight() {
         let sessions = Sessions::new(Duration::from_secs(1));

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1559,19 +1559,33 @@ struct Channel {
     messages: PipeReader,
 }
 
-/// Serializes worker spawns, so an inheritable handle reaches only the child it was made for.
+/// Serializes **every** process this server creates, so an inheritable handle reaches only the
+/// child it was made for. Held by [`spawn_worker`], by the TTD recorder ([`crate::ttd`]), and by
+/// the stand-in children the tests below spawn — every `spawn()` in this process, without
+/// exception, because that is what the guarantee is made of.
 ///
 /// A handle marked inheritable is inherited by **every** process created while it is marked, and
-/// `CreateProcess` cannot narrow that without a full `STARTUPINFOEX` handle list. Two overlapping
-/// opens would therefore cross-inherit each other's channel ends, and the damage is concrete: a
-/// worker holding another worker's *write* end keeps that pipe from ever reporting EOF, so the
-/// supervisor would never learn that the other worker had exited — [`reader`]'s tail would not
-/// run, and the calls that worker owed replies to would wait for ever.
+/// `CreateProcess` cannot narrow that without a full `STARTUPINFOEX` handle list. So the hazard is
+/// not "two opens racing" but "anything at all starting during the marking window". Two overlapping
+/// opens would cross-inherit each other's channel ends; a `record_trace` landing there would hand
+/// them to `TTD.exe`, which then outlives the whole recording. Either way the damage is the same
+/// and it is concrete: a process holding a worker's *message write end* keeps that pipe from ever
+/// reporting EOF, so the supervisor never learns that worker exited — [`reader`]'s tail does not
+/// run, the calls it owed replies to wait for ever, and the session can never be reclaimed.
 ///
 /// std holds a lock of its own across the same window for the stdio handles it prepares, which is
 /// the same reasoning applied to the same hazard; this one covers the handles std knows nothing
-/// about. Nothing else in this process spawns children, so between them the window is closed.
+/// about. **A new `Command::spawn` anywhere in this crate has to take it** — see [`spawn_guard`].
 static SPAWN_LOCK: Mutex<()> = Mutex::new(());
+
+/// Claims [`SPAWN_LOCK`] for the caller's own `spawn()`. Hold it across the call and no longer.
+///
+/// Every process creation in this server goes through here, including ones that have nothing to do
+/// with debug sessions: the flag is a property of the *process*, not of the spawn that set it, so a
+/// child started for any reason during the window inherits whatever is marked.
+pub(crate) fn spawn_guard() -> std::sync::MutexGuard<'static, ()> {
+    SPAWN_LOCK.lock().unwrap_or_else(|e| e.into_inner())
+}
 
 /// Marks a handle inheritable, so the child gets a copy of it.
 fn inheritable(handle: &impl AsRawHandle) -> std::io::Result<()> {
@@ -1603,7 +1617,7 @@ fn spawn_worker(exe: &Path) -> std::io::Result<(Child, Channel)> {
     let (their_requests, our_requests) = std::io::pipe()?;
     let (our_messages, their_messages) = std::io::pipe()?;
 
-    let _one_spawn_at_a_time = SPAWN_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let _one_spawn_at_a_time = spawn_guard();
     inheritable(&their_requests)?;
     inheritable(&their_messages)?;
     let child = Command::new(exe)
@@ -1719,27 +1733,67 @@ fn clipped(line: &str) -> String {
 async fn log_stray_output(id: String, stdout: ChildStdout) {
     let mut stdout = BufReader::new(stdout);
     let mut line = Vec::new();
-    loop {
-        line.clear();
-        // Bytes and then a lossy decode, not `lines()`. Whatever prints here is not ours and owes
-        // us no encoding — an extension writing in the console's code page is not UTF-8 — and a
-        // decode error must not be able to end this loop. Stopping the drain is the one outcome
-        // that matters: the pipe would fill, and the next write would block the engine thread
-        // inside DbgEng, which is a session lost to output nobody even wanted.
-        match stdout.read_until(b'\n', &mut line).await {
-            // EOF, or a broken pipe: the worker is gone and there is nothing left to drain.
-            Ok(0) | Err(_) => return,
-            Ok(_) => {}
-        }
+    while let Some(dropped) = next_capped_line(&mut stdout, &mut line).await {
+        // A lossy decode, not `lines()`. Whatever prints here is not ours and owes us no encoding
+        // — an extension writing in the console's code page is not UTF-8 — and a decode error
+        // must not be able to end this loop. Stopping the drain is the one outcome that matters:
+        // the pipe would fill, and the next write would block the engine thread inside DbgEng,
+        // which is a session lost to output nobody even wanted.
         let text = String::from_utf8_lossy(&line);
         let text = text.trim_end_matches(['\r', '\n']);
-        if text.trim().is_empty() {
+        if text.trim().is_empty() && dropped == 0 {
             continue;
         }
+        let dropped = if dropped > 0 {
+            format!(" [+{dropped} further bytes on this line, discarded]")
+        } else {
+            String::new()
+        };
         tracing::info!(
-            "session {id}: its engine worker wrote to stdout: {}",
+            "session {id}: its engine worker wrote to stdout: {}{dropped}",
             clipped(text)
         );
+    }
+}
+
+/// Reads the next line into `line`, keeping at most [`LOGGED_LINE_LIMIT`] bytes of it and
+/// reporting how many were thrown away. `None` at EOF or on a broken pipe.
+///
+/// The cap is the point, and it is not about the log. Draining a worker's stdout moves the cost of
+/// runaway output off the worker — where a full pipe blocked the engine thread — and onto the
+/// supervisor, which is only an improvement if what arrives is bounded: reading to a newline that
+/// never comes would let one session's noisy extension grow this buffer until the whole server
+/// runs out of memory, and take every other session with it. [`clipped`] bounds what is *logged*,
+/// which is a different thing and too late.
+async fn next_capped_line<R: tokio::io::AsyncBufRead + Unpin>(
+    stdout: &mut R,
+    line: &mut Vec<u8>,
+) -> Option<usize> {
+    line.clear();
+    let mut dropped = 0usize;
+    loop {
+        // `fill_buf`/`consume` rather than `read_until`, because this has to decide what to keep
+        // *before* it is buffered.
+        let (consumed, complete) = {
+            let chunk = stdout.fill_buf().await.ok()?;
+            if chunk.is_empty() {
+                // EOF. A last line with no terminator is still a line worth logging.
+                return (!line.is_empty() || dropped > 0).then_some(dropped);
+            }
+            let (upto, complete) = match chunk.iter().position(|&b| b == b'\n') {
+                Some(at) => (at + 1, true),
+                None => (chunk.len(), false),
+            };
+            let room = LOGGED_LINE_LIMIT.saturating_sub(line.len());
+            let kept = upto.min(room);
+            line.extend_from_slice(&chunk[..kept]);
+            dropped += upto - kept;
+            (upto, complete)
+        };
+        stdout.consume(consumed);
+        if complete {
+            return Some(dropped);
+        }
     }
 }
 
@@ -1940,6 +1994,51 @@ mod tests {
         let _ = child.wait().await;
     }
 
+    /// Draining a worker's stdout moves runaway output off the worker, where a full pipe blocked
+    /// the engine thread, and onto the supervisor — which is only an improvement if what arrives
+    /// is bounded. So the cap is applied to what is *buffered*, not just to what is logged: a
+    /// line with no newline in sight must not be able to grow this buffer until the server runs
+    /// out of memory and takes every other session with it.
+    ///
+    /// Read through an 8-byte buffer, so the cap has to hold across many small chunks — a pipe
+    /// hands over whatever has arrived, not whole lines.
+    #[tokio::test]
+    async fn a_line_from_a_worker_is_capped_before_it_is_buffered() {
+        let mut input = b"short\n".to_vec();
+        let overrun = LOGGED_LINE_LIMIT * 3;
+        input.extend(std::iter::repeat_n(b'x', overrun));
+        input.push(b'\n');
+        input.extend_from_slice(b"a last line, unterminated");
+        let mut stdout = BufReader::with_capacity(8, &input[..]);
+        let mut line = Vec::new();
+
+        assert_eq!(next_capped_line(&mut stdout, &mut line).await, Some(0));
+        assert_eq!(line, b"short\n");
+
+        let dropped = next_capped_line(&mut stdout, &mut line)
+            .await
+            .expect("the long line");
+        assert_eq!(
+            line.len(),
+            LOGGED_LINE_LIMIT,
+            "the buffer grew past the cap, so a worker printing without newlines is unbounded"
+        );
+        assert_eq!(
+            dropped,
+            overrun + 1 - LOGGED_LINE_LIMIT,
+            "the discarded bytes are miscounted, so the log would understate what was dropped"
+        );
+
+        // EOF ends a line rather than losing it: an unterminated last line is still output.
+        assert_eq!(next_capped_line(&mut stdout, &mut line).await, Some(0));
+        assert_eq!(line, b"a last line, unterminated");
+        assert_eq!(
+            next_capped_line(&mut stdout, &mut line).await,
+            None,
+            "the drain must end at EOF"
+        );
+    }
+
     /// A worker line reaches the log clipped, and says how much was left out. An extension in a
     /// loop must not be able to bury the log under one line.
     #[test]
@@ -2085,6 +2184,25 @@ mod tests {
             released: AtomicBool::new(false),
             child: Mutex::new(None),
         })
+    }
+
+    /// A long-lived child to stand in for a worker, where what is under test is which sessions own
+    /// a process rather than what that process is.
+    ///
+    /// Under [`spawn_guard`] like every other spawn here, and for a reason these tests can hit:
+    /// `cargo test` runs them as threads of one process, alongside
+    /// [`a_workers_stdout_is_not_its_protocol_channel`], which marks a channel inheritable. A
+    /// stand-in created inside that window would inherit the stand-in worker's message write end
+    /// and hold it for its full 30 seconds — the pipe would never report EOF, and that test would
+    /// fail waiting for it. The hazard is process-wide; so is the rule.
+    fn stand_in_child() -> Child {
+        let _one_spawn_at_a_time = spawn_guard();
+        Command::new("cmd")
+            .args(["/c", "ping", "-n", "30", "127.0.0.1"])
+            .stdout(Stdio::null())
+            .kill_on_drop(true)
+            .spawn()
+            .expect("spawn a stand-in child")
     }
 
     fn registry_of(sessions: &[Arc<Session>]) -> Sessions {
@@ -2477,12 +2595,7 @@ mod tests {
         let reclaimed = dormant("sess-reclaimed", SessionState::Open);
         // A stand-in for the worker: any child process will do, since what is under test is
         // which sessions the registry hands to shutdown, not what the process is.
-        let child = Command::new("cmd")
-            .args(["/c", "ping", "-n", "30", "127.0.0.1"])
-            .stdout(Stdio::null())
-            .kill_on_drop(true)
-            .spawn()
-            .expect("spawn a stand-in child");
+        let child = stand_in_child();
         *reclaimed.child.lock().unwrap() = Some(child);
         // Claimed for reclamation: closed already, release still to come.
         reclaimed.set_state(SessionState::Closed("reclaimed".to_string()));
@@ -2521,12 +2634,7 @@ mod tests {
             "sess-releasing",
             SessionState::Closed("reclaimed".to_string()),
         );
-        let child = Command::new("cmd")
-            .args(["/c", "ping", "-n", "30", "127.0.0.1"])
-            .stdout(Stdio::null())
-            .kill_on_drop(true)
-            .spawn()
-            .expect("spawn a stand-in child");
+        let child = stand_in_child();
         *releasing.child.lock().unwrap() = Some(child);
         {
             let mut registry = sessions.registry();

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -2010,6 +2010,16 @@ mod tests {
     /// too, so a refactor that stops matching fails loudly instead of quietly checking nothing.
     #[test]
     fn every_process_spawn_in_this_crate_takes_the_spawn_lock() {
+        // Assembled at run time rather than written as literals, because this function is *in* the
+        // source it reads. Written out, the two lines below would each match themselves: the
+        // matcher would count as a spawn site, and — the guard's name being on the line above it —
+        // as a *guarded* one. The floor asserted at the end would then be satisfied by the checker
+        // itself, which is the one line that cannot stop matching, and a real spawn site could drop
+        // out of the marker with nothing to notice. Splitting them keeps the checker invisible to
+        // itself, which is what leaves the floor counting only real spawns.
+        let a_spawn = [".spawn", "()"].concat();
+        let the_guard = ["spawn_", "guard()"].concat();
+
         let mut sites = 0;
         let mut unguarded = Vec::new();
         for file in rust_sources(&PathBuf::from(concat!(env!("CARGO_MANIFEST_DIR"), "/src"))) {
@@ -2025,10 +2035,10 @@ mod tests {
                 if code.starts_with("fn ") || code.contains(" fn ") {
                     guarded = false;
                 }
-                if code.contains("spawn_guard()") {
+                if code.contains(&the_guard) {
                     guarded = true;
                 }
-                if code.contains(".spawn()") {
+                if code.contains(&a_spawn) {
                     sites += 1;
                     if !guarded {
                         unguarded.push(format!("{}:{}", file.display(), n + 1));
@@ -2038,7 +2048,9 @@ mod tests {
         }
         assert!(
             unguarded.is_empty(),
-            "these spawn a process without holding `engine::spawn_guard()` in the same function, \
+            // `engine::spawn_guard` without its parentheses, for the reason above: written in
+            // full it would be one more line the checker sees as a guard.
+            "these spawn a process without holding `engine::spawn_guard` in the same function, \
              so a child started there can inherit a worker's protocol channel and keep it from \
              ever reporting EOF: {unguarded:?}"
         );

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,10 +48,13 @@ fn call_timeout() -> Duration {
 fn main() -> Result<()> {
     // Read the role before anything else: a worker has no use for a tokio runtime, and its
     // engine thread must be free to block in DbgEng indefinitely.
-    let is_worker = std::env::args().any(|arg| arg == worker::WORKER_FLAG);
+    let args: Vec<String> = std::env::args().collect();
+    let is_worker = args.iter().any(|arg| arg == worker::WORKER_FLAG);
     init_logging();
     if is_worker {
-        worker::run();
+        // The rest of the command line is the worker's half of the protocol channel — two
+        // inherited pipe handles, which is why a worker started by hand cannot get anywhere.
+        worker::run(&args);
     }
 
     tokio::runtime::Builder::new_multi_thread()

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -6,11 +6,23 @@
 //! a closure cannot cross a process boundary, so the closures became the variants of
 //! [`EngineOp`].
 //!
-//! One line of JSON per message in each direction: requests down the worker's stdin, messages
-//! up its stdout. Line-delimited rather than length-prefixed so that a stray write to the
-//! worker's stdout — DbgEng output is captured through `IDebugOutputCallbacks`, but nothing
-//! *guarantees* every extension behaves — corrupts one line the supervisor can log and skip,
-//! rather than desynchronizing the stream permanently.
+//! One line of JSON per message in each direction, on a **channel of the protocol's own**: a pair
+//! of anonymous pipes the supervisor creates and the worker inherits, requests down one and
+//! messages up the other. The worker's standard handles carry none of it.
+//!
+//! That is a correctness property, not tidiness. The channel used to be the worker's stdin and
+//! stdout, which is the same stdout any code in that process can write to — DbgEng's own output
+//! is captured through `IDebugOutputCallbacks` and never lands there, but an extension DLL that
+//! prints to the console directly does. A stray *unterminated* line then swallowed the message
+//! written after it, and the supervisor drops what it cannot parse: the reply is lost, and since
+//! only a `Done` removes a waiter, the caller times out and its session stays busy — and so
+//! unreclaimable — for the life of the server. One stray `printf` cost a session permanently.
+//!
+//! An anonymous pipe has no name to open and is reachable only through an inherited handle, so
+//! nothing outside this pair of processes can write on it, and inside the worker nothing but
+//! `worker::emit` holds it. "Stray output cannot corrupt a reply" is therefore a
+//! property of the plumbing rather than a convention about who prints where — which is what lets
+//! the framing stay line-delimited and cheap.
 
 use serde::{Deserialize, Serialize};
 

--- a/src/ttd.rs
+++ b/src/ttd.rs
@@ -125,9 +125,17 @@ pub fn record_launch(
     if let Some(dir) = working_dir {
         cmd.current_dir(dir);
     }
-    let mut child = cmd
-        .spawn()
-        .map_err(|e| format!("failed to launch TTD.exe: {e}"))?;
+    // Under the server's spawn lock, like every other process this server creates. Nothing here
+    // wants an inherited handle — but a worker being spawned at this moment has its protocol
+    // channel marked inheritable, and marking is process-wide: a recorder started inside that
+    // window would inherit that worker's message write end and, since it outlives the whole
+    // recording, keep the pipe from ever reporting EOF when the worker exits. That session would
+    // then never settle. See `engine::SPAWN_LOCK`.
+    let mut child = {
+        let _one_spawn_at_a_time = crate::engine::spawn_guard();
+        cmd.spawn()
+    }
+    .map_err(|e| format!("failed to launch TTD.exe: {e}"))?;
 
     let pid = child.id();
 

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -2,7 +2,8 @@
 //!
 //! dbgeng.dll holds **one debuggee session per process**, so a session is a process here rather
 //! than a thread. The supervisor ([`crate::engine`]) spawns one of these per open target and
-//! talks to it over stdin/stdout ([`crate::proto`]).
+//! talks to it over a private pair of inherited pipes ([`crate::proto`]) — *not* over this
+//! process's standard handles, which anything linked into it may write to.
 //!
 //! Inside the worker the old confinement rules still apply — DbgEng wants serialized,
 //! single-threaded access, and `WaitForEvent` must run on the session-owning thread — so the
@@ -12,13 +13,14 @@
 //! watchdog cannot reach a wait that is still establishing the link). That used to park the
 //! server's only engine thread; here it parks this process, which the supervisor can kill.
 //!
-//! Which is why the stdin reader lives on the *main* thread and exits the process outright on
+//! Which is why the request reader lives on the *main* thread and exits the process outright on
 //! EOF instead of joining the engine thread: at EOF the engine thread may be parked forever,
 //! and waiting for it would recreate the very wedge this design removes.
 
-use std::io::{BufRead, Write};
+use std::io::{BufRead, BufReader, PipeReader, PipeWriter, Write};
+use std::os::windows::io::{FromRawHandle, RawHandle};
 use std::panic::{AssertUnwindSafe, catch_unwind};
-use std::sync::mpsc;
+use std::sync::{Mutex, OnceLock, mpsc};
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -33,6 +35,35 @@ use crate::server::{
 /// The argument that turns this executable into a worker. Not a documented CLI: the supervisor
 /// re-executes itself with it, and nothing else should.
 pub const WORKER_FLAG: &str = "--engine-worker";
+
+/// The flags carrying this worker's two ends of the protocol channel, as raw handle values:
+/// requests to read, messages to write ([`crate::proto`]).
+///
+/// Even less of a CLI than [`WORKER_FLAG`]. A handle number means nothing outside the process
+/// that inherited it, so these are only ever valid in the child the supervisor spawned with them.
+pub const REQUESTS_FLAG: &str = "--requests-handle=";
+pub const MESSAGES_FLAG: &str = "--messages-handle=";
+
+/// Reads the two inherited handle values off the command line.
+///
+/// There is deliberately no fallback to stdin/stdout when they are missing. Falling back is the
+/// exposure this channel exists to remove — a worker that quietly spoke the protocol over its
+/// standard handles again would be back to sharing them with whatever an extension DLL prints.
+fn channel_handles(args: &[String]) -> Result<(usize, usize), String> {
+    let value = |flag: &str| {
+        let raw = args
+            .iter()
+            .find_map(|arg| arg.strip_prefix(flag))
+            .ok_or_else(|| format!("no `{flag}<handle>` on the command line"))?;
+        match raw.parse::<usize>() {
+            // A null handle is not a channel: it would fail every read or write, silently, for
+            // the life of the process.
+            Ok(0) | Err(_) => Err(format!("`{flag}{raw}` is not a usable handle value")),
+            Ok(handle) => Ok(handle),
+        }
+    };
+    Ok((value(REQUESTS_FLAG)?, value(MESSAGES_FLAG)?))
+}
 
 /// How long to wait for a target to stop after open/attach/launch (ms).
 ///
@@ -85,7 +116,7 @@ fn watchdog_budget_ms(patience: Duration, queued: Duration) -> u32 {
 /// the case that matters: exiting without it leaves the target machine halted.
 const ABRUPT_EXIT_RELEASE: Duration = Duration::from_secs(5);
 
-/// What the stdin reader hands to the engine thread.
+/// What the request reader hands to the engine thread.
 enum Job {
     /// A request from the supervisor, stamped when it was read.
     Run(Instant, WorkerRequest),
@@ -94,7 +125,28 @@ enum Job {
 }
 
 /// Runs this process as an engine worker. Never returns.
-pub fn run() -> ! {
+pub fn run(args: &[String]) -> ! {
+    let (requests, messages) = match channel_handles(args) {
+        Ok(handles) => handles,
+        Err(why) => {
+            // Nothing can be *reported*: the channel a supervisor would be listening on is the
+            // very thing that is missing. So this goes to stderr, and the exit is what the
+            // supervisor reads — its end of the channel closes and it says the worker exited
+            // before it was ready, which is exactly what happened.
+            tracing::error!("worker: {why}; this executable is not meant to be run by hand");
+            std::process::exit(2);
+        }
+    };
+    // SAFETY: these are the two handles the supervisor created for this process and passed on the
+    // command line, inherited by `CreateProcess` and owned by nothing else here — the supervisor
+    // closed its copies as soon as the spawn returned (`engine::spawn_worker`). Wrapping them
+    // takes that ownership; they close when this process does, which is what gives the supervisor
+    // its EOF.
+    let requests = unsafe { PipeReader::from_raw_handle(requests as RawHandle) };
+    let messages = unsafe { PipeWriter::from_raw_handle(messages as RawHandle) };
+    // Installed before the engine thread exists, so nothing can reach `emit` without a channel.
+    let _ = MESSAGES.set(Mutex::new(messages));
+
     // Each request is stamped when it is *read*, so the engine thread can tell how long it then
     // waited its turn — the half of the watchdog budget only this process can measure.
     let (tx, rx) = mpsc::channel::<Job>();
@@ -111,8 +163,7 @@ pub fn run() -> ! {
         std::process::exit(1);
     }
 
-    let stdin = std::io::stdin();
-    for line in stdin.lock().lines() {
+    for line in BufReader::new(requests).lines() {
         let Ok(line) = line else { break };
         if line.trim().is_empty() {
             continue;
@@ -133,8 +184,8 @@ pub fn run() -> ! {
         }
     }
 
-    // stdin closed: the supervisor ended this session, or died. Either way this process has no
-    // reason to exist.
+    // The request channel closed: the supervisor ended this session, or died. Either way this
+    // process has no reason to exist.
     //
     // This is the *only* thing that ends a worker the supervisor did not explicitly kill — it does
     // not set `kill_on_drop`, deliberately (`engine::Sessions::spawn`). So the path below has to
@@ -243,34 +294,76 @@ fn engine_thread(rx: mpsc::Receiver<Job>) {
             execute(&engine, request.id, request.op, queued)
         }))
         .unwrap_or_else(|_| Err("debugger operation panicked".to_string()));
-        emit(&WorkerMessage::Done {
-            id: request.id,
-            result,
-        });
+        let id = request.id;
+        // A `Done` is what removes the supervisor's waiter, so one that never arrives costs the
+        // caller its session rather than its result: the call times out, the waiter stays, and
+        // the session counts as busy — and so stays unreclaimable — for the life of the server.
+        // The channel now makes corruption impossible, but delivery is still worth insisting on.
+        if let Emit::Unencodable = emit(&WorkerMessage::Done { id, result }) {
+            // The result could not be serialized, so send one that cannot fail to be: plain text
+            // in the same shape. The caller loses the output, not the session.
+            emit(&WorkerMessage::Done {
+                id,
+                result: Err(
+                    "the debugger's result could not be encoded for the supervisor".to_string(),
+                ),
+            });
+        }
+        // `Unwritable` gets no retry, and needs none: the supervisor holds the only read end, so
+        // a channel that will not take a write means it is gone — its request channel has closed
+        // too, and the teardown at the end of `run` is already on its way. The supervisor fails
+        // every outstanding call out when this process exits, which answers this caller.
     }
 }
 
-/// Writes one message to stdout. Only the engine thread writes, so the lock is uncontended;
-/// it is taken anyway because `Stdout` is shared and a torn line would desynchronize the
-/// supervisor's reader.
-fn emit(message: &WorkerMessage) {
-    let Ok(line) = serde_json::to_string(message) else {
-        // Every variant is plain data, so this cannot happen — but a worker that dies silently
-        // here would look to the supervisor like an engine crash.
+/// The channel this worker writes its messages on: its end of the pipe the supervisor is reading
+/// ([`crate::proto`]). One per process and for the life of the process, installed by [`run`]
+/// before anything exists that could emit.
+///
+/// Global for the same reason stdout was: `emit` is reached from the engine thread, from inside
+/// an opener's milestones, and from the main thread's startup path, and threading a handle
+/// through all of that would buy nothing — there is exactly one channel, and no code path may
+/// choose a different one.
+static MESSAGES: OnceLock<Mutex<PipeWriter>> = OnceLock::new();
+
+/// What became of a message [`emit`] was asked to send.
+enum Emit {
+    Sent,
+    /// It could not be serialized. Every variant is plain data, so this is a bug rather than a
+    /// condition — but see the `Done` path in [`engine_thread`] for why it is still handled.
+    Unencodable,
+    /// It could not be written. The supervisor holds the only read end, so this means it is gone
+    /// or going, and the request channel is at EOF or about to be.
+    Unwritable,
+}
+
+/// Writes one message on the protocol channel.
+///
+/// The whole message is one `write_all` under one lock, and the channel is private to this pair
+/// of processes, so a message always arrives as its own line. Nothing else here holds the handle,
+/// and an anonymous pipe has no name for anything else to open — which is what makes framing a
+/// matter of what this function does rather than of what nobody else happens to print.
+fn emit(message: &WorkerMessage) -> Emit {
+    let Ok(mut line) = serde_json::to_string(message) else {
         tracing::error!("worker: could not encode {message:?}");
-        return;
+        return Emit::Unencodable;
     };
-    let stdout = std::io::stdout();
-    let mut stdout = stdout.lock();
-    // Leading newline, not just a trailing one. DbgEng's own output reaches the supervisor through
-    // `IDebugOutputCallbacks` and never comes this way, but an extension DLL that writes to the
-    // console directly does — and if it left its last line *unterminated*, a trailing-newline-only
-    // message would be appended to that text and arrive as one unparseable line. The supervisor
-    // skips what it cannot parse, so the reply would be lost outright: the caller times out, its
-    // waiter is never removed, and the session stays busy and unreclaimable for good. Opening with
-    // a newline terminates whatever came before, so a message always starts its own line.
-    let _ = write!(stdout, "\n{line}\n");
-    let _ = stdout.flush();
+    line.push('\n');
+    let Some(channel) = MESSAGES.get() else {
+        tracing::error!("worker: no protocol channel to write {message:?} on");
+        return Emit::Unwritable;
+    };
+    let mut channel = channel.lock().unwrap_or_else(|e| e.into_inner());
+    match channel
+        .write_all(line.as_bytes())
+        .and_then(|()| channel.flush())
+    {
+        Ok(()) => Emit::Sent,
+        Err(e) => {
+            tracing::error!("worker: could not write to the protocol channel ({e})");
+            Emit::Unwritable
+        }
+    }
 }
 
 /// Runs one op against this worker's engine. `queued` is how long it waited its turn here, which
@@ -494,7 +587,9 @@ where
     T: FnOnce(&dyn Fn()) -> Result<(), String>,
     R: FnOnce() -> Result<String, String>,
 {
-    transition(&|| emit(&WorkerMessage::Committed { id }))?;
+    transition(&|| {
+        emit(&WorkerMessage::Committed { id });
+    })?;
     emit(&WorkerMessage::Opened { id });
     report()
 }
@@ -614,6 +709,56 @@ fn reachable(e: &DebugEngine, args: ReachabilityOp) -> Result<String, String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ---- the protocol channel this worker was handed -------------------------------
+
+    fn args(list: &[&str]) -> Vec<String> {
+        list.iter().map(|a| a.to_string()).collect()
+    }
+
+    /// The ordinary case: the supervisor's command line, read back as the two handles.
+    #[test]
+    fn the_channel_is_read_off_the_command_line() {
+        let handles = channel_handles(&args(&[
+            "windbg-mcp.exe",
+            WORKER_FLAG,
+            "--requests-handle=132",
+            "--messages-handle=140",
+        ]));
+        assert_eq!(handles, Ok((132, 140)));
+    }
+
+    /// Every way the pair can be missing or unusable is refused, and none of them may fall back
+    /// to a standard handle: a worker that quietly spoke the protocol over stdout again would be
+    /// back to sharing it with whatever an extension prints, which is the whole exposure.
+    #[test]
+    fn a_worker_without_a_usable_channel_is_refused() {
+        for line in [
+            // Started by hand, with no channel at all.
+            args(&["windbg-mcp.exe", WORKER_FLAG]),
+            // Half a channel is no channel.
+            args(&["windbg-mcp.exe", WORKER_FLAG, "--requests-handle=132"]),
+            args(&["windbg-mcp.exe", WORKER_FLAG, "--messages-handle=140"]),
+            // Present but unusable: a null handle fails every read and write, silently.
+            args(&[
+                "windbg-mcp.exe",
+                WORKER_FLAG,
+                "--requests-handle=0",
+                "--messages-handle=140",
+            ]),
+            args(&[
+                "windbg-mcp.exe",
+                WORKER_FLAG,
+                "--requests-handle=132",
+                "--messages-handle=oops",
+            ]),
+        ] {
+            assert!(
+                channel_handles(&line).is_err(),
+                "accepted a command line that carries no usable channel: {line:?}"
+            );
+        }
+    }
 
     // The watchdog budget, as arithmetic. What it is *wired to* needs a real engine and a real
     // target, and lives in `tests/mcp_smoke.rs`'s bounded-command tier — the wiring now spans two

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -18,13 +18,14 @@
 //! and waiting for it would recreate the very wedge this design removes.
 
 use std::io::{BufRead, BufReader, PipeReader, PipeWriter, Write};
-use std::os::windows::io::{FromRawHandle, RawHandle};
+use std::os::windows::io::{AsRawHandle, FromRawHandle, RawHandle};
 use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::sync::{Mutex, OnceLock, mpsc};
 use std::thread;
 use std::time::{Duration, Instant};
 
 use win_kexp::dbgeng::{DebugEngine, RunToOutcome};
+use windows_sys::Win32::Foundation::{HANDLE_FLAG_INHERIT, SetHandleInformation};
 
 use crate::proto::{EngineOp, ReachabilityOp, WorkerMessage, WorkerRequest};
 use crate::server::{
@@ -63,6 +64,18 @@ fn channel_handles(args: &[String]) -> Result<(usize, usize), String> {
         }
     };
     Ok((value(REQUESTS_FLAG)?, value(MESSAGES_FLAG)?))
+}
+
+/// Clears `HANDLE_FLAG_INHERIT` on a handle this process inherited, so no child of *this* process
+/// gets a copy in turn. The supervisor's side of the same flag is `engine::inheritable`.
+fn stop_inheriting(handle: RawHandle) -> std::io::Result<()> {
+    // SAFETY: the handle is owned by this process for the rest of its life, and this only changes
+    // a flag on it.
+    let ok = unsafe { SetHandleInformation(handle, HANDLE_FLAG_INHERIT, 0) };
+    if ok == 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(())
 }
 
 /// How long to wait for a target to stop after open/attach/launch (ms).
@@ -144,6 +157,23 @@ pub fn run(args: &[String]) -> ! {
     // its EOF.
     let requests = unsafe { PipeReader::from_raw_handle(requests as RawHandle) };
     let messages = unsafe { PipeWriter::from_raw_handle(messages as RawHandle) };
+    // The inheritable flag came with them and has done its job; carrying it further is how the
+    // channel would escape this process. DbgEng creates children of its own — a launched debuggee,
+    // whatever an extension shells out to — and one that inherited the message end would keep that
+    // pipe from reporting EOF after this worker exits, which is exactly the signal the supervisor
+    // settles a session on. Warned about rather than fatal: the channel itself still works, and
+    // the risk only materializes if something is spawned here at all.
+    for (what, handle) in [
+        ("requests", requests.as_raw_handle()),
+        ("messages", messages.as_raw_handle()),
+    ] {
+        if let Err(e) = stop_inheriting(handle) {
+            tracing::warn!(
+                "worker: could not stop the {what} channel being inherited ({e}); a process this \
+                 debugger starts could hold it open past this worker's exit"
+            );
+        }
+    }
     // Installed before the engine thread exists, so nothing can reach `emit` without a channel.
     let _ = MESSAGES.set(Mutex::new(messages));
 

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -292,8 +292,8 @@ impl Server {
     /// Terminates the supervisor outright, giving it no chance to run its own shutdown.
     ///
     /// Stdin is *not* closed first — that would be the graceful path this is the opposite of. The
-    /// point is to leave the workers with nothing but their own stdin reaching EOF as the dead
-    /// supervisor's handles are closed.
+    /// point is to leave the workers with nothing but EOF on their own request channels, as the
+    /// dead supervisor's handles are closed.
     fn kill_supervisor(mut self) {
         self.child.kill().expect("terminate the supervisor");
         self.child.wait().expect("reap the supervisor");
@@ -1202,8 +1202,8 @@ fn engine_workers_do_not_outlive_the_connection() {
     );
 
     // Two ways it can be gone, and this asserts only the outcome: shutdown asked it to release
-    // and then ended it, or — for a worker shutdown never saw — its own stdin closed as the
-    // supervisor exited. Either way, no process is left behind.
+    // and then ended it, or — for a worker shutdown never saw — its own request channel closed as
+    // the supervisor exited. Either way, no process is left behind.
     let deadline = Instant::now() + Duration::from_secs(20);
     while process_alive(worker) && Instant::now() < deadline {
         std::thread::sleep(Duration::from_millis(50));
@@ -1222,10 +1222,10 @@ fn engine_workers_do_not_outlive_the_connection() {
 /// registered after shutdown had walked the registry, say) would die with its target still
 /// attached, and a live kernel left attached-but-halted is a machine that needs rebooting.
 ///
-/// So the guarantee is the worker's own: stdin reaching EOF means "the supervisor is gone", and it
-/// asks its engine to release before exiting, bounded. Killed outright here, the supervisor
-/// contributes nothing — no shutdown, no `EndSession`, not even a clean stdin close — which is
-/// exactly the case where nothing else can stand in.
+/// So the guarantee is the worker's own: EOF on its request channel means "the supervisor is
+/// gone", and it asks its engine to release before exiting, bounded. Killed outright here, the
+/// supervisor contributes nothing — no shutdown, no `EndSession`, not even a channel closed
+/// cleanly — which is exactly the case where nothing else can stand in.
 #[test]
 fn a_worker_lets_go_and_exits_when_its_supervisor_is_killed_outright() {
     let Some(dump) = target_tier() else { return };
@@ -1247,7 +1247,7 @@ fn a_worker_lets_go_and_exits_when_its_supervisor_is_killed_outright() {
     assert!(
         !process_alive(worker),
         "engine worker pid {worker} outlived a killed supervisor — with nothing terminating it, \
-         EOF on its stdin is the only thing that ends it, and it did not"
+         EOF on its request channel is the only thing that ends it, and it did not"
     );
 }
 


### PR DESCRIPTION
Closes #65.

## The exposure

The supervisor↔worker protocol rode the worker's stdin and stdout — the same stdout any code in that process can write to. DbgEng's own output never lands there (it is captured through `IDebugOutputCallbacks`), but an extension DLL that prints to the console directly does, and an **unterminated** stray line swallowed the message written after it.

The supervisor drops what it cannot parse, and only a `Done` removes a waiter, so the cost of one stray `printf` was not a lost line but a lost session: the call timed out, its waiter stayed, and the session counted as busy — and so could never be reclaimed — for the life of the server. a5fc0e6 mitigated it by opening each message with a newline; the property was still a convention about who prints where.

## The channel

Each worker now gets a pair of anonymous pipes, created by the supervisor and inherited across the spawn: requests down one, messages up the other. An anonymous pipe has no name to open and is reachable only through an inherited handle, so nothing outside that pair of processes can write on it — "stray output cannot corrupt a reply" is a property of the plumbing rather than of what happens to be loaded.

Marking, spawning and closing all happen under one lock. A handle is inheritable from the moment it is marked until it is closed, and **every** process created in between gets a copy: two overlapping opens would cross-inherit, and a worker holding another worker's *write* end keeps that pipe from ever reporting EOF — so the supervisor would never learn the other worker had exited, and the calls it owed replies to would wait for ever. std holds a lock of its own across the same window for the stdio handles it prepares; this one covers the handles std knows nothing about.

Both directions moved, not just the one the report names. The request side carries the KD connection string, key and all, and a request consumed by something else costs the same session the same way — a reply that never comes.

## What the worker's standard handles are now

- **stdout**: piped and drained into the log, per session. Nothing of ours writes there, so anything that arrives was printed by something else in that process — which is the first time an extension's console output has been visible at all. Drained rather than discarded because an unread pipe fills and the *next* write blocks the engine thread inside DbgEng; read as bytes and decoded lossily, because an extension writing in the console's code page is not UTF-8 and a decode error must not be able to stop the drain.
- **stdin**: `NUL`, emphatically not inherited — the supervisor's stdin is the MCP transport, and a worker holding it could consume the client's requests.
- **stderr**: inherited, as before.

Anonymous pipes cannot be read or written asynchronously on Windows (they are not overlapped handles), so the message reader and the request pump are threads. `reader` stays a task: settling a session touches the registry and the worker's process handle, which is where both belong.

## Keeping a lost `Done` from stranding a waiter

The issue asks for this to be bounded independently of the framing, so it is answered directly:

- a result that cannot be encoded is replaced by a `Done` that says so — the caller loses the output, not the session;
- a channel that will not take a write means the supervisor is gone, its request channel is at EOF or about to be, and its exit fails every outstanding call out;
- worker exit still settles the session and fails its callers out, unchanged.

Teardown is otherwise unchanged in substance: EOF on the request channel now means what EOF on stdin meant, and a worker still releases its target before it exits. Comments, README, CLAUDE.md, `docs/smoke-test.md` and `examples/ctrl_c_teardown.ps1` say so rather than continuing to claim stdin.

`windows-sys` becomes a direct dependency (`Win32_Foundation`, for `SetHandleInformation`). It was already in the tree via tokio, so nothing new is compiled.

## Verification

- `cargo test` — 104 unit + 18 smoke, all pass. New: the channel-handle parser (including "half a channel is no channel" and a null handle), log clipping, and `a_workers_stdout_is_not_its_protocol_channel`, where `cmd.exe` stands in for the hazard — handed a worker's command line it prints its banner and an unterminated prompt to stdout, says nothing on the channel, and exits. The supervisor must hear silence and then EOF, which also catches a supervisor copy of a child's end left open.
- Debugger tier (`$env:WINDBG_MCP_SMOKE_DUMP = "1"; cargo test --test mcp_smoke`) — all pass in ~20s: real workers handshake over the new channel, open the dump, coexist, a parked kernel attach is reclaimed by pid, and no worker outlives the connection.
- By hand against the dev build: a dump session opens, executes, reads registers and releases cleanly; pointing `WINDBG_MCP_WORKER_EXE` at `cmd.exe` shows its banner **and its unterminated prompt line** logged as `session …: its engine worker wrote to stdout: …`, with the open failing cleanly and the server unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved supervisor–worker communication using dedicated protocol channels.
  * Prevented extension output from interfering with protocol messages.
  * Added logging for stray worker output, including clipping of excessively long lines.
  * Improved worker shutdown when the request channel closes.

* **Documentation**
  * Updated protocol, lifecycle, troubleshooting and smoke-test documentation.
  * Added guidance covering channel failures and worker teardown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->