### PR TITLE
chore(deps): repin win-kexp to the corrected page-range flags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -884,7 +884,7 @@ dependencies = [
 [[package]]
 name = "win-kexp"
 version = "0.1.0"
-source = "git+https://github.com/glslang/win-kexp?branch=main#0b617c676f5e1cd875c0455f058d494a3fd4f112"
+source = "git+https://github.com/glslang/win-kexp?branch=main#ae958fbe33f2076322b148239f5ddfffe8032db3"
 dependencies = [
  "byte-strings",
  "goblin",


### PR DESCRIPTION
Repins `win-kexp` to `ae958fb` (glslang/win-kexp#92, which closed glslang/win-kexp#90).
Lock bump only — no code changes here.

## What it fixes, seen from this side

`_HEAP_PAGE_RANGE_DESCRIPTOR.RangeFlags` bit `0x01` means *the range is in use*, and the
allocator sets it on every unit of every allocated range. win-kexp had been reading it as
"this is an LFH subsegment", so VS subsegments, plain page-range and large allocations, and
Verifier special pool were all parsed as LFH subsegment headers, refused, and dropped **at
region creation** — before the walk could index anything inside them.

The consequence for the tools in this repo is the one thing they are built not to do:
`pool_find_tag`, `pool_census` and `pool_chunk` were answering from a snapshot that silently
omitted a fifth of the pool, with nothing in the output to say so.

## Measured over KDNET against Server 26100

Live-kernel smoke tier, before and after the dependency:

| | before | after | |
|---|---|---|---|
| chunks walked | 437,732 | **530,680** | +92,948 (+21%) |
| allocated | 244,874 | **306,227** | +61,353 (+25%) |
| `rejecting implausible LFH metadata` | 5,532 | **0** | gone |
| `cannot read LFH subsegment … sparse` | 1,970 | **15** | −99% |
| diagnostics | 7,856 in 9 categories | 5,324 in 11 | −32% |
| walk time | 23.7s | 52.3s | 2.2× |

Different boots, so the totals are not strictly comparable — but 5,532 → 0 is categorical.

A walk now costs 52.3s of its 120s `DEFAULT_WALK_BUDGET` because it decodes the regions it
used to discard. Headroom is 2.3× rather than 5×; still comfortable, worth knowing before
anything else lengthens the walk. Relevant to #75 (passing this server's real remaining
patience instead of the default).

## Verification

- `cargo test`: 121 unit + 21 smoke, all pass.
- `WINDBG_MCP_SMOKE_DUMP=1 cargo test --test mcp_smoke`: 21 pass in 22s, so the pool tools
  were exercised through a real DbgEng session, not just fixtures.
- Live-kernel tier (`live_kernel`, 3 tests): all pass, session detaches cleanly, target left
  running. That run is the measurement above.

## Known, upstream, not blocking

Two diagnostics grew because win-kexp#92 made code reachable that had never run against a
real kernel. Both are filed upstream and neither claims anything as absent — `complete` is
cleared and the spans are filed as `Unreadable`:

- glslang/win-kexp#93 — 884 `rejecting implausible VS chunk size`, the VS decoder's first
  live outing.
- glslang/win-kexp#94 — `valid-region query made no progress` 24 → 3,285, which abandons the
  rest of a region rather than skipping the page, and so may be capping the gain above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
