### PR TITLE
pool: four MCP tools over win-kexp's pool walker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -884,7 +884,7 @@ dependencies = [
 [[package]]
 name = "win-kexp"
 version = "0.1.0"
-source = "git+https://github.com/glslang/win-kexp?branch=main#38eeafd36cbd037a7fdda08b9209ad9bf60c1d5d"
+source = "git+https://github.com/glslang/win-kexp?branch=main#ce8bce2ad21bac007c835ef6ca198341737fae06"
 dependencies = [
  "byte-strings",
  "goblin",

--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ gh attestation verify <zip> --repo glslang/windbg-mcp `
 | TTD nav | `step_back` (`t-`), `step_over_back` (`p-`), `reverse_go` (`g-`), `goto_position` (`!tt`) |
 | TTD analysis | `ttd_calls`, `ttd_memory`, `ttd_events`, `index_trace`, `record_trace` |
 | Driver IOCTL | `decode_ioctl`, `driver_object`, `device_object`, `irp_stack`, `ioctl_trace`, `reachable_from_dispatch` |
-| Kernel pool | `pool_find_tag`, `pool_chunk`, `pool_census` |
+| Kernel pool | `pool_find_tag`, `pool_chunk`, `pool_census`, `pool_diagnostics` |
 | Raw     | `execute` — run any debugger command, returns full text output |
 
 ### Sessions and session handles
@@ -355,7 +355,7 @@ timeline). For anything else, `dx` evaluates arbitrary data-model/LINQ expressio
   exists, and the path is reported), while `NOT REACHABLE` is best-effort within the explored
   bounds. If the dispatch uses a `switch(IoControlCode)` jump table (common), pass the specific
   handler VA as `from` to scope past it, or confirm dynamically with a breakpoint + `go`.
-- The **kernel pool** tools (`pool_find_tag`, `pool_chunk`, `pool_census`) walk the allocator's own
+- The **kernel pool** tools (`pool_find_tag`, `pool_chunk`, `pool_census`, `pool_diagnostics`) walk the allocator's own
   descriptors through win-kexp rather than shelling out to `!pool`/`!poolused`, so all three read
   one snapshot and cannot disagree with each other. They need a **broken-in x64 kernel** target.
   Walking every pool page is expensive, so the snapshot is **cached per session** and reused; pass
@@ -365,7 +365,7 @@ timeline). For anything else, `dx` evaluates arbitrary data-model/LINQ expressio
   specific address with `pool_chunk` instead), and `pool_chunk` distinguishes "free hole inside a
   walked region" (a chunk whose state is not `Allocated`) from "address not covered by the snapshot"
   — the difference between a dangling pointer and one that never pointed at pool. `pool_chunk` also
-  reports the **neighbouring** chunks, which is what tells you what a reclaim would land next to.
+  reports the **neighbouring** chunks, which is what tells you what a reclaim would land next to. `pool_diagnostics` returns the walk's own diagnostics filtered by substring: a real walk emits tens of thousands across a hundred-plus categories, so any per-call summary truncates and the one line explaining a specific heap is never in the truncated head — filter by a heap address or a phrase to reach it.
 - **Crash-dump triage uses `!ext.analyze -v`**, not `!analyze` — the bundled engine only resolves
   the module-qualified form (see *Bundling the WinDbg engine*). On a **partial minidump**, reads of
   pages that weren't captured raise `An unexpected exception was raised (0x80040205)` rather than a

--- a/README.md
+++ b/README.md
@@ -356,15 +356,17 @@ timeline). For anything else, `dx` evaluates arbitrary data-model/LINQ expressio
   bounds. If the dispatch uses a `switch(IoControlCode)` jump table (common), pass the specific
   handler VA as `from` to scope past it, or confirm dynamically with a breakpoint + `go`.
 - The **kernel pool** tools (`pool_find_tag`, `pool_chunk`, `pool_census`, `pool_diagnostics`) walk the allocator's own
-  descriptors through win-kexp rather than shelling out to `!pool`/`!poolused`, so all three read
+  descriptors through win-kexp rather than shelling out to `!pool`/`!poolused`, so all four read
   one snapshot and cannot disagree with each other. They need a **broken-in x64 kernel** target.
   Walking every pool page is expensive, so the snapshot is **cached per session** and reused; pass
   `refresh: true` after letting the target run, or you are reading a photograph of a target that has
   since moved. Two semantics worth knowing: only *allocated* chunks are indexed by tag (a freed
   chunk's tag is not reliably preserved, so `pool_find_tag` never reports freed memory — ask about a
   specific address with `pool_chunk` instead), and `pool_chunk` distinguishes "free hole inside a
-  walked region" (a chunk whose state is not `Allocated`) from "address not covered by the snapshot"
-  — the difference between a dangling pointer and one that never pointed at pool. `pool_chunk` also
+  walked region" (a chunk in an explicitly free state — `ReusableFree` or `CachedFree`) from
+  "address not covered by the snapshot" — the difference between a dangling pointer and one that
+  never pointed at pool. A span reported `Unreadable` is neither: that is the walk's own limit
+  (a Verifier guard page reads that way), not evidence the allocator freed anything. `pool_chunk` also
   reports the **neighbouring** chunks, which is what tells you what a reclaim would land next to. `pool_diagnostics` returns the walk's own diagnostics filtered by substring: a real walk emits tens of thousands across a hundred-plus categories, so any per-call summary truncates and the one line explaining a specific heap is never in the truncated head — filter by a heap address or a phrase to reach it.
 - **Crash-dump triage uses `!ext.analyze -v`**, not `!analyze` — the bundled engine only resolves
   the module-qualified form (see *Bundling the WinDbg engine*). On a **partial minidump**, reads of

--- a/README.md
+++ b/README.md
@@ -362,11 +362,14 @@ timeline). For anything else, `dx` evaluates arbitrary data-model/LINQ expressio
   `refresh: true` after letting the target run, or you are reading a photograph of a target that has
   since moved. Two semantics worth knowing: only *allocated* chunks are indexed by tag (a freed
   chunk's tag is not reliably preserved, so `pool_find_tag` never reports freed memory — ask about a
-  specific address with `pool_chunk` instead), and `pool_chunk` distinguishes "free hole inside a
-  walked region" (a chunk in an explicitly free state — `ReusableFree` or `CachedFree`) from
-  "address not covered by the snapshot" — the difference between a dangling pointer and one that
-  never pointed at pool. A span reported `Unreadable` is neither: that is the walk's own limit
-  (a Verifier guard page reads that way), not evidence the allocator freed anything. `pool_chunk` also
+  specific address with `pool_chunk` instead), and `pool_chunk` reports three outcomes that are
+  easy to conflate. A chunk in an explicitly free state (`ReusableFree` or `CachedFree`) is the
+  one that means a pointer the target still holds is dangling. An address **not covered by the
+  snapshot** is not the opposite finding: a region the walk never reached looks exactly like
+  memory that was never pool, so read the coverage the tools print — and `pool_diagnostics` for
+  what was missed — before concluding the pointer never pointed at pool. A span reported
+  `Unreadable` is the walk's own limit (a Verifier guard page reads that way) and says nothing
+  about whether the allocator freed anything. `pool_chunk` also
   reports the **neighbouring** chunks, which is what tells you what a reclaim would land next to. `pool_diagnostics` returns the walk's own diagnostics filtered by substring: a real walk emits tens of thousands across a hundred-plus categories, so any per-call summary truncates and the one line explaining a specific heap is never in the truncated head — filter by a heap address or a phrase to reach it.
 - **Crash-dump triage uses `!ext.analyze -v`**, not `!analyze` — the bundled engine only resolves
   the module-qualified form (see *Bundling the WinDbg engine*). On a **partial minidump**, reads of

--- a/README.md
+++ b/README.md
@@ -247,6 +247,7 @@ gh attestation verify <zip> --repo glslang/windbg-mcp `
 | TTD nav | `step_back` (`t-`), `step_over_back` (`p-`), `reverse_go` (`g-`), `goto_position` (`!tt`) |
 | TTD analysis | `ttd_calls`, `ttd_memory`, `ttd_events`, `index_trace`, `record_trace` |
 | Driver IOCTL | `decode_ioctl`, `driver_object`, `device_object`, `irp_stack`, `ioctl_trace`, `reachable_from_dispatch` |
+| Kernel pool | `pool_find_tag`, `pool_chunk`, `pool_census` |
 | Raw     | `execute` — run any debugger command, returns full text output |
 
 ### Sessions and session handles
@@ -354,6 +355,17 @@ timeline). For anything else, `dx` evaluates arbitrary data-model/LINQ expressio
   exists, and the path is reported), while `NOT REACHABLE` is best-effort within the explored
   bounds. If the dispatch uses a `switch(IoControlCode)` jump table (common), pass the specific
   handler VA as `from` to scope past it, or confirm dynamically with a breakpoint + `go`.
+- The **kernel pool** tools (`pool_find_tag`, `pool_chunk`, `pool_census`) walk the allocator's own
+  descriptors through win-kexp rather than shelling out to `!pool`/`!poolused`, so all three read
+  one snapshot and cannot disagree with each other. They need a **broken-in x64 kernel** target.
+  Walking every pool page is expensive, so the snapshot is **cached per session** and reused; pass
+  `refresh: true` after letting the target run, or you are reading a photograph of a target that has
+  since moved. Two semantics worth knowing: only *allocated* chunks are indexed by tag (a freed
+  chunk's tag is not reliably preserved, so `pool_find_tag` never reports freed memory — ask about a
+  specific address with `pool_chunk` instead), and `pool_chunk` distinguishes "free hole inside a
+  walked region" (a chunk whose state is not `Allocated`) from "address not covered by the snapshot"
+  — the difference between a dangling pointer and one that never pointed at pool. `pool_chunk` also
+  reports the **neighbouring** chunks, which is what tells you what a reclaim would land next to.
 - **Crash-dump triage uses `!ext.analyze -v`**, not `!analyze` — the bundled engine only resolves
   the module-qualified form (see *Bundling the WinDbg engine*). On a **partial minidump**, reads of
   pages that weren't captured raise `An unexpected exception was raised (0x80040205)` rather than a

