### PR TITLE
Take the pool-walk budget from win-kexp, and cover it on a live kernel

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,17 +103,18 @@ cargo test --test mcp_smoke -- --ignored --nocapture --test-threads=1 bounded
 ```
 
 A fourth tier drives a **real KDNET target** through a full session lifecycle — attach, work
-alongside a second session, detach gracefully — and separately checks that a client *disconnect*
-releases a live kernel session rather than killing its worker. It is gated on the connection string
-(which nobody can guess) *and* `#[ignore]`d, so a stale variable can never freeze a VM during an
-ordinary `cargo test`. Run it last, on its own:
+alongside a second session, detach gracefully — separately checks that a client *disconnect*
+releases a live kernel session rather than killing its worker, and covers the **pool walk**
+(`pool_find_tag`/`pool_census`), whose cost only exists over a live link. It is gated on the
+connection string (which nobody can guess) *and* `#[ignore]`d, so a stale variable can never freeze
+a VM during an ordinary `cargo test`. Run it last, on its own:
 
 ```pwsh
 $env:WINDBG_MCP_SMOKE_KERNEL = "net:port=50000,key=<w.x.y.z>"
 cargo test --test mcp_smoke -- --ignored --nocapture --test-threads=1 live_kernel
 ```
 
-`--test-threads=1` is not optional: the filter matches **two** tests, and the KD transport is
+`--test-threads=1` is not optional: the filter matches **three** tests, and the KD transport is
 single-owner, so in parallel the second attach fails and can leave the target halted.
 
 ## Live kernel + driver IOCTL gotchas (learned driving HEVD over KDNET)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -884,7 +884,7 @@ dependencies = [
 [[package]]
 name = "win-kexp"
 version = "0.1.0"
