### PR TITLE
Resolve KDNET connections from a server-side profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`attach_kernel` can name its target by `profile`**, so a KDNET debug key never has to travel in
+  an MCP request ([#81](https://github.com/glslang/windbg-mcp/issues/81)).
+
+  A connection string carries the target's key, and a key passed as a tool argument does not stay in
+  the tool call: an MCP client keeps a transcript, and the one key handed over during the
+  MessageManager CTF session ended up replicated across 524 records of it — through messages, tool
+  calls, context snapshots and compaction summaries. That is what a transcript *is*, not a client
+  misbehaving, so the server had to offer a way for the secret never to enter the request at all.
+
+  `attach_kernel` now takes **exactly one** of `connection` (unchanged, still supported for a target
+  nothing is configured for) or `profile`, a non-secret name this process resolves from
+  `WINDBG_MCP_PROFILE_<NAME>` in its environment or from `%USERPROFILE%\.windbg-mcp\profiles.json`
+  (`WINDBG_MCP_PROFILES` overrides the path). Sources are re-read per attach, so adding a profile
+  does not mean restarting the client. Passing both, or neither, is a tool error naming the
+  alternative, and the "neither" case lists the profiles this host has — which is what lets an agent
+  find one instead of asking the user for a string it would then have to keep.
+
+  The exclusivity is enforced at runtime rather than in the schema: an untagged `oneOf` renders as a
+  schema composition clients handle unevenly, the same reason `session_id` is repeated per tool
+  struct rather than flattened. Both fields are therefore optional on the wire (`tools/list` golden
+  updated).
+
+### Changed
+
+- **Connection strings are redacted everywhere but the one call that dials them.** `key=` and
+  `password=` values are masked in session reports, errors and logs, whichever selector opened the
+  session: `session_status` now shows
+  `kernel target: profile "ctf-vm" (net:port=50000,key=<redacted>)`.
+
+  The guarantee is structural rather than a discipline. The value lives in a `kdconn::Connection`
+  whose `Debug` and `Display` are the redacted form, so a log line, a `{:?}` on `EngineOp`, or a
+  session label cannot carry the raw string; it is unwrapped at exactly one call site, handing it to
+  DbgEng inside the session's own worker process. Redaction masks *values inside connection strings*
+  only — debugger output is never rewritten, which on a CTF target would be its own kind of damage.
+
+  Errors on the profile path never echo a value either. A connection string typed into `profile` —
+  the one mistake that would defeat the whole feature — is refused by naming the shape a profile
+  name has, not by quoting back what it was handed.
+
 ## [0.5.0] - 2026-08-08
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   Errors on the profile path never echo a value either. A connection string typed into `profile` —
   the one mistake that would defeat the whole feature — is refused by naming the shape a profile
-  name has, not by quoting back what it was handed.
+  name has, not by quoting back what it was handed. The same applies to a *configured* name: an
+  entry whose name is not a name is skipped and located, never quoted, because the way that happens
+  is an entry written the wrong way round.
+
+- **An engine worker is spawned without the profile variables.** It is told the one connection it
+  is opening over its private pipe and resolves nothing itself, so `WINDBG_MCP_PROFILE_*` and
+  `WINDBG_MCP_PROFILES` are stripped from its environment — a `launch`ed debuggee inherits its
+  worker's environment, and a debuggee is exactly the untrusted program that must not receive every
+  configured kernel key.
 
 ## [0.5.0] - 2026-08-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,10 +21,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `attach_kernel` now takes **exactly one** of `connection` (unchanged, still supported for a target
   nothing is configured for) or `profile`, a non-secret name this process resolves from
   `WINDBG_MCP_PROFILE_<NAME>` in its environment or from `%USERPROFILE%\.windbg-mcp\profiles.json`
-  (`WINDBG_MCP_PROFILES` overrides the path). Sources are re-read per attach, so adding a profile
-  does not mean restarting the client. Passing both, or neither, is a tool error naming the
-  alternative, and the "neither" case lists the profiles this host has — which is what lets an agent
-  find one instead of asking the user for a string it would then have to keep.
+  (`WINDBG_MCP_PROFILES` overrides the path; environment-variable names are matched
+  case-insensitively, as Windows matches them). The **file** is re-read on every attach, so adding
+  a profile to it takes effect immediately — an environment variable is read from the server's own
+  environment at startup, so it belongs in the client's server definition and needs a restart to
+  change. Passing both selectors, or neither, is a tool error naming the alternative, and the
+  "neither" case lists the profiles this host has — which is what lets an agent find one instead of
+  asking the user for a string it would then have to keep.
 
   The exclusivity is enforced at runtime rather than in the schema: an untagged `oneOf` renders as a
   schema composition clients handle unevenly, the same reason `session_id` is repeated per tool
@@ -50,11 +53,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   entry whose name is not a name is skipped and located, never quoted, because the way that happens
   is an entry written the wrong way round.
 
-- **An engine worker is spawned without the profile variables.** It is told the one connection it
-  is opening over its private pipe and resolves nothing itself, so `WINDBG_MCP_PROFILE_*` and
-  `WINDBG_MCP_PROFILES` are stripped from its environment — a `launch`ed debuggee inherits its
-  worker's environment, and a debuggee is exactly the untrusted program that must not receive every
-  configured kernel key.
+- **Neither process this server creates inherits the profile variables.** An engine worker is told
+  the one connection it is opening over its private pipe and resolves nothing itself, and the TTD
+  recorder needs no connection at all — so `WINDBG_MCP_PROFILE_*` and `WINDBG_MCP_PROFILES` are
+  stripped from both. What each of them then launches is the reason: a `launch`ed debuggee inherits
+  its worker's environment, and `TTD.exe` hands its own to the recorded target. Those are precisely
+  the untrusted programs that must not receive every configured kernel key.
 
 ## [0.5.0] - 2026-08-08
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,8 @@ ourselves** — do not add third-party DbgEng crates).
 Re-executed with `--engine-worker` it owns exactly one debug session, because dbgeng.dll holds one
 debuggee session per process. Key source: `src/engine.rs` (the supervisor — session registry,
 worker supervision, routing), `src/worker.rs` (the child process and the engine thread inside it),
-`src/proto.rs` (the wire protocol between them), `src/server.rs` (the MCP tools), `src/ttd.rs`,
+`src/proto.rs` (the wire protocol between them), `src/server.rs` (the MCP tools),
+`src/kdconn.rs` (KDNET connection profiles and the redacting `Connection` type), `src/ttd.rs`,
 `src/main.rs` (role selection).
 
 Practical consequences when debugging this server: a stack trace or log line can come from either
@@ -118,6 +119,14 @@ cargo test --test mcp_smoke -- --ignored --nocapture --test-threads=1 live_kerne
 single-owner, so in parallel the second attach fails and can leave the target halted.
 
 ## Live kernel + driver IOCTL gotchas (learned driving HEVD over KDNET)
+
+**Attach by `profile`, not by connection string.** `attach_kernel { "profile": "<name>" }` resolves
+the connection inside the server (`src/kdconn.rs`), so the target's debug key never lands in a tool
+argument — and therefore never in the session transcript, where one key previously ended up
+replicated across hundreds of records. `attach_kernel {}` lists the profiles this host has.
+Configure one with `WINDBG_MCP_PROFILE_<NAME>` or `%USERPROFILE%\.windbg-mcp\profiles.json`; raw
+`connection` still works for a target nothing is configured for. The live smoke tier below keeps
+using `WINDBG_MCP_SMOKE_KERNEL` because that variable *is* the local configuration.
 
 **KDNET attach is a blocking wait, by design.** A live kernel needs `WaitForEvent(INFINITE)` (a finite
 timeout returns `E_NOTIMPL` and never drives the link). So if the target isn't reachable, the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,8 +125,15 @@ the connection inside the server (`src/kdconn.rs`), so the target's debug key ne
 argument — and therefore never in the session transcript, where one key previously ended up
 replicated across hundreds of records. `attach_kernel {}` lists the profiles this host has.
 Configure one with `WINDBG_MCP_PROFILE_<NAME>` or `%USERPROFILE%\.windbg-mcp\profiles.json`; raw
-`connection` still works for a target nothing is configured for. The live smoke tier below keeps
-using `WINDBG_MCP_SMOKE_KERNEL` because that variable *is* the local configuration.
+`connection` still works for a target nothing is configured for. Note the live smoke tier below is
+one of those: `WINDBG_MCP_SMOKE_KERNEL` is a raw connection string, passed straight to
+`attach_kernel { "connection": … }`, and is deliberately *not* a profile — the tier has to exercise
+the explicit path, and it is a variable in a developer's own shell rather than something a client
+ever sees.
+
+A worker process does **not** inherit `WINDBG_MCP_PROFILE_*` (`engine::spawn_worker` strips them):
+it is told the one connection it is opening over its private pipe, and a `launch`ed debuggee would
+otherwise inherit every configured key on the host.
 
 **KDNET attach is a blocking wait, by design.** A live kernel needs `WaitForEvent(INFINITE)` (a finite
 timeout returns `E_NOTIMPL` and never drives the link). So if the target isn't reachable, the

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -46,6 +46,21 @@ with a tool error naming the alternative. The "neither" error lists the profiles
 is the load-bearing part: an agent that cannot discover a profile name asks the user, the user
 answers with a connection string, and the key is in the transcript after all.
 
+**Where the resolved value is allowed to go.** Only into the op sent down one worker's private
+pipe. The worker is spawned *without* `WINDBG_MCP_PROFILE_*` in its environment
+(`engine::spawn_worker`), which matters for the process after it: `launch` runs an arbitrary binary
+under the debugger, that binary inherits its worker's environment, and a debuggee is the least
+trustworthy process this server ever creates. Resolution happens in the supervisor for a second
+reason too — a selector the caller must fix is refused before any worker is spawned, so a typo
+costs a message rather than a session to end.
+
+**Configured names are validated on the way in, not on the way out.** A name is *rendered* — in
+the profile list, in a session label, in a collision report — so a name that is not one never
+enters the map. The failure that motivates this is not exotic: an entry written the wrong way round
+makes the JSON key the connection string, and an unvalidated name would then print a key out of the
+error saying the entry is wrong. Rejections are located and counted, never quoted, for the same
+reason a mistyped `profile` argument is not echoed.
+
 **Status.** Implemented. Unit tests in `src/kdconn.rs` (fake values throughout); protocol-tier and
 debugger-tier smoke tests assert the fake key reaches neither the transport nor the log.
 

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -47,12 +47,14 @@ is the load-bearing part: an agent that cannot discover a profile name asks the 
 answers with a connection string, and the key is in the transcript after all.
 
 **Where the resolved value is allowed to go.** Only into the op sent down one worker's private
-pipe. The worker is spawned *without* `WINDBG_MCP_PROFILE_*` in its environment
-(`engine::spawn_worker`), which matters for the process after it: `launch` runs an arbitrary binary
-under the debugger, that binary inherits its worker's environment, and a debuggee is the least
-trustworthy process this server ever creates. Resolution happens in the supervisor for a second
-reason too — a selector the caller must fix is refused before any worker is spawned, so a typo
-costs a message rather than a session to end.
+pipe. Both processes this server creates are spawned *without* `WINDBG_MCP_PROFILE_*` in their
+environment — the engine worker (`engine::spawn_worker`) and the TTD recorder (`ttd::record_launch`)
+— and what matters is the process after each of them: `launch` runs an arbitrary binary under the
+debugger and `TTD.exe` launches the recorded target, both inheriting the environment they were
+given. Those are the least trustworthy processes in any of these workflows, and frequently the
+whole reason for the session. Resolution happens in the supervisor for a second reason too — a
+selector the caller must fix is refused before any worker is spawned, so a typo costs a message
+rather than a session to end.
 
 **Configured names are validated on the way in, not on the way out.** A name is *rendered* — in
 the profile list, in a session label, in a collision report — so a name that is not one never

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -5,6 +5,52 @@ status. Keep entries short; link to code with `file:line` where it helps a futur
 
 ---
 