--- a/examples/messagemanager/mm_client.ps1
+++ b/examples/messagemanager/mm_client.ps1
@@ -1,0 +1,296 @@
+<#
+.SYNOPSIS
+    Driver client for the MessageManager CTF driver (\\.\MessageDevice).
+
+.DESCRIPTION
+    Runs on the *target* VM, out-of-band from the kernel debug session. windbg-mcp drives
+    the debugger; it cannot issue DeviceIoControl itself, so this is the other half of the
+    loop: it exercises the driver while the debugger observes the pool.
+
+    The driver exposes four METHOD_BUFFERED IOCTLs (DeviceType 0x22, FILE_ANY_ACCESS):
+
+      0x222000  Create()            -> ULONG id            (OutputBufferLength >= 4)
+      0x222004  Delete(ULONG id)                           (InputBufferLength  >= 4)
+      0x222008  SetData(id, len, data)                     (see layout below)
+      0x22200C  Flush(ULONG sel)    sel: 0 = small list, 1 = large list
+
+    SetData input layout (note the *unaligned* 64-bit length at +4):
+
+        +0x00  ULONG      Id
+        +0x04  ULONGLONG  Length      (unaligned)
+        +0x0C  UCHAR      Data[Length]
+
+    and its gates: InputBufferLength >= 0xC, Length >= 0x20, Length + 0xC <= 0x3000,
+    InputBufferLength >= Length + 0xC. A message whose Length >= 0x200 is linked into the
+    "large" list, otherwise the "small" list.
+
+.PARAMETER Op
+    Create | Delete | SetData | Flush | Demo | Race | Stress
+
+.EXAMPLE
+    .\mm_client.ps1 -Op Demo
+    Allocate one message and give it a 0x40-byte body, printing the id. Leaves it alive so
+    the debugger can walk it in the pool.
+
+.EXAMPLE
+    .\mm_client.ps1 -Op Race -Seconds 20
+    Drive the SetData/Flush cross-list race that the unsynchronized list move exposes.
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [ValidateSet('Create', 'Delete', 'SetData', 'Flush', 'Demo', 'Race', 'Stress')]
+    [string] $Op,
+
+    [uint32] $Id = 0,
+    [int]    $Length = 0x40,
+    [byte]   $Fill = 0x41,
+    [uint32] $Sel = 0,
+    [int]    $Seconds = 15,
+    [int]    $Threads = 4,
+    [string] $Device = '\\.\MessageDevice'
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+Add-Type -Namespace MM -Name Native -MemberDefinition @'
+    [System.Runtime.InteropServices.DllImport("kernel32.dll", SetLastError = true, CharSet = System.Runtime.InteropServices.CharSet.Unicode)]
+    public static extern System.IntPtr CreateFileW(
+        string lpFileName, uint dwDesiredAccess, uint dwShareMode, System.IntPtr lpSecurityAttributes,
+        uint dwCreationDisposition, uint dwFlagsAndAttributes, System.IntPtr hTemplateFile);
+
+    [System.Runtime.InteropServices.DllImport("kernel32.dll", SetLastError = true)]
+    public static extern bool DeviceIoControl(
+        System.IntPtr hDevice, uint dwIoControlCode,
+        byte[] lpInBuffer, uint nInBufferSize,
+        byte[] lpOutBuffer, uint nOutBufferSize,
+        out uint lpBytesReturned, System.IntPtr lpOverlapped);
+
+    [System.Runtime.InteropServices.DllImport("kernel32.dll", SetLastError = true)]
+    public static extern bool CloseHandle(System.IntPtr hObject);
+'@
+
+$IOCTL_CREATE  = [uint32] 0x222000
+$IOCTL_DELETE  = [uint32] 0x222004
+$IOCTL_SETDATA = [uint32] 0x222008
+$IOCTL_FLUSH   = [uint32] 0x22200C
+
+# NB: PowerShell parses an 8-digit hex literal as a *signed* Int32, so 0xC0000000 becomes
+# -1073741824 and casting it to [uint32] throws. Write the value in decimal instead.
+$GENERIC_RW    = [uint32] 3221225472   # GENERIC_READ | GENERIC_WRITE
+$FILE_SHARE_RW = [uint32] 3
+$OPEN_EXISTING = [uint32] 3
+$INVALID       = [System.IntPtr] (-1)
+
+function Open-Device {
+    $h = [MM.Native]::CreateFileW($Device, $GENERIC_RW, $FILE_SHARE_RW,
+        [System.IntPtr]::Zero, $OPEN_EXISTING, 0, [System.IntPtr]::Zero)
+    if ($h -eq $INVALID) {
+        $e = [System.Runtime.InteropServices.Marshal]::GetLastWin32Error()
+        throw ("CreateFile('{0}') failed: {1} (0x{1:x8}) - {2}" -f $Device, $e,
+            ([System.ComponentModel.Win32Exception] $e).Message)
+    }
+    return $h
+}
+
+function Invoke-Ioctl($h, [uint32] $code, [byte[]] $inBuf, [int] $outLen) {
+    if ($null -eq $inBuf) { $inBuf = New-Object byte[] 0 }
+    $outBuf = if ($outLen -gt 0) { New-Object byte[] $outLen } else { $null }
+    [uint32] $ret = 0
+    $ok = [MM.Native]::DeviceIoControl($h, $code, $inBuf, [uint32] $inBuf.Length,
+        $outBuf, [uint32] $outLen, [ref] $ret, [System.IntPtr]::Zero)
+    $err = [System.Runtime.InteropServices.Marshal]::GetLastWin32Error()
+    return [pscustomobject]@{ Ok = $ok; Error = $err; Returned = $ret; Output = $outBuf }
+}
+
+function New-Message($h) {
+    $r = Invoke-Ioctl $h $IOCTL_CREATE $null 4
+    if (-not $r.Ok) { throw ("Create failed: Win32 {0}" -f $r.Error) }
+    return [BitConverter]::ToUInt32($r.Output, 0)
+}
+
+function Remove-Message($h, [uint32] $id) {
+    $r = Invoke-Ioctl $h $IOCTL_DELETE ([BitConverter]::GetBytes($id)) 0
+    return $r
+}
+
+# Builds the SetData input buffer: Id (4) | Length (8, unaligned) | Data[Length]
+function New-SetDataBuffer([uint32] $id, [int] $len, [byte] $fill) {
+    $buf = New-Object byte[] ($len + 0xC)
+    [Array]::Copy([BitConverter]::GetBytes($id), 0, $buf, 0, 4)
+    [Array]::Copy([BitConverter]::GetBytes([uint64] $len), 0, $buf, 4, 8)
+    for ($i = 0; $i -lt $len; $i++) { $buf[0xC + $i] = $fill }
+    return $buf
+}
+
+function Set-MessageData($h, [uint32] $id, [int] $len, [byte] $fill) {
+    $r = Invoke-Ioctl $h $IOCTL_SETDATA (New-SetDataBuffer $id $len $fill) 0
+    return $r
+}
+
+function Clear-List($h, [uint32] $sel) {
+    return Invoke-Ioctl $h $IOCTL_FLUSH ([BitConverter]::GetBytes($sel)) 0
+}
+
+# ---------------------------------------------------------------------------
+
+$h = Open-Device
+Write-Host ("Opened {0}" -f $Device) -ForegroundColor DarkGray
+
+try {
+    switch ($Op) {
+        'Create' {
+            $newId = New-Message $h
+            Write-Host ("Create -> id = 0x{0:x}" -f $newId) -ForegroundColor Green
+        }
+
+        'Delete' {
+            $r = Remove-Message $h $Id
+            if ($r.Ok) { Write-Host ("Delete(0x{0:x}) -> SUCCESS" -f $Id) -ForegroundColor Green }
+            else       { Write-Host ("Delete(0x{0:x}) -> Win32 {1}" -f $Id, $r.Error) -ForegroundColor Yellow }
+        }
+
+        'SetData' {
+            $r = Set-MessageData $h $Id $Length $Fill
+            if ($r.Ok) {
+                Write-Host ("SetData(0x{0:x}, len=0x{1:x}) -> SUCCESS  [{2} list]" -f `
+                    $Id, $Length, $(if ($Length -ge 0x200) { 'large' } else { 'small' })) -ForegroundColor Green
+            } else {
+                Write-Host ("SetData(0x{0:x}, len=0x{1:x}) -> Win32 {2}" -f $Id, $Length, $r.Error) -ForegroundColor Yellow
+            }
+        }
+
+        'Flush' {
+            $r = Clear-List $h $Sel
+            Write-Host ("Flush({0}) -> {1}" -f $Sel, $(if ($r.Ok) { 'SUCCESS' } else { "Win32 $($r.Error)" })) `
+                -ForegroundColor $(if ($r.Ok) { 'Green' } else { 'Yellow' })
+        }
+
+        # One message, one body. Leaves it alive and linked so the debugger can find the
+        # Tgsm / Tfub allocations and walk the object.
+        'Demo' {
+            $newId = New-Message $h
+            Write-Host ("Create  -> id = 0x{0:x}" -f $newId) -ForegroundColor Green
+            $r = Set-MessageData $h $newId $Length $Fill
+            Write-Host ("SetData -> len = 0x{0:x}, fill = 0x{1:x2}, list = {2}, {3}" -f `
+                $Length, $Fill, $(if ($Length -ge 0x200) { 'large' } else { 'small' }),
+                $(if ($r.Ok) { 'SUCCESS' } else { "Win32 $($r.Error)" })) -ForegroundColor Green
+            Write-Host ""
+            Write-Host "Message is alive and linked. In the debugger:" -ForegroundColor Cyan
+            Write-Host "    !poolused 2 Tgsm      # message objects (NonPaged, 0x68)" -ForegroundColor Cyan
+            Write-Host "    !poolfind Tgsm        # locate them" -ForegroundColor Cyan
+            Write-Host ("    dq MessageManager+0x3150 L2   # small list head" ) -ForegroundColor Cyan
+        }
+
+        # Allocate a spread of messages across both lists, so the pool has a population
+        # worth looking at (grooming / tag census material).
+        'Stress' {
+            $ids = New-Object System.Collections.ArrayList
+            for ($i = 0; $i -lt $Threads; $i++) {
+                $newId = New-Message $h
+                [void] $ids.Add($newId)
+                $len = if ($i % 2 -eq 0) { 0x40 } else { 0x400 }
+                [void] (Set-MessageData $h $newId $len ([byte](0x41 + $i)))
+                Write-Host ("  id 0x{0:x}  len 0x{1:x}  ({2})" -f $newId, $len,
+                    $(if ($len -ge 0x200) { 'large' } else { 'small' }))
+            }
+            Write-Host ("Allocated {0} messages." -f $ids.Count) -ForegroundColor Green
+        }
+
+        # The bug: SetData moves a message between the small and large lists while holding
+        # only the per-message mutex - never the *source* list's lock - and Delete/Flush
+        # drop the refcount and free without that per-message mutex. Racing a length
+        # oscillation against Flush corrupts the refcount and frees a message that a live
+        # handle still points at.
+        'Race' {
+            Write-Host ("Racing SetData(list move) against Flush for {0}s on {1} threads..." -f $Seconds, $Threads) -ForegroundColor Yellow
+            Write-Host "If the target bugchecks, the debugger will break in." -ForegroundColor Yellow
+
+            $csharp = @'
+using System;
+using System.Runtime.InteropServices;
+using System.Threading;
+
+public class MMRace {
+    [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+    static extern IntPtr CreateFileW(string n, uint a, uint s, IntPtr sa, uint c, uint f, IntPtr t);
+    [DllImport("kernel32.dll", SetLastError = true)]
+    static extern bool DeviceIoControl(IntPtr h, uint code, byte[] inb, uint inl,
+                                       byte[] outb, uint outl, out uint ret, IntPtr ov);
+    [DllImport("kernel32.dll", SetLastError = true)]
+    static extern bool CloseHandle(IntPtr h);
+
+    const uint CREATE = 0x222000, DELETE = 0x222004, SETDATA = 0x222008, FLUSH = 0x22200C;
+
+    static IntPtr Open(string dev) {
+        IntPtr h = CreateFileW(dev, 0xC0000000, 3, IntPtr.Zero, 3, 0, IntPtr.Zero);
+        if (h == (IntPtr)(-1)) throw new Exception("CreateFile failed: " + Marshal.GetLastWin32Error());
+        return h;
+    }
+
+    static byte[] SetBuf(uint id, int len, byte fill) {
+        byte[] b = new byte[len + 0xC];
+        Buffer.BlockCopy(BitConverter.GetBytes(id), 0, b, 0, 4);
+        Buffer.BlockCopy(BitConverter.GetBytes((ulong)len), 0, b, 4, 8);
+        for (int i = 0; i < len; i++) b[0xC + i] = fill;
+        return b;
+    }
+
+    public static void Run(string dev, int seconds, int threads) {
+        IntPtr h = Open(dev);
+        uint ret;
+        DateTime stop = DateTime.UtcNow.AddSeconds(seconds);
+        long iterations = 0;
+
+        // A pool of live message ids whose lengths we oscillate across the 0x200 boundary,
+        // so every SetData takes the unlocked cross-list unlink path.
+        int n = 32;
+        uint[] ids = new uint[n];
+        for (int i = 0; i < n; i++) {
+            byte[] o = new byte[4];
+            DeviceIoControl(h, CREATE, new byte[0], 0, o, 4, out ret, IntPtr.Zero);
+            ids[i] = BitConverter.ToUInt32(o, 0);
+            DeviceIoControl(h, SETDATA, SetBuf(ids[i], 0x40, 0x41), (uint)(0x40 + 0xC), null, 0, out ret, IntPtr.Zero);
+        }
+        Console.WriteLine("seeded {0} messages, first id = 0x{1:x}", n, ids[0]);
+
+        Thread[] ts = new Thread[threads];
+        for (int t = 0; t < threads; t++) {
+            int me = t;
+            ts[t] = new Thread(delegate() {
+                IntPtr th = Open(dev);
+                uint r;
+                Random rnd = new Random(me * 7919 + 13);
+                while (DateTime.UtcNow < stop) {
+                    uint id = ids[rnd.Next(n)];
+                    if ((me & 1) == 0) {
+                        // oscillate across the small/large threshold -> unlocked list move
+                        int len = (rnd.Next(2) == 0) ? 0x40 : 0x400;
+                        DeviceIoControl(th, SETDATA, SetBuf(id, len, (byte)0x42),
+                                        (uint)(len + 0xC), null, 0, out r, IntPtr.Zero);
+                    } else {
+                        // concurrently tear the lists down under their own lock
+                        uint sel = (uint)rnd.Next(2);
+                        DeviceIoControl(th, FLUSH, BitConverter.GetBytes(sel), 4, null, 0, out r, IntPtr.Zero);
+                    }
+                    Interlocked.Increment(ref iterations);
+                }
+                CloseHandle(th);
+            });
+            ts[t].Start();
+        }
+        foreach (Thread x in ts) x.Join();
+        Console.WriteLine("done, {0} iterations", iterations);
+        CloseHandle(h);
+    }
+}
+'@
+            Add-Type -TypeDefinition $csharp -Language CSharp
+            [MMRace]::Run($Device, $Seconds, $Threads)
+        }
+    }
+}
+finally {
+    [void][MM.Native]::CloseHandle($h)
+}

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -96,6 +96,10 @@ pub enum EngineOp {
         timeout_ms: u32,
     },
     Reachability(ReachabilityOp),
+    /// A pool query. Like [`Self::Reachability`] this is one indivisible job: a query may have
+    /// to walk every pool page, and letting another call for the same session interleave would
+    /// let the walk describe a target that moved underneath it.
+    Pool(PoolOp),
     /// Release the target. The supervisor tears the worker down afterwards — under
     /// process-per-session a worker outlives its target for no reason.
     EndSession,
@@ -127,6 +131,44 @@ pub struct ReachabilityOp {
     pub max_functions: usize,
     pub max_depth: usize,
     pub recipe: bool,
+}
+
+/// The pool tools' arguments, after the supervisor has applied its defaults.
+///
+/// One variant per question rather than one op with optional fields: the three answers have
+/// different shapes, and a caller that asked for a census should not be able to get a chunk
+/// lookup back because a field defaulted.
+///
+/// `refresh` forces a fresh walk of the pool. It is off by default because walking every pool
+/// page is expensive enough that repeating it per query would make the tools unusable — the
+/// snapshot is cached per session and invalidated when the debugger reports the session
+/// changed. Pass it after resuming the target, when the cached view is a photograph of a
+/// target that has since moved.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum PoolOp {
+    /// Every *allocated* chunk carrying `tag`.
+    FindTag {
+        tag: String,
+        /// `Some(true)` paged only, `Some(false)` nonpaged only, `None` both.
+        paged: Option<bool>,
+        refresh: bool,
+        limit: usize,
+    },
+    /// The chunk containing `address`, with its immediate neighbours.
+    Chunk { address: String, refresh: bool },
+    /// Per-tag totals across the whole snapshot, heaviest consumer first.
+    Census { refresh: bool, limit: usize },
+    /// The walk's own diagnostics, verbatim, optionally narrowed to a substring.
+    ///
+    /// A real walk emits tens of thousands of these across a hundred-plus categories, so
+    /// the summaries the other tools print necessarily truncate. When a specific heap or
+    /// address is under suspicion, the one line that explains it is reliably *not* in the
+    /// truncated head — hence a filter rather than a bigger cap.
+    Diagnostics {
+        filter: Option<String>,
+        refresh: bool,
+        limit: usize,
+    },
 }
 
 /// A request down the worker's stdin. `id` is echoed on every message the op produces.

--- a/src/server.rs
+++ b/src/server.rs
@@ -18,7 +18,7 @@ use crate::engine::{
     Call, EngineError, MAX_SESSIONS, OpenError, OpenReport, SessionKind, SessionSnapshot,
     SessionState, Sessions,
 };
-use crate::proto::{EngineOp, ReachabilityOp};
+use crate::proto::{EngineOp, PoolOp, ReachabilityOp};
 use crate::ttd;
 
 /// How long to wait for an execution-control command (go/step/reverse) to reach its
@@ -1180,6 +1180,76 @@ pub struct SymbolPathArgs {
 }
 
 #[derive(Deserialize, JsonSchema)]
+pub struct PoolFindTagArgs {
+    /// Pool tag to find: 1..4 ASCII bytes, e.g. "Tgsm". This is the tag as the debugger
+    /// *displays* it — the tag bytes in memory order. A driver whose source passes the C
+    /// literal 'msgT' therefore appears here as "Tgsm", not "msgT".
+    pub tag: String,
+    /// Restrict to one allocator: true = paged only, false = nonpaged only. Omit for both.
+    #[serde(default)]
+    pub paged: Option<bool>,
+    /// Force a fresh walk instead of reusing this session's cached snapshot (default false).
+    /// Walking every pool page is expensive, so a snapshot is cached and reused; pass this
+    /// after letting the target run, when the cached view describes a target that has moved.
+    #[serde(default)]
+    pub refresh: Option<bool>,
+    /// Maximum rows to print (default 64).
+    #[serde(default)]
+    pub limit: Option<u32>,
+    /// Session handle from open_dump/open_trace/attach_*/launch. Optional; pass it to
+    /// refuse the call if this server's debug target has been replaced since you opened it.
+    #[serde(default)]
+    pub session_id: Option<String>,
+}
+
+#[derive(Deserialize, JsonSchema)]
+pub struct PoolChunkArgs {
+    /// Address to locate, in any form the debugger prints or accepts: a backtick address
+    /// ("ffffc00f`6ec02f90"), a bare hex run, "0x"-hex, or decimal. A bare run of 8+ hex
+    /// digits is read as hex, following WinDbg's convention.
+    pub address: String,
+    /// Force a fresh walk instead of reusing this session's cached snapshot (default false).
+    #[serde(default)]
+    pub refresh: Option<bool>,
+    /// Session handle from open_dump/open_trace/attach_*/launch. Optional; pass it to
+    /// refuse the call if this server's debug target has been replaced since you opened it.
+    #[serde(default)]
+    pub session_id: Option<String>,
+}
+
+#[derive(Deserialize, JsonSchema)]
+pub struct PoolCensusArgs {
+    /// Force a fresh walk instead of reusing this session's cached snapshot (default false).
+    #[serde(default)]
+    pub refresh: Option<bool>,
+    /// Maximum tags to print (default 40).
+    #[serde(default)]
+    pub limit: Option<u32>,
+    /// Session handle from open_dump/open_trace/attach_*/launch. Optional; pass it to
+    /// refuse the call if this server's debug target has been replaced since you opened it.
+    #[serde(default)]
+    pub session_id: Option<String>,
+}
+
+#[derive(Deserialize, JsonSchema)]
+pub struct PoolDiagnosticsArgs {
+    /// Case-insensitive substring to narrow the diagnostics to, e.g. a heap address
+    /// ("ffff8c8f0d300000") or a phrase ("cannot fully discover heap"). Omit for all.
+    #[serde(default)]
+    pub filter: Option<String>,
+    /// Maximum lines to print (default 60).
+    #[serde(default)]
+    pub limit: Option<u32>,
+    /// Force a fresh walk instead of reusing this session's cached snapshot (default false).
+    #[serde(default)]
+    pub refresh: Option<bool>,
+    /// Session handle from open_dump/open_trace/attach_*/launch. Optional; pass it to
+    /// refuse the call if this server's debug target has been replaced since you opened it.
+    #[serde(default)]
+    pub session_id: Option<String>,
+}
+
+#[derive(Deserialize, JsonSchema)]
 pub struct DriverObjectArgs {
     /// Driver object name, e.g. "mydriver" or "\\Driver\\mydriver".
     pub name: String,
@@ -1716,6 +1786,128 @@ impl WindbgServer {
                     append: args.append.unwrap_or(true),
                     reload: args.reload.unwrap_or_default(),
                 },
+            )
+            .await;
+        engine_result(out)
+    }
+
+    /// Find every **allocated** kernel pool chunk carrying a tag, with its size, allocator
+    /// and backend. Needs a broken-in x64 kernel target.
+    /// This walks the pool's own descriptors rather than shelling out to `!poolused`, so the
+    /// result is structured and consistent with `pool_chunk`/`pool_census`.
+    /// Only allocated chunks are indexed by tag — a freed chunk's tag is not reliably
+    /// preserved by the allocator, so this never reports freed memory. To ask whether one
+    /// specific address has been freed, use `pool_chunk`.
+    #[rmcp::tool(annotations(
+        title = "Find pool chunks by tag",
+        read_only_hint = true,
+        destructive_hint = false,
+        idempotent_hint = true,
+        open_world_hint = true
+    ))]
+    async fn pool_find_tag(
+        &self,
+        Parameters(args): Parameters<PoolFindTagArgs>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let out = self
+            .run(
+                args.session_id.as_deref(),
+                EngineOp::Pool(PoolOp::FindTag {
+                    tag: args.tag,
+                    paged: args.paged,
+                    refresh: args.refresh.unwrap_or(false),
+                    limit: args.limit.unwrap_or(64) as usize,
+                }),
+            )
+            .await;
+        engine_result(out)
+    }
+
+    /// Identify the pool chunk containing an address, **with its immediate neighbours**.
+    /// Needs a broken-in x64 kernel target.
+    /// This is the use-after-free question: it reports whether the chunk is still Allocated
+    /// or has been freed, and what now borders it — which is what decides whether a pointer
+    /// the target still holds is dangling, and what a reclaim would land next to.
+    /// "Not in the snapshot" and "free" are reported differently: a free hole inside a walked
+    /// region comes back as a chunk whose state is not Allocated, while an address outside
+    /// every region is reported as uncovered.
+    #[rmcp::tool(annotations(
+        title = "Locate a pool chunk by address",
+        read_only_hint = true,
+        destructive_hint = false,
+        idempotent_hint = true,
+        open_world_hint = true
+    ))]
+    async fn pool_chunk(
+        &self,
+        Parameters(args): Parameters<PoolChunkArgs>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let out = self
+            .run(
+                args.session_id.as_deref(),
+                EngineOp::Pool(PoolOp::Chunk {
+                    address: args.address,
+                    refresh: args.refresh.unwrap_or(false),
+                }),
+            )
+            .await;
+        engine_result(out)
+    }
+
+    /// The pool walk's own diagnostics, verbatim, optionally narrowed by substring.
+    /// Needs a broken-in x64 kernel target.
+    /// Use this when a chunk you can see with `!pool` does not appear in `pool_find_tag`
+    /// or `pool_chunk`. A real walk emits tens of thousands of diagnostics across a
+    /// hundred-plus categories, so the summaries the other tools print are necessarily
+    /// truncated — and the one line explaining a specific heap is reliably not in the
+    /// truncated head. Filter by a heap address or a phrase to get at it.
+    #[rmcp::tool(annotations(
+        title = "Filter pool walk diagnostics",
+        read_only_hint = true,
+        destructive_hint = false,
+        idempotent_hint = true,
+        open_world_hint = true
+    ))]
+    async fn pool_diagnostics(
+        &self,
+        Parameters(args): Parameters<PoolDiagnosticsArgs>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let out = self
+            .run(
+                args.session_id.as_deref(),
+                EngineOp::Pool(PoolOp::Diagnostics {
+                    filter: args.filter,
+                    refresh: args.refresh.unwrap_or(false),
+                    limit: args.limit.unwrap_or(60) as usize,
+                }),
+            )
+            .await;
+        engine_result(out)
+    }
+
+    /// Per-tag census of the kernel pool: allocation counts and bytes, heaviest first.
+    /// Needs a broken-in x64 kernel target.
+    /// The structured answer to what `!poolused` renders as text, taken from the same walk
+    /// as `pool_find_tag` and `pool_chunk` so the three cannot disagree. Useful for spotting
+    /// which tag a driver's allocations are landing under before querying it by name.
+    #[rmcp::tool(annotations(
+        title = "Census pool usage by tag",
+        read_only_hint = true,
+        destructive_hint = false,
+        idempotent_hint = true,
+        open_world_hint = true
+    ))]
+    async fn pool_census(
+        &self,
+        Parameters(args): Parameters<PoolCensusArgs>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let out = self
+            .run(
+                args.session_id.as_deref(),
+                EngineOp::Pool(PoolOp::Census {
+                    refresh: args.refresh.unwrap_or(false),
+                    limit: args.limit.unwrap_or(40) as usize,
+                }),
             )
             .await;
         engine_result(out)

--- a/src/server.rs
+++ b/src/server.rs
@@ -1837,8 +1837,10 @@ impl WindbgServer {
     /// or has been freed, and what now borders it — which is what decides whether a pointer
     /// the target still holds is dangling, and what a reclaim would land next to.
     /// "Not in the snapshot" and "free" are reported differently: a free hole inside a walked
-    /// region comes back as a chunk whose state is not Allocated, while an address outside
-    /// every region is reported as uncovered.
+    /// region comes back as a chunk in an explicitly free state (`ReusableFree` or
+    /// `CachedFree`), while an address outside every region is reported as uncovered. A third
+    /// state, `Unreadable`, is neither — it means the walk could not read the span (a Verifier
+    /// guard page reads exactly this way), so it says nothing about whether the chunk is live.
     #[rmcp::tool(annotations(
         title = "Locate a pool chunk by address",
         read_only_hint = true,

--- a/src/server.rs
+++ b/src/server.rs
@@ -1179,6 +1179,14 @@ pub struct SymbolPathArgs {
     pub session_id: Option<String>,
 }
 
+/// Most rows or lines a pool tool will render in one response.
+///
+/// The worker builds the whole reply as a single `String` before it crosses the pipe, so an
+/// unbounded `limit` is a request to allocate a snapshot-sized buffer — hundreds of thousands
+/// of chunks, or ~19k diagnostic lines on an idle machine. Clamping costs a caller nothing
+/// they can act on; a worker killed mid-session costs them the session.
+const MAX_POOL_ROWS: u32 = 2000;
+
 #[derive(Deserialize, JsonSchema)]
 pub struct PoolFindTagArgs {
     /// Pool tag to find: 1..4 ASCII bytes, e.g. "Tgsm". This is the tag as the debugger
@@ -1816,7 +1824,7 @@ impl WindbgServer {
                     tag: args.tag,
                     paged: args.paged,
                     refresh: args.refresh.unwrap_or(false),
-                    limit: args.limit.unwrap_or(64) as usize,
+                    limit: args.limit.unwrap_or(64).min(MAX_POOL_ROWS) as usize,
                 }),
             )
             .await;
@@ -1878,7 +1886,7 @@ impl WindbgServer {
                 EngineOp::Pool(PoolOp::Diagnostics {
                     filter: args.filter,
                     refresh: args.refresh.unwrap_or(false),
-                    limit: args.limit.unwrap_or(60) as usize,
+                    limit: args.limit.unwrap_or(60).min(MAX_POOL_ROWS) as usize,
                 }),
             )
             .await;
@@ -1906,7 +1914,7 @@ impl WindbgServer {
                 args.session_id.as_deref(),
                 EngineOp::Pool(PoolOp::Census {
                     refresh: args.refresh.unwrap_or(false),
-                    limit: args.limit.unwrap_or(40) as usize,
+                    limit: args.limit.unwrap_or(40).min(MAX_POOL_ROWS) as usize,
                 }),
             )
             .await;

--- a/src/server.rs
+++ b/src/server.rs
@@ -1838,9 +1838,11 @@ impl WindbgServer {
     /// the target still holds is dangling, and what a reclaim would land next to.
     /// "Not in the snapshot" and "free" are reported differently: a free hole inside a walked
     /// region comes back as a chunk in an explicitly free state (`ReusableFree` or
-    /// `CachedFree`), while an address outside every region is reported as uncovered. A third
-    /// state, `Unreadable`, is neither — it means the walk could not read the span (a Verifier
-    /// guard page reads exactly this way), so it says nothing about whether the chunk is live.
+    /// `CachedFree`), while an address outside every region is reported as uncovered — which
+    /// means it is not pool *or* the walk never reached it, so check the coverage the result
+    /// prints before reading it as "never was pool". A third state, `Unreadable`, is neither:
+    /// the walk could not read the span (a Verifier guard page reads exactly this way), so it
+    /// says nothing about whether the chunk is live.
     #[rmcp::tool(annotations(
         title = "Locate a pool chunk by address",
         read_only_hint = true,

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -674,9 +674,18 @@ fn summarize_diagnostics(lines: &[String]) -> Vec<(String, usize)> {
 fn append_walk_report(out: &mut String, e: &DebugEngine) {
     match query::snapshot_report(e, false) {
         Ok(report) => {
+            // `complete` is not implied by an empty diagnostics list: a walk can end
+            // partway through without saying anything. Report it explicitly, or a caller
+            // reads a truncated snapshot as a healthy one.
             out.push_str(&format!(
-                "\n--- pool walk ---\nchunks walked: {} ({} allocated)\n",
-                report.total_chunks, report.allocated_chunks
+                "\n--- pool walk ---\nchunks walked: {} ({} allocated), coverage: {}\n",
+                report.total_chunks,
+                report.allocated_chunks,
+                if report.complete {
+                    "complete"
+                } else {
+                    "INCOMPLETE - the walk did not reach everything it set out to"
+                }
             ));
             if report.diagnostics.is_empty() {
                 out.push_str("the walk reported no diagnostics.\n");

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -25,9 +25,11 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use win_kexp::dbgeng::{DebugEngine, RunToOutcome};
+use win_kexp::pool::query::{self, PoolPageFilter};
+use win_kexp::pool::{PoolSpan, PoolState};
 use windows_sys::Win32::Foundation::{HANDLE_FLAG_INHERIT, SetHandleInformation};
 
-use crate::proto::{EngineOp, ReachabilityOp, WorkerMessage, WorkerRequest};
+use crate::proto::{EngineOp, PoolOp, ReachabilityOp, WorkerMessage, WorkerRequest};
 use crate::server::{
     fmt_addr, format_recipe, format_report, hexdump, parse_eval, parse_lm_base, parse_u64,
     parse_windbg_addr, path_recipe, reachability,
@@ -582,6 +584,7 @@ fn execute(e: &DebugEngine, id: u64, op: EngineOp, queued: Duration) -> Result<S
             timeout_ms,
         } => run_to_address(e, &address, timeout_ms),
         EngineOp::Reachability(args) => reachable(e, args),
+        EngineOp::Pool(args) => pool(e, args),
         EngineOp::EndSession => e
             .end_session()
             .map(|_| "session ended".to_string())
@@ -592,6 +595,336 @@ fn execute(e: &DebugEngine, id: u64, op: EngineOp, queued: Duration) -> Result<S
 /// Maps any error to a `String` for the wire.
 fn es<E: ToString>(e: E) -> String {
     e.to_string()
+}
+
+/// Column header for the chunk tables below. Kept next to [`pool_row`] so the two cannot
+/// drift out of alignment.
+const POOL_COLUMNS: &str =
+    "address               size  state          kind                    backend  tag   numa";
+
+/// Renders one chunk as a fixed-width row.
+///
+/// The address column is `usable_address` — what the allocation call *returned*, and so the
+/// value that appears in the target's own pointers. `header_address` is where the allocator's
+/// bookkeeping starts and is rarely what a caller is holding.
+fn pool_row(span: &PoolSpan) -> String {
+    format!(
+        "{:<18}  {:>5}  {:<13}  {:<22}  {:<7}  {:<4}  {}",
+        fmt_addr(span.usable_address),
+        format!("{:#x}", span.size),
+        format!("{:?}", span.state),
+        format!("{:?}", span.pool_kind),
+        format!("{:?}", span.backend),
+        span.display_tag,
+        span.numa_node,
+    )
+}
+
+/// Parses a pool address in any form a caller is likely to paste.
+///
+/// [`parse_windbg_addr`] is tried first because it accepts the backtick form that debugger
+/// output actually prints; it requires >= 8 hex digits, so shorter `0x`-hex and decimal fall
+/// through to [`parse_u64`]. A bare 8+ digit run is read as hex, matching WinDbg's own
+/// convention rather than Rust's.
+fn parse_pool_addr(text: &str) -> Result<u64, String> {
+    parse_windbg_addr(text).map_or_else(|| parse_u64(text), Ok)
+}
+
+/// Replaces the variable parts of a diagnostic — addresses and indices — so that lines
+/// describing the same *kind* of problem collapse together.
+///
+/// A hex-looking run has to be at least 4 characters to count, or short decimal counts
+/// ("depth is 16") would be blanked too and lines that differ meaningfully would merge.
+fn diagnostic_category(line: &str) -> String {
+    line.split_whitespace()
+        .map(|word| {
+            let trimmed = word.trim_matches(|c: char| !c.is_ascii_alphanumeric());
+            let hexish = trimmed.len() >= 4 && trimmed.chars().all(|c| c.is_ascii_hexdigit());
+            if trimmed.starts_with("0x") || hexish {
+                "<addr>"
+            } else {
+                word
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// Groups diagnostics by category, commonest first.
+fn summarize_diagnostics(lines: &[String]) -> Vec<(String, usize)> {
+    let mut counts: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
+    for line in lines {
+        *counts.entry(diagnostic_category(line)).or_default() += 1;
+    }
+    let mut grouped: Vec<_> = counts.into_iter().collect();
+    grouped.sort_by(|left, right| right.1.cmp(&left.1).then_with(|| left.0.cmp(&right.0)));
+    grouped
+}
+
+/// Appends what the walk itself managed, so an empty answer explains itself.
+///
+/// Without this, an empty result is ambiguous in the worst way: "the pool holds no such
+/// chunk" and "the walk reached almost none of the pool" render identically. The snapshot
+/// is already cached by the time this runs, so the extra query costs nothing.
+///
+/// The diagnostics are *categorised* rather than listed: a real walk emits tens of
+/// thousands, and the first forty of those are a sample of whichever heap happened to be
+/// walked first, not of the problem. Counts per category say which failures actually
+/// dominate; one verbatim example per category keeps the concrete address available.
+fn append_walk_report(out: &mut String, e: &DebugEngine) {
+    match query::snapshot_report(e, false) {
+        Ok(report) => {
+            out.push_str(&format!(
+                "\n--- pool walk ---\nchunks walked: {} ({} allocated)\n",
+                report.total_chunks, report.allocated_chunks
+            ));
+            if report.diagnostics.is_empty() {
+                out.push_str("the walk reported no diagnostics.\n");
+                return;
+            }
+            let grouped = summarize_diagnostics(&report.diagnostics);
+            out.push_str(&format!(
+                "{} diagnostic(s) in {} categor{}:\n",
+                report.diagnostics.len(),
+                grouped.len(),
+                if grouped.len() == 1 { "y" } else { "ies" }
+            ));
+            for (category, count) in grouped.iter().take(25) {
+                out.push_str(&format!("  {count:>7}x  {category}\n"));
+            }
+            if grouped.len() > 25 {
+                out.push_str(&format!("  ... {} more categories\n", grouped.len() - 25));
+            }
+            // The last few verbatim: heaps are walked in order, so the tail is where the
+            // most recently discovered ones (special pool included) report.
+            out.push_str("\nlast 12 verbatim:\n");
+            let tail = report.diagnostics.len().saturating_sub(12);
+            for line in report.diagnostics.iter().skip(tail) {
+                out.push_str("  ");
+                out.push_str(line);
+                out.push('\n');
+            }
+        }
+        Err(error) => out.push_str(&format!("\n(could not summarise the walk: {error})\n")),
+    }
+}
+
+fn pool(e: &DebugEngine, args: PoolOp) -> Result<String, String> {
+    match args {
+        PoolOp::FindTag {
+            tag,
+            paged,
+            refresh,
+            limit,
+        } => {
+            let filter = paged.map(|paged| {
+                if paged {
+                    PoolPageFilter::Paged
+                } else {
+                    PoolPageFilter::NonPaged
+                }
+            });
+            let spans = query::find_tag(e, &tag, filter, refresh).map_err(es)?;
+            let mut out = render_find_tag(&tag, filter, &spans, limit);
+            if spans.is_empty() {
+                append_walk_report(&mut out, e);
+            }
+            Ok(out)
+        }
+        PoolOp::Chunk { address, refresh } => {
+            let address = parse_pool_addr(&address)?;
+            match query::chunk_at(e, address, refresh).map_err(es)? {
+                Some(found) => Ok(render_chunk(address, &found)),
+                // "Not in the snapshot" and "free" are different answers, and conflating them
+                // would be the difference between "this pointer is dangling" and "this pointer
+                // never pointed at pool".
+                None => {
+                    let mut out = format!(
+                        "{} is not covered by the pool snapshot.\n\nThat is not the same as \
+                         \"free\": a free hole inside a walked region comes back as a chunk \
+                         whose state is not Allocated. An address outside every region is \
+                         either not pool at all, or sits in a region this walk did not reach. \
+                         If the target has run since the snapshot was taken, retry with \
+                         refresh=true.",
+                        fmt_addr(address)
+                    );
+                    append_walk_report(&mut out, e);
+                    Ok(out)
+                }
+            }
+        }
+        PoolOp::Diagnostics {
+            filter,
+            refresh,
+            limit,
+        } => {
+            let report = query::snapshot_report(e, refresh).map_err(es)?;
+            Ok(render_diagnostics(&report, filter.as_deref(), limit))
+        }
+        // The census *is* the state of the walk, so it always carries the report.
+        PoolOp::Census { refresh, limit } => {
+            let census = query::tag_census(e, refresh).map_err(es)?;
+            let mut out = render_census(&census, limit);
+            append_walk_report(&mut out, e);
+            Ok(out)
+        }
+    }
+}
+
+fn render_find_tag(
+    tag: &str,
+    filter: Option<PoolPageFilter>,
+    spans: &[PoolSpan],
+    limit: usize,
+) -> String {
+    let scope = match filter {
+        Some(PoolPageFilter::Paged) => " in paged pool",
+        Some(PoolPageFilter::NonPaged) => " in nonpaged pool",
+        None => "",
+    };
+    if spans.is_empty() {
+        return format!(
+            "No allocated chunks carry tag `{tag}`{scope}.\n\nOnly *allocated* chunks are \
+             indexed by tag: a freed chunk's tag is not reliably preserved by the allocator, so \
+             this never reports freed memory. To ask about one address that may have been freed, \
+             use `pool_chunk`. If the target has run since the snapshot was taken, retry with \
+             refresh=true."
+        );
+    }
+    let total: u64 = spans.iter().map(|span| span.size).sum();
+    let mut out = format!(
+        "tag `{tag}`{scope}: {} allocation(s), {total:#x} bytes total\n\n{POOL_COLUMNS}\n",
+        spans.len()
+    );
+    for span in spans.iter().take(limit) {
+        out.push_str(&pool_row(span));
+        out.push('\n');
+    }
+    if spans.len() > limit {
+        out.push_str(&format!(
+            "\n... {} more not shown; raise `limit` to see them.\n",
+            spans.len() - limit
+        ));
+    }
+    out
+}
+
+fn render_chunk(address: u64, found: &query::PoolNeighbourhood) -> String {
+    let chunk = &found.chunk;
+    let mut out = format!(
+        "{} is {:#x} byte(s) into a {:#x}-byte chunk tagged `{}` ({:?}).\n\n{POOL_COLUMNS}\n",
+        fmt_addr(address),
+        address.saturating_sub(chunk.usable_address),
+        chunk.size,
+        chunk.display_tag,
+        chunk.state,
+    );
+    if let Some(previous) = &found.previous {
+        out.push_str(&format!("{}   prev\n", pool_row(previous)));
+    }
+    out.push_str(&format!("{}   <== containing chunk\n", pool_row(chunk)));
+    if let Some(next) = &found.next {
+        out.push_str(&format!("{}   next\n", pool_row(next)));
+    }
+    if found.previous.is_none() && found.next.is_none() {
+        out.push_str("\n(no neighbouring chunks in the same heap)\n");
+    }
+    if chunk.state != PoolState::Allocated {
+        out.push_str(&format!(
+            "\nThis chunk is {:?}, not Allocated: any pointer the target still holds to it is a \
+             use-after-free.\n",
+            chunk.state
+        ));
+    }
+    if chunk.heap.special {
+        out.push_str(
+            "\nThis is Driver Verifier special pool: the allocation owns a whole page and is \
+             butted against a guard page, so an overflow or a touch after free faults at once \
+             instead of quietly corrupting a neighbour. A freed special-pool page is unmapped, \
+             so its former contents cannot be read back.\n",
+        );
+    }
+    out
+}
+
+/// Selects the diagnostics matching `filter` (case-insensitive substring), verbatim.
+fn select_diagnostics<'a>(lines: &'a [String], filter: Option<&str>) -> Vec<&'a String> {
+    let needle = filter.map(str::to_ascii_lowercase);
+    lines
+        .iter()
+        .filter(|line| {
+            needle
+                .as_ref()
+                .is_none_or(|needle| line.to_ascii_lowercase().contains(needle.as_str()))
+        })
+        .collect()
+}
+
+fn render_diagnostics(
+    report: &query::PoolSnapshotReport,
+    filter: Option<&str>,
+    limit: usize,
+) -> String {
+    let matching = select_diagnostics(&report.diagnostics, filter);
+    let scope = match filter {
+        Some(filter) => format!(" matching \"{filter}\""),
+        None => String::new(),
+    };
+    if matching.is_empty() {
+        return format!(
+            "No diagnostics{scope}.\n\nThe walk emitted {} diagnostic(s) in total over {} \
+             chunk(s) ({} allocated). If you expected a match, check the spelling — the \
+             filter is a plain case-insensitive substring, not a pattern.",
+            report.diagnostics.len(),
+            report.total_chunks,
+            report.allocated_chunks
+        );
+    }
+    let mut out = format!(
+        "{} of {} diagnostic(s){scope}:\n\n",
+        matching.len(),
+        report.diagnostics.len()
+    );
+    for line in matching.iter().take(limit) {
+        out.push_str("  ");
+        out.push_str(line);
+        out.push('\n');
+    }
+    if matching.len() > limit {
+        out.push_str(&format!(
+            "\n... {} more match; raise `limit` to see them.\n",
+            matching.len() - limit
+        ));
+    }
+    out
+}
+
+fn render_census(census: &[query::PoolTagSummary], limit: usize) -> String {
+    if census.is_empty() {
+        return "The pool snapshot contains no allocated chunks.".to_string();
+    }
+    let mut out = format!(
+        "{} distinct tag(s) allocated, heaviest first.\n\ntag      allocs        bytes  \
+         nonpaged   paged\n",
+        census.len()
+    );
+    for entry in census.iter().take(limit) {
+        out.push_str(&format!(
+            "{:<6}  {:>7}  {:>11}  {:>8}  {:>6}\n",
+            entry.display_tag,
+            entry.allocations,
+            format!("{:#x}", entry.total_bytes),
+            entry.nonpaged_allocations,
+            entry.paged_allocations,
+        ));
+    }
+    if census.len() > limit {
+        out.push_str(&format!(
+            "\n... {} more not shown; raise `limit` to see them.\n",
+            census.len() - limit
+        ));
+    }
+    out
 }
 
 /// Runs an opener as **transition, then report**, announcing the two milestones the supervisor
@@ -739,6 +1072,104 @@ fn reachable(e: &DebugEngine, args: ReachabilityOp) -> Result<String, String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ---- pool walk diagnostics ------------------------------------------------------
+
+    /// Addresses vary per boot and per heap; the *kind* of failure is what a reader needs.
+    #[test]
+    fn diagnostic_categories_collapse_addresses() {
+        assert_eq!(
+            diagnostic_category("unreadable VS free tree node 0xbb3b57d239731c20: sparse"),
+            "unreadable VS free tree node <addr> sparse"
+        );
+        assert_eq!(
+            diagnostic_category("rejecting descriptor 19 at 0xffff8c8f0de00260 with bad sig"),
+            "rejecting descriptor 19 at <addr> with bad sig"
+        );
+    }
+
+    /// Short numbers are meaningful ("depth is 16") and must survive, or lines that differ
+    /// in a real way would be merged into one category.
+    #[test]
+    fn short_numbers_are_not_treated_as_addresses() {
+        assert_eq!(
+            diagnostic_category("VS list depth is 16, but only 1 entries were readable"),
+            "VS list depth is 16, but only 1 entries were readable"
+        );
+    }
+
+    #[test]
+    fn diagnostics_group_by_category_commonest_first() {
+        let lines = vec![
+            "unreadable VS free tree node 0xaaaaaaaaaaaaaaaa: sparse".to_string(),
+            "unreadable VS free tree node 0xbbbbbbbbbbbbbbbb: sparse".to_string(),
+            "unreadable VS free tree node 0xcccccccccccccccc: sparse".to_string(),
+            "per-session paged heaps are not included".to_string(),
+        ];
+        let grouped = summarize_diagnostics(&lines);
+        assert_eq!(grouped.len(), 2);
+        assert_eq!(grouped[0].1, 3);
+        assert!(grouped[0].0.contains("<addr>"));
+        assert_eq!(grouped[1].1, 1);
+    }
+
+    #[test]
+    fn diagnostics_filter_is_a_case_insensitive_substring() {
+        let lines = vec![
+            "cannot fully discover heap 0xffff8c8f0d300000: read failed".to_string(),
+            "LFH slot 0xffffb28ac16fcf30+0xe0 would cross a page".to_string(),
+            "rejecting page segment 0xdeadbeef with invalid signature".to_string(),
+        ];
+        // The whole point: find the one line about a specific heap among the noise.
+        let hits = select_diagnostics(&lines, Some("FFFF8C8F0D300000"));
+        assert_eq!(hits.len(), 1);
+        assert!(hits[0].starts_with("cannot fully discover heap"));
+
+        assert_eq!(select_diagnostics(&lines, Some("cross a page")).len(), 1);
+        assert_eq!(select_diagnostics(&lines, None).len(), 3);
+        assert!(select_diagnostics(&lines, Some("no such text")).is_empty());
+    }
+
+    // ---- pool address parsing ------------------------------------------------------
+
+    /// The form debugger output actually prints. Callers paste these straight from a
+    /// `dq`/`!pool` line, backtick and all.
+    #[test]
+    fn pool_addr_accepts_the_backtick_form() {
+        assert_eq!(
+            parse_pool_addr("ffffc00f`6ec02f90"),
+            Ok(0xffffc00f_6ec02f90)
+        );
+    }
+
+    /// A bare run of 8+ hex digits is hex, matching WinDbg rather than Rust. `6ec02f90`
+    /// is a plausible decimal string too, and reading it as decimal would silently point
+    /// the query at unrelated memory.
+    #[test]
+    fn pool_addr_reads_a_bare_run_as_hex() {
+        assert_eq!(parse_pool_addr("6ec02f90"), Ok(0x6ec02f90));
+        assert_eq!(parse_pool_addr("00401000"), Ok(0x0040_1000));
+    }
+
+    /// Shorter tokens fall through to the decimal/`0x` parser, since the WinDbg form
+    /// deliberately requires 8+ digits so it cannot swallow a mnemonic or short immediate.
+    #[test]
+    fn pool_addr_falls_through_to_prefixed_and_decimal() {
+        assert_eq!(parse_pool_addr("0x1000"), Ok(0x1000));
+        assert_eq!(parse_pool_addr("4096"), Ok(4096));
+        // 0x-prefixed stays hex even when long enough to reach the WinDbg parser, because
+        // the `x` is not a hex digit and that parser rejects it.
+        assert_eq!(
+            parse_pool_addr("0xffffc00f6ec02f90"),
+            Ok(0xffffc00f_6ec02f90)
+        );
+    }
+
+    #[test]
+    fn pool_addr_rejects_nonsense() {
+        assert!(parse_pool_addr("not-an-address").is_err());
+        assert!(parse_pool_addr("").is_err());
+    }
 
     // ---- the protocol channel this worker was handed -------------------------------
 

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -661,6 +661,26 @@ fn summarize_diagnostics(lines: &[String]) -> Vec<(String, usize)> {
     grouped
 }
 
+/// The caveat an answer needs when the walk that produced it did not finish, or `None` when
+/// it did — so a healthy answer stays quiet.
+///
+/// A *nonempty* result looks self-explanatory in a way an empty one does not, which is what
+/// makes it the more dangerous of the two: "3 allocations, 0x138 bytes total" reads as the
+/// whole set whether the walk covered the whole pool or a corner of it. `find_tag` can only
+/// report what the walk indexed, so under partial coverage that count is a floor. Saying so is
+/// the difference between "there are three of these" and "these are the three I could see".
+fn coverage_caveat(report: &query::PoolSnapshotReport) -> Option<String> {
+    if report.complete {
+        return None;
+    }
+    Some(format!(
+        "\n--- pool walk ---\ncoverage: INCOMPLETE - the walk reached {} chunk(s) but not \
+         everything it set out to, so the count above is a floor, not a total; there may be \
+         more. `pool_diagnostics` says what it could not reach.\n",
+        report.total_chunks
+    ))
+}
+
 /// Appends what the walk itself managed, so an empty answer explains itself.
 ///
 /// Without this, an empty result is ambiguous in the worst way: "the pool holds no such
@@ -737,6 +757,10 @@ fn pool(e: &DebugEngine, args: PoolOp) -> Result<String, String> {
             let mut out = render_find_tag(&tag, filter, &spans, limit);
             if spans.is_empty() {
                 append_walk_report(&mut out, e);
+            } else if let Ok(report) = query::snapshot_report(e, false)
+                && let Some(caveat) = coverage_caveat(&report)
+            {
+                out.push_str(&caveat);
             }
             Ok(out)
         }
@@ -1151,6 +1175,34 @@ mod tests {
         assert_eq!(select_diagnostics(&lines, Some("cross a page")).len(), 1);
         assert_eq!(select_diagnostics(&lines, None).len(), 3);
         assert!(select_diagnostics(&lines, Some("no such text")).is_empty());
+    }
+
+    fn report(complete: bool) -> query::PoolSnapshotReport {
+        query::PoolSnapshotReport {
+            total_chunks: 4211,
+            allocated_chunks: 3007,
+            complete,
+            diagnostics: Vec::new(),
+        }
+    }
+
+    /// A found-something answer carries its own count, and that count is only a total if the
+    /// walk finished. Left unsaid, "3 allocations" from a walk that reached a fraction of the
+    /// pool reads as "there are exactly 3".
+    #[test]
+    fn an_incomplete_walk_says_so_even_when_it_found_something() {
+        let caveat = coverage_caveat(&report(false)).expect("an incomplete walk must be flagged");
+        assert!(caveat.contains("INCOMPLETE"), "{caveat}");
+        assert!(caveat.contains("4211"), "{caveat}");
+        // Not merely "incomplete": the caller has to know which way the number is wrong.
+        assert!(caveat.contains("floor"), "{caveat}");
+    }
+
+    /// The other half: a complete walk must not decorate every answer with a warning, or the
+    /// warning stops meaning anything on the walk that matters.
+    #[test]
+    fn a_complete_walk_adds_no_caveat() {
+        assert_eq!(coverage_caveat(&report(true)), None);
     }
 
     // ---- pool address parsing ------------------------------------------------------

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -838,12 +838,21 @@ fn render_chunk(address: u64, found: &query::PoolNeighbourhood) -> String {
     if found.previous.is_none() && found.next.is_none() {
         out.push_str("\n(no neighbouring chunks in the same heap)\n");
     }
-    if chunk.state != PoolState::Allocated {
-        out.push_str(&format!(
+    match chunk.state {
+        PoolState::Allocated => {}
+        // Only these two mean the allocator actually released the chunk.
+        PoolState::ReusableFree | PoolState::CachedFree => out.push_str(&format!(
             "\nThis chunk is {:?}, not Allocated: any pointer the target still holds to it is a \
              use-after-free.\n",
             chunk.state
-        ));
+        )),
+        // `Unreadable` is a limit of the walk, not a fact about lifetime — a Verifier guard
+        // page reads exactly this way. Calling it a use-after-free would turn "could not
+        // read" into a verdict, which is the one mistake this tool must not make.
+        PoolState::Unreadable => out.push_str(
+            "\nThis span could not be read, so its state is unknown. That is a limit of the \
+             walk, not evidence that the allocator freed it.\n",
+        ),
     }
     if chunk.heap.special {
         out.push_str(
@@ -881,9 +890,14 @@ fn render_diagnostics(
     };
     if matching.is_empty() {
         return format!(
-            "No diagnostics{scope}.\n\nThe walk emitted {} diagnostic(s) in total over {} \
+            "No diagnostics{scope}.\n\nThe walk was {}. It emitted {} diagnostic(s) in total over {} \
              chunk(s) ({} allocated). If you expected a match, check the spelling — the \
              filter is a plain case-insensitive substring, not a pattern.",
+            if report.complete {
+                "complete"
+            } else {
+                "INCOMPLETE"
+            },
             report.diagnostics.len(),
             report.total_chunks,
             report.allocated_chunks

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -666,17 +666,17 @@ fn summarize_diagnostics(lines: &[String]) -> Vec<(String, usize)> {
 ///
 /// A *nonempty* result looks self-explanatory in a way an empty one does not, which is what
 /// makes it the more dangerous of the two: "3 allocations, 0x138 bytes total" reads as the
-/// whole set whether the walk covered the whole pool or a corner of it. `find_tag` can only
-/// report what the walk indexed, so under partial coverage that count is a floor. Saying so is
-/// the difference between "there are three of these" and "these are the three I could see".
+/// whole set whether the walk covered the whole pool or a corner of it. Every list here is
+/// drawn from what the walk indexed, so under partial coverage a count is a floor. Saying so
+/// is the difference between "there are three of these" and "these are the three I could see".
 fn coverage_caveat(report: &query::PoolSnapshotReport) -> Option<String> {
     if report.complete {
         return None;
     }
     Some(format!(
-        "\n--- pool walk ---\ncoverage: INCOMPLETE - the walk reached {} chunk(s) but not \
-         everything it set out to, so the count above is a floor, not a total; there may be \
-         more. `pool_diagnostics` says what it could not reach.\n",
+        "\n--- pool walk ---\ncoverage: INCOMPLETE - the walk reached {} chunk(s), but not \
+         everything it set out to. What is listed above is therefore a floor, not a total: \
+         there may be more the walk never saw.\n",
         report.total_chunks
     ))
 }
@@ -943,6 +943,11 @@ fn render_diagnostics(
             matching.len() - limit
         ));
     }
+    // "2 of 2 diagnostics" is an exact-looking claim about a walk that may have stopped before
+    // whole heaps. The empty branch above already says which; a nonempty one owes the same.
+    if let Some(caveat) = coverage_caveat(report) {
+        out.push_str(&caveat);
+    }
     out
 }
 
@@ -1177,13 +1182,17 @@ mod tests {
         assert!(select_diagnostics(&lines, Some("no such text")).is_empty());
     }
 
-    fn report(complete: bool) -> query::PoolSnapshotReport {
+    fn report_with(complete: bool, diagnostics: &[&str]) -> query::PoolSnapshotReport {
         query::PoolSnapshotReport {
             total_chunks: 4211,
             allocated_chunks: 3007,
             complete,
-            diagnostics: Vec::new(),
+            diagnostics: diagnostics.iter().map(|line| line.to_string()).collect(),
         }
+    }
+
+    fn report(complete: bool) -> query::PoolSnapshotReport {
+        report_with(complete, &[])
     }
 
     /// A found-something answer carries its own count, and that count is only a total if the
@@ -1203,6 +1212,30 @@ mod tests {
     #[test]
     fn a_complete_walk_adds_no_caveat() {
         assert_eq!(coverage_caveat(&report(true)), None);
+    }
+
+    /// The filtered list has the same failure mode as a tag result: "1 of 2 diagnostic(s)" is
+    /// an exact-looking claim, and a walk that stopped before whole heaps never produced the
+    /// diagnostics those heaps would have emitted.
+    #[test]
+    fn filtered_diagnostics_carry_the_coverage_state() {
+        let lines = [
+            "cannot fully discover heap 0xffff8c8f0d300000: read failed",
+            "LFH slot 0xffffb28ac16fcf30+0xe0 would cross a page",
+        ];
+        let rendered = render_diagnostics(&report_with(false, &lines), Some("heap"), 10);
+        assert!(
+            rendered.contains("cannot fully discover heap"),
+            "{rendered}"
+        );
+        assert!(rendered.contains("INCOMPLETE"), "{rendered}");
+
+        let rendered = render_diagnostics(&report_with(true, &lines), Some("heap"), 10);
+        assert!(
+            rendered.contains("cannot fully discover heap"),
+            "{rendered}"
+        );
+        assert!(!rendered.contains("INCOMPLETE"), "{rendered}");
     }
 
     // ---- pool address parsing ------------------------------------------------------

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -768,17 +768,16 @@ fn pool(e: &DebugEngine, args: PoolOp) -> Result<String, String> {
             let address = parse_pool_addr(&address)?;
             match query::chunk_at(e, address, refresh).map_err(es)? {
                 Some(found) => Ok(render_chunk(address, &found)),
-                // "Not in the snapshot" and "free" are different answers, and conflating them
-                // would be the difference between "this pointer is dangling" and "this pointer
-                // never pointed at pool".
+                // "Not in the snapshot" and "free" are different answers, and reporting this one
+                // as free would manufacture a dangling pointer out of a gap in the walk.
                 None => {
                     let mut out = format!(
                         "{} is not covered by the pool snapshot.\n\nThat is not the same as \
-                         \"free\": a free hole inside a walked region comes back as a chunk \
-                         whose state is not Allocated. An address outside every region is \
-                         either not pool at all, or sits in a region this walk did not reach. \
-                         If the target has run since the snapshot was taken, retry with \
-                         refresh=true.",
+                         \"free\": a free hole inside a walked region comes back as a chunk in \
+                         an explicitly free state (ReusableFree or CachedFree). An address \
+                         outside every region is either not pool at all, or sits in a region \
+                         this walk did not reach. If the target has run since the snapshot was \
+                         taken, retry with refresh=true.",
                         fmt_addr(address)
                     );
                     append_walk_report(&mut out, e);

--- a/tests/golden/tools_list.json
+++ b/tests/golden/tools_list.json
@@ -3,7 +3,7 @@
     "(none)",
     "https://json-schema.org/draft/2020-12/schema"
   ],
-  "toolCount": 37,
+  "toolCount": 41,
   "tools": [
     {
       "hints": {
@@ -314,6 +314,77 @@
         "path"
       ],
       "title": "Open TTD trace"
+    },
+    {
+      "hints": {
+        "destructive": false,
+        "idempotent": true,
+        "openWorld": true,
+        "readOnly": true
+      },
+      "name": "pool_census",
+      "params": [
+        "limit: integer|null/uint32",
+        "refresh: boolean|null",
+        "session_id: string|null"
+      ],
+      "required": [],
+      "title": "Census pool usage by tag"
+    },
+    {
+      "hints": {
+        "destructive": false,
+        "idempotent": true,
+        "openWorld": true,
+        "readOnly": true
+      },
+      "name": "pool_chunk",
+      "params": [
+        "address: string",
+        "refresh: boolean|null",
+        "session_id: string|null"
+      ],
+      "required": [
+        "address"
+      ],
+      "title": "Locate a pool chunk by address"
+    },
+    {
+      "hints": {
+        "destructive": false,
+        "idempotent": true,
+        "openWorld": true,
+        "readOnly": true
+      },
+      "name": "pool_diagnostics",
+      "params": [
+        "filter: string|null",
+        "limit: integer|null/uint32",
+        "refresh: boolean|null",
+        "session_id: string|null"
+      ],
+      "required": [],
+      "title": "Filter pool walk diagnostics"
+    },
+    {
+      "hints": {
+        "destructive": false,
+        "idempotent": true,
+        "openWorld": true,
+        "readOnly": true
+      },
+      "name": "pool_find_tag",
+      "params": [
+        "limit: integer|null/uint32",
+        "paged: boolean|null",
+        "refresh: boolean|null",
+        "session_id: string|null",
+        "tag: string"
+      ],
+      "required": [
+        "tag"
+      ],
+      "title": "Find pool chunks by tag"
     },
     {
       "hints": {


### PR DESCRIPTION
> **Draft — blocked on [glslang/win-kexp#80](https://github.com/glslang/win-kexp/pull/80).** This needs win-kexp's `pool::query` API. Once #80 lands on `main` I'll `cargo update -p win-kexp` and push the lock bump, at which point CI can go green. Opening now so the two are reviewable together.

Adds `pool_find_tag`, `pool_chunk`, `pool_census` and `pool_diagnostics` (38 → 42 tools). All four go through win-kexp's own descriptor walk rather than `!pool`/`!poolused` text, reading one cached snapshot, so they cannot disagree with each other.

## Distinctions the tools keep deliberately

- **`pool_find_tag` reports only allocated chunks.** A freed chunk's tag is not reliably preserved by the allocator, so listing them would be inventing data. Ask about a specific possibly-freed address with `pool_chunk`.
- **`pool_chunk` separates "free hole in a walked region" from "not covered by the snapshot".** That is the difference between a dangling pointer and one that never pointed at pool; collapsing them would make the tool useless for the question it exists to answer. It also reports the neighbouring chunks — what a reclaim would land next to.

## Why `pool_diagnostics`

A real walk emits ~18k diagnostics across 135+ categories. Any per-call summary truncates, and the line explaining one specific heap is reliably *not* in the truncated head. A plain case-insensitive substring filter found a special-pool misclassification in a single call — and disproved a wrong hypothesis in another, which is the part that saved the most time.

Relatedly, every result now carries the walk's own state (chunks seen, diagnostics grouped by category) whenever it comes back empty. "The pool holds no such chunk" and "the walk reached almost none of the pool" rendering identically hid a real bug for three rounds.

## Notes for review

- `open_world_hint = true` on all four: layout resolution can trigger a PDB download, and over KDNET the target itself is remote. The existing invariant test caught me getting this wrong.
- Rendering lives in the worker; the typed data stays in win-kexp.
- `examples/messagemanager/` is a client for a CTF driver, run on the target VM — the server cannot issue `DeviceIoControl` itself.
- Golden `tools_list.json` re-recorded; the diff adds only the four tool names.

## Verification

114 unit + 18 smoke tests pass, `cargo fmt` and clippy clean. Exercised end to end against a live Windows 26100 KDNET target, including a driver under `verifier /flags 0x1` where `pool_find_tag Tgsm` resolves to `ffff8c8f13a02f90 / 0x68 / SpecialNonPagedNx`, matching `!pool` exactly, and `pool_chunk` shows the guard page as an `Unreadable` neighbour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added four read-only kernel pool inspection tools for tag searches, chunk inspection, diagnostics, and allocation censuses.
  * Added session-scoped snapshot caching, refresh controls, filtering, paging, coverage details, neighbouring-chunk information, and result limits.
  * Added a PowerShell client supporting MessageManager create, delete, data, flush, demo, stress, and race workflows.
* **Documentation**
  * Documented the tools, x64 kernel-target requirement, caching behaviour, filtering, and coverage distinctions.
* **Testing**
  * Added coverage for diagnostic grouping, filtering, address formats, and the expanded tool catalogue.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->