### PR TITLE
fix: report the diagnostic count the walk produced, not the one it kept

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -884,7 +884,7 @@ dependencies = [
 [[package]]
 name = "win-kexp"
 version = "0.1.0"
-source = "git+https://github.com/glslang/win-kexp?branch=main#1c7b474876ecc18a61564bc48c3b9d7b355aa4e9"
+source = "git+https://github.com/glslang/win-kexp?branch=main#0b617c676f5e1cd875c0455f058d494a3fd4f112"
 dependencies = [
  "byte-strings",
  "goblin",

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -253,7 +253,11 @@ about. This is the other half — an attach that lands:
   partly on disk, so `sparse virtual range` diagnostics are physics rather than a defect, and the
   coverage caveat is doing its job. The categories that are *not* explained that way are worth
   reading — this run showed ~5.6k LFH subsegments rejected as implausible
-  (glslang/win-kexp#90), and the diagnostic total itself is currently understated (#77).
+  (glslang/win-kexp#90). Read the per-category counts as the volume: the walk keeps only a
+  handful of messages per category verbatim, so the list of examples is a sample and its length
+  says nothing about how much the walk complained. The header total is the walk's own count
+  (#77) — before that fix it was the length of the sample, which understated a real run by two
+  orders of magnitude.
   Where the walk *does* complete it also checks the snapshot was cached rather than
   re-walked, and that `pool_census` and `pool_find_tag` agree about the heaviest tag in it. That
   last comparison additionally needs the census to expose a tag that renders unambiguously: pool

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -26,7 +26,7 @@ use std::time::{Duration, Instant};
 
 use win_kexp::dbgeng::{DebugEngine, RunToOutcome};
 use win_kexp::pool::query::{self, PoolPageFilter};
-use win_kexp::pool::{PoolSpan, PoolState};
+use win_kexp::pool::{DiagnosticShape, PoolDiagnostics, PoolSpan, PoolState};
 use windows_sys::Win32::Foundation::{HANDLE_FLAG_INHERIT, SetHandleInformation};
 
 use crate::proto::{EngineOp, PoolOp, ReachabilityOp, WorkerMessage, WorkerRequest};
@@ -630,35 +630,26 @@ fn parse_pool_addr(text: &str) -> Result<u64, String> {
     parse_windbg_addr(text).map_or_else(|| parse_u64(text), Ok)
 }
 
-/// Replaces the variable parts of a diagnostic — addresses and indices — so that lines
-/// describing the same *kind* of problem collapse together.
+/// The walk's own diagnostic categories, commonest first.
 ///
-/// A hex-looking run has to be at least 4 characters to count, or short decimal counts
-/// ("depth is 16") would be blanked too and lines that differ meaningfully would merge.
-fn diagnostic_category(line: &str) -> String {
-    line.split_whitespace()
-        .map(|word| {
-            let trimmed = word.trim_matches(|c: char| !c.is_ascii_alphanumeric());
-            let hexish = trimmed.len() >= 4 && trimmed.chars().all(|c| c.is_ascii_hexdigit());
-            if trimmed.starts_with("0x") || hexish {
-                "<addr>"
-            } else {
-                word
-            }
-        })
-        .collect::<Vec<_>>()
-        .join(" ")
+/// The grouping is the walk's, not ours: it collapses floods as it goes and keeps a total per
+/// category, so re-deriving categories here would count the *sample* it kept — off by two
+/// orders of magnitude on a live target — and report that as a fact about the pool. Only the
+/// ordering is a presentation choice, and it belongs on this side.
+/// "1 category" / "24 categories" — the irregular plural shows up in every rendering here.
+fn categories_phrase(count: usize) -> String {
+    format!("{count} categor{}", if count == 1 { "y" } else { "ies" })
 }
 
-/// Groups diagnostics by category, commonest first.
-fn summarize_diagnostics(lines: &[String]) -> Vec<(String, usize)> {
-    let mut counts: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
-    for line in lines {
-        *counts.entry(diagnostic_category(line)).or_default() += 1;
-    }
-    let mut grouped: Vec<_> = counts.into_iter().collect();
-    grouped.sort_by(|left, right| right.1.cmp(&left.1).then_with(|| left.0.cmp(&right.0)));
-    grouped
+fn diagnostic_categories(diagnostics: &PoolDiagnostics) -> Vec<&DiagnosticShape> {
+    let mut categories: Vec<&DiagnosticShape> = diagnostics.shapes().iter().collect();
+    categories.sort_by(|left, right| {
+        right
+            .total
+            .cmp(&left.total)
+            .then_with(|| left.shape.cmp(&right.shape))
+    });
+    categories
 }
 
 /// The caveat an answer needs when the walk that produced it did not finish, or `None` when
@@ -690,52 +681,68 @@ fn coverage_caveat(report: &query::PoolSnapshotReport) -> Option<String> {
 /// The diagnostics are *categorised* rather than listed: a real walk emits tens of
 /// thousands, and the first forty of those are a sample of whichever heap happened to be
 /// walked first, not of the problem. Counts per category say which failures actually
-/// dominate; one verbatim example per category keeps the concrete address available.
+/// dominate; the verbatim tail keeps concrete addresses available.
 fn append_walk_report(out: &mut String, e: &DebugEngine) {
     match query::snapshot_report(e, false) {
-        Ok(report) => {
-            // `complete` is not implied by an empty diagnostics list: a walk can end
-            // partway through without saying anything. Report it explicitly, or a caller
-            // reads a truncated snapshot as a healthy one.
-            out.push_str(&format!(
-                "\n--- pool walk ---\nchunks walked: {} ({} allocated), coverage: {}\n",
-                report.total_chunks,
-                report.allocated_chunks,
-                if report.complete {
-                    "complete"
-                } else {
-                    "INCOMPLETE - the walk did not reach everything it set out to"
-                }
-            ));
-            if report.diagnostics.is_empty() {
-                out.push_str("the walk reported no diagnostics.\n");
-                return;
-            }
-            let grouped = summarize_diagnostics(&report.diagnostics);
-            out.push_str(&format!(
-                "{} diagnostic(s) in {} categor{}:\n",
-                report.diagnostics.len(),
-                grouped.len(),
-                if grouped.len() == 1 { "y" } else { "ies" }
-            ));
-            for (category, count) in grouped.iter().take(25) {
-                out.push_str(&format!("  {count:>7}x  {category}\n"));
-            }
-            if grouped.len() > 25 {
-                out.push_str(&format!("  ... {} more categories\n", grouped.len() - 25));
-            }
-            // The last few verbatim: heaps are walked in order, so the tail is where the
-            // most recently discovered ones (special pool included) report.
-            out.push_str("\nlast 12 verbatim:\n");
-            let tail = report.diagnostics.len().saturating_sub(12);
-            for line in report.diagnostics.iter().skip(tail) {
-                out.push_str("  ");
-                out.push_str(line);
-                out.push('\n');
-            }
-        }
+        Ok(report) => out.push_str(&render_walk_report(&report)),
         Err(error) => out.push_str(&format!("\n(could not summarise the walk: {error})\n")),
     }
+}
+
+/// The body of [`append_walk_report`], split out so the counts can be tested without an engine.
+fn render_walk_report(report: &query::PoolSnapshotReport) -> String {
+    // `complete` is not implied by an empty diagnostics list: a walk can end partway
+    // through without saying anything. Report it explicitly, or a caller reads a truncated
+    // snapshot as a healthy one.
+    let mut out = format!(
+        "\n--- pool walk ---\nchunks walked: {} ({} allocated), coverage: {}\n",
+        report.total_chunks,
+        report.allocated_chunks,
+        if report.complete {
+            "complete"
+        } else {
+            "INCOMPLETE - the walk did not reach everything it set out to"
+        }
+    );
+    if report.diagnostics.is_empty() {
+        out.push_str("the walk reported no diagnostics.\n");
+        return out;
+    }
+    let categories = diagnostic_categories(&report.diagnostics);
+    out.push_str(&format!(
+        "{} diagnostic(s) in {}:\n",
+        report.diagnostics.emitted(),
+        categories_phrase(categories.len())
+    ));
+    for category in categories.iter().take(25) {
+        out.push_str(&format!(
+            "  {:>7}x  {}\n",
+            category.total,
+            category.shape.trim()
+        ));
+    }
+    if categories.len() > 25 {
+        out.push_str(&format!(
+            "  ... {} more categories\n",
+            categories.len() - 25
+        ));
+    }
+    // The last few verbatim: heaps are walked in order, so the tail is where the most
+    // recently discovered ones (special pool included) report. These are only the messages
+    // the walk kept — a capped sample per category — so say so, or "last 12" reads as the
+    // tail of everything rather than the tail of the sample.
+    let examples = report.diagnostics.examples();
+    let shown = examples.len().min(12);
+    out.push_str(&format!(
+        "\nlast {shown} of the {} kept verbatim (the rest are in the counts above):\n",
+        examples.len()
+    ));
+    for line in examples.iter().skip(examples.len() - shown) {
+        out.push_str("  ");
+        out.push_str(line);
+        out.push('\n');
+    }
+    out
 }
 
 fn pool(e: &DebugEngine, args: PoolOp) -> Result<String, String> {
@@ -888,30 +895,52 @@ fn render_chunk(address: u64, found: &query::PoolNeighbourhood) -> String {
     out
 }
 
-/// Selects the diagnostics matching `filter` (case-insensitive substring), verbatim.
-fn select_diagnostics<'a>(lines: &'a [String], filter: Option<&str>) -> Vec<&'a String> {
+/// Whether `text` contains `needle`, case-insensitively; every text matches no needle.
+fn matches_filter(text: &str, needle: Option<&str>) -> bool {
+    needle.is_none_or(|needle| text.to_ascii_lowercase().contains(needle))
+}
+
+/// Selects the messages the walk kept verbatim that match `filter`.
+fn select_examples<'a>(diagnostics: &'a PoolDiagnostics, filter: Option<&str>) -> Vec<&'a String> {
     let needle = filter.map(str::to_ascii_lowercase);
-    lines
+    diagnostics
+        .examples()
         .iter()
-        .filter(|line| {
-            needle
-                .as_ref()
-                .is_none_or(|needle| line.to_ascii_lowercase().contains(needle.as_str()))
-        })
+        .filter(|line| matches_filter(line, needle.as_deref()))
         .collect()
 }
 
+/// Selects the categories whose shape matches `filter`, commonest first.
+fn select_categories<'a>(
+    diagnostics: &'a PoolDiagnostics,
+    filter: Option<&str>,
+) -> Vec<&'a DiagnosticShape> {
+    let needle = filter.map(str::to_ascii_lowercase);
+    diagnostic_categories(diagnostics)
+        .into_iter()
+        .filter(|category| matches_filter(&category.shape, needle.as_deref()))
+        .collect()
+}
+
+/// Lists the walk's complaints: the verbatim ones it kept, then what the counts say.
+///
+/// Both halves are needed and neither substitutes for the other. The walk keeps only a
+/// handful of messages per category, so the verbatim list is where a concrete address can be
+/// found and is *not* where volume can be read; the categories carry the real totals and have
+/// had their addresses generalised away. Printing only the first would answer "how many of
+/// these were there?" with the size of a sample.
 fn render_diagnostics(
     report: &query::PoolSnapshotReport,
     filter: Option<&str>,
     limit: usize,
 ) -> String {
-    let matching = select_diagnostics(&report.diagnostics, filter);
+    let examples = select_examples(&report.diagnostics, filter);
+    let categories = select_categories(&report.diagnostics, filter);
     let scope = match filter {
         Some(filter) => format!(" matching \"{filter}\""),
         None => String::new(),
     };
-    if matching.is_empty() {
+    if examples.is_empty() && categories.is_empty() {
         return format!(
             "No diagnostics{scope}.\n\nThe walk was {}. It emitted {} diagnostic(s) in total over {} \
              chunk(s) ({} allocated). If you expected a match, check the spelling — the \
@@ -921,26 +950,54 @@ fn render_diagnostics(
             } else {
                 "INCOMPLETE"
             },
-            report.diagnostics.len(),
+            report.diagnostics.emitted(),
             report.total_chunks,
             report.allocated_chunks
         );
     }
     let mut out = format!(
-        "{} of {} diagnostic(s){scope}:\n\n",
-        matching.len(),
-        report.diagnostics.len()
+        "The walk emitted {} diagnostic(s) in {}.\n\n",
+        report.diagnostics.emitted(),
+        categories_phrase(report.diagnostics.shapes().len())
     );
-    for line in matching.iter().take(limit) {
-        out.push_str("  ");
-        out.push_str(line);
-        out.push('\n');
-    }
-    if matching.len() > limit {
+    if !examples.is_empty() {
         out.push_str(&format!(
-            "\n... {} more match; raise `limit` to see them.\n",
-            matching.len() - limit
+            "{} of {} kept verbatim{scope} (the walk keeps a few per category, so this is a \
+             sample — the counts below are the volume):\n\n",
+            examples.len(),
+            report.diagnostics.examples().len()
         ));
+        for line in examples.iter().take(limit) {
+            out.push_str("  ");
+            out.push_str(line);
+            out.push('\n');
+        }
+        if examples.len() > limit {
+            out.push_str(&format!(
+                "\n... {} more match; raise `limit` to see them.\n",
+                examples.len() - limit
+            ));
+        }
+    }
+    if !categories.is_empty() {
+        out.push_str(&format!(
+            "\n{}{scope}, commonest first — the count is every message of that shape, not just \
+             the ones kept above:\n\n",
+            categories_phrase(categories.len())
+        ));
+        for category in categories.iter().take(limit) {
+            out.push_str(&format!(
+                "  {:>7}x  {}\n",
+                category.total,
+                category.shape.trim()
+            ));
+        }
+        if categories.len() > limit {
+            out.push_str(&format!(
+                "\n... {} more; raise `limit` to see them.\n",
+                categories_phrase(categories.len() - limit)
+            ));
+        }
     }
     // "2 of 2 diagnostics" is an exact-looking claim about a walk that may have stopped before
     // whole heaps. The empty branch above already says which; a nonempty one owes the same.
@@ -1126,61 +1183,6 @@ mod tests {
 
     // ---- pool walk diagnostics ------------------------------------------------------
 
-    /// Addresses vary per boot and per heap; the *kind* of failure is what a reader needs.
-    #[test]
-    fn diagnostic_categories_collapse_addresses() {
-        assert_eq!(
-            diagnostic_category("unreadable VS free tree node 0xbb3b57d239731c20: sparse"),
-            "unreadable VS free tree node <addr> sparse"
-        );
-        assert_eq!(
-            diagnostic_category("rejecting descriptor 19 at 0xffff8c8f0de00260 with bad sig"),
-            "rejecting descriptor 19 at <addr> with bad sig"
-        );
-    }
-
-    /// Short numbers are meaningful ("depth is 16") and must survive, or lines that differ
-    /// in a real way would be merged into one category.
-    #[test]
-    fn short_numbers_are_not_treated_as_addresses() {
-        assert_eq!(
-            diagnostic_category("VS list depth is 16, but only 1 entries were readable"),
-            "VS list depth is 16, but only 1 entries were readable"
-        );
-    }
-
-    #[test]
-    fn diagnostics_group_by_category_commonest_first() {
-        let lines = vec![
-            "unreadable VS free tree node 0xaaaaaaaaaaaaaaaa: sparse".to_string(),
-            "unreadable VS free tree node 0xbbbbbbbbbbbbbbbb: sparse".to_string(),
-            "unreadable VS free tree node 0xcccccccccccccccc: sparse".to_string(),
-            "per-session paged heaps are not included".to_string(),
-        ];
-        let grouped = summarize_diagnostics(&lines);
-        assert_eq!(grouped.len(), 2);
-        assert_eq!(grouped[0].1, 3);
-        assert!(grouped[0].0.contains("<addr>"));
-        assert_eq!(grouped[1].1, 1);
-    }
-
-    #[test]
-    fn diagnostics_filter_is_a_case_insensitive_substring() {
-        let lines = vec![
-            "cannot fully discover heap 0xffff8c8f0d300000: read failed".to_string(),
-            "LFH slot 0xffffb28ac16fcf30+0xe0 would cross a page".to_string(),
-            "rejecting page segment 0xdeadbeef with invalid signature".to_string(),
-        ];
-        // The whole point: find the one line about a specific heap among the noise.
-        let hits = select_diagnostics(&lines, Some("FFFF8C8F0D300000"));
-        assert_eq!(hits.len(), 1);
-        assert!(hits[0].starts_with("cannot fully discover heap"));
-
-        assert_eq!(select_diagnostics(&lines, Some("cross a page")).len(), 1);
-        assert_eq!(select_diagnostics(&lines, None).len(), 3);
-        assert!(select_diagnostics(&lines, Some("no such text")).is_empty());
-    }
-
     fn report_with(complete: bool, diagnostics: &[&str]) -> query::PoolSnapshotReport {
         query::PoolSnapshotReport {
             total_chunks: 4211,
@@ -1188,6 +1190,126 @@ mod tests {
             complete,
             diagnostics: diagnostics.iter().map(|line| line.to_string()).collect(),
         }
+    }
+
+    /// A flood of one complaint plus one of another — a live walk in miniature. The flood is
+    /// deliberately larger than the walk's verbatim cap, which is the whole difficulty.
+    fn flooded_report() -> query::PoolSnapshotReport {
+        let mut lines: Vec<String> = (0..500)
+            .map(|node| format!("unreadable VS free tree node {node:#018x}: sparse"))
+            .collect();
+        lines.push("per-session paged heaps are not included".to_string());
+        query::PoolSnapshotReport {
+            total_chunks: 4211,
+            allocated_chunks: 3007,
+            complete: false,
+            diagnostics: lines.into_iter().collect(),
+        }
+    }
+
+    #[test]
+    fn diagnostics_group_by_category_commonest_first() {
+        let report = report_with(
+            true,
+            &[
+                "unreadable VS free tree node 0xaaaaaaaaaaaaaaaa: sparse",
+                "unreadable VS free tree node 0xbbbbbbbbbbbbbbbb: sparse",
+                "unreadable VS free tree node 0xcccccccccccccccc: sparse",
+                "per-session paged heaps are not included",
+            ],
+        );
+        let categories = diagnostic_categories(&report.diagnostics);
+        assert_eq!(categories.len(), 2);
+        assert_eq!(categories[0].total, 3);
+        assert!(
+            categories[0]
+                .shape
+                .starts_with("unreadable VS free tree node")
+        );
+        assert_eq!(categories[1].total, 1);
+    }
+
+    /// The count in the header is the walk's, not the length of the sample the walk kept.
+    ///
+    /// Measured on a live 26100 kernel this read "71 diagnostic(s)" for a walk that made
+    /// ~7,700 complaints, because the number came from counting the surviving lines. It
+    /// describes the collapsing and reads as a fact about the pool (glslang/windbg-mcp#77).
+    #[test]
+    fn the_walk_report_counts_what_the_walk_emitted() {
+        let report = flooded_report();
+        let kept = report.diagnostics.examples().len();
+        assert!(
+            kept < 501,
+            "the fixture must exercise the cap, or it proves nothing: {kept} kept"
+        );
+
+        let rendered = render_walk_report(&report);
+        assert!(
+            rendered.contains("501 diagnostic(s) in 2 categories"),
+            "{rendered}"
+        );
+        assert!(
+            !rendered.contains(&format!("{kept} diagnostic(s)")),
+            "the sample size must not be presented as the walk's count: {rendered}"
+        );
+    }
+
+    /// Every category's count is the true one, and no count is hidden behind a placeholder —
+    /// the two remaining faults from the same cause. Before, the collapse summaries arrived
+    /// as ordinary lines, so they were re-grouped into categories of their own and their
+    /// counts blanked by this side's address-masking (`and 492 more` → `and <addr> more`).
+    #[test]
+    fn categories_are_findings_not_collapse_summaries() {
+        let rendered = render_walk_report(&flooded_report());
+        assert!(rendered.contains("500x"), "{rendered}");
+        assert!(
+            !rendered.contains("more like"),
+            "a collapse summary must not appear as a category: {rendered}"
+        );
+        assert!(
+            !rendered.contains("<addr>"),
+            "nothing may mask a count: {rendered}"
+        );
+    }
+
+    #[test]
+    fn diagnostics_filter_is_a_case_insensitive_substring() {
+        let report = report_with(
+            true,
+            &[
+                "cannot fully discover heap 0xffff8c8f0d300000: read failed",
+                "LFH slot 0xffffb28ac16fcf30+0xe0 would cross a page",
+                "rejecting page segment 0xdeadbeef with invalid signature",
+            ],
+        );
+        // The whole point: find the one line about a specific heap among the noise.
+        let hits = select_examples(&report.diagnostics, Some("FFFF8C8F0D300000"));
+        assert_eq!(hits.len(), 1);
+        assert!(hits[0].starts_with("cannot fully discover heap"));
+
+        assert_eq!(
+            select_examples(&report.diagnostics, Some("cross a page")).len(),
+            1
+        );
+        assert_eq!(select_examples(&report.diagnostics, None).len(), 3);
+        assert!(select_examples(&report.diagnostics, Some("no such text")).is_empty());
+    }
+
+    /// An address only ever appears in a kept message — the categories have had theirs
+    /// generalised away — so a filter that finds one must still not leave the reader
+    /// believing the sample is the volume.
+    #[test]
+    fn a_filtered_listing_reports_the_walk_not_the_sample() {
+        let report = flooded_report();
+        let rendered = render_diagnostics(&report, Some("free tree node"), 10);
+        assert!(
+            rendered.contains("501 diagnostic(s)"),
+            "the walk's own count is missing: {rendered}"
+        );
+        assert!(
+            rendered.contains("500x"),
+            "the matching category owes its true total: {rendered}"
+        );
     }
 
     fn report(complete: bool) -> query::PoolSnapshotReport {

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -945,6 +945,11 @@ fn split_row_budget(limit: usize, examples: usize, categories: usize) -> (usize,
 /// found and is *not* where volume can be read; the categories carry the real totals and have
 /// had their addresses generalised away. Printing only the first would answer "how many of
 /// these were there?" with the size of a sample.
+///
+/// That trade has a sharp edge, and it is the reason for the note in the examples branch: the
+/// two halves are filtered independently and an address can only ever match the first, so a
+/// filter that finds its heap gets no counts at all — and must be told that rather than
+/// pointed at a volume the response does not contain.
 fn render_diagnostics(
     report: &query::PoolSnapshotReport,
     filter: Option<&str>,
@@ -979,8 +984,8 @@ fn render_diagnostics(
     let (example_rows, category_rows) = split_row_budget(limit, examples.len(), categories.len());
     if !examples.is_empty() {
         out.push_str(&format!(
-            "{} of {} kept verbatim{scope} (the walk keeps a few per category, so this is a \
-             sample — the counts below are the volume):\n\n",
+            "{} of {} kept verbatim{scope} (the walk keeps only a few per category, so this is \
+             a sample):\n\n",
             examples.len(),
             report.diagnostics.examples().len()
         ));
@@ -995,11 +1000,25 @@ fn render_diagnostics(
                 examples.len() - example_rows
             ));
         }
+        // A filter naming a concrete value is the documented case — "an address
+        // (ffff8c8f0d300000)" — and it is exactly the one that cannot match a category, because
+        // generalising those values away is what lets a category carry a count. Promising the
+        // volume anyway would repeat #77's mistake in the header: pointing at a number that is
+        // not there, and leaving a capped sample as the only figure on the page.
+        if categories.is_empty() && filter.is_some() {
+            out.push_str(&format!(
+                "\nNo category matches{scope}, so there is no volume to report for it. A \
+                 category is the message with its numbers generalised away, which is what lets \
+                 it carry a count — so a filter naming a concrete value can only ever match the \
+                 verbatim sample above. Filter on the wording instead, or drop the filter, to \
+                 see how often this kind of complaint occurred.\n"
+            ));
+        }
     }
     if !categories.is_empty() {
         out.push_str(&format!(
             "\n{}{scope}, commonest first — the count is every message of that shape, not just \
-             the ones kept above:\n\n",
+             the ones kept verbatim:\n\n",
             categories_phrase(categories.len())
         ));
         for category in categories.iter().take(category_rows) {
@@ -1380,6 +1399,46 @@ mod tests {
 
         // Nothing is truncated when both halves already fit.
         assert_eq!(split_row_budget(60, 5, 3), (5, 3));
+    }
+
+    /// Filtering by a concrete address — the tool's own documented example — can match a kept
+    /// message but never a category, because generalising numbers away is exactly what lets a
+    /// category carry a count. So this is the one shape of request that legitimately has no
+    /// volume to report, and it must say so rather than promise one: a header pointing at
+    /// counts that were never rendered leaves a capped sample as the only figure on the page,
+    /// which is #77's mistake moved into the prose.
+    #[test]
+    fn an_address_filter_admits_it_has_no_volume_to_report() {
+        let report = report_with(
+            true,
+            &[
+                "cannot fully discover heap 0xffff8c8f0d300000: read failed",
+                "LFH slot 0xffffb28ac16fcf30+0xe0 would cross a page",
+            ],
+        );
+        let rendered = render_diagnostics(&report, Some("ffff8c8f0d300000"), 10);
+        assert!(
+            rendered.contains("cannot fully discover heap"),
+            "{rendered}"
+        );
+        assert!(
+            rendered.contains("No category matches"),
+            "an example-only match must say the volume is missing: {rendered}"
+        );
+        // And it must point somewhere: "no counts" without a way to get them is a dead end.
+        assert!(
+            rendered.contains("Filter on the wording instead"),
+            "{rendered}"
+        );
+
+        // The wording filter is the one that *can* answer it, and must not carry the note.
+        let rendered = render_diagnostics(&report, Some("discover heap"), 10);
+        assert!(rendered.contains("1 category"), "{rendered}");
+        assert!(!rendered.contains("No category matches"), "{rendered}");
+
+        // Nor may an unfiltered listing, which has every category by definition.
+        let rendered = render_diagnostics(&report, None, 10);
+        assert!(!rendered.contains("No category matches"), "{rendered}");
     }
 
     /// An address only ever appears in a kept message — the categories have had theirs

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -922,6 +922,22 @@ fn select_categories<'a>(
         .collect()
 }
 
+/// Splits `limit` rows between the two halves of a diagnostics listing.
+///
+/// `limit` bounds the whole reply — the worker builds it as one `String` before it crosses the
+/// pipe — so the two sections share one budget rather than each taking it in full.
+///
+/// Spending it in print order would be simpler and is wrong: a flood of examples would take
+/// the lot and drop the category counts entirely, which is the very number this listing exists
+/// to report. So each half is offered half the budget and hands back what it does not need.
+/// Every shape contributes at least one example, so the categories are never the more numerous
+/// half — in practice this means "the categories in full, the examples take the rest", and the
+/// even split only bites on a target with an unusual number of distinct complaints.
+fn split_row_budget(limit: usize, examples: usize, categories: usize) -> (usize, usize) {
+    let for_examples = examples.min((limit / 2).max(limit.saturating_sub(categories)));
+    (for_examples, categories.min(limit - for_examples))
+}
+
 /// Lists the walk's complaints: the verbatim ones it kept, then what the counts say.
 ///
 /// Both halves are needed and neither substitutes for the other. The walk keeps only a
@@ -960,6 +976,7 @@ fn render_diagnostics(
         report.diagnostics.emitted(),
         categories_phrase(report.diagnostics.shapes().len())
     );
+    let (example_rows, category_rows) = split_row_budget(limit, examples.len(), categories.len());
     if !examples.is_empty() {
         out.push_str(&format!(
             "{} of {} kept verbatim{scope} (the walk keeps a few per category, so this is a \
@@ -967,15 +984,15 @@ fn render_diagnostics(
             examples.len(),
             report.diagnostics.examples().len()
         ));
-        for line in examples.iter().take(limit) {
+        for line in examples.iter().take(example_rows) {
             out.push_str("  ");
             out.push_str(line);
             out.push('\n');
         }
-        if examples.len() > limit {
+        if examples.len() > example_rows {
             out.push_str(&format!(
                 "\n... {} more match; raise `limit` to see them.\n",
-                examples.len() - limit
+                examples.len() - example_rows
             ));
         }
     }
@@ -985,17 +1002,17 @@ fn render_diagnostics(
              the ones kept above:\n\n",
             categories_phrase(categories.len())
         ));
-        for category in categories.iter().take(limit) {
+        for category in categories.iter().take(category_rows) {
             out.push_str(&format!(
                 "  {:>7}x  {}\n",
                 category.total,
                 category.shape.trim()
             ));
         }
-        if categories.len() > limit {
+        if categories.len() > category_rows {
             out.push_str(&format!(
                 "\n... {} more; raise `limit` to see them.\n",
-                categories_phrase(categories.len() - limit)
+                categories_phrase(categories.len() - category_rows)
             ));
         }
     }
@@ -1293,6 +1310,76 @@ mod tests {
         );
         assert_eq!(select_examples(&report.diagnostics, None).len(), 3);
         assert!(select_examples(&report.diagnostics, Some("no such text")).is_empty());
+    }
+
+    /// A report with far more of both halves than any budget will print.
+    ///
+    /// The shapes are told apart by *wording*, not by a number: the walk generalises every
+    /// number-bearing token, so `complaint 1` and `complaint 2` would be one shape and the
+    /// fixture would quietly collapse to a single category.
+    fn crowded_report() -> query::PoolSnapshotReport {
+        let lines: Vec<String> = ('a'..='i')
+            .flat_map(|first| ('a'..='j').map(move |second| format!("{first}{second}")))
+            .flat_map(|kind| {
+                (0..20).map(move |node| format!("cannot read {kind} at node {node:#018x}"))
+            })
+            .collect();
+        query::PoolSnapshotReport {
+            total_chunks: 4211,
+            allocated_chunks: 3007,
+            complete: true,
+            diagnostics: lines.into_iter().collect(),
+        }
+    }
+
+    /// Counts the rendered diagnostic rows — verbatim messages and category counts alike.
+    fn rendered_rows(rendered: &str) -> usize {
+        rendered
+            .lines()
+            .filter(|line| line.starts_with("  ") && !line.trim().is_empty())
+            .count()
+    }
+
+    /// `limit` bounds the whole reply, not each section of it.
+    ///
+    /// The worker builds the reply as one `String` before it crosses the pipe, which is why
+    /// `MAX_POOL_ROWS` exists at all — an unbounded listing is a request to allocate a
+    /// snapshot-sized buffer, and a worker killed mid-session costs the caller the session.
+    /// Two sections that each restart the budget quietly double the ceiling the clamp was
+    /// chosen to enforce.
+    #[test]
+    fn the_row_limit_bounds_the_whole_listing() {
+        let report = crowded_report();
+        for limit in [1, 7, 60, 200] {
+            let rendered = render_diagnostics(&report, None, limit);
+            let rows = rendered_rows(&rendered);
+            assert!(
+                rows <= limit,
+                "limit {limit} produced {rows} rows:\n{rendered}"
+            );
+        }
+
+        // And it must still spend the budget rather than hoard it: a listing that prints two
+        // rows under a limit of 60 satisfies the bound above and is useless.
+        let rendered = render_diagnostics(&report, None, 60);
+        assert_eq!(rendered_rows(&rendered), 60, "{rendered}");
+    }
+
+    /// Neither half may be squeezed out by the other. The categories carry the counts, so a
+    /// flood of verbatim examples taking the whole budget would reintroduce #77 one level up:
+    /// a listing whose only visible numbers describe the sample.
+    #[test]
+    fn both_halves_of_the_listing_get_a_share() {
+        let (examples, categories) = split_row_budget(60, 900, 90);
+        assert!(examples > 0 && categories > 0, "{examples}, {categories}");
+        assert_eq!(examples + categories, 60);
+
+        // The common shape: few categories, many examples. The categories fit whole and the
+        // examples take everything left, rather than each half being held to half.
+        assert_eq!(split_row_budget(60, 71, 24), (36, 24));
+
+        // Nothing is truncated when both halves already fit.
+        assert_eq!(split_row_budget(60, 5, 3), (5, 3));
     }
 
     /// An address only ever appears in a kept message — the categories have had theirs

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -2365,6 +2365,88 @@ fn a_census_table_yields_its_heaviest_tag() {
     ));
 }
 
+/// The walk's stated diagnostic total, and the per-category counts printed beneath it.
+fn diagnostic_counts(report: &str) -> Option<(usize, Vec<usize>)> {
+    let total = report.lines().find_map(|line| {
+        let (count, _) = line.split_once(" diagnostic(s) in ")?;
+        count.trim().parse::<usize>().ok()
+    })?;
+    let categories = report
+        .lines()
+        .filter_map(|line| {
+            let trimmed = line.trim_start();
+            let digits: String = trimmed.chars().take_while(|c| c.is_ascii_digit()).collect();
+            // `x` and two spaces, or a `0x1f40` in some other table would read as a category.
+            (!digits.is_empty() && trimmed[digits.len()..].starts_with("x  "))
+                .then(|| digits.parse().ok())
+                .flatten()
+        })
+        .collect();
+    Some((total, categories))
+}
+
+/// A walk's diagnostic total has to account for the categories printed beneath it.
+///
+/// The arithmetic is trivial — a sum is at least the part of it you can see — and it is exactly
+/// what broke. The total used to be the number of *lines that survived* the walk's collapsing, so
+/// a real run printed "71 diagnostic(s)" above a category reading "5621x" (#77): a statement about
+/// this code's own truncation, rendered as a measurement of the target. Fixtures cannot catch it
+/// because nothing collapses until a category floods, so this live tier is the only place the two
+/// numbers are ever far enough apart to disagree.
+fn assert_diagnostic_total_covers_its_categories(report: &str) {
+    if report.contains("the walk reported no diagnostics.") {
+        return;
+    }
+    let (total, categories) = diagnostic_counts(report)
+        .unwrap_or_else(|| panic!("no diagnostic summary to check in:\n{report}"));
+    assert!(
+        !categories.is_empty(),
+        "a diagnostic total with no categories under it means this parser stopped matching, and \
+         a check that silently matches nothing is not a check:\n{report}"
+    );
+    let listed: usize = categories.iter().sum();
+    assert!(
+        total >= listed,
+        "the walk reported {total} diagnostic(s) but the categories under it account for {listed} \
+         — so the total is counting something other than the messages the walk emitted, and a \
+         reader takes it for a property of the target (#77):\n{report}"
+    );
+}
+
+/// Pinned in the default tier for the same reason as the census parser above: the live check it
+/// feeds is the *only* one that can see this fault, so a parser that quietly stops matching would
+/// take the proof with it and leave the live run passing.
+#[test]
+fn a_walk_report_yields_its_diagnostic_counts() {
+    let report = "--- pool walk ---\nchunks walked: 413279 (234110 allocated), coverage: \
+                  INCOMPLETE - the walk did not reach everything it set out to\n\
+                  7731 diagnostic(s) in 24 categories:\n\
+                  \x205621x  rejecting implausible LFH metadata at #\n\
+                  \x201770x  cannot read LFH subsegment # sparse virtual range at #\n\
+                  \nlast 12 of the 71 kept verbatim (the rest are in the counts above):\n\
+                  \x20 rejecting implausible LFH metadata at 0xffff8c8f0de00260\n";
+
+    let (total, categories) = diagnostic_counts(report).expect("the summary is right there");
+    assert_eq!(total, 7731);
+    assert_eq!(categories, vec![5621, 1770]);
+    // The verbatim example carries an address, not a count, and must not be read as a category.
+    assert_diagnostic_total_covers_its_categories(report);
+
+    // The shape of the bug: a total that counted surviving lines instead of messages.
+    let understated = report.replace("7731 diagnostic(s)", "71 diagnostic(s)");
+    assert!(
+        std::panic::catch_unwind(|| assert_diagnostic_total_covers_its_categories(&understated))
+            .is_err(),
+        "the check has to reject the very output that motivated it"
+    );
+
+    // A quiet walk has nothing to reconcile, and must not be made to fail for it.
+    assert_diagnostic_total_covers_its_categories(
+        "--- pool walk ---\nchunks walked: 5 (4 allocated), coverage: complete\n\
+         the walk reported no diagnostics.\n",
+    );
+}
+
 /// A pool walk over a live kernel: the query that used to take the session with it.
 ///
 /// This is the tier the budget in glslang/win-kexp#88 was written for, and the only one that can
@@ -2556,6 +2638,7 @@ fn a_live_kernel_pool_walk_is_bounded_and_leaves_its_session_usable() {
                 .collect::<Vec<_>>()
                 .join("\n");
             println!("why the walk fell short:\n{report}");
+            assert_diagnostic_total_covers_its_categories(&report);
         }
 
         match heaviest_census_tag(&census) {


### PR DESCRIPTION
Closes #77. **Draft — blocked on glslang/win-kexp#91**, which has to merge before this can
build. The `Cargo.lock` repin is the one commit still missing.

## The problem

`append_walk_report` printed `report.diagnostics.len()`. win-kexp collapsed floods of
near-identical complaints *before* handing the list over, so that length counted the lines
that survived collapsing rather than the messages the walk emitted. Against Server 26100
over KDNET:

```text
71 diagnostic(s) in 24 categories:
        8x  cannot read LFH subsegment <addr> sparse virtual range at <addr> (valid <addr>
        ...
        1x  ... and <addr> more like `rejecting implausible LFH metadata at #`
```

The real number was in the tail — `and 5621 more`, `and 1770 more` — so that walk made on
the order of **7,700** complaints. "71 diagnostic(s)" reads as a measurement of the target
and is an artifact of our own processing.

Two more faults, same cause:

- The collapse summaries arrived as ordinary lines, so `summarize_diagnostics` re-grouped
  them into categories of their own, competing with real findings for the 25 printed slots.
- `diagnostic_category` blanked their numbers, so `and 5621 more` became
  `and <addr> more` — destroying the very number that made the line worth keeping.

## The change

Upstream now hands the grouping over as data instead of prose (win-kexp#91), so:

- the header count is `PoolDiagnostics::emitted()` — what the walk said;
- the table rows are the walk's own per-category totals, uncollapsed and unmasked;
- the verbatim tail says it is a **sample** ("last 9 of the 9 kept verbatim"), because it is.

`diagnostic_category` and `summarize_diagnostics` are deleted. Re-deriving categories on
this side is what made the counts unrecoverable in the first place, and a second, subtly
different shaping of the same messages had no reader once the walk's own was available.

**One deliberate behaviour change:** the categories are coarser. win-kexp generalises every
number-bearing token, where this side kept short ones, so `depth is 16` and `depth is 32`
now share a category. The concrete values remain in the verbatim examples — and having the
grouping that decides *what gets collapsed* differ from the grouping that gets *displayed*
is exactly what made the counts untrustworthy.

`pool_diagnostics` now prints both halves explicitly, since neither substitutes for the
other — the kept messages are where a concrete address is found and say nothing about
volume; the categories carry the real totals and have had their addresses generalised away:

```text
The walk emitted 501 diagnostic(s) in 2 categories.

8 of 9 kept verbatim matching "free tree node" (the walk keeps a few per category, so this
is a sample — the counts below are the volume):

  unreadable VS free tree node 0x0000000000000000: sparse
  ...

1 category matching "free tree node", commonest first — the count is every message of that
shape, not just the ones kept above:

      500x  unreadable VS free tree node # sparse
```

## Verification

`render_walk_report` is split out of `append_walk_report` so the counts are testable without
an engine. Three unit tests cover the three faults, and two were checked by mutation:

- reverting the header to `examples().len()` (the bug) fails
  `the_walk_report_counts_what_the_walk_emitted`;
- switching the verbatim tail from `examples()` to `lines()` — a plausible edit, since
  `lines()` looks like the fuller list — fails `categories_are_findings_not_collapse_summaries`
  on the reappearance of `more like`.

`cargo test` — 118 + 21 pass. `cargo clippy --all-targets` clean.

The live tier gains the one cross-check no fixture can make: **a walk's stated total has to
account for the categories printed beneath it.** Nothing collapses until a category floods,
so only a real target puts the two numbers far enough apart to disagree — this check would
have failed on the run in #77. Its parser is pinned by a default-tier test, because a check
that silently stops matching is not a check.

## Not fixed here

win-kexp#90 — the ~5.6k LFH subsegments rejected as implausible after a successful header
read. This PR makes that number legible; it does not explain it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pool-walk diagnostic reporting so totals reflect all diagnostics, while displayed examples remain capped and sampled by category.
  * Improved diagnostic filtering across both retained examples and diagnostic categories.
  * Added clearer handling and validation for incomplete walks and zero-diagnostic reports.

* **Documentation**
  * Updated smoke-test guidance to explain diagnostic sampling and complete diagnostic totals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->