-source = "git+https://github.com/glslang/win-kexp?branch=main#ce8bce2ad21bac007c835ef6ca198341737fae06"
+source = "git+https://github.com/glslang/win-kexp?branch=main#1c7b474876ecc18a61564bc48c3b9d7b355aa4e9"
 dependencies = [
  "byte-strings",
  "goblin",

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -243,7 +243,11 @@ about. This is the other half — an attach that lands:
   next call is served **immediately** rather than waiting out the rest of a walk, and that whatever
   came back **states its own coverage**. A truncated walk is a perfectly good outcome here, and the
   expected one on a busy kernel — so the test never asserts the walk was complete, only that it said
-  which it was. Where the walk *does* complete it also checks the snapshot was cached rather than
+  which it was, and it prints the walk's own diagnostic categories when it fell short, which is the
+  part worth reading. **Measured against Server 26100 over KDNET: a forced walk returned in 21.9s
+  and reported INCOMPLETE.** That is well inside the 120s budget, so on that target the coverage
+  gap is not the deadline — and scoping the walk (glslang/win-kexp#89) would not change it.
+  Where the walk *does* complete it also checks the snapshot was cached rather than
   re-walked, and that `pool_census` and `pool_find_tag` agree about the heaviest tag in it. That
   last comparison additionally needs the census to expose a tag that renders unambiguously: pool
   tags are four raw bytes, unprintable ones render as `.` — and so does a literal `.` — so a tag

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -222,11 +222,16 @@ about. This is the other half — an attach that lands:
   (`_EX_POOL_HEAP_MANAGER_STATE`, the page-range descriptors, the VS and LFH headers) and none of
   that is in the export table, so without them every pool query fails before reading a byte.
   Symbols are never fetched over the KD wire. The test runs `.symfix+` and `.reload /f nt` itself
-  and prints `.sympath`, `lm m nt` and `x nt!ExPoolState` when it cannot get them — but note the
-  symbol *cache* belongs to the debugger binary, and the harness spawns the **dev** build, so it
-  does not inherit whatever a release build has already downloaded. The first run against a given
-  kernel build therefore has to fetch that build's `ntkrnlmp.pdb`, and needs a symbol path that can
-  reach a store. `pool_find_tag` with `refresh` then walks every
+  under `!sym noisy` and prints `!lmi nt`, `lm m nt` and `x nt!ExPoolState` when it cannot get
+  them. Two traps live here. The symbol *cache* belongs to the debugger binary — a bare `srv*`
+  expands to `cache*;SRV*<msdl>`, and that cache sits beside the exe — so the dev build the harness
+  spawns does not inherit what a release build downloaded; the tier names one shared store to avoid
+  that. And a symbol server can only be queried by PDB **GUID**, read from the image's debug
+  directory: if that cannot be read, `!sym noisy` shows `ntkrnlmp.pdb - file not found` with no
+  `SYMSRV:` line above it, which is a lookup that never happened rather than a download that
+  failed. Where you already have a symbol path that works for the target, set
+  `WINDBG_MCP_SMOKE_SYMBOLS` to it and the tier will use that instead. `pool_find_tag` with
+  `refresh` then walks every
   committed pool page, which over KDNET is the query that used to run for minutes past its caller's
   timeout and leave everything behind it queued. Only this tier can show it: against the sample dump
   the same walk is local memory and finishes in well under a second, so the assertions would pass

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -244,9 +244,14 @@ about. This is the other half — an attach that lands:
   came back **states its own coverage**. A truncated walk is a perfectly good outcome here, and the
   expected one on a busy kernel — so the test never asserts the walk was complete, only that it said
   which it was, and it prints the walk's own diagnostic categories when it fell short, which is the
-  part worth reading. **Measured against Server 26100 over KDNET: a forced walk returned in 21.9s
-  and reported INCOMPLETE.** That is well inside the 120s budget, so on that target the coverage
-  gap is not the deadline — and scoping the walk (glslang/win-kexp#89) would not change it.
+  part worth reading. **Measured against Server 26100 over KDNET: a forced walk returned in ~20s,
+  indexed 413k chunks (234k allocated), and reported INCOMPLETE.** That is well inside the 120s
+  budget, so on that target the coverage gap is not the deadline — and scoping the walk
+  (glslang/win-kexp#89) would not change it. Expect INCOMPLETE on any live kernel: paged pool is
+  partly on disk, so `sparse virtual range` diagnostics are physics rather than a defect, and the
+  coverage caveat is doing its job. The categories that are *not* explained that way are worth
+  reading — this run showed ~5.6k LFH subsegments rejected as implausible
+  (glslang/win-kexp#90), and the diagnostic total itself is currently understated (#77).
   Where the walk *does* complete it also checks the snapshot was cached rather than
   re-walked, and that `pool_census` and `pool_find_tag` agree about the heaviest tag in it. That
   last comparison additionally needs the census to expose a tag that renders unambiguously: pool

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -245,8 +245,10 @@ about. This is the other half — an attach that lands:
   which it was, and it prints the walk's own diagnostic categories when it fell short, which is the
   part worth reading. **Measured against Server 26100 over KDNET: a forced walk returned in ~20s,
   indexed 413k chunks (234k allocated), and reported INCOMPLETE.** That is well inside the 120s
-  budget, so on that target the coverage gap is not the deadline — and scoping the walk
-  (glslang/win-kexp#89) would not change it. Expect INCOMPLETE on any live kernel: paged pool is
+  budget, so on that target the coverage gap is not the deadline — which is why scoping the walk
+  to one side of the pool was closed unbuilt (glslang/win-kexp#89): it would have bought a faster
+  query at the cost of a cache that keys on scope, against four-fold headroom that already exists.
+  Expect INCOMPLETE on any live kernel: paged pool is
   partly on disk, so `sparse virtual range` diagnostics are physics rather than a defect, and the
   coverage caveat is doing its job. The categories that are *not* explained that way are worth
   reading — this run showed ~5.6k LFH subsegments rejected as implausible

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -221,21 +221,20 @@ about. This is the other half — an attach that lands:
   which is a real precondition rather than a formality: the walker decodes segment-heap internals
   (`_EX_POOL_HEAP_MANAGER_STATE`, the page-range descriptors, the VS and LFH headers) and none of
   that is in the export table, so without them every pool query fails before reading a byte.
-  Symbols are never fetched over the KD wire. The test runs `.symfix+` and `.reload /f nt` itself
-  under `!sym noisy` and prints `!lmi nt`, `lm m nt` and `x nt!ExPoolState` when it cannot get
-  them. **The harness spawns the *dev* binary, and the engine DLLs live beside the release one**
-  — `setup.md` has you copy them there, because that is what the plugin runs. Without
-  `symsrv.dll` a symbol store cannot be read at all and without `msdia140.dll` a PDB cannot be
-  parsed, so a PDB already sitting in the cache comes back as `file not found`. The tier copies
-  them across from `target\release` before starting the server, and says so. The other trap:
-  **`.symfix` and a bare `srv*` name no local cache** — both expand
-  to `cache*;SRV*<msdl>`, where `cache*` is not a directory. A symbol-server element with no usable
-  downstream store is skipped, and a skipped element reads exactly like an absent PDB:
-  `DBGHELP: ntkrnlmp.pdb - file not found`, with no `SYMSRV:` line above it because nothing was
-  ever asked. So the tier passes an explicit cache to `.symfix+`, and reloads with a bare
-  `.reload /f` rather than `.reload /f nt`, which rests on the `nt` alias resolving. Where you
-  already have a symbol path that works for the target, set `WINDBG_MCP_SMOKE_SYMBOLS` to it and
-  that is used instead. `pool_find_tag` with `refresh` then walks every
+  Symbols are never fetched over the KD wire. The tier sets a path with `set_symbol_path` — the
+  typed tool, so `.sympath`'s line-swallowing cannot bite — pointed at a store under
+  `target\release\sym` that dev and release builds share, then reloads under `!sym noisy` and
+  prints `!lmi nt`, `lm m nt` and `x nt!ExPoolState` when it cannot get them.
+  **The trap that actually bit: the harness spawns the *dev* binary, and the engine DLLs live
+  beside the release one** — `setup.md` has you copy them there, because that is what the plugin
+  runs. `dbgeng.dll` is in System32, so the dev binary opens targets and runs commands perfectly;
+  it just has no `symsrv.dll` to read a symbol store and no `msdia140.dll` to parse a PDB, so a
+  PDB already sitting in the cache comes back as `file not found` with the error summary blaming
+  the store. The tier copies the engine across before starting the server, and says so. It also
+  reloads with a bare `.reload /f` rather than `.reload /f nt`, which rests on the `nt` alias
+  resolving. Where you already have a symbol path that works for the target, set
+  `WINDBG_MCP_SMOKE_SYMBOLS` to it and that is used instead. `pool_find_tag` with `refresh` then
+  walks every
   committed pool page, which over KDNET is the query that used to run for minutes past its caller's
   timeout and leave everything behind it queued. Only this tier can show it: against the sample dump
   the same walk is local memory and finishes in well under a second, so the assertions would pass

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -186,8 +186,8 @@ $env:WINDBG_MCP_SMOKE_KERNEL = "net:port=50000,key=<w.x.y.z>"
 cargo test --test mcp_smoke -- --ignored --nocapture --test-threads=1 live_kernel
 ```
 
-`--test-threads=1` is required, not tidiness: the filter matches **two** tests, and the KD
-transport is single-owner, so run in parallel the second attach fails and can leave the target
+`--test-threads=1` is required, not tidiness: the filter matches **three** tests, and the KD
+transport is single-owner, so run in parallel the later attaches fail and can leave the target
 halted.
 
 The connection string is the one from `bcdedit /dbgsettings` on the target (or the `kd -k` command
@@ -217,6 +217,16 @@ about. This is the other half — an attach that lands:
   read either side of the disconnect — a halted kernel takes no clock interrupt, so its uptime
   stands still while a released one keeps counting. Re-attaching alone proves nothing here: a
   frozen target still answers its KD stub.
+- **A pool walk is bounded and gives the session back.** `pool_find_tag` with `refresh` walks every
+  committed pool page, which over KDNET is the query that used to run for minutes past its caller's
+  timeout and leave everything behind it queued. Only this tier can show it: against the sample dump
+  the same walk is local memory and finishes in well under a second, so the assertions would pass
+  for the wrong reason. The claims are that the call **returns** inside its budget, that the very
+  next call is served **immediately** rather than waiting out the rest of a walk, and that whatever
+  came back **states its own coverage**. A truncated walk is a perfectly good outcome here, and the
+  expected one on a busy kernel — so the test never asserts the walk was complete, only that it said
+  which it was. Where the walk *does* complete it also checks the snapshot was cached rather than
+  re-walked, and that `pool_census` and `pool_find_tag` agree about the heaviest tag in it.
 
 The first run of this tier found a real bug — shutdown killed workers outright, so a disconnect
 froze the target — which no dump-based tier could have found, because killing a worker that holds

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -187,8 +187,8 @@ cargo test --test mcp_smoke -- --ignored --nocapture --test-threads=1 live_kerne
 ```
 
 `--test-threads=1` is required, not tidiness: the filter matches **three** tests, and the KD
-transport is single-owner, so run in parallel the later attaches fail and can leave the target
-halted.
+transport is single-owner. Run them in parallel and the later attaches fail, which can leave the
+target halted.
 
 The connection string is the one from `bcdedit /dbgsettings` on the target (or the `kd -k` command
 you would otherwise use). It is **never** guessable, so the tier is gated on it rather than on a
@@ -226,7 +226,11 @@ about. This is the other half — an attach that lands:
   came back **states its own coverage**. A truncated walk is a perfectly good outcome here, and the
   expected one on a busy kernel — so the test never asserts the walk was complete, only that it said
   which it was. Where the walk *does* complete it also checks the snapshot was cached rather than
-  re-walked, and that `pool_census` and `pool_find_tag` agree about the heaviest tag in it.
+  re-walked, and that `pool_census` and `pool_find_tag` agree about the heaviest tag in it. That
+  last comparison additionally needs the census to expose a tag that renders unambiguously: pool
+  tags are four raw bytes, unprintable ones render as `.` — and so does a literal `.` — so a tag
+  containing one cannot be turned back into the bytes it came from. That is a fact about rendering
+  and says nothing about the walk, so it skips the comparison with a note rather than failing.
 
 The first run of this tier found a real bug — shutdown killed workers outright, so a disconnect
 froze the target — which no dump-based tier could have found, because killing a worker that holds

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -231,8 +231,9 @@ about. This is the other half — an attach that lands:
   it just has no `symsrv.dll` to read a symbol store and no `msdia140.dll` to parse a PDB, so a
   PDB already sitting in the cache comes back as `file not found` with the error summary blaming
   the store. The tier copies the engine across before starting the server, and says so. It also
-  reloads with a bare `.reload /f` rather than `.reload /f nt`, which rests on the `nt` alias
-  resolving. Where you already have a symbol path that works for the target, set
+  reloads with a bare `.reload /f`, which is slower than `.reload /f nt` but is the form measured
+  working end to end here and takes the module name out of the set of things a failure could be.
+  Where you already have a symbol path that works for the target, set
   `WINDBG_MCP_SMOKE_SYMBOLS` to it and that is used instead. `pool_find_tag` with `refresh` then
   walks every
   committed pool page, which over KDNET is the query that used to run for minutes past its caller's

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -223,7 +223,12 @@ about. This is the other half — an attach that lands:
   that is in the export table, so without them every pool query fails before reading a byte.
   Symbols are never fetched over the KD wire. The test runs `.symfix+` and `.reload /f nt` itself
   under `!sym noisy` and prints `!lmi nt`, `lm m nt` and `x nt!ExPoolState` when it cannot get
-  them. The trap worth knowing: **`.symfix` and a bare `srv*` name no local cache** — both expand
+  them. **The harness spawns the *dev* binary, and the engine DLLs live beside the release one**
+  — `setup.md` has you copy them there, because that is what the plugin runs. Without
+  `symsrv.dll` a symbol store cannot be read at all and without `msdia140.dll` a PDB cannot be
+  parsed, so a PDB already sitting in the cache comes back as `file not found`. The tier copies
+  them across from `target\release` before starting the server, and says so. The other trap:
+  **`.symfix` and a bare `srv*` name no local cache** — both expand
   to `cache*;SRV*<msdl>`, where `cache*` is not a directory. A symbol-server element with no usable
   downstream store is skipped, and a skipped element reads exactly like an absent PDB:
   `DBGHELP: ntkrnlmp.pdb - file not found`, with no `SYMSRV:` line above it because nothing was

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -223,15 +223,14 @@ about. This is the other half — an attach that lands:
   that is in the export table, so without them every pool query fails before reading a byte.
   Symbols are never fetched over the KD wire. The test runs `.symfix+` and `.reload /f nt` itself
   under `!sym noisy` and prints `!lmi nt`, `lm m nt` and `x nt!ExPoolState` when it cannot get
-  them. Two traps live here. The symbol *cache* belongs to the debugger binary — a bare `srv*`
-  expands to `cache*;SRV*<msdl>`, and that cache sits beside the exe — so the dev build the harness
-  spawns does not inherit what a release build downloaded; the tier names one shared store to avoid
-  that. And a symbol server can only be queried by PDB **GUID**, read from the image's debug
-  directory: if that cannot be read, `!sym noisy` shows `ntkrnlmp.pdb - file not found` with no
-  `SYMSRV:` line above it, which is a lookup that never happened rather than a download that
-  failed. Where you already have a symbol path that works for the target, set
-  `WINDBG_MCP_SMOKE_SYMBOLS` to it and the tier will use that instead. `pool_find_tag` with
-  `refresh` then walks every
+  them. The trap worth knowing: **`.symfix` and a bare `srv*` name no local cache** — both expand
+  to `cache*;SRV*<msdl>`, where `cache*` is not a directory. A symbol-server element with no usable
+  downstream store is skipped, and a skipped element reads exactly like an absent PDB:
+  `DBGHELP: ntkrnlmp.pdb - file not found`, with no `SYMSRV:` line above it because nothing was
+  ever asked. So the tier passes an explicit cache to `.symfix+`, and reloads with a bare
+  `.reload /f` rather than `.reload /f nt`, which rests on the `nt` alias resolving. Where you
+  already have a symbol path that works for the target, set `WINDBG_MCP_SMOKE_SYMBOLS` to it and
+  that is used instead. `pool_find_tag` with `refresh` then walks every
   committed pool page, which over KDNET is the query that used to run for minutes past its caller's
   timeout and leave everything behind it queued. Only this tier can show it: against the sample dump
   the same walk is local memory and finishes in well under a second, so the assertions would pass

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -217,7 +217,16 @@ about. This is the other half — an attach that lands:
   read either side of the disconnect — a halted kernel takes no clock interrupt, so its uptime
   stands still while a released one keeps counting. Re-attaching alone proves nothing here: a
   frozen target still answers its KD stub.
-- **A pool walk is bounded and gives the session back.** `pool_find_tag` with `refresh` walks every
+- **A pool walk is bounded and gives the session back.** Needs **full `nt` symbols on this host**,
+  which is a real precondition rather than a formality: the walker decodes segment-heap internals
+  (`_EX_POOL_HEAP_MANAGER_STATE`, the page-range descriptors, the VS and LFH headers) and none of
+  that is in the export table, so without them every pool query fails before reading a byte.
+  Symbols are never fetched over the KD wire. The test runs `.symfix+` and `.reload /f nt` itself
+  and prints `.sympath`, `lm m nt` and `x nt!ExPoolState` when it cannot get them — but note the
+  symbol *cache* belongs to the debugger binary, and the harness spawns the **dev** build, so it
+  does not inherit whatever a release build has already downloaded. The first run against a given
+  kernel build therefore has to fetch that build's `ntkrnlmp.pdb`, and needs a symbol path that can
+  reach a store. `pool_find_tag` with `refresh` then walks every
   committed pool page, which over KDNET is the query that used to run for minutes past its caller's
   timeout and leave everything behind it queued. Only this tier can show it: against the sample dump
   the same walk is local memory and finishes in well under a second, so the assertions would pass

--- a/skills/windbg-debugging/SKILL.md
+++ b/skills/windbg-debugging/SKILL.md
@@ -68,27 +68,24 @@ a bare `execute`, which only sets the run state and doesn't move the target.
   carrying the debugger's own text — read it and adjust (wrong symbol, unmapped address, target
   still running). So do a refused handle and a session whose engine died; all of them are things
   you can act on. Only "no engine could be started at all" is a transport-level protocol error.
-- **Symbol *names* (`module!func`) need three things together:** (a) `msdia140.dll`
-  bundled next to the binary, (b) a symbol path **naming a local cache** (`execute` →
-  `.sympath+ srv*C:\ProgramData\Dbg\sym*https://msdl.microsoft.com/download/symbols`), and
-  (c) a `.reload /f` at a *stopped* position (after a `go`/breakpoint, **not** straight off
-  a `goto_position`/`!tt`). Without these you silently get export symbols only and
-  `module!name` lookups fail. Address-based queries, navigation, and memory reads still
-  work without symbols — query by address.
-- **A symbol path with no local cache downloads nothing, silently.** A bare `srv*` or a
-  plain `.symfix` expands to `cache*;SRV*<msdl>`, where `cache*` is not a directory — the
-  server element is skipped rather than used, and the result is identical to a PDB that does
-  not exist. Under `!sym noisy`, `DBGHELP: <mod>.pdb - file not found` with **no `SYMSRV:`
-  line above it** means nothing was ever asked, so it is the path at fault, not the network:
-  re-running will not fix it. Verify with `lm m <mod>` (`(pdb symbols)` vs `(export
-  symbols)`) — never with `x <mod>!<sym>`, which prints *nothing* when unresolved, so its
-  silence proves nothing. Details in [setup.md](setup.md).
-- **Before blaming the path, check the engine.** The identical `file not found` appears when
-  the PDB *is* cached and there is no `symsrv.dll`/`msdia140.dll` beside the binary to read
-  and parse it — `dbgeng.dll` is in System32, so a bare binary works for everything except
-  symbols. `!lmi <mod>` settles it: a **CODEVIEW line with a GUID** plus
-  `Symbol Type: EXPORT` means the identity was known and the lookup still failed, so it is
-  the engine or the store, not the target. No CODEVIEW line is the opposite problem.
+- **Symbol *names* (`module!func`) need three things together:** (a) `msdia140.dll` and
+  `symsrv.dll` bundled next to the binary, (b) a symbol path — set it with the
+  **`set_symbol_path`** tool (`srv*C:\ProgramData\Dbg\sym*https://msdl.microsoft.com/download/symbols`,
+  `append: true`), which goes through the DbgEng API and so avoids `.sympath` swallowing the
+  rest of the command line — and (c) a `.reload /f` at a *stopped* position (after a
+  `go`/breakpoint, **not** straight off a `goto_position`/`!tt`). Without these you silently
+  get export symbols only and `module!name` lookups fail. Address-based queries, navigation,
+  and memory reads still work without symbols — query by address.
+- **`file not found` for a PDB usually means the engine, not the path.** `dbgeng.dll` is in
+  System32, so a binary with no DLLs beside it opens targets and runs commands happily — it
+  just has no `symsrv.dll` to read a symbol store and no `msdia140.dll` to parse a PDB, and
+  the error summary then blames the store (`invalid UNC store`, `pingme.txt`) while the PDB
+  sits in it. `!lmi <mod>` settles it: a **CODEVIEW line with a GUID** plus
+  `Symbol Type: EXPORT` means the identity was known and the lookup still failed — engine or
+  store, not the target. **No CODEVIEW line** is the opposite problem, and a different fix.
+  Verify with `lm m <mod>` (`(pdb symbols)` vs `(export symbols)`) — never with
+  `x <mod>!<sym>`, which prints *nothing* when unresolved, so its silence proves nothing.
+  Details in [setup.md](setup.md).
 - **The pool tools need *private* `nt` types, not exports** — they decode segment-heap
   internals, so `missing kernel pool symbols (ExPoolState)` is a symbol problem on *this*
   host (symbols never come over the KD wire), not a statement about the target's pool.

--- a/skills/windbg-debugging/SKILL.md
+++ b/skills/windbg-debugging/SKILL.md
@@ -72,7 +72,8 @@ a bare `execute`, which only sets the run state and doesn't move the target.
   `symsrv.dll` bundled next to the binary, (b) a symbol path — set it with the
   **`set_symbol_path`** tool (`srv*C:\ProgramData\Dbg\sym*https://msdl.microsoft.com/download/symbols`,
   `append: true`), which goes through the DbgEng API and so avoids `.sympath` swallowing the
-  rest of the command line — and (c) a `.reload /f` at a *stopped* position (after a
+  rest of the command line — and (c) a module-qualified `.reload /f <mod>` at a *stopped*
+  position (bare `.reload /f` walks every loaded module, which on a live kernel is slow) (after a
   `go`/breakpoint, **not** straight off a `goto_position`/`!tt`). Without these you silently
   get export symbols only and `module!name` lookups fail. Address-based queries, navigation,
   and memory reads still work without symbols — query by address.

--- a/skills/windbg-debugging/SKILL.md
+++ b/skills/windbg-debugging/SKILL.md
@@ -69,12 +69,23 @@ a bare `execute`, which only sets the run state and doesn't move the target.
   still running). So do a refused handle and a session whose engine died; all of them are things
   you can act on. Only "no engine could be started at all" is a transport-level protocol error.
 - **Symbol *names* (`module!func`) need three things together:** (a) `msdia140.dll`
-  bundled next to the binary, (b) a symbol path (`execute` →
-  `.sympath srv*C:\ProgramData\Dbg\sym*https://msdl.microsoft.com/download/symbols`), and
+  bundled next to the binary, (b) a symbol path **naming a local cache** (`execute` →
+  `.sympath+ srv*C:\ProgramData\Dbg\sym*https://msdl.microsoft.com/download/symbols`), and
   (c) a `.reload /f` at a *stopped* position (after a `go`/breakpoint, **not** straight off
   a `goto_position`/`!tt`). Without these you silently get export symbols only and
   `module!name` lookups fail. Address-based queries, navigation, and memory reads still
   work without symbols — query by address.
+- **A symbol path with no local cache downloads nothing, silently.** A bare `srv*` or a
+  plain `.symfix` expands to `cache*;SRV*<msdl>`, where `cache*` is not a directory — the
+  server element is skipped rather than used, and the result is identical to a PDB that does
+  not exist. Under `!sym noisy`, `DBGHELP: <mod>.pdb - file not found` with **no `SYMSRV:`
+  line above it** means nothing was ever asked, so it is the path at fault, not the network:
+  re-running will not fix it. Verify with `lm m <mod>` (`(pdb symbols)` vs `(export
+  symbols)`) — never with `x <mod>!<sym>`, which prints *nothing* when unresolved, so its
+  silence proves nothing. Details in [setup.md](setup.md).
+- **The pool tools need *private* `nt` types, not exports** — they decode segment-heap
+  internals, so `missing kernel pool symbols (ExPoolState)` is a symbol problem on *this*
+  host (symbols never come over the KD wire), not a statement about the target's pool.
 - **`!`-extension commands need the WinDbg `winext\` extensions bundled** next to the engine
   ([setup.md](setup.md)) **and** the module-qualified form: use `!ext.analyze -v`, not bare
   `!analyze` (which this engine resolves to *"No export analyze found"* even after `.load ext`).

--- a/skills/windbg-debugging/SKILL.md
+++ b/skills/windbg-debugging/SKILL.md
@@ -83,6 +83,12 @@ a bare `execute`, which only sets the run state and doesn't move the target.
   re-running will not fix it. Verify with `lm m <mod>` (`(pdb symbols)` vs `(export
   symbols)`) — never with `x <mod>!<sym>`, which prints *nothing* when unresolved, so its
   silence proves nothing. Details in [setup.md](setup.md).
+- **Before blaming the path, check the engine.** The identical `file not found` appears when
+  the PDB *is* cached and there is no `symsrv.dll`/`msdia140.dll` beside the binary to read
+  and parse it — `dbgeng.dll` is in System32, so a bare binary works for everything except
+  symbols. `!lmi <mod>` settles it: a **CODEVIEW line with a GUID** plus
+  `Symbol Type: EXPORT` means the identity was known and the lookup still failed, so it is
+  the engine or the store, not the target. No CODEVIEW line is the opposite problem.
 - **The pool tools need *private* `nt` types, not exports** — they decode segment-heap
   internals, so `missing kernel pool symbols (ExPoolState)` is a symbol problem on *this*
   host (symbols never come over the KD wire), not a statement about the target's pool.

--- a/skills/windbg-debugging/setup.md
+++ b/skills/windbg-debugging/setup.md
@@ -152,6 +152,29 @@ symbol server was queried at all. A download that failed would have logged the a
 this is a *path* problem, not a network or availability problem, and re-running will not fix
 it. Always give a cache directory.
 
+### …but check the engine before blaming the path
+
+The same `file not found` appears when the PDB **is** in the cache and the engine simply
+cannot read it. `dbgeng.dll` exists in System32, so a binary with no DLLs beside it opens
+targets and runs commands quite happily — it just has no `symsrv.dll` to read a symbol store
+and no `msdia140.dll` to parse a PDB. The error summary then blames the store
+(`invalid UNC store`, `pingme.txt` missing) even though the store is fine.
+
+`!lmi <mod>` separates the two, and is worth running before changing any path:
+
+```text
+Debug Data Dirs: Type  Size     VA  Pointer
+             CODEVIEW    25, 54ea8,   54ea8 RSDS - GUID: {3E0BF93D-...-9CDCB8C7}
+               Age: 1, Pdb: ntkrnlmp.pdb
+    Symbol Type: EXPORT   - PDB not found
+```
+
+A **CODEVIEW line with a GUID** means the identity was read from the image and the lookup
+still failed — engine or store, not the target. The store directory for that PDB is the GUID
+with the age appended (`3E0BF93D…9CDCB8C71`), so you can check by hand whether it is already
+cached. **No CODEVIEW line** is the other failure: the image headers could not be read, and
+no symbol server can be queried without them.
+
 Two more things that mislead here:
 
 - `.reload /f` unqualified re-reads the whole module list. `.reload /f nt` rests on the `nt`

--- a/skills/windbg-debugging/setup.md
+++ b/skills/windbg-debugging/setup.md
@@ -124,41 +124,33 @@ Symbol *names* fail silently without all three of:
    can't parse any PDB (`dia error 0x8007007e`) and falls back to *export* symbols, so
    `module!name` lookups fail even with the right PDB cached. `symsrv.dll` is needed to
    read a symbol-store cache.
-2. **A symbol path that names a local cache:** `execute` →
-   `.sympath+ srv*C:\ProgramData\Dbg\sym*https://msdl.microsoft.com/download/symbols`,
-   or equivalently `.symfix+ C:\ProgramData\Dbg\sym`. **The cache is not optional** — see
-   below.
+2. **A symbol path:** use the **`set_symbol_path`** tool with
+   `srv*C:\ProgramData\Dbg\sym*https://msdl.microsoft.com/download/symbols` and
+   `append: true`. It goes through DbgEng's `Append/SetSymbolPath`, so it avoids
+   `.sympath`'s habit of swallowing the rest of the command line. Naming the cache
+   explicitly is *recommended*, not required — `.symfix` with no argument uses the `sym`
+   subdirectory of the debugger's installation directory — but an explicit path is
+   predictable and lets several binaries share one store.
 3. **A `.reload /f` at a stopped position** (after a `go`/breakpoint, not off a bare
    `!tt`). Confirm with `execute` → `lm m <mod>`: `(pdb symbols)` means it worked,
    `(export symbols)` means it didn't.
 
-### The cache is the part that is easy to omit and impossible to spot
+### Check the engine before blaming the path
 
-A bare `srv*`, or `.symfix` with no directory after it, expands to
-`cache*;SRV*https://msdl.microsoft.com/download/symbols` — and that `cache*` names no
-directory. A symbol-server element with no downstream store is **skipped**, not used, so
-nothing is ever downloaded and nothing says so. The result is indistinguishable from a PDB
-that does not exist:
+**This is the one that actually bit, and the path is the tempting explanation.** The same
+`file not found` appears when the PDB *is* in the cache and the engine simply cannot read
+it. `dbgeng.dll` exists in System32, so a binary with no DLLs beside it opens targets and
+runs commands quite happily — it just has no `symsrv.dll` to read a symbol store and no
+`msdia140.dll` to parse a PDB. Under `!sym noisy` you get:
 
 ```text
-$ !sym noisy
-$ .reload /f
 DBGHELP: ntkrnlmp.pdb - file not found
 DBGHELP: nt - export symbols
 ```
 
-Read that pair carefully: `file not found` with **no `SYMSRV:` line above it** means no
-symbol server was queried at all. A download that failed would have logged the attempt. So
-this is a *path* problem, not a network or availability problem, and re-running will not fix
-it. Always give a cache directory.
-
-### …but check the engine before blaming the path
-
-The same `file not found` appears when the PDB **is** in the cache and the engine simply
-cannot read it. `dbgeng.dll` exists in System32, so a binary with no DLLs beside it opens
-targets and runs commands quite happily — it just has no `symsrv.dll` to read a symbol store
-and no `msdia140.dll` to parse a PDB. The error summary then blames the store
-(`invalid UNC store`, `pingme.txt` missing) even though the store is fine.
+with **no `SYMSRV:` line above it**, and an error summary blaming the store (`invalid UNC
+store`, `pingme.txt` missing) when the store is fine and the PDB is sitting in it. Nothing
+in that output points at the engine, which is why it is worth knowing.
 
 `!lmi <mod>` separates the two, and is worth running before changing any path:
 

--- a/skills/windbg-debugging/setup.md
+++ b/skills/windbg-debugging/setup.md
@@ -131,8 +131,10 @@ Symbol *names* fail silently without all three of:
    explicitly is *recommended*, not required — `.symfix` with no argument uses the `sym`
    subdirectory of the debugger's installation directory — but an explicit path is
    predictable and lets several binaries share one store.
-3. **A `.reload /f` at a stopped position** (after a `go`/breakpoint, not off a bare
-   `!tt`). Confirm with `execute` → `lm m <mod>`: `(pdb symbols)` means it worked,
+3. **A `.reload /f <mod>` at a stopped position** (after a `go`/breakpoint, not off a bare
+   `!tt`), module-qualified so it fetches the PDB you actually want rather than walking
+   every loaded module. Under `!sym noisy` when it does not work, so the search is
+   visible. Confirm with `execute` → `lm m <mod>`: `(pdb symbols)` means it worked,
    `(export symbols)` means it didn't.
 
 ### Check the engine before blaming the path
@@ -169,8 +171,9 @@ no symbol server can be queried without them.
 
 Two more things that mislead here:
 
-- `.reload /f` unqualified re-reads the whole module list. `.reload /f nt` rests on the `nt`
-  alias resolving and can quietly do nothing when that is the part that is wrong.
+- `.reload /f <mod>` fetches one module's PDB; bare `.reload /f` walks every loaded module,
+  which on a live kernel is a couple of hundred of them and correspondingly slow. Reach for
+  the unqualified form only to rule the module name out as the variable.
 - `x <mod>!<symbol>` prints **nothing at all** for an unresolved name — no error, no
   diagnostic. Its silence is not confirmation. `lm m <mod>` is the check that answers.
 

--- a/skills/windbg-debugging/setup.md
+++ b/skills/windbg-debugging/setup.md
@@ -124,11 +124,51 @@ Symbol *names* fail silently without all three of:
    can't parse any PDB (`dia error 0x8007007e`) and falls back to *export* symbols, so
    `module!name` lookups fail even with the right PDB cached. `symsrv.dll` is needed to
    read a symbol-store cache.
-2. **A symbol path:** `execute` →
-   `.sympath srv*C:\ProgramData\Dbg\sym*https://msdl.microsoft.com/download/symbols`
+2. **A symbol path that names a local cache:** `execute` →
+   `.sympath+ srv*C:\ProgramData\Dbg\sym*https://msdl.microsoft.com/download/symbols`,
+   or equivalently `.symfix+ C:\ProgramData\Dbg\sym`. **The cache is not optional** — see
+   below.
 3. **A `.reload /f` at a stopped position** (after a `go`/breakpoint, not off a bare
    `!tt`). Confirm with `execute` → `lm m <mod>`: `(pdb symbols)` means it worked,
    `(export symbols)` means it didn't.
+
+### The cache is the part that is easy to omit and impossible to spot
+
+A bare `srv*`, or `.symfix` with no directory after it, expands to
+`cache*;SRV*https://msdl.microsoft.com/download/symbols` — and that `cache*` names no
+directory. A symbol-server element with no downstream store is **skipped**, not used, so
+nothing is ever downloaded and nothing says so. The result is indistinguishable from a PDB
+that does not exist:
+
+```text
+$ !sym noisy
+$ .reload /f
+DBGHELP: ntkrnlmp.pdb - file not found
+DBGHELP: nt - export symbols
+```
+
+Read that pair carefully: `file not found` with **no `SYMSRV:` line above it** means no
+symbol server was queried at all. A download that failed would have logged the attempt. So
+this is a *path* problem, not a network or availability problem, and re-running will not fix
+it. Always give a cache directory.
+
+Two more things that mislead here:
+
+- `.reload /f` unqualified re-reads the whole module list. `.reload /f nt` rests on the `nt`
+  alias resolving and can quietly do nothing when that is the part that is wrong.
+- `x <mod>!<symbol>` prints **nothing at all** for an unresolved name — no error, no
+  diagnostic. Its silence is not confirmation. `lm m <mod>` is the check that answers.
+
+Symbols are never fetched from the target over the KD wire, so all of this is about the
+**debugging host**, whatever the target is.
+
+### Kernel pool tools need *private* `nt` types
+
+`pool_find_tag`, `pool_census`, `pool_chunk` and `pool_diagnostics` decode segment-heap
+internals (`_EX_POOL_HEAP_MANAGER_STATE`, the page-range descriptors, the VS and LFH
+headers). Exports are not enough. Without full type information every pool query fails up
+front with `missing kernel pool symbols (ExPoolState); run '.reload /f nt' and retry` — which
+is a symbol problem on this host, not a statement about the target's pool.
 
 Offline / no symbols? Navigation, memory reads, disassembly, and the data model still work
 — query by address instead of by name.

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -1984,6 +1984,19 @@ fn disconnecting_releases_a_live_kernel_session_rather_than_killing_it() {
     };
 
     // --- now assert ----------------------------------------------------------------------
+    //
+    // The detach first, before the disconnect's own outcome and before any earlier failure is
+    // propagated. Every one of those would otherwise mask it, and a masked ungraceful detach is a
+    // machine left halted — the loudest fact available and the only one needing action now. The
+    // failures below are all diagnosis, and they keep.
+    if let Some(released) = &released
+        && let Some(why) = ungraceful_detach(released, &ended)
+    {
+        panic!(
+            "THE TARGET MAY STILL BE HALTED — the final detach was not graceful: {why}\n\n\
+             Anything else this run has to say is below; check the machine first."
+        );
+    }
     match exit {
         Ok(code) => assert_eq!(code, Some(0), "a disconnect should still be a clean exit"),
         Err(panic) => resume_unwind(panic),
@@ -2002,12 +2015,6 @@ fn disconnecting_releases_a_live_kernel_session_rather_than_killing_it() {
         "the target was not reattachable after a disconnect — the previous session did not let go \
          of it cleanly, and this run could not put it back:\n{report}"
     );
-    // The same three ways a detach goes wrong as the other live tiers, rather than the one.
-    if let Some(released) = &released
-        && let Some(why) = ungraceful_detach(released, &ended)
-    {
-        panic!("the final detach must be graceful, or the target is left frozen — {why}");
-    }
     match (before, after) {
         (Some(before), Some(after)) => {
             let ran_for = after.saturating_sub(before);
@@ -2043,16 +2050,33 @@ const POOL_CEILING: Duration = Duration::from_secs(170);
 /// caller leaves the engine busy, and everything behind it waits out the rest of the walk.
 const NOT_QUEUED: Duration = Duration::from_secs(30);
 
+/// What the pool tier's server is told its per-call timeout is, rather than inheriting one.
+///
+/// Comfortably above win-kexp's 120s walk budget, so a walk that behaves is never cut off, and
+/// below [`POOL_CALL_BUDGET`] so the server is always the one to answer first.
+const SERVER_CALL_TIMEOUT: Duration = Duration::from_secs(300);
+
 /// How long this *harness* waits on a pool call — deliberately longer than the server's own.
 ///
-/// `TARGET_STEP` is 240s and the server gives an engine call 300s, so a walk that ran away would
-/// have the harness give up first. That is the wrong order here. The client panicking while the
-/// walk is still running means the `end_session` in the cleanup queues behind it, misses its grace
-/// period, and the worker is **killed** — which on a broken-in kernel leaves the guest halted. On
-/// the exact failure path this test exists to detect, that would freeze the machine it is
-/// diagnosing. Waiting past the server's own timeout lets it answer first, so the cleanup always
-/// runs against an idle engine.
+/// `TARGET_STEP` is 240s, below the server's timeout, so a walk that ran away would have the
+/// harness give up first. That is the wrong order here. The client panicking while the walk is
+/// still running means the `end_session` in the cleanup queues behind it, misses its grace period,
+/// and the worker is **killed** — which on a broken-in kernel leaves the guest halted. On the
+/// exact failure path this test exists to detect, that would freeze the machine it is diagnosing.
+///
+/// The ordering only holds if the server's timeout is known, which is why the test pins
+/// [`SERVER_CALL_TIMEOUT`] rather than letting an operator's `WINDBG_MCP_CALL_TIMEOUT_SECS`
+/// through: a short value times out mid-walk and a long one puts the harness first again.
 const POOL_CALL_BUDGET: Duration = Duration::from_secs(330);
+
+/// What a query served from a cached snapshot may take.
+///
+/// A fixed bound rather than a fraction of the first walk's time, because two live walks vary and
+/// a second one that happened to be quicker would satisfy a relative comparison while having
+/// re-walked the entire pool — proving the opposite of what it claims. A cached answer is a lookup
+/// over an in-memory index and does not touch the wire at all; the measured walk it is being told
+/// apart from is ~20s.
+const CACHED_QUERY_CEILING: Duration = Duration::from_secs(5);
 
 /// A tag no allocator will have used, so answering has to walk the whole pool.
 ///
@@ -2069,6 +2093,9 @@ const POOL_ROOT_SYMBOL: &str = "nt!ExPoolState";
 /// The `x` that resolves [`POOL_ROOT_SYMBOL`], as one string so its output can be told apart
 /// from every other command's by comparing against the command that produced it.
 const POOL_ROOT_PROBE: &str = "x nt!ExPoolState";
+
+/// The `lm` that reports what `nt` loaded, kept as one string for the same reason.
+const LOADED_MODULE_PROBE: &str = "lm m nt";
 
 /// Where downloaded PDBs are kept — named explicitly, because the default is not a path.
 ///
@@ -2162,9 +2189,13 @@ const SYMBOLS_ENV: &str = "WINDBG_MCP_SMOKE_SYMBOLS";
 /// were spent on a `.reload` that printed nothing and loaded nothing, which is indistinguishable
 /// from success until something asks for a symbol.
 ///
-/// `.reload /f` unqualified, not `.reload /f nt`: it re-reads the module list rather than resting
-/// on the `nt` alias resolving, which is the more reliable instruction on a live kernel and the
-/// one that does not quietly do nothing when the alias is the part that is wrong.
+/// `.reload /f` unqualified, not `.reload /f nt`. The original reason was wrong — `.reload /f nt`
+/// looked like it "quietly did nothing" when the actual fault was a missing `symsrv.dll`, and the
+/// module name was never the variable. It stays unqualified anyway, for a smaller reason: this is
+/// a manual tier run against one machine, the unqualified form is what was measured working end to
+/// end, and it removes the module name from the set of things a future failure here could be. The
+/// cost is a slower run, which nothing on this path is optimising for. Anywhere symbol *speed*
+/// matters, `.reload /f <mod>` is the right instruction — see `skills/windbg-debugging/setup.md`.
 fn load_kernel_symbols(server: &mut Server, session: &str) -> KernelSymbols {
     // DbgHelp will create the store, but only once it has decided to use it; making it first
     // removes one way for a symbol-server element to be quietly unusable.
@@ -2196,6 +2227,7 @@ fn load_kernel_symbols(server: &mut Server, session: &str) -> KernelSymbols {
     );
 
     let mut probe = String::new();
+    let mut loaded = String::new();
     for command in [
         "!sym noisy",
         ".reload /f",
@@ -2205,7 +2237,7 @@ fn load_kernel_symbols(server: &mut Server, session: &str) -> KernelSymbols {
         // could not. The two failures look identical without it.
         "!lmi nt",
         // The line that settles whether a PDB actually loaded.
-        "lm m nt",
+        LOADED_MODULE_PROBE,
         POOL_ROOT_PROBE,
     ] {
         let call = server.call_tool(
@@ -2220,15 +2252,22 @@ fn load_kernel_symbols(server: &mut Server, session: &str) -> KernelSymbols {
             ""
         };
         transcript.push_str(&format!("\n$ {command}{failed}\n{}\n", output.trim()));
-        if command == POOL_ROOT_PROBE {
-            // Everything DbgEng echoes back is the command itself; what is left is the answer.
-            // `x` prints *nothing* for a name it cannot resolve, so the remainder being empty is
-            // the whole signal — and checking the transcript for the symbol's name instead would
-            // match the echo and pass regardless.
-            probe = output.replace(command, "").trim().to_string();
+        // Each answer kept apart from the echoed command that produced it, and from every other
+        // command's output. Searching the whole transcript conflates them: `x`'s echo contains
+        // the symbol name whether or not it resolved, and `.reload /f` loads *every* module, so a
+        // `(pdb symbols)` anywhere in it says nothing about `nt`.
+        let answer = output.replace(command, "").trim().to_string();
+        match command {
+            POOL_ROOT_PROBE => probe = answer,
+            LOADED_MODULE_PROBE => loaded = answer,
+            _ => {}
         }
     }
-    KernelSymbols { transcript, probe }
+    KernelSymbols {
+        transcript,
+        probe,
+        loaded,
+    }
 }
 
 /// What [`load_kernel_symbols`] managed, kept apart so each can be checked on its own terms.
@@ -2237,6 +2276,9 @@ struct KernelSymbols {
     transcript: String,
     /// `x <pool root>` with the echoed command removed: empty means it did not resolve.
     probe: String,
+    /// `lm m nt` with the echo removed, so `(pdb symbols)` is read about **`nt`** and not about
+    /// whichever of the couple of hundred modules `.reload /f` also touched.
+    loaded: String,
 }
 
 /// What `pool_census` had to say about the heaviest tag it found.
@@ -2351,7 +2393,16 @@ fn a_live_kernel_pool_walk_is_bounded_and_leaves_its_session_usable() {
     // only tier that needs symbols, and so the only one that ever noticed they were impossible.
     let engine = ensure_engine_beside_test_binary();
     println!("engine: {engine}");
-    let mut server = Server::started();
+    // Pinned, not inherited. Every cleanup-safety argument here rests on the server's own call
+    // timeout sitting *below* `POOL_CALL_BUDGET`, so that the server answers first and the
+    // `end_session` below never queues behind a running walk. `WINDBG_MCP_CALL_TIMEOUT_SECS` is an
+    // operational knob an operator may well have set, and either direction breaks that ordering: a
+    // short value times out mid-walk, a value above the harness budget puts the harness first
+    // again. Both end with the worker killed and the kernel left halted.
+    let mut server = Server::started_with(&[(
+        "WINDBG_MCP_CALL_TIMEOUT_SECS",
+        &SERVER_CALL_TIMEOUT.as_secs().to_string(),
+    )]);
 
     let attached = server.call_tool(
         "attach_kernel",
@@ -2382,7 +2433,7 @@ fn a_live_kernel_pool_walk_is_bounded_and_leaves_its_session_usable() {
         // an earlier version of this check passed a run in which nothing had loaded and let the
         // failure surface three calls later as an unexplained pool error.
         assert!(
-            transcript.contains("pdb symbols"),
+            symbols.loaded.contains("pdb symbols"),
             "`nt` loaded without a PDB, so the pool walker has no types to decode with and this \
              tier can prove nothing about it.\n\nSymbols never cross the KD wire, so this is \
              always about *this* machine. Read `!lmi nt` below first: `Symbol Type: EXPORT - PDB \
@@ -2415,8 +2466,10 @@ fn a_live_kernel_pool_walk_is_bounded_and_leaves_its_session_usable() {
         let absent = text_of(&walk["result"]);
         // Before the timing, because a call that *failed* also returns fast: the first live run
         // of this test measured 6.8ms and passed every deadline assertion below, having never
-        // walked a single page. A tool error is text like any other to `tool_text`, so nothing
-        // here may be believed until this holds.
+        // walked a single page. Both kinds of failure, because they look nothing alike from here:
+        // a JSON-RPC error carries no `result` at all, so `is_tool_error` reads false and an
+        // empty `absent` would sail through every check that follows.
+        assert_no_error(&walk, "pool_find_tag on a live kernel");
         assert!(
             !is_tool_error(&walk),
             "the pool walk failed outright, so nothing below would be measuring a walk. If this \
@@ -2477,6 +2530,7 @@ fn a_live_kernel_pool_walk_is_bounded_and_leaves_its_session_usable() {
         );
         let census_took = census_started.elapsed();
         let census = text_of(&census_call["result"]);
+        assert_no_error(&census_call, "pool_census on a live kernel");
         assert!(
             !is_tool_error(&census_call),
             "pool_census failed:\n{census}"
@@ -2511,11 +2565,17 @@ fn a_live_kernel_pool_walk_is_bounded_and_leaves_its_session_usable() {
             HeaviestTag::Queryable(tag) if complete => {
                 // The census had to come off the cached snapshot too, or the reuse below is
                 // measured against a snapshot *it* took rather than the walk's.
+                //
+                // Against a fixed bound, not against `walked_for`: two live walks vary, and a
+                // second one that happened to be quicker than the first would satisfy a relative
+                // comparison while having re-walked the whole pool. A cached answer is a lookup
+                // over an in-memory index and is not in the same order of magnitude.
                 assert!(
-                    census_took < walked_for,
-                    "the census took {census_took:?} against the walk's {walked_for:?}, so it \
-                     walked again rather than reusing the completed snapshot — anything the \
-                     reuse check says after that is about the census's walk, not the first one"
+                    census_took < CACHED_QUERY_CEILING,
+                    "the census took {census_took:?}, past the {CACHED_QUERY_CEILING:?} a lookup \
+                     over a cached snapshot should need, so it walked again rather than reusing \
+                     the completed one — anything the reuse check says after that is about the \
+                     census's walk, not the first one"
                 );
                 let cached = Instant::now();
                 let call = server.call_tool(
@@ -2535,9 +2595,10 @@ fn a_live_kernel_pool_walk_is_bounded_and_leaves_its_session_usable() {
                      same snapshot:\n{found}"
                 );
                 assert!(
-                    reuse < walked_for,
-                    "a second query took {reuse:?} against the first walk's {walked_for:?} — a \
-                     complete snapshot is meant to be cached and reused, not walked again"
+                    reuse < CACHED_QUERY_CEILING,
+                    "a second query took {reuse:?}, past the {CACHED_QUERY_CEILING:?} a cached \
+                     lookup should need — a complete snapshot is meant to be reused, not walked \
+                     again (the first walk, for scale, took {walked_for:?})"
                 );
                 println!("`{tag}` found again from the cached snapshot in {reuse:?}");
             }

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -2401,6 +2401,19 @@ fn a_live_kernel_pool_walk_is_bounded_and_leaves_its_session_usable() {
             "the census reports this walk {}",
             if complete { "complete" } else { "INCOMPLETE" }
         );
+        // An incomplete walk is an acceptable outcome, but "incomplete" on its own is not a
+        // finding — the categories are. The census already carries them, so printing that
+        // section costs nothing and turns a run of this tier into a measurement of the target
+        // rather than a pass. Measured 21.9s and INCOMPLETE against Server 26100, which is well
+        // inside the budget: on that target the coverage gap is *not* the deadline.
+        if !complete {
+            let report: String = census
+                .lines()
+                .skip_while(|line| !line.starts_with("--- pool walk ---"))
+                .collect::<Vec<_>>()
+                .join("\n");
+            println!("why the walk fell short:\n{report}");
+        }
 
         match heaviest_census_tag(&census) {
             // What one tool saw, the other has to find. Only meaningful when the walk completed:

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -2041,6 +2041,65 @@ const POOL_ROOT_SYMBOL: &str = "nt!ExPoolState";
 /// mixed separators.
 const SYMBOL_CACHE: &str = concat!(env!("CARGO_MANIFEST_DIR"), "\\target\\release\\sym");
 
+/// The debugging engine a debugger process needs *beside its own exe*.
+///
+/// `dbgeng.dll` exists in System32, so a binary without these still opens targets, runs commands
+/// and passes almost every test here — it just cannot do symbols. `symsrv.dll` is what reads a
+/// symbol *store*, and `msdia140.dll` is what parses a PDB once found; without them a PDB sitting
+/// in the cache is reported as `file not found`, complete with a SYMSRV error summary blaming the
+/// store. Which is what four runs of this tier were actually looking at.
+const ENGINE_DLLS: [&str; 6] = [
+    "dbgeng.dll",
+    "dbghelp.dll",
+    "dbgcore.dll",
+    "dbgmodel.dll",
+    "msdia140.dll",
+    "symsrv.dll",
+];
+
+/// Puts the engine beside the binary this harness spawns, copying from a release build if needed.
+///
+/// `setup.md` has the operator copy these next to the **release** binary, because that is what the
+/// plugin runs. The harness spawns the **dev** build, and nothing had ever put them there — so the
+/// tiers that need symbols could not work from a `cargo test` at all, and said so in a way that
+/// pointed at the target instead.
+///
+/// Returns what it did, for the transcript. A failure here is reported by the caller rather than
+/// panicking, since the tier's own message explains what is missing far better than a copy error.
+fn ensure_engine_beside_test_binary() -> String {
+    let Some(dir) = std::path::Path::new(EXE).parent() else {
+        return "cannot locate the test binary's directory".into();
+    };
+    let missing: Vec<&str> = ENGINE_DLLS
+        .iter()
+        .copied()
+        .filter(|dll| !dir.join(dll).exists())
+        .collect();
+    if missing.is_empty() {
+        return format!("engine already beside {}", dir.display());
+    }
+    // The release tree is where `setup.md` has them put, so it is the one place worth looking.
+    let source = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("target\\release");
+    let mut copied = Vec::new();
+    for dll in &missing {
+        match std::fs::copy(source.join(dll), dir.join(dll)) {
+            Ok(_) => copied.push(*dll),
+            Err(error) => {
+                return format!(
+                    "{} is not beside {} and could not be copied from {}: {error}. Follow the \
+                     engine-bundling step in skills/windbg-debugging/setup.md — without \
+                     symsrv.dll a symbol store cannot be read at all, and without msdia140.dll a \
+                     PDB cannot be parsed once found.",
+                    dll,
+                    dir.display(),
+                    source.display()
+                );
+            }
+        }
+    }
+    format!("copied {} into {}", copied.join(", "), dir.display())
+}
+
 /// A symbol path the operator knows works for this target, overriding [`SYMBOL_CACHE`].
 ///
 /// Getting a kernel's PDB onto a debugging host is an environment problem — a reachable store, a
@@ -2216,6 +2275,10 @@ fn a_live_kernel_pool_walk_is_bounded_and_leaves_its_session_usable() {
     let Some(connection) = kernel_tier() else {
         return;
     };
+    // Before the server starts, because the engine is loaded when the worker does. This is the
+    // only tier that needs symbols, and so the only one that ever noticed they were impossible.
+    let engine = ensure_engine_beside_test_binary();
+    println!("engine: {engine}");
     let mut server = Server::started();
 
     let attached = server.call_tool(
@@ -2248,14 +2311,14 @@ fn a_live_kernel_pool_walk_is_bounded_and_leaves_its_session_usable() {
         assert!(
             symbols.contains("pdb symbols"),
             "`nt` loaded without a PDB, so the pool walker has no types to decode with and this \
-             tier can prove nothing about it.\n\nThis is an environment problem, not a \
-             regression: symbols are never fetched over the KD wire, so it is about *this* \
-             machine getting the target build's ntkrnlmp.pdb. Read the transcript below — \
-             `DBGHELP: ntkrnlmp.pdb - file not found` with no `SYMSRV:` line above it means no \
-             symbol server was queried at all, which happens when the image's debug directory \
-             could not be read and there is no GUID to look one up by; `!lmi nt` says which. If \
-             you have a symbol path that works for this target, set {SYMBOLS_ENV} to it and \
-             re-run.\n{symbols}"
+             tier can prove nothing about it.\n\nSymbols never cross the KD wire, so this is \
+             always about *this* machine. Read `!lmi nt` below first: `Symbol Type: EXPORT - PDB \
+             not found` **with a CODEVIEW GUID present** means the identity was known and the \
+             lookup still failed — which is the engine, not the target and not the path. That is \
+             what `symsrv.dll` (reads a symbol store) and `msdia140.dll` (parses the PDB) are \
+             for, and this run reports them as: {engine}. A CODEVIEW line that is *absent* is \
+             the other failure, and a different fix. If you have a symbol path known to work \
+             here, set {SYMBOLS_ENV} to it.\n{symbols}"
         );
 
         // A forced walk. `refresh` is the expensive path and the one that wedged; nothing is

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -1974,6 +1974,13 @@ const NOT_QUEUED: Duration = Duration::from_secs(30);
 /// If it ever collides the test says so and stays honest rather than failing; change it then.
 const ABSENT_TAG: &str = "Zq7x";
 
+/// Microsoft's public symbol store, appended so the walker can resolve `nt`'s private types.
+///
+/// The pool walker decodes segment-heap internals — `_EX_POOL_HEAP_MANAGER_STATE`,
+/// `_HEAP_PAGE_RANGE_DESCRIPTOR`, the VS and LFH headers — and none of that is in the public
+/// export table. Without full type information every pool query fails before it reads a byte.
+const MS_SYMBOL_SERVER: &str = "srv*https://msdl.microsoft.com/download/symbols";
+
 /// What `pool_census` had to say about the heaviest tag it found.
 ///
 /// Three outcomes, not two, and collapsing the last two is a real bug: "the census listed
@@ -2102,15 +2109,44 @@ fn a_live_kernel_pool_walk_is_bounded_and_leaves_its_session_usable() {
     let outcome = catch_unwind(AssertUnwindSafe(|| {
         assert_no_error(&attached, "attach_kernel");
 
+        // The walker needs full nt type information — `_EX_POOL_HEAP_MANAGER_STATE` and the rest
+        // of the allocator's private types — and a fresh attach does not force-load it. This is
+        // the documented precondition; doing it here rather than assuming it is what lets the
+        // tier set up its own target. Symbols are never fetched over the KD wire, so this is
+        // about *this* host's symbol path, not the target's.
+        server.tool_text(
+            "set_symbol_path",
+            json!({ "path": MS_SYMBOL_SERVER, "append": true, "session_id": session }),
+            TARGET_STEP,
+        );
+        let reloaded = server.tool_text(
+            "execute",
+            json!({ "command": ".reload /f nt", "session_id": session }),
+            TARGET_STEP,
+        );
+
         // A forced walk. `refresh` is the expensive path and the one that wedged; nothing is
         // cached this early anyway, but asking for it says so rather than relying on it.
         let started = Instant::now();
-        let absent = server.tool_text(
+        let walk = server.call_tool(
             "pool_find_tag",
             json!({ "tag": ABSENT_TAG, "refresh": true, "session_id": session }),
             TARGET_STEP,
         );
         let walked_for = started.elapsed();
+        let absent = text_of(&walk["result"]);
+        // Before the timing, because a call that *failed* also returns fast: the first live run
+        // of this test measured 6.8ms and passed every deadline assertion below, having never
+        // walked a single page. A tool error is text like any other to `tool_text`, so nothing
+        // here may be believed until this holds.
+        assert!(
+            !is_tool_error(&walk),
+            "the pool walk failed outright, so nothing below would be measuring a walk. If this \
+             names missing kernel pool symbols, this host cannot resolve full type information \
+             for `nt`; the walker needs it and it is never fetched over the KD wire. Fix the \
+             symbol path and re-run — the tier proves nothing without it.\n{absent}\n\n\
+             `.reload /f nt` had said:\n{reloaded}"
+        );
         println!("a forced pool walk over a live kernel returned in {walked_for:?}");
         assert!(
             walked_for < POOL_CEILING,
@@ -2135,7 +2171,9 @@ fn a_live_kernel_pool_walk_is_bounded_and_leaves_its_session_usable() {
         );
 
         // An empty answer has to say what the walk managed, or "no such chunk" and "the walk
-        // reached almost none of the pool" are the same sentence.
+        // reached almost none of the pool" are the same sentence. Reachable only because the
+        // call succeeded — the first live run took this branch on an *error* text and announced
+        // that the tag existed, inventing a fact about the pool out of a failure to look at it.
         if absent.contains("No allocated chunks carry tag") {
             assert!(
                 absent.contains("--- pool walk ---") && absent.contains("chunks walked:"),
@@ -2143,16 +2181,21 @@ fn a_live_kernel_pool_walk_is_bounded_and_leaves_its_session_usable() {
             );
         } else {
             eprintln!(
-                "NOTE: `{ABSENT_TAG}` exists on this target, so the empty-answer check was \
-                 skipped. Change ABSENT_TAG."
+                "NOTE: `{ABSENT_TAG}` really is allocated on this target, so the empty-answer \
+                 check was skipped. Change ABSENT_TAG."
             );
         }
 
         // The census is the state of the walk, so it carries the report whatever it found.
-        let census = server.tool_text(
+        let census_call = server.call_tool(
             "pool_census",
             json!({ "session_id": session, "limit": 8 }),
             TARGET_STEP,
+        );
+        let census = text_of(&census_call["result"]);
+        assert!(
+            !is_tool_error(&census_call),
+            "pool_census failed:\n{census}"
         );
         assert!(
             census.contains("--- pool walk ---") && census.contains("chunks walked:"),
@@ -2170,12 +2213,17 @@ fn a_live_kernel_pool_walk_is_bounded_and_leaves_its_session_usable() {
             // walks of a moving target and could honestly disagree.
             HeaviestTag::Queryable(tag) if complete => {
                 let cached = Instant::now();
-                let found = server.tool_text(
+                let call = server.call_tool(
                     "pool_find_tag",
                     json!({ "tag": tag, "session_id": session }),
                     TARGET_STEP,
                 );
                 let reuse = cached.elapsed();
+                let found = text_of(&call["result"]);
+                assert!(
+                    !is_tool_error(&call),
+                    "looking up the census's own heaviest tag `{tag}` failed:\n{found}"
+                );
                 assert!(
                     found.contains(&format!("tag `{tag}`")) && found.contains("allocation(s)"),
                     "the census called `{tag}` the heaviest tag, so find_tag must find it in the \

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -1883,11 +1883,25 @@ fn disconnecting_releases_a_live_kernel_session_rather_than_killing_it() {
     );
     let status = server.tool_text("session_status", json!({}), STEP);
     let worker = engine_pid_of(&status, &session);
-    let before = system_uptime(&server.tool_text(
+    // `call_tool`, for the reason the block below spells out: at this point the target is broken
+    // in and the release is still several steps away, so a panic here would leave it halted. The
+    // uptime is a nice-to-have — the comparison at the end already reports honestly when it could
+    // not be read — and nothing worth freezing a machine over.
+    let timed = server.call_tool(
         "execute",
         json!({ "command": ".time", "session_id": session }),
         TARGET_STEP,
-    ));
+    );
+    let before = if is_tool_error(&timed) {
+        eprintln!(
+            "NOTE: `.time` failed before the disconnect, so the uptime comparison cannot be \
+             made:\n{}",
+            text_of(&timed["result"])
+        );
+        None
+    } else {
+        system_uptime(&text_of(&timed["result"]))
+    };
 
     // --- act, and *collect* rather than assert -------------------------------------------
     //
@@ -1938,19 +1952,35 @@ fn disconnecting_releases_a_live_kernel_session_rather_than_killing_it() {
     // Keyed on the handle, not on `landed`: a re-attach that claimed the target and then failed
     // its wait comes back as a tool error *with* a session, and skipping the release for it would
     // leave the target halted — the one thing this test exists to catch.
-    let (after, ended) = match maybe_session_id(&report) {
+    let (after, ended, released) = match maybe_session_id(&report) {
         Some(session) => {
-            let after = system_uptime(&again.tool_text(
+            // `call_tool`, not `tool_text`. This `.time` is *expected* to fail on the very path
+            // the handle-keyed match above exists for — a re-attach that claimed the target and
+            // then failed its wait answers nothing — and `tool_text` is strict now, so a panic
+            // here would skip the release below and leave the target halted. That is the failure
+            // this whole test exists to detect, arriving through the test itself.
+            let timed = again.call_tool(
                 "execute",
                 json!({ "command": ".time", "session_id": session }),
                 TARGET_STEP,
-            ));
+            );
+            let after = if is_tool_error(&timed) {
+                eprintln!(
+                    "NOTE: `.time` failed on the re-attached session, so the uptime comparison \
+                     below cannot be made:\n{}",
+                    text_of(&timed["result"])
+                );
+                None
+            } else {
+                system_uptime(&text_of(&timed["result"]))
+            };
             // The release. From here the target is running again whatever the assertions say.
-            let ended =
-                again.tool_text("end_session", json!({ "session_id": session }), TARGET_STEP);
-            (after, ended)
+            let released =
+                again.call_tool("end_session", json!({ "session_id": session }), TARGET_STEP);
+            let ended = text_of(&released["result"]);
+            (after, ended, Some(released))
         }
-        None => (None, String::new()),
+        None => (None, String::new(), None),
     };
 
     // --- now assert ----------------------------------------------------------------------
@@ -1972,10 +2002,12 @@ fn disconnecting_releases_a_live_kernel_session_rather_than_killing_it() {
         "the target was not reattachable after a disconnect — the previous session did not let go \
          of it cleanly, and this run could not put it back:\n{report}"
     );
-    assert!(
-        !ended.contains("terminated"),
-        "the final detach must be graceful, or the target is left frozen:\n{ended}"
-    );
+    // The same three ways a detach goes wrong as the other live tiers, rather than the one.
+    if let Some(released) = &released
+        && let Some(why) = ungraceful_detach(released, &ended)
+    {
+        panic!("the final detach must be graceful, or the target is left frozen — {why}");
+    }
     match (before, after) {
         (Some(before), Some(after)) => {
             let ran_for = after.saturating_sub(before);

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -2027,26 +2027,21 @@ const ABSENT_TAG: &str = "Zq7x";
 /// and a walk that fails afterwards would be telling us something new.
 const POOL_ROOT_SYMBOL: &str = "nt!ExPoolState";
 
-/// One symbol store for the whole repo, with the public server upstream of it.
+/// Where downloaded PDBs are kept — named explicitly, because the default is not a path.
 ///
-/// A bare `srv*` expands to `cache*;SRV*<msdl>`, and that `cache*` resolves beside the **debugger
-/// binary** — so a release build and the dev build this harness spawns keep separate caches.
-/// Measured while diagnosing exactly that: `target/release/sym` held both kernel PDBs, including
-/// the live target's, while `target/debug/sym` did not exist at all. The tier was failing on a
-/// machine that already had the symbols it needed, and would have gone on failing until it
-/// re-downloaded them into a second cache.
+/// `.symfix` and a bare `srv*` both expand to `cache*;SRV*<msdl>`, and that `cache*` names no
+/// directory at all. A symbol *server* element with no usable downstream store is skipped, and a
+/// skipped element looks exactly like an absent PDB: `DBGHELP: ntkrnlmp.pdb - file not found`,
+/// with no `SYMSRV:` line above it because nothing was ever asked. Four runs of this tier were
+/// spent reading that as evidence about the target. `.symfix+ <cache>` is the documented spelling.
 ///
-/// Naming one store fixes it in both directions: what a release run has already fetched is found,
-/// and what this fetches is kept where the next run of either build will find it.
-/// Backslashes throughout: `CARGO_MANIFEST_DIR` supplies them and a downstream *store* path is
-/// not a place to find out whether DbgHelp minds the mixed separators the obvious spelling gives.
-const SHARED_SYMBOL_STORE: &str = concat!(
-    "srv*",
-    env!("CARGO_MANIFEST_DIR"),
-    "\\target\\release\\sym*https://msdl.microsoft.com/download/symbols"
-);
+/// `target\release\sym` rather than somewhere fresh: this repo's release builds have been caching
+/// there already, so a dev run finds what a release run fetched instead of filling a second store.
+/// Backslashes throughout — a store path is not the place to find out how DbgHelp feels about
+/// mixed separators.
+const SYMBOL_CACHE: &str = concat!(env!("CARGO_MANIFEST_DIR"), "\\target\\release\\sym");
 
-/// A symbol path the operator knows works for this target, overriding [`SHARED_SYMBOL_STORE`].
+/// A symbol path the operator knows works for this target, overriding [`SYMBOL_CACHE`].
 ///
 /// Getting a kernel's PDB onto a debugging host is an environment problem — a reachable store, a
 /// proxy, the right build — and one this test is in no position to solve. Where it has already
@@ -2060,20 +2055,31 @@ const SYMBOLS_ENV: &str = "WINDBG_MCP_SMOKE_SYMBOLS";
 /// which a fresh attach force-loads. Symbols are never fetched over the KD wire either, so this is
 /// entirely about *this* host.
 ///
-/// `.sympath+` adds [`SHARED_SYMBOL_STORE`] rather than replacing anything, so a host with a
-/// curated path keeps it. `!sym noisy` wraps the reload because a failed symbol load is otherwise
-/// **completely silent** — three runs of this tier were spent on a `.reload /f nt` that printed
-/// nothing and loaded nothing, which is indistinguishable from success until something asks for a
-/// symbol. The rest is read back so a failure is a reading rather than a guess.
+/// Both forms *append*, so a host with a curated path keeps it. `!sym noisy` wraps the reload
+/// because a failed symbol load is otherwise **completely silent** — several runs of this tier
+/// were spent on a `.reload` that printed nothing and loaded nothing, which is indistinguishable
+/// from success until something asks for a symbol.
+///
+/// `.reload /f` unqualified, not `.reload /f nt`: it re-reads the module list rather than resting
+/// on the `nt` alias resolving, which is the more reliable instruction on a live kernel and the
+/// one that does not quietly do nothing when the alias is the part that is wrong.
 fn load_kernel_symbols(server: &mut Server, session: &str) -> String {
     let mut transcript = String::new();
+    // DbgHelp will create the store, but only once it has decided to use it; making it first
+    // removes one way for a symbol-server element to be quietly unusable.
+    let _ = std::fs::create_dir_all(SYMBOL_CACHE);
+    // An operator-supplied path is a whole path spec and goes in as one; the default is a cache
+    // directory for `.symfix+`, which builds the canonical `SRV*<cache>*<msdl>` around it.
+    let set_path = match std::env::var(SYMBOLS_ENV) {
+        Ok(path) if !path.trim().is_empty() => format!(".sympath+ {}", path.trim()),
+        _ => format!(".symfix+ {SYMBOL_CACHE}"),
+    };
     // `lm m nt` is the line that settles it: "(pdb symbols)" and a path, or "(export symbols)"
     // and the walker has nothing to decode with.
-    let store = std::env::var(SYMBOLS_ENV).unwrap_or_else(|_| SHARED_SYMBOL_STORE.to_string());
     for command in [
         "!sym noisy".to_string(),
-        format!(".sympath+ {store}"),
-        ".reload /f nt".to_string(),
+        set_path,
+        ".reload /f".to_string(),
         "!sym quiet".to_string(),
         // `!lmi` is the one that says whether an identity was available at all: it prints the
         // debug directory's PDB name, GUID and age when the image headers could be read, and

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -1822,17 +1822,19 @@ fn a_live_kernel_session_attaches_coexists_and_detaches_cleanly() {
     // Always, whatever happened above — the target is frozen until this runs.
     let ended = server.call_tool("end_session", json!({ "session_id": session }), TARGET_STEP);
     let ended_text = text_of(&ended["result"]);
-    if let Err(panic) = outcome {
-        eprintln!("detached after the failure below:\n{ended_text}");
-        resume_unwind(panic);
+    // Same ordering as the pool tier, and for the same reason: resuming the original panic first
+    // would skip every check below it, so a failed detach is masked exactly when the machine is
+    // most likely to be sitting halted. A caught panic has already printed itself.
+    match (outcome, ungraceful_detach(&ended, &ended_text)) {
+        (Err(_), Some(why)) => panic!(
+            "THE TARGET MAY STILL BE HALTED — {why}\n\nThis run had already failed, for the \
+             reason printed above; that is what to investigate, but check the machine first."
+        ),
+        (Err(panic), None) => resume_unwind(panic),
+        (Ok(()), Some(why)) => panic!("{why}"),
+        (Ok(()), None) => {}
     }
 
-    assert_no_error(&ended, "end_session on a live kernel");
-    assert!(
-        !ended_text.contains("terminated"),
-        "the worker was killed instead of detaching — DbgEng leaves a detached-but-halted kernel \
-         frozen, so this would have left the target stopped and its KD stub wedged:\n{ended_text}"
-    );
     assert!(
         ended_text.contains("closed"),
         "end_session should report the session closed:\n{ended_text}"
@@ -2528,21 +2530,52 @@ fn a_live_kernel_pool_walk_is_bounded_and_leaves_its_session_usable() {
     // Always, whatever happened above — the target is frozen until this runs.
     let ended = server.call_tool("end_session", json!({ "session_id": session }), TARGET_STEP);
     let ended_text = text_of(&ended["result"]);
-    if let Err(panic) = outcome {
-        eprintln!("detached after the failure below:\n{ended_text}");
-        resume_unwind(panic);
+    let ungraceful = ungraceful_detach(&ended, &ended_text);
+
+    // Four outcomes, and the ordering is the point. A panic caught here has *already* printed its
+    // own message and location — `catch_unwind` does not suppress the hook — so leading with the
+    // target costs nothing and puts the fact needing action first. The alternative, resuming the
+    // original panic and letting the detach checks below go unrun, hides a halted machine behind
+    // whichever assertion happened to fail earlier.
+    match (outcome, ungraceful) {
+        (Err(_), Some(why)) => panic!(
+            "THE TARGET MAY STILL BE HALTED — {why}\n\nThis run had already failed, for the \
+             reason printed above; that is what to investigate, but check the machine first."
+        ),
+        (Err(panic), None) => {
+            eprintln!("the target was released cleanly despite the failure above");
+            resume_unwind(panic);
+        }
+        (Ok(()), Some(why)) => panic!("{why}"),
+        (Ok(()), None) => {}
     }
-    assert_no_error(&ended, "end_session after a pool walk");
-    // A tool error here reports a session that could not be released — a worker that exited or
-    // crashed, say — and its text need not contain "terminated", so the check below would pass
-    // having confirmed no graceful detach at all. The target can be left halted by exactly that.
-    assert!(
-        !is_tool_error(&ended),
-        "end_session reported a failure, so no graceful detach was confirmed and the target may \
-         still be halted:\n{ended_text}"
-    );
-    assert!(
-        !ended_text.contains("terminated"),
-        "the worker was killed instead of detaching, which leaves the target halted:\n{ended_text}"
-    );
+}
+
+/// Why a detach cannot be called graceful, or `None` when it can.
+///
+/// Three ways to fail and they are easy to conflate. A protocol error means the call did not
+/// arrive; a *tool* error means it did and the session could not be released — a worker that
+/// exited or crashed, whose text need not contain "terminated" — and "terminated" itself means the
+/// worker was killed. Only the last was checked for a long time, so the first two passed as clean
+/// detaches. All three leave a broken-in kernel halted, which is the one outcome this tier must
+/// never report as success.
+fn ungraceful_detach(ended: &Value, text: &str) -> Option<String> {
+    if !ended["error"].is_null() {
+        return Some(format!(
+            "end_session was answered with a JSON-RPC error, so nothing released the target: {}",
+            ended["error"]
+        ));
+    }
+    if is_tool_error(ended) {
+        return Some(format!(
+            "end_session reported a failure, so no graceful detach was confirmed:\n{text}"
+        ));
+    }
+    if text.contains("terminated") {
+        return Some(format!(
+            "the worker was killed instead of detaching, and DbgEng leaves a detached-but-halted \
+             kernel frozen:\n{text}"
+        ));
+    }
+    None
 }

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -283,11 +283,29 @@ impl Server {
         )
     }
 
-    /// The text a tool call produced, whether it succeeded or reported a tool error.
+    /// The text of a tool call that **worked**, for the callers that only proceed if it did.
+    ///
+    /// Strict about `isError`, not just about protocol errors, and that is the whole point. This
+    /// used to hand back a tool error's text as readily as a result, which reads as harmless —
+    /// the text is still there to assert on — and is not: a *failed* call also returns in
+    /// milliseconds, and its text contains none of the phrases a happy-path assertion looks for.
+    /// So a caller measuring how long something took gets a number produced by nothing happening,
+    /// and a caller branching on content takes the `else`. Both were live in the pool tier: a
+    /// walk that never ran satisfied its deadline in 6.8ms, and a lookup that had errored was
+    /// reported as proof that the tag existed.
+    ///
+    /// A test that *expects* a failure has always used [`Self::call_tool`] with [`is_tool_error`],
+    /// which is the right way round: the dangerous reading should be the one you have to spell out.
     fn tool_text(&mut self, name: &str, args: Value, budget: Duration) -> String {
         let response = self.call_tool(name, args, budget);
         assert_no_error(&response, &format!("tools/call {name}"));
-        text_of(&response["result"])
+        let text = text_of(&response["result"]);
+        assert!(
+            !is_tool_error(&response),
+            "`{name}` reported a tool error, so nothing that follows is measuring what it \
+             thinks:\n{text}"
+        );
+        text
     }
 
     /// Terminates the supervisor outright, giving it no chance to run its own shutdown.
@@ -856,6 +874,34 @@ fn bad_calls_are_rejected_without_killing_the_session() {
     assert!(
         text.contains("METHOD_BUFFERED"),
         "the session must still work after bad calls, got:\n{text}"
+    );
+}
+
+/// The harness's own guard, pinned because losing it is silent and expensive.
+///
+/// `tool_text` used to hand back a tool error's text like any other result. Nothing failed when
+/// it did — the caller carried on with a string that merely lacked whatever it was about to look
+/// for, so an assertion on *content* took its else-branch and an assertion on *elapsed time*
+/// measured a call that did nothing and passed comfortably. Both happened in the live pool tier.
+///
+/// `go` with no session open is the cheapest real tool error: a routing failure, which this
+/// server deliberately reports as a result rather than a protocol error.
+#[test]
+fn tool_text_refuses_to_hand_back_a_failed_call() {
+    let mut server = Server::started();
+
+    // The panic below is the expected result, so its message and the `RUST_BACKTRACE` note are
+    // muted — printed, they read exactly like a failure in a test that passed. The hook is
+    // process-wide for the moment it is swapped, which is the price of not crying wolf.
+    let previous = std::panic::take_hook();
+    std::panic::set_hook(Box::new(|_| {}));
+    let refused = catch_unwind(AssertUnwindSafe(|| server.tool_text("go", json!({}), STEP)));
+    std::panic::set_hook(previous);
+
+    assert!(
+        refused.is_err(),
+        "tool_text returned the text of a failed call; every caller of it treats what it \
+         returns as an answer"
     );
 }
 
@@ -1981,6 +2027,23 @@ const ABSENT_TAG: &str = "Zq7x";
 /// and a walk that fails afterwards would be telling us something new.
 const POOL_ROOT_SYMBOL: &str = "nt!ExPoolState";
 
+/// One symbol store for the whole repo, with the public server upstream of it.
+///
+/// A bare `srv*` expands to `cache*;SRV*<msdl>`, and that `cache*` resolves beside the **debugger
+/// binary** — so a release build and the dev build this harness spawns keep separate caches.
+/// Measured while diagnosing exactly that: `target/release/sym` held both kernel PDBs, including
+/// the live target's, while `target/debug/sym` did not exist at all. The tier was failing on a
+/// machine that already had the symbols it needed, and would have gone on failing until it
+/// re-downloaded them into a second cache.
+///
+/// Naming one store fixes it in both directions: what a release run has already fetched is found,
+/// and what this fetches is kept where the next run of either build will find it.
+const SHARED_SYMBOL_STORE: &str = concat!(
+    "srv*",
+    env!("CARGO_MANIFEST_DIR"),
+    "/target/release/sym*https://msdl.microsoft.com/download/symbols"
+);
+
 /// Gets full `nt` type information in front of the walker, and returns the transcript.
 ///
 /// The walker decodes segment-heap internals — `_EX_POOL_HEAP_MANAGER_STATE`, the page-range
@@ -1988,23 +2051,23 @@ const POOL_ROOT_SYMBOL: &str = "nt!ExPoolState";
 /// which a fresh attach force-loads. Symbols are never fetched over the KD wire either, so this is
 /// entirely about *this* host.
 ///
-/// `.symfix+` rather than `.symfix`, so a host that already has a curated symbol path keeps it and
-/// gains the public store, rather than having it replaced by this test. `.sympath` is echoed back
-/// because a failure here is almost always the path, and guessing at it from a bare "missing
-/// symbols" is how the last two runs of this were spent.
+/// `.sympath+` adds [`SHARED_SYMBOL_STORE`] rather than replacing anything, so a host with a
+/// curated path keeps it. `!sym noisy` wraps the reload because a failed symbol load is otherwise
+/// **completely silent** — three runs of this tier were spent on a `.reload /f nt` that printed
+/// nothing and loaded nothing, which is indistinguishable from success until something asks for a
+/// symbol. The rest is read back so a failure is a reading rather than a guess.
 fn load_kernel_symbols(server: &mut Server, session: &str) -> String {
     let mut transcript = String::new();
-    // `lm m nt` is the line that settles it — "(pdb symbols)" and a path, or "(deferred)" and
-    // nothing loaded. Note the store these land in belongs to the *debugger binary*: `srv*`
-    // expands to `cache*;SRV*<msdl>`, and the default cache sits beside the exe. The harness
-    // spawns the **dev** build, so it does not inherit whatever a release build has cached, and
-    // the first run against a given kernel has to download that build's PDB.
+    // `lm m nt` is the line that settles it: "(pdb symbols)" and a path, or "(export symbols)"
+    // and the walker has nothing to decode with.
     for command in [
-        ".symfix+",
-        ".reload /f nt",
-        ".sympath",
-        "lm m nt",
-        &format!("x {POOL_ROOT_SYMBOL}"),
+        "!sym noisy".to_string(),
+        format!(".sympath+ {SHARED_SYMBOL_STORE}"),
+        ".reload /f nt".to_string(),
+        "!sym quiet".to_string(),
+        ".sympath".to_string(),
+        "lm m nt".to_string(),
+        format!("x {POOL_ROOT_SYMBOL}"),
     ] {
         let call = server.call_tool(
             "execute",
@@ -2157,12 +2220,16 @@ fn a_live_kernel_pool_walk_is_bounded_and_leaves_its_session_usable() {
         // pool failure with no way to tell whether the path, the reload, or the walker was at
         // fault.
         let symbols = load_kernel_symbols(&mut server, &session);
+        // Keyed on `lm` reporting a PDB, not on the absence of an error string. `x` against an
+        // unresolved symbol prints *nothing at all* — no "Couldn't resolve", no diagnostic — so
+        // an earlier version of this check passed a run in which nothing had loaded and let the
+        // failure surface three calls later as an unexplained pool error.
         assert!(
-            !symbols.contains("Couldn't resolve") && !symbols.contains("[FAILED]"),
-            "this host cannot resolve {POOL_ROOT_SYMBOL}, so the pool walker has nothing to \
-             decode with and this tier can prove nothing. Symbols are never fetched over the KD \
-             wire — fix *this* machine's symbol path (a reachable store, and a local cache it \
-             can write to) and re-run.\n{symbols}"
+            symbols.contains("pdb symbols"),
+            "`nt` loaded without a PDB, so the pool walker has no types to decode with and this \
+             tier can prove nothing. Symbols are never fetched over the KD wire — this is about \
+             *this* machine reaching a store that carries the target build's ntkrnlmp.pdb.\
+             \n{symbols}"
         );
 
         // A forced walk. `refresh` is the expensive path and the one that wedged; nothing is

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -24,8 +24,9 @@
 //!   worker — so the only place the wiring exists as a whole is the shipped binary.
 //! * **Live kernel** (`#[ignore]`d **and** `WINDBG_MCP_SMOKE_KERNEL=<connection string>`) — a
 //!   real KDNET target. The only tier that touches another machine, and the only one that can
-//!   prove a kernel attach still *lands* and lets go cleanly rather than merely parks. Run it
-//!   last, on its own.
+//!   prove a kernel attach still *lands* and lets go cleanly rather than merely parks, or that a
+//!   pool walk stays inside its budget when every page it reads crosses a wire. Run it last, on
+//!   its own.
 //!
 //! See `docs/smoke-test.md` for the runbook.
 
@@ -1951,4 +1952,228 @@ fn disconnecting_releases_a_live_kernel_session_rather_than_killing_it() {
              proved only that the session was released and the target stayed reachable"
         ),
     }
+}
+
+/// How long a pool query may take before the budget it carries has failed to do its job.
+///
+/// win-kexp's `DEFAULT_WALK_BUDGET` is 120s and this server currently takes that default (#75),
+/// so the walk is bounded there; the slack covers the reads already in flight when the deadline
+/// passes, the render, and the round trip. Deliberately well under `TARGET_STEP`, so a breach
+/// fails *here* with a diagnosis rather than as an opaque harness timeout.
+const POOL_CEILING: Duration = Duration::from_secs(170);
+
+/// How long a call made *after* a walk returned may wait.
+///
+/// Generous by an order of magnitude — `registers` on a broken-in kernel is one `r` over the
+/// wire. The failure this catches is not slowness, it is **queueing**: a walk that outlived its
+/// caller leaves the engine busy, and everything behind it waits out the rest of the walk.
+const NOT_QUEUED: Duration = Duration::from_secs(30);
+
+/// A tag no allocator will have used, so answering has to walk the whole pool.
+///
+/// If it ever collides the test says so and stays honest rather than failing; change it then.
+const ABSENT_TAG: &str = "Zq7x";
+
+/// The heaviest tag in `pool_census` output, or `None` if the shape is not what this expects.
+///
+/// `None` skips the cross-check rather than failing it: a tag whose bytes are not printable
+/// renders as something this has no business guessing at, and a walk that reached nothing has no
+/// heaviest tag at all. The caller tells those two apart.
+fn heaviest_census_tag(census: &str) -> Option<String> {
+    let mut lines = census
+        .lines()
+        .skip_while(|line| !(line.starts_with("tag ") && line.contains("allocs")));
+    lines.next()?;
+    let tag = lines
+        .find(|line| !line.trim().is_empty())?
+        .split_whitespace()
+        .next()?;
+    // Only a tag this test can hand straight back to `pool_find_tag`.
+    let usable = (1..=4).contains(&tag.len())
+        && tag
+            .bytes()
+            .all(|byte| byte.is_ascii_graphic() && byte != b'.');
+    usable.then(|| tag.to_string())
+}
+
+/// Pinned in the default tier, because the failure it guards against is a *silent skip*: every
+/// assertion it feeds is conditional on `Some`, so a parser that stops matching takes the proof
+/// with it and the live run still passes.
+#[test]
+fn a_census_table_yields_its_heaviest_tag() {
+    let census = "3 distinct tag(s) allocated, heaviest first.\n\n\
+                  tag      allocs        bytes  nonpaged   paged\n\
+                  MmSt        912       0x1f40       912       0\n\
+                  Tgsm          4         0x1a0         4       0\n\
+                  \n--- pool walk ---\nchunks walked: 5 (4 allocated), coverage: complete\n";
+    assert_eq!(heaviest_census_tag(census).as_deref(), Some("MmSt"));
+
+    // A walk that found nothing has no heaviest tag, and neither branch may invent one.
+    assert_eq!(
+        heaviest_census_tag("The pool snapshot contains no allocated chunks."),
+        None
+    );
+    // Unprintable tag bytes render as something we cannot hand back to `pool_find_tag`.
+    assert_eq!(
+        heaviest_census_tag(
+            "tag      allocs        bytes  nonpaged   paged\n....          1          0x10         1       0\n"
+        ),
+        None
+    );
+}
+
+/// A pool walk over a live kernel: the query that used to take the session with it.
+///
+/// This is the tier the budget in glslang/win-kexp#88 was written for, and the only one that can
+/// exercise it. Against the checked-in dump a walk is local memory and finishes in well under a
+/// second, so every assertion below would pass for the wrong reason. Against a live KDNET target
+/// it is every committed pool page over the wire — which is where the walk ran for minutes, the
+/// tool call timed out, and the engine kept going, leaving the session unusable until it was
+/// killed. Killing a worker that holds a broken-in kernel leaves the guest halted.
+///
+/// What that means for the assertions: the interesting one is *not* that a chunk was found. It is
+/// that the call **came back**, that the session took work **immediately afterwards**, and that
+/// whatever came back said how much of the pool it had actually seen. A truncated walk is an
+/// acceptable outcome here, and an expected one on a busy kernel, so this asserts that coverage is
+/// **stated** — never that it is total. Asserting completeness would fail on exactly the targets
+/// this exists to cover.
+///
+/// Runs under `catch_unwind` for the reason every test in this tier does: from the attach onward
+/// the target is broken in, and a panic that skipped the detach would leave someone's VM frozen.
+#[test]
+#[ignore = "needs a live KDNET target and its connection string; run manually, last"]
+fn a_live_kernel_pool_walk_is_bounded_and_leaves_its_session_usable() {
+    let Some(connection) = kernel_tier() else {
+        return;
+    };
+    let mut server = Server::started();
+
+    let attached = server.call_tool(
+        "attach_kernel",
+        json!({ "connection": connection }),
+        TARGET_STEP,
+    );
+    let report = text_of(&attached["result"]);
+    let Some(session) = maybe_session_id(&report) else {
+        assert_no_error(&attached, "attach_kernel");
+        panic!(
+            "the attach did not land, and left no session behind. The target must be booted with \
+             debugging enabled and dialling this host, and the KD transport is single-owner:\n\
+             {report}"
+        );
+    };
+
+    let outcome = catch_unwind(AssertUnwindSafe(|| {
+        assert_no_error(&attached, "attach_kernel");
+
+        // A forced walk. `refresh` is the expensive path and the one that wedged; nothing is
+        // cached this early anyway, but asking for it says so rather than relying on it.
+        let started = Instant::now();
+        let absent = server.tool_text(
+            "pool_find_tag",
+            json!({ "tag": ABSENT_TAG, "refresh": true, "session_id": session }),
+            TARGET_STEP,
+        );
+        let walked_for = started.elapsed();
+        println!("a forced pool walk over a live kernel returned in {walked_for:?}");
+        assert!(
+            walked_for < POOL_CEILING,
+            "the walk took {walked_for:?}, past the {POOL_CEILING:?} its budget should hold it \
+             to — either the deadline is not enforced, or some loop in the walk is not polling it"
+        );
+
+        // The engine is free the moment the walk returns. Before the budget it was not: the
+        // caller's timeout fired, the walk carried on, and this call waited out the remainder.
+        let follow_up = Instant::now();
+        let registers =
+            server.tool_text("registers", json!({ "session_id": session }), TARGET_STEP);
+        let waited = follow_up.elapsed();
+        assert!(
+            registers.contains("rip="),
+            "the session should still be a broken-in kernel after a pool walk:\n{registers}"
+        );
+        assert!(
+            waited < NOT_QUEUED,
+            "a call made after the walk returned waited {waited:?} — it queued behind an engine \
+             that was still walking, which is the failure the budget exists to prevent"
+        );
+
+        // An empty answer has to say what the walk managed, or "no such chunk" and "the walk
+        // reached almost none of the pool" are the same sentence.
+        if absent.contains("No allocated chunks carry tag") {
+            assert!(
+                absent.contains("--- pool walk ---") && absent.contains("chunks walked:"),
+                "an empty result must carry the walk's own coverage:\n{absent}"
+            );
+        } else {
+            eprintln!(
+                "NOTE: `{ABSENT_TAG}` exists on this target, so the empty-answer check was \
+                 skipped. Change ABSENT_TAG."
+            );
+        }
+
+        // The census is the state of the walk, so it carries the report whatever it found.
+        let census = server.tool_text(
+            "pool_census",
+            json!({ "session_id": session, "limit": 8 }),
+            TARGET_STEP,
+        );
+        assert!(
+            census.contains("--- pool walk ---") && census.contains("chunks walked:"),
+            "the census must always report the walk behind it:\n{census}"
+        );
+        let complete = census.contains("coverage: complete");
+        println!(
+            "the census reports this walk {}",
+            if complete { "complete" } else { "INCOMPLETE" }
+        );
+
+        match heaviest_census_tag(&census) {
+            // What one tool saw, the other has to find. Only meaningful when the walk completed:
+            // an incomplete snapshot is deliberately not cached, so these would be two separate
+            // walks of a moving target and could honestly disagree.
+            Some(tag) if complete => {
+                let cached = Instant::now();
+                let found = server.tool_text(
+                    "pool_find_tag",
+                    json!({ "tag": tag, "session_id": session }),
+                    TARGET_STEP,
+                );
+                let reuse = cached.elapsed();
+                assert!(
+                    found.contains(&format!("tag `{tag}`")) && found.contains("allocation(s)"),
+                    "the census called `{tag}` the heaviest tag, so find_tag must find it in the \
+                     same snapshot:\n{found}"
+                );
+                assert!(
+                    reuse < walked_for,
+                    "a second query took {reuse:?} against the first walk's {walked_for:?} — a \
+                     complete snapshot is meant to be cached and reused, not walked again"
+                );
+                println!("`{tag}` found again from the cached snapshot in {reuse:?}");
+            }
+            Some(tag) => eprintln!(
+                "NOTE: the walk was incomplete, so the census/find_tag cross-check on `{tag}` was \
+                 skipped — those would be two different walks"
+            ),
+            None => assert!(
+                !complete,
+                "a walk reporting itself complete on a live kernel, with no allocated chunk at \
+                 all, is not credible:\n{census}"
+            ),
+        }
+    }));
+
+    // Always, whatever happened above — the target is frozen until this runs.
+    let ended = server.call_tool("end_session", json!({ "session_id": session }), TARGET_STEP);
+    let ended_text = text_of(&ended["result"]);
+    if let Err(panic) = outcome {
+        eprintln!("detached after the failure below:\n{ended_text}");
+        resume_unwind(panic);
+    }
+    assert_no_error(&ended, "end_session after a pool walk");
+    assert!(
+        !ended_text.contains("terminated"),
+        "the worker was killed instead of detaching, which leaves the target halted:\n{ended_text}"
+    );
 }

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -2038,11 +2038,20 @@ const POOL_ROOT_SYMBOL: &str = "nt!ExPoolState";
 ///
 /// Naming one store fixes it in both directions: what a release run has already fetched is found,
 /// and what this fetches is kept where the next run of either build will find it.
+/// Backslashes throughout: `CARGO_MANIFEST_DIR` supplies them and a downstream *store* path is
+/// not a place to find out whether DbgHelp minds the mixed separators the obvious spelling gives.
 const SHARED_SYMBOL_STORE: &str = concat!(
     "srv*",
     env!("CARGO_MANIFEST_DIR"),
-    "/target/release/sym*https://msdl.microsoft.com/download/symbols"
+    "\\target\\release\\sym*https://msdl.microsoft.com/download/symbols"
 );
+
+/// A symbol path the operator knows works for this target, overriding [`SHARED_SYMBOL_STORE`].
+///
+/// Getting a kernel's PDB onto a debugging host is an environment problem — a reachable store, a
+/// proxy, the right build — and one this test is in no position to solve. Where it has already
+/// been solved, this is how to say so.
+const SYMBOLS_ENV: &str = "WINDBG_MCP_SMOKE_SYMBOLS";
 
 /// Gets full `nt` type information in front of the walker, and returns the transcript.
 ///
@@ -2060,12 +2069,18 @@ fn load_kernel_symbols(server: &mut Server, session: &str) -> String {
     let mut transcript = String::new();
     // `lm m nt` is the line that settles it: "(pdb symbols)" and a path, or "(export symbols)"
     // and the walker has nothing to decode with.
+    let store = std::env::var(SYMBOLS_ENV).unwrap_or_else(|_| SHARED_SYMBOL_STORE.to_string());
     for command in [
         "!sym noisy".to_string(),
-        format!(".sympath+ {SHARED_SYMBOL_STORE}"),
+        format!(".sympath+ {store}"),
         ".reload /f nt".to_string(),
         "!sym quiet".to_string(),
-        ".sympath".to_string(),
+        // `!lmi` is the one that says whether an identity was available at all: it prints the
+        // debug directory's PDB name, GUID and age when the image headers could be read, and
+        // says so when they could not. Without that identity a symbol *server* cannot be
+        // queried — only a filename search, which is what "ntkrnlmp.pdb - file not found" with
+        // no `SYMSRV:` line above it means.
+        "!lmi nt".to_string(),
         "lm m nt".to_string(),
         format!("x {POOL_ROOT_SYMBOL}"),
     ] {
@@ -2227,9 +2242,14 @@ fn a_live_kernel_pool_walk_is_bounded_and_leaves_its_session_usable() {
         assert!(
             symbols.contains("pdb symbols"),
             "`nt` loaded without a PDB, so the pool walker has no types to decode with and this \
-             tier can prove nothing. Symbols are never fetched over the KD wire — this is about \
-             *this* machine reaching a store that carries the target build's ntkrnlmp.pdb.\
-             \n{symbols}"
+             tier can prove nothing about it.\n\nThis is an environment problem, not a \
+             regression: symbols are never fetched over the KD wire, so it is about *this* \
+             machine getting the target build's ntkrnlmp.pdb. Read the transcript below — \
+             `DBGHELP: ntkrnlmp.pdb - file not found` with no `SYMSRV:` line above it means no \
+             symbol server was queried at all, which happens when the image's debug directory \
+             could not be read and there is no GUID to look one up by; `!lmi nt` says which. If \
+             you have a symbol path that works for this target, set {SYMBOLS_ENV} to it and \
+             re-run.\n{symbols}"
         );
 
         // A forced walk. `refresh` is the expensive path and the one that wedged; nothing is

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -886,23 +886,17 @@ fn bad_calls_are_rejected_without_killing_the_session() {
 ///
 /// `go` with no session open is the cheapest real tool error: a routing failure, which this
 /// server deliberately reports as a result rather than a protocol error.
+///
+/// `#[should_panic]` rather than `catch_unwind`: catching it means muting the panic hook, so that
+/// a passing test does not print what reads as a failure — and that hook is **process-wide**, so
+/// any other test panicking in the same moment would lose its message and backtrace while still
+/// failing. The attribute buys the same guarantee with none of that, and `expected` stops it
+/// passing on an unrelated panic such as the server failing to start.
 #[test]
+#[should_panic(expected = "reported a tool error")]
 fn tool_text_refuses_to_hand_back_a_failed_call() {
     let mut server = Server::started();
-
-    // The panic below is the expected result, so its message and the `RUST_BACKTRACE` note are
-    // muted — printed, they read exactly like a failure in a test that passed. The hook is
-    // process-wide for the moment it is swapped, which is the price of not crying wolf.
-    let previous = std::panic::take_hook();
-    std::panic::set_hook(Box::new(|_| {}));
-    let refused = catch_unwind(AssertUnwindSafe(|| server.tool_text("go", json!({}), STEP)));
-    std::panic::set_hook(previous);
-
-    assert!(
-        refused.is_err(),
-        "tool_text returned the text of a failed call; every caller of it treats what it \
-         returns as an answer"
-    );
+    server.tool_text("go", json!({}), STEP);
 }
 
 // ---- tier 2: a real debugger target -------------------------------------------
@@ -2015,6 +2009,17 @@ const POOL_CEILING: Duration = Duration::from_secs(170);
 /// caller leaves the engine busy, and everything behind it waits out the rest of the walk.
 const NOT_QUEUED: Duration = Duration::from_secs(30);
 
+/// How long this *harness* waits on a pool call — deliberately longer than the server's own.
+///
+/// `TARGET_STEP` is 240s and the server gives an engine call 300s, so a walk that ran away would
+/// have the harness give up first. That is the wrong order here. The client panicking while the
+/// walk is still running means the `end_session` in the cleanup queues behind it, misses its grace
+/// period, and the worker is **killed** — which on a broken-in kernel leaves the guest halted. On
+/// the exact failure path this test exists to detect, that would freeze the machine it is
+/// diagnosing. Waiting past the server's own timeout lets it answer first, so the cleanup always
+/// runs against an idle engine.
+const POOL_CALL_BUDGET: Duration = Duration::from_secs(330);
+
 /// A tag no allocator will have used, so answering has to walk the whole pool.
 ///
 /// If it ever collides the test says so and stays honest rather than failing; change it then.
@@ -2026,6 +2031,10 @@ const ABSENT_TAG: &str = "Zq7x";
 /// actually in hand — and it is the exact name the walker fails on, so a probe that passes here
 /// and a walk that fails afterwards would be telling us something new.
 const POOL_ROOT_SYMBOL: &str = "nt!ExPoolState";
+
+/// The `x` that resolves [`POOL_ROOT_SYMBOL`], as one string so its output can be told apart
+/// from every other command's by comparing against the command that produced it.
+const POOL_ROOT_PROBE: &str = "x nt!ExPoolState";
 
 /// Where downloaded PDBs are kept — named explicitly, because the default is not a path.
 ///
@@ -2122,49 +2131,78 @@ const SYMBOLS_ENV: &str = "WINDBG_MCP_SMOKE_SYMBOLS";
 /// `.reload /f` unqualified, not `.reload /f nt`: it re-reads the module list rather than resting
 /// on the `nt` alias resolving, which is the more reliable instruction on a live kernel and the
 /// one that does not quietly do nothing when the alias is the part that is wrong.
-fn load_kernel_symbols(server: &mut Server, session: &str) -> String {
-    let mut transcript = String::new();
+fn load_kernel_symbols(server: &mut Server, session: &str) -> KernelSymbols {
     // DbgHelp will create the store, but only once it has decided to use it; making it first
     // removes one way for a symbol-server element to be quietly unusable.
     let _ = std::fs::create_dir_all(SYMBOL_CACHE);
-    // An operator-supplied path is a whole path spec and goes in as one; the default is a cache
-    // directory for `.symfix+`, which builds the canonical `SRV*<cache>*<msdl>` around it.
-    let set_path = match std::env::var(SYMBOLS_ENV) {
-        Ok(path) if !path.trim().is_empty() => format!(".sympath+ {}", path.trim()),
-        _ => format!(".symfix+ {SYMBOL_CACHE}"),
-    };
-    // `lm m nt` is the line that settles it: "(pdb symbols)" and a path, or "(export symbols)"
-    // and the walker has nothing to decode with.
+    let path = std::env::var(SYMBOLS_ENV)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| {
+            format!("srv*{SYMBOL_CACHE}*https://msdl.microsoft.com/download/symbols")
+        });
+
+    // The typed tool, not `.sympath+` through `execute`: it goes through DbgEng's
+    // Append/SetSymbolPath, so it cannot fall foul of `.sympath` swallowing the rest of the
+    // command line — the quirk this repo documents and works around everywhere else.
+    let configured = server.call_tool(
+        "set_symbol_path",
+        json!({ "path": path, "append": true, "session_id": session }),
+        TARGET_STEP,
+    );
+    let mut transcript = format!(
+        "\n$ set_symbol_path append={path}{}\n{}\n",
+        if is_tool_error(&configured) {
+            " [FAILED]"
+        } else {
+            ""
+        },
+        text_of(&configured["result"]).trim()
+    );
+
+    let mut probe = String::new();
     for command in [
-        "!sym noisy".to_string(),
-        set_path,
-        ".reload /f".to_string(),
-        "!sym quiet".to_string(),
-        // `!lmi` is the one that says whether an identity was available at all: it prints the
-        // debug directory's PDB name, GUID and age when the image headers could be read, and
-        // says so when they could not. Without that identity a symbol *server* cannot be
-        // queried — only a filename search, which is what "ntkrnlmp.pdb - file not found" with
-        // no `SYMSRV:` line above it means.
-        "!lmi nt".to_string(),
-        "lm m nt".to_string(),
-        format!("x {POOL_ROOT_SYMBOL}"),
+        "!sym noisy",
+        ".reload /f",
+        "!sym quiet",
+        // `!lmi` says whether an identity was available at all: it prints the debug directory's
+        // PDB name, GUID and age when the image headers could be read, and says so when they
+        // could not. The two failures look identical without it.
+        "!lmi nt",
+        // The line that settles whether a PDB actually loaded.
+        "lm m nt",
+        POOL_ROOT_PROBE,
     ] {
         let call = server.call_tool(
             "execute",
             json!({ "command": command, "session_id": session }),
             TARGET_STEP,
         );
+        let output = text_of(&call["result"]);
         let failed = if is_tool_error(&call) {
             " [FAILED]"
         } else {
             ""
         };
-        transcript.push_str(&format!(
-            "\n$ {command}{failed}\n{}\n",
-            text_of(&call["result"]).trim()
-        ));
+        transcript.push_str(&format!("\n$ {command}{failed}\n{}\n", output.trim()));
+        if command == POOL_ROOT_PROBE {
+            // Everything DbgEng echoes back is the command itself; what is left is the answer.
+            // `x` prints *nothing* for a name it cannot resolve, so the remainder being empty is
+            // the whole signal — and checking the transcript for the symbol's name instead would
+            // match the echo and pass regardless.
+            probe = output.replace(command, "").trim().to_string();
+        }
     }
-    transcript
+    KernelSymbols { transcript, probe }
+}
+
+/// What [`load_kernel_symbols`] managed, kept apart so each can be checked on its own terms.
+struct KernelSymbols {
+    /// Everything that was run and what it said — the failure message's whole value.
+    transcript: String,
+    /// `x <pool root>` with the echoed command removed: empty means it did not resolve.
+    probe: String,
 }
 
 /// What `pool_census` had to say about the heaviest tag it found.
@@ -2304,21 +2342,31 @@ fn a_live_kernel_pool_walk_is_bounded_and_leaves_its_session_usable() {
         // pool failure with no way to tell whether the path, the reload, or the walker was at
         // fault.
         let symbols = load_kernel_symbols(&mut server, &session);
+        let transcript = &symbols.transcript;
         // Keyed on `lm` reporting a PDB, not on the absence of an error string. `x` against an
         // unresolved symbol prints *nothing at all* — no "Couldn't resolve", no diagnostic — so
         // an earlier version of this check passed a run in which nothing had loaded and let the
         // failure surface three calls later as an unexplained pool error.
         assert!(
-            symbols.contains("pdb symbols"),
+            transcript.contains("pdb symbols"),
             "`nt` loaded without a PDB, so the pool walker has no types to decode with and this \
              tier can prove nothing about it.\n\nSymbols never cross the KD wire, so this is \
              always about *this* machine. Read `!lmi nt` below first: `Symbol Type: EXPORT - PDB \
              not found` **with a CODEVIEW GUID present** means the identity was known and the \
-             lookup still failed — which is the engine, not the target and not the path. That is \
-             what `symsrv.dll` (reads a symbol store) and `msdia140.dll` (parses the PDB) are \
-             for, and this run reports them as: {engine}. A CODEVIEW line that is *absent* is \
-             the other failure, and a different fix. If you have a symbol path known to work \
-             here, set {SYMBOLS_ENV} to it.\n{symbols}"
+             lookup still failed — which is the engine or the store, not the target. That is what \
+             `symsrv.dll` (reads a symbol store) and `msdia140.dll` (parses the PDB) are for, and \
+             this run reports them as: {engine}. A CODEVIEW line that is *absent* is the other \
+             failure, and a different fix. If you have a symbol path known to work here, set \
+             {SYMBOLS_ENV} to it.\n{transcript}"
+        );
+        // A PDB for `nt` is necessary and not sufficient: the walker wants this *private* global,
+        // and a public-only PDB would satisfy the check above while leaving every pool query to
+        // fail. Checked on the probe's own output, since searching the whole transcript for the
+        // name would match the echoed command and pass no matter what.
+        assert!(
+            !symbols.probe.is_empty(),
+            "`nt` has a PDB but {POOL_ROOT_SYMBOL} did not resolve, so the pool walker still has \
+             nothing to start from — the PDB may lack private symbols.\n{transcript}"
         );
 
         // A forced walk. `refresh` is the expensive path and the one that wedged; nothing is
@@ -2327,7 +2375,7 @@ fn a_live_kernel_pool_walk_is_bounded_and_leaves_its_session_usable() {
         let walk = server.call_tool(
             "pool_find_tag",
             json!({ "tag": ABSENT_TAG, "refresh": true, "session_id": session }),
-            TARGET_STEP,
+            POOL_CALL_BUDGET,
         );
         let walked_for = started.elapsed();
         let absent = text_of(&walk["result"]);
@@ -2340,7 +2388,7 @@ fn a_live_kernel_pool_walk_is_bounded_and_leaves_its_session_usable() {
             "the pool walk failed outright, so nothing below would be measuring a walk. If this \
              names missing kernel pool symbols after the probe above resolved, then the walker \
              wants type information the public store does not carry, which is a different \
-             problem from an unset symbol path.\n{absent}\n\nsymbol setup said:{symbols}"
+             problem from an unset symbol path.\n{absent}\n\nsymbol setup said:{transcript}"
         );
         println!("a forced pool walk over a live kernel returned in {walked_for:?}");
         assert!(
@@ -2382,11 +2430,18 @@ fn a_live_kernel_pool_walk_is_bounded_and_leaves_its_session_usable() {
         }
 
         // The census is the state of the walk, so it carries the report whatever it found.
+        //
+        // Timed, because it runs *between* the walk and the reuse check below and would otherwise
+        // hide the very regression that check is for: if the walk's snapshot were discarded, this
+        // call would quietly take a fresh one and cache *that*, and the later `reuse < walked_for`
+        // would still pass while proving nothing about the original walk.
+        let census_started = Instant::now();
         let census_call = server.call_tool(
             "pool_census",
             json!({ "session_id": session, "limit": 8 }),
-            TARGET_STEP,
+            POOL_CALL_BUDGET,
         );
+        let census_took = census_started.elapsed();
         let census = text_of(&census_call["result"]);
         assert!(
             !is_tool_error(&census_call),
@@ -2420,11 +2475,19 @@ fn a_live_kernel_pool_walk_is_bounded_and_leaves_its_session_usable() {
             // an incomplete snapshot is deliberately not cached, so these would be two separate
             // walks of a moving target and could honestly disagree.
             HeaviestTag::Queryable(tag) if complete => {
+                // The census had to come off the cached snapshot too, or the reuse below is
+                // measured against a snapshot *it* took rather than the walk's.
+                assert!(
+                    census_took < walked_for,
+                    "the census took {census_took:?} against the walk's {walked_for:?}, so it \
+                     walked again rather than reusing the completed snapshot — anything the \
+                     reuse check says after that is about the census's walk, not the first one"
+                );
                 let cached = Instant::now();
                 let call = server.call_tool(
                     "pool_find_tag",
                     json!({ "tag": tag, "session_id": session }),
-                    TARGET_STEP,
+                    POOL_CALL_BUDGET,
                 );
                 let reuse = cached.elapsed();
                 let found = text_of(&call["result"]);
@@ -2470,6 +2533,14 @@ fn a_live_kernel_pool_walk_is_bounded_and_leaves_its_session_usable() {
         resume_unwind(panic);
     }
     assert_no_error(&ended, "end_session after a pool walk");
+    // A tool error here reports a session that could not be released — a worker that exited or
+    // crashed, say — and its text need not contain "terminated", so the check below would pass
+    // having confirmed no graceful detach at all. The target can be left halted by exactly that.
+    assert!(
+        !is_tool_error(&ended),
+        "end_session reported a failure, so no graceful detach was confirmed and the target may \
+         still be halted:\n{ended_text}"
+    );
     assert!(
         !ended_text.contains("terminated"),
         "the worker was killed instead of detaching, which leaves the target halted:\n{ended_text}"

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -1974,52 +1974,88 @@ const NOT_QUEUED: Duration = Duration::from_secs(30);
 /// If it ever collides the test says so and stays honest rather than failing; change it then.
 const ABSENT_TAG: &str = "Zq7x";
 
-/// The heaviest tag in `pool_census` output, or `None` if the shape is not what this expects.
+/// What `pool_census` had to say about the heaviest tag it found.
 ///
-/// `None` skips the cross-check rather than failing it: a tag whose bytes are not printable
-/// renders as something this has no business guessing at, and a walk that reached nothing has no
-/// heaviest tag at all. The caller tells those two apart.
-fn heaviest_census_tag(census: &str) -> Option<String> {
+/// Three outcomes, not two, and collapsing the last two is a real bug: "the census listed
+/// nothing" is a claim about the *pool* and worth asserting on, while "the heaviest tag does not
+/// render unambiguously" is a fact about **rendering** that says nothing about the walk. Treating
+/// the second as the first fails a perfectly healthy run whose busiest tag happens to be binary.
+enum HeaviestTag {
+    /// A tag that can be handed straight back to `pool_find_tag`.
+    Queryable(String),
+    /// A tag is listed, but this test cannot reconstruct the bytes behind it. `display_tag`
+    /// maps every unprintable byte to `.` — and a literal `.` to the same thing — so a rendering
+    /// containing one could have come from either.
+    Ambiguous,
+    /// The census listed no allocated chunk at all.
+    NothingListed,
+}
+
+/// The heaviest tag in `pool_census` output.
+fn heaviest_census_tag(census: &str) -> HeaviestTag {
     let mut lines = census
         .lines()
         .skip_while(|line| !(line.starts_with("tag ") && line.contains("allocs")));
-    lines.next()?;
-    let tag = lines
-        .find(|line| !line.trim().is_empty())?
-        .split_whitespace()
-        .next()?;
-    // Only a tag this test can hand straight back to `pool_find_tag`.
-    let usable = (1..=4).contains(&tag.len())
-        && tag
-            .bytes()
-            .all(|byte| byte.is_ascii_graphic() && byte != b'.');
-    usable.then(|| tag.to_string())
+    if lines.next().is_none() {
+        return HeaviestTag::NothingListed;
+    }
+    let Some(row) = lines.find(|line| !line.trim().is_empty()) else {
+        return HeaviestTag::NothingListed;
+    };
+    // A fixed-width column, read as one. Splitting on whitespace looks equivalent and is not:
+    // `display_tag` keeps spaces, so a real tag like `Ntf ` would come back as `Ntf`, which is a
+    // *different* four bytes — the cross-check below would then query a tag nobody allocated and
+    // blame the walk for not finding it. Every rendering is exactly four characters.
+    let tag: String = row.chars().take(4).collect();
+    if tag.chars().count() != 4 || tag.contains('.') {
+        return HeaviestTag::Ambiguous;
+    }
+    HeaviestTag::Queryable(tag)
 }
 
-/// Pinned in the default tier, because the failure it guards against is a *silent skip*: every
-/// assertion it feeds is conditional on `Some`, so a parser that stops matching takes the proof
-/// with it and the live run still passes.
+/// Pinned in the default tier, because the failure it guards against is a *silent skip*: the
+/// cross-check it feeds only runs on `Queryable`, so a parser that stops matching takes the proof
+/// with it and the live run still passes. The three-way split matters just as much — collapsing
+/// `Ambiguous` into `NothingListed` turns an unremarkable target into a test failure.
 #[test]
 fn a_census_table_yields_its_heaviest_tag() {
-    let census = "3 distinct tag(s) allocated, heaviest first.\n\n\
-                  tag      allocs        bytes  nonpaged   paged\n\
-                  MmSt        912       0x1f40       912       0\n\
-                  Tgsm          4         0x1a0         4       0\n\
-                  \n--- pool walk ---\nchunks walked: 5 (4 allocated), coverage: complete\n";
-    assert_eq!(heaviest_census_tag(census).as_deref(), Some("MmSt"));
+    const HEADER: &str = "tag      allocs        bytes  nonpaged   paged";
+    let table = |rows: &str| {
+        format!(
+            "3 distinct tag(s) allocated, heaviest first.\n\n{HEADER}\n{rows}\n\
+             \n--- pool walk ---\nchunks walked: 5 (4 allocated), coverage: complete\n"
+        )
+    };
 
-    // A walk that found nothing has no heaviest tag, and neither branch may invent one.
-    assert_eq!(
+    assert!(matches!(
+        heaviest_census_tag(&table(
+            "MmSt        912       0x1f40       912       0\n\
+             Tgsm          4         0x1a0         4       0"
+        )),
+        HeaviestTag::Queryable(tag) if tag == "MmSt"
+    ));
+
+    // A three-byte tag is rendered padded with the space it actually contains, and `parse_tag`
+    // takes it straight back. Splitting on whitespace would hand `pool_find_tag` the three-byte
+    // `Ntf` instead — a different tag, which nothing allocated, blamed on the walk.
+    assert!(matches!(
+        heaviest_census_tag(&table("Ntf         912       0x1f40       912       0")),
+        HeaviestTag::Queryable(tag) if tag == "Ntf "
+    ));
+
+    // A walk that found nothing has no heaviest tag, and nothing may invent one.
+    assert!(matches!(
         heaviest_census_tag("The pool snapshot contains no allocated chunks."),
-        None
-    );
-    // Unprintable tag bytes render as something we cannot hand back to `pool_find_tag`.
-    assert_eq!(
-        heaviest_census_tag(
-            "tag      allocs        bytes  nonpaged   paged\n....          1          0x10         1       0\n"
-        ),
-        None
-    );
+        HeaviestTag::NothingListed
+    ));
+
+    // Unprintable tag bytes render as `.`, and so does a literal `.` — the rendering cannot be
+    // turned back into bytes. That is a fact about rendering, not about the pool, so it must not
+    // read as "the walk found nothing".
+    assert!(matches!(
+        heaviest_census_tag(&table("Nt.f        912       0x1f40       912       0")),
+        HeaviestTag::Ambiguous
+    ));
 }
 
 /// A pool walk over a live kernel: the query that used to take the session with it.
@@ -2132,7 +2168,7 @@ fn a_live_kernel_pool_walk_is_bounded_and_leaves_its_session_usable() {
             // What one tool saw, the other has to find. Only meaningful when the walk completed:
             // an incomplete snapshot is deliberately not cached, so these would be two separate
             // walks of a moving target and could honestly disagree.
-            Some(tag) if complete => {
+            HeaviestTag::Queryable(tag) if complete => {
                 let cached = Instant::now();
                 let found = server.tool_text(
                     "pool_find_tag",
@@ -2152,11 +2188,17 @@ fn a_live_kernel_pool_walk_is_bounded_and_leaves_its_session_usable() {
                 );
                 println!("`{tag}` found again from the cached snapshot in {reuse:?}");
             }
-            Some(tag) => eprintln!(
+            HeaviestTag::Queryable(tag) => eprintln!(
                 "NOTE: the walk was incomplete, so the census/find_tag cross-check on `{tag}` was \
                  skipped — those would be two different walks"
             ),
-            None => assert!(
+            // Not a failure, and not evidence about the walk: plenty of drivers use tag bytes
+            // that do not render, and the busiest allocator on this target may be one of them.
+            HeaviestTag::Ambiguous => eprintln!(
+                "NOTE: the heaviest tag does not render unambiguously, so the census/find_tag \
+                 cross-check was skipped"
+            ),
+            HeaviestTag::NothingListed => assert!(
                 !complete,
                 "a walk reporting itself complete on a live kernel, with no allocated chunk at \
                  all, is not credible:\n{census}"

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -1974,12 +1974,55 @@ const NOT_QUEUED: Duration = Duration::from_secs(30);
 /// If it ever collides the test says so and stays honest rather than failing; change it then.
 const ABSENT_TAG: &str = "Zq7x";
 
-/// Microsoft's public symbol store, appended so the walker can resolve `nt`'s private types.
+/// The global the pool walker needs before it can read anything: the allocator's root.
 ///
-/// The pool walker decodes segment-heap internals — `_EX_POOL_HEAP_MANAGER_STATE`,
-/// `_HEAP_PAGE_RANGE_DESCRIPTOR`, the VS and LFH headers — and none of that is in the public
-/// export table. Without full type information every pool query fails before it reads a byte.
-const MS_SYMBOL_SERVER: &str = "srv*https://msdl.microsoft.com/download/symbols";
+/// It is not an export, so resolving it is the cheapest honest proof that full `nt` symbols are
+/// actually in hand — and it is the exact name the walker fails on, so a probe that passes here
+/// and a walk that fails afterwards would be telling us something new.
+const POOL_ROOT_SYMBOL: &str = "nt!ExPoolState";
+
+/// Gets full `nt` type information in front of the walker, and returns the transcript.
+///
+/// The walker decodes segment-heap internals — `_EX_POOL_HEAP_MANAGER_STATE`, the page-range
+/// descriptors, the VS and LFH headers — none of which is in the public export table, and none of
+/// which a fresh attach force-loads. Symbols are never fetched over the KD wire either, so this is
+/// entirely about *this* host.
+///
+/// `.symfix+` rather than `.symfix`, so a host that already has a curated symbol path keeps it and
+/// gains the public store, rather than having it replaced by this test. `.sympath` is echoed back
+/// because a failure here is almost always the path, and guessing at it from a bare "missing
+/// symbols" is how the last two runs of this were spent.
+fn load_kernel_symbols(server: &mut Server, session: &str) -> String {
+    let mut transcript = String::new();
+    // `lm m nt` is the line that settles it — "(pdb symbols)" and a path, or "(deferred)" and
+    // nothing loaded. Note the store these land in belongs to the *debugger binary*: `srv*`
+    // expands to `cache*;SRV*<msdl>`, and the default cache sits beside the exe. The harness
+    // spawns the **dev** build, so it does not inherit whatever a release build has cached, and
+    // the first run against a given kernel has to download that build's PDB.
+    for command in [
+        ".symfix+",
+        ".reload /f nt",
+        ".sympath",
+        "lm m nt",
+        &format!("x {POOL_ROOT_SYMBOL}"),
+    ] {
+        let call = server.call_tool(
+            "execute",
+            json!({ "command": command, "session_id": session }),
+            TARGET_STEP,
+        );
+        let failed = if is_tool_error(&call) {
+            " [FAILED]"
+        } else {
+            ""
+        };
+        transcript.push_str(&format!(
+            "\n$ {command}{failed}\n{}\n",
+            text_of(&call["result"]).trim()
+        ));
+    }
+    transcript
+}
 
 /// What `pool_census` had to say about the heaviest tag it found.
 ///
@@ -2109,20 +2152,17 @@ fn a_live_kernel_pool_walk_is_bounded_and_leaves_its_session_usable() {
     let outcome = catch_unwind(AssertUnwindSafe(|| {
         assert_no_error(&attached, "attach_kernel");
 
-        // The walker needs full nt type information — `_EX_POOL_HEAP_MANAGER_STATE` and the rest
-        // of the allocator's private types — and a fresh attach does not force-load it. This is
-        // the documented precondition; doing it here rather than assuming it is what lets the
-        // tier set up its own target. Symbols are never fetched over the KD wire, so this is
-        // about *this* host's symbol path, not the target's.
-        server.tool_text(
-            "set_symbol_path",
-            json!({ "path": MS_SYMBOL_SERVER, "append": true, "session_id": session }),
-            TARGET_STEP,
-        );
-        let reloaded = server.tool_text(
-            "execute",
-            json!({ "command": ".reload /f nt", "session_id": session }),
-            TARGET_STEP,
+        // The documented precondition, satisfied rather than assumed — and then *checked*.
+        // Asking for symbols and carrying on regardless is what made the previous run report a
+        // pool failure with no way to tell whether the path, the reload, or the walker was at
+        // fault.
+        let symbols = load_kernel_symbols(&mut server, &session);
+        assert!(
+            !symbols.contains("Couldn't resolve") && !symbols.contains("[FAILED]"),
+            "this host cannot resolve {POOL_ROOT_SYMBOL}, so the pool walker has nothing to \
+             decode with and this tier can prove nothing. Symbols are never fetched over the KD \
+             wire — fix *this* machine's symbol path (a reachable store, and a local cache it \
+             can write to) and re-run.\n{symbols}"
         );
 
         // A forced walk. `refresh` is the expensive path and the one that wedged; nothing is
@@ -2142,10 +2182,9 @@ fn a_live_kernel_pool_walk_is_bounded_and_leaves_its_session_usable() {
         assert!(
             !is_tool_error(&walk),
             "the pool walk failed outright, so nothing below would be measuring a walk. If this \
-             names missing kernel pool symbols, this host cannot resolve full type information \
-             for `nt`; the walker needs it and it is never fetched over the KD wire. Fix the \
-             symbol path and re-run — the tier proves nothing without it.\n{absent}\n\n\
-             `.reload /f nt` had said:\n{reloaded}"
+             names missing kernel pool symbols after the probe above resolved, then the walker \
+             wants type information the public store does not carry, which is a different \
+             problem from an unset symbol path.\n{absent}\n\nsymbol setup said:{symbols}"
         );
         println!("a forced pool walk over a live kernel returned in {walked_for:?}");
         assert!(


### PR DESCRIPTION
Two commits: the lock bump that brings in the fix, and the test that proves it where the fix matters.

## The bump

Picks up glslang/win-kexp#88, `ce8bce2a` → `1c7b4748`. **No source change** — `bool: Into<PoolWalk>` keeps every call site compiling and hands it the default budget.

The failure it closes is one this server produced. `pool_find_tag` and `pool_census` on the live KDNET target ran for minutes; the tool call timed out and the engine kept walking, so every later call to that session queued behind it, and reclaiming the session meant killing the worker — which on a broken-in kernel leaves the guest halted. During the MessageManager work that meant abandoning the pool tools entirely and locating objects by hand through `!handle` → `FILE_OBJECT` → `dps`.

A walk now enforces its own wall-clock ceiling and returns the chunks it reached with the coverage it managed.

## The test

`a_live_kernel_pool_walk_is_bounded_and_leaves_its_session_usable`, in the live-kernel tier.

It has to be that tier. Against the checked-in dump a pool walk is local memory and finishes in well under a second, so every assertion below would pass without the fix present at all. The cost only exists when each page crosses a wire.

It asserts the three things the failure actually consisted of:

- the call **returns**, inside a ceiling set below `TARGET_STEP` so a breach fails with a diagnosis instead of an opaque harness hang;
- the **next** call is served immediately rather than queueing behind an engine still walking — that queueing is what made one bad query cost the whole session;
- whatever came back **states its own coverage**.

**It never asserts the walk completed.** A truncated walk is a good outcome here and the expected one on a busy kernel; requiring completeness would fail on exactly the targets this exists to cover. Where the walk does complete, two further claims become checkable and are: the snapshot was cached rather than re-walked, and `pool_census` and `pool_find_tag` agree about the heaviest tag in it. Under a truncated walk those would be two separate walks of a moving target and could honestly disagree, so the comparison is skipped with a note rather than risked.

Like everything in this tier the body runs under `catch_unwind` with the detach after it — a panic that skipped the detach would leave the VM frozen.

`heaviest_census_tag` is pinned by an ordinary test in the default tier, because every assertion it feeds is conditional on `Some`: a parser that stopped matching would take the proof with it and the live run would still pass. That follows the precedent of `a_kdnet_connection_string_yields_its_port`.

## Verification

135 tests pass, clippy and fmt clean. The live test is `#[ignore]`d and gated on the connection string, so it cannot run by accident. **It has not been run against the VM yet** — that needs the target up, and it is the one thing here I cannot check for you:

```pwsh
$env:WINDBG_MCP_SMOKE_KERNEL = "net:port=50000,key=<w.x.y.z>"
cargo test --test mcp_smoke -- --ignored --nocapture --test-threads=1 live_kernel
```

Docs updated: that filter now matches three tests, not two.

## Follow-ups

- #75 — take *our* remaining deadline instead of win-kexp's 120s default. With `WINDBG_MCP_CALL_TIMEOUT_SECS` set low, today's default is still longer than the caller's budget.
- glslang/win-kexp#89 — scope the walk to the paged/nonpaged side the query asked for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded live-kernel smoke testing to cover pool walking over the network.
  * Added checks for timeout enforcement, session usability after interruptions, coverage reporting, snapshot reuse, and pool data consistency.
  * Added validation for empty or unusable pool tags and ensured sessions detach cleanly after testing.
  * Improved handling and reporting of failed tool calls.

* **Documentation**
  * Updated verification instructions to reflect the expanded three-test suite and new pool-walking coverage.
  * Clarified symbol-cache setup, troubleshooting, and private kernel type requirements for pool analysis.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->