+## The KDNET key is resolved server-side, and connection strings are a type (2026-08-09, issue #81)
+
+**Context.** `attach_kernel` took a raw DbgEng connection string, and a KDNET one carries the
+target's debug key. A tool argument is not a private channel: the client owns the transcript, and
+during the MessageManager CTF session the single key supplied was replicated into 524 records of it
+— messages, tool calls, context snapshots, compaction summaries. Nothing the client did was wrong;
+that is what keeping a conversation *means*. The server's fault was giving the client no way to
+avoid handling the secret in the first place.
+
+**Decision.** Two changes, and they answer different halves of the problem.
+
+- **Profiles.** `attach_kernel` takes exactly one of `connection` (unchanged) or `profile`, a name
+  resolved inside this process from `WINDBG_MCP_PROFILE_<NAME>` or a machine-local JSON file
+  (`src/kdconn.rs`). The name is not a secret, so it can be repeated through a transcript
+  indefinitely at no cost. This is the half that keeps the key out of the request.
+- **`Connection`, a string that cannot be printed.** Its `Debug` and `Display` render redacted, and
+  the raw value is reachable only through `expose()` — called once, in the worker, handing it to
+  DbgEng. This is the half that covers the string that *is* still supplied explicitly.
+
+**Why a type rather than "remember to redact".** The leak surfaces are not one place: a session
+label shown by `session_status` and by the "no room to open another" list, a tool error, a log line,
+and `EngineOp`'s derived `Debug` — which nothing prints today, and which the next person to debug
+the pipe protocol will reach for. A redaction helper called at each of those is correct until
+someone adds the fifth. Making the *value* unprintable moves the guarantee from a review checklist
+to the type system, at the cost of one `expose()` call whose name says what it does.
+
+**Why redaction is scoped to connection strings.** The obvious stronger move — filter every string
+leaving the server for `key=` — was rejected. This server's whole job is returning debugger output
+verbatim, and on a CTF target a flag can look like anything; a filter that rewrote `!reg` output or
+a memory dump would corrupt the answers people came for, silently and in the direction of "the tool
+is lying to me". So `redact` masks values in *connection strings*, at the points where a connection
+string is rendered, and nothing else.
+
+**Why exclusivity is a runtime check, not a schema `oneOf`.** An untagged enum renders as a schema
+composition, and clients handle those unevenly — the same reason each tool's arguments are a plain
+self-contained object with `session_id` repeated rather than flattened (`src/server.rs`, "Tool
+parameter types"). Both fields are optional on the wire and `kdconn::select` refuses both/neither
+with a tool error naming the alternative. The "neither" error lists the profiles the host has, which
+is the load-bearing part: an agent that cannot discover a profile name asks the user, the user
+answers with a connection string, and the key is in the transcript after all.
+
+**Status.** Implemented. Unit tests in `src/kdconn.rs` (fake values throughout); protocol-tier and
+debugger-tier smoke tests assert the fake key reaches neither the transport nor the log.
+
+---
+
 ## One process per debug session (2026-08-02, issue #61)
 
 **Context.** A live-kernel attach waits for its target with `WaitForEvent(INFINITE)` — a finite

--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ process. Two things follow, and they are why it is built this way:
   extension DLL that prints to the console writes to the worker's stdout, which is drained into the
   log and carries nothing else.
 - **`server.rs`** — the MCP tools (see below), built with `rmcp`'s `#[tool_router]`/`#[tool_handler]`.
+- **`kdconn.rs`** — kernel connection strings, the one tool argument that is a secret: profile
+  resolution, and the `Connection` type whose `Debug`/`Display` are redacted so a key can only be
+  unwrapped deliberately (see [Kernel connection profiles](#kernel-connection-profiles-keeping-the-kdnet-key-out-of-the-transcript)).
 - **`ttd.rs`** — locates `TTD.exe` and launches trace recording.
 - **`main.rs`** — role selection (supervisor or worker), tokio + stdio transport. **Logs go to
   stderr** (stdout is the JSON-RPC channel); workers inherit the supervisor's stderr, so everything
@@ -301,6 +304,52 @@ reach the target than a name list can enumerate, and the data model is extensibl
 guarantee, and it is enforced at the front of that session's queue, after everything queued ahead of
 it: checking on the caller's side would leave a window in which an `execute { ".opendump …" }`
 already queued ahead retires the handle between a caller's check and its call.
+
+### Kernel connection profiles (keeping the KDNET key out of the transcript)
+
+A KDNET connection string carries the target's debug key — `net:port=50000,key=<w.x.y.z>` — and that
+key is all anyone on the same network needs to take the debug link. Passing it as a tool argument
+puts it somewhere this server does not control: an MCP client keeps a transcript, and a key handed
+over once is then copied into messages, tool calls, context snapshots and compaction summaries. That
+is what a transcript *is*, not a client misbehaving, so the fix is that the secret never enters the
+request.
+
+`attach_kernel` therefore takes **exactly one** of two selectors:
+
+```jsonc
+{ "profile": "ctf-vm" }                          // resolved on this host; no key in the request
+{ "connection": "net:port=50000,key=1.2.3.4" }   // the raw string, still supported
+```
+
+Configure a profile either way — the environment is checked first, then the file:
+
+```pwsh
+# Per profile, in the environment the MCP server is launched with. The variable's own suffix is
+# the profile name, lowercased: this defines `ctf_vm`, and `ctf-vm` finds it too.
+$env:WINDBG_MCP_PROFILE_CTF_VM = "net:port=50000,key=1.2.3.4"
+```
+
+```jsonc
+// %USERPROFILE%\.windbg-mcp\profiles.json  (override the path with WINDBG_MCP_PROFILES)
+{
+  "ctf-vm": "net:port=50000,key=1.2.3.4",
+  "lab":    "net:port=50001,key=5.6.7.8"
+}
+```
+
+Keep that file out of any repository — it holds keys, and it is deliberately machine-local. Names
+are matched case-insensitively with `-`, `_` and `.` equivalent, and they are re-read on every
+attach, so adding one does not mean restarting the client. `attach_kernel` with **neither** selector
+answers with the names this host has, which is how an agent discovers them without ever asking the
+user for a string.
+
+Connection strings are redacted everywhere else on principle, whichever selector opened the session:
+`session_status` reports `kernel target: profile "ctf-vm" (net:port=50000,key=<redacted>)`, and the
+value is held in a type whose `Debug`/`Display` are the redacted form, so a log line or an error can
+only ever carry the masked one ([`src/kdconn.rs`](./src/kdconn.rs)). The raw string is unwrapped at
+exactly one call site, handing it to DbgEng inside the session's own worker process. Redaction
+covers `key=` and `password=` values in any connection string, and masks nothing else — debugger
+output is never rewritten.
 
 ### Typed operands are operands, not commands
 

--- a/README.md
+++ b/README.md
@@ -338,10 +338,15 @@ $env:WINDBG_MCP_PROFILE_CTF_VM = "net:port=50000,key=1.2.3.4"
 ```
 
 Keep that file out of any repository — it holds keys, and it is deliberately machine-local. Names
-are matched case-insensitively with `-`, `_` and `.` equivalent, and they are re-read on every
-attach, so adding one does not mean restarting the client. `attach_kernel` with **neither** selector
-answers with the names this host has, which is how an agent discovers them without ever asking the
-user for a string.
+are matched case-insensitively with `-`, `_` and `.` equivalent (as are the environment-variable
+names themselves, since Windows matches those that way).
+
+The two sources differ in **when a change lands**. The file is re-read on every attach, so adding a
+profile to it works immediately with nothing restarted — that is the one to edit mid-session. An
+environment variable is read from the server's own environment, fixed when the process started, so
+it belongs in the MCP client's server definition and takes a server restart to change.
+`attach_kernel` with **neither** selector answers with the names this host has, which is how an
+agent discovers them without ever asking the user for a string.
 
 Configured profiles stay in the supervisor: an engine worker is spawned **without** the
 `WINDBG_MCP_PROFILE_*` variables, and is told only the one connection it is opening, over its

--- a/README.md
+++ b/README.md
@@ -343,6 +343,11 @@ attach, so adding one does not mean restarting the client. `attach_kernel` with 
 answers with the names this host has, which is how an agent discovers them without ever asking the
 user for a string.
 
+Configured profiles stay in the supervisor: an engine worker is spawned **without** the
+`WINDBG_MCP_PROFILE_*` variables, and is told only the one connection it is opening, over its
+private pipe. A `launch`ed debuggee inherits its worker's environment, and a debuggee is exactly the
+untrusted program that must not be handed every kernel key on the host.
+
 Connection strings are redacted everywhere else on principle, whichever selector opened the session:
 `session_status` reports `kernel target: profile "ctf-vm" (net:port=50000,key=<redacted>)`, and the
 value is held in a type whose `Debug`/`Display` are the redacted form, so a log line or an error can

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -73,6 +73,18 @@ $env:UPDATE_GOLDEN = "1"; cargo test --test mcp_smoke tools_list_matches
 inside the same document. External or dangling refs break strict client-side validators, and a
 codegen dependency can introduce them with no change here.
 
+**Kernel connection secrecy.** `attach_kernel` takes exactly one of `connection` and `profile`, and
+the schema cannot say so — both are optional there, deliberately (an untagged `oneOf` renders as a
+schema composition clients handle unevenly). So the exclusivity is this server's own check, and
+these tests are what hold it: both selectors and neither are each refused as a **tool** error naming
+the alternative, and neither refusal spawns a worker. A profile that does not exist is answered with
+the names that do, and a connection string typed into `profile` — the mistake that would defeat the
+whole feature — is refused *without being echoed back*. Every one of these runs a fake profile
+(`WINDBG_MCP_PROFILE_SMOKE_KDNET`, pointed at a documentation-range address) and asserts that key
+appears on neither the JSON-RPC transport nor the log, checked against every line the server ever
+wrote rather than against one result. `WINDBG_MCP_PROFILES` is pointed at a path that does not
+exist, so a developer's real profiles can never be read into a failure message.
+
 **Debugger tier.** Opens the checked-in kernel crash dump, confirms it mints a `session_id` that
 `session_status` reports, reads it through `modules` / `registers` / `backtrace`, then checks the
 session-handle contract on the wire (a stale handle is refused; the handle stops working once
@@ -92,6 +104,11 @@ processes, so they need real ones:
   reclaims the parked session with `end_session`, checking by pid that the worker process is gone.
   It skips itself if the attach fails outright instead of parking (a busy UDP port), because there
   is nothing to assert about a park that did not happen.
+- *A profile-named attach opens a session and discloses no key.* The same dead-port park, opened by
+  `profile` instead of `connection`: `session_status` names the profile and reports the connection
+  as `key=<redacted>`, and the key is absent from the transport and the log for the whole life of
+  the session. The unit tests prove the resolution and the redaction; only this proves they hold
+  over the wire, which is where [#81](https://github.com/glslang/windbg-mcp/issues/81) was.
 - *No worker outlives the connection.* Reads the engine pid out of `session_status`, disconnects,
   and checks the process is gone — otherwise every disconnect leaks a debugger process, and for a
   launch or an attach, a debuggee with it.

--- a/skills/windbg-debugging/SKILL.md
+++ b/skills/windbg-debugging/SKILL.md
@@ -70,11 +70,14 @@ a bare `execute`, which only sets the run state and doesn't move the target.
   you can act on. Only "no engine could be started at all" is a transport-level protocol error.
 - **Attach a KDNET kernel target by `profile`, not by connection string.** A connection string
   carries the target's debug key, and once it arrives as a tool argument it is in the transcript
-  for good. `attach_kernel { "profile": "<name>" }` has the server resolve it locally instead;
-  `attach_kernel {}` with no arguments lists the profiles this host has, so you never have to
-  guess a name or ask the user for a secret you don't need. Fall back to
-  `attach_kernel { "connection": "…" }` only when no profile covers the target — and never invent
-  a key. [setup.md](setup.md) covers configuring one.
+  for good. `attach_kernel { "profile": "<name>" }` has the server resolve it locally instead, and
+  `attach_kernel {}` with no arguments lists the profiles this host has — so you never have to
+  guess a name. **If none covers the target, ask the user to create a profile rather than asking
+  for the connection string**; they can set `WINDBG_MCP_PROFILE_<NAME>` or add a line to
+  `%USERPROFILE%\.windbg-mcp\profiles.json`, and it is picked up on the next attach with nothing
+  restarted. Only if they decline is `attach_kernel { "connection": "…" }` the answer — and say
+  that puts the key in the transcript, so it is their call. Never invent a key.
+  [live-and-kernel.md](live-and-kernel.md) has the exact wording to give them.
 - **Symbol *names* (`module!func`) need three things together:** (a) `msdia140.dll` and
   `symsrv.dll` bundled next to the binary, (b) a symbol path — set it with the
   **`set_symbol_path`** tool (`srv*C:\ProgramData\Dbg\sym*https://msdl.microsoft.com/download/symbols`,

--- a/skills/windbg-debugging/SKILL.md
+++ b/skills/windbg-debugging/SKILL.md
@@ -68,6 +68,13 @@ a bare `execute`, which only sets the run state and doesn't move the target.
   carrying the debugger's own text — read it and adjust (wrong symbol, unmapped address, target
   still running). So do a refused handle and a session whose engine died; all of them are things
   you can act on. Only "no engine could be started at all" is a transport-level protocol error.
+- **Attach a KDNET kernel target by `profile`, not by connection string.** A connection string
+  carries the target's debug key, and once it arrives as a tool argument it is in the transcript
+  for good. `attach_kernel { "profile": "<name>" }` has the server resolve it locally instead;
+  `attach_kernel {}` with no arguments lists the profiles this host has, so you never have to
+  guess a name or ask the user for a secret you don't need. Fall back to
+  `attach_kernel { "connection": "…" }` only when no profile covers the target — and never invent
+  a key. [setup.md](setup.md) covers configuring one.
 - **Symbol *names* (`module!func`) need three things together:** (a) `msdia140.dll` and
   `symsrv.dll` bundled next to the binary, (b) a symbol path — set it with the
   **`set_symbol_path`** tool (`srv*C:\ProgramData\Dbg\sym*https://msdl.microsoft.com/download/symbols`,

--- a/skills/windbg-debugging/SKILL.md
+++ b/skills/windbg-debugging/SKILL.md
@@ -73,10 +73,12 @@ a bare `execute`, which only sets the run state and doesn't move the target.
   for good. `attach_kernel { "profile": "<name>" }` has the server resolve it locally instead, and
   `attach_kernel {}` with no arguments lists the profiles this host has — so you never have to
   guess a name. **If none covers the target, ask the user to create a profile rather than asking
-  for the connection string**; they can set `WINDBG_MCP_PROFILE_<NAME>` or add a line to
-  `%USERPROFILE%\.windbg-mcp\profiles.json`, and it is picked up on the next attach with nothing
-  restarted. Only if they decline is `attach_kernel { "connection": "…" }` the answer — and say
-  that puts the key in the transcript, so it is their call. Never invent a key.
+  for the connection string** — specifically to add a line to `%USERPROFILE%\.windbg-mcp\profiles.json`,
+  which is re-read on every attach, so it works with nothing restarted. (A
+  `WINDBG_MCP_PROFILE_<NAME>` variable is read from the server's own environment at startup, so
+  setting one in a shell now does nothing until the server restarts — don't offer it as the
+  immediate fix.) Only if they decline is `attach_kernel { "connection": "…" }` the answer — and
+  say that puts the key in the transcript, so it is their call. Never invent a key.
   [live-and-kernel.md](live-and-kernel.md) has the exact wording to give them.
 - **Symbol *names* (`module!func`) need three things together:** (a) `msdia140.dll` and
   `symsrv.dll` bundled next to the binary, (b) a symbol path — set it with the

--- a/skills/windbg-debugging/live-and-kernel.md
+++ b/skills/windbg-debugging/live-and-kernel.md
@@ -13,22 +13,34 @@ Pick one entry point:
 - **Attach to a running process.** `attach_process { "pid": 1234 }` — breaks in.
 - **Local kernel.** `attach_kernel_local {}` — breaks in and returns `vertarget`.
 - **Remote kernel (KDNET).** `attach_kernel` — connects, breaks in, and returns `vertarget`.
-  Takes **exactly one** of two ways to name the target, in this order of preference:
-  1. `attach_kernel { "profile": "<name>" }` — a connection configured on the debugger host,
-     which the server resolves locally. **Prefer this.** A connection string carries the
-     target's debug key, and a key that arrives as a tool argument is in the transcript for
-     good. Don't know the names? Call `attach_kernel {}` with no arguments — the refusal lists
-     the profiles this host has, so you never have to guess one.
-  2. `attach_kernel { "connection": "net:port=<n>,key=<w.x.y.z>" }` — the raw string, for a
-     target no profile covers. **Ask the user for the actual connection string**; the port and
-     key come from the target's KDNET setup (`bcdedit /dbgsettings` on the target, or the
-     `windbgx -k` / `kd -k` command they use) and cannot be guessed — never invent a
-     placeholder key. Worth telling the user a profile would keep it out of the transcript next
-     time ([setup.md](setup.md)).
+  A connection string carries the target's **debug key**, and a key that arrives as a tool
+  argument is in this conversation's transcript for good — copied on through context snapshots
+  and summaries. So the order below is not a style preference; step 3 is the one to get right.
+  1. **Know the profile name?** `attach_kernel { "profile": "<name>" }`. Done.
+  2. **Don't?** Call `attach_kernel {}` with no arguments. The refusal lists the profiles this
+     host has, so you never have to guess a name or ask the user for anything.
+  3. **No profile covers the target?** **Ask the user to create one** — do not ask for a
+     connection string. Give them both options and let them pick:
+
+     ```pwsh
+     # a) permanent, in %USERPROFILE%\.windbg-mcp\profiles.json
+     #    { "ctf-vm": "net:port=50000,key=<w.x.y.z>" }
+     # b) this session only
+     $env:WINDBG_MCP_PROFILE_CTF_VM = "net:port=50000,key=<w.x.y.z>"
+     ```
+
+     The values come from the target's KDNET setup (`bcdedit /dbgsettings` on the target, or
+     the `windbgx -k` / `kd -k` command they already use) — you cannot guess them, and must
+     never invent a placeholder key. Profiles are re-read on every attach, so once they say
+     it's saved, go straight to step 1: **nothing needs restarting**.
+  4. **Only if the user declines** — a one-off target, or they'd rather not configure anything
+     — fall back to `attach_kernel { "connection": "net:port=<n>,key=<w.x.y.z>" }`. Say plainly
+     that the key will then be in the transcript, so it is their call, not a silent default.
 
   Passing both, or neither, is refused. So is a connection string put in `profile` by mistake —
   and it is not echoed back. Sessions report their connection with the key masked
   (`net:port=50000,key=<redacted>`), so `session_status` still tells two kernel targets apart.
+  Full configuration details: [setup.md](setup.md).
 
 Each of these opens a session of its own and returns a `session_id` — opening one does not close
 another, so you can keep a kernel attach live while you look at a dump. Pass the id on later calls

--- a/skills/windbg-debugging/live-and-kernel.md
+++ b/skills/windbg-debugging/live-and-kernel.md
@@ -20,19 +20,22 @@ Pick one entry point:
   2. **Don't?** Call `attach_kernel {}` with no arguments. The refusal lists the profiles this
      host has, so you never have to guess a name or ask the user for anything.
   3. **No profile covers the target?** **Ask the user to create one** — do not ask for a
-     connection string. Give them both options and let them pick:
+     connection string. Ask for the **file**, which is the only route that works mid-session:
 
-     ```pwsh
-     # a) permanent, in %USERPROFILE%\.windbg-mcp\profiles.json
-     #    { "ctf-vm": "net:port=50000,key=<w.x.y.z>" }
-     # b) this session only
-     $env:WINDBG_MCP_PROFILE_CTF_VM = "net:port=50000,key=<w.x.y.z>"
+     ```jsonc
+     // %USERPROFILE%\.windbg-mcp\profiles.json — create it if it isn't there
+     { "ctf-vm": "net:port=50000,key=<w.x.y.z>" }
      ```
 
      The values come from the target's KDNET setup (`bcdedit /dbgsettings` on the target, or
      the `windbgx -k` / `kd -k` command they already use) — you cannot guess them, and must
-     never invent a placeholder key. Profiles are re-read on every attach, so once they say
-     it's saved, go straight to step 1: **nothing needs restarting**.
+     never invent a placeholder key. The file is re-read on **every** attach, so the moment
+     they say it's saved, go to step 1; nothing needs restarting.
+
+     Do **not** offer `$env:WINDBG_MCP_PROFILE_…` as the fix for right now. The server reads
+     its *own* environment, fixed when it started, so a variable set in the user's shell after
+     that changes nothing until the server restarts. It is worth mentioning only as the way to
+     configure a profile permanently in the MCP client's server definition.
   4. **Only if the user declines** — a one-off target, or they'd rather not configure anything
      — fall back to `attach_kernel { "connection": "net:port=<n>,key=<w.x.y.z>" }`. Say plainly
      that the key will then be in the transcript, so it is their call, not a silent default.

--- a/skills/windbg-debugging/live-and-kernel.md
+++ b/skills/windbg-debugging/live-and-kernel.md
@@ -12,11 +12,23 @@ Pick one entry point:
   `sxe ibp` initial-breakpoint filter, which a bare host leaves off).
 - **Attach to a running process.** `attach_process { "pid": 1234 }` — breaks in.
 - **Local kernel.** `attach_kernel_local {}` — breaks in and returns `vertarget`.
-- **Remote kernel (KDNET).** `attach_kernel { "connection": "net:port=<n>,key=<w.x.y.z>" }`
-  — connects, breaks in, and returns `vertarget`. **Ask the user for the actual
-  connection string**; the port and key are specific to the target's KDNET setup (from
-  `bcdedit /dbgsettings` on the target, or the `windbgx -k` / `kd -k` command they use)
-  and cannot be guessed — never invent a placeholder key.
+- **Remote kernel (KDNET).** `attach_kernel` — connects, breaks in, and returns `vertarget`.
+  Takes **exactly one** of two ways to name the target, in this order of preference:
+  1. `attach_kernel { "profile": "<name>" }` — a connection configured on the debugger host,
+     which the server resolves locally. **Prefer this.** A connection string carries the
+     target's debug key, and a key that arrives as a tool argument is in the transcript for
+     good. Don't know the names? Call `attach_kernel {}` with no arguments — the refusal lists
+     the profiles this host has, so you never have to guess one.
+  2. `attach_kernel { "connection": "net:port=<n>,key=<w.x.y.z>" }` — the raw string, for a
+     target no profile covers. **Ask the user for the actual connection string**; the port and
+     key come from the target's KDNET setup (`bcdedit /dbgsettings` on the target, or the
+     `windbgx -k` / `kd -k` command they use) and cannot be guessed — never invent a
+     placeholder key. Worth telling the user a profile would keep it out of the transcript next
+     time ([setup.md](setup.md)).
+
+  Passing both, or neither, is refused. So is a connection string put in `profile` by mistake —
+  and it is not echoed back. Sessions report their connection with the key masked
+  (`net:port=50000,key=<redacted>`), so `session_status` still tells two kernel targets apart.
 
 Each of these opens a session of its own and returns a `session_id` — opening one does not close
 another, so you can keep a kernel attach live while you look at a dump. Pass the id on later calls

--- a/skills/windbg-debugging/setup.md
+++ b/skills/windbg-debugging/setup.md
@@ -219,7 +219,12 @@ $env:WINDBG_MCP_PROFILE_CTF_VM = "net:port=50000,key=1.2.3.4"
 
 This file holds keys: keep it out of every repository, and out of any directory that gets synced
 or shared. Names are matched case-insensitively with `-`, `_` and `.` equivalent, and the sources
-are re-read on every attach — adding a profile does not mean restarting the MCP client.
+are re-read on every attach — adding a profile does not mean restarting the MCP client. Two
+consequences of that matching worth knowing, both reported when a lookup fails: `ctf-vm` and
+`ctf.vm` in the *same* source are one name, so the second is ignored rather than silently reaching
+a different machine; and an entry whose name is not a name (letters, digits, `-`, `_`, `.`) is
+skipped without being quoted back, because the usual cause is an entry written the wrong way round
+— which would make the name the connection string.
 
 Raw connection strings stay supported (`attach_kernel { "connection": "net:port=…,key=…" }`) for a
 target no profile covers. Either way the session reports itself with the key masked —

--- a/skills/windbg-debugging/setup.md
+++ b/skills/windbg-debugging/setup.md
@@ -199,16 +199,12 @@ messages, tool calls, context snapshots and compaction summaries. Configure the 
 **this host** instead and `attach_kernel { "profile": "<name>" }` names it without the key ever
 entering the request.
 
-Either source works; the environment is checked first, then the file.
+Either source works; the environment is checked first, then the file. **They differ in when a
+change takes effect**, which decides which one to reach for:
 
-**Environment**, in whatever launches the MCP server (the variable's suffix is the profile name,
-lowercased — this defines `ctf_vm`, and `ctf-vm` resolves to it too):
-
-```pwsh
-$env:WINDBG_MCP_PROFILE_CTF_VM = "net:port=50000,key=1.2.3.4"
-```
-
-**File** — `%USERPROFILE%\.windbg-mcp\profiles.json`, or wherever `WINDBG_MCP_PROFILES` points:
+**File** — `%USERPROFILE%\.windbg-mcp\profiles.json`, or wherever `WINDBG_MCP_PROFILES` points.
+Re-read on **every attach**, so an edit works immediately, with nothing restarted. This is the one
+to add a profile to mid-session:
 
 ```json
 {
@@ -216,6 +212,18 @@ $env:WINDBG_MCP_PROFILE_CTF_VM = "net:port=50000,key=1.2.3.4"
   "lab":    "net:port=50001,key=5.6.7.8"
 }
 ```
+
+**Environment**, in whatever launches the MCP server — the client's server definition, or the shell
+the client itself was started from. The variable's suffix is the profile name, lowercased, so this
+defines `ctf_vm` (and `ctf-vm` resolves to it too):
+
+```pwsh
+$env:WINDBG_MCP_PROFILE_CTF_VM = "net:port=50000,key=1.2.3.4"
+```
+
+The server reads its *own* environment, which was fixed when it started, so setting this in a shell
+alongside a running server changes nothing until that server is restarted. Use it for a profile you
+want configured permanently; use the file for one you want now.
 
 This file holds keys: keep it out of every repository, and out of any directory that gets synced
 or shared. Names are matched case-insensitively with `-`, `_` and `.` equivalent, and the sources

--- a/skills/windbg-debugging/setup.md
+++ b/skills/windbg-debugging/setup.md
@@ -228,11 +228,15 @@ want configured permanently; use the file for one you want now.
 This file holds keys: keep it out of every repository, and out of any directory that gets synced
 or shared. Names are matched case-insensitively with `-`, `_` and `.` equivalent, and the sources
 are re-read on every attach — adding a profile does not mean restarting the MCP client. Two
-consequences of that matching worth knowing, both reported when a lookup fails: `ctf-vm` and
-`ctf.vm` in the *same* source are one name, so the second is ignored rather than silently reaching
-a different machine; and an entry whose name is not a name (letters, digits, `-`, `_`, `.`) is
-skipped without being quoted back, because the usual cause is an entry written the wrong way round
-— which would make the name the connection string.
+consequences of that matching worth knowing:
+
+- `ctf-vm` and `ctf.vm` in the **same** source are one name. If they point at different targets,
+  *neither* resolves until you rename or remove one — guessing would open a session on the wrong
+  machine while reporting it as the right one. (Two spellings of the *same* connection are fine,
+  and the environment overriding the file is the documented precedence, not a conflict.)
+- An entry whose name is not a name (letters, digits, `-`, `_`, `.`) is skipped, and not quoted
+  back in the error — the usual cause is an entry written the wrong way round, which would make
+  the name the connection string.
 
 Raw connection strings stay supported (`attach_kernel { "connection": "net:port=…,key=…" }`) for a
 target no profile covers. Either way the session reports itself with the key masked —

--- a/skills/windbg-debugging/setup.md
+++ b/skills/windbg-debugging/setup.md
@@ -191,6 +191,41 @@ is a symbol problem on this host, not a statement about the target's pool.
 Offline / no symbols? Navigation, memory reads, disassembly, and the data model still work
 — query by address instead of by name.
 
+## Kernel connection profiles — configure once, keep the key out of the transcript
+
+A KDNET connection string carries the target's debug key (`net:port=50000,key=<w.x.y.z>`), and a
+key passed as a tool argument is in the MCP client's transcript from then on — copied through
+messages, tool calls, context snapshots and compaction summaries. Configure the connection on
+**this host** instead and `attach_kernel { "profile": "<name>" }` names it without the key ever
+entering the request.
+
+Either source works; the environment is checked first, then the file.
+
+**Environment**, in whatever launches the MCP server (the variable's suffix is the profile name,
+lowercased — this defines `ctf_vm`, and `ctf-vm` resolves to it too):
+
+```pwsh
+$env:WINDBG_MCP_PROFILE_CTF_VM = "net:port=50000,key=1.2.3.4"
+```
+
+**File** — `%USERPROFILE%\.windbg-mcp\profiles.json`, or wherever `WINDBG_MCP_PROFILES` points:
+
+```json
+{
+  "ctf-vm": "net:port=50000,key=1.2.3.4",
+  "lab":    "net:port=50001,key=5.6.7.8"
+}
+```
+
+This file holds keys: keep it out of every repository, and out of any directory that gets synced
+or shared. Names are matched case-insensitively with `-`, `_` and `.` equivalent, and the sources
+are re-read on every attach — adding a profile does not mean restarting the MCP client.
+
+Raw connection strings stay supported (`attach_kernel { "connection": "net:port=…,key=…" }`) for a
+target no profile covers. Either way the session reports itself with the key masked —
+`kernel target: profile "ctf-vm" (net:port=50000,key=<redacted>)` — so `session_status` can still
+tell two kernel targets apart. `attach_kernel` with no arguments lists the profiles this host has.
+
 ## Elevation matrix
 
 | Operation | Administrator? |

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -37,6 +37,7 @@ use tokio::process::{Child, ChildStdout, Command};
 use tokio::sync::{mpsc, oneshot};
 use windows_sys::Win32::Foundation::{HANDLE_FLAG_INHERIT, SetHandleInformation};
 
+use crate::kdconn;
 use crate::proto::{EngineOp, WorkerMessage, WorkerRequest};
 use crate::worker::{MESSAGES_FLAG, REQUESTS_FLAG, WORKER_FLAG};
 
@@ -1620,7 +1621,15 @@ fn spawn_worker(exe: &Path) -> std::io::Result<(Child, Channel)> {
     let _one_spawn_at_a_time = spawn_guard();
     inheritable(&their_requests)?;
     inheritable(&their_messages)?;
-    let child = Command::new(exe)
+    let mut command = Command::new(exe);
+    // Configured KDNET connections stay in the supervisor. A worker is told the *one* connection
+    // it is opening, down its private pipe, and has no use for the rest — while a `launch`ed
+    // debuggee inherits this environment in turn, and a debuggee is exactly the untrusted program
+    // that must not be handed every kernel key on the host.
+    for name in kdconn::env_names() {
+        command.env_remove(name);
+    }
+    let child = command
         .arg(WORKER_FLAG)
         .arg(format!(
             "{REQUESTS_FLAG}{}",

--- a/src/kdconn.rs
+++ b/src/kdconn.rs
@@ -49,6 +49,10 @@ const SECRET_PARAMS: &[&str] = &["key", "password"];
 /// a mask that preserved length would leak the key's shape.
 const MASK: &str = "<redacted>";
 
+/// How long a profile name may be. Generous for a name, short enough that nothing anyone would
+/// mistake for a connection string or a pasted secret gets in under it.
+const NAME_LIMIT: usize = 64;
+
 /// A kernel connection string, with the secret sealed in.
 ///
 /// `Debug` and `Display` both render [`redact`]ed, which is the point: this type exists so that
@@ -132,11 +136,30 @@ pub fn redact(connection: &str) -> String {
     }
 }
 
+/// Which of the two sources a profile came from. Carried so that a name defined twice can say
+/// whether that was the documented environment-over-file override or a collision inside one
+/// source, which are opposite things to tell an operator.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum Source {
+    Env,
+    File,
+}
+
+impl Source {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Env => "the environment",
+            Self::File => "the profile file",
+        }
+    }
+}
+
 /// One configured profile, keyed in [`Profiles`] by its normalized name but remembering the name
 /// as it was actually written — that is what an operator will recognise in an error.
 struct Profile {
     name: String,
     connection: Connection,
+    source: Source,
 }
 
 /// The kernel connection profiles configured on this host.
@@ -145,10 +168,12 @@ struct Profile {
 /// restarting the server (and, more to the point, does not mean restarting the MCP client).
 pub struct Profiles {
     entries: BTreeMap<String, Profile>,
-    /// A profile file that exists but could not be used. Kept rather than raised immediately: it
-    /// must not break an attach that passes `connection` and needs no profiles at all, but it also
-    /// must not make a typo'd file look identical to "no such profile".
-    problem: Option<String>,
+    /// What had to be refused while reading the sources: a file that could not be parsed, an
+    /// entry whose name is not a name, a second spelling of a name already taken. Reported when a
+    /// lookup fails rather than raised at read time — none of it should break an attach that
+    /// passes `connection` and wants no profiles at all, but a misconfiguration must not look
+    /// identical to "no such profile" either.
+    notes: Vec<String>,
     /// Where a profile file would be read from, for the "how do I configure one" advice. `None`
     /// only when the host has no `USERPROFILE`, which on Windows means something is very wrong.
     file: Option<PathBuf>,
@@ -162,27 +187,68 @@ impl Profiles {
     /// server's process is a deliberate override of a file that is shared with every other
     /// process the user runs.
     pub fn from_host() -> Self {
-        let mut entries = from_env(std::env::vars());
-
         let file = profiles_file();
-        let mut problem = None;
-        match file.as_deref().map(read_profile_file) {
+        let mut profiles = Self {
+            entries: BTreeMap::new(),
+            notes: Vec::new(),
+            file,
+        };
+        for (name, connection) in env_entries(std::env::vars()) {
+            profiles.admit(name, &connection, Source::Env);
+        }
+        match profiles.file.as_deref().map(read_profile_file) {
             Some(Ok(from_file)) => {
                 for (name, connection) in from_file {
-                    entries.entry(normalize(&name)).or_insert(Profile {
-                        name,
-                        connection: Connection::new(connection),
-                    });
+                    profiles.admit(name, &connection, Source::File);
                 }
             }
-            Some(Err(why)) => problem = Some(why),
+            Some(Err(why)) => profiles.notes.push(why),
             None => {}
         }
+        profiles
+    }
 
-        Self {
-            entries,
-            problem,
-            file,
+    /// Takes one configured entry, or records why it could not.
+    ///
+    /// **Both sources go through here**, and the validation is the reason. A name is *displayed* —
+    /// in [`Self::listed`], in a session label, in an unknown-profile error — so a name that is
+    /// not a name must never reach the map: the likeliest way to get one is an entry written the
+    /// wrong way round, which makes the JSON *key* the connection string. A rejection is therefore
+    /// counted and located, never quoted.
+    fn admit(&mut self, name: String, connection: &str, source: Source) {
+        if !is_profile_name(&name) {
+            self.notes.push(format!(
+                "an entry in {} was skipped: its name is not one (letters, digits, `-`, `_` or \
+                 `.`, up to {NAME_LIMIT} characters). It is not repeated here, because the usual \
+                 cause is an entry written the wrong way round — which would make the name a \
+                 connection string.",
+                source.label()
+            ));
+            return;
+        }
+        match self.entries.entry(normalize(&name)) {
+            std::collections::btree_map::Entry::Occupied(taken) => {
+                let kept = taken.get();
+                // Environment over file is the documented precedence, not a mistake. Two
+                // spellings within *one* source are: they are the same profile once `-`, `_` and
+                // `.` are treated alike, one of them silently wins, and the cost of not saying so
+                // is an operator dialling a name that reaches a different machine.
+                if kept.source == source {
+                    self.notes.push(format!(
+                        "`{name}` in {} is ignored: `{}` was read first and the two are one name \
+                         once `-`, `_` and `.` are treated alike.",
+                        source.label(),
+                        kept.name
+                    ));
+                }
+            }
+            std::collections::btree_map::Entry::Vacant(slot) => {
+                slot.insert(Profile {
+                    name,
+                    connection: Connection::new(connection),
+                    source,
+                });
+            }
         }
     }
 
@@ -190,22 +256,15 @@ impl Profiles {
     /// environment, which in edition 2024 is `unsafe` and races every other test in the binary.
     #[cfg(test)]
     fn from_pairs(pairs: &[(&str, &str)]) -> Self {
-        Self {
-            entries: pairs
-                .iter()
-                .map(|(name, connection)| {
-                    (
-                        normalize(name),
-                        Profile {
-                            name: (*name).to_string(),
-                            connection: Connection::new(*connection),
-                        },
-                    )
-                })
-                .collect(),
-            problem: None,
+        let mut profiles = Self {
+            entries: BTreeMap::new(),
+            notes: Vec::new(),
             file: Some(PathBuf::from(r"C:\Users\test\.windbg-mcp\profiles.json")),
+        };
+        for (name, connection) in pairs {
+            profiles.admit((*name).to_string(), connection, Source::File);
         }
+        profiles
     }
 
     fn get(&self, name: &str) -> Option<&Profile> {
@@ -213,7 +272,8 @@ impl Profiles {
     }
 
     /// The configured names, as they were written. Names are not secrets — that is the whole
-    /// point of them — so they are safe to put in an error a client will keep.
+    /// point of them, and [`Self::admit`] is what makes sure a name is one — so they are safe to
+    /// put in an error a client will keep.
     fn names(&self) -> Vec<&str> {
         self.entries.values().map(|p| p.name.as_str()).collect()
     }
@@ -227,14 +287,18 @@ impl Profiles {
             ),
             None => format!("or from a JSON file named by {PROFILES_FILE_ENV}"),
         };
-        let problem = match &self.problem {
-            Some(why) => format!("\n\nThe profile file could not be read: {why}"),
-            None => String::new(),
+        let notes = match self.notes.as_slice() {
+            [] => String::new(),
+            notes => format!(
+                "\n\nThe configuration was read with problems, which may be why the profile you \
+                 want is missing:\n- {}",
+                notes.join("\n- ")
+            ),
         };
         format!(
             "Profiles are resolved by this server, on this host: from `{PROFILE_ENV_PREFIX}<NAME>` \
              in its environment {file}. Names are matched case-insensitively, with `-` and `_` \
-             equivalent. Ask the user to add one — this server cannot.{problem}"
+             equivalent. Ask the user to add one — this server cannot.{notes}"
         )
     }
 
@@ -247,34 +311,41 @@ impl Profiles {
     }
 }
 
-/// The profiles a set of environment variables defines.
+/// Every environment variable this module reads, by name.
+///
+/// Public so [`crate::engine`] can strip them from a worker's environment. A worker is told the
+/// one connection it is opening, down its private pipe, and resolves nothing itself — so it has no
+/// use for any of these, and a `launch`ed debuggee inherits the worker's environment in turn.
+/// Handing an untrusted program every configured kernel key is the outcome being avoided.
+pub fn env_names() -> Vec<String> {
+    env_names_in(std::env::vars_os().filter_map(|(key, _)| key.into_string().ok()))
+}
+
+/// The filter behind [`env_names`], over a supplied set so it can be tested against fixed input
+/// rather than against whatever the developer's shell happens to hold.
+fn env_names_in(keys: impl Iterator<Item = String>) -> Vec<String> {
+    keys.filter(|key| key.starts_with(PROFILE_ENV_PREFIX) || key == PROFILES_FILE_ENV)
+        .collect()
+}
+
+/// The (name, connection) pairs a set of environment variables defines.
 ///
 /// Split out from [`Profiles::from_host`] so the mapping is testable: `std::env::set_var` is
 /// `unsafe` in edition 2024 and mutates state every other test in this binary shares, so the only
 /// way to prove `WINDBG_MCP_PROFILE_CTF_VM` defines the profile `ctf-vm` is to hand the scan its
 /// variables rather than the process's.
-fn from_env(vars: impl Iterator<Item = (String, String)>) -> BTreeMap<String, Profile> {
-    let mut entries = BTreeMap::new();
-    for (key, value) in vars {
-        let Some(suffix) = key.strip_prefix(PROFILE_ENV_PREFIX) else {
-            continue;
-        };
+fn env_entries(vars: impl Iterator<Item = (String, String)>) -> Vec<(String, String)> {
+    vars.filter_map(|(key, value)| {
+        let suffix = key.strip_prefix(PROFILE_ENV_PREFIX)?;
         if suffix.is_empty() || value.trim().is_empty() {
-            continue;
+            return None;
         }
         // The variable's own suffix *is* the profile's name, lowercased — an environment variable
         // cannot carry a hyphen, so `WINDBG_MCP_PROFILE_CTF_VM` lists as `ctf_vm`. Asking for
         // `ctf-vm` still finds it: both normalize to the same key.
-        let name = suffix.to_ascii_lowercase();
-        entries.insert(
-            normalize(&name),
-            Profile {
-                name,
-                connection: Connection::new(value.trim()),
-            },
-        );
-    }
-    entries
+        Some((suffix.to_ascii_lowercase(), value.trim().to_string()))
+    })
+    .collect()
 }
 
 /// Where the profile file lives on this host.
@@ -316,7 +387,8 @@ fn read_profile_file(path: &Path) -> Result<BTreeMap<String, String>, String> {
     for (name, value) in object {
         let connection = value.as_str().ok_or_else(|| {
             format!(
-                "profile `{name}` in {} must be a string (its connection string)",
+                "{} in {} must be a string (its connection string)",
+                referred_to_as(name),
                 path.display()
             )
         })?;
@@ -429,13 +501,30 @@ fn resolve(name: &str, profiles: &Profiles) -> Result<Selected, String> {
     }
 }
 
-/// Whether this is a profile name rather than something else that got put in the field.
+/// Whether this is a profile name rather than something else that got put where one belongs.
+///
+/// The charset is what makes a name safe to *render*: no `=`, so a connection string cannot pass;
+/// no line breaks, so nothing configured here can inject a line into a tool result.
 fn is_profile_name(name: &str) -> bool {
     !name.is_empty()
-        && name.len() <= 64
+        && name.len() <= NAME_LIMIT
         && name
             .chars()
             .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.'))
+}
+
+/// How a configured entry is referred to in a message.
+///
+/// A name that is not a name is *located*, never quoted: the likeliest reason a JSON key fails
+/// [`is_profile_name`] is an entry written the wrong way round, which makes the key the connection
+/// string — and quoting it would put the key in the transcript this whole module exists to keep it
+/// out of.
+fn referred_to_as(name: &str) -> String {
+    if is_profile_name(name) {
+        format!("profile `{name}`")
+    } else {
+        "an entry whose name is not a profile name".to_string()
+    }
 }
 
 #[cfg(test)]
@@ -566,6 +655,24 @@ mod tests {
         }
     }
 
+    /// What a worker's environment has to be stripped of. Everything this module reads, and
+    /// nothing else — a worker still needs `PATH`, `SystemRoot` and the rest to run at all.
+    #[test]
+    fn the_variables_a_worker_must_not_inherit_are_this_modules_own() {
+        let names = env_names_in(
+            [
+                "WINDBG_MCP_PROFILE_CTF_VM",
+                "WINDBG_MCP_PROFILES",
+                "WINDBG_MCP_CALL_TIMEOUT_SECS",
+                "PATH",
+                "WINDBG_MCP_SMOKE_KERNEL",
+            ]
+            .into_iter()
+            .map(String::from),
+        );
+        assert_eq!(names, ["WINDBG_MCP_PROFILE_CTF_VM", "WINDBG_MCP_PROFILES"]);
+    }
+
     /// The environment half of the same claim, on the real scan: a variable defines a profile
     /// under its own spelling, and the hyphenated name a person would type finds it anyway.
     #[test]
@@ -578,17 +685,70 @@ mod tests {
         ]
         .map(|(k, v)| (k.to_string(), v.to_string()));
 
-        let profiles = Profiles {
-            entries: from_env(vars.into_iter()),
-            problem: None,
+        let mut profiles = Profiles {
+            entries: BTreeMap::new(),
+            notes: Vec::new(),
             file: None,
         };
+        for (name, connection) in env_entries(vars.into_iter()) {
+            profiles.admit(name, &connection, Source::Env);
+        }
         assert_eq!(profiles.names(), ["ctf_vm"]);
         for asked in ["ctf-vm", "ctf_vm", "CTF-VM"] {
             let selected =
                 resolve(asked, &profiles).unwrap_or_else(|e| panic!("{asked} should resolve: {e}"));
             assert_eq!(selected.connection.expose(), FAKE);
         }
+    }
+
+    /// A configured *name* is rendered — in the profile list, in a session label — so a name that
+    /// is not a name must not get in. The way that happens in practice is an entry written the
+    /// wrong way round, which makes the JSON key the connection string; admitting it would print
+    /// a key out of the very error that says the entry is wrong.
+    #[test]
+    fn a_configured_entry_whose_name_is_not_a_name_is_refused_without_being_quoted() {
+        let profiles = Profiles::from_pairs(&[
+            ("ctf-vm", FAKE),
+            (FAKE, "net:port=1,key=9.9.9.9"),
+            ("has\na newline", "net:port=2,key=8.8.8.8"),
+        ]);
+        assert_eq!(profiles.names(), ["ctf-vm"]);
+
+        let err = resolve("typo", &profiles).unwrap_err();
+        assert!(err.contains("its name is not one"), "{err}");
+        for leaked in [FAKE_KEY, "9.9.9.9", "8.8.8.8", "port=1", "\n a newline"] {
+            assert!(!err.contains(leaked), "the note quoted `{leaked}`:\n{err}");
+        }
+    }
+
+    /// Two spellings of one name inside a single source are a collision, not an override: one
+    /// silently wins, and the cost of not saying so is an operator dialling a name that reaches a
+    /// different machine. Environment-over-file *is* the documented precedence and stays quiet.
+    #[test]
+    fn two_spellings_of_one_name_in_one_source_are_reported() {
+        let profiles =
+            Profiles::from_pairs(&[("ctf-vm", FAKE), ("ctf.vm", "net:port=1,key=9.9.9.9")]);
+        assert_eq!(profiles.names(), ["ctf-vm"], "the first read wins");
+        let err = resolve("nope", &profiles).unwrap_err();
+        assert!(
+            err.contains("`ctf.vm`") && err.contains("is ignored"),
+            "the shadowed spelling has to be named, or it looks configured:\n{err}"
+        );
+        assert!(!err.contains("9.9.9.9"), "{err}");
+
+        let mut override_case = Profiles {
+            entries: BTreeMap::new(),
+            notes: Vec::new(),
+            file: None,
+        };
+        override_case.admit("ctf_vm".into(), FAKE, Source::Env);
+        override_case.admit("ctf-vm".into(), "net:port=1,key=9.9.9.9", Source::File);
+        assert_eq!(override_case.entries.len(), 1);
+        assert!(
+            override_case.notes.is_empty(),
+            "the environment overriding the file is documented behaviour, not a problem: {:?}",
+            override_case.notes
+        );
     }
 
     #[test]

--- a/src/kdconn.rs
+++ b/src/kdconn.rs
@@ -106,9 +106,11 @@ impl fmt::Debug for Connection {
 /// `=` **inside** a masked value is consumed with it rather than restarting the scan — which is
 /// the case a naive split-on-`=` gets wrong, and it gets it wrong by emitting the tail of a key.
 ///
-/// **All** ASCII whitespace is a boundary, line breaks included. Anything narrower is a way to
-/// defeat this: `net:port=1,\r\nkey=…` would parse as a parameter called `"\r\nkey"`, match no
-/// secret, and hand the key straight back through the session label.
+/// **All** ASCII whitespace is a boundary, line breaks included, and whitespace between the `=`
+/// and the value is skipped rather than read as an empty value. Both are ways this has been
+/// defeated: `net:port=1,\r\nkey=…` parsed as a parameter called `"\r\nkey"` and matched no
+/// secret, and `key= …` measured a zero-length value and masked nothing. Each ended with the key
+/// back in the session label, which is the one place it must never be.
 pub fn redact(connection: &str) -> String {
     let name_delim = |c: char| matches!(c, ',' | ';' | ':' | '=') || c.is_ascii_whitespace();
     let value_delim = |c: char| matches!(c, ',' | ';') || c.is_ascii_whitespace();
@@ -127,9 +129,19 @@ pub fn redact(connection: &str) -> String {
         out.push('=');
         let value = &tail[1..];
         if SECRET_PARAMS.iter().any(|p| p.eq_ignore_ascii_case(name)) {
+            // Whitespace *after* the `=` is a gap before the value, not the value being empty —
+            // and whitespace is a value delimiter, so failing to skip it is how `key= 1.2.3.4`
+            // came out whole: the value measured zero length, nothing was masked, and the rest of
+            // the string (key included) was then emitted verbatim by the no-more-`=` exit.
+            let gap = value.len()
+                - value
+                    .trim_start_matches(|c: char| c.is_ascii_whitespace())
+                    .len();
+            let (spacing, value) = value.split_at(gap);
+            out.push_str(spacing);
             let end = value.find(value_delim).unwrap_or(value.len());
-            // An empty value has nothing to mask, and masking it would invent a secret that is
-            // not there — the honest rendering of `key=` is `key=`.
+            // A genuinely empty value has nothing to mask, and masking it would invent a secret
+            // that is not there — the honest rendering of `key=` is `key=`.
             if end > 0 {
                 out.push_str(MASK);
             }
@@ -164,6 +176,11 @@ struct Profile {
     name: String,
     connection: Connection,
     source: Source,
+    /// Other spellings from the same source that normalize to this name and point somewhere
+    /// **else**. Non-empty makes this profile unusable, deliberately: the server cannot tell which
+    /// target was meant, and the failure mode of guessing is attaching to the wrong kernel while
+    /// believing otherwise. A duplicate that agrees is not recorded here — nothing can go wrong.
+    conflicts: Vec<String>,
 }
 
 /// The kernel connection profiles configured on this host.
@@ -241,19 +258,21 @@ impl Profiles {
             return;
         }
         match self.entries.entry(normalize(&name)) {
-            std::collections::btree_map::Entry::Occupied(taken) => {
-                let kept = taken.get();
-                // Environment over file is the documented precedence, not a mistake. Two
-                // spellings within *one* source are: they are the same profile once `-`, `_` and
-                // `.` are treated alike, one of them silently wins, and the cost of not saying so
-                // is an operator dialling a name that reaches a different machine.
-                if kept.source == source {
+            std::collections::btree_map::Entry::Occupied(mut taken) => {
+                let kept = taken.get_mut();
+                // Environment over file is the documented precedence, not a mistake, and neither
+                // is a duplicate that agrees with itself. Two spellings within *one* source that
+                // name **different** targets are: they are one name once `-`, `_` and `.` are
+                // treated alike, and nothing here can know which was meant.
+                if kept.source == source && kept.connection.expose() != connection {
                     self.notes.push(format!(
-                        "`{name}` in {} is ignored: `{}` was read first and the two are one name \
-                         once `-`, `_` and `.` are treated alike.",
+                        "`{name}` and `{}` in {} are one name once `-`, `_` and `.` are treated \
+                         alike, but name different targets, so neither can be used until one is \
+                         renamed or removed.",
+                        kept.name,
                         source.label(),
-                        kept.name
                     ));
+                    kept.conflicts.push(name);
                 }
             }
             std::collections::btree_map::Entry::Vacant(slot) => {
@@ -261,6 +280,7 @@ impl Profiles {
                     name,
                     connection: Connection::new(connection),
                     source,
+                    conflicts: Vec::new(),
                 });
             }
         }
@@ -535,6 +555,19 @@ fn resolve(name: &str, profiles: &Profiles) -> Result<Selected, String> {
         ));
     }
     match profiles.get(name) {
+        // Configured twice, for two different targets. Refused rather than resolved to whichever
+        // was read first: this server cannot know which was meant, and the cost of guessing is a
+        // session on the wrong kernel that reports itself as the right one. The names are all
+        // valid ones (`admit` saw to that), so listing them is safe and is the whole fix.
+        Some(profile) if !profile.conflicts.is_empty() => Err(format!(
+            "the profile named `{name}` is configured more than once, for different targets: {}. \
+             Those are one name to this server, which treats `-`, `_` and `.` alike and ignores \
+             case, so it cannot tell which was meant — and dialling the wrong one would open a \
+             session on the wrong machine. Ask the user to rename or remove all but one; the \
+             others here are usable in the meantime. {}",
+            once_each(profile),
+            profiles.listed()
+        )),
         Some(profile) => Ok(Selected {
             label: format!("profile \"{}\" ({})", profile.name, profile.connection),
             connection: profile.connection.clone(),
@@ -545,6 +578,15 @@ fn resolve(name: &str, profiles: &Profiles) -> Result<Selected, String> {
             profiles.how_to_configure()
         )),
     }
+}
+
+/// The colliding spellings of one profile, as an error should list them.
+fn once_each(profile: &Profile) -> String {
+    std::iter::once(&profile.name)
+        .chain(&profile.conflicts)
+        .map(|name| format!("`{name}`"))
+        .collect::<Vec<_>>()
+        .join(", ")
 }
 
 /// Whether this is a connection string this server will dial.
@@ -642,18 +684,30 @@ mod tests {
         assert!(!out.contains("cd"), "{out}");
     }
 
-    /// A line break before a secret parameter must not smuggle it past the scan. With only space
-    /// and tab as boundaries the name parsed as `"\r\nkey"`, matched nothing, and the key came
-    /// back through the session label — the one output redaction exists to keep clean.
+    /// Whitespace around a secret parameter must not smuggle it past the scan, on either side of
+    /// the `=`. Before the name, too narrow a delimiter set parsed `"\r\nkey"` and matched
+    /// nothing; after the `=`, the value measured zero length and nothing was masked. Both ended
+    /// the same way — the key back in the session label, the one output redaction exists to keep
+    /// clean.
     #[test]
     fn redaction_treats_every_ascii_whitespace_as_a_parameter_boundary() {
-        for gap in ["\r\n", "\n", "\r", "\t", " ", "\x0c"] {
-            let out = redact(&format!("net:port=1,{gap}key={FAKE_KEY}"));
+        for gap in ["\r\n", "\n", "\r", "\t", " ", "\x0c", "  "] {
+            let before = redact(&format!("net:port=1,{gap}key={FAKE_KEY}"));
             assert!(
-                !out.contains(FAKE_KEY),
-                "gap {gap:?} defeated redaction: {out}"
+                !before.contains(FAKE_KEY),
+                "gap {gap:?} before the name defeated redaction: {before}"
             );
-            assert!(out.contains("key=<redacted>"), "gap {gap:?}: {out}");
+            assert!(before.contains("key=<redacted>"), "gap {gap:?}: {before}");
+
+            let after = redact(&format!("net:port=1,key={gap}{FAKE_KEY},target=host"));
+            assert!(
+                !after.contains(FAKE_KEY),
+                "gap {gap:?} after the `=` defeated redaction: {after}"
+            );
+            assert!(
+                after.contains(MASK) && after.ends_with(",target=host"),
+                "the gap and the rest of the string survive: {after}"
+            );
         }
     }
 
@@ -849,21 +903,32 @@ mod tests {
         }
     }
 
-    /// Two spellings of one name inside a single source are a collision, not an override: one
-    /// silently wins, and the cost of not saying so is an operator dialling a name that reaches a
-    /// different machine. Environment-over-file *is* the documented precedence and stays quiet.
+    /// Two spellings of one name in one source, naming **different** targets, must not resolve to
+    /// whichever was read first. Nothing here can know which was meant, and the cost of guessing
+    /// is a session on the wrong kernel that reports itself as the right one — so both spellings
+    /// are refused until an operator picks. A note alone would not do it: notes surface when a
+    /// lookup *fails*, and this lookup used to succeed.
     #[test]
-    fn two_spellings_of_one_name_in_one_source_are_reported() {
+    fn one_name_configured_for_two_targets_is_refused_not_guessed() {
         let profiles =
             Profiles::from_pairs(&[("ctf-vm", FAKE), ("ctf.vm", "net:port=1,key=9.9.9.9")]);
-        assert_eq!(profiles.names(), ["ctf-vm"], "the first read wins");
-        let err = resolve("nope", &profiles).unwrap_err();
-        assert!(
-            err.contains("`ctf.vm`") && err.contains("is ignored"),
-            "the shadowed spelling has to be named, or it looks configured:\n{err}"
-        );
-        assert!(!err.contains("9.9.9.9"), "{err}");
+        for asked in ["ctf-vm", "ctf.vm", "CTF_VM"] {
+            let err = resolve(asked, &profiles)
+                .err()
+                .unwrap_or_else(|| panic!("`{asked}` must not resolve to a guess"));
+            assert!(
+                err.contains("`ctf-vm`") && err.contains("`ctf.vm`"),
+                "{err}"
+            );
+            assert!(err.contains("different targets"), "{err}");
+            assert!(!err.contains(FAKE_KEY) && !err.contains("9.9.9.9"), "{err}");
+        }
+    }
 
+    /// The two collisions that are *not* ambiguous, and so must stay usable: the documented
+    /// environment-over-file override, and a duplicate that simply agrees with itself.
+    #[test]
+    fn an_override_and_a_duplicate_that_agrees_are_not_conflicts() {
         let mut override_case = Profiles {
             entries: BTreeMap::new(),
             notes: Vec::new(),
@@ -876,6 +941,18 @@ mod tests {
             override_case.notes.is_empty(),
             "the environment overriding the file is documented behaviour, not a problem: {:?}",
             override_case.notes
+        );
+        let selected = resolve("ctf-vm", &override_case).expect("the override resolves");
+        assert_eq!(selected.connection.expose(), FAKE, "the environment wins");
+
+        let agreeing = Profiles::from_pairs(&[("lab-vm", FAKE), ("lab.vm", FAKE)]);
+        assert!(agreeing.notes.is_empty(), "{:?}", agreeing.notes);
+        assert_eq!(
+            resolve("lab.vm", &agreeing)
+                .expect("two spellings of one target are not ambiguous")
+                .connection
+                .expose(),
+            FAKE
         );
     }
 

--- a/src/kdconn.rs
+++ b/src/kdconn.rs
@@ -105,9 +105,13 @@ impl fmt::Debug for Connection {
 /// preceding delimiter and the `=`, and a value runs to the next `,`/`;`/whitespace. That means an
 /// `=` **inside** a masked value is consumed with it rather than restarting the scan — which is
 /// the case a naive split-on-`=` gets wrong, and it gets it wrong by emitting the tail of a key.
+///
+/// **All** ASCII whitespace is a boundary, line breaks included. Anything narrower is a way to
+/// defeat this: `net:port=1,\r\nkey=…` would parse as a parameter called `"\r\nkey"`, match no
+/// secret, and hand the key straight back through the session label.
 pub fn redact(connection: &str) -> String {
-    const NAME_DELIMS: &[char] = &[',', ';', ':', '=', ' ', '\t'];
-    const VALUE_DELIMS: &[char] = &[',', ';', ' ', '\t'];
+    let name_delim = |c: char| matches!(c, ',' | ';' | ':' | '=') || c.is_ascii_whitespace();
+    let value_delim = |c: char| matches!(c, ',' | ';') || c.is_ascii_whitespace();
 
     let mut out = String::with_capacity(connection.len());
     let mut rest = connection;
@@ -117,13 +121,13 @@ pub fn redact(connection: &str) -> String {
             return out;
         };
         let (head, tail) = rest.split_at(eq);
-        // All the delimiters are ASCII, so a byte index past one is a char boundary.
-        let name = &head[head.rfind(NAME_DELIMS).map_or(0, |i| i + 1)..];
+        // Every delimiter above is ASCII, so a byte index just past one is a char boundary.
+        let name = &head[head.rfind(name_delim).map_or(0, |i| i + 1)..];
         out.push_str(head);
         out.push('=');
         let value = &tail[1..];
         if SECRET_PARAMS.iter().any(|p| p.eq_ignore_ascii_case(name)) {
-            let end = value.find(VALUE_DELIMS).unwrap_or(value.len());
+            let end = value.find(value_delim).unwrap_or(value.len());
             // An empty value has nothing to mask, and masking it would invent a secret that is
             // not there — the honest rendering of `key=` is `key=`.
             if end > 0 {
@@ -216,6 +220,16 @@ impl Profiles {
     /// wrong way round, which makes the JSON *key* the connection string. A rejection is therefore
     /// counted and located, never quoted.
     fn admit(&mut self, name: String, connection: &str, source: Source) {
+        if is_profile_name(&name) && !is_dialable(connection) {
+            // Named, because the name passed its own check and so is safe to print — and the
+            // operator needs to know *which* entry to go and fix. The value stays unquoted.
+            self.notes.push(format!(
+                "profile `{name}` in {} was skipped: its connection string contains a control \
+                 character, which no connection string does.",
+                source.label()
+            ));
+            return;
+        }
         if !is_profile_name(&name) {
             self.notes.push(format!(
                 "an entry in {} was skipped: its name is not one (letters, digits, `-`, `_` or \
@@ -298,7 +312,11 @@ impl Profiles {
         format!(
             "Profiles are resolved by this server, on this host: from `{PROFILE_ENV_PREFIX}<NAME>` \
              in its environment {file}. Names are matched case-insensitively, with `-` and `_` \
-             equivalent. Ask the user to add one — this server cannot.{notes}"
+             equivalent.\n\nThis server cannot add one, but the user can, and that is the better \
+             ask than a connection string: adding `{{ \"<name>\": \"net:port=<n>,key=<w.x.y.z>\" }}` \
+             to that file (or setting `{PROFILE_ENV_PREFIX}<NAME>`) lets every later attach name it \
+             instead, and the key stays on this host. Profiles are re-read per attach, so nothing \
+             needs restarting.{notes}"
         )
     }
 
@@ -324,8 +342,24 @@ pub fn env_names() -> Vec<String> {
 /// The filter behind [`env_names`], over a supplied set so it can be tested against fixed input
 /// rather than against whatever the developer's shell happens to hold.
 fn env_names_in(keys: impl Iterator<Item = String>) -> Vec<String> {
-    keys.filter(|key| key.starts_with(PROFILE_ENV_PREFIX) || key == PROFILES_FILE_ENV)
-        .collect()
+    keys.filter(|key| {
+        profile_env_suffix(key).is_some() || key.eq_ignore_ascii_case(PROFILES_FILE_ENV)
+    })
+    .collect()
+}
+
+/// The profile name an environment variable defines, if it defines one.
+///
+/// Matched **case-insensitively**, because Windows environment-variable names are: a variable set
+/// as `$env:Windbg_Mcp_Profile_Ctf` is stored and enumerated with that spelling, and a
+/// case-sensitive test would then miss it twice over — the profile would not resolve, *and* the
+/// variable would survive [`env_names`]'s scrubbing into every worker and every launched debuggee.
+/// The second is the one that matters: a name we fail to recognise is still a key in the
+/// environment.
+fn profile_env_suffix(key: &str) -> Option<&str> {
+    let (head, suffix) = key.split_at_checked(PROFILE_ENV_PREFIX.len())?;
+    head.eq_ignore_ascii_case(PROFILE_ENV_PREFIX)
+        .then_some(suffix)
 }
 
 /// The (name, connection) pairs a set of environment variables defines.
@@ -336,7 +370,7 @@ fn env_names_in(keys: impl Iterator<Item = String>) -> Vec<String> {
 /// variables rather than the process's.
 fn env_entries(vars: impl Iterator<Item = (String, String)>) -> Vec<(String, String)> {
     vars.filter_map(|(key, value)| {
-        let suffix = key.strip_prefix(PROFILE_ENV_PREFIX)?;
+        let suffix = profile_env_suffix(&key)?;
         if suffix.is_empty() || value.trim().is_empty() {
             return None;
         }
@@ -450,7 +484,16 @@ pub fn select(connection: Option<String>, profile: Option<String>) -> Result<Sel
                 .to_string(),
         ),
         (Some(connection), None) => {
-            let connection = Connection::new(connection.trim());
+            let connection = connection.trim();
+            if !is_dialable(connection) {
+                return Err(
+                    "`connection` contains a control character, which no connection string does. \
+                     It is not repeated here, in case it carries a key. Pass it on one line, e.g. \
+                     \"net:port=50000,key=<w.x.y.z>\"."
+                        .to_string(),
+                );
+            }
+            let connection = Connection::new(connection);
             Ok(Selected {
                 label: connection.redacted(),
                 connection,
@@ -499,6 +542,19 @@ fn resolve(name: &str, profiles: &Profiles) -> Result<Selected, String> {
             profiles.how_to_configure()
         )),
     }
+}
+
+/// Whether this is a connection string this server will dial.
+///
+/// Deliberately a low bar — DbgEng owns the syntax, and reimplementing it here would reject
+/// transports nobody here has heard of — but a **control character** is never part of one, and
+/// letting one through costs more than the check. The label built from a connection goes into
+/// `session_status`'s multi-line report, so an embedded line break can forge a session line in a
+/// report a model then reasons about. ([`redact`] treats line breaks as parameter boundaries, so
+/// this is no longer also the difference between a masked key and a disclosed one — but it was,
+/// and the cheapest way to keep it from becoming that again is to refuse the input.)
+fn is_dialable(connection: &str) -> bool {
+    !connection.is_empty() && !connection.chars().any(char::is_control)
 }
 
 /// Whether this is a profile name rather than something else that got put where one belongs.
@@ -581,6 +637,21 @@ mod tests {
         let out = redact("net:port=1,password=ab=cd=ef,target=host");
         assert_eq!(out, "net:port=1,password=<redacted>,target=host");
         assert!(!out.contains("cd"), "{out}");
+    }
+
+    /// A line break before a secret parameter must not smuggle it past the scan. With only space
+    /// and tab as boundaries the name parsed as `"\r\nkey"`, matched nothing, and the key came
+    /// back through the session label — the one output redaction exists to keep clean.
+    #[test]
+    fn redaction_treats_every_ascii_whitespace_as_a_parameter_boundary() {
+        for gap in ["\r\n", "\n", "\r", "\t", " ", "\x0c"] {
+            let out = redact(&format!("net:port=1,{gap}key={FAKE_KEY}"));
+            assert!(
+                !out.contains(FAKE_KEY),
+                "gap {gap:?} defeated redaction: {out}"
+            );
+            assert!(out.contains("key=<redacted>"), "gap {gap:?}: {out}");
+        }
     }
 
     #[test]
@@ -671,6 +742,60 @@ mod tests {
             .map(String::from),
         );
         assert_eq!(names, ["WINDBG_MCP_PROFILE_CTF_VM", "WINDBG_MCP_PROFILES"]);
+    }
+
+    /// Windows environment-variable names are case-insensitive but keep the spelling they were
+    /// created with, so `$env:Windbg_Mcp_Profile_Ctf` enumerates exactly like that. A
+    /// case-sensitive test would miss it twice: the profile would not resolve, *and* the variable
+    /// would survive the scrubbing into every worker and every launched debuggee — a key we chose
+    /// not to recognise is still a key in the environment.
+    #[test]
+    fn environment_names_are_matched_the_way_windows_matches_them() {
+        let spellings = [
+            "WINDBG_MCP_PROFILE_CTF",
+            "Windbg_Mcp_Profile_Ctf",
+            "windbg_mcp_profile_ctf",
+        ];
+        for spelling in spellings {
+            let vars = [(spelling.to_string(), FAKE.to_string())];
+            assert_eq!(
+                env_entries(vars.into_iter()),
+                [("ctf".to_string(), FAKE.to_string())],
+                "{spelling} should define the profile `ctf`"
+            );
+            assert_eq!(
+                env_names_in([spelling.to_string()].into_iter()),
+                [spelling],
+                "{spelling} must be scrubbed from a worker's environment"
+            );
+        }
+        assert_eq!(
+            env_names_in([String::from("windbg_mcp_profiles")].into_iter()),
+            ["windbg_mcp_profiles"]
+        );
+    }
+
+    /// A control character is in no connection string, and the label built from one lands in
+    /// `session_status`'s multi-line report — where a line break can forge a session line.
+    #[test]
+    fn a_connection_carrying_a_control_character_is_refused_without_being_echoed() {
+        let err = select(Some(format!("net:port=1,\nkey={FAKE_KEY}")), None).unwrap_err();
+        assert!(err.contains("control character"), "{err}");
+        assert!(!err.contains(FAKE_KEY), "{err}");
+
+        // Same gate on the configured path: the entry is named (its name passed its own check)
+        // and the value is not.
+        let profiles = Profiles::from_pairs(&[
+            ("ctf-vm", FAKE),
+            ("broken", &format!("net:\nkey={FAKE_KEY}")),
+        ]);
+        assert_eq!(profiles.names(), ["ctf-vm"]);
+        let err = resolve("broken", &profiles).unwrap_err();
+        assert!(
+            err.contains("`broken`") && err.contains("control character"),
+            "{err}"
+        );
+        assert!(!err.contains(FAKE_KEY), "{err}");
     }
 
     /// The environment half of the same claim, on the real scan: a variable defines a profile

--- a/src/kdconn.rs
+++ b/src/kdconn.rs
@@ -1,0 +1,689 @@
+//! Kernel connection strings — the one tool argument that is a **secret**.
+//!
+//! A KDNET connection string carries the target's debug key (`net:port=50000,key=w.x.y.z`), and a
+//! key is all an attacker on the same network needs to take over the debug link. Passing it as a
+//! tool argument puts it somewhere this server does not control: an MCP client keeps its own
+//! transcript, and a key handed over once is then replicated through messages, tool calls, context
+//! snapshots and compaction summaries. That is not the client misbehaving — it is what a
+//! transcript *is* — so the fix has to be that the secret never enters the request.
+//!
+//! Two things here do that:
+//!
+//! - **Profiles.** `attach_kernel { "profile": "ctf-vm" }` names a connection this process
+//!   resolves from its own environment or a local file. The name is not a secret; the string it
+//!   resolves to never leaves this process except down the private pipe to the session's own
+//!   engine worker.
+//! - **[`Connection`], a value that cannot be printed.** Its `Debug` and `Display` render the
+//!   redacted form, so the raw string is reachable only through [`Connection::expose`] — one call
+//!   site, in the worker, handing it to DbgEng. Every other route to a log line, an error, or a
+//!   session report is redacted by construction rather than by remembering to redact.
+//!
+//! Redaction still matters with profiles in place, because `connection` stays supported: a target
+//! whose key is not configured anywhere has to be reachable, and an operator driving this server
+//! by hand should not have to write a config file first.
+
+use std::collections::BTreeMap;
+use std::fmt;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+/// Environment prefix for a single profile: `WINDBG_MCP_PROFILE_CTF_VM=net:port=50000,key=…`
+/// defines the profile `ctf-vm`.
+const PROFILE_ENV_PREFIX: &str = "WINDBG_MCP_PROFILE_";
+
+/// Overrides where the profile file is read from. Machine-local configuration, so it is expected
+/// to be set per host rather than shipped.
+const PROFILES_FILE_ENV: &str = "WINDBG_MCP_PROFILES";
+
+/// The profile file's default location under the user's profile directory.
+const DEFAULT_PROFILES_FILE: &[&str] = &[".windbg-mcp", "profiles.json"];
+
+/// Connection-string parameters whose value is a secret.
+///
+/// `key` is KDNET's; `password` is what `.server`/`.remote` connection strings use. Matched
+/// case-insensitively and only as a whole parameter name, so `pubkey=` is not mistaken for one.
+const SECRET_PARAMS: &[&str] = &["key", "password"];
+
+/// What a redacted secret is replaced with. Deliberately not the same length as any real value —
+/// a mask that preserved length would leak the key's shape.
+const MASK: &str = "<redacted>";
+
+/// A kernel connection string, with the secret sealed in.
+///
+/// `Debug` and `Display` both render [`redact`]ed, which is the point: this type exists so that
+/// putting a connection string in a log line, an error, or a session report is *safe by default*
+/// and exposing it takes a deliberate [`Connection::expose`]. Serialization is transparent — the
+/// raw string crosses the supervisor↔worker pipe, which is a pair of anonymous pipes nothing
+/// outside those two processes can read (see [`crate::proto`]).
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct Connection(String);
+
+impl Connection {
+    pub fn new(raw: impl Into<String>) -> Self {
+        Self(raw.into())
+    }
+
+    /// The raw string, key and all — for handing to DbgEng and nothing else.
+    ///
+    /// The **only** way the secret leaves this type. Anything that renders a connection for a
+    /// human or a log wants `Display`/[`Connection::redacted`] instead.
+    pub fn expose(&self) -> &str {
+        &self.0
+    }
+
+    /// The connection as it is safe to report: shape intact, secrets masked.
+    pub fn redacted(&self) -> String {
+        redact(&self.0)
+    }
+}
+
+impl fmt::Display for Connection {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.redacted())
+    }
+}
+
+impl fmt::Debug for Connection {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Connection({:?})", self.redacted())
+    }
+}
+
+/// Masks the secret parameters of a connection string, leaving everything else readable.
+///
+/// `net:port=50000,key=1.2.3.4` → `net:port=50000,key=<redacted>`. The transport and the port are
+/// what let a person tell two sessions apart, and neither is a secret, so this masks *values* and
+/// never the whole string.
+///
+/// Scans for `<name>=`, decides on the name, and skips the value: a name is what sits between the
+/// preceding delimiter and the `=`, and a value runs to the next `,`/`;`/whitespace. That means an
+/// `=` **inside** a masked value is consumed with it rather than restarting the scan — which is
+/// the case a naive split-on-`=` gets wrong, and it gets it wrong by emitting the tail of a key.
+pub fn redact(connection: &str) -> String {
+    const NAME_DELIMS: &[char] = &[',', ';', ':', '=', ' ', '\t'];
+    const VALUE_DELIMS: &[char] = &[',', ';', ' ', '\t'];
+
+    let mut out = String::with_capacity(connection.len());
+    let mut rest = connection;
+    loop {
+        let Some(eq) = rest.find('=') else {
+            out.push_str(rest);
+            return out;
+        };
+        let (head, tail) = rest.split_at(eq);
+        // All the delimiters are ASCII, so a byte index past one is a char boundary.
+        let name = &head[head.rfind(NAME_DELIMS).map_or(0, |i| i + 1)..];
+        out.push_str(head);
+        out.push('=');
+        let value = &tail[1..];
+        if SECRET_PARAMS.iter().any(|p| p.eq_ignore_ascii_case(name)) {
+            let end = value.find(VALUE_DELIMS).unwrap_or(value.len());
+            // An empty value has nothing to mask, and masking it would invent a secret that is
+            // not there — the honest rendering of `key=` is `key=`.
+            if end > 0 {
+                out.push_str(MASK);
+            }
+            rest = &value[end..];
+        } else {
+            rest = value;
+        }
+    }
+}
+
+/// One configured profile, keyed in [`Profiles`] by its normalized name but remembering the name
+/// as it was actually written — that is what an operator will recognise in an error.
+struct Profile {
+    name: String,
+    connection: Connection,
+}
+
+/// The kernel connection profiles configured on this host.
+///
+/// Read afresh for every attach rather than cached at startup, so adding a profile does not mean
+/// restarting the server (and, more to the point, does not mean restarting the MCP client).
+pub struct Profiles {
+    entries: BTreeMap<String, Profile>,
+    /// A profile file that exists but could not be used. Kept rather than raised immediately: it
+    /// must not break an attach that passes `connection` and needs no profiles at all, but it also
+    /// must not make a typo'd file look identical to "no such profile".
+    problem: Option<String>,
+    /// Where a profile file would be read from, for the "how do I configure one" advice. `None`
+    /// only when the host has no `USERPROFILE`, which on Windows means something is very wrong.
+    file: Option<PathBuf>,
+}
+
+impl Profiles {
+    /// Reads the profiles this host defines: environment first, then the file for any name the
+    /// environment did not already define.
+    ///
+    /// Environment wins because it is the more specific of the two — a variable set for this
+    /// server's process is a deliberate override of a file that is shared with every other
+    /// process the user runs.
+    pub fn from_host() -> Self {
+        let mut entries = from_env(std::env::vars());
+
+        let file = profiles_file();
+        let mut problem = None;
+        match file.as_deref().map(read_profile_file) {
+            Some(Ok(from_file)) => {
+                for (name, connection) in from_file {
+                    entries.entry(normalize(&name)).or_insert(Profile {
+                        name,
+                        connection: Connection::new(connection),
+                    });
+                }
+            }
+            Some(Err(why)) => problem = Some(why),
+            None => {}
+        }
+
+        Self {
+            entries,
+            problem,
+            file,
+        }
+    }
+
+    /// A fixed set, for tests: resolution has to be provable without mutating the process
+    /// environment, which in edition 2024 is `unsafe` and races every other test in the binary.
+    #[cfg(test)]
+    fn from_pairs(pairs: &[(&str, &str)]) -> Self {
+        Self {
+            entries: pairs
+                .iter()
+                .map(|(name, connection)| {
+                    (
+                        normalize(name),
+                        Profile {
+                            name: (*name).to_string(),
+                            connection: Connection::new(*connection),
+                        },
+                    )
+                })
+                .collect(),
+            problem: None,
+            file: Some(PathBuf::from(r"C:\Users\test\.windbg-mcp\profiles.json")),
+        }
+    }
+
+    fn get(&self, name: &str) -> Option<&Profile> {
+        self.entries.get(&normalize(name))
+    }
+
+    /// The configured names, as they were written. Names are not secrets — that is the whole
+    /// point of them — so they are safe to put in an error a client will keep.
+    fn names(&self) -> Vec<&str> {
+        self.entries.values().map(|p| p.name.as_str()).collect()
+    }
+
+    /// The tail of an error that has to explain where profiles come from.
+    fn how_to_configure(&self) -> String {
+        let file = match &self.file {
+            Some(path) => format!(
+                "or from a JSON object mapping name to connection string in {}",
+                path.display()
+            ),
+            None => format!("or from a JSON file named by {PROFILES_FILE_ENV}"),
+        };
+        let problem = match &self.problem {
+            Some(why) => format!("\n\nThe profile file could not be read: {why}"),
+            None => String::new(),
+        };
+        format!(
+            "Profiles are resolved by this server, on this host: from `{PROFILE_ENV_PREFIX}<NAME>` \
+             in its environment {file}. Names are matched case-insensitively, with `-` and `_` \
+             equivalent. Ask the user to add one — this server cannot.{problem}"
+        )
+    }
+
+    /// The "which profiles exist" clause, phrased for whichever of the two cases holds.
+    fn listed(&self) -> String {
+        match self.names().as_slice() {
+            [] => "No profiles are configured on this host.".to_string(),
+            names => format!("Configured profiles: {}.", names.join(", ")),
+        }
+    }
+}
+
+/// The profiles a set of environment variables defines.
+///
+/// Split out from [`Profiles::from_host`] so the mapping is testable: `std::env::set_var` is
+/// `unsafe` in edition 2024 and mutates state every other test in this binary shares, so the only
+/// way to prove `WINDBG_MCP_PROFILE_CTF_VM` defines the profile `ctf-vm` is to hand the scan its
+/// variables rather than the process's.
+fn from_env(vars: impl Iterator<Item = (String, String)>) -> BTreeMap<String, Profile> {
+    let mut entries = BTreeMap::new();
+    for (key, value) in vars {
+        let Some(suffix) = key.strip_prefix(PROFILE_ENV_PREFIX) else {
+            continue;
+        };
+        if suffix.is_empty() || value.trim().is_empty() {
+            continue;
+        }
+        // The variable's own suffix *is* the profile's name, lowercased — an environment variable
+        // cannot carry a hyphen, so `WINDBG_MCP_PROFILE_CTF_VM` lists as `ctf_vm`. Asking for
+        // `ctf-vm` still finds it: both normalize to the same key.
+        let name = suffix.to_ascii_lowercase();
+        entries.insert(
+            normalize(&name),
+            Profile {
+                name,
+                connection: Connection::new(value.trim()),
+            },
+        );
+    }
+    entries
+}
+
+/// Where the profile file lives on this host.
+fn profiles_file() -> Option<PathBuf> {
+    if let Some(override_path) = std::env::var_os(PROFILES_FILE_ENV)
+        && !override_path.is_empty()
+    {
+        return Some(PathBuf::from(override_path));
+    }
+    std::env::var_os("USERPROFILE").map(|home| {
+        DEFAULT_PROFILES_FILE
+            .iter()
+            .fold(PathBuf::from(home), |path, part| path.join(part))
+    })
+}
+
+/// Reads the profile file. A file that is not there is not a problem — configuring no profiles is
+/// the default — so that reads as an empty set rather than an error.
+///
+/// Parsed as a generic `Value` and walked by hand rather than deserialized into a typed map,
+/// because the values here are secrets and serde's type errors quote the value they rejected
+/// (`invalid type: integer 5`). Walking it means every message this can produce names a *key*, and
+/// syntax errors from `serde_json` carry a position rather than any content.
+fn read_profile_file(path: &Path) -> Result<BTreeMap<String, String>, String> {
+    let text = match std::fs::read_to_string(path) {
+        Ok(text) => text,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(BTreeMap::new()),
+        Err(e) => return Err(format!("{} could not be read ({e})", path.display())),
+    };
+    let parsed: serde_json::Value = serde_json::from_str(&text)
+        .map_err(|e| format!("{} is not valid JSON ({e})", path.display()))?;
+    let object = parsed.as_object().ok_or_else(|| {
+        format!(
+            "{} must be a JSON object mapping profile name to connection string",
+            path.display()
+        )
+    })?;
+    let mut out = BTreeMap::new();
+    for (name, value) in object {
+        let connection = value.as_str().ok_or_else(|| {
+            format!(
+                "profile `{name}` in {} must be a string (its connection string)",
+                path.display()
+            )
+        })?;
+        if !connection.trim().is_empty() {
+            out.insert(name.clone(), connection.trim().to_string());
+        }
+    }
+    Ok(out)
+}
+
+/// The form two profile names are compared in: case-insensitive, and `-`/`_`/`.` interchangeable.
+///
+/// Needed because the same profile can be written three ways — `ctf-vm` in a request, `ctf-vm` in
+/// the file, `WINDBG_MCP_PROFILE_CTF_VM` in the environment, where the variable name cannot carry
+/// a hyphen at all. Without normalization an environment-defined profile could not be named the
+/// way anyone would write it.
+fn normalize(name: &str) -> String {
+    name.chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() {
+                c.to_ascii_lowercase()
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+/// A resolved kernel target: the string to dial, and how the session may describe itself.
+///
+/// `Debug`-printable in full, because both fields already are: the label is redacted at
+/// construction and [`Connection`]'s own `Debug` is the redacted one.
+#[derive(Debug)]
+pub struct Selected {
+    pub connection: Connection,
+    /// What `session_status` (and the "no room to open another" list) shows for this session.
+    /// Redacted at construction, so nothing downstream has to remember to redact it.
+    pub label: String,
+}
+
+/// Turns `attach_kernel`'s two selectors into one target, or explains why it cannot.
+///
+/// Exactly one of them is required, and that is enforced here rather than in the schema. The
+/// alternative — an untagged `oneOf` — renders as a schema composition that clients handle
+/// unevenly (the same reason `session_id` is repeated per tool struct instead of flattened), and
+/// the cost of enforcing it at runtime is one tool error with text the model can act on.
+///
+/// Errors never echo a value: a caller who puts a connection string in `profile` by mistake — the
+/// most likely way to get this wrong, and the one that would defeat the whole feature — is told
+/// what shape a profile name has, not shown what they sent.
+pub fn select(connection: Option<String>, profile: Option<String>) -> Result<Selected, String> {
+    let connection = connection.filter(|c| !c.trim().is_empty());
+    let profile = profile.filter(|p| !p.trim().is_empty());
+    match (connection, profile) {
+        (Some(_), Some(_)) => Err(
+            "attach_kernel takes exactly one of `connection` or `profile`, and both were given. \
+             Pass `profile` alone to have this server resolve the connection locally, or \
+             `connection` alone to dial the string as given."
+                .to_string(),
+        ),
+        (Some(connection), None) => {
+            let connection = Connection::new(connection.trim());
+            Ok(Selected {
+                label: connection.redacted(),
+                connection,
+            })
+        }
+        (None, Some(profile)) => resolve(profile.trim(), &Profiles::from_host()),
+        (None, None) => Err(neither(&Profiles::from_host())),
+    }
+}
+
+/// What a caller who named no target is told. Its job is to make `profile` the obvious next call
+/// by naming the profiles that already exist — a caller who has to ask the user anyway will ask
+/// for the connection string, and then the key is in the transcript.
+fn neither(profiles: &Profiles) -> String {
+    format!(
+        "attach_kernel takes exactly one of `connection` or `profile`, and neither was given. \
+         `profile` names a connection this server resolves on this host, so the target's debug \
+         key never enters this request (or the client transcript that keeps it); `connection` is \
+         the raw string, e.g. \"net:port=50000,key=<w.x.y.z>\". {} {}",
+        profiles.listed(),
+        profiles.how_to_configure()
+    )
+}
+
+/// Looks a profile up, or says what to do about it not being there.
+fn resolve(name: &str, profiles: &Profiles) -> Result<Selected, String> {
+    if !is_profile_name(name) {
+        // The value is not echoed back, deliberately. This is the branch a mistyped
+        // `profile: "net:port=50000,key=…"` lands in, and echoing it would write the key into
+        // exactly the transcript profiles exist to keep it out of.
+        return Err(format!(
+            "`profile` must be the *name* of a connection configured on this host — letters, \
+             digits, `-`, `_` or `.`, e.g. \"ctf-vm\" — and the value given is not one. If it was \
+             a connection string, pass it as `connection` instead. {}",
+            profiles.listed()
+        ));
+    }
+    match profiles.get(name) {
+        Some(profile) => Ok(Selected {
+            label: format!("profile \"{}\" ({})", profile.name, profile.connection),
+            connection: profile.connection.clone(),
+        }),
+        None => Err(format!(
+            "no kernel connection profile named `{name}` is configured on this host. {} {}",
+            profiles.listed(),
+            profiles.how_to_configure()
+        )),
+    }
+}
+
+/// Whether this is a profile name rather than something else that got put in the field.
+fn is_profile_name(name: &str) -> bool {
+    !name.is_empty()
+        && name.len() <= 64
+        && name
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.'))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every test here uses this. A real key is `w.x.y.z` dotted decimal; this is the same shape
+    /// so the redaction is exercised the way it will be used, and it is not anyone's key.
+    const FAKE: &str = "net:port=50000,key=1.2.3.4";
+    const FAKE_KEY: &str = "1.2.3.4";
+
+    #[test]
+    fn redaction_masks_the_key_and_keeps_the_rest() {
+        assert_eq!(redact(FAKE), "net:port=50000,key=<redacted>");
+    }
+
+    #[test]
+    fn redaction_masks_a_key_wherever_it_sits() {
+        assert_eq!(
+            redact("net:key=a.b.c.d,port=50000"),
+            "net:key=<redacted>,port=50000"
+        );
+        assert_eq!(redact("key=a.b.c.d"), "key=<redacted>");
+        assert_eq!(
+            redact("net:port=1,key=a.b.c.d,target=host"),
+            "net:port=1,key=<redacted>,target=host"
+        );
+    }
+
+    #[test]
+    fn redaction_is_case_insensitive_and_covers_remote_passwords() {
+        assert_eq!(
+            redact("net:port=1,KEY=a.b.c.d"),
+            "net:port=1,KEY=<redacted>"
+        );
+        assert_eq!(
+            redact("npipe:pipe=dbg,server=box,password=hunter2"),
+            "npipe:pipe=dbg,server=box,password=<redacted>"
+        );
+    }
+
+    /// A parameter that merely *ends* in `key` is a different parameter, and masking it would
+    /// hide something a caller needs to read back.
+    #[test]
+    fn redaction_matches_whole_parameter_names_only() {
+        assert_eq!(redact("net:port=1,pubkey=abc"), "net:port=1,pubkey=abc");
+        assert_eq!(redact("net:port=1,keying=abc"), "net:port=1,keying=abc");
+    }
+
+    /// A key containing `=` must be consumed whole. Split-on-`=` would resume inside the value
+    /// and emit its tail — the one failure mode of this function that leaks the thing it hides.
+    #[test]
+    fn redaction_consumes_a_value_containing_an_equals_sign() {
+        let out = redact("net:port=1,password=ab=cd=ef,target=host");
+        assert_eq!(out, "net:port=1,password=<redacted>,target=host");
+        assert!(!out.contains("cd"), "{out}");
+    }
+
+    #[test]
+    fn redaction_leaves_a_string_with_no_secret_alone() {
+        for s in ["net:port=50000", "com:port=com1,baud=115200", "", "key"] {
+            assert_eq!(redact(s), s);
+        }
+        // Nothing to mask is not the same as something to hide.
+        assert_eq!(redact("net:port=1,key="), "net:port=1,key=");
+    }
+
+    #[test]
+    fn a_connection_never_renders_its_key() {
+        let c = Connection::new(FAKE);
+        assert!(!format!("{c}").contains(FAKE_KEY));
+        assert!(!format!("{c:?}").contains(FAKE_KEY));
+        assert_eq!(c.expose(), FAKE, "expose is the one way through");
+    }
+
+    /// The wire form has to stay a bare string: the worker deserializes it from JSON that this
+    /// type is only a supervisor-side wrapper around.
+    #[test]
+    fn a_connection_serializes_transparently() {
+        let json = serde_json::to_string(&Connection::new(FAKE)).unwrap();
+        assert_eq!(json, format!("\"{FAKE}\""));
+        let back: Connection = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.expose(), FAKE);
+    }
+
+    #[test]
+    fn selecting_both_or_neither_is_refused() {
+        let both = select(Some(FAKE.into()), Some("ctf-vm".into())).unwrap_err();
+        assert!(both.contains("exactly one"), "{both}");
+        assert!(
+            both.contains("`connection`") && both.contains("`profile`"),
+            "{both}"
+        );
+
+        let neither = select(None, None).unwrap_err();
+        assert!(neither.contains("exactly one"), "{neither}");
+        assert!(neither.contains("`profile`"), "{neither}");
+
+        // Blank is the same as absent, or a client that helpfully sends `""` gets a report of a
+        // session opened on an empty connection string.
+        let blank = select(Some("   ".into()), None).unwrap_err();
+        assert!(blank.contains("exactly one"), "{blank}");
+    }
+
+    #[test]
+    fn an_explicit_connection_is_dialed_as_given_and_labelled_redacted() {
+        let selected = select(Some(format!("  {FAKE}  ")), None).unwrap();
+        assert_eq!(selected.connection.expose(), FAKE, "trimmed, not rewritten");
+        assert_eq!(selected.label, "net:port=50000,key=<redacted>");
+    }
+
+    #[test]
+    fn a_profile_resolves_to_its_connection_without_naming_the_key() {
+        let profiles = Profiles::from_pairs(&[("ctf-vm", FAKE)]);
+        let selected = resolve("ctf-vm", &profiles).unwrap();
+        assert_eq!(selected.connection.expose(), FAKE);
+        assert!(selected.label.contains("ctf-vm"), "{}", selected.label);
+        assert!(!selected.label.contains(FAKE_KEY), "{}", selected.label);
+    }
+
+    /// The same profile is written three ways — request, file, environment variable — and the
+    /// environment form cannot carry a hyphen at all.
+    #[test]
+    fn profile_names_match_across_the_forms_they_are_written_in() {
+        let profiles = Profiles::from_pairs(&[("ctf-vm", FAKE)]);
+        for asked in ["ctf-vm", "CTF-VM", "ctf_vm", "Ctf_Vm"] {
+            assert!(resolve(asked, &profiles).is_ok(), "{asked} should resolve");
+        }
+    }
+
+    /// The environment half of the same claim, on the real scan: a variable defines a profile
+    /// under its own spelling, and the hyphenated name a person would type finds it anyway.
+    #[test]
+    fn an_environment_variable_defines_the_profile_its_name_spells() {
+        let vars = [
+            ("WINDBG_MCP_PROFILE_CTF_VM", FAKE),
+            // Neither of these is a profile: one is blank, one is a different variable.
+            ("WINDBG_MCP_PROFILE_BLANK", "   "),
+            ("WINDBG_MCP_CALL_TIMEOUT_SECS", "30"),
+        ]
+        .map(|(k, v)| (k.to_string(), v.to_string()));
+
+        let profiles = Profiles {
+            entries: from_env(vars.into_iter()),
+            problem: None,
+            file: None,
+        };
+        assert_eq!(profiles.names(), ["ctf_vm"]);
+        for asked in ["ctf-vm", "ctf_vm", "CTF-VM"] {
+            let selected =
+                resolve(asked, &profiles).unwrap_or_else(|e| panic!("{asked} should resolve: {e}"));
+            assert_eq!(selected.connection.expose(), FAKE);
+        }
+    }
+
+    #[test]
+    fn an_unknown_profile_names_the_ones_that_exist() {
+        let profiles = Profiles::from_pairs(&[("ctf-vm", FAKE), ("lab", "net:port=1,key=9.9.9.9")]);
+        let err = resolve("typo", &profiles).unwrap_err();
+        assert!(err.contains("`typo`"), "{err}");
+        assert!(err.contains("ctf-vm") && err.contains("lab"), "{err}");
+        assert!(!err.contains(FAKE_KEY) && !err.contains("9.9.9.9"), "{err}");
+    }
+
+    /// The mistake that would defeat the whole feature: a connection string typed into `profile`.
+    /// It has to be refused *and* not quoted back, or the key lands in the transcript anyway.
+    #[test]
+    fn a_connection_string_in_the_profile_field_is_refused_without_being_echoed() {
+        let profiles = Profiles::from_pairs(&[("ctf-vm", FAKE)]);
+        let err = resolve(FAKE, &profiles).unwrap_err();
+        assert!(err.contains("`connection`"), "{err}");
+        assert!(
+            !err.contains(FAKE_KEY),
+            "the error quoted the key back: {err}"
+        );
+        assert!(!err.contains("port=50000"), "{err}");
+    }
+
+    #[test]
+    fn no_error_on_the_profile_path_can_carry_a_secret() {
+        let profiles = Profiles::from_pairs(&[("ctf-vm", FAKE)]);
+        for asked in [
+            "typo",
+            FAKE,
+            "",
+            "key=1.2.3.4",
+            "  ",
+            "ctf vm",
+            &"x".repeat(500),
+        ] {
+            if let Err(err) = resolve(asked, &profiles) {
+                assert!(!err.contains(FAKE_KEY), "for {asked:?}: {err}");
+            }
+        }
+    }
+
+    /// The message a caller gets for naming no target at all has to point at `profile` *and* say
+    /// which ones exist — a caller who has to go and ask the user anyway will come back with a
+    /// connection string, and then the key is in the transcript after all.
+    #[test]
+    fn naming_no_target_points_at_the_profiles_that_exist() {
+        let err = neither(&Profiles::from_pairs(&[("ctf-vm", FAKE), ("lab", FAKE)]));
+        assert!(err.contains("exactly one"), "{err}");
+        assert!(err.contains("ctf-vm") && err.contains("lab"), "{err}");
+        assert!(err.contains(PROFILE_ENV_PREFIX), "{err}");
+        assert!(!err.contains(FAKE_KEY), "{err}");
+
+        let none = neither(&Profiles::from_pairs(&[]));
+        assert!(none.contains("No profiles are configured"), "{none}");
+    }
+
+    #[test]
+    fn a_profile_file_is_optional_but_a_broken_one_is_reported() {
+        let dir = std::env::temp_dir().join(format!("windbg-mcp-kdconn-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let missing = dir.join("does-not-exist.json");
+        assert!(read_profile_file(&missing).unwrap().is_empty());
+
+        let good = dir.join("good.json");
+        std::fs::write(
+            &good,
+            format!("{{ \"ctf-vm\": \"{FAKE}\", \"blank\": \"\" }}"),
+        )
+        .unwrap();
+        let parsed = read_profile_file(&good).unwrap();
+        assert_eq!(parsed.get("ctf-vm").map(String::as_str), Some(FAKE));
+        assert!(
+            !parsed.contains_key("blank"),
+            "an empty value is not a profile"
+        );
+
+        let bad = dir.join("bad.json");
+        std::fs::write(&bad, "{ not json").unwrap();
+        assert!(
+            read_profile_file(&bad)
+                .unwrap_err()
+                .contains("not valid JSON")
+        );
+
+        // A non-string value names the key, never the value — serde's own type error would have
+        // quoted the value, and the values in this file are keys.
+        let typed = dir.join("typed.json");
+        std::fs::write(&typed, "{ \"ctf-vm\": 12345 }").unwrap();
+        let err = read_profile_file(&typed).unwrap_err();
+        assert!(err.contains("`ctf-vm`"), "{err}");
+        assert!(!err.contains("12345"), "{err}");
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+}

--- a/src/kdconn.rs
+++ b/src/kdconn.rs
@@ -312,11 +312,14 @@ impl Profiles {
         format!(
             "Profiles are resolved by this server, on this host: from `{PROFILE_ENV_PREFIX}<NAME>` \
              in its environment {file}. Names are matched case-insensitively, with `-` and `_` \
-             equivalent.\n\nThis server cannot add one, but the user can, and that is the better \
-             ask than a connection string: adding `{{ \"<name>\": \"net:port=<n>,key=<w.x.y.z>\" }}` \
-             to that file (or setting `{PROFILE_ENV_PREFIX}<NAME>`) lets every later attach name it \
-             instead, and the key stays on this host. Profiles are re-read per attach, so nothing \
-             needs restarting.{notes}"
+             equivalent.\n\nThis server cannot add one, but the user can, and asking them for that \
+             beats asking for a connection string — every later attach then names it, and the key \
+             stays on this host. **The file is the one to ask for now**: it is re-read on every \
+             attach, so adding `{{ \"<name>\": \"net:port=<n>,key=<w.x.y.z>\" }}` to it works \
+             immediately. A `{PROFILE_ENV_PREFIX}<NAME>` variable is read from *this process's* \
+             environment, which was fixed when it started — setting one in a shell now changes \
+             nothing until this server is restarted, so that route is for the MCP client's server \
+             definition rather than for right now.{notes}"
         )
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@
 //! session that cannot be unwound be killed without taking the server with it.
 
 mod engine;
+mod kdconn;
 mod proto;
 mod server;
 mod ttd;

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -26,6 +26,8 @@
 
 use serde::{Deserialize, Serialize};
 
+use crate::kdconn::Connection;
+
 /// One unit of debugger work, as it crosses the process boundary.
 ///
 /// The variants are deliberately **tool-shaped, not DbgEng-shaped**. Several tools are more than
@@ -44,8 +46,12 @@ pub enum EngineOp {
         path: String,
     },
     AttachKernelLocal,
+    /// The one op carrying a **secret**. [`Connection`] serializes as the bare string it always
+    /// was — this channel is a pair of anonymous pipes, and nothing outside these two processes
+    /// can read it — but renders redacted everywhere else, so the `Debug` this enum derives
+    /// cannot become the leak. See [`crate::kdconn`].
     AttachKernel {
-        connection: String,
+        connection: Connection,
     },
     AttachProcess {
         pid: u32,

--- a/src/server.rs
+++ b/src/server.rs
@@ -18,6 +18,7 @@ use crate::engine::{
     Call, EngineError, MAX_SESSIONS, OpenError, OpenReport, SessionKind, SessionSnapshot,
     SessionState, Sessions,
 };
+use crate::kdconn;
 use crate::proto::{EngineOp, PoolOp, ReachabilityOp};
 use crate::ttd;
 
@@ -1026,10 +1027,22 @@ pub struct PathArgs {
     pub path: String,
 }
 
+/// `attach_kernel`'s target, named one of two ways. Exactly one is required, and that is checked
+/// at runtime rather than in the schema — see [`crate::kdconn::select`] for why.
 #[derive(Deserialize, JsonSchema)]
 pub struct ConnectionArgs {
-    /// Kernel debugging connection string, e.g. "net:port=50000,key=...".
-    pub connection: String,
+    /// Raw kernel debugging connection string, e.g. "net:port=50000,key=<w.x.y.z>". Pass exactly
+    /// one of `connection` or `profile`. This puts the target's KDNET key in this request — and
+    /// so into whatever transcript the client keeps — so prefer `profile` when the host has one
+    /// configured. Never invent a key: ask the user for the string, or for a profile name.
+    #[serde(default)]
+    pub connection: Option<String>,
+    /// Name of a kernel connection configured on this host, e.g. "ctf-vm", which this server
+    /// resolves locally so the key never appears in this request. Pass exactly one of
+    /// `connection` or `profile`. A wrong or absent name is answered with the names that do
+    /// exist, so guessing costs one call rather than a leaked key.
+    #[serde(default)]
+    pub profile: Option<String>,
 }
 
 #[derive(Deserialize, JsonSchema)]
@@ -1739,6 +1752,10 @@ impl WindbgServer {
     }
 
     /// Attach to a kernel target over a connection string (e.g. KDNET).
+    /// Takes exactly one of `profile` (a connection configured on this host, which the server
+    /// resolves locally — the target's debug key never enters this request) or `connection` (the
+    /// raw string, key and all). Prefer `profile`; call it with neither to be told which profiles
+    /// this host has.
     /// Opens a new session in its own engine process — sessions already open are left alone —
     /// and returns a `session_id` that routes later calls to it.
     /// A live kernel attach waits for the target to dial in, and that wait has no timeout and
@@ -1759,11 +1776,19 @@ impl WindbgServer {
         &self,
         Parameters(args): Parameters<ConnectionArgs>,
     ) -> Result<CallToolResult, ErrorData> {
+        // Resolved here, in the supervisor, and *before* a worker exists: a selector the caller
+        // has to fix should cost them a message, not a spawned process and a session to end. The
+        // label that comes back is already redacted, so the session can describe itself in
+        // `session_status` without holding the key anywhere but in the op below.
+        let selected = match kdconn::select(args.connection, args.profile) {
+            Ok(selected) => selected,
+            Err(why) => return tool_error(why),
+        };
         self.opened(
             SessionKind::Kernel,
-            args.connection.clone(),
+            selected.label,
             EngineOp::AttachKernel {
-                connection: args.connection,
+                connection: selected.connection,
             },
         )
         .await

--- a/src/ttd.rs
+++ b/src/ttd.rs
@@ -117,8 +117,17 @@ pub fn record_launch(
         .arg(target)
         .stdout(Stdio::from(log))
         .stderr(Stdio::from(log_err));
+    // Configured kernel connections do not reach the recorder. TTD.exe launches `target` with
+    // this environment inherited, and the recorded target is an arbitrary binary — frequently the
+    // least trustworthy program on the machine, which is usually *why* it is being recorded. Same
+    // scrub as `engine::spawn_worker`, for the same reason: this is the other process this server
+    // creates, and nothing about recording needs a KDNET key.
+    for name in crate::kdconn::env_names() {
+        cmd.env_remove(name);
+    }
     // Pass through the validated environment (e.g. an anti-analysis env guard) and cwd to the
-    // recorded target. TTD.exe launches `target` with this environment inherited.
+    // recorded target. TTD.exe launches `target` with this environment inherited. Applied after
+    // the scrub above, so an entry the caller passed deliberately still wins.
     for (key, val) in parsed_env {
         cmd.env(key, val);
     }

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -492,7 +492,9 @@ fn execute(e: &DebugEngine, id: u64, op: EngineOp, queued: Duration) -> Result<S
                 // This `wait` is the one that can never return: `SetInterrupt` cannot reach a
                 // wait still establishing the link, so a guest that never dials in parks here
                 // for good. It parks *this process*, which the supervisor can kill.
-                let pending = e.attach_kernel_begin(&connection).map_err(es)?;
+                // The one place the key is unwrapped, and the last: it goes straight into
+                // DbgEng. Everything else that touches this value renders it redacted.
+                let pending = e.attach_kernel_begin(connection.expose()).map_err(es)?;
                 commit();
                 pending.wait().map_err(es)
             },

--- a/tests/golden/tools_list.json
+++ b/tests/golden/tools_list.json
@@ -14,11 +14,10 @@
       },
       "name": "attach_kernel",
       "params": [
-        "connection: string"
+        "connection: string|null",
+        "profile: string|null"
       ],
-      "required": [
-        "connection"
-      ],
+      "required": [],
       "title": "Attach to kernel target"
     },
     {

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -999,6 +999,12 @@ fn an_unknown_profile_is_refused_with_the_names_that_exist_but_no_values() {
         "the refusal echoed the key it was handed:\n{text}"
     );
 
+    // One more round trip before reading the log. stderr is drained by a thread of its own with
+    // no ordering against the transport, so a line the server wrote while handling the call above
+    // may still be in the pipe — and an assertion that something is *absent* passes on a line
+    // nobody has read yet. The response to this call orders the server past both refusals.
+    server.tool_text("session_status", json!({}), STEP);
+
     // The whole point, restated over the transport itself: nothing carrying that key was ever
     // written to the client, and nothing to the log either.
     assert!(
@@ -1424,6 +1430,9 @@ fn a_profile_attach_names_its_target_without_disclosing_the_key() {
     );
     // The abandoned attach is still outstanding; its session is gone, so it has to be answered.
     server.await_id(attaching, "attach_kernel", Duration::from_secs(60));
+    // A round trip after the teardown, for the same reason as in the protocol tier: the log is
+    // drained by an unordered thread, and a negative assertion passes on a line nobody read yet.
+    server.tool_text("session_status", json!({}), STEP);
 
     assert!(
         !server.stdout_lines().iter().any(|l| l.contains(key)),

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -881,6 +881,133 @@ fn bad_calls_are_rejected_without_killing_the_session() {
     );
 }
 
+/// A fake KDNET connection for the profile tests, and the key inside it.
+///
+/// The whole point of asserting on this value is that it must appear **nowhere** a client can see,
+/// so it has to be one no real host would produce by coincidence — hence a documentation-range
+/// address, and not anyone's key.
+const FAKE_PROFILE: (&str, &str) = ("net:port=50008,key=203.0.113.9", "203.0.113.9");
+
+/// Environment defining exactly one profile and no others.
+///
+/// An environment variable cannot carry a hyphen, so this defines `smoke_kdnet` — which
+/// `smoke-kdnet` also resolves to, and the attach below relies on that. `WINDBG_MCP_PROFILES` is
+/// pointed at a path that does not exist on purpose: the developer running this may have real
+/// profiles configured, and reading them would make these tests vary by host — and put real
+/// profile names in a failure message.
+fn profile_env() -> [(&'static str, &'static str); 2] {
+    [
+        ("WINDBG_MCP_PROFILE_SMOKE_KDNET", FAKE_PROFILE.0),
+        (
+            "WINDBG_MCP_PROFILES",
+            r"C:\nonexistent\windbg-mcp-smoke.json",
+        ),
+    ]
+}
+
+/// `attach_kernel`'s two selectors are exclusive, and the check is this server's own — the schema
+/// leaves both optional, so nothing upstream enforces it.
+///
+/// Both failures have to arrive as *tool* errors with the alternative named, not as protocol
+/// errors: a model that gets "invalid params" back cannot tell which of the two to drop. Neither
+/// costs a worker, which is the other half — a mistyped selector must not leave a session to end.
+///
+/// Needs no debugger, so it runs in the protocol tier: both refusals happen in the supervisor,
+/// before anything is spawned.
+#[test]
+fn attach_kernel_refuses_both_selectors_and_neither() {
+    let mut server = Server::started_with(&profile_env());
+
+    let both = server.call_tool(
+        "attach_kernel",
+        json!({ "connection": "net:port=50009,key=1.1.1.1", "profile": "smoke" }),
+        STEP,
+    );
+    assert_no_error(&both, "attach_kernel with both selectors");
+    let text = text_of(&both["result"]);
+    assert!(
+        is_tool_error(&both),
+        "naming a target twice must be refused, got:\n{text}"
+    );
+    assert!(
+        text.contains("exactly one") && text.contains("`profile`"),
+        "the refusal must name the choice, got:\n{text}"
+    );
+
+    let neither = server.call_tool("attach_kernel", json!({}), STEP);
+    assert_no_error(&neither, "attach_kernel with no selector");
+    let text = text_of(&neither["result"]);
+    assert!(
+        is_tool_error(&neither),
+        "naming no target must be refused, got:\n{text}"
+    );
+    assert!(
+        text.contains("`profile`") && text.contains("`connection`"),
+        "the refusal must name both ways to say what to attach to, got:\n{text}"
+    );
+
+    // Neither refusal reached the engine, so there is nothing to clean up — which is the claim.
+    let sessions = server.tool_text("session_status", json!({}), STEP);
+    assert!(
+        sessions.contains("No debug session"),
+        "a refused selector must not leave a session behind:\n{sessions}"
+    );
+}
+
+/// A profile that is not configured has to be answered with the ones that are — and without the
+/// value of any of them. Guessing a name should cost a call; it must never cost a key.
+///
+/// The second half is the mistake that would defeat the whole feature: a caller who puts a
+/// connection string into `profile`. Quoting it back would write the key into exactly the
+/// transcript profiles exist to keep it out of, so the refusal names the *shape* of a profile
+/// name instead.
+///
+/// Protocol tier: every one of these is refused in the supervisor, before a worker exists.
+#[test]
+fn an_unknown_profile_is_refused_with_the_names_that_exist_but_no_values() {
+    let (connection, key) = FAKE_PROFILE;
+    let mut server = Server::started_with(&profile_env());
+
+    let unknown = server.call_tool("attach_kernel", json!({ "profile": "no-such-vm" }), STEP);
+    assert_no_error(&unknown, "attach_kernel with an unknown profile");
+    let text = text_of(&unknown["result"]);
+    assert!(is_tool_error(&unknown), "got:\n{text}");
+    // Listed under the variable's own spelling — an environment variable cannot carry a hyphen —
+    // while `smoke-kdnet` still resolves to it, which the tier-2 attach below relies on.
+    assert!(
+        text.contains("smoke_kdnet"),
+        "the refusal must name the profiles that do exist, got:\n{text}"
+    );
+    assert!(
+        !text.contains(key),
+        "the refusal disclosed a profile's key:\n{text}"
+    );
+
+    let mistyped = server.call_tool("attach_kernel", json!({ "profile": connection }), STEP);
+    assert_no_error(
+        &mistyped,
+        "attach_kernel with a connection string as the profile",
+    );
+    let text = text_of(&mistyped["result"]);
+    assert!(is_tool_error(&mistyped), "got:\n{text}");
+    assert!(
+        text.contains("`connection`"),
+        "the refusal must point at the field that takes a connection string, got:\n{text}"
+    );
+    assert!(
+        !text.contains(key),
+        "the refusal echoed the key it was handed:\n{text}"
+    );
+
+    // The whole point, restated over the transport itself: nothing carrying that key was ever
+    // written to the client, and nothing to the log either.
+    assert!(
+        !server.stdout_lines().iter().any(|l| l.contains(key)),
+        "a key reached the JSON-RPC transport"
+    );
+    assert!(!server.stderr().contains(key), "a key reached the log");
+}
+
 /// The harness's own guard, pinned because losing it is silent and expensive.
 ///
 /// `tool_text` used to hand back a tool error's text like any other result. Nothing failed when
@@ -1224,6 +1351,88 @@ fn a_kernel_attach_that_never_connects_costs_one_session_and_can_be_ended() {
         "end_session",
         json!({ "session_id": dump_session }),
         TARGET_STEP,
+    );
+}
+
+/// A profile-named attach opens the session it names, and the key never leaves this process.
+///
+/// The unit tests prove the resolution and the redaction; only this proves the two hold **over the
+/// wire**, which is where the issue actually was. The target is deliberately unreachable, so the
+/// attach parks — everything asserted here (the session exists, describes itself, and can be
+/// ended) is true of a parked attach, and a park costs no VM.
+///
+/// Two claims, and the second is the one that matters:
+///
+/// - `session_status` names the *profile*, so a caller can still tell two kernel sessions apart
+///   without either of them printing a key.
+/// - The key appears on neither the transport nor the log, at any point in the session's life.
+///   That is asserted against every line the server ever wrote, not against one result, because
+///   the failure this guards is a key surfacing somewhere nobody looked.
+#[test]
+fn a_profile_attach_names_its_target_without_disclosing_the_key() {
+    if target_tier().is_none() {
+        return;
+    }
+    let (_, key) = FAKE_PROFILE;
+    let mut server = Server::started_with(&profile_env());
+
+    let attaching = server.send_request(
+        "tools/call",
+        json!({
+            "name": "attach_kernel",
+            "arguments": { "profile": "smoke-kdnet" },
+        }),
+    );
+
+    let deadline = Instant::now() + Duration::from_secs(30);
+    let parked = loop {
+        let status = server.tool_text("session_status", json!({}), STEP);
+        if status.contains("waiting") && status.contains("kernel target") {
+            break Some(status);
+        }
+        if Instant::now() >= deadline {
+            break None;
+        }
+        std::thread::sleep(Duration::from_millis(200));
+    };
+    let Some(status) = parked else {
+        skip("the profile attach did not reach the parked state (port 50008 busy?)");
+        return;
+    };
+
+    // Named for the profile *as configured* (`smoke_kdnet`), not as the caller spelled it
+    // (`smoke-kdnet`) — the point is that the session is identifiable, and the configured name is
+    // the one an operator can look up.
+    assert!(
+        status.contains("smoke_kdnet"),
+        "the session should describe itself by the profile it was opened from:\n{status}"
+    );
+    assert!(
+        status.contains("key=<redacted>"),
+        "the connection should be reported with its key masked, not omitted:\n{status}"
+    );
+
+    let kernel_session = status
+        .lines()
+        .find(|l| l.contains("kernel target"))
+        .map(|l| l.split_whitespace().next().unwrap_or_default().to_string())
+        .expect("the kernel session should be listed");
+    server.tool_text(
+        "end_session",
+        json!({ "session_id": kernel_session }),
+        Duration::from_secs(120),
+    );
+    // The abandoned attach is still outstanding; its session is gone, so it has to be answered.
+    server.await_id(attaching, "attach_kernel", Duration::from_secs(60));
+
+    assert!(
+        !server.stdout_lines().iter().any(|l| l.contains(key)),
+        "the profile's key reached the JSON-RPC transport"
+    );
+    assert!(
+        !server.stderr().contains(key),
+        "the profile's key reached the log:\n{}",
+        server.stderr()
     );
 }
 


### PR DESCRIPTION
Closes #81.

## The problem

`attach_kernel` took a raw DbgEng connection string, and a KDNET one carries the target's debug key. A tool argument is not a private channel: the client owns the transcript, and during the MessageManager CTF session the single key supplied was replicated into 524 records of it — messages, tool calls, context snapshots, compaction summaries. Nothing the client did was wrong; that is what keeping a conversation *means*. The server's fault was giving it no way to avoid handling the secret in the first place.

## What changed

**Profiles.** `attach_kernel` takes exactly one of:

```jsonc
{ "profile": "ctf-vm" }                          // resolved on this host; no key in the request
{ "connection": "net:port=50000,key=1.2.3.4" }   // unchanged, still supported
```

Profiles come from `WINDBG_MCP_PROFILE_<NAME>` in the server's environment (checked first) or `%USERPROFILE%\.windbg-mcp\profiles.json` (`WINDBG_MCP_PROFILES` overrides the path) — machine-local, outside any repo. Names are matched case-insensitively with `-`/`_`/`.` equivalent, and both sources are re-read per attach, so adding one does not mean restarting the MCP client.

Passing both, or neither, is a tool error naming the alternative. The "neither" case lists the profiles the host has, and that part is load-bearing: an agent that cannot discover a name asks the user, the user answers with a connection string, and the key is in the transcript after all.

**A connection string that cannot be printed.** The value lives in `kdconn::Connection`, whose `Debug` and `Display` render redacted; the raw string is reachable only through `expose()`, called at exactly one site — handing it to DbgEng inside the session's own worker. So a session label (`session_status`, the "no room" list), a tool error, a log line, and `EngineOp`'s derived `Debug` can only ever carry `key=<redacted>`. That is a property of the type rather than a rule to remember at four call sites and forget at the fifth.

`session_status` now reads:

```
sess-… (current) — kernel target: profile "ctf-vm" (net:port=50000,key=<redacted>)  [engine pid 4276, opened 0.1s ago]
```

## Two decisions worth flagging

- **Redaction is scoped to connection strings**, not to every string leaving the server. Filtering all output for `key=` would rewrite `!reg` output or a memory dump, and on a CTF target a flag can look like anything — a debugger that quietly edits its answers is a worse failure than the one being fixed.
- **Exclusivity is a runtime check, not a schema `oneOf`.** An untagged enum renders as a schema composition clients handle unevenly — the same reason `session_id` is repeated per tool struct instead of flattened. Both fields are optional on the wire, so the `tools/list` golden is re-recorded (`connection: string` required → `connection`/`profile` both `string|null`, none required).

Rationale is recorded in `DECISIONS.md`.

## Testing

- `cargo fmt --all --check`, `cargo clippy --all-targets` — clean.
- `cargo test` — 139 unit + 24 smoke, all passing. 17 new unit tests in `src/kdconn.rs` cover redaction (including a value containing `=`, which a split-on-`=` implementation would leak the tail of), profile resolution across the three spellings a name is written in, and the property that **no error on this path can carry a secret**.
- `WINDBG_MCP_SMOKE_DUMP=1 cargo test --test mcp_smoke` — passing, including the new end-to-end profile attach: a park on a dead port opened by `profile`, asserting the session names its profile, reports `key=<redacted>`, and that the fake key appears on neither the JSON-RPC transport nor the log across every line the server ever wrote.
- `cargo build --release` compiles; the final replace hits the known `os error 5` from the MCP server holding the exe (see `CLAUDE.md`). CI builds it on a fresh runner.
- markdownlint clean over the CI globs.

All test values are fake — a documentation-range address, never a real key.

## Docs

README (new section + architecture list), `skills/windbg-debugging/{SKILL,setup,live-and-kernel}.md` (the agent-facing path: prefer `profile`, discover names with `attach_kernel {}`, never invent a key), `docs/smoke-test.md`, `CHANGELOG.md`, `DECISIONS.md`, `CLAUDE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - `attach_kernel` supports named host-configured profiles and direct connection strings.
  - Profile discovery is available when no selector is supplied.
  - Profile names are matched consistently regardless of case or separators.

- **Security**
  - Connection keys are redacted from status, logs, errors and diagnostics.
  - Invalid or conflicting requests are rejected before a session is created.
  - Configured connection details are protected from launched debugging processes.

- **Documentation**
  - Added guidance for configuring profiles, attaching to kernels and validating secrecy safeguards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->