### PR TITLE
Run debugger transactions with a rollback the engine owns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,62 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`debug_batch`: an ordered sequence of debugger steps as one transaction, with assertions and a
+  rollback the engine process owns** ([#82](https://github.com/glslang/windbg-mcp/issues/82)).
+
+  A tool call is a request/response, so a client driving a multi-step debugger transaction decides
+  what to do next *after* each answer — and the case that matters is the one where no answer
+  arrives. A call that times out, or a client that disconnects, leaves whatever the earlier calls
+  changed in place: a patched instruction, an armed breakpoint, a target left running. On a kernel
+  target that is not an inconvenience. The MessageManager CTF session grew a private JSON-RPC
+  client for exactly this (`target/mcp_batch.ps1`, referenced 204 times and revised 18); the shape
+  it converged on is what this tool is.
+
+  A batch is submitted as one op and executed inside the session's worker process. Steps are
+  `command` (raw), `resume` (a command that moves the target, plus the wait), `run_to` (a
+  HIT/STOPPED ELSEWHERE/TIMEOUT verdict), `eval` (a MASM expression's value) and `read_memory`.
+  Each may carry assertions — `contains`, `not_contains`, or `eval`, which compares two MASM
+  expressions and so covers registers, memory and any relation between them — and an `eval` step
+  may `capture` its value under a name later steps interpolate as `{{name}}`.
+
+  **The `always` block runs on every path**: success, a debugger error, an assertion that did not
+  hold, the deadline expiring. Part of the budget is reserved for it before the first step runs,
+  because what is left after a step that ran to its own deadline is nothing. The worker owns that
+  deadline, sized from the caller's remaining patience the same way a bounded command's watchdog
+  is, so the rollback has finished and the report has been written before the tool call gives up —
+  which is the only reason the report is worth anything.
+
+  The result names every step that ran, the exact failing one, what each step changed, whether the
+  rollback completed (reported *beside* the original failure, never instead of it), and whether the
+  session is left stopped, running, detached or uncertain. A batch that did not commit comes back as
+  a tool error carrying that whole report.
+
+  Validation is up front and engine-free: a forward capture reference, a capture on a step that has
+  no value, a duplicate name, a `;` in a typed operand, an empty or oversized batch are all refused
+  before a single step runs. A batch containing a target-changing command retires the session handle
+  ahead of running, as `execute` does. The executor drives a `Debuggee` trait rather than DbgEng, so
+  assertion failure, a command failure after a mutation, deadline expiry and a rollback that itself
+  fails are unit-tested without a debugger; the dump tier drives a real engine to both outcomes.
+
+  Two limits are documented rather than papered over. DbgEng reports most command failures by
+  printing them and returning success, so a raw step that prints an error is a step that
+  *succeeded* — assert on its output if that matters. And what a step "changed" is a best-effort
+  classification of the command text, biased toward reporting a change: a reporting aid, not what
+  makes a mutation recoverable. The `always` block is.
+
+  Validated against the workflow it was filed for, not against a guess at it: the CTF session's own
+  transcript records all 18 revisions of the throwaway client and all 188 of its invocations — 1,681
+  steps, of which 1,672 are shapes the step language covers. The 9 that are not are pool-tool calls
+  (`pool_chunk`, `pool_census`, `pool_find_tag`), which are win-kexp walks rather than debugger
+  commands and so have no `execute` to fall back on; that gap is [`FOLLOWUPS.md`](./FOLLOWUPS.md)
+  item 17. Two of the client's revisions exist only to work around gaps this closes — a compound
+  assertion rewritten as three pseudo-register assignments and three regexes, and a duplicate of its
+  run-to verb whose only difference was restoring a patch "on both hit and timeout". The longest
+  single invocation, 32 steps, is transcribed as a regression test.
+
+  `tools/list` gains one tool and its first nested schema, so the recorded wire surface now has
+  `$defs` (`usesDefs` flips to `true`); the refs stay internal and single-dialect.
+
 - **`attach_kernel` can name its target by `profile`**, so a KDNET debug key never has to travel in
   an MCP request ([#81](https://github.com/glslang/windbg-mcp/issues/81)).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,12 +27,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   expressions and so covers registers, memory and any relation between them — and an `eval` step
   may `capture` its value under a name later steps interpolate as `{{name}}`.
 
-  **The `always` block runs on every path**: success, a debugger error, an assertion that did not
-  hold, the deadline expiring. Part of the budget is reserved for it before the first step runs,
-  because what is left after a step that ran to its own deadline is nothing. The worker owns that
-  deadline, sized from the caller's remaining patience the same way a bounded command's watchdog
-  is, so the rollback has finished and the report has been written before the tool call gives up —
-  which is the only reason the report is worth anything.
+  **The `always` block is reached on every path**: success, a debugger error, an assertion that did
+  not hold, the deadline expiring. Part of the budget is reserved for it before the first step runs,
+  because what is left after a step that ran to its own deadline is nothing, and cleanup continues
+  past its own failures. The worker owns that deadline, sized from the caller's remaining patience
+  the same way a bounded command's watchdog is, so the rollback has finished and the report has been
+  written before the tool call gives up — which is the only reason the report is worth anything.
+
+  Two edges are reported rather than papered over. The reserve buys the rollback *time*, not a
+  guarantee: a step that overruns far enough to consume the reserve as well leaves cleanup with no
+  budget, and the result then says `rollback: INCOMPLETE` and names each step that never started.
+  And the strong guarantee is against a call **timeout** — a client **disconnect** is treated as
+  `end_session` on every session, so a batch still running when that grace expires is terminated
+  with its worker, mid-transaction.
 
   The result names every step that ran, the exact failing one, what each step changed, whether the
   rollback completed (reported *beside* the original failure, never instead of it), and whether the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,9 +28,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   may `capture` its value under a name later steps interpolate as `{{name}}`.
 
   **The `always` block is reached on every path**: success, a debugger error, an assertion that did
-  not hold, the deadline expiring. Part of the budget is reserved for it before the first step runs,
-  because what is left after a step that ran to its own deadline is nothing, and cleanup continues
-  past its own failures. The worker owns that deadline, sized from the caller's remaining patience
+  not hold, the deadline expiring, a panic out of the debugger (win-kexp methods do panic — several
+  use `.expect` — and the worker's own `catch_unwind` is around the whole op, so each engine call a
+  step makes is guarded individually). Part of the budget is reserved for it before the first step
+  runs, because what is left after a step that ran to its own deadline is nothing, and cleanup
+  continues past its own failures. The worker owns that deadline, sized from the caller's remaining patience
   the same way a bounded command's watchdog is, so the rollback has finished and the report has been
   written before the tool call gives up — which is the only reason the report is worth anything.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the same way a bounded command's watchdog is, so the rollback has finished and the report has been
   written before the tool call gives up — which is the only reason the report is worth anything.
 
+A batch whose caller has already given up is **not started at all**: a job stays queued after
+  its waiter times out, so the worker checks what patience is left before the first step and
+  refuses outright rather than applying mutations nobody is waiting to hear about. That is where a
+  batch parts company with a bounded command, which floors its watchdog instead — that one is
+  already running and the job left is to free the worker; this one has not started, and not
+  starting is what leaves the target as the caller last saw it.
+
   Two edges are reported rather than papered over. The reserve buys the rollback *time*, not a
   guarantee: a step that overruns far enough to consume the reserve as well leaves cleanup with no
   budget, and the result then says `rollback: INCOMPLETE` and names each step that never started.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,8 +49,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a tool error carrying that whole report.
 
   Validation is up front and engine-free: a forward capture reference, a capture on a step that has
-  no value, a duplicate name, a `;` in a typed operand, an empty or oversized batch are all refused
-  before a single step runs. A batch containing a target-changing command retires the session handle
+  no value, a duplicate name, a `;` in a typed operand, an empty or oversized batch, a deadline too
+  short to seat a step and its reserve, and — uniquely among this server's tools — any field the
+  schema does not name are all refused before a single step runs. The last is there because those
+  typos fail *open*: `"aways"` for `always` is a batch with no rollback that then reports
+  `COMMITTED`, and a misspelt `expect` is a step that asserts nothing and commits anyway. A batch containing a target-changing command retires the session handle
   ahead of running, as `execute` does. The executor drives a `Debuggee` trait rather than DbgEng, so
   assertion failure, a command failure after a mutation, deadline expiry and a rollback that itself
   fails are unit-tested without a debugger; the dump tier drives a real engine to both outcomes.

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -5,6 +5,58 @@ status. Keep entries short; link to code with `file:line` where it helps a futur
 
 ---
 
+## The rollback belongs to the worker, not the client (2026-08-09, #82)
+
+**Context.** Multi-step debugger work that mutates a target — patch a byte, arm a breakpoint,
+resume a thread — has to undo itself. Driven as separate tool calls, the undo is a *later request*,
+and the failure mode is structural rather than accidental: the call that would carry the cleanup is
+exactly the call that times out, and a client that disconnects sends nothing at all. The
+MessageManager session grew a private PowerShell JSON-RPC client to work around this and revised it
+eighteen times; every revision added something the server could not express (a verdict check, a
+target-object assertion, ordered cleanup, rollback after a wrong object or a failed reclaim).
+
+**Decision.** `debug_batch` submits the whole sequence as one `EngineOp`, and the **worker process**
+executes it: steps, assertions, and an `always` block that runs on every path, before the reply is
+written (`src/batch.rs`). The client's timeout can no longer land between a mutation and its undo,
+because there is nothing left for it to land between.
+
+**Three properties follow, and they are the design.** The *deadline is the worker's* — a share of
+the budget is reserved for `always` before the first step runs, since what is left after a step that
+consumed its own deadline is nothing, and the budget itself is clamped to the caller's remaining
+patience (`worker::batch_budget`) so the report lands ahead of the tool call's timeout. The
+*rollback is unconditional* — a failure inside it is recorded beside the original, never in place of
+it, and cleanup continues past its own failures because a patch that cannot be restored must not
+stop a breakpoint from being cleared. And the *executor never touches DbgEng*: it drives a
+`Debuggee` trait with a virtual clock, so assertion failure, a command failure after a mutation,
+deadline expiry and a failed rollback are all unit tests rather than things a live target has to be
+persuaded to reproduce.
+
+**What is deliberately best-effort, and labelled as such.** Which steps "changed" something is a
+first-token classification of the command (`batch::mutation`), biased toward over-reporting for the
+same reason `changes_debug_target` is: an over-report costs a line of text, a missed one leaves a
+mutation nobody knows to undo. It decides nothing about what runs. Likewise the session-state probe
+answers `Stopped` only from a reading it actually got, and never reads a refused probe as
+"detached" — that verdict comes from what the batch ran, because a probe cannot tell a released
+target from a running one, and turning "could not read" into a verdict is the mistake the pool
+tools already learned not to make.
+
+**Validated against the workflow it was filed for.** The CTF session's own transcript
+(`~/.codex/sessions/2026/08/08`) records all 18 revisions of the throwaway client and all 188 of its
+invocations — 1,681 individual steps. Classified against the step language: 1,672 of them are
+`command`, `run_to`, `resume` or `eval` shapes, and **9 are pool-tool calls a batch cannot reach**
+(`@chunkt1`, `@census`, `@find`, `@findr`). Two of the client's revisions exist only to work around
+gaps this design closes — its eighth replaced a compound `.if` assertion with three pseudo-register
+assignments and three regexes over printed output, and its sixteenth added a duplicate of `@run`
+whose only difference was restoring a patch "on both hit and timeout", which is `always` hand-rolled.
+`batch::tests::the_messagemanager_sequence_is_a_valid_batch` is the longest single invocation
+transcribed, and its sibling drives the wrong-target failure the client wrote that rollback for.
+
+**Status.** Adopted. Two things are still owed: pool steps (FOLLOWUPS item 17, the one gap the
+transcript found) and a live-kernel exercise of a *mutating* batch (item 16) — the dump tier proves
+the wiring and both outcomes, but a dump has nothing worth restoring.
+
+---
+
 ## Connection strings are parsed, not scanned (2026-08-09, follows #81)
 
 **Context.** Redaction started as a scanner: walk the raw string, and at each `=` work out where

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -26,7 +26,10 @@ consumed its own deadline is nothing, and the budget itself is clamped to the ca
 patience (`worker::batch_budget`) so the report lands ahead of the tool call's timeout. The
 *rollback is reached unconditionally* — a failure inside it is recorded beside the original, never
 in place of it, and cleanup continues past its own failures because a patch that cannot be restored
-must not stop a breakpoint from being cleared. What the reserve buys is time to run, not a promise:
+must not stop a breakpoint from being cleared. Three paths lead to it and all three are handled in
+`batch::run`: a debugger error, an expired deadline, and an unwind — every engine call goes through
+`batch::guarded`, because `worker::engine_thread` catches panics at *op* granularity and one from a
+step would otherwise leave `run` without ever reaching `always`. What the reserve buys is time to run, not a promise:
 a step that overruns it too leaves cleanup with no budget, and the report then says the rollback is
 incomplete rather than implying it happened. And the *executor never touches DbgEng*: it drives a
 `Debuggee` trait with a virtual clock, so assertion failure, a command failure after a mutation,

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -16,7 +16,7 @@ eighteen times; every revision added something the server could not express (a v
 target-object assertion, ordered cleanup, rollback after a wrong object or a failed reclaim).
 
 **Decision.** `debug_batch` submits the whole sequence as one `EngineOp`, and the **worker process**
-executes it: steps, assertions, and an `always` block that runs on every path, before the reply is
+executes it: steps, assertions, and an `always` block reached on every path, before the reply is
 written (`src/batch.rs`). The client's timeout can no longer land between a mutation and its undo,
 because there is nothing left for it to land between.
 
@@ -24,9 +24,11 @@ because there is nothing left for it to land between.
 the budget is reserved for `always` before the first step runs, since what is left after a step that
 consumed its own deadline is nothing, and the budget itself is clamped to the caller's remaining
 patience (`worker::batch_budget`) so the report lands ahead of the tool call's timeout. The
-*rollback is unconditional* — a failure inside it is recorded beside the original, never in place of
-it, and cleanup continues past its own failures because a patch that cannot be restored must not
-stop a breakpoint from being cleared. And the *executor never touches DbgEng*: it drives a
+*rollback is reached unconditionally* — a failure inside it is recorded beside the original, never
+in place of it, and cleanup continues past its own failures because a patch that cannot be restored
+must not stop a breakpoint from being cleared. What the reserve buys is time to run, not a promise:
+a step that overruns it too leaves cleanup with no budget, and the report then says the rollback is
+incomplete rather than implying it happened. And the *executor never touches DbgEng*: it drives a
 `Debuggee` trait with a virtual clock, so assertion failure, a command failure after a mutation,
 deadline expiry and a failed rollback are all unit tests rather than things a live target has to be
 persuaded to reproduce.
@@ -51,9 +53,18 @@ whose only difference was restoring a patch "on both hit and timeout", which is 
 `batch::tests::the_messagemanager_sequence_is_a_valid_batch` is the longest single invocation
 transcribed, and its sibling drives the wrong-target failure the client wrote that rollback for.
 
-**Status.** Adopted. Two things are still owed: pool steps (FOLLOWUPS item 17, the one gap the
-transcript found) and a live-kernel exercise of a *mutating* batch (item 16) — the dump tier proves
-the wiring and both outcomes, but a dump has nothing worth restoring.
+**The guarantee is against a timeout, not against a disconnect.** The budget clamp makes the first
+one total: the rollback runs and the report is written before the caller's wait expires. A client
+disconnect is different in kind — `Sessions::shutdown` treats it as `end_session` on everything and
+gives each session `SHUTDOWN_RELEASE_TIMEOUT` before terminating its worker, so a batch still
+running then is killed mid-transaction. Deliberately not widened here: lengthening that grace slows
+every disconnect, and making it conditional on what a worker is running is a change to the teardown
+path every session depends on. Documented as the boundary it is, and filed as FOLLOWUPS item 18.
+
+**Status.** Adopted. Three things are still owed: pool steps (FOLLOWUPS item 17, the one gap the
+transcript found), a live-kernel exercise of a *mutating* batch (item 16) — the dump tier proves the
+wiring and both outcomes, but a dump has nothing worth restoring — and the disconnect grace above
+(item 18).
 
 ---
 

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -4,10 +4,10 @@ Deferred work, in five clusters: items 1–6 come from the reachability-confirma
 recipe + `run_to_address`, merged 2026-07-04), items 7–11 from surveying this server against the
 MCP `2026-07-28` extensions (tasks, apps), item 12 from the opener split
 (glslang/win-kexp#71, 2026-08-01), items 13–14 from the bounded-command coverage review
-(#46, 2026-08-02), item 15 from the private worker channel (#65 / #72, 2026-08-04), and items 16–17
+(#46, 2026-08-02), item 15 from the private worker channel (#65 / #72, 2026-08-04), and items 16–18
 from transactional batches (#82, 2026-08-09/10 — item 17 is what validating the tool against the CTF
-session's own transcript turned up). Each item notes its repo, why it was deferred, and where it
-picks up. See [`DECISIONS.md`](./DECISIONS.md) for the design rationale (D1–D5) items 1–6 extend,
+session's own transcript turned up, and item 18 what reviewing it did). Each item notes its repo,
+why it was deferred, and where it picks up. See [`DECISIONS.md`](./DECISIONS.md) for the design rationale (D1–D5) items 1–6 extend,
 and the 2026-08-02 entries that items 13–14 and item 10 extend.
 
 Items are roughly ordered by how soon they're worth doing, within each cluster. **Item 10 has
@@ -382,3 +382,30 @@ back on.
   `batch::Debuggee`, which would gain one method per capability so the executor stays engine-free.
   `@chunkt1`'s real shape is the test case: capture a register with `eval`, then ask `pool_chunk`
   about `{{that}}` — the capture half already works.
+
+## 18. [windbg-mcp] Let a running batch finish its rollback when the client disconnects
+
+`debug_batch` (#82) makes one guarantee totally and a weaker version of it partially. Against a call
+**timeout** the rollback is safe by construction: the batch budget is clamped to the caller's
+remaining patience, so `always` has run and the report has been written before the wait expires.
+Against a client **disconnect** it is not. `Sessions::shutdown` treats a disconnect as `end_session`
+on every session; the `EndSession` op queues behind the batch, `release` waits
+`SHUTDOWN_RELEASE_TIMEOUT` (5s), and then the worker is killed — mid-transaction, with the patch
+still applied.
+
+- **What it costs today:** a batch that patches a live kernel and is still running 5s after the
+  client goes away leaves the patch in place and, for a kernel session killed rather than released,
+  the target halted. The window is small, but it is exactly the case the tool exists for.
+- **Why deferred:** the two obvious fixes are both worse than the gap. Lengthening
+  `SHUTDOWN_RELEASE_TIMEOUT` slows *every* disconnect for a case that is rare, and the constant is
+  short on purpose (a session that cannot let go in a few seconds never will). Making the grace
+  conditional on what the worker is running means the supervisor tracking op identity through
+  teardown — a change to the path every session's shutdown depends on, landed alongside a new
+  feature, with the failure mode "the client hangs on disconnect".
+- **Where it picks up:** `Sessions::shutdown`/`release` in `src/engine.rs`. The shape worth trying
+  first is a *signal* rather than a longer wait — tell the worker to abandon its remaining steps and
+  jump to `always`, which `batch::run` is already structured for (every failure path falls through
+  to the same block), then wait the existing grace on that. It needs the side channel item 7
+  describes, for the same reason: a worker busy in DbgEng is not draining its request queue.
+- **Meanwhile:** documented as the boundary it is, in `README.md`, the skill playbook and the tool
+  description — a disconnect is not a way to abort a batch safely; `end_session` is.

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -4,8 +4,10 @@ Deferred work, in five clusters: items 1–6 come from the reachability-confirma
 recipe + `run_to_address`, merged 2026-07-04), items 7–11 from surveying this server against the
 MCP `2026-07-28` extensions (tasks, apps), item 12 from the opener split
 (glslang/win-kexp#71, 2026-08-01), items 13–14 from the bounded-command coverage review
-(#46, 2026-08-02), and item 15 from the private worker channel (#65 / #72, 2026-08-04). Each item
-notes its repo, why it was deferred, and where it picks up. See [`DECISIONS.md`](./DECISIONS.md) for the design rationale (D1–D5) items 1–6 extend,
+(#46, 2026-08-02), item 15 from the private worker channel (#65 / #72, 2026-08-04), and items 16–17
+from transactional batches (#82, 2026-08-09/10 — item 17 is what validating the tool against the CTF
+session's own transcript turned up). Each item notes its repo, why it was deferred, and where it
+picks up. See [`DECISIONS.md`](./DECISIONS.md) for the design rationale (D1–D5) items 1–6 extend,
 and the 2026-08-02 entries that items 13–14 and item 10 extend.
 
 Items are roughly ordered by how soon they're worth doing, within each cluster. **Item 10 has
@@ -338,3 +340,45 @@ and no other spawn site needs to know the rule exists.
   the crate's own source and fails if a `.spawn()` appears without `spawn_guard` held in the same
   function. The convention is pinned rather than merely documented, which is what makes this an
   improvement to *how* the property is held rather than a fix to a live hole.
+
+## 16. [windbg-mcp] Exercise a *mutating* `debug_batch` against a live kernel target
+
+`debug_batch` (#82) is proved at two altitudes: `src/batch.rs` drives the executor over a scripted
+debuggee with a virtual clock (assertion failure, a command failure after a mutation, deadline
+expiry, a rollback that itself fails), and the debugger tier drives a real engine to both outcomes
+over the wire. Neither covers the case the tool was built for — a **write that is then restored**
+on a target that would notice.
+
+- **Why deferred:** a crash dump has nothing worth restoring, and the live-kernel tier is
+  `#[ignore]`d and gated on a connection string precisely so an ordinary `cargo test` can never
+  reach a VM. So this belongs beside the existing `live_kernel` tests, run by hand.
+- **What it should assert:** save a byte with an `eval`+`capture`, patch it, fail an assertion
+  deliberately, and confirm from a *later, separate* call that the `always` block put the original
+  back — the point being that nothing after the batch had to be sent for that to happen. Then the
+  same batch with the call budget shortened (`WINDBG_MCP_CALL_TIMEOUT_SECS`) below the batch's own
+  deadline, to check the clamp in `worker::batch_budget` really keeps the report ahead of the
+  caller's timeout on a target where steps take real time.
+- **Where it picks up:** `tests/mcp_smoke.rs`, the `live_kernel` filter; the harness for setting and
+  reading back a byte already exists in the MessageManager tier.
+
+## 17. [windbg-mcp] Let a `debug_batch` step call a typed tool, starting with the pool queries
+
+The one gap the MessageManager transcript found in `debug_batch` (#82). Its step vocabulary reaches
+anything that is a *debugger command*, which is almost every typed tool in this server — but not the
+ones that are not commands at all. The pool tools are win-kexp walks over the allocator's own
+structures, so `pool_find_tag`, `pool_chunk` and `pool_census` have no `execute` equivalent to fall
+back on.
+
+- **How much it cost the workflow it is measured against:** 9 of 1,681 steps (`@chunkt1`, `@census`,
+  `@find`, `@findr`). Small, but not incidental — `@chunkt1` sat *inside* the 32-step transaction,
+  between a code patch and its restore, so a batch expressing that sequence today has to drop it.
+- **Why deferred:** the shape is a design question, not a missing wire. `PoolOp` already crosses to
+  the worker and `worker::pool` already renders it, so the plumbing is short; what needs deciding is
+  whether a step names a *tool* generically (open-ended, and every tool's arguments then have to
+  exist in the batch schema twice) or whether the batch grows one variant per typed tool worth
+  having in a transaction. The second is smaller and matches how `StepAction` is already justified —
+  variants exist for what a raw command cannot express — but it is a list that will keep growing.
+- **Where it picks up:** `StepAction` in `src/batch.rs`, `PoolOp` in `src/proto.rs`, and
+  `batch::Debuggee`, which would gain one method per capability so the executor stays engine-free.
+  `@chunkt1`'s real shape is the test case: capture a register with `eval`, then ask `pool_chunk`
+  about `{{that}}` — the capture half already works.

--- a/README.md
+++ b/README.md
@@ -395,10 +395,10 @@ cleanup is exactly the call that times out, and a disconnect sends nothing at al
 that costs the VM: an un-restored patch, or a target left halted.
 
 `debug_batch` submits the whole sequence as one op. It runs **inside the session's engine process**,
-which owns the deadline, so the `always` block runs on every path — success, a debugger error, an
-assertion that did not hold, the deadline expiring — before the tool call returns. Part of the budget
-is reserved for it up front, because "what is left" after a step that ran to its own deadline is
-nothing.
+which owns the deadline, so the `always` block is reached on every path — success, a debugger error,
+an assertion that did not hold, the deadline expiring — before the tool call returns. Part of the
+budget is reserved for it up front, because "what is left" after a step that ran to its own deadline
+is nothing.
 
 ```jsonc
 {
@@ -429,10 +429,21 @@ rollback completed — reported *beside* the original failure, never instead of 
 session is left stopped, running, detached, or uncertain. A batch that did not commit comes back as a
 tool error carrying that whole report.
 
-Two honest limits. A raw command that prints an error and returns success is a step that *succeeded*
-with that text (DbgEng reports most failures that way), so assert on it if it matters. And what a
-step "changed" is a best-effort classification of the command, biased toward reporting a change: it
-is a reporting aid, and the `always` block, not the classifier, is what makes a mutation recoverable.
+Four honest limits, none of them hidden in the report:
+
+- A raw command that prints an error and returns success is a step that *succeeded* with that text
+  (DbgEng reports most failures that way), so assert on it if it matters.
+- What a step "changed" is a best-effort classification of the command, biased toward reporting a
+  change: it is a reporting aid, and the `always` block, not the classifier, is what makes a
+  mutation recoverable.
+- The reserve buys the rollback *time*, not a guarantee. A step that overruns far enough to consume
+  the reserve as well leaves cleanup with no budget; the block is then skipped and the result says
+  `rollback: INCOMPLETE`, naming each step that did not run.
+- The strong guarantee is against a **call timeout**: the batch budget is clamped so the rollback
+  finishes and the report is written before the caller gives up. A **client disconnect** is weaker —
+  teardown treats it as `end_session` on every session, and a batch still running when that grace
+  expires is terminated with its worker, mid-transaction. Keep a batch that patches a live kernel
+  comfortably inside that grace, or end the session yourself rather than dropping the connection.
 
 ### Error reporting
 

--- a/README.md
+++ b/README.md
@@ -246,7 +246,8 @@ gh attestation verify <zip> --repo glslang/windbg-mcp `
 |-------|-------|
 | Session | `open_dump`, `open_trace`, `attach_kernel_local`, `attach_kernel`, `attach_process`, `launch`, `end_session`, `session_status` |
 | State   | `registers`, `read_memory`, `backtrace`, `modules`, `threads`, `disassemble`, `dx` |
-| Control | `go`, `step_over`, `step_into`, `set_breakpoint` |
+| Control | `go`, `step_over`, `step_into`, `set_breakpoint`, `run_to_address` |
+| Transaction | `debug_batch` — an ordered sequence with assertions and a rollback the engine process runs on every path |
 | TTD nav | `step_back` (`t-`), `step_over_back` (`p-`), `reverse_go` (`g-`), `goto_position` (`!tt`) |
 | TTD analysis | `ttd_calls`, `ttd_memory`, `ttd_events`, `index_trace`, `record_trace` |
 | Driver IOCTL | `decode_ioctl`, `driver_object`, `device_object`, `irp_stack`, `ioctl_trace`, `reachable_from_dispatch` |
@@ -385,6 +386,53 @@ that could retire the session handle.
 
 Nothing legitimate is lost: these parameters were always single operands. Use `execute` to run a
 command list — it is annotated destructive and retires the handle when a command changes the target.
+
+### Transactional batches (`debug_batch`)
+
+A sequence that *mutates* a target — patch a byte, arm a breakpoint, resume a thread — has to put
+things back afterwards, and a client cannot be relied on to do it. The call that would have sent the
+cleanup is exactly the call that times out, and a disconnect sends nothing at all. On a kernel target
+that costs the VM: an un-restored patch, or a target left halted.
+
+`debug_batch` submits the whole sequence as one op. It runs **inside the session's engine process**,
+which owns the deadline, so the `always` block runs on every path — success, a debugger error, an
+assertion that did not hold, the deadline expiring — before the tool call returns. Part of the budget
+is reserved for it up front, because "what is left" after a step that ran to its own deadline is
+nothing.
+
+```jsonc
+{
+  "steps": [
+    { "op": "eval", "expr": "poi(hevd!Guard)", "capture": "orig" },   // save
+    { "op": "command", "command": "eq hevd!Guard 0" },                // patch
+    { "op": "run_to", "address": "hevd!TriggerUaf",                   // confirm, with a verdict
+      "expect": [{ "check": "contains", "text": "VERDICT: HIT" }] },
+    { "op": "eval", "expr": "@rcx",
+      "expect": [{ "check": "eval", "expr": "(@rcx > 0x1000)", "equals": "1" }] }
+  ],
+  "always": [
+    { "op": "command", "command": "eq hevd!Guard {{orig}}" },         // restore, whatever happened
+    { "op": "command", "command": "bc *" }
+  ]
+}
+```
+
+Five step kinds: `command` (raw), `resume` (a command that moves the target, plus the wait),
+`run_to` (a HIT/STOPPED ELSEWHERE/TIMEOUT verdict), `eval` (a MASM expression's value), and
+`read_memory`. Assertions are `contains`, `not_contains`, and `eval` — the last compares two MASM
+expressions, so registers, memory and relations between them are all one check. An `eval` step may
+`capture` its value under a name that later steps interpolate as `{{name}}`; a reference that names
+no earlier capture is refused before anything runs.
+
+The report names every step that ran, the exact one that failed, what each step changed, whether the
+rollback completed — reported *beside* the original failure, never instead of it — and whether the
+session is left stopped, running, detached, or uncertain. A batch that did not commit comes back as a
+tool error carrying that whole report.
+
+Two honest limits. A raw command that prints an error and returns success is a step that *succeeded*
+with that text (DbgEng reports most failures that way), so assert on it if it matters. And what a
+step "changed" is a best-effort classification of the command, biased toward reporting a change: it
+is a reporting aid, and the `always` block, not the classifier, is what makes a mutation recoverable.
 
 ### Error reporting
 

--- a/README.md
+++ b/README.md
@@ -424,6 +424,12 @@ expressions, so registers, memory and relations between them are all one check. 
 `capture` its value under a name that later steps interpolate as `{{name}}`; a reference that names
 no earlier capture is refused before anything runs.
 
+**A field this tool does not know is an error, not something to ignore** — the one place in this
+server where that is true. Serde drops unknown fields silently, so `"aways"` for `always` would be a
+batch with no rollback block at all: mutations applied, nothing restored, `COMMITTED` reported. The
+same goes for a misspelt `expect`, which is a step that asserts nothing and lets the batch commit.
+Both fail *open*, so both are refused by name.
+
 The report names every step that ran, the exact one that failed, what each step changed, whether the
 rollback completed — reported *beside* the original failure, never instead of it — and whether the
 session is left stopped, running, detached, or uncertain. A batch that did not commit comes back as a

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -57,7 +57,8 @@ on this server's behalf, this test is where you find out, and the choice is impl
 suppress it — not ship an advertisement clients will call into a dead end.
 
 **Tool surface golden.** `tests/golden/tools_list.json` records the *structural* `tools/list`
-surface as it appears on the wire: JSON Schema dialect, `$defs` usage, tool count, and per tool its
+surface as it appears on the wire: JSON Schema dialect, `$defs` usage (`true` since `debug_batch`
+introduced the first nested schema), tool count, and per tool its
 name, title, four behaviour hints, required arguments, and each parameter's type/format/enum. It
 deliberately excludes descriptions, so prose edits do not churn it while a `schemars` dialect
 switch, an `rmcp` annotation-casing change, or an accidental tool rename all land as a readable
@@ -112,6 +113,12 @@ processes, so they need real ones:
 - *No worker outlives the connection.* Reads the engine pid out of `session_status`, disconnects,
   and checks the process is gone — otherwise every disconnect leaks a debugger process, and for a
   launch or an attach, a debuggee with it.
+- *A batch commits or fails, and its rollback runs either way.* `src/batch.rs` proves the executor
+  over a scripted debuggee; this proves the wiring — argument schema, the op crossing the pipe, the
+  engine seam, the report coming back — by running one batch to `COMMITTED` (with a capture bound
+  from one step and interpolated into the next) and one to `FAILED at step 2 of 3`, with the same
+  `always` block on both. The claim only a real engine can settle is the second one: the rollback
+  ran **inside the worker process**, on the failing path, before the tool call returned.
 
 This tier is also the only end-to-end check of the **protocol channel** — the inherited pipe pair a
 worker speaks on ([`proto.rs`](../src/proto.rs)). Handles are passed on the worker's command line

--- a/skills/windbg-debugging/SKILL.md
+++ b/skills/windbg-debugging/SKILL.md
@@ -32,7 +32,8 @@ already does the job.
 |-------|-------|
 | Session | `open_dump`, `open_trace`, `attach_kernel_local`, `attach_kernel`, `attach_process`, `launch`, `end_session`, `session_status` |
 | State | `registers`, `read_memory`, `backtrace`, `modules`, `threads`, `disassemble`, `dx` |
-| Control | `go`, `step_over`, `step_into`, `set_breakpoint` |
+| Control | `go`, `step_over`, `step_into`, `set_breakpoint`, `run_to_address` |
+| Transaction | `debug_batch` — an ordered sequence with assertions and a rollback the engine runs on every path |
 | TTD nav | `step_back` (`t-`), `step_over_back` (`p-`), `reverse_go` (`g-`), `goto_position` (`!tt`) |
 | TTD analysis | `ttd_calls`, `ttd_memory`, `ttd_events`, `index_trace`, `record_trace` |
 | Raw | `execute` — run any debugger command, returns full text output |
@@ -41,6 +42,15 @@ The forward control tools (`go`/`step_over`/`step_into`) and the reverse ones
 (`reverse_go`/`step_over_back`/`step_back`) mirror a debugger UI's F9/F8/F7 and their
 Shift variants. They issue the command **and pump the engine to the next stop** — unlike
 a bare `execute`, which only sets the run state and doesn't move the target.
+
+**When a sequence mutates the target, run it as one `debug_batch`, not as separate calls.** A
+patched byte, an armed breakpoint or a resumed thread has to be put back, and the call that would
+have sent the cleanup is exactly the one that times out — a disconnect sends nothing at all. A
+batch's `always` block runs inside the engine process on every path, including a failed assertion
+and an expired deadline, so cleanup cannot be lost; the report names the exact failing step, what
+each step changed, whether the rollback completed, and whether the target is left stopped, running
+or gone. Save what you are about to overwrite with an `eval` step's `capture`, and restore it in
+`always` as `{{name}}`.
 
 ## Cross-cutting gotchas (apply to every workflow)
 

--- a/skills/windbg-debugging/SKILL.md
+++ b/skills/windbg-debugging/SKILL.md
@@ -33,7 +33,7 @@ already does the job.
 | Session | `open_dump`, `open_trace`, `attach_kernel_local`, `attach_kernel`, `attach_process`, `launch`, `end_session`, `session_status` |
 | State | `registers`, `read_memory`, `backtrace`, `modules`, `threads`, `disassemble`, `dx` |
 | Control | `go`, `step_over`, `step_into`, `set_breakpoint`, `run_to_address` |
-| Transaction | `debug_batch` — an ordered sequence with assertions and a rollback the engine runs on every path |
+| Transaction | `debug_batch` — an ordered sequence with assertions and a rollback the engine runs, not the client |
 | TTD nav | `step_back` (`t-`), `step_over_back` (`p-`), `reverse_go` (`g-`), `goto_position` (`!tt`) |
 | TTD analysis | `ttd_calls`, `ttd_memory`, `ttd_events`, `index_trace`, `record_trace` |
 | Raw | `execute` — run any debugger command, returns full text output |
@@ -45,12 +45,19 @@ a bare `execute`, which only sets the run state and doesn't move the target.
 
 **When a sequence mutates the target, run it as one `debug_batch`, not as separate calls.** A
 patched byte, an armed breakpoint or a resumed thread has to be put back, and the call that would
-have sent the cleanup is exactly the one that times out — a disconnect sends nothing at all. A
-batch's `always` block runs inside the engine process on every path, including a failed assertion
-and an expired deadline, so cleanup cannot be lost; the report names the exact failing step, what
-each step changed, whether the rollback completed, and whether the target is left stopped, running
-or gone. Save what you are about to overwrite with an `eval` step's `capture`, and restore it in
+have sent the cleanup is exactly the one that times out. A batch's `always` block is reached inside
+the engine process on every path, including a failed assertion and an expired deadline, and part of
+the budget is reserved so it has time to run; the report names the exact failing step, what each
+step changed, whether the rollback completed, and whether the target is left stopped, running or
+gone. Save what you are about to overwrite with an `eval` step's `capture`, and restore it in
 `always` as `{{name}}`.
+
+Two edges to keep in mind. If a step overruns far enough to consume the reserve too, cleanup is
+skipped and the result says `rollback: INCOMPLETE` — believe it rather than the intent. And the
+guarantee is against a call *timeout*, not against a client *disconnect*: a disconnect is treated as
+`end_session` on every session and gives a batch only a few seconds' grace before its worker is
+terminated, so end a session holding a patched kernel yourself instead of just dropping the
+connection.
 
 ## Cross-cutting gotchas (apply to every workflow)
 

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -21,8 +21,8 @@
 //! * **`always` is reached on every path.** Success, a debugger error, an assertion that did not
 //!   hold, an expired deadline, a panic out of the debugger — all of them fall through to the same
 //!   block, cleanup continues past its own failures, and a failure inside it is recorded beside the
-//!   original rather than replacing it. What the reserve buys is *time to run*, not a guarantee: a step that overruns
-//!   far enough to consume the reserve as well leaves cleanup with no budget, and then the block is
+//!   original rather than replacing it. What the reserve buys is *time to run*, not a guarantee: a
+//!   step that overruns far enough to consume the reserve too leaves cleanup with no budget, and
 //!   skipped and the report says the rollback is incomplete. That is the honest edge, and it is
 //!   pinned by a test rather than left to be discovered.
 //! * **The executor never touches DbgEng.** It drives a [`Debuggee`], which the worker implements
@@ -76,11 +76,15 @@ pub const DEFAULT_BATCH_MS: u32 = 120_000;
 
 /// The shortest deadline a batch may ask for.
 ///
-/// Below this there is no batch: the reserve is half the budget, a step is armed with at least
-/// [`MIN_STEP_BUDGET_MS`], and a budget under a second means every step *and* every cleanup step
-/// is skipped before it starts. A caller who writes `0` gets a batch that does nothing and reports
-/// nothing useful about why, which is worse than being told the number is unusable.
-pub const MIN_BATCH_MS: u32 = 1_000;
+/// **Derived, not chosen.** For a short batch the reserve is half the budget, so the steps get the
+/// other half — and the floor below means the very first step is armed for [`MIN_STEP_BUDGET_MS`]
+/// however little of that half is left. Any budget under twice that floor therefore lets step one
+/// run past the steps deadline and spend the reserve the rollback needs, which is the failure this
+/// whole module is built to prevent, arriving through the argument meant to bound it.
+///
+/// At exactly this value the two are equal: the steps get one floor's worth, the reserve keeps
+/// one, and a step that overruns can eat into the reserve but cannot exhaust it.
+pub const MIN_BATCH_MS: u32 = 2 * MIN_STEP_BUDGET_MS;
 
 /// The budget a batch is built with, from what the caller asked for.
 ///
@@ -91,7 +95,10 @@ pub fn budget_ms(requested: Option<u32>) -> Result<u32, String> {
     match requested {
         None => Ok(DEFAULT_BATCH_MS),
         Some(ms) if ms < MIN_BATCH_MS => Err(format!(
-            "`timeout_ms` is {ms}; a batch needs at least {MIN_BATCH_MS} ms. Part of the budget is              reserved for the `always` block, so a deadline this short would skip every step and              every cleanup step before either started. Omit `timeout_ms` for the {DEFAULT_BATCH_MS}              ms default."
+            "`timeout_ms` is {ms}; a batch needs at least {MIN_BATCH_MS} ms. Part of the budget is \
+             reserved for the `always` block, and a step is armed with at least \
+             {MIN_STEP_BUDGET_MS} ms, so a deadline this short would spend the rollback's reserve \
+             on the first step. Omit `timeout_ms` for the {DEFAULT_BATCH_MS} ms default."
         )),
         Some(ms) => Ok(ms),
     }
@@ -150,6 +157,23 @@ pub enum StepAction {
 }
 
 impl StepAction {
+    /// Whether `key` is one this variant legitimately occupies in a flattened step.
+    ///
+    /// Spelled out rather than derived because serde will not tell us: a flattened internally
+    /// tagged enum leaves the keys it matched in the shared buffer, so this is the only way to
+    /// tell a variant's own field from a caller's typo. `a_well_formed_step_leaves_nothing_in_the
+    /// _catch_all` is what stops this list drifting from the variants above.
+    fn owns(&self, key: &str) -> bool {
+        let fields: &[&str] = match self {
+            Self::Command { .. } => &["command"],
+            Self::Resume { .. } => &["command", "timeout_ms"],
+            Self::RunTo { .. } => &["address", "timeout_ms"],
+            Self::Eval { .. } => &["expr"],
+            Self::ReadMemory { .. } => &["address", "size"],
+        };
+        key == "op" || fields.contains(&key)
+    }
+
     /// The command line this action runs, for the report. Not what is sent to the engine for the
     /// non-command variants — it is what a reader needs to see to know what the step did.
     fn rendered(&self) -> String {
@@ -250,9 +274,38 @@ pub struct BatchStep {
     /// step has a value to bind.
     #[serde(default)]
     pub capture: Option<String>,
+    /// Every key the step carried alongside the named fields above — the action's own included.
+    ///
+    /// Here so [`Self::unknown_fields`] can find the ones that belong to nothing. Serde ignores
+    /// unknown fields by default, which is the wrong default for a step: a misspelt `expect` is a
+    /// step that asserts nothing while reading as though it asserts, and it fails *open* — the
+    /// batch commits. `deny_unknown_fields` cannot say so here, because serde makes that attribute
+    /// and `flatten` mutually exclusive and `action` is flattened to keep a step one flat object.
+    ///
+    /// It collects the action's keys too, rather than only the leftovers: serde hands the same
+    /// buffered content to every flattened field, so an internally tagged enum does not consume
+    /// what it matched. Subtracting them is [`StepAction::owns`]'s job.
+    ///
+    /// **Never serialized.** This exists for one check at the supervisor's edge and has no business
+    /// on the wire — and writing it there is not merely redundant, it is corrupting: flattening a
+    /// map that already holds `op` and the action's fields emits each of them *twice*, and the
+    /// worker rejects the duplicate key, discards the request, and answers nobody. That costs the
+    /// caller the session, not the call (see [`crate::proto`]).
+    #[serde(flatten, skip_serializing)]
+    #[schemars(skip)]
+    pub extra: BTreeMap<String, serde_json::Value>,
 }
 
 impl BatchStep {
+    /// The keys this step carried that nothing in the schema claims — a typo, in practice.
+    fn unknown_fields(&self) -> Vec<&str> {
+        self.extra
+            .keys()
+            .map(String::as_str)
+            .filter(|key| !self.action.owns(key))
+            .collect()
+    }
+
     fn label(&self) -> String {
         match &self.name {
             Some(name) if !name.trim().is_empty() => name.clone(),
@@ -360,6 +413,17 @@ pub fn validate(steps: &[BatchStep], always: &[BatchStep]) -> Result<(), String>
     for (block, block_name) in [(steps, "steps"), (always, "always")] {
         for (index, step) in block.iter().enumerate() {
             let where_ = format!("`{block_name}` step {}", index + 1);
+            // First, because it is the check that catches a batch which *looks* right. Refused
+            // rather than ignored: the dangerous typo here is silent and fails open — a misspelt
+            // `expect` is a step that asserts nothing and lets the batch commit.
+            let unknown = step.unknown_fields();
+            if !unknown.is_empty() {
+                return Err(format!(
+                    "{where_} has field(s) this tool does not know: {}. A step takes `op` and that \
+                     op's own fields, plus `name`, `expect` and `capture` — check the spelling.",
+                    unknown.join(", ")
+                ));
+            }
             validate_operands(step, &where_)?;
             if step.expect.len() > MAX_CHECKS {
                 return Err(format!(
@@ -560,20 +624,11 @@ pub trait Debuggee {
     fn elapsed(&self) -> Duration;
 }
 
-/// Runs one engine call, turning a panic into a step failure.
+/// Runs one engine call, turning a panic into a step failure so [`run`] still reaches `always`.
 ///
-/// The unwind is the third path that would otherwise skip the rollback, after a debugger error and
-/// an expired deadline — and the least obvious, because nothing in this module can raise it.
-/// `worker::engine_thread` already catches panics, but at *op* granularity: it wraps the whole
-/// `execute`, so an unwind from a step leaves [`run`] without ever reaching `always`, with the
-/// patch still applied. And this is not hypothetical — that same `catch_unwind` exists because
-/// several win-kexp methods use `.expect`, which is exactly what a batch step calls.
-///
-/// So the guard belongs here, where the promise is made, rather than being left to the layer
-/// above. `AssertUnwindSafe` is sound for the same reason it is there: the only state a
-/// [`Debuggee`] implementation holds across a call is the engine handle and the clock, neither of
-/// which a panic can leave half-written, and the engine itself survives — the worker's own comment
-/// makes the same argument for the same reason.
+/// Needed because the only other guard is `worker::engine_thread`'s, which wraps a whole op — an
+/// unwind from a step would pass straight through the rollback. Not hypothetical: several win-kexp
+/// methods use `.expect`, and a step calls into them.
 fn guarded(call: impl FnOnce() -> Result<String, String>) -> Result<String, String> {
     catch_unwind(AssertUnwindSafe(call)).unwrap_or_else(|payload| {
         // The message, when the payload carries one. A bare "panicked" would tell a caller that
@@ -887,9 +942,18 @@ fn run_step(
             );
             break;
         }
-        if let Err(why) = evaluate(d, check, &output, deadline) {
-            result = StepResult::Unmet(why);
-            break;
+        match evaluate(d, check, &output, deadline) {
+            Ok(()) => {}
+            Err(CheckFailed::Unmet(why)) => {
+                result = StepResult::Unmet(why);
+                break;
+            }
+            // Not `Unmet`: nothing was learned about the target, so calling it a failed
+            // assertion would report a verdict the batch never reached.
+            Err(CheckFailed::Expired(why)) => {
+                result = StepResult::Failed(why);
+                break;
+            }
         }
     }
 
@@ -922,22 +986,40 @@ fn run_step(
     }
 }
 
+/// Why an assertion did not hold, which is not one thing.
+///
+/// An assertion that was *checked and failed* is a verdict about the target; one that never got
+/// checked because the clock ran out is a verdict about the batch. They read the same in a report
+/// unless they are kept apart here, and they call for opposite next moves — fix the target, or
+/// give the batch more room.
+enum CheckFailed {
+    Unmet(String),
+    Expired(String),
+}
+
 /// One side of an [`Check::Eval`] comparison: what the debugger makes of a MASM expression.
 ///
-/// Takes the *deadline* rather than a budget, and sizes its own watchdog from the clock at the
-/// moment it runs — a check is two of these, and the second must not be armed with the time the
-/// first one already spent.
-fn eval_value(d: &mut impl Debuggee, expr: &str, deadline: Duration) -> Result<u64, String> {
+/// Takes the *deadline* rather than a budget and re-reads the clock itself, because a check is two
+/// of these and the second must be told what the first one left. It refuses outright rather than
+/// falling back on [`MIN_STEP_BUDGET_MS`] when nothing is left: that floor exists so a query which
+/// *has* to run is never armed with a disabled watchdog, and using it to start a query that did
+/// not have to run would spend the rollback's reserve on an assertion.
+fn eval_value(d: &mut impl Debuggee, expr: &str, deadline: Duration) -> Result<u64, CheckFailed> {
+    if d.elapsed() >= deadline {
+        return Err(CheckFailed::Expired(format!(
+            "the batch ran out of time before `? ({expr})` could be evaluated"
+        )));
+    }
     let budget_ms = step_budget_ms(d.elapsed(), deadline).max(MIN_STEP_BUDGET_MS);
     // Parenthesized, so a relational expression (`@rcx > 0x1000`) is evaluated as one value
     // rather than losing its precedence against whatever `?` does with the rest of the line.
     let text = guarded(|| d.command(&format!("? ({expr})"), budget_ms))
-        .map_err(|why| format!("`? ({expr})` failed: {why}"))?;
+        .map_err(|why| CheckFailed::Unmet(format!("`? ({expr})` failed: {why}")))?;
     parse_eval(&text).ok_or_else(|| {
-        format!(
+        CheckFailed::Unmet(format!(
             "`? ({expr})` printed no value; the debugger answered: {}",
             text.trim()
-        )
+        ))
     })
 }
 
@@ -947,7 +1029,7 @@ fn evaluate(
     check: &Check,
     output: &str,
     deadline: Duration,
-) -> Result<(), String> {
+) -> Result<(), CheckFailed> {
     match check {
         Check::Contains { text } => {
             // Case-insensitive: debugger output mixes symbol casing freely, and a check that
@@ -958,7 +1040,9 @@ fn evaluate(
             {
                 Ok(())
             } else {
-                Err(format!("the output does not contain \"{text}\""))
+                Err(CheckFailed::Unmet(format!(
+                    "the output does not contain \"{text}\""
+                )))
             }
         }
         Check::NotContains { text } => {
@@ -966,7 +1050,9 @@ fn evaluate(
                 .to_ascii_lowercase()
                 .contains(&text.to_ascii_lowercase())
             {
-                Err(format!("the output contains \"{text}\", which it must not"))
+                Err(CheckFailed::Unmet(format!(
+                    "the output contains \"{text}\", which it must not"
+                )))
             } else {
                 Ok(())
             }
@@ -977,11 +1063,11 @@ fn evaluate(
             if left == right {
                 Ok(())
             } else {
-                Err(format!(
+                Err(CheckFailed::Unmet(format!(
                     "`{expr}` is {} ({left:#x}), `{equals}` is {} ({right:#x})",
                     fmt_addr(left),
                     fmt_addr(right)
-                ))
+                )))
             }
         }
     }
@@ -1313,6 +1399,7 @@ mod tests {
             action,
             expect: Vec::new(),
             capture: None,
+            extra: BTreeMap::new(),
         }
     }
 
@@ -1810,6 +1897,76 @@ mod tests {
 
     // ---- validation --------------------------------------------------------
 
+    /// The catch-all must take *only* what the schema does not name. If serde routed a variant's
+    /// own fields into it too, every well-formed step would be refused — so this pins the shape
+    /// the typo check depends on.
+    #[test]
+    fn a_well_formed_step_leaves_nothing_in_the_catch_all() {
+        for json in [
+            serde_json::json!({"op": "command", "command": "lm"}),
+            serde_json::json!({
+                "op": "run_to", "address": "nt!Foo", "timeout_ms": 5000,
+                "name": "go", "expect": [{"check": "contains", "text": "HIT"}]
+            }),
+            serde_json::json!({"op": "eval", "expr": "@rcx", "capture": "x"}),
+            serde_json::json!({"op": "read_memory", "address": "0x1000", "size": 64}),
+            serde_json::json!({"op": "resume", "command": "g"}),
+        ] {
+            let step: BatchStep = serde_json::from_value(json.clone()).expect("valid step");
+            assert!(
+                step.unknown_fields().is_empty(),
+                "{json} left {:?} unaccounted for",
+                step.unknown_fields()
+            );
+        }
+    }
+
+    /// A batch is a value that crosses a process boundary, so it has to survive its own encoding.
+    ///
+    /// Pinned because it did not, once: the typo-catching map is flattened, so serializing it wrote
+    /// `op` and the action's fields a second time, and the worker rejected the duplicate key and
+    /// discarded the request — which costs a caller their session rather than their call, because
+    /// only a reply removes the supervisor's waiter. Unit tests over `run` never touch the wire, so
+    /// nothing but the smoke tier saw it.
+    #[test]
+    fn a_batch_survives_being_encoded_for_the_worker() {
+        let (steps, always) = messagemanager_sequence();
+        let sent = BatchOp {
+            steps,
+            always,
+            budget_ms: 60_000,
+            patience_ms: 60_000,
+        };
+        let line = serde_json::to_string(&sent).expect("a batch must encode");
+        let back: BatchOp = serde_json::from_str(&line).expect("and decode");
+
+        assert_eq!(back.steps.len(), sent.steps.len());
+        assert_eq!(back.always.len(), sent.always.len());
+        for (before, after) in sent.steps.iter().zip(&back.steps) {
+            assert_eq!(before.action.rendered(), after.action.rendered());
+            assert_eq!(before.expect.len(), after.expect.len());
+            assert_eq!(before.capture, after.capture);
+        }
+        // And what came back is still a batch this server would accept.
+        validate(&back.steps, &back.always).expect("a round-tripped batch stays valid");
+    }
+
+    /// The typo that fails *open*: a misspelt `expect` is a step that asserts nothing and commits.
+    #[test]
+    fn a_misspelt_step_field_is_refused_rather_than_ignored() {
+        let step: BatchStep = serde_json::from_value(serde_json::json!({
+            "op": "command",
+            "command": "eb fffff800`00001000 90",
+            "expects": [{"check": "contains", "text": "never seen"}]
+        }))
+        .expect("serde accepts it — which is the problem");
+        assert_eq!(step.expect.len(), 0, "the assertions were silently dropped");
+
+        let why = validate(&[step], &[]).unwrap_err();
+        assert!(why.contains("expects"), "{why}");
+        assert!(why.contains("check the spelling"), "{why}");
+    }
+
     #[test]
     fn a_forward_capture_reference_is_refused_before_anything_runs() {
         let batch = vec![
@@ -2132,6 +2289,45 @@ mod tests {
     /// The path where the rollback guarantee genuinely fails: a step overran so far that even the
     /// reserve is gone. Nothing can be done about it — but the report must say so rather than
     /// leave a caller believing the cleanup ran.
+    /// Within one `eval` check the two queries are sequential, so the second must be told what the
+    /// first left. Falling back on the minimum watchdog would start debugger work the step no
+    /// longer had time for — and spend the rollback's reserve on an assertion.
+    #[test]
+    fn the_second_half_of_an_eval_check_does_not_start_past_the_deadline() {
+        // 60s budget → 30s steps deadline. The left query alone costs 35s.
+        let mut d = stopped()
+            .on("lm", Ok("start end module"))
+            .slow("? (left", Ok(EVAL_ONE), Duration::from_secs(35))
+            .on("? (right", Ok(EVAL_ONE))
+            .on("bc *", Ok(""));
+        let batch = op(
+            vec![BatchStep {
+                expect: vec![Check::Eval {
+                    expr: "left".to_string(),
+                    equals: "right".to_string(),
+                }],
+                ..cmd("lm")
+            }],
+            vec![cmd("bc *")],
+        );
+
+        let report = run(&mut d, &batch, BUDGET);
+
+        assert!(
+            !d.ran("? (right"),
+            "the right-hand query must not start past the deadline: {:?}",
+            d.calls
+        );
+        // A timeout, not an unmet assertion: nothing was learned about the target.
+        assert_eq!(report.outcome, BatchOutcome::TimedOut { at: 1 });
+        assert!(
+            render(&report).contains("ran out of time"),
+            "{}",
+            render(&report)
+        );
+        assert!(d.ran("bc *"), "the reserve survived: {:?}", d.calls);
+    }
+
     #[test]
     fn a_cleanup_step_past_the_whole_budget_is_skipped_and_reported_as_incomplete() {
         // One step costs 100s against a 60s budget, so the `always` block cannot start at all.

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -1,0 +1,1890 @@
+//! Transactional debugger batches: ordered steps, assertions, and a rollback the **worker** owns.
+//!
+//! Everything here exists because of one asymmetry. A tool call is a request/response, so a client
+//! driving a multi-step debugger transaction has to decide *after* each answer what to do next —
+//! and the case that matters is precisely the one where no answer arrives. A call that times out,
+//! or a client that disconnects, leaves whatever the earlier calls changed in place: a patched
+//! instruction, an armed breakpoint, a target left running. On a kernel target that is not an
+//! inconvenience; an un-restored patch or a missed detach costs the VM.
+//!
+//! So the sequence is submitted as one op and executed inside the session's worker process, where
+//! the cleanup block can be run by the same code that ran the mutations, on the same engine
+//! thread, before the reply is written. The client's timeout can no longer land between a mutation
+//! and its undo, because there is nothing for it to land *between*.
+//!
+//! Three things follow from that, and they are the whole design:
+//!
+//! * **The deadline is the worker's.** [`run`] is handed a total budget and reserves part of it for
+//!   the `always` block before it starts, so "the steps ran out of time" and "the rollback ran out
+//!   of time" are different events. The supervisor sizes that budget from the caller's remaining
+//!   patience (`worker::batch_budget`) so the report lands *before* the tool call gives up.
+//! * **`always` runs on every path.** Success, a debugger error, an assertion that did not hold, an
+//!   expired deadline — all of them fall through to the same block, and a failure inside it is
+//!   recorded beside the original rather than replacing it.
+//! * **The executor never touches DbgEng.** It drives a [`Debuggee`], which the worker implements
+//!   over a real engine and the tests implement over a script. Assertion failure, a command failure
+//!   after a mutation, deadline expiry and a rollback that itself fails are therefore all testable
+//!   without a debugger — which matters because those four paths are the ones a live target is
+//!   least willing to reproduce on demand.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt::Write as _;
+use std::time::Duration;
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::server::{
+    EXEC_WAIT_MS, Quotes, changes_debug_target, fmt_addr, parse_eval, reject_command_breakers,
+};
+
+/// The most steps one batch may carry, per block.
+///
+/// A bound rather than a judgement: the whole batch runs as one indivisible job on the session's
+/// engine thread, so its length is also how long every other call to that session waits. Well past
+/// the eighteen-step sequence that motivated this (see the `messagemanager` walkthrough), and far
+/// short of a batch that could hold a session for its own reasons.
+pub const MAX_STEPS: usize = 64;
+
+/// The most assertions one step may carry. An `eval` check costs an engine round trip, so this
+/// bounds the hidden work behind a step as much as it bounds the argument.
+pub const MAX_CHECKS: usize = 16;
+
+/// How much of the total budget is held back for the `always` block, so a rollback still runs
+/// after the steps have used the clock up.
+///
+/// Reserved *up front* rather than taken from what is left, because "what is left" after a step
+/// that ran to its own deadline is nothing. Capped at half the budget so a short batch still
+/// spends most of its time on the work it was asked to do.
+const ROLLBACK_RESERVE: Duration = Duration::from_secs(30);
+
+/// The smallest watchdog a step is armed with. Zero *disables* win-kexp's watchdog, so a step
+/// dequeued at or past the deadline must not round down to it.
+const MIN_STEP_BUDGET_MS: u32 = 1_000;
+
+/// How much of a step's output the report carries, and how much it carries for the step that
+/// failed. The failing step is what the caller has to act on, so it gets the bigger share; the
+/// rest are context.
+const STEP_OUTPUT_CHARS: usize = 1_500;
+const FAILED_OUTPUT_CHARS: usize = 8_000;
+
+// ---- the step language ----------------------------------------------------
+
+/// What one step does.
+///
+/// Internally tagged and flattened into [`BatchStep`], so a step reads as one flat object
+/// (`{"op": "command", "command": "bp nt!Foo"}`) rather than a wrapper around a wrapper. The
+/// vocabulary is deliberately small: almost every typed tool in this server is a thin wrapper over
+/// `execute_command`, so [`Self::Command`] already covers them, and the variants that exist beside
+/// it are the ones a raw command genuinely cannot express as a single unit — a wait for the target
+/// to stop, a run-to verdict, a value this batch can bind a name to.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "op", rename_all = "snake_case")]
+pub enum StepAction {
+    /// Run a raw debugger command to completion and keep its output.
+    ///
+    /// Note what this does **not** assert: DbgEng prints most failures and returns success, so a
+    /// command that says "Couldn't resolve error at 'nt!Nope'" is a step that *succeeded* with
+    /// that text. Assert on it with a `contains` check if it matters.
+    Command { command: String },
+    /// Run a command that moves the target (`g`, `p`, `t`, `g @$ra`, a TTD reverse) and wait for
+    /// the next stop.
+    Resume {
+        command: String,
+        /// How long to wait for the stop, in ms. Clamped to what is left of the batch's budget.
+        #[serde(default)]
+        timeout_ms: Option<u32>,
+    },
+    /// Run until `address` and report a verdict: HIT, STOPPED ELSEWHERE, or TIMEOUT. The verdict
+    /// is text in the step's output, so assert on it with `contains`.
+    RunTo {
+        address: String,
+        #[serde(default)]
+        timeout_ms: Option<u32>,
+    },
+    /// Evaluate a MASM expression (`@rcx`, `poi(@rsp+0x18)`, `nt!NtCreateFile`) and keep its
+    /// value. The only step a `capture` may be attached to.
+    Eval { expr: String },
+    /// Hex-dump `size` bytes at `address`.
+    ReadMemory { address: String, size: u32 },
+}
+
+impl StepAction {
+    /// The command line this action runs, for the report. Not what is sent to the engine for the
+    /// non-command variants — it is what a reader needs to see to know what the step did.
+    fn rendered(&self) -> String {
+        match self {
+            Self::Command { command } | Self::Resume { command, .. } => command.clone(),
+            Self::RunTo { address, .. } => format!("run to {address}"),
+            Self::Eval { expr } => format!("? {expr}"),
+            Self::ReadMemory { address, size } => format!("read {size} bytes at {address}"),
+        }
+    }
+
+    /// This action with every `{{name}}` reference resolved.
+    fn substituted(
+        &self,
+        resolve: &mut impl FnMut(&str) -> Option<String>,
+    ) -> Result<Self, String> {
+        Ok(match self {
+            Self::Command { command } => Self::Command {
+                command: substitute(command, resolve)?,
+            },
+            Self::Resume {
+                command,
+                timeout_ms,
+            } => Self::Resume {
+                command: substitute(command, resolve)?,
+                timeout_ms: *timeout_ms,
+            },
+            Self::RunTo {
+                address,
+                timeout_ms,
+            } => Self::RunTo {
+                address: substitute(address, resolve)?,
+                timeout_ms: *timeout_ms,
+            },
+            Self::Eval { expr } => Self::Eval {
+                expr: substitute(expr, resolve)?,
+            },
+            Self::ReadMemory { address, size } => Self::ReadMemory {
+                address: substitute(address, resolve)?,
+                size: *size,
+            },
+        })
+    }
+}
+
+/// One assertion over a step's result.
+///
+/// `eval` is the general one: it evaluates two MASM expressions and compares them numerically, so
+/// a register, a memory word, a symbol address and any relation between them are all one check —
+/// `{"check": "eval", "expr": "(@rcx > 0x1000)", "equals": "1"}` asserts an inequality without
+/// needing a check kind for it. The two text checks exist because verdicts and stop reasons arrive
+/// as debugger prose, not as numbers.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "check", rename_all = "snake_case")]
+pub enum Check {
+    /// The step's output must contain `text` (case-insensitive).
+    Contains { text: String },
+    /// The step's output must not contain `text` (case-insensitive).
+    NotContains { text: String },
+    /// `expr` and `equals` must evaluate to the same value. Both are MASM expressions, so
+    /// `equals` may be a literal (`0x41414141`) or another expression (`nt!Foo`).
+    Eval { expr: String, equals: String },
+}
+
+impl Check {
+    fn substituted(
+        &self,
+        resolve: &mut impl FnMut(&str) -> Option<String>,
+    ) -> Result<Self, String> {
+        Ok(match self {
+            Self::Contains { text } => Self::Contains {
+                text: substitute(text, resolve)?,
+            },
+            Self::NotContains { text } => Self::NotContains {
+                text: substitute(text, resolve)?,
+            },
+            Self::Eval { expr, equals } => Self::Eval {
+                expr: substitute(expr, resolve)?,
+                equals: substitute(equals, resolve)?,
+            },
+        })
+    }
+}
+
+/// One step: an action, what must hold after it, and optionally a name for its value.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct BatchStep {
+    /// A label for the report. Defaults to the command the step runs.
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(flatten)]
+    pub action: StepAction,
+    /// Assertions evaluated after the action succeeds. The first that does not hold fails the
+    /// step — and so the batch.
+    #[serde(default)]
+    pub expect: Vec<Check>,
+    /// Binds this step's value to a name later steps interpolate as `{{name}}`. Only an `eval`
+    /// step has a value to bind.
+    #[serde(default)]
+    pub capture: Option<String>,
+}
+
+impl BatchStep {
+    fn label(&self) -> String {
+        match &self.name {
+            Some(name) if !name.trim().is_empty() => name.clone(),
+            _ => self.action.rendered(),
+        }
+    }
+}
+
+/// The op as it crosses to the worker: both blocks, the deadline the caller asked for, and the
+/// deadline the caller's own patience allows.
+///
+/// `patience_ms` is filled in by the supervisor's pump, exactly as it is for
+/// [`crate::proto::EngineOp::BoundedCommand`] — the value a caller constructs is ignored. It is
+/// what keeps the reply ahead of the tool call's timeout, which is the only reason the rollback
+/// report is worth anything.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BatchOp {
+    pub steps: Vec<BatchStep>,
+    pub always: Vec<BatchStep>,
+    pub budget_ms: u32,
+    pub patience_ms: u32,
+}
+
+// ---- capture references ---------------------------------------------------
+
+/// Replaces every `{{name}}` in `text` with what `resolve` returns for it.
+///
+/// `{{` always opens a reference: no debugger command language in this server's vocabulary uses a
+/// doubled brace, so there is nothing to escape and no ambiguity about whether a batch meant to
+/// interpolate. A malformed or unresolvable reference is an error rather than a passthrough,
+/// because the alternative is running `eb {{orig}} 41` against a target.
+fn substitute(
+    text: &str,
+    resolve: &mut impl FnMut(&str) -> Option<String>,
+) -> Result<String, String> {
+    let mut out = String::with_capacity(text.len());
+    let mut rest = text;
+    while let Some(open) = rest.find("{{") {
+        out.push_str(&rest[..open]);
+        let after = &rest[open + 2..];
+        let Some(close) = after.find("}}") else {
+            return Err(format!(
+                "`{{{{` is never closed by `}}}}` in `{text}`; a capture reference is written \
+                 `{{{{name}}}}`"
+            ));
+        };
+        let name = &after[..close];
+        if name.is_empty() || !name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_') {
+            return Err(format!(
+                "`{{{{{name}}}}}` is not a capture name — letters, digits and `_` only"
+            ));
+        }
+        let Some(value) = resolve(name) else {
+            return Err(format!("`{{{{{name}}}}}` is not bound"));
+        };
+        out.push_str(&value);
+        rest = &after[close + 2..];
+    }
+    out.push_str(rest);
+    Ok(out)
+}
+
+/// Whether `name` is usable as a capture name.
+fn is_capture_name(name: &str) -> bool {
+    !name.is_empty()
+        && name.starts_with(|c: char| c.is_ascii_alphabetic() || c == '_')
+        && name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
+}
+
+// ---- validation -----------------------------------------------------------
+
+/// Checks a batch before any of it runs.
+///
+/// Everything here is decidable without a debugger, and all of it is worth deciding *first*: the
+/// failure this rejects is a batch that applies three mutations and then trips over a typo in the
+/// fourth step, which is the exact shape the rollback block exists to survive but which nobody
+/// should have to survive.
+///
+/// The reference rule is the interesting part, and it is one rule for both blocks: a `{{name}}`
+/// must be captured by an **earlier** step in execution order — `steps` then `always` — so a batch
+/// cannot be written that could only work in a different order.
+///
+/// What that rule deliberately *permits* is the ordinary rollback: `always` runs after every step,
+/// so a cleanup step may name a capture from anywhere in `steps`, including one the batch may never
+/// reach. Whether it was actually bound is a runtime question, and [`run`] answers it by skipping
+/// the step and saying which capture was missing. Refusing it here would reject "restore what step
+/// 5 saved" on the grounds that step 5 *might* not run — which is precisely when the restore
+/// matters.
+pub fn validate(steps: &[BatchStep], always: &[BatchStep]) -> Result<(), String> {
+    if steps.is_empty() {
+        return Err("`steps` is empty; a batch needs at least one step".to_string());
+    }
+    for (block, name) in [(steps, "steps"), (always, "always")] {
+        if block.len() > MAX_STEPS {
+            return Err(format!(
+                "`{name}` has {} steps; at most {MAX_STEPS} are allowed. A batch runs as one \
+                 indivisible job on its session, so its length is also how long every other call \
+                 to that session waits.",
+                block.len()
+            ));
+        }
+    }
+
+    let mut bound: BTreeSet<String> = BTreeSet::new();
+    for (block, block_name) in [(steps, "steps"), (always, "always")] {
+        for (index, step) in block.iter().enumerate() {
+            let where_ = format!("`{block_name}` step {}", index + 1);
+            validate_operands(step, &where_)?;
+            if step.expect.len() > MAX_CHECKS {
+                return Err(format!(
+                    "{where_} has {} checks; at most {MAX_CHECKS} are allowed",
+                    step.expect.len()
+                ));
+            }
+            // `bound` accumulates in execution order across both blocks, so it *is* "what an
+            // earlier step bound" for either of them — no special case for `always`.
+            let visible = &bound;
+            let mut resolve = |name: &str| visible.contains(name).then(String::new);
+            let unresolved = |e: String| {
+                format!(
+                    "{where_}: {e}. A step can only use a capture bound by an earlier step; the \
+                     captures in scope here are {}.",
+                    if visible.is_empty() {
+                        "none".to_string()
+                    } else {
+                        visible
+                            .iter()
+                            .map(|n| format!("`{{{{{n}}}}}`"))
+                            .collect::<Vec<_>>()
+                            .join(", ")
+                    }
+                )
+            };
+            step.action.substituted(&mut resolve).map_err(&unresolved)?;
+            for check in &step.expect {
+                check.substituted(&mut resolve).map_err(&unresolved)?;
+            }
+
+            if let Some(capture) = &step.capture {
+                if !is_capture_name(capture) {
+                    return Err(format!(
+                        "{where_}: `{capture}` is not a capture name — it must start with a \
+                         letter or `_` and hold only letters, digits and `_`"
+                    ));
+                }
+                if !matches!(step.action, StepAction::Eval { .. }) {
+                    return Err(format!(
+                        "{where_} captures `{capture}`, but only an `eval` step has a value to \
+                         bind. Add an `eval` step for the value you want — `{{\"op\": \"eval\", \
+                         \"expr\": \"@rcx\", \"capture\": \"{capture}\"}}` — and interpolate it \
+                         as `{{{{{capture}}}}}`."
+                    ));
+                }
+                if !bound.insert(capture.clone()) {
+                    return Err(format!(
+                        "{where_} captures `{capture}`, which an earlier step already bound. A \
+                         capture names one value for the whole batch."
+                    ));
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Refuses an operand that could end the command this batch builds around it.
+///
+/// The same reasoning as [`reject_command_breakers`] in the typed tools, applied to the two step
+/// fields that are interpolated into a command rather than *being* one: a `;` in an `eval`
+/// expression turns `? <expr>` into a command list. Raw `command`/`resume` steps are exempt for
+/// the same reason `execute` is — chaining is what they are for — and are scanned for
+/// target-changing commands instead ([`retires_handle`]).
+///
+/// Interpolation cannot re-open this hole: a capture is bound to a `0x`-prefixed number, so no
+/// value a batch can produce carries a separator.
+fn validate_operands(step: &BatchStep, where_: &str) -> Result<(), String> {
+    let operand = |field: &str, value: &str| {
+        reject_command_breakers(field, value, Quotes::Rejected)
+            .map_err(|e| format!("{where_}: {e}"))
+    };
+    match &step.action {
+        StepAction::RunTo { address, .. } | StepAction::ReadMemory { address, .. } => {
+            operand("address", address)?;
+        }
+        StepAction::Eval { expr } => operand("expr", expr)?,
+        StepAction::Command { .. } | StepAction::Resume { .. } => {}
+    }
+    for check in &step.expect {
+        if let Check::Eval { expr, equals } = check {
+            operand("expr", expr)?;
+            operand("equals", equals)?;
+        }
+    }
+    Ok(())
+}
+
+/// Whether any command in this batch replaces or releases the debug target, and so must retire the
+/// session handle before the batch runs.
+///
+/// Read on the supervisor side, over the batch as written: interpolation only ever substitutes
+/// numbers, so a command that looks harmless here cannot become a `.detach` by the time it runs.
+pub fn retires_handle(steps: &[BatchStep], always: &[BatchStep]) -> bool {
+    steps.iter().chain(always).any(|step| match &step.action {
+        StepAction::Command { command } | StepAction::Resume { command, .. } => {
+            changes_debug_target(command)
+        }
+        _ => false,
+    })
+}
+
+// ---- what a step changed --------------------------------------------------
+
+/// Session-control commands, taken from [`changes_debug_target`]'s list by asking it.
+const MEMORY_WRITES: &[&str] = &[
+    "e", "ea", "eb", "ed", "ef", "ep", "eq", "eu", "ew", "ez", "eza", "ezu", "f", "fp", "m",
+    ".readmem", ".fillmem",
+];
+const BREAKPOINTS: &[&str] = &[
+    "ba", "bc", "bd", "be", "bm", "bp", "br", "bs", "bsc", "bu", "sxd", "sxe", "sxi", "sxn",
+];
+const EXECUTION: &[&str] = &[
+    "g", "gc", "gh", "gn", "gu", "p", "pa", "pc", "pt", "t", "ta", "tb", "tc", "tt", "wt", "-g",
+    "-p", "-t",
+];
+const ENGINE: &[&str] = &[
+    ".load",
+    ".loadby",
+    ".unload",
+    ".unloadall",
+    ".reload",
+    ".sympath",
+    ".sympath+",
+    ".symfix",
+    ".symfix+",
+    ".srcpath",
+    ".srcpath+",
+    ".exepath",
+];
+
+/// What a raw command changes, as far as a first-token match can tell.
+///
+/// **Best-effort, and biased toward reporting a change.** DbgEng has more ways to touch a target
+/// than a name list can enumerate, and the two errors are not symmetric: an over-report costs one
+/// line of text in a report, while a missed one leaves a mutation the reader does not know to undo.
+/// This is a reporting aid — it decides nothing about what runs — and the `always` block, not this
+/// list, is what actually makes a mutation recoverable.
+pub fn mutation(command: &str) -> Option<String> {
+    let mut kinds: Vec<&'static str> = Vec::new();
+    for segment in command.split([';', '\n', '\r']) {
+        let Some(first) = segment.split_whitespace().next() else {
+            continue;
+        };
+        let token = first.to_ascii_lowercase();
+        let kind = if changes_debug_target(segment) {
+            "the debug target"
+        } else if MEMORY_WRITES.contains(&token.as_str()) {
+            "memory"
+        } else if token == "r" && segment.contains('=') {
+            "registers"
+        } else if BREAKPOINTS.contains(&token.as_str()) {
+            "breakpoints"
+        } else if EXECUTION.contains(&token.as_str()) {
+            "execution"
+        } else if ENGINE.contains(&token.as_str()) {
+            "engine settings"
+        } else {
+            continue;
+        };
+        if !kinds.contains(&kind) {
+            kinds.push(kind);
+        }
+    }
+    (!kinds.is_empty()).then(|| kinds.join(" + "))
+}
+
+/// What an action changes, for the report.
+fn action_mutation(action: &StepAction) -> Option<String> {
+    match action {
+        StepAction::Command { command } => mutation(command),
+        // A resume moves the target by definition, whatever else its command does.
+        StepAction::Resume { command, .. } => Some(match mutation(command) {
+            Some(more) if more != "execution" => more,
+            _ => "execution".to_string(),
+        }),
+        StepAction::RunTo { .. } => Some("execution".to_string()),
+        StepAction::Eval { .. } | StepAction::ReadMemory { .. } => None,
+    }
+}
+
+// ---- the engine seam ------------------------------------------------------
+
+/// What [`run`] needs from a debugger. Implemented over a real engine by the worker, and over a
+/// script by the tests — see the module docs for why that seam is where it is.
+pub trait Debuggee {
+    /// Run a command to completion, self-aborting after `budget_ms`.
+    fn command(&mut self, command: &str, budget_ms: u32) -> Result<String, String>;
+    /// Run a command that moves the target, waiting up to `timeout_ms` for the next stop.
+    fn resume(&mut self, command: &str, timeout_ms: u32) -> Result<String, String>;
+    /// Run to `address` and report a verdict.
+    fn run_to(&mut self, address: &str, timeout_ms: u32) -> Result<String, String>;
+    /// Hex-dump `size` bytes at `address`.
+    fn read_memory(&mut self, address: &str, size: u32) -> Result<String, String>;
+    /// How long this batch has been running.
+    fn elapsed(&self) -> Duration;
+}
+
+// ---- results --------------------------------------------------------------
+
+/// How one step ended.
+#[derive(Debug, Clone, PartialEq)]
+pub enum StepResult {
+    Ok,
+    /// The debugger refused the operation.
+    Failed(String),
+    /// The action succeeded and an assertion did not hold.
+    Unmet(String),
+    /// Never attempted, and why.
+    Skipped(String),
+}
+
+impl StepResult {
+    fn tag(&self) -> &'static str {
+        match self {
+            Self::Ok => "OK",
+            Self::Failed(_) => "FAILED",
+            Self::Unmet(_) => "UNMET",
+            Self::Skipped(_) => "SKIPPED",
+        }
+    }
+
+    fn detail(&self) -> Option<&str> {
+        match self {
+            Self::Ok => None,
+            Self::Failed(why) | Self::Unmet(why) | Self::Skipped(why) => Some(why),
+        }
+    }
+}
+
+/// One step, as the report tells it.
+#[derive(Debug, Clone)]
+pub struct StepOutcome {
+    /// 1-based position within its block.
+    pub position: usize,
+    pub label: String,
+    /// The action after interpolation — what actually ran, not what was written.
+    pub rendered: String,
+    /// What this step changed, if [`mutation`] recognised anything. Recorded whether or not the
+    /// step then succeeded: a command that errors may already have written.
+    pub changes: Option<String>,
+    pub result: StepResult,
+    pub output: String,
+}
+
+impl StepOutcome {
+    fn skipped(position: usize, step: &BatchStep, why: impl Into<String>) -> Self {
+        Self {
+            position,
+            label: step.label(),
+            rendered: step.action.rendered(),
+            changes: None,
+            result: StepResult::Skipped(why.into()),
+            output: String::new(),
+        }
+    }
+
+    fn ok(&self) -> bool {
+        self.result == StepResult::Ok
+    }
+}
+
+/// How the batch as a whole ended.
+#[derive(Debug, Clone, PartialEq)]
+pub enum BatchOutcome {
+    /// Every step ran and every assertion held.
+    Committed,
+    /// A step failed; `at` is its 1-based position.
+    Failed { at: usize },
+    /// The deadline expired; `at` is the 1-based position of the first step not attempted.
+    TimedOut { at: usize },
+}
+
+/// What the session holds once the batch is done — the question a caller cannot answer from the
+/// step list alone, and the one that decides whether their next call is safe.
+#[derive(Debug, Clone, PartialEq)]
+pub enum SessionAfter {
+    /// The engine answered with a current instruction pointer.
+    Stopped { ip: String },
+    /// The target was told to run and never reported a stop, and the probe found no stopped
+    /// context either.
+    Running { why: String },
+    /// A step released or replaced the target.
+    Detached { by: String },
+    /// The probe failed and nothing in the batch explains it.
+    Uncertain { why: String },
+}
+
+#[derive(Debug, Clone)]
+pub struct BatchReport {
+    pub steps: Vec<StepOutcome>,
+    pub always: Vec<StepOutcome>,
+    pub outcome: BatchOutcome,
+    pub after: SessionAfter,
+    /// Total budget the worker was given, for the report's header.
+    pub budget: Duration,
+    pub elapsed: Duration,
+}
+
+impl BatchReport {
+    pub fn committed(&self) -> bool {
+        self.outcome == BatchOutcome::Committed
+    }
+
+    /// Whether every `always` step completed. A rollback that did not is the thing a caller most
+    /// needs to see, so it gets its own predicate rather than being inferred from the list.
+    pub fn rollback_complete(&self) -> bool {
+        self.always.iter().all(StepOutcome::ok)
+    }
+
+    fn mutations(&self) -> Vec<&StepOutcome> {
+        self.steps
+            .iter()
+            .chain(&self.always)
+            .filter(|s| s.changes.is_some() && !matches!(s.result, StepResult::Skipped(_)))
+            .collect()
+    }
+}
+
+// ---- execution ------------------------------------------------------------
+
+/// Runs a batch to completion and reports what happened.
+///
+/// Never returns early and never propagates: every path — including an expired deadline — falls
+/// through to the `always` block and then to the state probe, because the report is the product
+/// here and a half-written one is the failure mode this tool exists to remove.
+pub fn run(d: &mut impl Debuggee, op: &BatchOp, budget: Duration) -> BatchReport {
+    // Reserved before a single step runs. Taken from what is left afterwards it would routinely
+    // be nothing, which is exactly the case the rollback is for.
+    let reserve = ROLLBACK_RESERVE.min(budget / 2);
+    let steps_deadline = budget.saturating_sub(reserve);
+
+    let mut bound: BTreeMap<String, String> = BTreeMap::new();
+    let mut steps: Vec<StepOutcome> = Vec::with_capacity(op.steps.len());
+    let mut outcome = BatchOutcome::Committed;
+
+    for (index, step) in op.steps.iter().enumerate() {
+        let position = index + 1;
+        // The reason matters: "an earlier step failed" and "the clock ran out" call for opposite
+        // next moves, and a step skipped after a timeout would otherwise be told the wrong one.
+        match &outcome {
+            BatchOutcome::Committed => {}
+            BatchOutcome::Failed { at } => {
+                steps.push(StepOutcome::skipped(
+                    position,
+                    step,
+                    format!("step {at} failed, so the batch stopped there"),
+                ));
+                continue;
+            }
+            BatchOutcome::TimedOut { at } => {
+                steps.push(StepOutcome::skipped(
+                    position,
+                    step,
+                    format!("the batch ran out of time at step {at}"),
+                ));
+                continue;
+            }
+        }
+        if d.elapsed() >= steps_deadline {
+            outcome = BatchOutcome::TimedOut { at: position };
+            steps.push(StepOutcome::skipped(
+                position,
+                step,
+                "the batch ran out of time before this step started",
+            ));
+            continue;
+        }
+        let done = run_step(d, step, position, steps_deadline, &mut bound);
+        if !done.ok() {
+            outcome = match &done.result {
+                // An assertion that did not hold is a verdict about the target, and stays one
+                // however long the step took to reach it.
+                StepResult::Unmet(_) => BatchOutcome::Failed { at: position },
+                // A step that ran out of its own budget is a timeout, not a plain failure: the
+                // advice differs (raise `timeout_ms` or narrow the batch, versus fix the step).
+                _ if d.elapsed() >= steps_deadline => BatchOutcome::TimedOut { at: position },
+                _ => BatchOutcome::Failed { at: position },
+            };
+        }
+        steps.push(done);
+    }
+
+    // The rollback block, on every path. Its own deadline is the *whole* budget, which is what the
+    // reserve above bought it.
+    let mut always: Vec<StepOutcome> = Vec::with_capacity(op.always.len());
+    for (index, step) in op.always.iter().enumerate() {
+        let position = index + 1;
+        if d.elapsed() >= budget {
+            always.push(StepOutcome::skipped(
+                position,
+                step,
+                "the batch ran out of time before this cleanup step started",
+            ));
+            continue;
+        }
+        // Cleanup continues past its own failures, deliberately: the steps are ordered, but a
+        // patch that cannot be restored must not stop a breakpoint from being cleared.
+        always.push(run_step(d, step, position, budget, &mut bound));
+    }
+
+    let after = probe_state(d, &steps, &always, budget);
+    BatchReport {
+        steps,
+        always,
+        outcome,
+        after,
+        budget,
+        elapsed: d.elapsed(),
+    }
+}
+
+/// The watchdog for a step, given the deadline it must finish inside.
+fn step_budget_ms(elapsed: Duration, deadline: Duration) -> u32 {
+    deadline
+        .saturating_sub(elapsed)
+        .as_millis()
+        .min(u32::MAX as u128) as u32
+}
+
+fn run_step(
+    d: &mut impl Debuggee,
+    step: &BatchStep,
+    position: usize,
+    deadline: Duration,
+    bound: &mut BTreeMap<String, String>,
+) -> StepOutcome {
+    let budget_ms = step_budget_ms(d.elapsed(), deadline).max(MIN_STEP_BUDGET_MS);
+    let mut resolve = |name: &str| bound.get(name).cloned();
+
+    // Resolved before anything runs, so an unbound reference costs nothing. In `always` this is
+    // the ordinary case, not an error in the batch: the step that would have bound it never ran.
+    let action = match step.action.substituted(&mut resolve) {
+        Ok(action) => action,
+        Err(why) => return StepOutcome::skipped(position, step, why),
+    };
+    let checks: Result<Vec<Check>, String> = step
+        .expect
+        .iter()
+        .map(|check| check.substituted(&mut resolve))
+        .collect();
+    let checks = match checks {
+        Ok(checks) => checks,
+        Err(why) => return StepOutcome::skipped(position, step, why),
+    };
+
+    let rendered = action.rendered();
+    let changes = action_mutation(&action);
+    let wait_ms = |requested: Option<u32>| {
+        requested
+            .unwrap_or(EXEC_WAIT_MS)
+            .min(budget_ms)
+            .max(MIN_STEP_BUDGET_MS)
+    };
+    let ran = match &action {
+        StepAction::Command { command } => d.command(command, budget_ms),
+        StepAction::Resume {
+            command,
+            timeout_ms,
+        } => d.resume(command, wait_ms(*timeout_ms)),
+        StepAction::RunTo {
+            address,
+            timeout_ms,
+        } => d.run_to(address, wait_ms(*timeout_ms)),
+        StepAction::Eval { expr } => d.command(&format!("? {expr}"), budget_ms),
+        StepAction::ReadMemory { address, size } => d.read_memory(address, *size),
+    };
+
+    let output = match ran {
+        Ok(output) => output,
+        Err(why) => {
+            return StepOutcome {
+                position,
+                label: step.label(),
+                rendered,
+                changes,
+                result: StepResult::Failed(why),
+                output: String::new(),
+            };
+        }
+    };
+
+    let mut result = StepResult::Ok;
+    for check in &checks {
+        if let Err(why) = evaluate(d, check, &output, budget_ms) {
+            result = StepResult::Unmet(why);
+            break;
+        }
+    }
+
+    // The capture binds only on a step that fully succeeded: a value read from a step whose
+    // assertions did not hold is a value about a state the batch has already rejected.
+    if result == StepResult::Ok
+        && let Some(capture) = &step.capture
+    {
+        match parse_eval(&output) {
+            Some(value) => {
+                bound.insert(capture.clone(), format!("{value:#x}"));
+            }
+            None => {
+                result = StepResult::Failed(format!(
+                    "`{rendered}` printed no value to capture as `{capture}`. The debugger \
+                     answered:\n{}",
+                    output.trim()
+                ));
+            }
+        }
+    }
+
+    StepOutcome {
+        position,
+        label: step.label(),
+        rendered,
+        changes,
+        result,
+        output,
+    }
+}
+
+/// One side of an [`Check::Eval`] comparison: what the debugger makes of a MASM expression.
+fn eval_value(d: &mut impl Debuggee, expr: &str, budget_ms: u32) -> Result<u64, String> {
+    // Parenthesized, so a relational expression (`@rcx > 0x1000`) is evaluated as one value
+    // rather than losing its precedence against whatever `?` does with the rest of the line.
+    let text = d
+        .command(&format!("? ({expr})"), budget_ms)
+        .map_err(|why| format!("`? ({expr})` failed: {why}"))?;
+    parse_eval(&text).ok_or_else(|| {
+        format!(
+            "`? ({expr})` printed no value; the debugger answered: {}",
+            text.trim()
+        )
+    })
+}
+
+/// Evaluates one assertion, `Ok(())` when it holds.
+fn evaluate(
+    d: &mut impl Debuggee,
+    check: &Check,
+    output: &str,
+    budget_ms: u32,
+) -> Result<(), String> {
+    match check {
+        Check::Contains { text } => {
+            // Case-insensitive: debugger output mixes symbol casing freely, and a check that
+            // fails on `Verdict` versus `VERDICT` would be a trap rather than an assertion.
+            if output
+                .to_ascii_lowercase()
+                .contains(&text.to_ascii_lowercase())
+            {
+                Ok(())
+            } else {
+                Err(format!("the output does not contain \"{text}\""))
+            }
+        }
+        Check::NotContains { text } => {
+            if output
+                .to_ascii_lowercase()
+                .contains(&text.to_ascii_lowercase())
+            {
+                Err(format!("the output contains \"{text}\", which it must not"))
+            } else {
+                Ok(())
+            }
+        }
+        Check::Eval { expr, equals } => {
+            let left = eval_value(d, expr, budget_ms)?;
+            let right = eval_value(d, equals, budget_ms)?;
+            if left == right {
+                Ok(())
+            } else {
+                Err(format!(
+                    "`{expr}` is {} ({left:#x}), `{equals}` is {} ({right:#x})",
+                    fmt_addr(left),
+                    fmt_addr(right)
+                ))
+            }
+        }
+    }
+}
+
+/// Asks what the session holds now.
+///
+/// The probe is one expression, `? @$ip`, and it is read conservatively. An answer means the
+/// engine has a stopped thread context, which is the only claim made. A refusal is *not* read as
+/// "detached" — that verdict is drawn from what the batch itself ran, because a probe cannot tell
+/// a released target apart from one that is merely running, and turning "could not read" into
+/// "detached" would be a verdict this code has not earned.
+fn probe_state(
+    d: &mut impl Debuggee,
+    steps: &[StepOutcome],
+    always: &[StepOutcome],
+    budget: Duration,
+) -> SessionAfter {
+    let released = steps
+        .iter()
+        .chain(always)
+        .filter(|s| !matches!(s.result, StepResult::Skipped(_)))
+        .find(|s| {
+            s.changes
+                .as_deref()
+                .is_some_and(|c| c.contains("the debug target"))
+        });
+    if let Some(step) = released {
+        return SessionAfter::Detached {
+            by: format!("`{}`", step.rendered),
+        };
+    }
+
+    // Told to run and never reported a stop: the target may still be running, and the probe below
+    // cannot distinguish that from a target that is gone.
+    let ran_on = steps.iter().chain(always).any(|s| {
+        s.changes
+            .as_deref()
+            .is_some_and(|c| c.contains("execution"))
+            && !s.ok()
+    });
+
+    let budget_ms = step_budget_ms(d.elapsed(), budget).max(MIN_STEP_BUDGET_MS);
+    match d.command("? @$ip", budget_ms) {
+        Ok(text) => match parse_eval(&text) {
+            Some(ip) => SessionAfter::Stopped { ip: fmt_addr(ip) },
+            None => SessionAfter::Uncertain {
+                why: format!(
+                    "`? @$ip` printed no address; the debugger answered: {}",
+                    text.trim()
+                ),
+            },
+        },
+        Err(why) if ran_on => SessionAfter::Running {
+            why: format!(
+                "a step resumed the target and did not report a stop, and `? @$ip` failed: {why}"
+            ),
+        },
+        Err(why) => SessionAfter::Uncertain {
+            why: format!("`? @$ip` failed: {why}"),
+        },
+    }
+}
+
+// ---- rendering ------------------------------------------------------------
+
+/// Truncates `text` to `limit` characters, saying how much it dropped.
+fn clip(text: &str, limit: usize) -> String {
+    let text = text.trim_end();
+    if text.chars().count() <= limit {
+        return text.to_string();
+    }
+    let kept: String = text.chars().take(limit).collect();
+    let dropped = text.chars().count() - limit;
+    format!("{kept}\n… {dropped} more characters not shown")
+}
+
+fn indent(text: &str, prefix: &str) -> String {
+    text.lines()
+        .map(|line| format!("{prefix}{line}\n"))
+        .collect()
+}
+
+/// Renders one block of steps. The step that did not succeed gets the larger output budget: it is
+/// the one the caller has to act on, and the rest are context for it.
+fn render_block(out: &mut String, title: &str, block: &[StepOutcome]) {
+    if block.is_empty() {
+        return;
+    }
+    let _ = writeln!(out, "\n---- {title} ----");
+    for step in block {
+        let changes = match &step.changes {
+            Some(changes) => format!("   [changes {changes}]"),
+            None => String::new(),
+        };
+        // An unlabelled step's label *is* its command, so printing both would say it twice.
+        let _ = if step.label == step.rendered {
+            writeln!(
+                out,
+                "{:>3}. {:<8} `{}`{changes}",
+                step.position,
+                step.result.tag(),
+                step.rendered
+            )
+        } else {
+            writeln!(
+                out,
+                "{:>3}. {:<8} {}\n     `{}`{changes}",
+                step.position,
+                step.result.tag(),
+                step.label,
+                step.rendered
+            )
+        };
+        if let Some(detail) = step.result.detail() {
+            out.push_str(&indent(detail, "     ! "));
+        }
+        if !step.output.trim().is_empty() {
+            let limit = if step.ok() {
+                STEP_OUTPUT_CHARS
+            } else {
+                FAILED_OUTPUT_CHARS
+            };
+            out.push_str(&indent(&clip(&step.output, limit), "     | "));
+        }
+    }
+}
+
+/// Renders the report as the tool's text output.
+pub fn render(report: &BatchReport) -> String {
+    let total = report.steps.len();
+    let mut out = match &report.outcome {
+        BatchOutcome::Committed => format!("BATCH: COMMITTED — all {total} step(s) ran\n"),
+        BatchOutcome::Failed { at } => format!("BATCH: FAILED at step {at} of {total}\n"),
+        BatchOutcome::TimedOut { at } => format!(
+            "BATCH: TIMED OUT at step {at} of {total} — the batch was given {:.0}s and used \
+             {:.0}s\n",
+            report.budget.as_secs_f64(),
+            report.elapsed.as_secs_f64()
+        ),
+    };
+
+    let mutations = report.mutations();
+    if mutations.is_empty() {
+        out.push_str("mutations: none recognised\n");
+    } else {
+        let _ = writeln!(
+            out,
+            "mutations: {} step(s) changed state —",
+            mutations.len()
+        );
+        for step in mutations {
+            let _ = writeln!(
+                out,
+                "  {} `{}` [{}]{}",
+                step.label,
+                step.rendered,
+                step.changes.as_deref().unwrap_or(""),
+                if step.ok() {
+                    ""
+                } else {
+                    " (the step did not succeed; it may still have changed something)"
+                }
+            );
+        }
+    }
+
+    if report.always.is_empty() {
+        out.push_str(
+            "rollback: no `always` block was supplied, so nothing was undone. Anything listed \
+             above is still in place.\n",
+        );
+    } else if report.rollback_complete() {
+        let _ = writeln!(
+            out,
+            "rollback: COMPLETE — all {} `always` step(s) ran",
+            report.always.len()
+        );
+    } else {
+        let stuck = report.always.iter().filter(|s| !s.ok()).count();
+        let _ = writeln!(
+            out,
+            "rollback: INCOMPLETE — {stuck} of {} `always` step(s) did not complete. See the \
+             `always` block below; this is reported beside the batch's own outcome, not instead \
+             of it.",
+            report.always.len()
+        );
+    }
+
+    let _ = writeln!(
+        out,
+        "session after: {}",
+        match &report.after {
+            SessionAfter::Stopped { ip } => format!("STOPPED at {ip}"),
+            SessionAfter::Running { why } => format!("RUNNING (or gone) — {why}"),
+            SessionAfter::Detached { by } =>
+                format!("DETACHED/REPLACED by {by}; this session's handle is retired"),
+            SessionAfter::Uncertain { why } => format!("UNCERTAIN — {why}"),
+        }
+    );
+
+    render_block(&mut out, "steps", &report.steps);
+    render_block(&mut out, "always (rollback)", &report.always);
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ---- a scripted debuggee ----------------------------------------------
+
+    /// One scripted answer: what the fake returns, and how long the call "takes".
+    struct Answer {
+        result: Result<String, String>,
+        costs: Duration,
+    }
+
+    /// A [`Debuggee`] that answers from a script and carries a virtual clock.
+    ///
+    /// The clock is the point. Deadline expiry is otherwise only reproducible by waiting, and a
+    /// test that waits out a 30s reserve is a test nobody runs — so time advances by whatever the
+    /// scripted answer says its call cost, and the executor's arithmetic is exercised exactly as
+    /// it would be against a slow target.
+    #[derive(Default)]
+    struct Script {
+        answers: Vec<(String, Answer)>,
+        calls: Vec<String>,
+        clock: Duration,
+    }
+
+    impl Script {
+        fn new() -> Self {
+            Self::default()
+        }
+
+        /// Answers any call whose text contains `matching`.
+        fn on(mut self, matching: &str, result: Result<&str, &str>) -> Self {
+            self.answers.push((
+                matching.to_string(),
+                Answer {
+                    result: result.map(str::to_string).map_err(str::to_string),
+                    costs: Duration::ZERO,
+                },
+            ));
+            self
+        }
+
+        /// As [`Self::on`], and the call advances the clock by `costs`.
+        fn slow(mut self, matching: &str, result: Result<&str, &str>, costs: Duration) -> Self {
+            self.answers.push((
+                matching.to_string(),
+                Answer {
+                    result: result.map(str::to_string).map_err(str::to_string),
+                    costs,
+                },
+            ));
+            self
+        }
+
+        fn answer(&mut self, call: &str) -> Result<String, String> {
+            self.calls.push(call.to_string());
+            let found = self
+                .answers
+                .iter()
+                .find(|(matching, _)| call.contains(matching.as_str()));
+            match found {
+                Some((_, answer)) => {
+                    let (result, costs) = (answer.result.clone(), answer.costs);
+                    self.clock += costs;
+                    result
+                }
+                // An unscripted call is a test bug, and a silent empty answer would hide it.
+                None => panic!(
+                    "the script has no answer for `{call}`; calls so far: {:?}",
+                    self.calls
+                ),
+            }
+        }
+
+        fn ran(&self, matching: &str) -> bool {
+            self.calls.iter().any(|c| c.contains(matching))
+        }
+    }
+
+    impl Debuggee for Script {
+        fn command(&mut self, command: &str, _budget_ms: u32) -> Result<String, String> {
+            self.answer(command)
+        }
+        fn resume(&mut self, command: &str, _timeout_ms: u32) -> Result<String, String> {
+            self.answer(command)
+        }
+        fn run_to(&mut self, address: &str, _timeout_ms: u32) -> Result<String, String> {
+            self.answer(&format!("run to {address}"))
+        }
+        fn read_memory(&mut self, address: &str, size: u32) -> Result<String, String> {
+            self.answer(&format!("read {size} at {address}"))
+        }
+        fn elapsed(&self) -> Duration {
+            self.clock
+        }
+    }
+
+    /// `? @$ip` answers, so every batch below can reach the state probe.
+    fn stopped() -> Script {
+        Script::new().on("? @$ip", Ok("Evaluate expression: 1 = fffff803`1a2b3c4d"))
+    }
+
+    fn step(action: StepAction) -> BatchStep {
+        BatchStep {
+            name: None,
+            action,
+            expect: Vec::new(),
+            capture: None,
+        }
+    }
+
+    fn cmd(command: &str) -> BatchStep {
+        step(StepAction::Command {
+            command: command.to_string(),
+        })
+    }
+
+    fn op(steps: Vec<BatchStep>, always: Vec<BatchStep>) -> BatchOp {
+        BatchOp {
+            steps,
+            always,
+            budget_ms: 60_000,
+            patience_ms: 60_000,
+        }
+    }
+
+    const BUDGET: Duration = Duration::from_secs(60);
+
+    // ---- the four paths the issue asks for --------------------------------
+
+    /// An assertion that does not hold stops the batch *and* runs the rollback — the case a
+    /// client-side loop gets right only when it is still there to notice.
+    #[test]
+    fn an_unmet_assertion_stops_the_batch_and_still_rolls_back() {
+        let mut d = stopped()
+            .on("eb fffff800", Ok(""))
+            .on(
+                "run to ",
+                Ok("VERDICT: TIMEOUT — did not reach fffff803`00001000\n"),
+            )
+            .on("never", Ok(""))
+            .on("eb restore", Ok(""));
+        let batch = op(
+            vec![
+                cmd("eb fffff800`00001000 90"),
+                BatchStep {
+                    expect: vec![Check::Contains {
+                        text: "VERDICT: HIT".to_string(),
+                    }],
+                    ..step(StepAction::RunTo {
+                        address: "fffff803`00001000".to_string(),
+                        timeout_ms: None,
+                    })
+                },
+                cmd("never runs"),
+            ],
+            vec![cmd("eb restore 41")],
+        );
+
+        let report = run(&mut d, &batch, BUDGET);
+
+        assert_eq!(report.outcome, BatchOutcome::Failed { at: 2 });
+        assert!(matches!(report.steps[1].result, StepResult::Unmet(_)));
+        assert!(matches!(report.steps[2].result, StepResult::Skipped(_)));
+        assert!(!d.ran("never"), "a step after the failure must not run");
+        assert!(d.ran("eb restore"), "the rollback must run");
+        assert!(report.rollback_complete());
+
+        let text = render(&report);
+        assert!(text.contains("BATCH: FAILED at step 2 of 3"), "{text}");
+        assert!(text.contains("VERDICT: HIT"), "{text}");
+        assert!(text.contains("rollback: COMPLETE"), "{text}");
+    }
+
+    /// A command that fails *after* a mutation: the mutation is reported even though the batch
+    /// did not commit, because it happened.
+    #[test]
+    fn a_command_failure_after_a_mutation_reports_both() {
+        let mut d = stopped()
+            .on("bp nt!NtCreateFile", Ok("breakpoint 0 set"))
+            .on(
+                "eb fffff800",
+                Err("Memory access error at 'fffff800`00001000'"),
+            )
+            .on("bc *", Ok(""));
+        let batch = op(
+            vec![cmd("bp nt!NtCreateFile"), cmd("eb fffff800`00001000 90")],
+            vec![cmd("bc *")],
+        );
+
+        let report = run(&mut d, &batch, BUDGET);
+
+        assert_eq!(report.outcome, BatchOutcome::Failed { at: 2 });
+        let text = render(&report);
+        // The breakpoint landed and must be listed as a mutation, and the failed write must be
+        // listed too — a write that errored may still have written.
+        assert!(text.contains("[breakpoints]"), "{text}");
+        assert!(text.contains("[memory]"), "{text}");
+        assert!(
+            text.contains("it may still have changed something"),
+            "{text}"
+        );
+        assert!(text.contains("Memory access error"), "{text}");
+    }
+
+    /// The deadline expires mid-batch: the remaining steps are skipped, and the rollback still
+    /// runs inside the reserve that was held back for it.
+    #[test]
+    fn an_expired_deadline_skips_the_rest_and_still_rolls_back() {
+        let mut d = stopped()
+            .slow(
+                "g",
+                Ok("Break instruction exception"),
+                Duration::from_secs(45),
+            )
+            .on("second", Ok(""))
+            .on("bc *", Ok(""));
+        let batch = op(
+            vec![
+                step(StepAction::Resume {
+                    command: "g".to_string(),
+                    timeout_ms: None,
+                }),
+                cmd("second step"),
+            ],
+            vec![cmd("bc *")],
+        );
+
+        // 60s budget, 30s reserve → the steps get 30s and the first one costs 45s.
+        let report = run(&mut d, &batch, BUDGET);
+
+        assert_eq!(report.outcome, BatchOutcome::TimedOut { at: 2 });
+        assert!(!d.ran("second"), "a step past the deadline must not run");
+        assert!(d.ran("bc *"), "the reserve exists so this still runs");
+        assert!(report.rollback_complete());
+        let text = render(&report);
+        assert!(text.contains("BATCH: TIMED OUT at step 2 of 2"), "{text}");
+    }
+
+    /// A rollback step that itself fails is reported beside the original failure, never instead
+    /// of it — and the later cleanup steps still run.
+    #[test]
+    fn a_failed_rollback_step_neither_hides_the_failure_nor_stops_the_cleanup() {
+        let mut d = stopped()
+            .on("eb fffff800", Ok(""))
+            .on(
+                "bp nowhere!Nope",
+                Err("Couldn't resolve error at 'nowhere!Nope'"),
+            )
+            .on("eb restore", Err("Memory access error"))
+            .on("bc *", Ok(""));
+        let batch = op(
+            vec![cmd("eb fffff800`00001000 90"), cmd("bp nowhere!Nope")],
+            vec![cmd("eb restore 41"), cmd("bc *")],
+        );
+
+        let report = run(&mut d, &batch, BUDGET);
+
+        assert_eq!(report.outcome, BatchOutcome::Failed { at: 2 });
+        assert!(!report.rollback_complete());
+        assert!(
+            d.ran("bc *"),
+            "cleanup continues past a failed cleanup step"
+        );
+
+        let text = render(&report);
+        assert!(text.contains("BATCH: FAILED at step 2 of 2"), "{text}");
+        assert!(text.contains("rollback: INCOMPLETE — 1 of 2"), "{text}");
+        assert!(text.contains("Couldn't resolve error"), "{text}");
+    }
+
+    // ---- captures ----------------------------------------------------------
+
+    #[test]
+    fn a_capture_is_interpolated_into_a_later_step() {
+        let mut d = stopped()
+            .on(
+                "? @rcx",
+                Ok("Evaluate expression: 4096 = 00000000`00001000"),
+            )
+            .on("dt nt!_EPROCESS 0x1000", Ok("+0x000 Pcb"));
+        let batch = op(
+            vec![
+                BatchStep {
+                    capture: Some("obj".to_string()),
+                    ..step(StepAction::Eval {
+                        expr: "@rcx".to_string(),
+                    })
+                },
+                cmd("dt nt!_EPROCESS {{obj}}"),
+            ],
+            vec![],
+        );
+
+        let report = run(&mut d, &batch, BUDGET);
+
+        assert!(report.committed(), "{}", render(&report));
+        assert!(
+            d.ran("dt nt!_EPROCESS 0x1000"),
+            "the capture should have been substituted: {:?}",
+            d.calls
+        );
+    }
+
+    /// The rollback case the validator deliberately does not reject: a cleanup step that restores
+    /// a value the failing run never captured. It is skipped, and says which capture was missing.
+    #[test]
+    fn a_rollback_that_needs_an_unbound_capture_is_skipped_with_the_reason() {
+        let mut d = stopped()
+            .on(
+                "bp nowhere!Nope",
+                Err("Couldn't resolve error at 'nowhere!Nope'"),
+            )
+            .on("? poi(", Ok("Evaluate expression: 1 = 00000000`00000001"))
+            .on("bc *", Ok(""));
+        let batch = op(
+            vec![
+                cmd("bp nowhere!Nope"),
+                BatchStep {
+                    capture: Some("orig".to_string()),
+                    ..step(StepAction::Eval {
+                        expr: "poi(fffff800`00001000)".to_string(),
+                    })
+                },
+            ],
+            vec![cmd("eq fffff800`00001000 {{orig}}"), cmd("bc *")],
+        );
+
+        let report = run(&mut d, &batch, BUDGET);
+
+        assert!(matches!(report.always[0].result, StepResult::Skipped(_)));
+        assert!(!report.rollback_complete());
+        let text = render(&report);
+        assert!(text.contains("`{{orig}}` is not bound"), "{text}");
+        assert!(d.ran("bc *"), "the rest of the cleanup still runs");
+    }
+
+    #[test]
+    fn an_eval_step_that_prints_no_value_fails_rather_than_binding_nothing() {
+        let mut d = stopped().on("? bogus!Nope", Ok("Couldn't resolve error at 'bogus!Nope'"));
+        let batch = op(
+            vec![BatchStep {
+                capture: Some("x".to_string()),
+                ..step(StepAction::Eval {
+                    expr: "bogus!Nope".to_string(),
+                })
+            }],
+            vec![],
+        );
+
+        let report = run(&mut d, &batch, BUDGET);
+        assert_eq!(report.outcome, BatchOutcome::Failed { at: 1 });
+    }
+
+    // ---- assertions --------------------------------------------------------
+
+    #[test]
+    fn an_eval_check_compares_two_expressions_and_reports_both_sides() {
+        let mut d = stopped()
+            .on("!drvobj", Ok("Driver object (ffffb00`0000) is for:"))
+            .on(
+                "? (@rcx)",
+                Ok("Evaluate expression: 65 = 00000000`00000041"),
+            )
+            .on(
+                "? (0x42)",
+                Ok("Evaluate expression: 66 = 00000000`00000042"),
+            );
+        let batch = op(
+            vec![BatchStep {
+                expect: vec![Check::Eval {
+                    expr: "@rcx".to_string(),
+                    equals: "0x42".to_string(),
+                }],
+                ..cmd("!drvobj \\Driver\\HEVD 7")
+            }],
+            vec![],
+        );
+
+        let report = run(&mut d, &batch, BUDGET);
+        assert_eq!(report.outcome, BatchOutcome::Failed { at: 1 });
+        let text = render(&report);
+        assert!(text.contains("00000000`00000041"), "{text}");
+        assert!(text.contains("00000000`00000042"), "{text}");
+    }
+
+    #[test]
+    fn a_not_contains_check_fails_when_the_text_is_present() {
+        let mut d = stopped().on("!analyze", Ok("PAGE_FAULT_IN_NONPAGED_AREA"));
+        let batch = op(
+            vec![BatchStep {
+                expect: vec![Check::NotContains {
+                    text: "PAGE_FAULT".to_string(),
+                }],
+                ..cmd("!analyze -v")
+            }],
+            vec![],
+        );
+        assert_eq!(
+            run(&mut d, &batch, BUDGET).outcome,
+            BatchOutcome::Failed { at: 1 }
+        );
+    }
+
+    // ---- session state -----------------------------------------------------
+
+    #[test]
+    fn a_batch_that_detaches_reports_the_target_as_gone_without_probing() {
+        let mut d = Script::new().on(".detach", Ok("Detached"));
+        let batch = op(vec![cmd(".detach")], vec![]);
+
+        let report = run(&mut d, &batch, BUDGET);
+
+        assert!(matches!(report.after, SessionAfter::Detached { .. }));
+        assert!(
+            !d.ran("@$ip"),
+            "a released target must not be probed: {:?}",
+            d.calls
+        );
+        assert!(render(&report).contains("DETACHED/REPLACED"));
+    }
+
+    #[test]
+    fn a_resume_that_never_stopped_leaves_the_session_reported_as_running() {
+        let mut d = Script::new()
+            .on("g", Err("the target did not stop within the timeout"))
+            .on("? @$ip", Err("No runnable debuggees error"));
+        let batch = op(
+            vec![step(StepAction::Resume {
+                command: "g".to_string(),
+                timeout_ms: Some(5_000),
+            })],
+            vec![],
+        );
+
+        let report = run(&mut d, &batch, BUDGET);
+        assert!(
+            matches!(report.after, SessionAfter::Running { .. }),
+            "{:?}",
+            report.after
+        );
+        assert!(render(&report).contains("session after: RUNNING"));
+    }
+
+    /// A probe that fails with nothing in the batch to explain it must not be read as "detached".
+    #[test]
+    fn an_unexplained_probe_failure_is_uncertain_not_detached() {
+        let mut d = Script::new()
+            .on("lm", Ok("start end module"))
+            .on("? @$ip", Err("No current thread"));
+        let report = run(&mut d, &op(vec![cmd("lm")], vec![]), BUDGET);
+        assert!(
+            matches!(report.after, SessionAfter::Uncertain { .. }),
+            "{:?}",
+            report.after
+        );
+    }
+
+    // ---- mutation classification -------------------------------------------
+
+    #[test]
+    fn mutations_are_classified_by_the_command_that_makes_them() {
+        assert_eq!(mutation("eb fffff800`1000 90").as_deref(), Some("memory"));
+        assert_eq!(mutation("r rax=1").as_deref(), Some("registers"));
+        assert_eq!(
+            mutation("bp nt!NtCreateFile").as_deref(),
+            Some("breakpoints")
+        );
+        assert_eq!(mutation("g").as_deref(), Some("execution"));
+        assert_eq!(mutation(".detach").as_deref(), Some("the debug target"));
+        // A register *read* is not a write.
+        assert_eq!(mutation("r rax"), None);
+        assert_eq!(mutation("dt nt!_EPROCESS"), None);
+        // Every segment counts, and each kind is named once.
+        assert_eq!(
+            mutation("bp nt!Foo; eb fffff800`1000 90; bc 0").as_deref(),
+            Some("breakpoints + memory")
+        );
+    }
+
+    #[test]
+    fn a_resume_always_counts_as_changing_execution() {
+        assert_eq!(
+            action_mutation(&StepAction::Resume {
+                command: "g @$ra".to_string(),
+                timeout_ms: None,
+            })
+            .as_deref(),
+            Some("execution")
+        );
+        assert_eq!(
+            action_mutation(&StepAction::Eval {
+                expr: "@rcx".to_string()
+            }),
+            None
+        );
+    }
+
+    // ---- validation --------------------------------------------------------
+
+    #[test]
+    fn a_forward_capture_reference_is_refused_before_anything_runs() {
+        let batch = vec![
+            cmd("eb fffff800`00001000 {{later}}"),
+            BatchStep {
+                capture: Some("later".to_string()),
+                ..step(StepAction::Eval {
+                    expr: "@rcx".to_string(),
+                })
+            },
+        ];
+        let why = validate(&batch, &[]).unwrap_err();
+        assert!(why.contains("`{{later}}` is not bound"), "{why}");
+        assert!(why.contains("steps` step 1"), "{why}");
+    }
+
+    #[test]
+    fn a_capture_on_a_non_eval_step_is_refused_with_the_alternative() {
+        let batch = vec![BatchStep {
+            capture: Some("out".to_string()),
+            ..cmd("lm")
+        }];
+        let why = validate(&batch, &[]).unwrap_err();
+        assert!(why.contains("only an `eval` step"), "{why}");
+        assert!(why.contains("\"op\": \"eval\""), "{why}");
+    }
+
+    #[test]
+    fn a_duplicate_capture_is_refused() {
+        let twice = |name: &str| BatchStep {
+            capture: Some(name.to_string()),
+            ..step(StepAction::Eval {
+                expr: "@rcx".to_string(),
+            })
+        };
+        let why = validate(&[twice("x"), twice("x")], &[]).unwrap_err();
+        assert!(why.contains("already bound"), "{why}");
+    }
+
+    /// The rollback's forward reference is the one that must be *allowed*: a cleanup step
+    /// restoring what a later main step captured is the ordinary shape.
+    #[test]
+    fn a_rollback_may_name_a_capture_from_any_step() {
+        let steps = vec![
+            cmd("eb fffff800`00001000 90"),
+            BatchStep {
+                capture: Some("orig".to_string()),
+                ..step(StepAction::Eval {
+                    expr: "poi(fffff800`00001000)".to_string(),
+                })
+            },
+        ];
+        validate(&steps, &[cmd("eq fffff800`00001000 {{orig}}")]).expect("allowed");
+    }
+
+    /// …but the rule is still "an earlier step", in execution order: a cleanup step may not name a
+    /// capture a *later* cleanup step binds, which could only ever be unbound when it ran.
+    #[test]
+    fn a_rollback_may_not_name_a_capture_from_a_later_rollback_step() {
+        let always = vec![
+            cmd("eq fffff800`00001000 {{late}}"),
+            BatchStep {
+                capture: Some("late".to_string()),
+                ..step(StepAction::Eval {
+                    expr: "@rcx".to_string(),
+                })
+            },
+        ];
+        let why = validate(&[cmd("lm")], &always).unwrap_err();
+        assert!(why.contains("`always` step 1"), "{why}");
+        assert!(why.contains("`{{late}}` is not bound"), "{why}");
+    }
+
+    #[test]
+    fn a_separator_in_a_typed_operand_is_refused() {
+        let why = validate(
+            &[step(StepAction::Eval {
+                expr: "@rcx; .detach".to_string(),
+            })],
+            &[],
+        )
+        .unwrap_err();
+        assert!(why.contains("contains a `;`"), "{why}");
+        // A raw command may chain — that is what it is for.
+        validate(&[cmd("bp nt!Foo; g")], &[]).expect("a raw command may chain");
+    }
+
+    #[test]
+    fn an_empty_batch_and_an_oversized_one_are_both_refused() {
+        assert!(validate(&[], &[]).unwrap_err().contains("empty"));
+        let many: Vec<BatchStep> = (0..=MAX_STEPS).map(|_| cmd("lm")).collect();
+        assert!(validate(&many, &[]).unwrap_err().contains("at most"));
+    }
+
+    #[test]
+    fn a_target_changing_command_in_either_block_retires_the_handle() {
+        assert!(retires_handle(&[cmd(".opendump other.dmp")], &[]));
+        assert!(retires_handle(&[cmd("lm")], &[cmd(".detach")]));
+        assert!(!retires_handle(
+            &[cmd("lm"), cmd("bp nt!Foo")],
+            &[cmd("bc *")]
+        ));
+    }
+
+    // ---- the sequence this tool was filed for -------------------------------
+
+    /// The MessageManager CTF sequence, as `debug_batch` expresses it — issue #82's last
+    /// acceptance criterion, discharged against the workflow itself rather than against a guess
+    /// at it.
+    ///
+    /// Transcribed from the longest single invocation of the throwaway PowerShell client the CTF
+    /// session grew (`target/mcp_batch.ps1`, 32 steps in one call), plus the rollback that client
+    /// hard-coded by its final revision. Every construct the script had a verb for is here: a
+    /// run-to verdict (`@run`), a register assertion against a saved pseudo-register
+    /// (`@asserttarget`), a structure assertion over three memory words (`@assertfake`), code
+    /// patches and their restores, and `bc *`.
+    ///
+    /// Two of the script's verbs are **not** here and cannot be: `@chunkt1` and `@census` call the
+    /// `pool_chunk`/`pool_census` tools, and a batch step cannot reach a typed tool that is not a
+    /// debugger command. Nine of the workflow's 1,681 steps were pool queries; the other 1,672 are
+    /// the shapes below.
+    fn messagemanager_sequence() -> (Vec<BatchStep>, Vec<BatchStep>) {
+        // The verdict check the script open-coded as `if ($verdict -notmatch 'VERDICT: HIT')`.
+        let run_to = |address: &str, ms: u32| BatchStep {
+            expect: vec![Check::Contains {
+                text: "VERDICT: HIT".to_string(),
+            }],
+            ..step(StepAction::RunTo {
+                address: address.to_string(),
+                timeout_ms: Some(ms),
+            })
+        };
+        // `@asserttarget`: the script could not compare two values, so it emitted
+        // `.if ($register != @$t6) { .echo MM_TARGET_MISMATCH }` and regex-matched the echo. An
+        // `eval` check is the same assertion without the round trip through prose.
+        let assert_target = |register: &str| BatchStep {
+            name: Some(format!("the break belongs to our MESSAGE ({register})")),
+            expect: vec![Check::Eval {
+                expr: register.to_string(),
+                equals: "@$t6".to_string(),
+            }],
+            ..step(StepAction::Eval {
+                expr: register.to_string(),
+            })
+        };
+        let steps = vec![
+            run_to("fffff806159516e4", 270_000),
+            cmd("r @$t7=fffff80615950000; r @$t6=@rbx; r; dd @$t6 L4"),
+            assert_target("@rbx"),
+            cmd("bc *"),
+            cmd("ed @$t6 3; eb @$t7+16e4 eb fe 90 90"),
+            run_to("fffff80615951502", 30_000),
+            assert_target("@rsi"),
+            cmd("bc *"),
+            cmd("ed @$t7+16e4 08538d48"),
+            run_to("fffff80615951706", 30_000),
+            assert_target("@rbx"),
+            cmd("bc *"),
+            run_to("fffff8061595151b", 30_000),
+            assert_target("@rsi"),
+            cmd("r @$t1=@rsi; db @$t1 L68"),
+            cmd("bc *"),
+            cmd("eb @$t7+1f00 f3 90 eb fc e9 27 f3 ff ff; eb @$t7+1230 e9 cb 0c 00 00"),
+            run_to("fffff80615951210", 90_000),
+            cmd("bc *"),
+            cmd("eb @$t7+1230 48 89 5c 24 08"),
+            run_to("fffff80615951560", 30_000),
+            // `@assertfake`: three fields of the reclaiming allocation. The script's first cut
+            // chained them into one `.if`, which did not evaluate as written, so its eighth
+            // revision replaced it with three `r @$tN=` assignments and three regexes over the
+            // printed output. Three `eval` checks say it once.
+            BatchStep {
+                name: Some("the reclaim landed on our fake MESSAGE".to_string()),
+                expect: vec![
+                    Check::Eval {
+                        expr: "poi(@$t1+18)".to_string(),
+                        equals: "0".to_string(),
+                    },
+                    Check::Eval {
+                        expr: "poi(@$t1+20)".to_string(),
+                        equals: "0x400".to_string(),
+                    },
+                    Check::Eval {
+                        expr: "by(@$t1+60)".to_string(),
+                        equals: "1".to_string(),
+                    },
+                ],
+                ..cmd("db @$t1 L68")
+            },
+            cmd("bc *"),
+            run_to("fffff8067fafa240", 30_000),
+            cmd("r; ln @rip; kv"),
+        ];
+        // Verbatim from the client's final revision — the restore it ran on the failure paths it
+        // could reach, and could not run on the ones it could not.
+        let always = vec![
+            cmd(
+                "ed @$t7+16e4 08538d48; eb @$t7+1656 54 66 75 62; eb @$t7+165e 00 01 00 00; \
+                 eb @$t7+1f03 00; eb @$t7+1230 48 89 5c 24 08",
+            ),
+            cmd("bc *"),
+        ];
+        (steps, always)
+    }
+
+    #[test]
+    fn the_messagemanager_sequence_is_a_valid_batch() {
+        let (steps, always) = messagemanager_sequence();
+        assert_eq!(steps.len(), 25);
+        validate(&steps, &always).expect("the sequence the tool was filed for must validate");
+        // It patches code and clears breakpoints, so it must not be mistaken for inspection.
+        assert!(
+            steps
+                .iter()
+                .filter_map(|s| action_mutation(&s.action))
+                .any(|m| m.contains("memory")),
+            "the code patches must be recognised as mutations"
+        );
+    }
+
+    /// The failure the client hand-rolled a rollback for: the race breakpoint fires for a
+    /// *different* MESSAGE than the one that was saved. Here it is one `eval` check, and the
+    /// restore is not conditional on anyone still being connected to send it.
+    #[test]
+    fn a_wrong_target_stops_the_messagemanager_sequence_and_restores_the_patches() {
+        let (steps, always) = messagemanager_sequence();
+        let mut d = stopped()
+            .on(
+                "run to ",
+                Ok("VERDICT: HIT — execution reached fffff806`159516e4"),
+            )
+            // The saved object and the one this break belongs to are different — the mismatch.
+            .on("? (@rbx)", Ok("Evaluate expression: 1 = ffffb08e`e358c080"))
+            .on("? (@$t6)", Ok("Evaluate expression: 1 = ffffb08e`e358d100"))
+            // Everything else — the `r`/`dd`/`eb`/`ed`/`bc` traffic — answers blank.
+            .on("", Ok(""));
+        let batch = op(steps, always);
+
+        let report = run(&mut d, &batch, BUDGET);
+
+        // Step 3 is the first `@asserttarget`.
+        assert_eq!(report.outcome, BatchOutcome::Failed { at: 3 });
+        assert!(report.rollback_complete(), "{}", render(&report));
+        assert!(
+            d.ran("ed @$t7+16e4 08538d48") && d.ran("bc *"),
+            "the code patches must be restored: {:?}",
+            d.calls
+        );
+        // Nothing past the failure ran — including the patches that would have been applied.
+        assert!(
+            !d.ran("eb @$t7+1f00"),
+            "the batch must stop at the mismatch: {:?}",
+            d.calls
+        );
+        let text = render(&report);
+        assert!(text.contains("BATCH: FAILED at step 3 of 25"), "{text}");
+        assert!(text.contains("ffffb08e`e358c080"), "{text}");
+        assert!(text.contains("ffffb08e`e358d100"), "{text}");
+    }
+
+    // ---- budget arithmetic --------------------------------------------------
+
+    #[test]
+    fn the_rollback_reserve_never_takes_more_than_half_the_budget() {
+        // A 10s batch reserves 5s, not the full 30s — otherwise the steps would get none.
+        let mut d = stopped().on("lm", Ok("start end module"));
+        let report = run(
+            &mut d,
+            &op(vec![cmd("lm")], vec![]),
+            Duration::from_secs(10),
+        );
+        assert!(report.committed(), "{}", render(&report));
+    }
+
+    #[test]
+    fn a_step_is_never_armed_with_a_zero_watchdog() {
+        // Zero disables win-kexp's watchdog, so the floor matters more than the arithmetic.
+        assert_eq!(
+            step_budget_ms(Duration::from_secs(90), Duration::from_secs(60)),
+            0
+        );
+        let mut d = stopped().slow("lm", Ok(""), Duration::from_secs(90));
+        let report = run(&mut d, &op(vec![cmd("lm"), cmd("lm")], vec![]), BUDGET);
+        assert_eq!(report.outcome, BatchOutcome::TimedOut { at: 2 });
+    }
+}

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -976,13 +976,35 @@ fn run_step(
         }
     }
 
+    // Clipped **here**, not at render time, and the difference is memory rather than presentation.
+    // The full text has done its work by now — the assertions read it and the capture parsed it —
+    // and a step that keeps it holds it until the whole batch ends. A `read_memory` step may
+    // return a megabyte of target memory as some five megabytes of hexdump, and a batch may carry
+    // sixty-four steps, so keeping every one whole would let a valid batch exhaust the worker and
+    // cost its session — walking straight past the read-size guard that exists to prevent exactly
+    // that.
+    //
+    // Clipping once, against the cap this step will actually be shown at, also keeps the dropped
+    // count honest: a second clip in the renderer would count from the first one's remainder and
+    // report a fraction of what was really left out.
+    let cap = report_cap(&result);
     StepOutcome {
         position,
         label: step.label(),
         rendered,
         changes,
         result,
-        output,
+        output: clip(&output, cap),
+    }
+}
+
+/// How much of a step's output survives into the report. The step that did not succeed is the one
+/// the caller has to act on, so it gets the larger share; the rest are context.
+fn report_cap(result: &StepResult) -> usize {
+    if matches!(result, StepResult::Ok) {
+        STEP_OUTPUT_CHARS
+    } else {
+        FAILED_OUTPUT_CHARS
     }
 }
 
@@ -1151,8 +1173,7 @@ fn indent(text: &str, prefix: &str) -> String {
         .collect()
 }
 
-/// Renders one block of steps. The step that did not succeed gets the larger output budget: it is
-/// the one the caller has to act on, and the rest are context for it.
+/// Renders one block of steps.
 fn render_block(out: &mut String, title: &str, block: &[StepOutcome]) {
     if block.is_empty() {
         return;
@@ -1185,13 +1206,10 @@ fn render_block(out: &mut String, title: &str, block: &[StepOutcome]) {
         if let Some(detail) = step.result.detail() {
             out.push_str(&indent(detail, "     ! "));
         }
+        // Already clipped to this step's cap when the outcome was built, so that the text was not
+        // carried whole for the life of the batch — see `run_step`.
         if !step.output.trim().is_empty() {
-            let limit = if step.ok() {
-                STEP_OUTPUT_CHARS
-            } else {
-                FAILED_OUTPUT_CHARS
-            };
-            out.push_str(&indent(&clip(&step.output, limit), "     | "));
+            out.push_str(&indent(&step.output, "     | "));
         }
     }
 }
@@ -1949,6 +1967,37 @@ mod tests {
         }
         // And what came back is still a batch this server would accept.
         validate(&back.steps, &back.always).expect("a round-tripped batch stays valid");
+    }
+
+    /// A step's output is clipped when the outcome is built, not when it is rendered, so a batch
+    /// cannot accumulate every step's full text and take the worker — and its session — down with
+    /// an allocation the read-size guard was supposed to bound.
+    #[test]
+    fn a_steps_output_is_bounded_when_it_is_recorded_not_when_it_is_printed() {
+        let huge = "A".repeat(FAILED_OUTPUT_CHARS * 4);
+        let mut d = stopped().on("db ", Ok(&huge));
+        let report = run(
+            &mut d,
+            &op(vec![cmd("db fffff800`00001000 L20000")], vec![]),
+            BUDGET,
+        );
+
+        let kept = report.steps[0].output.chars().count();
+        assert!(
+            kept <= STEP_OUTPUT_CHARS + 64,
+            "a successful step kept {kept} characters of a {}-character output",
+            huge.len()
+        );
+        // And the note says how much went missing, counted against the real output rather than
+        // against an already-truncated copy of it.
+        assert!(
+            report.steps[0].output.contains(&format!(
+                "{} more characters",
+                huge.len() - STEP_OUTPUT_CHARS
+            )),
+            "the dropped count must be measured against the whole output: {}",
+            &report.steps[0].output[report.steps[0].output.len().saturating_sub(80)..]
+        );
     }
 
     /// The typo that fails *open*: a misspelt `expect` is a step that asserts nothing and commits.

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -19,9 +19,9 @@
 //!   of time" are different events. The supervisor sizes that budget from the caller's remaining
 //!   patience (`worker::batch_budget`) so the report lands *before* the tool call gives up.
 //! * **`always` is reached on every path.** Success, a debugger error, an assertion that did not
-//!   hold, an expired deadline — all of them fall through to the same block, cleanup continues past
-//!   its own failures, and a failure inside it is recorded beside the original rather than
-//!   replacing it. What the reserve buys is *time to run*, not a guarantee: a step that overruns
+//!   hold, an expired deadline, a panic out of the debugger — all of them fall through to the same
+//!   block, cleanup continues past its own failures, and a failure inside it is recorded beside the
+//!   original rather than replacing it. What the reserve buys is *time to run*, not a guarantee: a step that overruns
 //!   far enough to consume the reserve as well leaves cleanup with no budget, and then the block is
 //!   skipped and the report says the rollback is incomplete. That is the honest edge, and it is
 //!   pinned by a test rather than left to be discovered.
@@ -33,6 +33,7 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::Write as _;
+use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::time::Duration;
 
 use schemars::JsonSchema;
@@ -559,6 +560,36 @@ pub trait Debuggee {
     fn elapsed(&self) -> Duration;
 }
 
+/// Runs one engine call, turning a panic into a step failure.
+///
+/// The unwind is the third path that would otherwise skip the rollback, after a debugger error and
+/// an expired deadline — and the least obvious, because nothing in this module can raise it.
+/// `worker::engine_thread` already catches panics, but at *op* granularity: it wraps the whole
+/// `execute`, so an unwind from a step leaves [`run`] without ever reaching `always`, with the
+/// patch still applied. And this is not hypothetical — that same `catch_unwind` exists because
+/// several win-kexp methods use `.expect`, which is exactly what a batch step calls.
+///
+/// So the guard belongs here, where the promise is made, rather than being left to the layer
+/// above. `AssertUnwindSafe` is sound for the same reason it is there: the only state a
+/// [`Debuggee`] implementation holds across a call is the engine handle and the clock, neither of
+/// which a panic can leave half-written, and the engine itself survives — the worker's own comment
+/// makes the same argument for the same reason.
+fn guarded(call: impl FnOnce() -> Result<String, String>) -> Result<String, String> {
+    catch_unwind(AssertUnwindSafe(call)).unwrap_or_else(|payload| {
+        // The message, when the payload carries one. A bare "panicked" would tell a caller that
+        // their transaction stopped without telling them what stopped it, and this is a report
+        // whose whole job is to say which step and why.
+        let why = payload
+            .downcast_ref::<&str>()
+            .map(|s| (*s).to_string())
+            .or_else(|| payload.downcast_ref::<String>().cloned());
+        match why {
+            Some(why) => Err(format!("the debugger operation panicked: {why}")),
+            None => Err("the debugger operation panicked".to_string()),
+        }
+    })
+}
+
 // ---- results --------------------------------------------------------------
 
 /// How one step ended.
@@ -815,7 +846,7 @@ fn run_step(
             .min(budget_ms)
             .max(MIN_STEP_BUDGET_MS)
     };
-    let ran = match &action {
+    let ran = guarded(|| match &action {
         StepAction::Command { command } => d.command(command, budget_ms),
         StepAction::Resume {
             command,
@@ -827,7 +858,7 @@ fn run_step(
         } => d.run_to(address, wait_ms(*timeout_ms)),
         StepAction::Eval { expr } => d.command(&format!("? {expr}"), budget_ms),
         StepAction::ReadMemory { address, size } => d.read_memory(address, *size),
-    };
+    });
 
     let output = match ran {
         Ok(output) => output,
@@ -900,8 +931,7 @@ fn eval_value(d: &mut impl Debuggee, expr: &str, deadline: Duration) -> Result<u
     let budget_ms = step_budget_ms(d.elapsed(), deadline).max(MIN_STEP_BUDGET_MS);
     // Parenthesized, so a relational expression (`@rcx > 0x1000`) is evaluated as one value
     // rather than losing its precedence against whatever `?` does with the rest of the line.
-    let text = d
-        .command(&format!("? ({expr})"), budget_ms)
+    let text = guarded(|| d.command(&format!("? ({expr})"), budget_ms))
         .map_err(|why| format!("`? ({expr})` failed: {why}"))?;
     parse_eval(&text).ok_or_else(|| {
         format!(
@@ -995,7 +1025,7 @@ fn probe_state(
     });
 
     let budget_ms = step_budget_ms(d.elapsed(), budget).max(MIN_STEP_BUDGET_MS);
-    match d.command("? @$ip", budget_ms) {
+    match guarded(|| d.command("? @$ip", budget_ms)) {
         Ok(text) => match parse_eval(&text) {
             Some(ip) => SessionAfter::Stopped { ip: fmt_addr(ip) },
             None => SessionAfter::Uncertain {
@@ -1181,7 +1211,12 @@ mod tests {
         answers: Vec<(String, Answer)>,
         calls: Vec<String>,
         clock: Duration,
+        /// Call fragments this script panics on rather than answers; see [`Script::panics`].
+        panic_on: Vec<String>,
     }
+
+    /// The message a scripted panic carries, so the report can be asserted to have kept it.
+    const PANIC: &str = "called `Option::unwrap()` on a `None` value";
 
     impl Script {
         fn new() -> Self {
@@ -1200,6 +1235,15 @@ mod tests {
             self
         }
 
+        /// Answers any call containing `matching` by panicking, the way several win-kexp methods
+        /// do (`.expect`).
+        fn panics(mut self, matching: &str) -> Self {
+            // Not an `answers` entry: the panic fires before the lookup, so one would only be
+            // there to look like an answer that is never given.
+            self.panic_on.push(matching.to_string());
+            self
+        }
+
         /// As [`Self::on`], and the call advances the clock by `costs`.
         fn slow(mut self, matching: &str, result: Result<&str, &str>, costs: Duration) -> Self {
             self.answers.push((
@@ -1214,6 +1258,9 @@ mod tests {
 
         fn answer(&mut self, call: &str) -> Result<String, String> {
             self.calls.push(call.to_string());
+            if self.panic_on.iter().any(|m| call.contains(m.as_str())) {
+                panic!("{PANIC}");
+            }
             let found = self
                 .answers
                 .iter()
@@ -1430,6 +1477,72 @@ mod tests {
         assert!(text.contains("BATCH: FAILED at step 2 of 2"), "{text}");
         assert!(text.contains("rollback: INCOMPLETE — 1 of 2"), "{text}");
         assert!(text.contains("Couldn't resolve error"), "{text}");
+    }
+
+    /// A panic out of the debugger is the third path that would skip the rollback, and the least
+    /// visible: nothing in this module raises it, and the worker's own `catch_unwind` is around
+    /// the whole op, so an unwind from a step would leave `run` without ever reaching `always`.
+    /// win-kexp methods do panic — that worker guard exists because several use `.expect`.
+    #[test]
+    fn a_panicking_step_fails_that_step_and_still_rolls_back() {
+        let mut d = stopped()
+            .on("eb fffff800", Ok(""))
+            .panics("!analyze")
+            .on("never", Ok(""))
+            .on("eb restore", Ok(""));
+        let batch = op(
+            vec![
+                cmd("eb fffff800`00001000 90"),
+                cmd("!analyze -v"),
+                cmd("never runs"),
+            ],
+            vec![cmd("eb restore 41")],
+        );
+
+        let report = run(&mut d, &batch, BUDGET);
+
+        assert_eq!(report.outcome, BatchOutcome::Failed { at: 2 });
+        assert!(d.ran("eb restore"), "the rollback must run: {:?}", d.calls);
+        assert!(report.rollback_complete());
+        assert!(!d.ran("never"), "the batch must stop at the panic");
+
+        // The panic's own message has to survive into the report: "your transaction stopped" is
+        // not an answer to "why".
+        let text = render(&report);
+        assert!(text.contains("panicked"), "{text}");
+        assert!(text.contains(PANIC), "{text}");
+    }
+
+    /// A panicking *cleanup* step must not take the rest of the cleanup with it.
+    #[test]
+    fn a_panicking_rollback_step_does_not_stop_the_rest_of_the_cleanup() {
+        let mut d = stopped()
+            .on(
+                "bp nowhere",
+                Err("Couldn't resolve error at 'nowhere!Nope'"),
+            )
+            .panics("eb restore")
+            .on("bc *", Ok(""));
+        let report = run(
+            &mut d,
+            &op(
+                vec![cmd("bp nowhere!Nope")],
+                vec![cmd("eb restore 41"), cmd("bc *")],
+            ),
+            BUDGET,
+        );
+
+        assert_eq!(report.outcome, BatchOutcome::Failed { at: 1 });
+        assert!(!report.rollback_complete());
+        assert!(
+            d.ran("bc *"),
+            "cleanup continues past a panic: {:?}",
+            d.calls
+        );
+        let text = render(&report);
+        // Both survive: the original failure and the panic in the cleanup.
+        assert!(text.contains("Couldn't resolve error"), "{text}");
+        assert!(text.contains("panicked"), "{text}");
     }
 
     // ---- captures ----------------------------------------------------------

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -18,9 +18,13 @@
 //!   the `always` block before it starts, so "the steps ran out of time" and "the rollback ran out
 //!   of time" are different events. The supervisor sizes that budget from the caller's remaining
 //!   patience (`worker::batch_budget`) so the report lands *before* the tool call gives up.
-//! * **`always` runs on every path.** Success, a debugger error, an assertion that did not hold, an
-//!   expired deadline — all of them fall through to the same block, and a failure inside it is
-//!   recorded beside the original rather than replacing it.
+//! * **`always` is reached on every path.** Success, a debugger error, an assertion that did not
+//!   hold, an expired deadline — all of them fall through to the same block, cleanup continues past
+//!   its own failures, and a failure inside it is recorded beside the original rather than
+//!   replacing it. What the reserve buys is *time to run*, not a guarantee: a step that overruns
+//!   far enough to consume the reserve as well leaves cleanup with no budget, and then the block is
+//!   skipped and the report says the rollback is incomplete. That is the honest edge, and it is
+//!   pinned by a test rather than left to be discovered.
 //! * **The executor never touches DbgEng.** It drives a [`Debuggee`], which the worker implements
 //!   over a real engine and the tests implement over a script. Assertion failure, a command failure
 //!   after a mutation, deadline expiry and a rollback that itself fails are therefore all testable
@@ -61,6 +65,36 @@ const ROLLBACK_RESERVE: Duration = Duration::from_secs(30);
 /// The smallest watchdog a step is armed with. Zero *disables* win-kexp's watchdog, so a step
 /// dequeued at or past the deadline must not round down to it.
 const MIN_STEP_BUDGET_MS: u32 = 1_000;
+
+/// Default deadline for a whole batch, when the caller names none (ms).
+///
+/// Comfortably more than a sequence of ordinary commands needs, and comfortably inside the default
+/// call budget so the rollback report lands before the caller gives up. A batch that wants longer
+/// asks for it; the worker still clamps it to the caller's remaining patience.
+pub const DEFAULT_BATCH_MS: u32 = 120_000;
+
+/// The shortest deadline a batch may ask for.
+///
+/// Below this there is no batch: the reserve is half the budget, a step is armed with at least
+/// [`MIN_STEP_BUDGET_MS`], and a budget under a second means every step *and* every cleanup step
+/// is skipped before it starts. A caller who writes `0` gets a batch that does nothing and reports
+/// nothing useful about why, which is worse than being told the number is unusable.
+pub const MIN_BATCH_MS: u32 = 1_000;
+
+/// The budget a batch is built with, from what the caller asked for.
+///
+/// Separate from [`validate`] because it answers a different question — that one is about the
+/// steps, this is about the clock — and because the answer is a value the caller's request is
+/// replaced by rather than a yes/no.
+pub fn budget_ms(requested: Option<u32>) -> Result<u32, String> {
+    match requested {
+        None => Ok(DEFAULT_BATCH_MS),
+        Some(ms) if ms < MIN_BATCH_MS => Err(format!(
+            "`timeout_ms` is {ms}; a batch needs at least {MIN_BATCH_MS} ms. Part of the budget is              reserved for the `always` block, so a deadline this short would skip every step and              every cleanup step before either started. Omit `timeout_ms` for the {DEFAULT_BATCH_MS}              ms default."
+        )),
+        Some(ms) => Ok(ms),
+    }
+}
 
 /// How much of a step's output the report carries, and how much it carries for the step that
 /// failed. The failing step is what the caller has to act on, so it gets the bigger share; the
@@ -106,6 +140,11 @@ pub enum StepAction {
     /// value. The only step a `capture` may be attached to.
     Eval { expr: String },
     /// Hex-dump `size` bytes at `address`.
+    ///
+    /// `address` is a **number** — decimal or `0x`-hex — not a debugger expression, matching the
+    /// `read_memory` tool. That is not a limitation in a batch: an `eval` step binds its value as
+    /// `0x`-hex, so `@rsp` or `poi(@rbx+8)` is one `eval` with a `capture` and then `{{name}}`
+    /// here.
     ReadMemory { address: String, size: u32 },
 }
 
@@ -425,7 +464,8 @@ pub fn retires_handle(steps: &[BatchStep], always: &[BatchStep]) -> bool {
 
 // ---- what a step changed --------------------------------------------------
 
-/// Session-control commands, taken from [`changes_debug_target`]'s list by asking it.
+/// Commands that write target memory. Session-control commands are deliberately absent:
+/// [`mutation`] asks [`changes_debug_target`] for those first, so `.detach` is not looked for here.
 const MEMORY_WRITES: &[&str] = &[
     "e", "ea", "eb", "ed", "ef", "ep", "eq", "eu", "ew", "ez", "eza", "ezu", "f", "fp", "m",
     ".readmem", ".fillmem",
@@ -805,7 +845,18 @@ fn run_step(
 
     let mut result = StepResult::Ok;
     for check in &checks {
-        if let Err(why) = evaluate(d, check, &output, budget_ms) {
+        // Re-read the clock between checks, not once for the step. An `eval` check is two engine
+        // queries, and a step may carry several — arming each of them with the budget computed
+        // before the *first* one would let a step's assertions run for a multiple of the time the
+        // step was given, and eat the reserve the rollback depends on.
+        if d.elapsed() >= deadline {
+            result = StepResult::Failed(
+                "the batch ran out of time before this step's assertions could be checked"
+                    .to_string(),
+            );
+            break;
+        }
+        if let Err(why) = evaluate(d, check, &output, deadline) {
             result = StepResult::Unmet(why);
             break;
         }
@@ -841,7 +892,12 @@ fn run_step(
 }
 
 /// One side of an [`Check::Eval`] comparison: what the debugger makes of a MASM expression.
-fn eval_value(d: &mut impl Debuggee, expr: &str, budget_ms: u32) -> Result<u64, String> {
+///
+/// Takes the *deadline* rather than a budget, and sizes its own watchdog from the clock at the
+/// moment it runs — a check is two of these, and the second must not be armed with the time the
+/// first one already spent.
+fn eval_value(d: &mut impl Debuggee, expr: &str, deadline: Duration) -> Result<u64, String> {
+    let budget_ms = step_budget_ms(d.elapsed(), deadline).max(MIN_STEP_BUDGET_MS);
     // Parenthesized, so a relational expression (`@rcx > 0x1000`) is evaluated as one value
     // rather than losing its precedence against whatever `?` does with the rest of the line.
     let text = d
@@ -860,7 +916,7 @@ fn evaluate(
     d: &mut impl Debuggee,
     check: &Check,
     output: &str,
-    budget_ms: u32,
+    deadline: Duration,
 ) -> Result<(), String> {
     match check {
         Check::Contains { text } => {
@@ -886,8 +942,8 @@ fn evaluate(
             }
         }
         Check::Eval { expr, equals } => {
-            let left = eval_value(d, expr, budget_ms)?;
-            let right = eval_value(d, equals, budget_ms)?;
+            let left = eval_value(d, expr, deadline)?;
+            let right = eval_value(d, equals, deadline)?;
             if left == right {
                 Ok(())
             } else {
@@ -1230,6 +1286,9 @@ mod tests {
 
     const BUDGET: Duration = Duration::from_secs(60);
 
+    /// What `? (…)` prints for a value of 1.
+    const EVAL_ONE: &str = "Evaluate expression: 1 = 00000000`00000001";
+
     // ---- the four paths the issue asks for --------------------------------
 
     /// An assertion that does not hold stops the batch *and* runs the rollback — the case a
@@ -1402,6 +1461,42 @@ mod tests {
         assert!(
             d.ran("dt nt!_EPROCESS 0x1000"),
             "the capture should have been substituted: {:?}",
+            d.calls
+        );
+    }
+
+    /// `read_memory` takes a number, not an expression — so the documented way to dump memory at
+    /// `@rsp` is an `eval` step in front of it. A capture binds as `0x`-hex, which is exactly what
+    /// that step accepts, so the two compose without the caller converting anything.
+    #[test]
+    fn a_capture_feeds_a_read_memory_step_that_takes_only_numbers() {
+        let mut d = stopped()
+            .on("? @rsp", Ok("Evaluate expression: 1 = ffff8001`0000f000"))
+            .on(
+                "read 64 at 0xffff80010000f000",
+                Ok("ffff80010000f000  90 90"),
+            );
+        let batch = op(
+            vec![
+                BatchStep {
+                    capture: Some("sp".to_string()),
+                    ..step(StepAction::Eval {
+                        expr: "@rsp".to_string(),
+                    })
+                },
+                step(StepAction::ReadMemory {
+                    address: "{{sp}}".to_string(),
+                    size: 64,
+                }),
+            ],
+            vec![],
+        );
+
+        let report = run(&mut d, &batch, BUDGET);
+        assert!(report.committed(), "{}", render(&report));
+        assert!(
+            d.ran("read 64 at 0xffff80010000f000"),
+            "the capture should have arrived as a number: {:?}",
             d.calls
         );
     }
@@ -1874,6 +1969,92 @@ mod tests {
             Duration::from_secs(10),
         );
         assert!(report.committed(), "{}", render(&report));
+    }
+
+    /// Assertions are engine work too, and a step may carry several — each an `eval` check worth
+    /// two queries. Arming them all from the clock as it stood before the *first* one would let a
+    /// step's checks run for a multiple of the time the step was given, and eat the reserve the
+    /// rollback depends on. The loop re-reads the clock between checks and stops at the deadline.
+    #[test]
+    fn assertions_cannot_run_past_the_step_deadline_and_eat_the_reserve() {
+        // 60s budget → 30s reserve → the steps get 30s. Each `?` query costs 20s.
+        let mut d = stopped()
+            .on("lm", Ok("start end module"))
+            .slow("? (first", Ok(EVAL_ONE), Duration::from_secs(20))
+            .slow("? (1)", Ok(EVAL_ONE), Duration::from_secs(20))
+            .on("? (second", Ok(EVAL_ONE))
+            .on("bc *", Ok(""));
+        let batch = op(
+            vec![BatchStep {
+                expect: vec![
+                    Check::Eval {
+                        expr: "first".to_string(),
+                        equals: "1".to_string(),
+                    },
+                    Check::Eval {
+                        expr: "second".to_string(),
+                        equals: "1".to_string(),
+                    },
+                ],
+                ..cmd("lm")
+            }],
+            vec![cmd("bc *")],
+        );
+
+        let report = run(&mut d, &batch, BUDGET);
+
+        // The first check's two queries put the clock at 40s, past the 30s step deadline, so the
+        // second check never starts.
+        assert!(
+            !d.ran("? (second"),
+            "assertions must stop at the step deadline: {:?}",
+            d.calls
+        );
+        assert_eq!(report.outcome, BatchOutcome::TimedOut { at: 1 });
+        // And the reserve did its job: the cleanup still ran.
+        assert!(d.ran("bc *"), "the rollback must survive: {:?}", d.calls);
+        assert!(report.rollback_complete());
+    }
+
+    /// The path where the rollback guarantee genuinely fails: a step overran so far that even the
+    /// reserve is gone. Nothing can be done about it — but the report must say so rather than
+    /// leave a caller believing the cleanup ran.
+    #[test]
+    fn a_cleanup_step_past_the_whole_budget_is_skipped_and_reported_as_incomplete() {
+        // One step costs 100s against a 60s budget, so the `always` block cannot start at all.
+        // The state probe still runs: past the deadline is exactly when a caller most needs to be
+        // told what the session is left holding.
+        let mut d = stopped().slow("lm", Ok(""), Duration::from_secs(100));
+        let report = run(
+            &mut d,
+            &op(vec![cmd("lm")], vec![cmd("bc *"), cmd("eb restore 41")]),
+            BUDGET,
+        );
+
+        assert!(
+            !d.ran("bc *") && !d.ran("eb restore"),
+            "there was no time left to run cleanup: {:?}",
+            d.calls
+        );
+        assert!(!report.rollback_complete());
+        let text = render(&report);
+        assert!(text.contains("rollback: INCOMPLETE — 2 of 2"), "{text}");
+        assert!(
+            text.contains("ran out of time before this cleanup step started"),
+            "{text}"
+        );
+    }
+
+    #[test]
+    fn a_batch_deadline_too_short_to_run_anything_is_refused() {
+        // Zero is the one a caller writes by accident, and it yields a batch that skips every step
+        // *and* every cleanup step — silently, without the reserve ever mattering.
+        let why = budget_ms(Some(0)).unwrap_err();
+        assert!(why.contains("at least"), "{why}");
+        assert!(why.contains("reserved for the `always` block"), "{why}");
+        assert!(budget_ms(Some(MIN_BATCH_MS - 1)).is_err());
+        assert_eq!(budget_ms(Some(MIN_BATCH_MS)), Ok(MIN_BATCH_MS));
+        assert_eq!(budget_ms(None), Ok(DEFAULT_BATCH_MS));
     }
 
     #[test]

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -37,6 +37,7 @@ use tokio::process::{Child, ChildStdout, Command};
 use tokio::sync::{mpsc, oneshot};
 use windows_sys::Win32::Foundation::{HANDLE_FLAG_INHERIT, SetHandleInformation};
 
+use crate::batch::BatchOp;
 use crate::kdconn;
 use crate::proto::{EngineOp, WorkerMessage, WorkerRequest};
 use crate::worker::{MESSAGES_FLAG, REQUESTS_FLAG, WORKER_FLAG};
@@ -1851,8 +1852,15 @@ fn pump(
         }
 
         let mut op = job.op;
-        if let EngineOp::BoundedCommand { patience_ms, .. } = &mut op {
-            *patience_ms = remaining_patience_ms(call_timeout, job.submitted);
+        // The two ops whose own deadline is derived from the caller's: what is written here is how
+        // much patience the caller had left when this job reached the front of the queue, and the
+        // worker sizes its watchdog (or its batch budget) from it. See `EngineOp::BoundedCommand`.
+        match &mut op {
+            EngineOp::BoundedCommand { patience_ms, .. }
+            | EngineOp::Batch(BatchOp { patience_ms, .. }) => {
+                *patience_ms = remaining_patience_ms(call_timeout, job.submitted);
+            }
+            _ => {}
         }
         let request = WorkerRequest { id: job.id, op };
         let Ok(mut line) = serde_json::to_string(&request) else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@
 //! is what dbgeng.dll's one-session-per-process rule makes the natural unit, and what lets a
 //! session that cannot be unwound be killed without taking the server with it.
 
+mod batch;
 mod engine;
 mod kdconn;
 mod proto;

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -26,6 +26,7 @@
 
 use serde::{Deserialize, Serialize};
 
+use crate::batch::BatchOp;
 use crate::kdconn::Connection;
 
 /// One unit of debugger work, as it crosses the process boundary.
@@ -106,6 +107,15 @@ pub enum EngineOp {
     /// to walk every pool page, and letting another call for the same session interleave would
     /// let the walk describe a target that moved underneath it.
     Pool(PoolOp),
+    /// A whole transaction: ordered steps, their assertions, and the rollback block that runs
+    /// whatever happens to them ([`crate::batch`]).
+    ///
+    /// The most emphatic case for one op being one indivisible job. The point of a batch is that
+    /// the caller's timeout cannot land between a mutation and its undo — which is only true
+    /// because the sequence crosses the boundary once, as a value, and the worker owns the
+    /// deadline. Splitting it into per-step round trips would put the client back in the middle
+    /// of it, which is the design this replaces.
+    Batch(BatchOp),
     /// Release the target. The supervisor tears the worker down afterwards — under
     /// process-per-session a worker outlives its target for no reason.
     EndSession,

--- a/src/server.rs
+++ b/src/server.rs
@@ -27,13 +27,6 @@ use crate::ttd;
 /// next stop (ms).
 pub(crate) const EXEC_WAIT_MS: u32 = 60_000;
 
-/// Default deadline for a whole `debug_batch` (ms).
-///
-/// Comfortably more than a sequence of ordinary commands needs, and comfortably inside the default
-/// call budget so the rollback report lands before the caller gives up. A batch that wants longer
-/// asks for it; the worker still clamps it to the caller's remaining patience.
-const DEFAULT_BATCH_MS: u32 = 120_000;
-
 /// How long an open may sit un-landed before `session_status` stops calling it normal.
 ///
 /// A KDNET link that is coming up resyncs in ~25s; a guest that is not booted in debug mode
@@ -1383,8 +1376,10 @@ pub struct DebugBatchArgs {
     /// `{"op": "resume", "command": "g"}` moves the target and waits for the next stop;
     /// `{"op": "run_to", "address": "hevd!Trigger"}` reports a HIT/STOPPED ELSEWHERE/TIMEOUT
     /// verdict; `{"op": "eval", "expr": "@rcx"}` reads a value; `{"op": "read_memory",
-    /// "address": "@rsp", "size": 64}` hex-dumps memory. Add `"expect"` to assert on the result
-    /// and `"capture"` (on an `eval` step) to bind its value for later steps as `{{name}}`.
+    /// "address": "0xfffff8000012c000", "size": 64}` hex-dumps memory — this one takes a *number*
+    /// (decimal or `0x`-hex), not an expression, so for `@rsp` or `poi(...)` put an `eval` step in
+    /// front of it and read the capture. Add `"expect"` to assert on the result and `"capture"`
+    /// (on an `eval` step) to bind its value for later steps as `{{name}}`.
     /// The batch stops at the first step that fails or whose assertions do not hold.
     pub steps: Vec<batch::BatchStep>,
     /// Cleanup/rollback steps, same shape as `steps`. They run **on every path** — success, a
@@ -2159,9 +2154,12 @@ impl WindbgServer {
     /// target — a patched byte, an armed breakpoint, a resumed thread — and something has to be
     /// put back afterwards: the `always` block runs inside the worker on every path, including
     /// an assertion that does not hold and the deadline expiring, so cleanup cannot be lost to a
-    /// call that times out or a client that disconnects. The result names every step that ran,
-    /// the exact one that failed, what each changed, whether the rollback completed, and whether
-    /// the target is left stopped, running, or gone.
+    /// call that times out. The result names every step that ran, the exact one that failed, what
+    /// each changed, whether the rollback completed, and whether the target is left stopped,
+    /// running, or gone. Two edges: a step that overruns far enough to consume the reserved
+    /// cleanup budget too leaves the rollback unrun, and the result says `rollback: INCOMPLETE`;
+    /// and a client *disconnect* is not a safe way to abort a batch — it is treated as
+    /// `end_session` everywhere and gives only a few seconds' grace, so end the session instead.
     #[rmcp::tool(annotations(
         title = "Run a transactional debugger batch",
         read_only_hint = false,
@@ -2180,12 +2178,16 @@ impl WindbgServer {
         if let Err(why) = batch::validate(&args.steps, &args.always) {
             return tool_error(why);
         }
+        let budget_ms = match batch::budget_ms(args.timeout_ms) {
+            Ok(budget_ms) => budget_ms,
+            Err(why) => return tool_error(why),
+        };
         // Read before the steps move into the op, and before any of them runs: a `.detach` that
         // reports an error may still have detached, so the handle has to be retired ahead of the
         // batch rather than in light of what it reported.
         let retires = batch::retires_handle(&args.steps, &args.always);
         let mut call = Call::new(EngineOp::Batch(batch::BatchOp {
-            budget_ms: args.timeout_ms.unwrap_or(DEFAULT_BATCH_MS),
+            budget_ms,
             // Filled in by the supervisor's pump when this job reaches the front of its session's
             // queue; see `EngineOp::Batch`.
             patience_ms: 0,

--- a/src/server.rs
+++ b/src/server.rs
@@ -14,6 +14,7 @@ use rmcp::model::{CallToolResult, ContentBlock};
 use schemars::JsonSchema;
 use serde::Deserialize;
 
+use crate::batch;
 use crate::engine::{
     Call, EngineError, MAX_SESSIONS, OpenError, OpenReport, SessionKind, SessionSnapshot,
     SessionState, Sessions,
@@ -24,7 +25,14 @@ use crate::ttd;
 
 /// How long to wait for an execution-control command (go/step/reverse) to reach its
 /// next stop (ms).
-const EXEC_WAIT_MS: u32 = 60_000;
+pub(crate) const EXEC_WAIT_MS: u32 = 60_000;
+
+/// Default deadline for a whole `debug_batch` (ms).
+///
+/// Comfortably more than a sequence of ordinary commands needs, and comfortably inside the default
+/// call budget so the rollback report lands before the caller gives up. A batch that wants longer
+/// asks for it; the worker still clamps it to the caller's remaining patience.
+const DEFAULT_BATCH_MS: u32 = 120_000;
 
 /// How long an open may sit un-landed before `session_status` stops calling it normal.
 ///
@@ -1367,6 +1375,36 @@ pub struct RunToAddressArgs {
     pub session_id: Option<String>,
 }
 
+/// A whole debugger transaction, for `debug_batch`.
+#[derive(Deserialize, JsonSchema)]
+pub struct DebugBatchArgs {
+    /// The steps to run, in order. Each is one flat object with an `op` field:
+    /// `{"op": "command", "command": "bp nt!NtCreateFile"}` runs a raw command;
+    /// `{"op": "resume", "command": "g"}` moves the target and waits for the next stop;
+    /// `{"op": "run_to", "address": "hevd!Trigger"}` reports a HIT/STOPPED ELSEWHERE/TIMEOUT
+    /// verdict; `{"op": "eval", "expr": "@rcx"}` reads a value; `{"op": "read_memory",
+    /// "address": "@rsp", "size": 64}` hex-dumps memory. Add `"expect"` to assert on the result
+    /// and `"capture"` (on an `eval` step) to bind its value for later steps as `{{name}}`.
+    /// The batch stops at the first step that fails or whose assertions do not hold.
+    pub steps: Vec<batch::BatchStep>,
+    /// Cleanup/rollback steps, same shape as `steps`. They run **on every path** — success, a
+    /// debugger error, an assertion that did not hold, or the deadline expiring — inside the
+    /// engine process, before this call returns. This is where an unpatch, a `bc *`, or a
+    /// re-`go` belongs: a client cannot be relied on to send it after a call that timed out.
+    /// Their failures are reported separately and never replace the batch's own outcome.
+    #[serde(default)]
+    pub always: Vec<batch::BatchStep>,
+    /// Deadline for the whole batch in milliseconds (default 120000). Part of it is reserved for
+    /// `always`, so a rollback still runs when the steps use the clock up. Clamped down to what
+    /// is left of this call's budget — it can only make the batch shorter, never longer.
+    #[serde(default)]
+    pub timeout_ms: Option<u32>,
+    /// Session handle from open_dump/open_trace/attach_*/launch. Optional; pass it to
+    /// refuse the call if this server's debug target has been replaced since you opened it.
+    #[serde(default)]
+    pub session_id: Option<String>,
+}
+
 // ---- Session handles -----------------------------------------------------
 //
 // An MCP connection is explicitly *not* a session: clients may interleave unrelated requests
@@ -1391,7 +1429,7 @@ pub struct RunToAddressArgs {
 
 /// Whether an operand may legitimately contain a double quote.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
-enum Quotes {
+pub(crate) enum Quotes {
     /// Only `dx`, whose data-model expressions use quoted string literals as a matter of
     /// course (`@$cursession.TTD.Calls("ntdll!Nt*")`).
     Allowed,
@@ -1420,7 +1458,11 @@ enum Quotes {
 ///
 /// Quotes are refused everywhere except `dx` — see [`Quotes`] for why a quote is never a
 /// legitimate part of an address, symbol, device name or breakpoint location.
-fn reject_command_breakers(field: &str, value: &str, quotes: Quotes) -> Result<(), String> {
+pub(crate) fn reject_command_breakers(
+    field: &str,
+    value: &str,
+    quotes: Quotes,
+) -> Result<(), String> {
     let bad = value
         .chars()
         .find(|c| matches!(c, ';' | '\n' | '\r') || (quotes == Quotes::Rejected && *c == '"'));
@@ -1573,7 +1615,7 @@ fn dx_executes_commands(expression: &str) -> bool {
 /// failure this mechanism exists to prevent. It cannot be exhaustive — DbgEng has more ways
 /// to reach the target than a name list can enumerate — so `execute` remains the one place
 /// where a handle is a strong hint rather than a guarantee.
-fn changes_debug_target(command: &str) -> bool {
+pub(crate) fn changes_debug_target(command: &str) -> bool {
     /// Session-control commands: open, attach to, release, or terminate a target.
     const RETIRES_SESSION: &[&str] = &[
         ".opendump",
@@ -2108,6 +2150,50 @@ impl WindbgServer {
             // may still have detached, and a handle that outlives its target is the failure
             // mode this whole mechanism exists to prevent.
             call = call.retiring("a raw `execute` command replaced or released the target");
+        }
+        engine_result(self.run_call(args.session_id.as_deref(), call).await)
+    }
+
+    /// Run an ordered sequence of debugger steps as one transaction, with assertions and a
+    /// rollback block the engine process owns. Use this whenever a sequence *mutates* the
+    /// target — a patched byte, an armed breakpoint, a resumed thread — and something has to be
+    /// put back afterwards: the `always` block runs inside the worker on every path, including
+    /// an assertion that does not hold and the deadline expiring, so cleanup cannot be lost to a
+    /// call that times out or a client that disconnects. The result names every step that ran,
+    /// the exact one that failed, what each changed, whether the rollback completed, and whether
+    /// the target is left stopped, running, or gone.
+    #[rmcp::tool(annotations(
+        title = "Run a transactional debugger batch",
+        read_only_hint = false,
+        destructive_hint = true,
+        idempotent_hint = false,
+        open_world_hint = true
+    ))]
+    async fn debug_batch(
+        &self,
+        Parameters(args): Parameters<DebugBatchArgs>,
+    ) -> Result<CallToolResult, ErrorData> {
+        // Everything decidable without a debugger is decided here, before a single step runs.
+        // The alternative is a batch that applies three mutations and then trips over a typo in
+        // the fourth — survivable, because that is what `always` is for, but not something a
+        // caller should have to survive.
+        if let Err(why) = batch::validate(&args.steps, &args.always) {
+            return tool_error(why);
+        }
+        // Read before the steps move into the op, and before any of them runs: a `.detach` that
+        // reports an error may still have detached, so the handle has to be retired ahead of the
+        // batch rather than in light of what it reported.
+        let retires = batch::retires_handle(&args.steps, &args.always);
+        let mut call = Call::new(EngineOp::Batch(batch::BatchOp {
+            budget_ms: args.timeout_ms.unwrap_or(DEFAULT_BATCH_MS),
+            // Filled in by the supervisor's pump when this job reaches the front of its session's
+            // queue; see `EngineOp::Batch`.
+            patience_ms: 0,
+            steps: args.steps,
+            always: args.always,
+        }));
+        if retires {
+            call = call.retiring("a `debug_batch` step replaced or released the target");
         }
         engine_result(self.run_call(args.session_id.as_deref(), call).await)
     }
@@ -2906,6 +2992,11 @@ uf-based call-graph walk, whether a code block — by address or module+RVA — 
 dispatch routine; REACHABLE is sound, NOT REACHABLE is best-effort, and a REACHABLE verdict includes a \
 directional path recipe of the on-path branch conditions). Confirm a static verdict live with \
 run_to_address (run to a block on a KDNET/VM kernel target and report HIT/STOPPED ELSEWHERE/TIMEOUT). \
+When a sequence *mutates* the target — a patched byte, an armed breakpoint, a resumed thread — run it as \
+one `debug_batch` rather than as separate calls: its `always` block runs inside the engine process on \
+every path, including a failed assertion and an expired deadline, so cleanup cannot be lost to a call \
+that times out or a client that disconnects, and the result names the exact failing step, what each step \
+changed, whether the rollback completed, and whether the target is left stopped, running or gone. \
 Use `execute` for any raw command not covered by a dedicated tool."
 )]
 impl rmcp::ServerHandler for WindbgServer {}
@@ -2969,7 +3060,14 @@ mod tests {
                 .unwrap()
         };
 
-        for name in ["execute", "launch", "record_trace", "end_session", "go"] {
+        for name in [
+            "execute",
+            "launch",
+            "record_trace",
+            "end_session",
+            "go",
+            "debug_batch",
+        ] {
             assert_eq!(
                 ann(name).read_only_hint,
                 Some(false),
@@ -3025,6 +3123,7 @@ mod tests {
             "go",
             "end_session",
             "modules",
+            "debug_batch",
             // Takes one to ask *about*, not to be checked against.
             "session_status",
         ] {
@@ -3486,6 +3585,40 @@ mod tests {
                 "the explanation must survive: {rendered}"
             );
         }
+    }
+
+    /// A malformed batch must be refused *before* it reaches a session, and as a tool error the
+    /// model can read. The check that proves it: this server has no session at all, so a batch
+    /// that got past validation would come back complaining about that instead.
+    #[tokio::test]
+    async fn a_malformed_batch_is_refused_before_it_reaches_a_session() {
+        let server = WindbgServer::new(Sessions::new(Duration::from_secs(1)));
+        let result = server
+            .debug_batch(Parameters(DebugBatchArgs {
+                steps: vec![
+                    serde_json::from_value(serde_json::json!({
+                        "op": "command",
+                        "command": "eb fffff800`00001000 {{never_bound}}"
+                    }))
+                    .unwrap(),
+                ],
+                always: Vec::new(),
+                timeout_ms: None,
+                session_id: None,
+            }))
+            .await
+            .expect("a bad batch is a tool error, not a protocol error");
+        assert_eq!(result.is_error, Some(true));
+        let text = result
+            .content
+            .iter()
+            .filter_map(|b| b.as_text().map(|t| t.text.clone()))
+            .collect::<String>();
+        assert!(text.contains("`{{never_bound}}` is not bound"), "{text}");
+        assert!(
+            !text.contains("session"),
+            "validation must not have reached a session: {text}"
+        );
     }
 
     #[test]

--- a/src/server.rs
+++ b/src/server.rs
@@ -1369,7 +1369,13 @@ pub struct RunToAddressArgs {
 }
 
 /// A whole debugger transaction, for `debug_batch`.
+///
+/// The one argument struct in this server that refuses unknown fields, and it is not fussiness:
+/// serde drops them silently, so `"aways"` for `always` would be accepted as a batch with **no
+/// rollback block** — mutations applied, nothing restored, and a `COMMITTED` verdict saying so.
+/// Every other tool's typo costs a wrong answer; this one's costs the target.
 #[derive(Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
 pub struct DebugBatchArgs {
     /// The steps to run, in order. Each is one flat object with an `op` field:
     /// `{"op": "command", "command": "bp nt!NtCreateFile"}` runs a raw command;
@@ -2156,8 +2162,10 @@ impl WindbgServer {
     /// an assertion that does not hold and the deadline expiring, so cleanup cannot be lost to a
     /// call that times out. The result names every step that ran, the exact one that failed, what
     /// each changed, whether the rollback completed, and whether the target is left stopped,
-    /// running, or gone. Two edges: a step that overruns far enough to consume the reserved
-    /// cleanup budget too leaves the rollback unrun, and the result says `rollback: INCOMPLETE`;
+    /// running, detached, or uncertain (the last when the debugger could not be asked — which is
+    /// reported as not knowing, never guessed at). Two edges: a step that overruns far enough to
+    /// consume the reserved cleanup budget too leaves the rollback unrun, and the result says
+    /// `rollback: INCOMPLETE`;
     /// and a client *disconnect* is not a safe way to abort a batch — it is treated as
     /// `end_session` everywhere and gives only a few seconds' grace, so end the session instead.
     #[rmcp::tool(annotations(
@@ -3621,6 +3629,32 @@ mod tests {
             !text.contains("session"),
             "validation must not have reached a session: {text}"
         );
+    }
+
+    /// The typo that would be worst to ignore: `always` misspelt is a batch with **no rollback
+    /// block**, which then applies its mutations and reports `COMMITTED` with nothing restored.
+    /// Serde drops unknown fields by default, so this only fails because the struct says otherwise.
+    #[test]
+    fn a_misspelt_rollback_block_is_refused_rather_than_silently_dropped() {
+        let args = serde_json::json!({
+            "steps": [{ "op": "command", "command": "eb fffff800`00001000 90" }],
+            "aways": [{ "op": "command", "command": "eb fffff800`00001000 41" }]
+        });
+        let refused = serde_json::from_value::<DebugBatchArgs>(args.clone())
+            .err()
+            .expect("an unknown field must be refused");
+        assert!(
+            refused.to_string().contains("aways"),
+            "the refusal should name the field: {refused}"
+        );
+
+        // Spelt correctly it deserializes, and the rollback is there.
+        let mut fixed = args.as_object().unwrap().clone();
+        let always = fixed.remove("aways").unwrap();
+        fixed.insert("always".to_string(), always);
+        let parsed: DebugBatchArgs =
+            serde_json::from_value(serde_json::Value::Object(fixed)).expect("valid");
+        assert_eq!(parsed.always.len(), 1);
     }
 
     #[test]

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -29,6 +29,7 @@ use win_kexp::pool::query::{self, PoolPageFilter};
 use win_kexp::pool::{DiagnosticShape, PoolDiagnostics, PoolSpan, PoolState};
 use windows_sys::Win32::Foundation::{HANDLE_FLAG_INHERIT, SetHandleInformation};
 
+use crate::batch::{self, BatchOp, Debuggee};
 use crate::proto::{EngineOp, PoolOp, ReachabilityOp, WorkerMessage, WorkerRequest};
 use crate::server::{
     fmt_addr, format_recipe, format_report, hexdump, parse_eval, parse_lm_base, parse_u64,
@@ -550,22 +551,7 @@ fn execute(e: &DebugEngine, id: u64, op: EngineOp, queued: Duration) -> Result<S
             timeout_ms,
         } => e.execute_and_wait(&command, timeout_ms).map_err(es),
         EngineOp::Registers => e.registers().map_err(es),
-        EngineOp::ReadMemory { address, size } => {
-            let addr = parse_u64(&address)?;
-            // Bounded before the allocation, not after. `size` arrives from the caller as a bare
-            // `u32`, and a large one costs that many bytes here plus a hexdump several times
-            // larger — enough to take the worker down with an OOM, which costs the caller their
-            // whole session for a number a model can produce by accident.
-            if size as usize > MAX_READ_BYTES {
-                return Err(format!(
-                    "`size` is {size} bytes; this tool reads at most {MAX_READ_BYTES}. Read the \
-                     range you need in pieces, or use `execute` with a `db`/`dd` command if you \
-                     want the debugger's own paging."
-                ));
-            }
-            let bytes = e.read_memory(addr, size as usize).map_err(es)?;
-            Ok(hexdump(addr, &bytes))
-        }
+        EngineOp::ReadMemory { address, size } => read_memory(e, &address, size),
         EngineOp::SymbolPath {
             path,
             append,
@@ -587,6 +573,7 @@ fn execute(e: &DebugEngine, id: u64, op: EngineOp, queued: Duration) -> Result<S
         } => run_to_address(e, &address, timeout_ms),
         EngineOp::Reachability(args) => reachable(e, args),
         EngineOp::Pool(args) => pool(e, args),
+        EngineOp::Batch(op) => run_batch(e, op, queued),
         EngineOp::EndSession => e
             .end_session()
             .map(|_| "session ended".to_string())
@@ -597,6 +584,102 @@ fn execute(e: &DebugEngine, id: u64, op: EngineOp, queued: Duration) -> Result<S
 /// Maps any error to a `String` for the wire.
 fn es<E: ToString>(e: E) -> String {
     e.to_string()
+}
+
+/// Reads target memory and renders it as a hex dump.
+///
+/// Free function rather than an inline arm because a batch step reads memory the same way, and a
+/// second copy of the bound below would be a second chance to get it wrong.
+fn read_memory(e: &DebugEngine, address: &str, size: u32) -> Result<String, String> {
+    let addr = parse_u64(address)?;
+    // Bounded before the allocation, not after. `size` arrives from the caller as a bare `u32`,
+    // and a large one costs that many bytes here plus a hexdump several times larger — enough to
+    // take the worker down with an OOM, which costs the caller their whole session for a number a
+    // model can produce by accident.
+    if size as usize > MAX_READ_BYTES {
+        return Err(format!(
+            "`size` is {size} bytes; this tool reads at most {MAX_READ_BYTES}. Read the range you \
+             need in pieces, or use `execute` with a `db`/`dd` command if you want the debugger's \
+             own paging."
+        ));
+    }
+    let bytes = e.read_memory(addr, size as usize).map_err(es)?;
+    Ok(hexdump(addr, &bytes))
+}
+
+/// How long a batch may run, given what it asked for and what its caller has left.
+///
+/// The batch's whole value is that its rollback runs *before* the tool call reports anything, so
+/// the budget has to end before the caller's patience does — [`WATCHDOG_HEADROOM`] again, for the
+/// same reason and with the same arithmetic as [`watchdog_budget_ms`]: patience as sent, minus the
+/// wait in this worker's queue, minus the headroom the reply needs.
+///
+/// The caller's `timeout_ms` can only make it *shorter*. A batch that asks for ten minutes inside
+/// a five-minute call budget would otherwise be a batch whose rollback report is guaranteed to
+/// arrive after nobody is listening — which is the failure this tool exists to remove, arriving
+/// by way of the argument that was supposed to prevent it.
+fn batch_budget(requested_ms: u32, patience: Duration, queued: Duration) -> Duration {
+    let allowed = patience
+        .saturating_sub(queued)
+        .saturating_sub(WATCHDOG_HEADROOM)
+        .max(WATCHDOG_HEADROOM);
+    allowed.min(Duration::from_millis(u64::from(requested_ms)))
+}
+
+/// A [`Debuggee`] over this worker's engine: the seam that keeps [`crate::batch`] free of DbgEng.
+struct BatchEngine<'a> {
+    e: &'a DebugEngine,
+    started: Instant,
+}
+
+impl Debuggee for BatchEngine<'_> {
+    fn command(&mut self, command: &str, budget_ms: u32) -> Result<String, String> {
+        // Bounded, always. A batch is the one place a runaway command would also strand a
+        // rollback, so the step self-aborts rather than eating the reserve.
+        self.e
+            .execute_command_bounded(command, budget_ms)
+            .map_err(es)
+    }
+
+    fn resume(&mut self, command: &str, timeout_ms: u32) -> Result<String, String> {
+        self.e.execute_and_wait(command, timeout_ms).map_err(es)
+    }
+
+    fn run_to(&mut self, address: &str, timeout_ms: u32) -> Result<String, String> {
+        run_to_address(self.e, address, timeout_ms)
+    }
+
+    fn read_memory(&mut self, address: &str, size: u32) -> Result<String, String> {
+        read_memory(self.e, address, size)
+    }
+
+    fn elapsed(&self) -> Duration {
+        self.started.elapsed()
+    }
+}
+
+/// Runs a batch and renders its report.
+///
+/// The report is the result either way — a failed transaction that did not say which step failed
+/// and whether the rollback ran would be worse than no report at all. `Err` only chooses how
+/// [`crate::server`] renders it: a tool-execution error the model can read and act on.
+fn run_batch(e: &DebugEngine, op: BatchOp, queued: Duration) -> Result<String, String> {
+    let budget = batch_budget(
+        op.budget_ms,
+        Duration::from_millis(u64::from(op.patience_ms)),
+        queued,
+    );
+    let mut engine = BatchEngine {
+        e,
+        started: Instant::now(),
+    };
+    let report = batch::run(&mut engine, &op, budget);
+    let rendered = batch::render(&report);
+    if report.committed() && report.rollback_complete() {
+        Ok(rendered)
+    } else {
+        Err(rendered)
+    }
 }
 
 /// Column header for the chunk tables below. Kept next to [`pool_row`] so the two cannot
@@ -1669,6 +1752,54 @@ mod tests {
         assert_eq!(
             watchdog_budget_ms(Duration::from_secs(u32::MAX as u64), Duration::ZERO),
             u32::MAX
+        );
+    }
+
+    // ---- the batch budget -------------------------------------------------
+
+    /// A batch gets what it asked for when the caller can afford it.
+    #[test]
+    fn a_batch_that_fits_gets_the_deadline_it_asked_for() {
+        assert_eq!(
+            batch_budget(60_000, Duration::from_secs(300), Duration::ZERO),
+            Duration::from_secs(60)
+        );
+    }
+
+    /// The property that makes the rollback report worth anything: **queue wait + batch budget
+    /// must leave the caller a headroom**, so the `always` block has finished and the report has
+    /// been written before the tool call gives up. A batch that asks for more than the call
+    /// budget is the case that would otherwise break it.
+    #[test]
+    fn a_batch_never_outlives_the_call_that_started_it() {
+        let patience = Duration::from_secs(300);
+        // Waits short enough that the floor below is not in play; past it the budget deliberately
+        // overruns, exactly as `watchdog_budget_ms`'s does.
+        for asked in [60_000, 300_000, 900_000, u32::MAX] {
+            for waited in [0, 30, 200, 270] {
+                let waited = Duration::from_secs(waited);
+                let budget = batch_budget(asked, patience, waited);
+                assert!(
+                    waited + budget <= patience,
+                    "asking for {asked}ms after a {waited:?} queue wait yielded {budget:?}, which \
+                     runs past the caller's {patience:?}"
+                );
+            }
+        }
+    }
+
+    /// Past the point where there is nothing left, the budget floors rather than reaching zero —
+    /// a zero-length batch would skip every step *and* its rollback, which is the one outcome
+    /// this tool must never produce.
+    #[test]
+    fn a_batch_dequeued_past_the_deadline_still_gets_enough_to_roll_back() {
+        assert_eq!(
+            batch_budget(120_000, Duration::from_secs(300), Duration::from_secs(400)),
+            WATCHDOG_HEADROOM
+        );
+        assert_eq!(
+            batch_budget(120_000, Duration::ZERO, Duration::ZERO),
+            WATCHDOG_HEADROOM
         );
     }
 }

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -618,12 +618,27 @@ fn read_memory(e: &DebugEngine, address: &str, size: u32) -> Result<String, Stri
 /// a five-minute call budget would otherwise be a batch whose rollback report is guaranteed to
 /// arrive after nobody is listening — which is the failure this tool exists to remove, arriving
 /// by way of the argument that was supposed to prevent it.
-fn batch_budget(requested_ms: u32, patience: Duration, queued: Duration) -> Duration {
-    let allowed = patience
+///
+/// `None` when there is not enough left to be worth starting, and **this is where a batch parts
+/// company with [`watchdog_budget_ms`]**. That one floors at [`WATCHDOG_HEADROOM`] rather than
+/// reaching zero, because its command is already running and the job left is to free the worker:
+/// bounding it 15s late beats never. A batch has not started. Handing it the same floor would run
+/// *mutations* for a caller who has already been told the call timed out — a job sits in the queue
+/// after its waiter has given up, so this is reachable by a long queue wait alone, and by any
+/// `WINDBG_MCP_CALL_TIMEOUT_SECS` under the headroom — and would then roll them back with nobody
+/// left to read whether that worked. Not starting is the only outcome that leaves the target as
+/// the caller last saw it.
+fn batch_budget(requested_ms: u32, patience: Duration, queued: Duration) -> Option<Duration> {
+    // What is left after reserving the headroom the reply needs to land inside the caller's wait.
+    let usable = patience
         .saturating_sub(queued)
-        .saturating_sub(WATCHDOG_HEADROOM)
-        .max(WATCHDOG_HEADROOM);
-    allowed.min(Duration::from_millis(u64::from(requested_ms)))
+        .saturating_sub(WATCHDOG_HEADROOM);
+    // The same floor the caller's own `timeout_ms` has to clear: below it the reserve cannot seat
+    // a step and a rollback, so there is no batch to run, only mutations to regret.
+    if usable < Duration::from_millis(u64::from(batch::MIN_BATCH_MS)) {
+        return None;
+    }
+    Some(usable.min(Duration::from_millis(u64::from(requested_ms))))
 }
 
 /// A [`Debuggee`] over this worker's engine: the seam that keeps [`crate::batch`] free of DbgEng.
@@ -664,11 +679,28 @@ impl Debuggee for BatchEngine<'_> {
 /// and whether the rollback ran would be worse than no report at all. `Err` only chooses how
 /// [`crate::server`] renders it: a tool-execution error the model can read and act on.
 fn run_batch(e: &DebugEngine, op: BatchOp, queued: Duration) -> Result<String, String> {
-    let budget = batch_budget(
+    let Some(budget) = batch_budget(
         op.budget_ms,
         Duration::from_millis(u64::from(op.patience_ms)),
         queued,
-    );
+    ) else {
+        // Answered rather than silently dropped: a `Done` is what releases the supervisor's waiter
+        // and frees this session, so the reply is worth sending even though its caller has stopped
+        // waiting for it. "Nothing ran" is the part that matters — it is what makes resubmitting
+        // safe, which is not true of a batch abandoned partway.
+        return Err(format!(
+            "This batch was not started: it reached the engine with {}s of its caller's timeout \
+             left, which is not enough to run it and report back before that timeout expires. \
+             Nothing was run and nothing was changed — no step, no assertion, no rollback — so \
+             the target is exactly as it was and resubmitting is safe. It waited {}s behind other \
+             work on this session; issue it when the session is idle, or raise the server's call \
+             timeout (WINDBG_MCP_CALL_TIMEOUT_SECS).",
+            Duration::from_millis(u64::from(op.patience_ms))
+                .saturating_sub(queued)
+                .as_secs(),
+            queued.as_secs(),
+        ));
+    };
     let mut engine = BatchEngine {
         e,
         started: Instant::now(),
@@ -1762,7 +1794,7 @@ mod tests {
     fn a_batch_that_fits_gets_the_deadline_it_asked_for() {
         assert_eq!(
             batch_budget(60_000, Duration::from_secs(300), Duration::ZERO),
-            Duration::from_secs(60)
+            Some(Duration::from_secs(60))
         );
     }
 
@@ -1778,7 +1810,7 @@ mod tests {
         for asked in [60_000, 300_000, 900_000, u32::MAX] {
             for waited in [0, 30, 200, 270] {
                 let waited = Duration::from_secs(waited);
-                let budget = batch_budget(asked, patience, waited);
+                let budget = batch_budget(asked, patience, waited).expect("still worth running");
                 assert!(
                     waited + budget <= patience,
                     "asking for {asked}ms after a {waited:?} queue wait yielded {budget:?}, which \
@@ -1788,18 +1820,36 @@ mod tests {
         }
     }
 
-    /// Past the point where there is nothing left, the budget floors rather than reaching zero —
-    /// a zero-length batch would skip every step *and* its rollback, which is the one outcome
-    /// this tool must never produce.
+    /// The one place a batch parts company with a bounded command: past the point where its
+    /// caller can still be answered, it does **not** start.
+    ///
+    /// `watchdog_budget_ms` floors instead, and is right to — its command is already running and
+    /// the job left is to free the worker. A batch has not started, so the same floor would apply
+    /// mutations for a caller already told the call timed out, then roll them back with nobody
+    /// left to read whether that worked.
     #[test]
-    fn a_batch_dequeued_past_the_deadline_still_gets_enough_to_roll_back() {
+    fn a_batch_whose_caller_has_given_up_is_not_started_at_all() {
+        // Dequeued long after the caller's timeout.
         assert_eq!(
             batch_budget(120_000, Duration::from_secs(300), Duration::from_secs(400)),
-            WATCHDOG_HEADROOM
+            None
+        );
+        // And the case a short `WINDBG_MCP_CALL_TIMEOUT_SECS` produces, with no queue wait at all.
+        assert_eq!(batch_budget(120_000, Duration::ZERO, Duration::ZERO), None);
+        assert_eq!(
+            batch_budget(120_000, WATCHDOG_HEADROOM, Duration::ZERO),
+            None
+        );
+
+        // The boundary: enough left for the headroom plus the smallest batch there can be.
+        let least = WATCHDOG_HEADROOM + Duration::from_millis(u64::from(batch::MIN_BATCH_MS));
+        assert_eq!(
+            batch_budget(120_000, least, Duration::ZERO),
+            Some(Duration::from_millis(u64::from(batch::MIN_BATCH_MS)))
         );
         assert_eq!(
-            batch_budget(120_000, Duration::ZERO, Duration::ZERO),
-            WATCHDOG_HEADROOM
+            batch_budget(120_000, least - Duration::from_millis(1), Duration::ZERO),
+            None
         );
     }
 }

--- a/tests/golden/tools_list.json
+++ b/tests/golden/tools_list.json
@@ -3,7 +3,7 @@
     "(none)",
     "https://json-schema.org/draft/2020-12/schema"
   ],
-  "toolCount": 41,
+  "toolCount": 42,
   "tools": [
     {
       "hints": {
@@ -61,6 +61,25 @@
       ],
       "required": [],
       "title": "Show call stack"
+    },
+    {
+      "hints": {
+        "destructive": true,
+        "idempotent": false,
+        "openWorld": true,
+        "readOnly": false
+      },
+      "name": "debug_batch",
+      "params": [
+        "always: array<ref(#/$defs/BatchStep)>",
+        "session_id: string|null",
+        "steps: array<ref(#/$defs/BatchStep)>",
+        "timeout_ms: integer|null/uint32"
+      ],
+      "required": [
+        "steps"
+      ],
+      "title": "Run a transactional debugger batch"
     },
     {
       "hints": {
@@ -665,5 +684,5 @@
       "title": "TTD: find accesses to a memory range"
     }
   ],
-  "usesDefs": false
+  "usesDefs": true
 }

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -16,7 +16,8 @@
 //!   symbols, no network.
 //! * **Target** (`WINDBG_MCP_SMOKE_DUMP=1`) — opens the sample crash dump through DbgEng, so
 //!   it needs `dbgeng.dll` and may reach a symbol server. Off by default; this is the tier
-//!   that catches a `win-kexp` regression.
+//!   that catches a `win-kexp` regression. It also runs a `debug_batch` to both outcomes,
+//!   because "the rollback ran inside the worker" is a claim only a real engine can settle.
 //! * **Bounded command** (`#[ignore]`d, run by hand) — deliberately runs away and waits out a
 //!   watchdog, so it is measured in minutes rather than seconds. It lives here rather than
 //!   beside the budget arithmetic in `src/engine.rs` because the two halves it proves are now
@@ -1149,6 +1150,109 @@ fn a_dump_session_opens_reads_and_closes() {
     assert!(
         is_tool_error(&after) || !after["error"].is_null(),
         "a handle from an ended session must be refused, got {after}"
+    );
+}
+
+/// `debug_batch` end to end against a real engine: a batch that commits, and one that fails an
+/// assertion — with the same `always` block on both.
+///
+/// The claim being tested is the one the tool exists for and the one no in-process test can make:
+/// the rollback runs **inside the worker process**, on the failing path, before the tool call
+/// returns. `src/batch.rs` proves the executor's logic over a scripted debuggee; this proves the
+/// wiring — argument schema, the op crossing the pipe, the engine seam, the report coming back.
+///
+/// Read-only against the checked-in kernel dump: the mutation the rollback would undo is left to
+/// the live-kernel tier, because a dump has nothing worth restoring.
+#[test]
+fn a_batch_commits_or_fails_and_its_rollback_runs_either_way() {
+    let Some(dump) = target_tier() else { return };
+    let mut server = Server::started();
+
+    let response = server.call_tool("open_dump", json!({ "path": dump }), TARGET_STEP);
+    assert_no_error(&response, "open_dump");
+    let session_id = session_id_of(&text_of(&response["result"]));
+
+    // A batch that should commit: a capture bound from one step and interpolated into the next,
+    // which is the whole of the "named values" contract in three steps.
+    let committed = server.tool_text(
+        "debug_batch",
+        json!({
+            "session_id": session_id,
+            "steps": [
+                { "op": "command", "command": "lm m nt",
+                  "expect": [{ "check": "contains", "text": "nt" }] },
+                { "op": "eval", "expr": "@$ip", "capture": "ip" },
+                { "op": "command", "command": "u {{ip}} L1", "name": "disassemble where we are" }
+            ],
+            "always": [{ "op": "command", "command": "lm m hal" }]
+        }),
+        TARGET_STEP,
+    );
+    assert!(
+        committed.contains("BATCH: COMMITTED"),
+        "the batch should have committed:
+{committed}"
+    );
+    assert!(
+        committed.contains("rollback: COMPLETE"),
+        "the `always` block should have run:
+{committed}"
+    );
+    assert!(
+        committed.contains("session after: STOPPED"),
+        "a dump is always stopped; the state probe should say so:
+{committed}"
+    );
+    // The interpolated step is rendered with the *substituted* address, so a `{{ip}}` surviving
+    // into the report would mean nothing was bound.
+    assert!(
+        !committed.contains("u {{ip}}"),
+        "the capture was not interpolated:
+{committed}"
+    );
+
+    // The same shape with an assertion that cannot hold. The batch must stop at that step, name
+    // it, skip what follows — and still run the cleanup.
+    let failing = server.call_tool(
+        "debug_batch",
+        json!({
+            "session_id": session_id,
+            "steps": [
+                { "op": "command", "command": "lm m nt" },
+                { "op": "command", "command": "lm m nt",
+                  "expect": [{ "check": "contains", "text": "no module is called this" }] },
+                { "op": "command", "command": "lm m hal", "name": "must not run" }
+            ],
+            "always": [{ "op": "command", "command": "version", "name": "cleanup" }]
+        }),
+        TARGET_STEP,
+    );
+    assert_no_error(&failing, "debug_batch");
+    assert!(
+        is_tool_error(&failing),
+        "a batch that did not commit must come back as a tool error: {failing}"
+    );
+    let text = text_of(&failing["result"]);
+    assert!(
+        text.contains("BATCH: FAILED at step 2 of 3"),
+        "the report must name the exact failing step:
+{text}"
+    );
+    assert!(
+        text.contains("SKIPPED"),
+        "the step after the failure must be reported as skipped:
+{text}"
+    );
+    assert!(
+        text.contains("rollback: COMPLETE"),
+        "the `always` block must run on the failing path — that is the whole point:
+{text}"
+    );
+
+    server.tool_text(
+        "end_session",
+        json!({ "session_id": session_id }),
+        TARGET_STEP,
     );
 }
 


### PR DESCRIPTION
Closes #82.

## Why

A tool call is a request/response, so a client driving a multi-step debugger transaction decides what to do next *after* each answer — and the case that matters is the one where no answer arrives. A call that times out, or a client that disconnects, leaves whatever the earlier calls changed in place: a patched instruction, an armed breakpoint, a target left running. On a kernel target that costs the VM.

The MessageManager CTF session grew a throwaway PowerShell JSON-RPC client for exactly this, and revised it 18 times. This is the shape it converged on, moved into the server.

## What

`debug_batch` submits the whole sequence as one `EngineOp`, and the **worker process** executes it — steps, assertions, and an `always` block that runs on every path, before the reply is written. The client's timeout can no longer land between a mutation and its undo, because there is nothing left for it to land between.

```jsonc
{
  "steps": [
    { "op": "eval", "expr": "poi(hevd!Guard)", "capture": "orig" },   // save
    { "op": "command", "command": "eq hevd!Guard 0" },                // patch
    { "op": "run_to", "address": "hevd!TriggerUaf",
      "expect": [{ "check": "contains", "text": "VERDICT: HIT" }] },
    { "op": "eval", "expr": "@rcx",
      "expect": [{ "check": "eval", "expr": "(@rcx > 0x1000)", "equals": "1" }] }
  ],
  "always": [
    { "op": "command", "command": "eq hevd!Guard {{orig}}" },         // restore, whatever happened
    { "op": "command", "command": "bc *" }
  ]
}
```

Steps: `command` (raw), `resume` (moves the target + waits), `run_to` (HIT/STOPPED ELSEWHERE/TIMEOUT verdict), `eval` (a MASM value), `read_memory`. Assertions: `contains`, `not_contains`, `eval` — the last compares two MASM expressions, so registers, memory and any relation between them are one check. An `eval` step may `capture` its value for later steps to interpolate as `{{name}}`.

Three properties carry the design:

- **The deadline is the worker's.** A share of the budget is reserved for `always` before the first step runs, since what is left after a step that consumed its own deadline is nothing. The budget is clamped to the caller's remaining patience (`worker::batch_budget`, the same arithmetic as the bounded-command watchdog) so the report lands ahead of the tool call's timeout — which is the only reason the report is worth anything.
- **The rollback is unconditional.** A failure inside it is recorded beside the original, never in place of it, and cleanup continues past its own failures: a patch that cannot be restored must not stop a breakpoint from being cleared.
- **The executor never touches DbgEng.** It drives a `Debuggee` trait with a virtual clock, so assertion failure, a command failure after a mutation, deadline expiry and a failed rollback are unit tests rather than things a live target has to be persuaded to reproduce.

The result names every step that ran, the exact failing one, what each changed, whether the rollback completed, and whether the session is left stopped, running, detached or uncertain. A batch that did not commit comes back as a tool error carrying that whole report.

Validation is engine-free and up front — a forward capture reference, a capture on a step with no value, a duplicate name, a `;` in a typed operand, an empty or oversized batch are all refused before a single step runs. A batch carrying a target-changing command retires the session handle ahead of running, as `execute` does.

## Validated against the workflow it was filed for

Not against a guess at it. The CTF session's transcript records all 18 revisions of the throwaway client and all 188 of its invocations — **1,681 individual steps**, classified against the step language:

| Script verb | Uses | `debug_batch` |
|---|---|---|
| raw command | 1362 | `command` ✅ |
| `@run` | 219 | `run_to` + `contains "VERDICT: HIT"` ✅ |
| `@asserttarget` | 44 | `eval` check ✅ |
| `@assertfake` | 27 | three `eval` checks ✅ |
| `@go` / `@goexpect` | 15 | `resume` (+ `contains`) ✅ |
| `@runtfub` | 5 | `run_to` in `steps`, restore in `always` ✅ |
| `@chunkt1`/`@census`/`@find`/`@findr` | **9** | **❌ no way to reach a pool tool** |

1,672 of 1,681 expressible. Two of the client's revisions exist only to work around gaps this closes: its 8th replaced a compound `.if` assertion (which did not evaluate as written) with three pseudo-register assignments and three regexes over printed output — now three `eval` checks; its 16th added a duplicate of `@run` whose sole difference was restoring a patch *"on both hit and timeout"*, which is `always` hand-rolled with a comment saying so.

The longest single invocation — 32 steps, mixing verdict checks, register assertions, code patches and `bc *` — is transcribed as a regression test, with a sibling that drives the wrong-target mismatch the client wrote its rollback for.

**Known gap, not papered over.** The 9 remaining steps are `pool_chunk`/`pool_census`/`pool_find_tag`, which are win-kexp walks rather than debugger commands and so have no `execute` to fall back on. `@chunkt1` sat *inside* the 32-step transaction, between a code patch and its restore, so a batch expressing that sequence today has to drop it. Filed as FOLLOWUPS item 17 with the design question (a generic "call a tool" step vs. one variant per tool) spelled out; deliberately not built here.

Two further limits are documented rather than hidden: DbgEng reports most command failures by *printing* them and returning success, so a raw step that prints an error is a step that succeeded — assert on it if it matters; and what a step "changed" is a best-effort first-token classification, biased toward over-reporting, a reporting aid rather than what makes a mutation recoverable.

## Testing

- `cargo test` — 179 unit (30 new in `src/batch.rs`) + 25 protocol-tier smoke, all passing.
- `cargo test --test mcp_smoke` with `WINDBG_MCP_SMOKE_DUMP=1` — the debugger tier against the checked-in kernel dump, including a new test that drives a real engine to both outcomes with the same `always` block, since "the rollback ran inside the worker" is a claim only a real engine can settle.
- `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, `markdownlint-cli2` over the CI globs — all clean.
- `tools/list` golden re-recorded: one new tool, and the first nested schema in the surface, so `usesDefs` flips to `true`. Refs stay internal and single-dialect.

Not covered: a live-kernel exercise of a *mutating* batch (FOLLOWUPS item 16). A dump has nothing worth restoring, and that tier is gated behind a connection string on purpose.

## Docs

`README.md` (new `debug_batch` section + tool table), `skills/windbg-debugging/SKILL.md`, `docs/smoke-test.md`, `CHANGELOG.md`, `DECISIONS.md` (new entry), `FOLLOWUPS.md` (items 16–17).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the `debug_batch` tool for ordered debugger operations, including assertions, captured values, expression evaluation, memory reads and run-to actions.
  - Added automatic cleanup and rollback through unconditional recovery steps, with timeout handling, validation and session-state reporting.
  - Added detailed failure reports covering failed or skipped steps, rollback status and final target state.

- **Documentation**
  - Updated tool listings, debugging guidance, README content and smoke-test documentation.

- **Tests**
  - Added coverage for commits, failures, timeouts, interpolation, rollback and end-to-end execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->