### PR TITLE
Let a teardown stop a batch instead of killing it mid-transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,16 +46,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   **A teardown while the batch is running is answered too**, and it is a different problem from a
   timeout: `end_session` and a client disconnect both release the target, and the op that does so
   queues *behind* the batch, so the grace used to expire with the transaction still open and the
-  worker was terminated mid-patch. The teardown now signals first — the batch stops at its next step,
-  runs `always`, and reports `BATCH: ABANDONED` — and then waits for it: the worker answers the
-  signal with **how long that batch may still need**, so the grace covers the step already inside
-  DbgEng as well as the rollback behind it. That figure is the batch's own remaining budget, which
-  was already clamped to the caller's patience, so a teardown never waits longer than the batch
-  could have run anyway. The signal is answered by the worker's *request reader*, not its engine
-  thread, because the engine thread is the one inside the batch; it is skipped entirely when a worker
-  owes no reply, so an ordinary disconnect costs exactly what it always did. A batch that reaches the
-  engine *after* the signal does not start at all, which is the same "nothing ran, resubmitting is
-  safe" answer as an unaffordable budget.
+  worker was terminated mid-patch. The worker's *request reader* now acts on that release as it
+  reads it, rather than only when the engine thread reaches it: the batch stops at its next step,
+  runs `always`, and reports `BATCH: ABANDONED`, while the reader answers with **how long that batch
+  may still need** — so the teardown's wait covers the step already inside DbgEng as well as the
+  rollback behind it. That figure is the batch's own remaining budget, already clamped to the
+  caller's patience, so a teardown never waits longer than the batch could have run anyway. A
+  session with nothing to unwind says nothing and costs exactly what it always did. A batch that
+  reaches the engine *after* the release does not start at all, which is the same "nothing ran,
+  resubmitting is safe" answer as an unaffordable budget.
 
   Two edges are reported rather than papered over. The reserve buys the rollback *time*, not a
   guarantee: a step that overruns far enough to consume the reserve as well leaves cleanup with no

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,19 +36,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the same way a bounded command's watchdog is, so the rollback has finished and the report has been
   written before the tool call gives up — which is the only reason the report is worth anything.
 
-A batch whose caller has already given up is **not started at all**: a job stays queued after
+  A batch whose caller has already given up is **not started at all**: a job stays queued after
   its waiter times out, so the worker checks what patience is left before the first step and
   refuses outright rather than applying mutations nobody is waiting to hear about. That is where a
   batch parts company with a bounded command, which floors its watchdog instead — that one is
   already running and the job left is to free the worker; this one has not started, and not
   starting is what leaves the target as the caller last saw it.
 
+  **A teardown while the batch is running is answered too**, and it is a different problem from a
+  timeout: `end_session` and a client disconnect both release the target, and the op that does so
+  queues *behind* the batch, so the grace used to expire with the transaction still open and the
+  worker was terminated mid-patch. The teardown now signals first — the batch stops at its next step,
+  runs `always`, and reports `BATCH: ABANDONED` — and holds its grace open for that session by the
+  rollback's own reserve. The signal is answered by the worker's *request reader*, not its engine
+  thread, because the engine thread is the one inside the batch; it is skipped entirely when a worker
+  owes no reply, so an ordinary disconnect costs exactly what it always did. A batch that reaches the
+  engine *after* the signal does not start at all, which is the same "nothing ran, resubmitting is
+  safe" answer as an unaffordable budget.
+
   Two edges are reported rather than papered over. The reserve buys the rollback *time*, not a
   guarantee: a step that overruns far enough to consume the reserve as well leaves cleanup with no
   budget, and the result then says `rollback: INCOMPLETE` and names each step that never started.
-  And the strong guarantee is against a call **timeout** — a client **disconnect** is treated as
-  `end_session` on every session, so a batch still running when that grace expires is terminated
-  with its worker, mid-transaction.
+  And no signal reaches a step already inside DbgEng, so a batch built from long steps still waits
+  out the one it is in — a step longer than the grace is still terminated mid-transaction.
 
   The result names every step that ran, the exact failing one, what each step changed, whether the
   rollback completed (reported *beside* the original failure, never instead of it), and whether the
@@ -63,7 +73,9 @@ A batch whose caller has already given up is **not started at all**: a job stays
   `COMMITTED`, and a misspelt `expect` is a step that asserts nothing and commits anyway. A batch containing a target-changing command retires the session handle
   ahead of running, as `execute` does. The executor drives a `Debuggee` trait rather than DbgEng, so
   assertion failure, a command failure after a mutation, deadline expiry and a rollback that itself
-  fails are unit-tested without a debugger; the dump tier drives a real engine to both outcomes.
+  fails are unit-tested without a debugger; the dump tier drives a real engine to both outcomes, and
+  to both teardowns — a real disconnect mid-batch, whose rollback has to leave a mark on the machine
+  because there is no client left to report to, and an `end_session` mid-batch, where there is.
 
   Two limits are documented rather than papered over. DbgEng reports most command failures by
   printing them and returning success, so a raw step that prints an error is a step that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,9 +50,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   reads it, rather than only when the engine thread reaches it: the batch stops at its next step,
   runs `always`, and reports `BATCH: ABANDONED`, while the reader answers with **how long that batch
   may still need** — so the teardown's wait covers the step already inside DbgEng as well as the
-  rollback behind it. That figure is the batch's own remaining budget, already clamped to the
-  caller's patience, so a teardown never waits longer than the batch could have run anyway. A
-  session with nothing to unwind says nothing and costs exactly what it always did. A batch that
+  rollback behind it. That figure is the batch's own remaining budget plus the overrun its executor
+  is allowed, already clamped to the caller's patience, so a teardown never waits longer than the
+  batch could have run anyway; it is re-read as the wait goes on, so a batch that finishes early can
+  hand the rest back and leave only what the release itself still needs. A session with nothing to
+  unwind says nothing and costs exactly what it always did. A batch that
   reaches the engine *after* the release does not start at all, which is the same "nothing ran,
   resubmitting is safe" answer as an unaffordable budget.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,8 +47,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   timeout: `end_session` and a client disconnect both release the target, and the op that does so
   queues *behind* the batch, so the grace used to expire with the transaction still open and the
   worker was terminated mid-patch. The teardown now signals first — the batch stops at its next step,
-  runs `always`, and reports `BATCH: ABANDONED` — and holds its grace open for that session by the
-  rollback's own reserve. The signal is answered by the worker's *request reader*, not its engine
+  runs `always`, and reports `BATCH: ABANDONED` — and then waits for it: the worker answers the
+  signal with **how long that batch may still need**, so the grace covers the step already inside
+  DbgEng as well as the rollback behind it. That figure is the batch's own remaining budget, which
+  was already clamped to the caller's patience, so a teardown never waits longer than the batch
+  could have run anyway. The signal is answered by the worker's *request reader*, not its engine
   thread, because the engine thread is the one inside the batch; it is skipped entirely when a worker
   owes no reply, so an ordinary disconnect costs exactly what it always did. A batch that reaches the
   engine *after* the signal does not start at all, which is the same "nothing ran, resubmitting is
@@ -57,8 +60,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Two edges are reported rather than papered over. The reserve buys the rollback *time*, not a
   guarantee: a step that overruns far enough to consume the reserve as well leaves cleanup with no
   budget, and the result then says `rollback: INCOMPLETE` and names each step that never started.
-  And no signal reaches a step already inside DbgEng, so a batch built from long steps still waits
-  out the one it is in — a step longer than the grace is still terminated mid-transaction.
+  And no signal *shortens* a step already inside DbgEng, so a batch built from long steps unwinds
+  only once the current step ends — the teardown waits that out rather than cutting it off, but a
+  step that ignores its own watchdog is still terminated mid-transaction.
 
   The result names every step that ran, the exact failing one, what each step changed, whether the
   rollback completed (reported *beside* the original failure, never instead of it), and whether the

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -97,6 +97,12 @@ so it decays instead of being owed in full whenever it happens to be read. And t
 retracts its bound to what the release still needs — a promise revised downwards is invisible to a
 wait that already committed to the whole of the old one.
 
+And the release keeps a grace of its own after all that, because it could not start until the
+transaction ended. The retraction usually delivers it, but a batch that runs to the bound it
+advertised emits that retraction at the instant the wait stops looking for one; resting on it
+winning that race would be resting on pipe scheduling, and losing means a worker killed as its
+release begins.
+
 A session with nothing to unwind says nothing and costs exactly what it always did, so an ordinary
 disconnect is untouched. What none of this can do is *shorten* a step already inside DbgEng — that
 is `SetInterrupt` bound to job identity, FOLLOWUPS item 7 — so a batch stops at its next step

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -65,11 +65,19 @@ terminated mid-patch. Neither obvious fix was worth taking: a longer grace is pa
 disconnect, including the parked kernel attach it was tuned against, and a supervisor that tracks
 what each worker is running is a change to the path every session's teardown depends on.
 
-So the teardown asks instead. `EngineOp::AbandonBatch` is answered by the worker's **request
-reader** rather than its engine thread — the one op that must be, since the thread it concerns is
-inside the batch — which sets a flag `batch::run` reads between steps and reports back, ahead of its
-own reply, **how long that batch may still need** (`WorkerMessage::RollingBack`). The grace is then
-widened for that session alone, by exactly that figure.
+So the teardown carries the signal itself. The worker's **request reader** acts on
+`EngineOp::EndSession` where it reads it — before queueing it for the engine thread, which is by
+definition busy inside the batch — setting a flag `batch::run` checks between steps and answering
+with **how long that batch may still need** (`WorkerMessage::RollingBack`). The teardown, already
+waiting on that op's reply, extends its wait by exactly that figure.
+
+A separate abandon op was the first shape, and review found what is wrong with it: telling a batch
+to stop is a sticky, one-way change to worker state, and two independently gated requests can come
+apart. A target-changing call landing between them retires the session, the release is then refused
+as stale, and the abandon has already aborted somebody's transaction and left a flag no later batch
+could get past — on a session that survives. Carried on the release, the property is structural
+rather than narrow: a gate refusal stops the request before it reaches the worker, and every request
+that reaches it is followed by the supervisor terminating that worker.
 
 Sizing it from the rollback's reserve instead was the first cut, and it was wrong in a way worth
 recording: the signal stops a batch at its *next* step, so what a teardown waits out is the step in
@@ -80,9 +88,10 @@ caller's patience already, and only the worker can measure it. The reserve then 
 what it always was — how much of the budget is held back for `always` — with nothing shortened to
 fit a teardown.
 
-The signal is skipped entirely when a worker owes no reply, which is every ordinary disconnect. What
-it cannot do is *shorten* a step already inside DbgEng — that is `SetInterrupt` bound to job
-identity, FOLLOWUPS item 7 — so a batch stops at its next step boundary, not where it stands.
+A session with nothing to unwind says nothing and costs exactly what it always did, so an ordinary
+disconnect is untouched. What none of this can do is *shorten* a step already inside DbgEng — that
+is `SetInterrupt` bound to job identity, FOLLOWUPS item 7 — so a batch stops at its next step
+boundary, not where it stands.
 
 **Status.** Adopted. Two things are still owed: pool steps (FOLLOWUPS item 17, the one gap the
 transcript found) and a live-kernel exercise of a *mutating* batch (item 16) — the dump tier proves

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -98,10 +98,13 @@ retracts its bound to what the release still needs — a promise revised downwar
 wait that already committed to the whole of the old one.
 
 And the release keeps a grace of its own after all that, because it could not start until the
-transaction ended. The retraction usually delivers it, but a batch that runs to the bound it
-advertised emits that retraction at the instant the wait stops looking for one; resting on it
-winning that race would be resting on pipe scheduling, and losing means a worker killed as its
-release begins.
+transaction ended — granted by the supervisor, measured from the moment the worker named, and owed
+only to a teardown that actually waited on a transaction. The division of labour is the point, and
+it took two rounds to find: the **worker** knows when its batch ended and says so; **how long a
+release then gets** is the supervisor's own grace, the same one it would have given a session that
+never ran a batch. When the worker named a release interval too, the supervisor waited that out and
+*then* started its grace, so a teardown spent two of them; when it named nothing, a batch running to
+its advertised bound raced the wait's last look and could be killed as the release began.
 
 A session with nothing to unwind says nothing and costs exactly what it always did, so an ordinary
 disconnect is untouched. What none of this can do is *shorten* a step already inside DbgEng — that

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -68,13 +68,21 @@ what each worker is running is a change to the path every session's teardown dep
 So the teardown asks instead. `EngineOp::AbandonBatch` is answered by the worker's **request
 reader** rather than its engine thread — the one op that must be, since the thread it concerns is
 inside the batch — which sets a flag `batch::run` reads between steps and reports back, ahead of its
-own reply, whether it found a batch to stop (`WorkerMessage::RollingBack`). The grace is then
-widened for that session alone, by `batch::ROLLBACK_RESERVE`, which is the most an `always` block
-can ever spend; an abandoned batch holds its rollback to exactly that, so the two agree by
-derivation rather than by a number chosen to look sufficient. The signal is skipped entirely when a
-worker owes no reply, which is every ordinary disconnect. What it cannot do is reach a step already
-inside DbgEng — that is `SetInterrupt` bound to job identity, FOLLOWUPS item 7 — so a batch stops at
-its next step boundary, not where it stands.
+own reply, **how long that batch may still need** (`WorkerMessage::RollingBack`). The grace is then
+widened for that session alone, by exactly that figure.
+
+Sizing it from the rollback's reserve instead was the first cut, and it was wrong in a way worth
+recording: the signal stops a batch at its *next* step, so what a teardown waits out is the step in
+flight and then the `always` block. A reserve-sized grace expires inside a long step and terminates
+the worker mid-patch — the same failure, arriving a little later, and only on the batches whose
+steps are slowest. The batch's own remaining budget is the honest figure, it is bounded by the
+caller's patience already, and only the worker can measure it. The reserve then goes back to being
+what it always was — how much of the budget is held back for `always` — with nothing shortened to
+fit a teardown.
+
+The signal is skipped entirely when a worker owes no reply, which is every ordinary disconnect. What
+it cannot do is *shorten* a step already inside DbgEng — that is `SetInterrupt` bound to job
+identity, FOLLOWUPS item 7 — so a batch stops at its next step boundary, not where it stands.
 
 **Status.** Adopted. Two things are still owed: pool steps (FOLLOWUPS item 17, the one gap the
 transcript found) and a live-kernel exercise of a *mutating* batch (item 16) — the dump tier proves

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -88,6 +88,15 @@ caller's patience already, and only the worker can measure it. The reserve then 
 what it always was — how much of the budget is held back for `always` — with nothing shortened to
 fit a teardown.
 
+Three properties keep that promise honest, and each of them was a defect first. The figure is
+**advertised with the overrun the executor is allowed** (`batch::OVERRUN_ALLOWANCE`): a budget
+bounds what a batch may *start*, and anything started just inside it still gets a watchdog floor, so
+the bare budget is not a bound the worker can keep. It is stored as an **instant, not an interval**,
+so it decays instead of being owed in full whenever it happens to be read. And the teardown
+**re-reads it** rather than committing to one extension, because a batch that finishes early
+retracts its bound to what the release still needs — a promise revised downwards is invisible to a
+wait that already committed to the whole of the old one.
+
 A session with nothing to unwind says nothing and costs exactly what it always did, so an ordinary
 disconnect is untouched. What none of this can do is *shorten* a step already inside DbgEng — that
 is `SetInterrupt` bound to job identity, FOLLOWUPS item 7 — so a batch stops at its next step

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -56,18 +56,29 @@ whose only difference was restoring a patch "on both hit and timeout", which is 
 `batch::tests::the_messagemanager_sequence_is_a_valid_batch` is the longest single invocation
 transcribed, and its sibling drives the wrong-target failure the client wrote that rollback for.
 
-**The guarantee is against a timeout, not against a disconnect.** The budget clamp makes the first
-one total: the rollback runs and the report is written before the caller's wait expires. A client
-disconnect is different in kind — `Sessions::shutdown` treats it as `end_session` on everything and
-gives each session `SHUTDOWN_RELEASE_TIMEOUT` before terminating its worker, so a batch still
-running then is killed mid-transaction. Deliberately not widened here: lengthening that grace slows
-every disconnect, and making it conditional on what a worker is running is a change to the teardown
-path every session depends on. Documented as the boundary it is, and filed as FOLLOWUPS item 18.
+**A timeout is answered by arithmetic; a teardown is answered by a signal** (2026-08-10, item 18).
+The budget clamp makes the first guarantee total: the rollback runs and the report is written before
+the caller's wait expires. A teardown — `Sessions::shutdown` on a disconnect, or `end_session` — is
+different in kind, because it does not wait on the batch's clock at all: the `EndSession` op queues
+*behind* the batch and the grace expires while the transaction is still open, so the worker was
+terminated mid-patch. Neither obvious fix was worth taking: a longer grace is paid on every
+disconnect, including the parked kernel attach it was tuned against, and a supervisor that tracks
+what each worker is running is a change to the path every session's teardown depends on.
 
-**Status.** Adopted. Three things are still owed: pool steps (FOLLOWUPS item 17, the one gap the
-transcript found), a live-kernel exercise of a *mutating* batch (item 16) — the dump tier proves the
-wiring and both outcomes, but a dump has nothing worth restoring — and the disconnect grace above
-(item 18).
+So the teardown asks instead. `EngineOp::AbandonBatch` is answered by the worker's **request
+reader** rather than its engine thread — the one op that must be, since the thread it concerns is
+inside the batch — which sets a flag `batch::run` reads between steps and reports back, ahead of its
+own reply, whether it found a batch to stop (`WorkerMessage::RollingBack`). The grace is then
+widened for that session alone, by `batch::ROLLBACK_RESERVE`, which is the most an `always` block
+can ever spend; an abandoned batch holds its rollback to exactly that, so the two agree by
+derivation rather than by a number chosen to look sufficient. The signal is skipped entirely when a
+worker owes no reply, which is every ordinary disconnect. What it cannot do is reach a step already
+inside DbgEng — that is `SetInterrupt` bound to job identity, FOLLOWUPS item 7 — so a batch stops at
+its next step boundary, not where it stands.
+
+**Status.** Adopted. Two things are still owed: pool steps (FOLLOWUPS item 17, the one gap the
+transcript found) and a live-kernel exercise of a *mutating* batch (item 16) — the dump tier proves
+the wiring and both outcomes, but a dump has nothing worth restoring.
 
 ---
 

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -437,7 +437,7 @@ killed outright still gets the rollback rather than a truncated transaction.
   rather than cutting it off, so the cost is latency rather than a lost rollback — but a step that
   outlives its own watchdog is still terminated mid-transaction. Shortening it is item 7
   (`SetInterrupt` bound to job identity), and that is the only part of this that needs it.
-- **Proof:** `src/batch.rs` unit-tests the executor's two new behaviours (stop and roll back; and
+- **Proof:** `src/batch.rs` unit-tests the executor's two new behaviours (stop and roll back, and
   the rollback keeping the same budget every other path gets, whichever step the signal landed in),
   `src/worker.rs` pins the pairing that makes "a batch runs while the teardown thinks nothing is
   running" unreachable and the remaining-budget figure the grace is sized from, and the dump tier

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -13,6 +13,8 @@ and the 2026-08-02 entries that items 13–14 and item 10 extend.
 Items are roughly ordered by how soon they're worth doing, within each cluster. **Item 10 has
 landed** (process-per-session, 2026-08-02); it is kept here rather than deleted because items 7, 8
 and 9 were all written against the single-engine design it replaced, and each now says what moved.
+**Item 18 has landed** (2026-08-10) and is kept for the opposite reason: it turned out to need much
+less of item 7 than it claimed to, and item 7 should be read knowing which half of it is still owed.
 
 ## 1. [win-kexp] Managed breakpoint lifecycle for `run_to_address` — **done upstream**
 
@@ -89,7 +91,14 @@ exactly as it does today.
 
 **Reshaped by item 10.** The interrupt is now a *per-session* concern: it has to reach one worker's
 engine, and it cannot travel as an ordinary op, because a worker whose engine is wedged is exactly
-the one not draining its request queue — it needs a side channel the worker's reader thread acts on.
+the one not draining its *engine* queue — it needs a request the worker's reader thread acts on
+where it reads it.
+
+**Item 18 built that half.** `EngineOp::AbandonBatch` is exactly such a request: answered by
+`worker::run`'s reader loop, never queued to the engine thread, so it lands while the engine is
+busy. What is left for this item is the part that touches DbgEng — `SetInterrupt` as a public
+win-kexp method, bound to job identity so a cancel cannot Ctrl+Break an unrelated job. The channel
+question is settled; no side channel was needed, because the reader was never blocked.
 The urgency dropped with the same change: `end_session` already ends any call by terminating the
 session, so an interrupt is no longer the only way out of a runaway command, just the graceful one
 that keeps the target.
@@ -358,6 +367,10 @@ on a target that would notice.
   same batch with the call budget shortened (`WINDBG_MCP_CALL_TIMEOUT_SECS`) below the batch's own
   deadline, to check the clamp in `worker::batch_budget` really keeps the report ahead of the
   caller's timeout on a target where steps take real time.
+- **And now the teardown paths too** (item 18, landed): patch a byte, disconnect mid-batch, and
+  read the byte back over a *fresh* attach — the dump tier proves the rollback ran by the file it
+  wrote, which is the shape of the claim but not the substance of it. Same again for `end_session`
+  arriving mid-batch, where the batch's own `BATCH: ABANDONED` report comes back to the client.
 - **Where it picks up:** `tests/mcp_smoke.rs`, the `live_kernel` filter; the harness for setting and
   reading back a byte already exists in the MessageManager tier.
 
@@ -383,29 +396,38 @@ back on.
   `@chunkt1`'s real shape is the test case: capture a register with `eval`, then ask `pool_chunk`
   about `{{that}}` — the capture half already works.
 
-## 18. [windbg-mcp] Let a running batch finish its rollback when the client disconnects
+## 18. [windbg-mcp] Let a running batch finish its rollback when the client disconnects — **done**
 
-`debug_batch` (#82) makes one guarantee totally and a weaker version of it partially. Against a call
+`debug_batch` (#82) made one guarantee totally and a weaker version of it partially. Against a call
 **timeout** the rollback is safe by construction: the batch budget is clamped to the caller's
 remaining patience, so `always` has run and the report has been written before the wait expires.
-Against a client **disconnect** it is not. `Sessions::shutdown` treats a disconnect as `end_session`
-on every session; the `EndSession` op queues behind the batch, `release` waits
-`SHUTDOWN_RELEASE_TIMEOUT` (5s), and then the worker is killed — mid-transaction, with the patch
-still applied.
+Against a **teardown** it was not. `Sessions::shutdown` treats a disconnect as `end_session` on every
+session; the `EndSession` op queues behind the batch, `release` waits `SHUTDOWN_RELEASE_TIMEOUT`
+(5s), and then the worker was killed — mid-transaction, with the patch still applied. `end_session`
+itself was the same shape with a longer number on it.
 
-- **What it costs today:** a batch that patches a live kernel and is still running 5s after the
-  client goes away leaves the patch in place and, for a kernel session killed rather than released,
-  the target halted. The window is small, but it is exactly the case the tool exists for.
-- **Why deferred:** the two obvious fixes are both worse than the gap. Lengthening
-  `SHUTDOWN_RELEASE_TIMEOUT` slows *every* disconnect for a case that is rare, and the constant is
-  short on purpose (a session that cannot let go in a few seconds never will). Making the grace
-  conditional on what the worker is running means the supervisor tracking op identity through
-  teardown — a change to the path every session's shutdown depends on, landed alongside a new
-  feature, with the failure mode "the client hangs on disconnect".
-- **Where it picks up:** `Sessions::shutdown`/`release` in `src/engine.rs`. The shape worth trying
-  first is a *signal* rather than a longer wait — tell the worker to abandon its remaining steps and
-  jump to `always`, which `batch::run` is already structured for (every failure path falls through
-  to the same block), then wait the existing grace on that. It needs the side channel item 7
-  describes, for the same reason: a worker busy in DbgEng is not draining its request queue.
-- **Meanwhile:** documented as the boundary it is, in `README.md`, the skill playbook and the tool
-  description — a disconnect is not a way to abort a batch safely; `end_session` is.
+Landed (2026-08-10) as the *signal* this item proposed rather than a longer wait, and it needed less
+than item 7 to build: a worker busy in DbgEng **is** draining its request queue, because the reader
+lives on the main thread and only hands work to the engine thread. So `EngineOp::AbandonBatch` is
+answered where it is read. It sets a flag `batch::run` checks between steps; the batch stops there,
+runs `always`, and reports `BATCH: ABANDONED`.
+
+What made the grace conditional without the supervisor tracking op identity: the worker answers the
+signal with `WorkerMessage::RollingBack` — a milestone, so it rides *ahead* of the reply on the same
+ordered channel and the flag is set by the time the call returns — and `engine::release_grace` adds
+`batch::ROLLBACK_RESERVE` for that session only. An ordinary disconnect is untouched, and not merely
+by arithmetic: the signal is skipped entirely when the worker owes no reply. A batch reaching the
+engine *after* the signal does not start, which is the same "nothing ran, resubmitting is safe"
+answer as an unaffordable budget, and the worker's own EOF path sets the flag too, so a supervisor
+killed outright still gets the rollback rather than a truncated transaction.
+
+- **What is still true, and now documented as the whole of the boundary:** no signal reaches a step
+  already inside DbgEng, so a batch stops at its *next* step. One step longer than the grace is
+  still terminated mid-transaction. That is item 7 (`SetInterrupt` bound to job identity), and it is
+  the only part of this that needs it.
+- **Proof:** `src/batch.rs` unit-tests the executor's two new behaviours (stop and roll back; the
+  rollback held to the reserve rather than to a budget nobody is waiting out), `src/worker.rs` pins
+  the flag pairing that makes "a batch runs while the teardown thinks nothing is running"
+  unreachable, and the dump tier drives both teardowns end to end — the disconnect one asserting
+  against a file the rollback wrote, because by then there is no client, supervisor or worker left
+  to ask.

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -94,11 +94,11 @@ engine, and it cannot travel as an ordinary op, because a worker whose engine is
 the one not draining its *engine* queue — it needs a request the worker's reader thread acts on
 where it reads it.
 
-**Item 18 built that half.** `EngineOp::AbandonBatch` is exactly such a request: answered by
-`worker::run`'s reader loop, never queued to the engine thread, so it lands while the engine is
-busy. What is left for this item is the part that touches DbgEng — `SetInterrupt` as a public
-win-kexp method, bound to job identity so a cancel cannot Ctrl+Break an unrelated job. The channel
-question is settled; no side channel was needed, because the reader was never blocked.
+**Item 18 built that half.** `worker::run`'s reader loop acts on `EngineOp::EndSession` where it
+reads it, before queueing it, so the signal lands while the engine is busy. What is left for this
+item is the part that touches DbgEng — `SetInterrupt` as a public win-kexp method, bound to job
+identity so a cancel cannot Ctrl+Break an unrelated job. The channel question is settled; no side
+channel was needed, because the reader was never blocked.
 The urgency dropped with the same change: `end_session` already ends any call by terminating the
 session, so an interrupt is no longer the only way out of a runaway command, just the graceful one
 that keeps the target.
@@ -408,17 +408,25 @@ itself was the same shape with a longer number on it.
 
 Landed (2026-08-10) as the *signal* this item proposed rather than a longer wait, and it needed less
 than item 7 to build: a worker busy in DbgEng **is** draining its request queue, because the reader
-lives on the main thread and only hands work to the engine thread. So `EngineOp::AbandonBatch` is
-answered where it is read. It sets a flag `batch::run` checks between steps; the batch stops there,
-runs `always`, and reports `BATCH: ABANDONED`.
+lives on the main thread and only hands work to the engine thread. So the reader acts on the
+teardown's own `EndSession` where it reads it, before queueing it for an engine thread that is by
+definition busy. It sets a flag `batch::run` checks between steps; the batch stops there, runs
+`always`, and reports `BATCH: ABANDONED`.
 
-What made the grace conditional without the supervisor tracking op identity: the worker answers the
-signal with `WorkerMessage::RollingBack { within_ms }` — a milestone, so it rides *ahead* of the
-reply on the same ordered channel and the figure is stored by the time the call returns — and
-`engine::release_grace` adds it for that session only. `within_ms` is the batch's own remaining
-budget, so the grace covers the step in flight as well as the rollback; sizing it from the reserve
-instead (the first cut, caught in review) expires inside a long step and terminates the worker
-mid-patch, which is the same failure one step later. An ordinary disconnect is untouched, and not
+What made the wait conditional without the supervisor tracking op identity: the worker answers with
+`WorkerMessage::RollingBack { within_ms }` — a milestone, so it arrives while the teardown is still
+waiting on that same op's reply — and the wait extends itself by that figure once its ordinary grace
+runs out. `within_ms` is the batch's own remaining budget, so it covers the step in flight as well
+as the rollback; sizing it from the reserve instead (the first cut, caught in review) expires inside
+a long step and terminates the worker mid-patch, which is the same failure one step later.
+
+Carrying the signal on the release rather than on an op of its own was also review's doing, and for
+a sharper reason: telling a batch to stop is sticky and one-way, so it must not be possible for a
+teardown that does not happen. Two separately gated requests can come apart — a target-changing call
+between them retires the session, the release is refused as stale, and the abandon has already
+aborted a transaction and left a flag no later batch could get past on a session that survives. On
+one request the property is structural: a gate refusal stops it before the worker sees it, and every
+request the worker does see is followed by that worker being terminated. An ordinary disconnect is untouched, and not
 merely by arithmetic: the signal is skipped entirely when the worker owes no reply. A batch reaching
 the engine *after* the signal does not start, which is the same "nothing ran, resubmitting is safe"
 answer as an unaffordable budget, and the worker's own EOF path sets the flag too, so a supervisor

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -413,21 +413,25 @@ answered where it is read. It sets a flag `batch::run` checks between steps; the
 runs `always`, and reports `BATCH: ABANDONED`.
 
 What made the grace conditional without the supervisor tracking op identity: the worker answers the
-signal with `WorkerMessage::RollingBack` — a milestone, so it rides *ahead* of the reply on the same
-ordered channel and the flag is set by the time the call returns — and `engine::release_grace` adds
-`batch::ROLLBACK_RESERVE` for that session only. An ordinary disconnect is untouched, and not merely
-by arithmetic: the signal is skipped entirely when the worker owes no reply. A batch reaching the
-engine *after* the signal does not start, which is the same "nothing ran, resubmitting is safe"
+signal with `WorkerMessage::RollingBack { within_ms }` — a milestone, so it rides *ahead* of the
+reply on the same ordered channel and the figure is stored by the time the call returns — and
+`engine::release_grace` adds it for that session only. `within_ms` is the batch's own remaining
+budget, so the grace covers the step in flight as well as the rollback; sizing it from the reserve
+instead (the first cut, caught in review) expires inside a long step and terminates the worker
+mid-patch, which is the same failure one step later. An ordinary disconnect is untouched, and not
+merely by arithmetic: the signal is skipped entirely when the worker owes no reply. A batch reaching
+the engine *after* the signal does not start, which is the same "nothing ran, resubmitting is safe"
 answer as an unaffordable budget, and the worker's own EOF path sets the flag too, so a supervisor
 killed outright still gets the rollback rather than a truncated transaction.
 
-- **What is still true, and now documented as the whole of the boundary:** no signal reaches a step
-  already inside DbgEng, so a batch stops at its *next* step. One step longer than the grace is
-  still terminated mid-transaction. That is item 7 (`SetInterrupt` bound to job identity), and it is
-  the only part of this that needs it.
-- **Proof:** `src/batch.rs` unit-tests the executor's two new behaviours (stop and roll back; the
-  rollback held to the reserve rather than to a budget nobody is waiting out), `src/worker.rs` pins
-  the flag pairing that makes "a batch runs while the teardown thinks nothing is running"
-  unreachable, and the dump tier drives both teardowns end to end — the disconnect one asserting
-  against a file the rollback wrote, because by then there is no client, supervisor or worker left
-  to ask.
+- **What is still true, and now documented as the whole of the boundary:** no signal *shortens* a
+  step already inside DbgEng, so a batch stops at its *next* step. The teardown waits that step out
+  rather than cutting it off, so the cost is latency rather than a lost rollback — but a step that
+  outlives its own watchdog is still terminated mid-transaction. Shortening it is item 7
+  (`SetInterrupt` bound to job identity), and that is the only part of this that needs it.
+- **Proof:** `src/batch.rs` unit-tests the executor's two new behaviours (stop and roll back; and
+  the rollback keeping the same budget every other path gets, whichever step the signal landed in),
+  `src/worker.rs` pins the pairing that makes "a batch runs while the teardown thinks nothing is
+  running" unreachable and the remaining-budget figure the grace is sized from, and the dump tier
+  drives both teardowns end to end — the disconnect one asserting against a file the rollback wrote,
+  because by then there is no client, supervisor or worker left to ask.

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -416,9 +416,11 @@ definition busy. It sets a flag `batch::run` checks between steps; the batch sto
 What made the wait conditional without the supervisor tracking op identity: the worker answers with
 `WorkerMessage::RollingBack { within_ms }` — a milestone, so it arrives while the teardown is still
 waiting on that same op's reply — and the wait extends itself by that figure once its ordinary grace
-runs out. `within_ms` is the batch's own remaining budget, so it covers the step in flight as well
-as the rollback; sizing it from the reserve instead (the first cut, caught in review) expires inside
-a long step and terminates the worker mid-patch, which is the same failure one step later.
+runs out. `within_ms` is the batch's own remaining budget plus the overrun its executor is allowed,
+so it covers the step in flight as well as the rollback; sizing it from the reserve instead (the
+first cut, caught in review) expires inside a long step and terminates the worker mid-patch, which
+is the same failure one step later. The wait re-reads it rather than committing once, because a
+batch that finishes early hands the rest back and keeps only what the release still needs.
 
 Carrying the signal on the release rather than on an op of its own was also review's doing, and for
 a sharper reason: telling a batch to stop is sticky and one-way, so it must not be possible for a

--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ process. Two things follow, and they are why it is built this way:
   lands in the same place. Workers never outlive the connection: a disconnect asks every session
   to release its target — all of them concurrently — waits **five seconds**, and terminates only
   the workers that have not finished by then; a worker also exits on its own once its request
-  channel closes.
+  channel closes. A session running a `debug_batch` is first told to abandon it, and then gets the
+  rollback's own reserve on top of that grace — the only case where a disconnect waits longer.
   Which of those two endings a session gets matters for a live kernel. DbgEng leaves a
   detached-but-halted kernel *frozen*, so a worker that releases its target leaves the machine
   running, while a worker that is terminated leaves it stopped. Five seconds is enough for an
@@ -396,9 +397,9 @@ that costs the VM: an un-restored patch, or a target left halted.
 
 `debug_batch` submits the whole sequence as one op. It runs **inside the session's engine process**,
 which owns the deadline, so the `always` block is reached on every path — success, a debugger error,
-an assertion that did not hold, the deadline expiring — before the tool call returns. Part of the
-budget is reserved for it up front, because "what is left" after a step that ran to its own deadline
-is nothing.
+an assertion that did not hold, the deadline expiring, the session being torn down under it — before
+the tool call returns. Part of the budget is reserved for it up front, because "what is left" after a
+step that ran to its own deadline is nothing.
 
 ```jsonc
 {
@@ -445,11 +446,14 @@ Four honest limits, none of them hidden in the report:
 - The reserve buys the rollback *time*, not a guarantee. A step that overruns far enough to consume
   the reserve as well leaves cleanup with no budget; the block is then skipped and the result says
   `rollback: INCOMPLETE`, naming each step that did not run.
-- The strong guarantee is against a **call timeout**: the batch budget is clamped so the rollback
-  finishes and the report is written before the caller gives up. A **client disconnect** is weaker —
-  teardown treats it as `end_session` on every session, and a batch still running when that grace
-  expires is terminated with its worker, mid-transaction. Keep a batch that patches a live kernel
-  comfortably inside that grace, or end the session yourself rather than dropping the connection.
+- Against a **call timeout** the guarantee is arithmetic: the batch budget is clamped so the
+  rollback finishes and the report is written before the caller gives up. Against a **teardown** —
+  `end_session`, or a client disconnect, both of which release the target — it is a signal instead.
+  The batch is told to stop, does so at its next step, runs `always`, and the teardown holds its
+  grace open for exactly the reserve that rollback is allowed to spend. What the signal cannot do is
+  reach a step already inside the debugger: a batch of long steps still waits for the current one,
+  and one long enough to outlast the grace is still terminated mid-transaction. Neither can it undo
+  what a batch has not recorded — the `always` block is still the only thing that puts anything back.
 
 ### Error reporting
 

--- a/README.md
+++ b/README.md
@@ -56,9 +56,9 @@ process. Two things follow, and they are why it is built this way:
   lands in the same place. Workers never outlive the connection: a disconnect asks every session
   to release its target — all of them concurrently — waits **five seconds**, and terminates only
   the workers that have not finished by then; a worker also exits on its own once its request
-  channel closes. A session running a `debug_batch` is first told to abandon it, and then gets as
-  long as that batch says it still needs on top of that grace — the only case where a disconnect
-  waits longer, and never longer than the batch's own budget allowed.
+  channel closes. A session running a `debug_batch` is told to abandon it by that same request, and
+  then gets as long as the batch says it still needs on top of the grace — the only case where a
+  disconnect waits longer, and never longer than the batch's own budget allowed.
   Which of those two endings a session gets matters for a live kernel. DbgEng leaves a
   detached-but-halted kernel *frozen*, so a worker that releases its target leaves the machine
   running, while a worker that is terminated leaves it stopped. Five seconds is enough for an

--- a/README.md
+++ b/README.md
@@ -56,8 +56,9 @@ process. Two things follow, and they are why it is built this way:
   lands in the same place. Workers never outlive the connection: a disconnect asks every session
   to release its target — all of them concurrently — waits **five seconds**, and terminates only
   the workers that have not finished by then; a worker also exits on its own once its request
-  channel closes. A session running a `debug_batch` is first told to abandon it, and then gets the
-  rollback's own reserve on top of that grace — the only case where a disconnect waits longer.
+  channel closes. A session running a `debug_batch` is first told to abandon it, and then gets as
+  long as that batch says it still needs on top of that grace — the only case where a disconnect
+  waits longer, and never longer than the batch's own budget allowed.
   Which of those two endings a session gets matters for a live kernel. DbgEng leaves a
   detached-but-halted kernel *frozen*, so a worker that releases its target leaves the machine
   running, while a worker that is terminated leaves it stopped. Five seconds is enough for an
@@ -449,11 +450,13 @@ Four honest limits, none of them hidden in the report:
 - Against a **call timeout** the guarantee is arithmetic: the batch budget is clamped so the
   rollback finishes and the report is written before the caller gives up. Against a **teardown** —
   `end_session`, or a client disconnect, both of which release the target — it is a signal instead.
-  The batch is told to stop, does so at its next step, runs `always`, and the teardown holds its
-  grace open for exactly the reserve that rollback is allowed to spend. What the signal cannot do is
-  reach a step already inside the debugger: a batch of long steps still waits for the current one,
-  and one long enough to outlast the grace is still terminated mid-transaction. Neither can it undo
-  what a batch has not recorded — the `always` block is still the only thing that puts anything back.
+  The batch is told to stop, does so at its next step, runs `always`, and the teardown waits: the
+  worker answers the signal with how long that batch may still need, so the wait covers the step in
+  flight as well as the rollback. That figure is the batch's own remaining budget, which was already
+  clamped to the caller's patience, so a teardown can never wait longer than the batch could have
+  run anyway. What the signal cannot do is *shorten* a step already inside the debugger, so a batch
+  of long steps stops at the end of the current one rather than where it stands — and it cannot undo
+  what the batch never recorded, since `always` is still the only thing that puts anything back.
 
 ### Error reporting
 

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -119,6 +119,15 @@ processes, so they need real ones:
   from one step and interpolated into the next) and one to `FAILED at step 2 of 3`, with the same
   `always` block on both. The claim only a real engine can settle is the second one: the rollback
   ran **inside the worker process**, on the failing path, before the tool call returned.
+- *A teardown mid-batch rolls it back first.* Two tests, one per teardown, both with a batch parked
+  in twenty seconds of `.sleep` steps. `end_session` gets the version with a client still attached:
+  it returns in seconds rather than waiting the batch out, and the batch's own call comes back
+  `BATCH: ABANDONED` with the rollback complete. The **disconnect** version has nobody left to
+  report to — client, supervisor and worker are all gone by the time it is checked — so the rollback
+  writes a file (`.logopen`/`.echo`/`.logclose`) and the assertion is made against the filesystem
+  afterwards, which is as close as a dump gets to the byte a live target would have restored. Both
+  wait for a marker the batch's *first* step writes before tearing anything down: timed with a sleep
+  instead, a slow machine would test the refuse-to-start path and pass just as green.
 
 This tier is also the only end-to-end check of the **protocol channel** — the inherited pipe pair a
 worker speaks on ([`proto.rs`](../src/proto.rs)). Handles are passed on the worker's command line

--- a/skills/windbg-debugging/SKILL.md
+++ b/skills/windbg-debugging/SKILL.md
@@ -55,8 +55,9 @@ gone. Save what you are about to overwrite with an `eval` step's `capture`, and 
 Two edges to keep in mind. If a step overruns far enough to consume the reserve too, cleanup is
 skipped and the result says `rollback: INCOMPLETE` — believe it rather than the intent. And a
 teardown while the batch runs — `end_session`, or a client disconnect — stops it at its **next**
-step and rolls it back first, reported as `BATCH: ABANDONED`; it cannot cut a step already inside
-the debugger short, so a batch built from long steps still waits out the one it is in.
+step and rolls it back first, reported as `BATCH: ABANDONED`; it cannot cut short a step already
+inside the debugger, so a batch built from long steps waits out the one it is in before it unwinds
+(the teardown waits with it).
 
 ## Cross-cutting gotchas (apply to every workflow)
 

--- a/skills/windbg-debugging/SKILL.md
+++ b/skills/windbg-debugging/SKILL.md
@@ -53,11 +53,10 @@ gone. Save what you are about to overwrite with an `eval` step's `capture`, and 
 `always` as `{{name}}`.
 
 Two edges to keep in mind. If a step overruns far enough to consume the reserve too, cleanup is
-skipped and the result says `rollback: INCOMPLETE` — believe it rather than the intent. And the
-guarantee is against a call *timeout*, not against a client *disconnect*: a disconnect is treated as
-`end_session` on every session and gives a batch only a few seconds' grace before its worker is
-terminated, so end a session holding a patched kernel yourself instead of just dropping the
-connection.
+skipped and the result says `rollback: INCOMPLETE` — believe it rather than the intent. And a
+teardown while the batch runs — `end_session`, or a client disconnect — stops it at its **next**
+step and rolls it back first, reported as `BATCH: ABANDONED`; it cannot cut a step already inside
+the debugger short, so a batch built from long steps still waits out the one it is in.
 
 ## Cross-cutting gotchas (apply to every workflow)
 

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -67,6 +67,21 @@ const ROLLBACK_RESERVE: Duration = Duration::from_secs(30);
 /// dequeued at or past the deadline must not round down to it.
 const MIN_STEP_BUDGET_MS: u32 = 1_000;
 
+/// How far past its budget a batch can still legitimately be running.
+///
+/// The budget bounds what may be **started**, not what may be finishing: an operation that begins a
+/// moment before the deadline is still armed with [`MIN_STEP_BUDGET_MS`], because a watchdog of
+/// zero is no watchdog at all. Three of those can stack at the end of a batch — the last cleanup
+/// step's action, an assertion inside it, and the state probe, which runs unconditionally — and
+/// win-kexp's watchdog needs a moment beyond that to interrupt and unwind.
+///
+/// Public because it is the difference between the budget and a bound the worker can actually
+/// *keep*, and something outside is relying on that bound: a teardown is told when the batch will
+/// be done and terminates the worker if it is not. Advertising the bare budget would have it kill
+/// a worker in the middle of the restore it was waiting for — which is the whole failure being
+/// avoided, arriving three seconds later.
+pub const OVERRUN_ALLOWANCE: Duration = Duration::from_millis(4 * MIN_STEP_BUDGET_MS as u64);
+
 /// Default deadline for a whole batch, when the caller names none (ms).
 ///
 /// Comfortably more than a sequence of ordinary commands needs, and comfortably inside the default
@@ -1667,6 +1682,57 @@ mod tests {
         let text = render(&report);
         assert!(text.contains("BATCH: ABANDONED at step 2 of 3"), "{text}");
         assert!(text.contains("rollback: COMPLETE"), "{text}");
+    }
+
+    /// **The bound the worker advertises to a teardown has to be one this executor keeps.**
+    ///
+    /// A teardown is told when the batch will be done and terminates the worker if it is not, so an
+    /// under-stated bound kills a worker in the middle of the restore the teardown was waiting for.
+    /// The budget alone is under-stated: it bounds what may be *started*, and everything started
+    /// just inside it is still armed with the watchdog floor — the last cleanup step's action, an
+    /// assertion within it, and the state probe, which runs whatever else happened.
+    ///
+    /// So this drives the worst case rather than asserting the arithmetic: a cleanup step that
+    /// starts a hair inside the budget and overruns, with an assertion behind it, and the probe
+    /// after that. What it must not exceed is `budget + OVERRUN_ALLOWANCE`.
+    #[test]
+    fn a_batch_finishes_inside_the_bound_its_worker_advertises() {
+        let step = Duration::from_millis(u64::from(MIN_STEP_BUDGET_MS));
+        // 60s budget, 30s reserve: the steps block ends at 30s, so the first step lands the clock a
+        // hair inside the *cleanup* deadline, and everything after it is a floor-armed overrun.
+        let mut d = stopped()
+            .slow("burn", Ok(""), Duration::from_millis(59_900))
+            .slow("restore", Ok(""), step)
+            .slow("? (1", Ok(EVAL_ONE), step)
+            .slow(
+                "? @$ip",
+                Ok("Evaluate expression: 1 = fffff803`1a2b3c4d"),
+                step,
+            );
+        let batch = op(
+            vec![cmd("burn the budget")],
+            vec![BatchStep {
+                expect: vec![Check::Eval {
+                    expr: "1".to_string(),
+                    equals: "1".to_string(),
+                }],
+                ..cmd("restore it")
+            }],
+        );
+
+        let report = run(&mut d, &batch, BUDGET);
+
+        assert!(
+            report.elapsed <= BUDGET + OVERRUN_ALLOWANCE,
+            "the batch ran {:?}, past the {:?} bound its worker advertises to a teardown — which \
+             would have the worker terminated mid-restore",
+            report.elapsed,
+            BUDGET + OVERRUN_ALLOWANCE
+        );
+        assert!(
+            report.elapsed > BUDGET,
+            "this test is only worth anything if it actually reaches past the budget"
+        );
     }
 
     /// **An abandoned batch's rollback keeps the whole budget**, exactly like every other path. It

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -61,12 +61,7 @@ pub const MAX_CHECKS: usize = 16;
 /// Reserved *up front* rather than taken from what is left, because "what is left" after a step
 /// that ran to its own deadline is nothing. Capped at half the budget so a short batch still
 /// spends most of its time on the work it was asked to do.
-///
-/// Public because it is also the longest a rollback can take, which is what a teardown has to wait
-/// out after telling a batch to abandon ([`Debuggee::abandoned`]). The supervisor derives its grace
-/// from this constant rather than picking one that happens to be long enough — see
-/// `engine::release_grace`.
-pub const ROLLBACK_RESERVE: Duration = Duration::from_secs(30);
+const ROLLBACK_RESERVE: Duration = Duration::from_secs(30);
 
 /// The smallest watchdog a step is armed with. Zero *disables* win-kexp's watchdog, so a step
 /// dequeued at or past the deadline must not round down to it.
@@ -633,7 +628,9 @@ pub trait Debuggee {
     /// Read between steps, never mid-step: this cannot reach a call already inside DbgEng, and
     /// pretending otherwise would be a promise the mechanism cannot keep. What it *is* is the
     /// difference between a rollback that runs and a worker terminated with the patch still
-    /// applied, because the teardown that sets it then waits for the `always` block.
+    /// applied, because the teardown that sets it then waits out the step in flight and the
+    /// `always` block after it — the batch's whole remaining budget, which is why nothing here
+    /// has to be shortened to fit a teardown.
     fn abandoned(&self) -> bool;
 }
 
@@ -876,19 +873,14 @@ pub fn run(d: &mut impl Debuggee, op: &BatchOp, budget: Duration) -> BatchReport
     }
 
     // The rollback block, on every path. Its own deadline is the *whole* budget, which is what the
-    // reserve above bought it — except when the batch was abandoned, where the budget is no longer
-    // the bound that matters. A teardown is waiting on this rollback and gives it the reserve, so
-    // running past that would only mean being terminated mid-cleanup with the report unwritten:
-    // the same failure, one step later. Held to the reserve, the block that fits is the block that
-    // runs, and what did not fit is *reported* as not having run.
-    let cleanup_deadline = match outcome {
-        BatchOutcome::Abandoned { .. } => (d.elapsed() + reserve).min(budget),
-        _ => budget,
-    };
+    // reserve above bought it — and that holds when the batch is abandoned too, rather than the
+    // rollback being cut short to fit a teardown's grace. The grace is sized from this budget
+    // instead (`worker::BatchSignal::abandon`), so shortening the block here would only mean
+    // skipping cleanup the teardown was already waiting for.
     let mut always: Vec<StepOutcome> = Vec::with_capacity(op.always.len());
     for (index, step) in op.always.iter().enumerate() {
         let position = index + 1;
-        if d.elapsed() >= cleanup_deadline {
+        if d.elapsed() >= budget {
             always.push(StepOutcome::skipped(
                 position,
                 step,
@@ -898,7 +890,7 @@ pub fn run(d: &mut impl Debuggee, op: &BatchOp, budget: Duration) -> BatchReport
         }
         // Cleanup continues past its own failures, deliberately: the steps are ordered, but a
         // patch that cannot be restored must not stop a breakpoint from being cleared.
-        always.push(run_step(d, step, position, cleanup_deadline, &mut bound));
+        always.push(run_step(d, step, position, budget, &mut bound));
     }
 
     let after = probe_state(d, &steps, &always, budget);
@@ -1677,41 +1669,70 @@ mod tests {
         assert!(text.contains("rollback: COMPLETE"), "{text}");
     }
 
-    /// An abandoned batch's rollback is held to the reserve, not to whatever is left of a budget
-    /// nobody is waiting out any more.
+    /// **An abandoned batch's rollback keeps the whole budget**, exactly like every other path. It
+    /// is not shortened to fit the teardown's grace — the grace is sized from that budget instead
+    /// (`worker::BatchSignal::abandon`), so shortening it here would only skip cleanup somebody was
+    /// already waiting for.
     ///
-    /// The teardown that sent the signal gives the rollback exactly `ROLLBACK_RESERVE` before it
-    /// terminates the worker, so cleanup that ran past that would be killed mid-step with the
-    /// report unwritten — the same loss one step later. Held to the reserve, what fits runs and
-    /// what does not is *reported* as not having run, which is the difference between an incomplete
-    /// rollback and an unknown one.
+    /// Both halves of this were once wrong in the same way. Holding the rollback to the reserve
+    /// dropped the third step below, *and* it depended on the outcome — so a signal arriving during
+    /// the batch's **last** step, where no further loop iteration exists to notice it, left the
+    /// outcome `Committed` and the cleanup on a different bound from an identical signal one step
+    /// earlier. The second run here is that case, and it must be indistinguishable from the first.
     #[test]
-    fn an_abandoned_rollback_is_held_to_the_reserve_it_is_given() {
-        let mut d = stopped()
-            .on("first", Ok(""))
-            // A first cleanup step that overruns the reserve on its own: the second is then past
-            // the deadline, even though the batch's own budget still has minutes left in it.
-            .slow("slow restore", Ok(""), Duration::from_secs(40))
-            .on("late restore", Ok(""))
-            .abandoned_after(1);
-        let batch = op(
-            vec![cmd("first step"), cmd("never runs")],
-            vec![cmd("slow restore"), cmd("late restore")],
+    fn an_abandoned_rollback_keeps_the_budget_every_other_path_gets() {
+        // Cleanup steps costing 20s each against a 60s budget: three of them fit, where the
+        // reserve (30s) would have seated two.
+        let scripted = || {
+            stopped()
+                .on("first", Ok(""))
+                .slow("restore", Ok(""), Duration::from_secs(20))
+                .slow("clear", Ok(""), Duration::from_secs(20))
+                .slow("bc *", Ok(""), Duration::from_secs(20))
+        };
+        let cleanup = || vec![cmd("restore it"), cmd("clear it"), cmd("bc *")];
+
+        // Signalled mid-batch: the outcome is `Abandoned`, and the rollback still runs whole.
+        let mut midway = scripted().abandoned_after(1);
+        let stopped_early = run(
+            &mut midway,
+            &op(vec![cmd("first step"), cmd("never runs")], cleanup()),
+            BUDGET,
         );
-
-        // Ten minutes: far more than the reserve, so anything the cleanup is bounded by here is
-        // the reserve rather than the budget.
-        let report = run(&mut d, &batch, Duration::from_secs(600));
-
-        assert_eq!(report.outcome, BatchOutcome::Abandoned { at: 2 });
-        assert!(d.ran("slow restore"), "the first cleanup step fits");
+        assert_eq!(stopped_early.outcome, BatchOutcome::Abandoned { at: 2 });
         assert!(
-            !d.ran("late restore"),
-            "the second is past the reserve, so it must not be started with a teardown waiting"
+            stopped_early.rollback_complete(),
+            "cleanup was cut short to fit a grace that is sized from the budget anyway: {:?}",
+            stopped_early.always
         );
-        assert!(!report.rollback_complete());
-        let text = render(&report);
-        assert!(text.contains("rollback: INCOMPLETE"), "{text}");
+
+        // Signalled during the *last* step, so `run`'s loop never sees it: the batch commits, and
+        // the rollback must be bounded identically. A bound that read the outcome would differ
+        // here, silently, in the case hardest to notice.
+        let mut at_the_end = scripted().abandoned_after(1);
+        let committed = run(
+            &mut at_the_end,
+            &op(vec![cmd("first step")], cleanup()),
+            BUDGET,
+        );
+        assert_eq!(
+            committed.outcome,
+            BatchOutcome::Committed,
+            "every step ran and every assertion held, whatever became of the session"
+        );
+        assert_eq!(
+            committed
+                .always
+                .iter()
+                .map(|s| s.result.tag())
+                .collect::<Vec<_>>(),
+            stopped_early
+                .always
+                .iter()
+                .map(|s| s.result.tag())
+                .collect::<Vec<_>>(),
+            "the rollback's bound must not depend on which step the signal landed in"
+        );
     }
 
     /// A rollback step that itself fails is reported beside the original failure, never instead

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -61,7 +61,12 @@ pub const MAX_CHECKS: usize = 16;
 /// Reserved *up front* rather than taken from what is left, because "what is left" after a step
 /// that ran to its own deadline is nothing. Capped at half the budget so a short batch still
 /// spends most of its time on the work it was asked to do.
-const ROLLBACK_RESERVE: Duration = Duration::from_secs(30);
+///
+/// Public because it is also the longest a rollback can take, which is what a teardown has to wait
+/// out after telling a batch to abandon ([`Debuggee::abandoned`]). The supervisor derives its grace
+/// from this constant rather than picking one that happens to be long enough — see
+/// `engine::release_grace`.
+pub const ROLLBACK_RESERVE: Duration = Duration::from_secs(30);
 
 /// The smallest watchdog a step is armed with. Zero *disables* win-kexp's watchdog, so a step
 /// dequeued at or past the deadline must not round down to it.
@@ -622,6 +627,14 @@ pub trait Debuggee {
     fn read_memory(&mut self, address: &str, size: u32) -> Result<String, String>;
     /// How long this batch has been running.
     fn elapsed(&self) -> Duration;
+    /// Whether something outside the batch has asked it to stop early and roll back — a client
+    /// disconnect, or an `end_session` for the session it is running on.
+    ///
+    /// Read between steps, never mid-step: this cannot reach a call already inside DbgEng, and
+    /// pretending otherwise would be a promise the mechanism cannot keep. What it *is* is the
+    /// difference between a rollback that runs and a worker terminated with the patch still
+    /// applied, because the teardown that sets it then waits for the `always` block.
+    fn abandoned(&self) -> bool;
 }
 
 /// Runs one engine call, turning a panic into a step failure so [`run`] still reaches `always`.
@@ -718,6 +731,15 @@ pub enum BatchOutcome {
     Failed { at: usize },
     /// The deadline expired; `at` is the 1-based position of the first step not attempted.
     TimedOut { at: usize },
+    /// The session is being torn down — the client disconnected, or someone ended it — so the
+    /// batch stopped and went to its rollback. `at` is the 1-based position of the first step not
+    /// attempted.
+    ///
+    /// Its own outcome rather than a timeout, because nothing about the target or the budget was
+    /// wrong: the steps that did not run were not *refused*, they were cut short by something the
+    /// batch has no quarrel with. Resubmitting from the top is the right next move, which is not
+    /// what a caller should conclude from either of the other two.
+    Abandoned { at: usize },
 }
 
 /// What the session holds once the batch is done — the question a caller cannot answer from the
@@ -805,6 +827,29 @@ pub fn run(d: &mut impl Debuggee, op: &BatchOp, budget: Duration) -> BatchReport
                 ));
                 continue;
             }
+            BatchOutcome::Abandoned { at } => {
+                steps.push(StepOutcome::skipped(
+                    position,
+                    step,
+                    format!(
+                        "the session was torn down while the batch was running, so it stopped at \
+                         step {at} and went to its rollback"
+                    ),
+                ));
+                continue;
+            }
+        }
+        // Before the deadline check, because the two are not the same news and this one is the
+        // more urgent: something is tearing this session down and the rollback is what is left
+        // worth doing. Between steps only — a step already inside DbgEng runs to its own end.
+        if d.abandoned() {
+            outcome = BatchOutcome::Abandoned { at: position };
+            steps.push(StepOutcome::skipped(
+                position,
+                step,
+                "the session was torn down before this step started",
+            ));
+            continue;
         }
         if d.elapsed() >= steps_deadline {
             outcome = BatchOutcome::TimedOut { at: position };
@@ -831,11 +876,19 @@ pub fn run(d: &mut impl Debuggee, op: &BatchOp, budget: Duration) -> BatchReport
     }
 
     // The rollback block, on every path. Its own deadline is the *whole* budget, which is what the
-    // reserve above bought it.
+    // reserve above bought it — except when the batch was abandoned, where the budget is no longer
+    // the bound that matters. A teardown is waiting on this rollback and gives it the reserve, so
+    // running past that would only mean being terminated mid-cleanup with the report unwritten:
+    // the same failure, one step later. Held to the reserve, the block that fits is the block that
+    // runs, and what did not fit is *reported* as not having run.
+    let cleanup_deadline = match outcome {
+        BatchOutcome::Abandoned { .. } => (d.elapsed() + reserve).min(budget),
+        _ => budget,
+    };
     let mut always: Vec<StepOutcome> = Vec::with_capacity(op.always.len());
     for (index, step) in op.always.iter().enumerate() {
         let position = index + 1;
-        if d.elapsed() >= budget {
+        if d.elapsed() >= cleanup_deadline {
             always.push(StepOutcome::skipped(
                 position,
                 step,
@@ -845,7 +898,7 @@ pub fn run(d: &mut impl Debuggee, op: &BatchOp, budget: Duration) -> BatchReport
         }
         // Cleanup continues past its own failures, deliberately: the steps are ordered, but a
         // patch that cannot be restored must not stop a breakpoint from being cleared.
-        always.push(run_step(d, step, position, budget, &mut bound));
+        always.push(run_step(d, step, position, cleanup_deadline, &mut bound));
     }
 
     let after = probe_state(d, &steps, &always, budget);
@@ -1226,6 +1279,12 @@ pub fn render(report: &BatchReport) -> String {
             report.budget.as_secs_f64(),
             report.elapsed.as_secs_f64()
         ),
+        BatchOutcome::Abandoned { at } => format!(
+            "BATCH: ABANDONED at step {at} of {total} — the session was being torn down (the \
+             client disconnected, or the session was ended), so the batch stopped there and ran \
+             its rollback. Nothing was wrong with the steps or the budget; resubmit the whole \
+             batch on a fresh session.\n"
+        ),
     };
 
     let mutations = report.mutations();
@@ -1317,6 +1376,9 @@ mod tests {
         clock: Duration,
         /// Call fragments this script panics on rather than answers; see [`Script::panics`].
         panic_on: Vec<String>,
+        /// How many calls this debuggee answers before it starts reporting itself abandoned; see
+        /// [`Script::abandoned_after`].
+        abandon_after: Option<usize>,
     }
 
     /// The message a scripted panic carries, so the report can be asserted to have kept it.
@@ -1345,6 +1407,14 @@ mod tests {
             // Not an `answers` entry: the panic fires before the lookup, so one would only be
             // there to look like an answer that is never given.
             self.panic_on.push(matching.to_string());
+            self
+        }
+
+        /// Reports the batch abandoned once `calls` calls have been answered — the scripted stand-in
+        /// for a teardown arriving mid-transaction, which is otherwise only reproducible by
+        /// disconnecting a client from a real worker.
+        fn abandoned_after(mut self, calls: usize) -> Self {
+            self.abandon_after = Some(calls);
             self
         }
 
@@ -1403,6 +1473,10 @@ mod tests {
         }
         fn elapsed(&self) -> Duration {
             self.clock
+        }
+        fn abandoned(&self) -> bool {
+            self.abandon_after
+                .is_some_and(|after| self.calls.len() >= after)
         }
     }
 
@@ -1550,6 +1624,94 @@ mod tests {
         assert!(report.rollback_complete());
         let text = render(&report);
         assert!(text.contains("BATCH: TIMED OUT at step 2 of 2"), "{text}");
+    }
+
+    /// A teardown arriving mid-transaction: the batch stops where it is and unwinds, rather than
+    /// running on to be killed with the patch still applied.
+    ///
+    /// This is the disconnect path. Nothing is wrong with the target or the budget — the session
+    /// is simply going away — so the outcome is neither a failure nor a timeout, and the steps that
+    /// did not run say which of the three it was, because the next move differs for each.
+    #[test]
+    fn an_abandoned_batch_stops_where_it_is_and_still_rolls_back() {
+        let mut d = stopped()
+            .on("eb fffff800", Ok(""))
+            .on("second", Ok(""))
+            .on("third", Ok(""))
+            .on("eb restore", Ok(""))
+            // The signal lands after the first step's command; `? @$ip` at the end is the only
+            // other call, and by then the rollback has run.
+            .abandoned_after(1);
+        let batch = op(
+            vec![
+                cmd("eb fffff800`00001000 90"),
+                cmd("second step"),
+                cmd("third step"),
+            ],
+            vec![cmd("eb restore 41")],
+        );
+
+        let report = run(&mut d, &batch, BUDGET);
+
+        assert_eq!(report.outcome, BatchOutcome::Abandoned { at: 2 });
+        assert!(!d.ran("second"), "a step after the signal must not run");
+        assert!(!d.ran("third"), "nor any step after that one");
+        assert!(
+            d.ran("eb restore"),
+            "the rollback is the whole reason for stopping early"
+        );
+        assert!(report.rollback_complete());
+        // Every skipped step says the session went away — not that something failed, and not that
+        // the clock ran out, which would send a caller looking for a bug or a bigger budget.
+        for step in &report.steps[1..] {
+            let StepResult::Skipped(why) = &step.result else {
+                panic!(
+                    "step {} should have been skipped: {:?}",
+                    step.position, step
+                );
+            };
+            assert!(why.contains("torn down"), "{why}");
+        }
+        let text = render(&report);
+        assert!(text.contains("BATCH: ABANDONED at step 2 of 3"), "{text}");
+        assert!(text.contains("rollback: COMPLETE"), "{text}");
+    }
+
+    /// An abandoned batch's rollback is held to the reserve, not to whatever is left of a budget
+    /// nobody is waiting out any more.
+    ///
+    /// The teardown that sent the signal gives the rollback exactly `ROLLBACK_RESERVE` before it
+    /// terminates the worker, so cleanup that ran past that would be killed mid-step with the
+    /// report unwritten — the same loss one step later. Held to the reserve, what fits runs and
+    /// what does not is *reported* as not having run, which is the difference between an incomplete
+    /// rollback and an unknown one.
+    #[test]
+    fn an_abandoned_rollback_is_held_to_the_reserve_it_is_given() {
+        let mut d = stopped()
+            .on("first", Ok(""))
+            // A first cleanup step that overruns the reserve on its own: the second is then past
+            // the deadline, even though the batch's own budget still has minutes left in it.
+            .slow("slow restore", Ok(""), Duration::from_secs(40))
+            .on("late restore", Ok(""))
+            .abandoned_after(1);
+        let batch = op(
+            vec![cmd("first step"), cmd("never runs")],
+            vec![cmd("slow restore"), cmd("late restore")],
+        );
+
+        // Ten minutes: far more than the reserve, so anything the cleanup is bounded by here is
+        // the reserve rather than the budget.
+        let report = run(&mut d, &batch, Duration::from_secs(600));
+
+        assert_eq!(report.outcome, BatchOutcome::Abandoned { at: 2 });
+        assert!(d.ran("slow restore"), "the first cleanup step fits");
+        assert!(
+            !d.ran("late restore"),
+            "the second is past the reserve, so it must not be started with a teardown waiting"
+        );
+        assert!(!report.rollback_complete());
+        let text = render(&report);
+        assert!(text.contains("rollback: INCOMPLETE"), "{text}");
     }
 
     /// A rollback step that itself fails is reported beside the original failure, never instead

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -330,7 +330,14 @@ pub struct Session {
     /// How long this session's worker said a transaction it was told to unwind still needs, or
     /// `None` while it has said nothing. Set from [`WorkerMessage::RollingBack`] and read by the
     /// teardown whose own request provoked it; see [`Sessions::release`].
-    unwinding: Mutex<Option<Duration>>,
+    ///
+    /// **Written by [`read_messages`]'s thread**, where the bytes arrive, rather than by [`reader`]
+    /// where every other message is handled. That is what the teardown's decision rests on: it
+    /// reads this once, when its grace expires, and killing a worker that is mid-rollback because
+    /// the runtime had not yet got round to dispatching the message would be the exact outcome the
+    /// message exists to prevent. Recorded on arrival, "the worker said so in time" means what it
+    /// says — it cannot turn on how busy this process was.
+    unwinding: Arc<Mutex<Option<Duration>>>,
     child: Mutex<Option<Child>>,
 }
 
@@ -1372,17 +1379,21 @@ impl Sessions {
         // Drained from the start, before the handshake: a worker that prints during startup must
         // not be able to block on a full pipe on its way to `Ready`.
         tokio::spawn(log_stray_output(id.to_string(), stdout));
-        let mut messages = match read_messages(id.to_string(), channel.messages) {
-            Ok(messages) => messages,
-            Err(e) => {
-                // Nothing has been asked of this worker yet, so it holds no target: killing it is
-                // the whole teardown.
-                let _ = child.start_kill();
-                return Err(format!(
-                    "could not start a reader for an engine worker's messages: {e}"
-                ));
-            }
-        };
+        // Created before the thread that records into it, and handed to the session below: see
+        // [`Session::unwinding`] for why it is written there rather than in `reader`.
+        let unwinding: Arc<Mutex<Option<Duration>>> = Arc::new(Mutex::new(None));
+        let mut messages =
+            match read_messages(id.to_string(), channel.messages, Arc::clone(&unwinding)) {
+                Ok(messages) => messages,
+                Err(e) => {
+                    // Nothing has been asked of this worker yet, so it holds no target: killing it is
+                    // the whole teardown.
+                    let _ = child.start_kill();
+                    return Err(format!(
+                        "could not start a reader for an engine worker's messages: {e}"
+                    ));
+                }
+            };
 
         // Nothing is registered until the worker says its engine exists. A session that cannot
         // debug is worse than no session: it would accept calls and fail every one.
@@ -1425,7 +1436,7 @@ impl Sessions {
             delivered: AtomicBool::new(false),
             phase: AtomicU8::new(OpenPhase::Started as u8),
             released: AtomicBool::new(false),
-            unwinding: Mutex::new(None),
+            unwinding,
             child: Mutex::new(Some(child)),
         });
 
@@ -1787,6 +1798,7 @@ fn spawn_worker(exe: &Path) -> std::io::Result<(Child, Channel)> {
 fn read_messages(
     id: String,
     pipe: PipeReader,
+    unwinding: Arc<Mutex<Option<Duration>>>,
 ) -> std::io::Result<mpsc::UnboundedReceiver<WorkerMessage>> {
     let (tx, rx) = mpsc::unbounded_channel();
     std::thread::Builder::new()
@@ -1799,6 +1811,13 @@ fn read_messages(
                 }
                 match serde_json::from_str::<WorkerMessage>(&line) {
                     Ok(message) => {
+                        // Recorded here, before the message is handed on, because a teardown reads
+                        // it against a deadline — see [`Session::unwinding`]. Everything this
+                        // message is *reported* as still happens in `reader`.
+                        if let WorkerMessage::RollingBack { within_ms, .. } = &message {
+                            *unwinding.lock().unwrap_or_else(|e| e.into_inner()) =
+                                Some(Duration::from_millis(u64::from(*within_ms)));
+                        }
                         if tx.send(message).is_err() {
                             break; // nobody is left to route it to
                         }
@@ -2008,12 +2027,11 @@ async fn reader(
                 session.reach(OpenPhase::Opened);
                 promote_opened(&session);
             }
-            // Recorded while the teardown that provoked it is still waiting on that job's `Done`,
-            // which is the whole point of it being a milestone: the wait consults this only after
-            // its own grace runs out, by which time this store is long since visible.
+            // Already recorded by the thread that read it — see [`Session::unwinding`] — so this
+            // arm only reports it. Nothing here is on the teardown's critical path, which is the
+            // whole reason the store is not here.
             WorkerMessage::RollingBack { id, within_ms } => {
                 let within = Duration::from_millis(u64::from(within_ms));
-                *session.unwinding.lock().unwrap_or_else(|e| e.into_inner()) = Some(within);
                 tracing::info!(
                     "session {}: job {id} found a transaction in flight and told it to roll back; \
                      it needs up to {within:?}",
@@ -2104,8 +2122,12 @@ mod tests {
              channel did with it"
         );
 
-        let mut messages =
-            read_messages("sess-stand-in".to_string(), channel.messages).expect("read messages");
+        let mut messages = read_messages(
+            "sess-stand-in".to_string(),
+            channel.messages,
+            Arc::new(Mutex::new(None)),
+        )
+        .expect("read messages");
         let heard = tokio::time::timeout(Duration::from_secs(10), messages.recv()).await;
         assert!(
             matches!(heard, Ok(None)),
@@ -2387,7 +2409,7 @@ mod tests {
             delivered: AtomicBool::new(true),
             phase: AtomicU8::new(phase as u8),
             released: AtomicBool::new(false),
-            unwinding: Mutex::new(None),
+            unwinding: Arc::new(Mutex::new(None)),
             child: Mutex::new(None),
         })
     }
@@ -2777,6 +2799,44 @@ mod tests {
     fn a_session_with_nothing_to_unwind_asks_for_no_extension() {
         let idle = dormant("sess-idle", SessionState::Open);
         assert_eq!(idle.unwinding_for(), None);
+    }
+
+    /// A rollback milestone is recorded by the thread that **reads** it, before it is handed on to
+    /// be dispatched at all.
+    ///
+    /// That ordering is the whole guarantee. A teardown reads this once, when its grace expires,
+    /// and then kills the worker; if the store happened where the message is *handled* instead, the
+    /// read could miss a milestone that arrived seconds earlier but had not been dispatched — and
+    /// the worker would be terminated mid-rollback for being unlucky with the runtime's scheduling.
+    /// Receiving the message here is the synchronisation point: the value has to be visible to
+    /// anyone who could observe the message at all.
+    #[tokio::test]
+    async fn a_rollback_milestone_is_recorded_where_it_arrives() {
+        let (arriving, mut worker) = std::io::pipe().expect("a pipe to stand in for a worker's");
+        let unwinding: Arc<Mutex<Option<Duration>>> = Arc::new(Mutex::new(None));
+        let mut messages = read_messages("sess-x".to_string(), arriving, Arc::clone(&unwinding))
+            .expect("start a reader");
+
+        let line = serde_json::to_string(&WorkerMessage::RollingBack {
+            id: 7,
+            within_ms: 90_000,
+        })
+        .expect("encode a milestone");
+        writeln!(worker, "{line}").expect("write it as a worker would");
+
+        let dispatched = tokio::time::timeout(Duration::from_secs(10), messages.recv())
+            .await
+            .expect("the milestone reached the dispatcher within 10s");
+        assert!(matches!(
+            dispatched,
+            Some(WorkerMessage::RollingBack { id: 7, .. })
+        ));
+        assert_eq!(
+            *unwinding.lock().unwrap(),
+            Some(Duration::from_millis(90_000)),
+            "the milestone was dispatched without having been recorded, so a teardown reading it \
+             on a deadline could miss one that had already arrived"
+        );
     }
 
     /// The gap `admit` exists to close: a worker that finishes its handshake after the client has

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -102,6 +102,16 @@ fn unwind_slice(within: Duration, left: Duration) -> Duration {
     within.min(left).min(UNWIND_RECHECK)
 }
 
+/// The last wait a teardown owes once the transaction it was waiting on has ended: the ordinary
+/// grace, for the release that could not start until now.
+///
+/// `None` when there was no transaction — an ordinary teardown is not lengthened by a mechanism it
+/// never used — and none when the teardown's own patience is spent, so the total stays bounded by
+/// what [`Sessions::call_as`] started with.
+fn release_handoff(base: Duration, left: Duration, unwound: bool) -> Option<Duration> {
+    (unwound && !left.is_zero()).then(|| base.min(left))
+}
+
 /// `CREATE_NEW_PROCESS_GROUP`, which every worker is spawned with.
 ///
 /// An interactive Ctrl+C is delivered to *every* process attached to the console, and a child
@@ -877,12 +887,28 @@ impl Sessions {
         // neither.
         if wait == Wait::UntilUnwound {
             let mut left = self.call_timeout;
+            let mut unwound = false;
             while let Some(within) = session.unwinding_for().filter(|_| !left.is_zero()) {
+                unwound = true;
                 let slice = unwind_slice(within, left);
                 if let Ok(reply) = tokio::time::timeout(slice, &mut rx).await {
                     return settled(reply);
                 }
                 left -= slice;
+            }
+            // The transaction is over — it either said so or ran out the bound it promised — and
+            // the release has not started until this moment, because it was queued behind it. So
+            // it gets the grace it would have had if there had been no transaction at all, rather
+            // than whatever the batch happened to leave over.
+            //
+            // A guarantee, where the worker's own retraction is only an optimisation: that message
+            // is emitted as the batch ends, so a batch that runs to its bound emits it at the very
+            // instant this loop stops looking. Resting on it arriving first would be resting on
+            // pipe scheduling, and losing costs a worker killed as its release begins.
+            if let Some(handoff) = release_handoff(budget, left, unwound)
+                && let Ok(reply) = tokio::time::timeout(handoff, &mut rx).await
+            {
+                return settled(reply);
             }
         }
         // A timeout is an operational outcome, not broken plumbing: the target may simply still be
@@ -2810,6 +2836,30 @@ mod tests {
         assert_eq!(unwind_slice(sliver, cap), sliver);
         // And the teardown's own patience bounds it, whatever the worker says.
         assert_eq!(unwind_slice(Duration::from_secs(110), sliver), sliver);
+    }
+
+    /// A release that could not start until the transaction ended gets the ordinary grace from
+    /// *that* moment, rather than whatever the batch happened to leave over.
+    ///
+    /// The worker retracts its promise as the batch ends, which usually arrives first and makes
+    /// this moot — but a batch that runs to the bound it advertised emits that retraction at the
+    /// very instant the wait above stops looking for one. Resting on it winning that race would be
+    /// resting on pipe scheduling, and losing means a worker killed as its release begins, which
+    /// for a live kernel is the halted target this whole path exists to avoid.
+    #[test]
+    fn a_release_that_waited_for_a_transaction_still_gets_its_own_grace() {
+        let base = SHUTDOWN_RELEASE_TIMEOUT;
+        let plenty = Duration::from_secs(300);
+        assert_eq!(release_handoff(base, plenty, true), Some(base));
+
+        // A teardown that never waited on a transaction is not lengthened by a mechanism it never
+        // used: this is what keeps an ordinary disconnect costing what it always did.
+        assert_eq!(release_handoff(base, plenty, false), None);
+
+        // And the teardown's own patience still bounds the total.
+        let sliver = base / 4;
+        assert_eq!(release_handoff(base, sliver, true), Some(sliver));
+        assert_eq!(release_handoff(base, Duration::ZERO, true), None);
     }
 
     /// A session that has said nothing about a transaction is never waited on for one — which is

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -337,7 +337,12 @@ pub struct Session {
     /// the runtime had not yet got round to dispatching the message would be the exact outcome the
     /// message exists to prevent. Recorded on arrival, "the worker said so in time" means what it
     /// says — it cannot turn on how busy this process was.
-    unwinding: Arc<Mutex<Option<Duration>>>,
+    ///
+    /// Held as the **instant the batch must be done by**, not as the interval the worker named. The
+    /// interval was measured when the milestone was sent and only ever shrinks after it, so reading
+    /// it later as though it were still owed would hand a teardown the whole of a batch budget that
+    /// had already been spent. A worker that finishes early retracts it by naming zero.
+    unwinding: Arc<Mutex<Option<Instant>>>,
     child: Mutex<Option<Child>>,
 }
 
@@ -423,13 +428,16 @@ impl Session {
             )
     }
 
-    /// How long the worker says the transaction it is unwinding still needs, if it has said.
+    /// How much longer the worker's transaction may still need, from *now* — `None` when it has
+    /// said nothing, and `None` again once the time it named has run out or it has said it is done.
     ///
     /// Read by the teardown that provoked it, after its own grace has run out — see
     /// [`Sessions::release`]. Nothing else consults it, and a session that never ran a batch never
     /// sets it, so an ordinary teardown neither reads nor pays for anything here.
     fn unwinding_for(&self) -> Option<Duration> {
-        *self.unwinding.lock().unwrap_or_else(|e| e.into_inner())
+        let by = (*self.unwinding.lock().unwrap_or_else(|e| e.into_inner()))?;
+        let left = by.saturating_duration_since(Instant::now());
+        (!left.is_zero()).then_some(left)
     }
 
     /// Answers every outstanding call with `why`. Used when the worker dies or is killed: those
@@ -1381,7 +1389,7 @@ impl Sessions {
         tokio::spawn(log_stray_output(id.to_string(), stdout));
         // Created before the thread that records into it, and handed to the session below: see
         // [`Session::unwinding`] for why it is written there rather than in `reader`.
-        let unwinding: Arc<Mutex<Option<Duration>>> = Arc::new(Mutex::new(None));
+        let unwinding: Arc<Mutex<Option<Instant>>> = Arc::new(Mutex::new(None));
         let mut messages =
             match read_messages(id.to_string(), channel.messages, Arc::clone(&unwinding)) {
                 Ok(messages) => messages,
@@ -1798,7 +1806,7 @@ fn spawn_worker(exe: &Path) -> std::io::Result<(Child, Channel)> {
 fn read_messages(
     id: String,
     pipe: PipeReader,
-    unwinding: Arc<Mutex<Option<Duration>>>,
+    unwinding: Arc<Mutex<Option<Instant>>>,
 ) -> std::io::Result<mpsc::UnboundedReceiver<WorkerMessage>> {
     let (tx, rx) = mpsc::unbounded_channel();
     std::thread::Builder::new()
@@ -1814,9 +1822,12 @@ fn read_messages(
                         // Recorded here, before the message is handed on, because a teardown reads
                         // it against a deadline — see [`Session::unwinding`]. Everything this
                         // message is *reported* as still happens in `reader`.
+                        // Turned into a deadline here, at the one moment the interval the worker
+                        // named is current. A later zero retracts it — that is a worker saying its
+                        // transaction is done and only the release is left.
                         if let WorkerMessage::RollingBack { within_ms, .. } = &message {
                             *unwinding.lock().unwrap_or_else(|e| e.into_inner()) =
-                                Some(Duration::from_millis(u64::from(*within_ms)));
+                                Some(Instant::now() + Duration::from_millis(u64::from(*within_ms)));
                         }
                         if tx.send(message).is_err() {
                             break; // nobody is left to route it to
@@ -2801,6 +2812,40 @@ mod tests {
         assert_eq!(idle.unwinding_for(), None);
     }
 
+    /// What the worker promised is owed *until the moment it named*, and not a second longer.
+    ///
+    /// The interval it sends is measured when the teardown reaches it, and only ever shrinks after
+    /// that. Read later as though it were still owed in full — which is what storing the interval
+    /// rather than the deadline would do — a teardown whose release then hangs would wait out the
+    /// remains of a batch budget that was spent long ago: minutes, with the defaults, for a
+    /// transaction already unwound. The same reading is what makes a worker's retraction work: it
+    /// names zero, and zero is instantly in the past.
+    #[test]
+    fn a_promise_that_has_run_out_buys_no_more_time() {
+        let session = dormant("sess-1", SessionState::Open);
+        let set = |deadline| *session.unwinding.lock().unwrap() = Some(deadline);
+
+        set(Instant::now() + Duration::from_secs(30));
+        let left = session
+            .unwinding_for()
+            .expect("a live promise is still owed");
+        assert!(
+            left > Duration::from_secs(25) && left <= Duration::from_secs(30),
+            "owed the time remaining, not {left:?}"
+        );
+
+        // Spent, and so worth nothing — the batch's own deadline has passed.
+        set(Instant::now()
+            .checked_sub(Duration::from_secs(1))
+            .unwrap_or_else(Instant::now));
+        assert_eq!(session.unwinding_for(), None);
+
+        // The retraction a worker sends when its batch finishes early: `within_ms: 0`, recorded as
+        // a deadline of now, and read as nothing left to wait for.
+        set(Instant::now());
+        assert_eq!(session.unwinding_for(), None);
+    }
+
     /// A rollback milestone is recorded by the thread that **reads** it, before it is handed on to
     /// be dispatched at all.
     ///
@@ -2813,7 +2858,7 @@ mod tests {
     #[tokio::test]
     async fn a_rollback_milestone_is_recorded_where_it_arrives() {
         let (arriving, mut worker) = std::io::pipe().expect("a pipe to stand in for a worker's");
-        let unwinding: Arc<Mutex<Option<Duration>>> = Arc::new(Mutex::new(None));
+        let unwinding: Arc<Mutex<Option<Instant>>> = Arc::new(Mutex::new(None));
         let mut messages = read_messages("sess-x".to_string(), arriving, Arc::clone(&unwinding))
             .expect("start a reader");
 
@@ -2831,11 +2876,31 @@ mod tests {
             dispatched,
             Some(WorkerMessage::RollingBack { id: 7, .. })
         ));
-        assert_eq!(
-            *unwinding.lock().unwrap(),
-            Some(Duration::from_millis(90_000)),
-            "the milestone was dispatched without having been recorded, so a teardown reading it \
-             on a deadline could miss one that had already arrived"
+        let by = unwinding.lock().unwrap().expect(
+            "the milestone was dispatched without having been recorded, so a teardown \
+                     reading it on a deadline could miss one that had already arrived",
+        );
+        let left = by.saturating_duration_since(Instant::now());
+        assert!(
+            left > Duration::from_secs(85) && left <= Duration::from_secs(90),
+            "recorded as a deadline 90s out, not {left:?}"
+        );
+
+        // And a zero retracts it: a worker whose transaction finished has nothing left to be
+        // waited for, however long it said it might need when it was told to stop.
+        let done = serde_json::to_string(&WorkerMessage::RollingBack {
+            id: 7,
+            within_ms: 0,
+        })
+        .expect("encode the retraction");
+        writeln!(worker, "{done}").expect("write it as a worker would");
+        tokio::time::timeout(Duration::from_secs(10), messages.recv())
+            .await
+            .expect("the retraction reached the dispatcher within 10s");
+        let by = unwinding.lock().unwrap().expect("still recorded");
+        assert!(
+            by <= Instant::now(),
+            "a finished transaction must not go on being waited for"
         );
     }
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -2840,8 +2840,7 @@ mod tests {
             .unwrap_or_else(Instant::now));
         assert_eq!(session.unwinding_for(), None);
 
-        // The retraction a worker sends when its batch finishes early: `within_ms: 0`, recorded as
-        // a deadline of now, and read as nothing left to wait for.
+        // The boundary itself: a deadline of exactly now is spent, not owed.
         set(Instant::now());
         assert_eq!(session.unwinding_for(), None);
     }
@@ -2886,11 +2885,12 @@ mod tests {
             "recorded as a deadline 90s out, not {left:?}"
         );
 
-        // And a zero retracts it: a worker whose transaction finished has nothing left to be
-        // waited for, however long it said it might need when it was told to stop.
+        // A later, smaller figure *retracts* it: a worker whose transaction has finished says so
+        // by naming only what the release still needs, however long it said it might need when it
+        // was told to stop. The last word wins, in both directions.
         let done = serde_json::to_string(&WorkerMessage::RollingBack {
             id: 7,
-            within_ms: 0,
+            within_ms: 5_000,
         })
         .expect("encode the retraction");
         writeln!(worker, "{done}").expect("write it as a worker would");
@@ -2898,9 +2898,15 @@ mod tests {
             .await
             .expect("the retraction reached the dispatcher within 10s");
         let by = unwinding.lock().unwrap().expect("still recorded");
+        let left = by.saturating_duration_since(Instant::now());
         assert!(
-            by <= Instant::now(),
-            "a finished transaction must not go on being waited for"
+            left <= Duration::from_secs(5),
+            "a finished transaction must not go on being waited out for the rest of its budget, \
+             and {left:?} is still most of it"
+        );
+        assert!(
+            !left.is_zero(),
+            "but the release it was holding up has not run yet, so it keeps its own moment"
         );
     }
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -81,25 +81,25 @@ const END_SESSION_TIMEOUT: Duration = Duration::from_secs(20);
 /// rather than the cost per session.
 const SHUTDOWN_RELEASE_TIMEOUT: Duration = Duration::from_secs(5);
 
-/// How much longer a teardown waits after its grace expires, when the worker has said it is
-/// unwinding a transaction and how long that still needs.
+/// How long a teardown commits to before looking at the worker's promise again.
 ///
-/// **Not a number chosen to look generous.** `within` is the batch's own remaining budget, measured
-/// by the process running it, and it covers the step in flight as well as the rollback — a batch is
-/// told to stop at its *next* step, so an extension sized for the rollback alone expires mid-step
-/// and terminates the worker with the patch still applied, which is the failure this whole path
-/// exists to remove.
+/// A promise can be **revised downwards**: a batch that finishes early retracts its bound to what
+/// the release still needs. A wait that committed to the whole of it in one `timeout` could not see
+/// that — the retraction would update a value nobody reads again, and a disconnect would sit out the
+/// rest of a batch budget with no transaction left to protect. So no single wait is longer than
+/// this, and the promise is re-read between them.
 ///
-/// That it is an *extension*, taken only after the ordinary grace has run out and only for a
-/// session that asked, is what keeps it affordable: a disconnect stays quick for the case the grace
-/// was tuned for — a parked kernel attach that will never unwind, where every extra second is spent
-/// for nothing.
-///
-/// `cap` bounds what the claim can cost. A batch's budget is already clamped to the caller's
-/// patience, so an honest worker never reaches it; it is here because a teardown must not be able
-/// to wait indefinitely on a number that arrives over a pipe.
-fn unwind_extension(within: Duration, cap: Duration) -> Duration {
-    within.min(cap)
+/// A second is chosen against what it competes with: the shortest grace it can follow is five
+/// seconds, and the thing being waited for takes seconds at least, so a re-read this often is
+/// invisible — while the wakeups it costs, on a path that runs once per session teardown, are not
+/// worth avoiding with machinery that would have to be woken from a thread with no runtime of its
+/// own.
+const UNWIND_RECHECK: Duration = Duration::from_secs(1);
+
+/// How long to wait before looking again, given what the worker last promised and how much of the
+/// teardown's total patience is left.
+fn unwind_slice(within: Duration, left: Duration) -> Duration {
+    within.min(left).min(UNWIND_RECHECK)
 }
 
 /// `CREATE_NEW_PROCESS_GROUP`, which every worker is spawned with.
@@ -870,15 +870,20 @@ impl Sessions {
         if let Ok(reply) = tokio::time::timeout(budget, &mut rx).await {
             return settled(reply);
         }
-        // The budget is spent. A teardown gets one extension, and only because the worker asked
-        // for it: `RollingBack` says a transaction is unwinding and how long it still needs, and
-        // it arrived while this very wait was running. See [`unwind_extension`].
-        if wait == Wait::UntilUnwound
-            && let Some(within) = session.unwinding_for()
-            && let Ok(reply) =
-                tokio::time::timeout(unwind_extension(within, self.call_timeout), &mut rx).await
-        {
-            return settled(reply);
+        // The budget is spent. A teardown keeps waiting only while the worker keeps saying it is
+        // unwinding a transaction — and it asks again every time it looks, because the answer
+        // moves in both directions: the batch may finish early and hand the rest back, or run on
+        // to the bound it promised. Committing to one extension read at this instant would honour
+        // neither.
+        if wait == Wait::UntilUnwound {
+            let mut left = self.call_timeout;
+            while let Some(within) = session.unwinding_for().filter(|_| !left.is_zero()) {
+                let slice = unwind_slice(within, left);
+                if let Ok(reply) = tokio::time::timeout(slice, &mut rx).await {
+                    return settled(reply);
+                }
+                left -= slice;
+            }
         }
         // A timeout is an operational outcome, not broken plumbing: the target may simply still be
         // running. Note the job itself is *not* cancelled — only this wait for it.
@@ -2784,23 +2789,27 @@ mod tests {
         );
     }
 
-    /// A teardown's extension is what its worker asked for, and no more.
+    /// A teardown never commits to more than one recheck at a time, however long the worker says
+    /// it needs — because the answer can be revised *downwards*.
     ///
-    /// The cap is the half worth pinning: a batch's budget is clamped to the caller's patience, so
-    /// an honest worker never reaches it, and it is here only so a teardown cannot be made to wait
-    /// for ever by a number that arrived over a pipe.
+    /// A batch that finishes early retracts its bound to what the release still needs, and a wait
+    /// that had already committed to the original figure could not see it: a disconnect would sit
+    /// out the rest of a batch budget with no transaction left to protect. The cap is the other
+    /// half — a teardown cannot be made to wait for ever by a number arriving over a pipe.
     #[test]
-    fn a_teardown_waits_for_what_its_worker_asks_and_never_past_the_cap() {
+    fn a_teardown_never_commits_to_more_than_one_recheck() {
         let cap = Duration::from_secs(300);
-        // A step that may still run for a minute is a minute this teardown waits. An extension
-        // sized for the rollback alone would expire inside that step, which is the failure the
-        // whole signal exists to remove.
-        let step_plus_rollback = Duration::from_secs(60);
+        // Minutes promised, but only ever a recheck at a time.
+        assert_eq!(unwind_slice(Duration::from_secs(110), cap), UNWIND_RECHECK);
         assert_eq!(
-            unwind_extension(step_plus_rollback, cap),
-            step_plus_rollback
+            unwind_slice(Duration::from_secs(86_400), cap),
+            UNWIND_RECHECK
         );
-        assert_eq!(unwind_extension(Duration::from_secs(86_400), cap), cap);
+        // Less than a recheck left to promise: wait exactly that, then look again.
+        let sliver = UNWIND_RECHECK / 4;
+        assert_eq!(unwind_slice(sliver, cap), sliver);
+        // And the teardown's own patience bounds it, whatever the worker says.
+        assert_eq!(unwind_slice(Duration::from_secs(110), sliver), sliver);
     }
 
     /// A session that has said nothing about a transaction is never waited on for one — which is

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -90,22 +90,27 @@ const SHUTDOWN_RELEASE_TIMEOUT: Duration = Duration::from_secs(5);
 /// manage that in two seconds is not going to roll anything back either.
 const ABANDON_ACK_TIMEOUT: Duration = Duration::from_secs(2);
 
-/// The grace a teardown gives a session, given whether its worker said a batch is rolling back.
+/// The grace a teardown gives a session: the ordinary `base`, plus however long the worker said a
+/// batch it is unwinding still needs.
 ///
-/// The extra is [`crate::batch::ROLLBACK_RESERVE`] and not a number chosen to look generous: that
-/// reserve is the most an `always` block can ever be given, and an abandoned batch holds its
-/// rollback to exactly it, so this is "as long as the rollback can possibly need" rather than a
-/// guess that will drift when the reserve changes.
+/// **Not a number chosen to look generous.** `unwinding` is the batch's own remaining budget,
+/// measured by the process running it, and it covers the step in flight as well as the rollback —
+/// the signal stops a batch at its *next* step, so a grace sized for the rollback alone expires
+/// mid-step and terminates the worker with the patch still applied, which is the failure this
+/// whole path exists to remove.
 ///
-/// The conditional is the point. A disconnect must stay quick for the case it was tuned for — a
-/// parked kernel attach that will never unwind, where every extra second is spent for nothing — so
-/// the longer wait is spent only where a worker has said, in the same round trip, that there is
-/// something to wait for.
-fn release_grace(base: Duration, rolling_back: bool) -> Duration {
-    if rolling_back {
-        base + crate::batch::ROLLBACK_RESERVE
-    } else {
-        base
+/// The conditional is what keeps that affordable. A disconnect must stay quick for the case it was
+/// tuned for — a parked kernel attach that will never unwind, where every extra second is spent for
+/// nothing — so the longer wait is spent only where a worker has said, in the same round trip, that
+/// there is something to wait for and how long it will take.
+///
+/// `cap` bounds what that claim can cost. A batch's budget is already clamped to the caller's
+/// patience, so an honest worker never reaches it; it is here because a teardown must not be able
+/// to wait indefinitely on a number that arrives over a pipe.
+fn release_grace(base: Duration, unwinding: Option<Duration>, cap: Duration) -> Duration {
+    match unwinding {
+        Some(within) => base + within.min(cap),
+        None => base,
     }
 }
 
@@ -334,10 +339,10 @@ pub struct Session {
     /// from the worker having crashed. This is what tells those two apart, and the difference is
     /// "the target was let go" versus "a live kernel may be sitting halted".
     released: AtomicBool,
-    /// Whether this session's worker reported a transactional batch rolling back in answer to
-    /// [`EngineOp::AbandonBatch`]. Read by the teardown that asked, to decide how long to hold the
-    /// door open; see [`release_grace`].
-    rolling_back: AtomicBool,
+    /// How long this session's worker said a transactional batch still needs, in answer to
+    /// [`EngineOp::AbandonBatch`] — `None` when it had none to abandon. Read by the teardown that
+    /// asked, to decide how long to hold the door open; see [`release_grace`].
+    rolling_back: Mutex<Option<Duration>>,
     child: Mutex<Option<Child>>,
 }
 
@@ -982,6 +987,7 @@ impl Sessions {
             END_SESSION_TIMEOUT,
             self.abandon_batch(session, Call::new(EngineOp::AbandonBatch).named(named))
                 .await,
+            self.call_timeout,
         );
         let call = Call::new(EngineOp::EndSession).named(named);
         let (reason, message) = match self.release(session, call, grace).await {
@@ -1053,16 +1059,19 @@ impl Sessions {
     /// is nothing running to abandon, so the round trip would buy nothing. Best-effort by
     /// construction: a signal that is refused, times out, or finds nothing simply leaves the
     /// ordinary grace in place, and the teardown proceeds exactly as it did before.
-    async fn abandon_batch(&self, session: &Arc<Session>, call: Call) -> bool {
+    async fn abandon_batch(&self, session: &Arc<Session>, call: Call) -> Option<Duration> {
         if !session.awaiting_reply() {
-            return false;
+            return None;
         }
         // The answer is not read from here: the worker reports it as a `RollingBack` milestone,
         // which travels ahead of this call's reply on the same ordered channel, so by the time this
         // returns the flag is set. Reading it off the reply text instead would be the same fact
         // arriving twice, in a form that has to be parsed back.
         let _ = self.call_within(session, call, ABANDON_ACK_TIMEOUT).await;
-        session.rolling_back.load(Ordering::SeqCst)
+        *session
+            .rolling_back
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
     }
 
     /// Asks a worker to release its target and then terminates it, without deciding *why* the
@@ -1139,6 +1148,7 @@ impl Sessions {
                     sessions
                         .abandon_batch(&session, Call::supervisor(EngineOp::AbandonBatch))
                         .await,
+                    sessions.call_timeout,
                 );
                 if grace != SHUTDOWN_RELEASE_TIMEOUT {
                     tracing::info!(
@@ -1426,7 +1436,7 @@ impl Sessions {
             delivered: AtomicBool::new(false),
             phase: AtomicU8::new(OpenPhase::Started as u8),
             released: AtomicBool::new(false),
-            rolling_back: AtomicBool::new(false),
+            rolling_back: Mutex::new(None),
             child: Mutex::new(Some(child)),
         });
 
@@ -2013,10 +2023,14 @@ async fn reader(
             // exists for, and it is the channel's ordering that provides it, not luck: messages
             // are read and handled in the order the worker wrote them, so the teardown waiting on
             // that `Done` cannot wake up before this store.
-            WorkerMessage::RollingBack { id } => {
-                session.rolling_back.store(true, Ordering::SeqCst);
+            WorkerMessage::RollingBack { id, within_ms } => {
+                let within = Duration::from_millis(u64::from(within_ms));
+                *session
+                    .rolling_back
+                    .lock()
+                    .unwrap_or_else(|e| e.into_inner()) = Some(within);
                 tracing::info!(
-                    "session {}: job {id} found a transaction in flight and told it to roll back",
+                    "session {}: job {id} found a transaction in flight and told it to roll back;                      it needs up to {within:?}",
                     session.id
                 );
             }
@@ -2387,7 +2401,7 @@ mod tests {
             delivered: AtomicBool::new(true),
             phase: AtomicU8::new(phase as u8),
             released: AtomicBool::new(false),
-            rolling_back: AtomicBool::new(false),
+            rolling_back: Mutex::new(None),
             child: Mutex::new(None),
         })
     }
@@ -2744,29 +2758,42 @@ mod tests {
     }
 
     /// The grace a teardown gives is the ordinary one unless a worker has said it is unwinding a
-    /// transaction — and then it is long enough for the whole rollback.
+    /// transaction — and then it covers everything that worker said it still needs.
     ///
     /// Both halves matter, and the first is the one that is easy to lose: lengthening the wait for
     /// every session would spend it on the case it was tuned against, a parked kernel attach that
-    /// will never let go however long anyone waits.
+    /// will never let go however long anyone waits. The second is why the figure comes from the
+    /// worker rather than from a constant here — what a teardown is waiting out is the step in
+    /// flight and then the rollback, and only the worker knows how long the step may still take.
     #[test]
-    fn only_a_session_that_is_rolling_back_gets_the_longer_grace() {
+    fn a_teardown_waits_only_for_what_its_worker_says_it_needs() {
+        let cap = Duration::from_secs(300);
+        for base in [SHUTDOWN_RELEASE_TIMEOUT, END_SESSION_TIMEOUT] {
+            assert_eq!(
+                release_grace(base, None, cap),
+                base,
+                "a session with nothing to unwind must cost exactly what it always did"
+            );
+            // A step that may still run for a minute is a minute this teardown waits, on top of
+            // the release behind it. A grace sized for the rollback alone would expire inside that
+            // step, which is the failure the whole signal exists to remove.
+            let step_plus_rollback = Duration::from_secs(60);
+            assert_eq!(
+                release_grace(base, Some(step_plus_rollback), cap),
+                base + step_plus_rollback
+            );
+        }
+        // The claim is bounded. A batch's budget is clamped to the caller's patience, so an honest
+        // worker never reaches this — it is here so a teardown cannot be made to wait for ever by
+        // a number arriving over a pipe.
         assert_eq!(
-            release_grace(SHUTDOWN_RELEASE_TIMEOUT, false),
-            SHUTDOWN_RELEASE_TIMEOUT,
-            "an ordinary disconnect must cost exactly what it always did"
+            release_grace(
+                SHUTDOWN_RELEASE_TIMEOUT,
+                Some(Duration::from_secs(86_400)),
+                cap
+            ),
+            SHUTDOWN_RELEASE_TIMEOUT + cap
         );
-        assert!(
-            release_grace(SHUTDOWN_RELEASE_TIMEOUT, true)
-                >= SHUTDOWN_RELEASE_TIMEOUT + crate::batch::ROLLBACK_RESERVE,
-            "a rollback gets the reserve it is allowed to spend, plus the release behind it"
-        );
-        // The same rule for the explicit end, where the base is longer to begin with.
-        assert_eq!(
-            release_grace(END_SESSION_TIMEOUT, false),
-            END_SESSION_TIMEOUT
-        );
-        assert!(release_grace(END_SESSION_TIMEOUT, true) > END_SESSION_TIMEOUT);
     }
 
     /// A teardown asks about a batch only when the worker owes a reply, which is what keeps the
@@ -2786,7 +2813,10 @@ mod tests {
         )
         .await
         .expect("asking an idle session must not wait on anything");
-        assert!(!asked, "nothing is running, so nothing is rolling back");
+        assert_eq!(
+            asked, None,
+            "nothing is running, so nothing is rolling back"
+        );
     }
 
     /// The gap `admit` exists to close: a worker that finishes its handshake after the client has

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1874,9 +1874,20 @@ fn read_messages(
                         // Turned into a deadline here, at the one moment the interval the worker
                         // named is current. A later zero retracts it — that is a worker saying its
                         // transaction is done and only the release is left.
+                        //
+                        // Kept **only if it is earlier**, which is what makes the order these
+                        // arrive in stop mattering. A worker's promise never grows: the bound is
+                        // fixed when the batch is claimed, and the one other thing it can say is
+                        // the moment that batch ended. But the two are emitted from different
+                        // threads — the promise by the worker's request reader, the retraction by
+                        // its engine thread — so a teardown landing exactly as a batch exits can
+                        // put them on the wire in either order. Taking the earlier means a stale
+                        // promise cannot undo a retraction that beat it here.
                         if let WorkerMessage::RollingBack { within_ms, .. } = &message {
-                            *unwinding.lock().unwrap_or_else(|e| e.into_inner()) =
-                                Some(Instant::now() + Duration::from_millis(u64::from(*within_ms)));
+                            let named =
+                                Instant::now() + Duration::from_millis(u64::from(*within_ms));
+                            let mut slot = unwinding.lock().unwrap_or_else(|e| e.into_inner());
+                            *slot = Some(slot.map_or(named, |had| had.min(named)));
                         }
                         if tx.send(message).is_err() {
                             break; // nobody is left to route it to
@@ -2991,6 +3002,27 @@ mod tests {
         assert!(
             by <= Instant::now(),
             "a finished transaction must not go on being waited out for the rest of its budget"
+        );
+
+        // And a promise that arrives *after* its own retraction cannot undo it. The two are
+        // emitted from different threads inside the worker — the promise by its request reader,
+        // the retraction by its engine thread — so a teardown landing exactly as a batch exits can
+        // put them on the wire in either order. Only the earlier deadline counts, so the order
+        // stops mattering.
+        let stale = serde_json::to_string(&WorkerMessage::RollingBack {
+            id: 7,
+            within_ms: 90_000,
+        })
+        .expect("encode a stale promise");
+        writeln!(worker, "{stale}").expect("write it as a worker would");
+        tokio::time::timeout(Duration::from_secs(10), messages.recv())
+            .await
+            .expect("the stale promise reached the dispatcher within 10s");
+        assert_eq!(
+            *unwinding.lock().unwrap(),
+            Some(by),
+            "a promise overtaken by its own retraction would have a teardown wait out a batch \
+             budget that is already spent"
         );
     }
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -81,37 +81,25 @@ const END_SESSION_TIMEOUT: Duration = Duration::from_secs(20);
 /// rather than the cost per session.
 const SHUTDOWN_RELEASE_TIMEOUT: Duration = Duration::from_secs(5);
 
-/// How long to wait for a worker to acknowledge [`EngineOp::AbandonBatch`] before giving up on the
-/// answer and tearing down on the ordinary grace.
+/// How much longer a teardown waits after its grace expires, when the worker has said it is
+/// unwinding a transaction and how long that still needs.
 ///
-/// Short because it measures the worker's *reader*, not its engine: the signal is answered where it
-/// is read, so nothing a debug session can do — a runaway command, a kernel wait that will never
-/// return — is in the way. What is left is process scheduling and a pipe. A worker that cannot
-/// manage that in two seconds is not going to roll anything back either.
-const ABANDON_ACK_TIMEOUT: Duration = Duration::from_secs(2);
-
-/// The grace a teardown gives a session: the ordinary `base`, plus however long the worker said a
-/// batch it is unwinding still needs.
+/// **Not a number chosen to look generous.** `within` is the batch's own remaining budget, measured
+/// by the process running it, and it covers the step in flight as well as the rollback — a batch is
+/// told to stop at its *next* step, so an extension sized for the rollback alone expires mid-step
+/// and terminates the worker with the patch still applied, which is the failure this whole path
+/// exists to remove.
 ///
-/// **Not a number chosen to look generous.** `unwinding` is the batch's own remaining budget,
-/// measured by the process running it, and it covers the step in flight as well as the rollback —
-/// the signal stops a batch at its *next* step, so a grace sized for the rollback alone expires
-/// mid-step and terminates the worker with the patch still applied, which is the failure this
-/// whole path exists to remove.
+/// That it is an *extension*, taken only after the ordinary grace has run out and only for a
+/// session that asked, is what keeps it affordable: a disconnect stays quick for the case the grace
+/// was tuned for — a parked kernel attach that will never unwind, where every extra second is spent
+/// for nothing.
 ///
-/// The conditional is what keeps that affordable. A disconnect must stay quick for the case it was
-/// tuned for — a parked kernel attach that will never unwind, where every extra second is spent for
-/// nothing — so the longer wait is spent only where a worker has said, in the same round trip, that
-/// there is something to wait for and how long it will take.
-///
-/// `cap` bounds what that claim can cost. A batch's budget is already clamped to the caller's
+/// `cap` bounds what the claim can cost. A batch's budget is already clamped to the caller's
 /// patience, so an honest worker never reaches it; it is here because a teardown must not be able
 /// to wait indefinitely on a number that arrives over a pipe.
-fn release_grace(base: Duration, unwinding: Option<Duration>, cap: Duration) -> Duration {
-    match unwinding {
-        Some(within) => base + within.min(cap),
-        None => base,
-    }
+fn unwind_extension(within: Duration, cap: Duration) -> Duration {
+    within.min(cap)
 }
 
 /// `CREATE_NEW_PROCESS_GROUP`, which every worker is spawned with.
@@ -339,10 +327,10 @@ pub struct Session {
     /// from the worker having crashed. This is what tells those two apart, and the difference is
     /// "the target was let go" versus "a live kernel may be sitting halted".
     released: AtomicBool,
-    /// How long this session's worker said a transactional batch still needs, in answer to
-    /// [`EngineOp::AbandonBatch`] — `None` when it had none to abandon. Read by the teardown that
-    /// asked, to decide how long to hold the door open; see [`release_grace`].
-    rolling_back: Mutex<Option<Duration>>,
+    /// How long this session's worker said a transaction it was told to unwind still needs, or
+    /// `None` while it has said nothing. Set from [`WorkerMessage::RollingBack`] and read by the
+    /// teardown whose own request provoked it; see [`Sessions::release`].
+    unwinding: Mutex<Option<Duration>>,
     child: Mutex<Option<Child>>,
 }
 
@@ -428,19 +416,13 @@ impl Session {
             )
     }
 
-    /// Whether the worker owes a reply to anything at all.
+    /// How long the worker says the transaction it is unwinding still needs, if it has said.
     ///
-    /// Narrower than [`Self::busy`], which also answers for a session nobody has been told about
-    /// yet. This is the precise question a teardown asks before signalling: a batch can only be in
-    /// flight if some call is outstanding, because the waiter is registered before the job is
-    /// queued and removed only when the worker answers. So an empty map means there is nothing to
-    /// abandon and the signal can be skipped — which is every ordinary disconnect.
-    fn awaiting_reply(&self) -> bool {
-        !self
-            .waiters
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
-            .is_empty()
+    /// Read by the teardown that provoked it, after its own grace has run out — see
+    /// [`Sessions::release`]. Nothing else consults it, and a session that never ran a batch never
+    /// sets it, so an ordinary teardown neither reads nor pays for anything here.
+    fn unwinding_for(&self) -> Option<Duration> {
+        *self.unwinding.lock().unwrap_or_else(|e| e.into_inner())
     }
 
     /// Answers every outstanding call with `why`. Used when the worker dies or is killed: those
@@ -518,6 +500,17 @@ impl Gate {
             On::Supervisor => true,
         }
     }
+}
+
+/// How a caller's wait answers a worker that says it needs longer.
+///
+/// Only a teardown accepts more time, and only because it is the only wait a worker can ask to
+/// extend: [`WorkerMessage::RollingBack`] is sent when an [`EngineOp::EndSession`] finds a
+/// transaction to unwind. Every other call keeps the budget it was given.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Wait {
+    Fixed,
+    UntilUnwound,
 }
 
 /// A call to run against a session.
@@ -631,9 +624,10 @@ impl Drop for Slot {
 enum Release {
     /// It released the target and said so.
     Released(String),
-    /// It never answered inside [`END_SESSION_TIMEOUT`] and was killed. The case this whole
-    /// design is for.
-    Parked,
+    /// It never answered inside the grace it was given — which is [`END_SESSION_TIMEOUT`] or
+    /// [`SHUTDOWN_RELEASE_TIMEOUT`], plus any extension the worker asked for to unwind a
+    /// transaction — and was killed. The case this whole design is for.
+    Parked { waited: Duration },
     /// It had already exited.
     AlreadyGone,
     /// The engine reported an error releasing the target. The worker was killed anyway.
@@ -806,17 +800,18 @@ impl Sessions {
         budget: Duration,
     ) -> Result<String, EngineError> {
         let id = session.next_id.fetch_add(1, Ordering::Relaxed);
-        self.call_as(session, call, budget, id).await
+        self.call_as(session, call, budget, id, Wait::Fixed).await
     }
 
     /// [`Self::call_within`] with the job id chosen by the caller, which only the opener does —
-    /// see [`OPENER_JOB`].
+    /// see [`OPENER_JOB`] — and with how this wait answers a worker that asks for more time.
     async fn call_as(
         &self,
         session: &Arc<Session>,
         call: Call,
         budget: Duration,
         id: u64,
+        wait: Wait,
     ) -> Result<String, EngineError> {
         let (tx, rx) = oneshot::channel();
         // Registered before the job is queued, so the session counts as busy from the moment the
@@ -849,20 +844,35 @@ impl Sessions {
                 .remove(&id);
             return Err(EngineError::Lost(worker_gone(&session.id)));
         }
-        match tokio::time::timeout(budget, rx).await {
-            Ok(Ok(result)) => result,
-            // The sender is dropped only when the worker's reader gives up on it, which it does
-            // by answering first — so this is the residual case, not the normal one.
-            Ok(Err(_)) => Err(EngineError::Lost(worker_gone(&session.id))),
-            // A timeout is an operational outcome, not broken plumbing: the target may simply
-            // still be running. Note the job itself is *not* cancelled — only this wait for it.
-            Err(_) => Err(EngineError::Timeout(format!(
-                "engine call timed out (the target may still be running). The session `{}` is \
-                 still holding this call; `session_status` reports it, and `end_session` ends it \
-                 outright — including by terminating the worker process if it will not unwind.",
-                session.id
-            ))),
+        // Borrowed rather than consumed, so an expired budget can be extended below without losing
+        // the reply that may still be coming.
+        let mut rx = rx;
+        // The sender is dropped only when the worker's reader gives up on it, which it does by
+        // answering first — so `Err` here is the residual case, not the normal one.
+        let settled = |reply: Result<Result<String, EngineError>, oneshot::error::RecvError>| {
+            reply.unwrap_or_else(|_| Err(EngineError::Lost(worker_gone(&session.id))))
+        };
+        if let Ok(reply) = tokio::time::timeout(budget, &mut rx).await {
+            return settled(reply);
         }
+        // The budget is spent. A teardown gets one extension, and only because the worker asked
+        // for it: `RollingBack` says a transaction is unwinding and how long it still needs, and
+        // it arrived while this very wait was running. See [`unwind_extension`].
+        if wait == Wait::UntilUnwound
+            && let Some(within) = session.unwinding_for()
+            && let Ok(reply) =
+                tokio::time::timeout(unwind_extension(within, self.call_timeout), &mut rx).await
+        {
+            return settled(reply);
+        }
+        // A timeout is an operational outcome, not broken plumbing: the target may simply still be
+        // running. Note the job itself is *not* cancelled — only this wait for it.
+        Err(EngineError::Timeout(format!(
+            "engine call timed out (the target may still be running). The session `{}` is still \
+             holding this call; `session_status` reports it, and `end_session` ends it outright — \
+             including by terminating the worker process if it will not unwind.",
+            session.id
+        )))
     }
 
     /// Opens a target in a fresh worker process.
@@ -898,7 +908,13 @@ impl Sessions {
         // On the reserved job id, so `reader` can still recognise this open if the caller's
         // timeout means nobody is left to settle it.
         let out = self
-            .call_as(&session, Call::new(op), self.call_timeout, OPENER_JOB)
+            .call_as(
+                &session,
+                Call::new(op),
+                self.call_timeout,
+                OPENER_JOB,
+                Wait::Fixed,
+            )
             .await;
         let outcome = match out {
             Ok(report) => {
@@ -980,17 +996,8 @@ impl Sessions {
     /// otherwise hold its session forever; killing it is the only thing that ends that wait, and
     /// under process-per-session it costs nothing else.
     pub async fn end(&self, session: &Arc<Session>, named: bool) -> Result<String, EngineError> {
-        // Gated the same way the end itself is, so a caller holding a handle this session will not
-        // honour cannot cut short a transaction they have no claim on. A refusal here needs no
-        // reporting: the `EndSession` below is refused identically and says so properly.
-        let grace = release_grace(
-            END_SESSION_TIMEOUT,
-            self.abandon_batch(session, Call::new(EngineOp::AbandonBatch).named(named))
-                .await,
-            self.call_timeout,
-        );
         let call = Call::new(EngineOp::EndSession).named(named);
-        let (reason, message) = match self.release(session, call, grace).await {
+        let (reason, message) = match self.release(session, call, END_SESSION_TIMEOUT).await {
             // A refused handle is the mechanism working, not a session to tear down.
             Release::Stale(why) => return Err(EngineError::Stale(why)),
             Release::Released(text) => (
@@ -1001,10 +1008,10 @@ impl Sessions {
                     session.id, session.pid
                 ),
             ),
-            Release::Parked => (
-                format!("terminated by end_session after {grace:?} without unwinding"),
+            Release::Parked { waited } => (
+                format!("terminated by end_session after {waited:?} without unwinding"),
                 format!(
-                    "Session `{}` did not release its target within {grace:?}, so \
+                    "Session `{}` did not release its target within {waited:?}, so \
                      its engine worker process (pid {}) was terminated.\n\nThat is the expected \
                      outcome for a session parked in a wait DbgEng cannot be interrupted out of — \
                      a live-kernel attach whose target never connected is the usual one. The \
@@ -1044,44 +1051,37 @@ impl Sessions {
         Ok(message)
     }
 
-    /// Tells a session's worker to abandon any transaction it is running and go to its rollback,
-    /// and reports whether there was one — which is what the teardown that follows sizes its grace
-    /// from ([`release_grace`]).
-    ///
-    /// This exists because of one ordering. A `debug_batch` is one indivisible job, so an
-    /// `EndSession` queues *behind* it; a teardown that only waited would find the batch still
-    /// mid-transaction when its grace expired and kill the worker with the patch still applied —
-    /// on a live kernel, the exact outcome the tool is for. The signal turns that wait into
-    /// something the batch can act on: it stops at its next step and runs `always`, and the
-    /// `EndSession` behind it lands on a target that has been put back.
-    ///
-    /// Skipped entirely when the worker owes no reply, which is every ordinary disconnect — there
-    /// is nothing running to abandon, so the round trip would buy nothing. Best-effort by
-    /// construction: a signal that is refused, times out, or finds nothing simply leaves the
-    /// ordinary grace in place, and the teardown proceeds exactly as it did before.
-    async fn abandon_batch(&self, session: &Arc<Session>, call: Call) -> Option<Duration> {
-        if !session.awaiting_reply() {
-            return None;
-        }
-        // The answer is not read from here: the worker reports it as a `RollingBack` milestone,
-        // which travels ahead of this call's reply on the same ordered channel, so by the time this
-        // returns the flag is set. Reading it off the reply text instead would be the same fact
-        // arriving twice, in a form that has to be parsed back.
-        let _ = self.call_within(session, call, ABANDON_ACK_TIMEOUT).await;
-        *session
-            .rolling_back
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
-    }
-
     /// Asks a worker to release its target and then terminates it, without deciding *why* the
     /// session is closing — `end_session` and reclamation share the teardown but not the reason,
     /// and the reason is what the caller reads afterwards.
+    ///
+    /// The wait is the one that can be extended. A `debug_batch` is one indivisible job, so this
+    /// `EndSession` queues *behind* it — but the worker's reader acts on the request as it reads
+    /// it, telling that batch to stop at its next step and roll back, and answering with how long
+    /// that leaves ([`WorkerMessage::RollingBack`]). So a grace that expires mid-transaction is
+    /// extended by what the worker asked for, instead of killing a worker with the target still
+    /// patched. A session with nothing to unwind never asks, and costs exactly `grace`.
+    ///
+    /// **Why the signal rides on this op rather than one of its own.** Telling a batch to stop is a
+    /// sticky, one-way change to worker state, so it must not be possible for a teardown that does
+    /// not happen. Sent separately it would be: the two requests are gated independently, and a
+    /// target-changing call landing between them retires the session, so the release is refused
+    /// while the abandon has already aborted somebody's transaction and left a flag no later batch
+    /// could get past. Carried on the release, the property is structural — the gate below refuses
+    /// before the request reaches the worker at all (the only path that returns without killing
+    /// it), and every request that *does* reach it is followed by [`Session::kill`] a few lines
+    /// down. Nothing can tell a batch to stop except a teardown that then ends the session.
     async fn release(&self, session: &Arc<Session>, call: Call, grace: Duration) -> Release {
-        let out = match self.call_within(session, call, grace).await {
+        let waited = Instant::now();
+        let id = session.next_id.fetch_add(1, Ordering::Relaxed);
+        let out = match self
+            .call_as(session, call, grace, id, Wait::UntilUnwound)
+            .await
+        {
             Err(EngineError::Stale(why)) => return Release::Stale(why),
             other => other,
         };
+        let waited = waited.elapsed();
         // Recorded **before** `fail_outstanding`, and the order is the whole point: that call is
         // what turns another teardown's wait on this same session into `Lost`, so the flag has to
         // be visible by the time anyone is failed out of it. Reordering these two lines silently
@@ -1093,7 +1093,10 @@ impl Sessions {
         session.kill();
         match out {
             Ok(text) => Release::Released(text),
-            Err(EngineError::Timeout(_)) => Release::Parked,
+            // Carries what it actually waited, because that is no longer one constant: a session
+            // unwinding a transaction is given the extra time it asked for, and a report naming
+            // the base grace would understate what was allowed before the worker was terminated.
+            Err(EngineError::Timeout(_)) => Release::Parked { waited },
             Err(EngineError::Lost(_)) => Release::AlreadyGone,
             Err(e) => Release::Refused(e.to_string()),
         }
@@ -1139,26 +1142,12 @@ impl Sessions {
                 session.set_state(SessionState::Closed(
                     "the server is shutting down".to_string(),
                 ));
-                // Before the release, because the release queues behind whatever this worker is
-                // running and this is what makes that queue shorter: a transaction in flight stops
-                // at its next step and unwinds, rather than being killed mid-patch when the grace
-                // runs out. The grace only grows for a session that says it is unwinding.
-                let grace = release_grace(
-                    SHUTDOWN_RELEASE_TIMEOUT,
-                    sessions
-                        .abandon_batch(&session, Call::supervisor(EngineOp::AbandonBatch))
-                        .await,
-                    sessions.call_timeout,
-                );
-                if grace != SHUTDOWN_RELEASE_TIMEOUT {
-                    tracing::info!(
-                        "shutting down: session {} is rolling a transaction back; giving it \
-                         {grace:?} to let go",
-                        session.id
-                    );
-                }
                 let outcome = sessions
-                    .release(&session, Call::supervisor(EngineOp::EndSession), grace)
+                    .release(
+                        &session,
+                        Call::supervisor(EngineOp::EndSession),
+                        SHUTDOWN_RELEASE_TIMEOUT,
+                    )
                     .await;
                 // `end_session` renders this for its caller. Shutdown has no caller — the client
                 // has already gone — so the log is the only place it can land, and it is exactly
@@ -1436,7 +1425,7 @@ impl Sessions {
             delivered: AtomicBool::new(false),
             phase: AtomicU8::new(OpenPhase::Started as u8),
             released: AtomicBool::new(false),
-            rolling_back: Mutex::new(None),
+            unwinding: Mutex::new(None),
             child: Mutex::new(Some(child)),
         });
 
@@ -1611,7 +1600,7 @@ fn shutdown_note(outcome: &Release, released: bool) -> ShutdownNote<'_> {
         Release::Released(_) => ShutdownNote::Released,
         Release::Stale(why) => ShutdownNote::Settled(why),
         _ if released => ShutdownNote::ReleasedElsewhere,
-        Release::Parked => ShutdownNote::Unreleased(
+        Release::Parked { .. } => ShutdownNote::Unreleased(
             "did not let go within the grace and its worker was terminated",
         ),
         Release::AlreadyGone => {
@@ -2019,18 +2008,15 @@ async fn reader(
                 session.reach(OpenPhase::Opened);
                 promote_opened(&session);
             }
-            // Set before the `Done` it precedes — which is the guarantee this whole milestone
-            // exists for, and it is the channel's ordering that provides it, not luck: messages
-            // are read and handled in the order the worker wrote them, so the teardown waiting on
-            // that `Done` cannot wake up before this store.
+            // Recorded while the teardown that provoked it is still waiting on that job's `Done`,
+            // which is the whole point of it being a milestone: the wait consults this only after
+            // its own grace runs out, by which time this store is long since visible.
             WorkerMessage::RollingBack { id, within_ms } => {
                 let within = Duration::from_millis(u64::from(within_ms));
-                *session
-                    .rolling_back
-                    .lock()
-                    .unwrap_or_else(|e| e.into_inner()) = Some(within);
+                *session.unwinding.lock().unwrap_or_else(|e| e.into_inner()) = Some(within);
                 tracing::info!(
-                    "session {}: job {id} found a transaction in flight and told it to roll back;                      it needs up to {within:?}",
+                    "session {}: job {id} found a transaction in flight and told it to roll back; \
+                     it needs up to {within:?}",
                     session.id
                 );
             }
@@ -2401,7 +2387,7 @@ mod tests {
             delivered: AtomicBool::new(true),
             phase: AtomicU8::new(phase as u8),
             released: AtomicBool::new(false),
-            rolling_back: Mutex::new(None),
+            unwinding: Mutex::new(None),
             child: Mutex::new(None),
         })
     }
@@ -2708,7 +2694,9 @@ mod tests {
     #[test]
     fn a_release_that_landed_elsewhere_outranks_this_attempt_failing() {
         for outcome in [
-            Release::Parked,
+            Release::Parked {
+                waited: END_SESSION_TIMEOUT,
+            },
             Release::AlreadyGone,
             Release::Refused("the engine said no".to_string()),
         ] {
@@ -2720,11 +2708,17 @@ mod tests {
         }
     }
 
+    fn parked() -> Release {
+        Release::Parked {
+            waited: SHUTDOWN_RELEASE_TIMEOUT,
+        }
+    }
+
     /// And with nothing else having released it, those same outcomes are the warning.
     #[test]
     fn nothing_having_released_the_target_is_what_deserves_the_warning() {
         assert!(matches!(
-            shutdown_note(&Release::Parked, false),
+            shutdown_note(&parked(), false),
             ShutdownNote::Unreleased(_)
         ));
         assert!(matches!(
@@ -2733,7 +2727,7 @@ mod tests {
         ));
         // The two say different things, because they need different investigation.
         assert_ne!(
-            shutdown_note(&Release::Parked, false),
+            shutdown_note(&parked(), false),
             shutdown_note(&Release::AlreadyGone, false)
         );
         // A refusal is its own outcome: the engine answered, it just said no, and the reason is
@@ -2757,66 +2751,32 @@ mod tests {
         );
     }
 
-    /// The grace a teardown gives is the ordinary one unless a worker has said it is unwinding a
-    /// transaction — and then it covers everything that worker said it still needs.
+    /// A teardown's extension is what its worker asked for, and no more.
     ///
-    /// Both halves matter, and the first is the one that is easy to lose: lengthening the wait for
-    /// every session would spend it on the case it was tuned against, a parked kernel attach that
-    /// will never let go however long anyone waits. The second is why the figure comes from the
-    /// worker rather than from a constant here — what a teardown is waiting out is the step in
-    /// flight and then the rollback, and only the worker knows how long the step may still take.
+    /// The cap is the half worth pinning: a batch's budget is clamped to the caller's patience, so
+    /// an honest worker never reaches it, and it is here only so a teardown cannot be made to wait
+    /// for ever by a number that arrived over a pipe.
     #[test]
-    fn a_teardown_waits_only_for_what_its_worker_says_it_needs() {
+    fn a_teardown_waits_for_what_its_worker_asks_and_never_past_the_cap() {
         let cap = Duration::from_secs(300);
-        for base in [SHUTDOWN_RELEASE_TIMEOUT, END_SESSION_TIMEOUT] {
-            assert_eq!(
-                release_grace(base, None, cap),
-                base,
-                "a session with nothing to unwind must cost exactly what it always did"
-            );
-            // A step that may still run for a minute is a minute this teardown waits, on top of
-            // the release behind it. A grace sized for the rollback alone would expire inside that
-            // step, which is the failure the whole signal exists to remove.
-            let step_plus_rollback = Duration::from_secs(60);
-            assert_eq!(
-                release_grace(base, Some(step_plus_rollback), cap),
-                base + step_plus_rollback
-            );
-        }
-        // The claim is bounded. A batch's budget is clamped to the caller's patience, so an honest
-        // worker never reaches this — it is here so a teardown cannot be made to wait for ever by
-        // a number arriving over a pipe.
+        // A step that may still run for a minute is a minute this teardown waits. An extension
+        // sized for the rollback alone would expire inside that step, which is the failure the
+        // whole signal exists to remove.
+        let step_plus_rollback = Duration::from_secs(60);
         assert_eq!(
-            release_grace(
-                SHUTDOWN_RELEASE_TIMEOUT,
-                Some(Duration::from_secs(86_400)),
-                cap
-            ),
-            SHUTDOWN_RELEASE_TIMEOUT + cap
+            unwind_extension(step_plus_rollback, cap),
+            step_plus_rollback
         );
+        assert_eq!(unwind_extension(Duration::from_secs(86_400), cap), cap);
     }
 
-    /// A teardown asks about a batch only when the worker owes a reply, which is what keeps the
-    /// signal off the path of every ordinary disconnect: an idle session has nothing running, so
-    /// there is nothing to abandon and no round trip worth making.
-    #[tokio::test]
-    async fn an_idle_session_is_never_asked_to_abandon_anything() {
-        let sessions = Sessions::new(Duration::from_secs(1));
-        // No worker behind it, so a signal that *were* sent would have to fail — and the queue is
-        // gone with the receiver, so it could not even be written.
+    /// A session that has said nothing about a transaction is never waited on for one — which is
+    /// what keeps an ordinary teardown costing exactly what it always did. Only a worker that was
+    /// told to unwind one ever answers, and only the teardown that told it consults this.
+    #[test]
+    fn a_session_with_nothing_to_unwind_asks_for_no_extension() {
         let idle = dormant("sess-idle", SessionState::Open);
-        assert!(!idle.awaiting_reply());
-
-        let asked = tokio::time::timeout(
-            Duration::from_millis(200),
-            sessions.abandon_batch(&idle, Call::supervisor(EngineOp::AbandonBatch)),
-        )
-        .await
-        .expect("asking an idle session must not wait on anything");
-        assert_eq!(
-            asked, None,
-            "nothing is running, so nothing is rolling back"
-        );
+        assert_eq!(idle.unwinding_for(), None);
     }
 
     /// The gap `admit` exists to close: a worker that finishes its handshake after the client has

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -103,13 +103,25 @@ fn unwind_slice(within: Duration, left: Duration) -> Duration {
 }
 
 /// The last wait a teardown owes once the transaction it was waiting on has ended: the ordinary
-/// grace, for the release that could not start until now.
+/// grace, measured from the moment the release could first have started.
+///
+/// `ended` is the last instant the worker named — the moment its batch finished, when it retracted,
+/// or the bound it promised and did not beat. Measuring from *there* rather than from now is what
+/// keeps the total honest: the grace this teardown already spent ran concurrently with a
+/// transaction the release was queued behind, so it bought the release nothing, but it should not
+/// buy it a second full helping either.
 ///
 /// `None` when there was no transaction — an ordinary teardown is not lengthened by a mechanism it
-/// never used — and none when the teardown's own patience is spent, so the total stays bounded by
-/// what [`Sessions::call_as`] started with.
-fn release_handoff(base: Duration, left: Duration, unwound: bool) -> Option<Duration> {
-    (unwound && !left.is_zero()).then(|| base.min(left))
+/// never used — and none when that grace is already spent or the teardown's own patience is, so the
+/// total stays bounded by what [`Sessions::call_as`] started with.
+fn release_handoff(
+    ended: Option<Instant>,
+    now: Instant,
+    base: Duration,
+    left: Duration,
+) -> Option<Duration> {
+    let owed = (ended? + base).saturating_duration_since(now).min(left);
+    (!owed.is_zero()).then_some(owed)
 }
 
 /// `CREATE_NEW_PROCESS_GROUP`, which every worker is spawned with.
@@ -444,6 +456,13 @@ impl Session {
     /// Read by the teardown that provoked it, after its own grace has run out — see
     /// [`Sessions::release`]. Nothing else consults it, and a session that never ran a batch never
     /// sets it, so an ordinary teardown neither reads nor pays for anything here.
+    /// The last moment this session's worker named for its transaction — when it ended, or the
+    /// bound it promised — or `None` if it never reported one. [`Self::unwinding_for`] is this read
+    /// as time remaining; the raw instant is what a release's own grace is measured from.
+    fn unwound_at(&self) -> Option<Instant> {
+        *self.unwinding.lock().unwrap_or_else(|e| e.into_inner())
+    }
+
     fn unwinding_for(&self) -> Option<Duration> {
         let by = (*self.unwinding.lock().unwrap_or_else(|e| e.into_inner()))?;
         let left = by.saturating_duration_since(Instant::now());
@@ -887,9 +906,7 @@ impl Sessions {
         // neither.
         if wait == Wait::UntilUnwound {
             let mut left = self.call_timeout;
-            let mut unwound = false;
             while let Some(within) = session.unwinding_for().filter(|_| !left.is_zero()) {
-                unwound = true;
                 let slice = unwind_slice(within, left);
                 if let Ok(reply) = tokio::time::timeout(slice, &mut rx).await {
                     return settled(reply);
@@ -905,7 +922,8 @@ impl Sessions {
             // is emitted as the batch ends, so a batch that runs to its bound emits it at the very
             // instant this loop stops looking. Resting on it arriving first would be resting on
             // pipe scheduling, and losing costs a worker killed as its release begins.
-            if let Some(handoff) = release_handoff(budget, left, unwound)
+            if let Some(handoff) =
+                release_handoff(session.unwound_at(), Instant::now(), budget, left)
                 && let Ok(reply) = tokio::time::timeout(handoff, &mut rx).await
             {
                 return settled(reply);
@@ -2850,16 +2868,29 @@ mod tests {
     fn a_release_that_waited_for_a_transaction_still_gets_its_own_grace() {
         let base = SHUTDOWN_RELEASE_TIMEOUT;
         let plenty = Duration::from_secs(300);
-        assert_eq!(release_handoff(base, plenty, true), Some(base));
+        let now = Instant::now();
+
+        // The transaction has just ended, so the release has its whole grace ahead of it.
+        assert_eq!(release_handoff(Some(now), now, base, plenty), Some(base));
+
+        // It ended a while ago and the release has been running since: it gets the rest, not
+        // another helping. Measuring from *now* instead would hand a second grace to every
+        // teardown that ever waited on a batch — which is what the retraction window used to do.
+        let third = base / 3;
+        assert_eq!(
+            release_handoff(Some(now - third), now, base, plenty),
+            Some(base - third)
+        );
+        assert_eq!(release_handoff(Some(now - base), now, base, plenty), None);
 
         // A teardown that never waited on a transaction is not lengthened by a mechanism it never
         // used: this is what keeps an ordinary disconnect costing what it always did.
-        assert_eq!(release_handoff(base, plenty, false), None);
+        assert_eq!(release_handoff(None, now, base, plenty), None);
 
         // And the teardown's own patience still bounds the total.
         let sliver = base / 4;
-        assert_eq!(release_handoff(base, sliver, true), Some(sliver));
-        assert_eq!(release_handoff(base, Duration::ZERO, true), None);
+        assert_eq!(release_handoff(Some(now), now, base, sliver), Some(sliver));
+        assert_eq!(release_handoff(Some(now), now, base, Duration::ZERO), None);
     }
 
     /// A session that has said nothing about a transaction is never waited on for one — which is
@@ -2944,12 +2975,12 @@ mod tests {
             "recorded as a deadline 90s out, not {left:?}"
         );
 
-        // A later, smaller figure *retracts* it: a worker whose transaction has finished says so
-        // by naming only what the release still needs, however long it said it might need when it
-        // was told to stop. The last word wins, in both directions.
+        // A retraction *replaces* it with the moment the batch ended, however long it said it
+        // might need when it was told to stop. The last word wins, in both directions — and what
+        // the release then gets is measured from that moment by `release_handoff`, not named here.
         let done = serde_json::to_string(&WorkerMessage::RollingBack {
             id: 7,
-            within_ms: 5_000,
+            within_ms: 0,
         })
         .expect("encode the retraction");
         writeln!(worker, "{done}").expect("write it as a worker would");
@@ -2957,15 +2988,9 @@ mod tests {
             .await
             .expect("the retraction reached the dispatcher within 10s");
         let by = unwinding.lock().unwrap().expect("still recorded");
-        let left = by.saturating_duration_since(Instant::now());
         assert!(
-            left <= Duration::from_secs(5),
-            "a finished transaction must not go on being waited out for the rest of its budget, \
-             and {left:?} is still most of it"
-        );
-        assert!(
-            !left.is_zero(),
-            "but the release it was holding up has not run yet, so it keeps its own moment"
+            by <= Instant::now(),
+            "a finished transaction must not go on being waited out for the rest of its budget"
         );
     }
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -81,6 +81,34 @@ const END_SESSION_TIMEOUT: Duration = Duration::from_secs(20);
 /// rather than the cost per session.
 const SHUTDOWN_RELEASE_TIMEOUT: Duration = Duration::from_secs(5);
 
+/// How long to wait for a worker to acknowledge [`EngineOp::AbandonBatch`] before giving up on the
+/// answer and tearing down on the ordinary grace.
+///
+/// Short because it measures the worker's *reader*, not its engine: the signal is answered where it
+/// is read, so nothing a debug session can do — a runaway command, a kernel wait that will never
+/// return — is in the way. What is left is process scheduling and a pipe. A worker that cannot
+/// manage that in two seconds is not going to roll anything back either.
+const ABANDON_ACK_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// The grace a teardown gives a session, given whether its worker said a batch is rolling back.
+///
+/// The extra is [`crate::batch::ROLLBACK_RESERVE`] and not a number chosen to look generous: that
+/// reserve is the most an `always` block can ever be given, and an abandoned batch holds its
+/// rollback to exactly it, so this is "as long as the rollback can possibly need" rather than a
+/// guess that will drift when the reserve changes.
+///
+/// The conditional is the point. A disconnect must stay quick for the case it was tuned for — a
+/// parked kernel attach that will never unwind, where every extra second is spent for nothing — so
+/// the longer wait is spent only where a worker has said, in the same round trip, that there is
+/// something to wait for.
+fn release_grace(base: Duration, rolling_back: bool) -> Duration {
+    if rolling_back {
+        base + crate::batch::ROLLBACK_RESERVE
+    } else {
+        base
+    }
+}
+
 /// `CREATE_NEW_PROCESS_GROUP`, which every worker is spawned with.
 ///
 /// An interactive Ctrl+C is delivered to *every* process attached to the console, and a child
@@ -306,6 +334,10 @@ pub struct Session {
     /// from the worker having crashed. This is what tells those two apart, and the difference is
     /// "the target was let go" versus "a live kernel may be sitting halted".
     released: AtomicBool,
+    /// Whether this session's worker reported a transactional batch rolling back in answer to
+    /// [`EngineOp::AbandonBatch`]. Read by the teardown that asked, to decide how long to hold the
+    /// door open; see [`release_grace`].
+    rolling_back: AtomicBool,
     child: Mutex<Option<Child>>,
 }
 
@@ -389,6 +421,21 @@ impl Session {
                 self.state(),
                 SessionState::Opening | SessionState::Attaching
             )
+    }
+
+    /// Whether the worker owes a reply to anything at all.
+    ///
+    /// Narrower than [`Self::busy`], which also answers for a session nobody has been told about
+    /// yet. This is the precise question a teardown asks before signalling: a batch can only be in
+    /// flight if some call is outstanding, because the waiter is registered before the job is
+    /// queued and removed only when the worker answers. So an empty map means there is nothing to
+    /// abandon and the signal can be skipped — which is every ordinary disconnect.
+    fn awaiting_reply(&self) -> bool {
+        !self
+            .waiters
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .is_empty()
     }
 
     /// Answers every outstanding call with `why`. Used when the worker dies or is killed: those
@@ -928,8 +975,16 @@ impl Sessions {
     /// otherwise hold its session forever; killing it is the only thing that ends that wait, and
     /// under process-per-session it costs nothing else.
     pub async fn end(&self, session: &Arc<Session>, named: bool) -> Result<String, EngineError> {
+        // Gated the same way the end itself is, so a caller holding a handle this session will not
+        // honour cannot cut short a transaction they have no claim on. A refusal here needs no
+        // reporting: the `EndSession` below is refused identically and says so properly.
+        let grace = release_grace(
+            END_SESSION_TIMEOUT,
+            self.abandon_batch(session, Call::new(EngineOp::AbandonBatch).named(named))
+                .await,
+        );
         let call = Call::new(EngineOp::EndSession).named(named);
-        let (reason, message) = match self.release(session, call, END_SESSION_TIMEOUT).await {
+        let (reason, message) = match self.release(session, call, grace).await {
             // A refused handle is the mechanism working, not a session to tear down.
             Release::Stale(why) => return Err(EngineError::Stale(why)),
             Release::Released(text) => (
@@ -941,11 +996,9 @@ impl Sessions {
                 ),
             ),
             Release::Parked => (
+                format!("terminated by end_session after {grace:?} without unwinding"),
                 format!(
-                    "terminated by end_session after {END_SESSION_TIMEOUT:?} without unwinding"
-                ),
-                format!(
-                    "Session `{}` did not release its target within {END_SESSION_TIMEOUT:?}, so \
+                    "Session `{}` did not release its target within {grace:?}, so \
                      its engine worker process (pid {}) was terminated.\n\nThat is the expected \
                      outcome for a session parked in a wait DbgEng cannot be interrupted out of — \
                      a live-kernel attach whose target never connected is the usual one. The \
@@ -983,6 +1036,33 @@ impl Sessions {
         };
         session.set_state(SessionState::Closed(reason));
         Ok(message)
+    }
+
+    /// Tells a session's worker to abandon any transaction it is running and go to its rollback,
+    /// and reports whether there was one — which is what the teardown that follows sizes its grace
+    /// from ([`release_grace`]).
+    ///
+    /// This exists because of one ordering. A `debug_batch` is one indivisible job, so an
+    /// `EndSession` queues *behind* it; a teardown that only waited would find the batch still
+    /// mid-transaction when its grace expired and kill the worker with the patch still applied —
+    /// on a live kernel, the exact outcome the tool is for. The signal turns that wait into
+    /// something the batch can act on: it stops at its next step and runs `always`, and the
+    /// `EndSession` behind it lands on a target that has been put back.
+    ///
+    /// Skipped entirely when the worker owes no reply, which is every ordinary disconnect — there
+    /// is nothing running to abandon, so the round trip would buy nothing. Best-effort by
+    /// construction: a signal that is refused, times out, or finds nothing simply leaves the
+    /// ordinary grace in place, and the teardown proceeds exactly as it did before.
+    async fn abandon_batch(&self, session: &Arc<Session>, call: Call) -> bool {
+        if !session.awaiting_reply() {
+            return false;
+        }
+        // The answer is not read from here: the worker reports it as a `RollingBack` milestone,
+        // which travels ahead of this call's reply on the same ordered channel, so by the time this
+        // returns the flag is set. Reading it off the reply text instead would be the same fact
+        // arriving twice, in a form that has to be parsed back.
+        let _ = self.call_within(session, call, ABANDON_ACK_TIMEOUT).await;
+        session.rolling_back.load(Ordering::SeqCst)
     }
 
     /// Asks a worker to release its target and then terminates it, without deciding *why* the
@@ -1050,12 +1130,25 @@ impl Sessions {
                 session.set_state(SessionState::Closed(
                     "the server is shutting down".to_string(),
                 ));
+                // Before the release, because the release queues behind whatever this worker is
+                // running and this is what makes that queue shorter: a transaction in flight stops
+                // at its next step and unwinds, rather than being killed mid-patch when the grace
+                // runs out. The grace only grows for a session that says it is unwinding.
+                let grace = release_grace(
+                    SHUTDOWN_RELEASE_TIMEOUT,
+                    sessions
+                        .abandon_batch(&session, Call::supervisor(EngineOp::AbandonBatch))
+                        .await,
+                );
+                if grace != SHUTDOWN_RELEASE_TIMEOUT {
+                    tracing::info!(
+                        "shutting down: session {} is rolling a transaction back; giving it \
+                         {grace:?} to let go",
+                        session.id
+                    );
+                }
                 let outcome = sessions
-                    .release(
-                        &session,
-                        Call::supervisor(EngineOp::EndSession),
-                        SHUTDOWN_RELEASE_TIMEOUT,
-                    )
+                    .release(&session, Call::supervisor(EngineOp::EndSession), grace)
                     .await;
                 // `end_session` renders this for its caller. Shutdown has no caller — the client
                 // has already gone — so the log is the only place it can land, and it is exactly
@@ -1333,6 +1426,7 @@ impl Sessions {
             delivered: AtomicBool::new(false),
             phase: AtomicU8::new(OpenPhase::Started as u8),
             released: AtomicBool::new(false),
+            rolling_back: AtomicBool::new(false),
             child: Mutex::new(Some(child)),
         });
 
@@ -1915,6 +2009,17 @@ async fn reader(
                 session.reach(OpenPhase::Opened);
                 promote_opened(&session);
             }
+            // Set before the `Done` it precedes — which is the guarantee this whole milestone
+            // exists for, and it is the channel's ordering that provides it, not luck: messages
+            // are read and handled in the order the worker wrote them, so the teardown waiting on
+            // that `Done` cannot wake up before this store.
+            WorkerMessage::RollingBack { id } => {
+                session.rolling_back.store(true, Ordering::SeqCst);
+                tracing::info!(
+                    "session {}: job {id} found a transaction in flight and told it to roll back",
+                    session.id
+                );
+            }
             WorkerMessage::Committed { id } | WorkerMessage::Opened { id } => {
                 tracing::warn!(
                     "session {}: job {id} reported an opener milestone",
@@ -2282,6 +2387,7 @@ mod tests {
             delivered: AtomicBool::new(true),
             phase: AtomicU8::new(phase as u8),
             released: AtomicBool::new(false),
+            rolling_back: AtomicBool::new(false),
             child: Mutex::new(None),
         })
     }
@@ -2635,6 +2741,52 @@ mod tests {
             shutdown_note(&Release::Stale("already closed".to_string()), false),
             ShutdownNote::Settled("already closed")
         );
+    }
+
+    /// The grace a teardown gives is the ordinary one unless a worker has said it is unwinding a
+    /// transaction — and then it is long enough for the whole rollback.
+    ///
+    /// Both halves matter, and the first is the one that is easy to lose: lengthening the wait for
+    /// every session would spend it on the case it was tuned against, a parked kernel attach that
+    /// will never let go however long anyone waits.
+    #[test]
+    fn only_a_session_that_is_rolling_back_gets_the_longer_grace() {
+        assert_eq!(
+            release_grace(SHUTDOWN_RELEASE_TIMEOUT, false),
+            SHUTDOWN_RELEASE_TIMEOUT,
+            "an ordinary disconnect must cost exactly what it always did"
+        );
+        assert!(
+            release_grace(SHUTDOWN_RELEASE_TIMEOUT, true)
+                >= SHUTDOWN_RELEASE_TIMEOUT + crate::batch::ROLLBACK_RESERVE,
+            "a rollback gets the reserve it is allowed to spend, plus the release behind it"
+        );
+        // The same rule for the explicit end, where the base is longer to begin with.
+        assert_eq!(
+            release_grace(END_SESSION_TIMEOUT, false),
+            END_SESSION_TIMEOUT
+        );
+        assert!(release_grace(END_SESSION_TIMEOUT, true) > END_SESSION_TIMEOUT);
+    }
+
+    /// A teardown asks about a batch only when the worker owes a reply, which is what keeps the
+    /// signal off the path of every ordinary disconnect: an idle session has nothing running, so
+    /// there is nothing to abandon and no round trip worth making.
+    #[tokio::test]
+    async fn an_idle_session_is_never_asked_to_abandon_anything() {
+        let sessions = Sessions::new(Duration::from_secs(1));
+        // No worker behind it, so a signal that *were* sent would have to fail — and the queue is
+        // gone with the receiver, so it could not even be written.
+        let idle = dormant("sess-idle", SessionState::Open);
+        assert!(!idle.awaiting_reply());
+
+        let asked = tokio::time::timeout(
+            Duration::from_millis(200),
+            sessions.abandon_batch(&idle, Call::supervisor(EngineOp::AbandonBatch)),
+        )
+        .await
+        .expect("asking an idle session must not wait on anything");
+        assert!(!asked, "nothing is running, so nothing is rolling back");
     }
 
     /// The gap `admit` exists to close: a worker that finishes its handshake after the client has

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -116,6 +116,20 @@ pub enum EngineOp {
     /// deadline. Splitting it into per-step round trips would put the client back in the middle
     /// of it, which is the design this replaces.
     Batch(BatchOp),
+    /// Abandon a running [`Self::Batch`]: stop before the next step and go straight to its
+    /// `always` block. Sent by a teardown — a client disconnect, or `end_session` — so the
+    /// rollback runs before the worker is asked to let the target go.
+    ///
+    /// **The one op the worker does not run on its engine thread.** Every other variant here is a
+    /// job for that thread, and this one exists precisely because that thread is busy: it is
+    /// inside the batch being abandoned. So the worker's *request reader* handles it where it
+    /// reads it, which it can, because the reader is never blocked by the engine — it drains this
+    /// channel into an in-process queue and nothing more.
+    ///
+    /// It does not interrupt a step already inside DbgEng; the batch stops at the next step
+    /// boundary. Interrupting the engine itself is a different mechanism (`SetInterrupt`, bound to
+    /// job identity) and is not this.
+    AbandonBatch,
     /// Release the target. The supervisor tears the worker down afterwards — under
     /// process-per-session a worker outlives its target for no reason.
     EndSession,
@@ -213,6 +227,16 @@ pub enum WorkerMessage {
     /// that report. This is also what moves a kernel attach out of the state it can park in
     /// forever.
     Opened { id: u64 },
+    /// An [`EngineOp::AbandonBatch`] found a batch in flight, and its rollback is running now.
+    /// `id` is the abandon request's, like every other message here.
+    ///
+    /// A milestone rather than part of the reply, for the same reason [`Self::Committed`] is: it
+    /// says something the supervisor has to act on *before* the `Done` it precedes. The two travel
+    /// the same ordered channel and are processed in order, so by the time the abandon call
+    /// returns, the session already knows a rollback is under way — which is what lets the
+    /// teardown hold its grace open for that one session and no other. Absent, the ordinary short
+    /// grace stands.
+    RollingBack { id: u64 },
     /// The op finished. `Err` is a debugger-level failure with the engine's own text.
     Done {
         id: u64,

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -127,8 +127,9 @@ pub enum EngineOp {
     /// channel into an in-process queue and nothing more.
     ///
     /// It does not interrupt a step already inside DbgEng; the batch stops at the next step
-    /// boundary. Interrupting the engine itself is a different mechanism (`SetInterrupt`, bound to
-    /// job identity) and is not this.
+    /// boundary, and the worker says how long that leaves it ([`WorkerMessage::RollingBack`]) so
+    /// the teardown can wait for the step as well as the rollback. Interrupting the engine itself
+    /// is a different mechanism (`SetInterrupt`, bound to job identity) and is not this.
     AbandonBatch,
     /// Release the target. The supervisor tears the worker down afterwards — under
     /// process-per-session a worker outlives its target for no reason.
@@ -227,16 +228,23 @@ pub enum WorkerMessage {
     /// that report. This is also what moves a kernel attach out of the state it can park in
     /// forever.
     Opened { id: u64 },
-    /// An [`EngineOp::AbandonBatch`] found a batch in flight, and its rollback is running now.
-    /// `id` is the abandon request's, like every other message here.
+    /// An [`EngineOp::AbandonBatch`] found a batch in flight, and it will be done — stopped,
+    /// rolled back and reported — within `within_ms`. `id` is the abandon request's, like every
+    /// other message here.
     ///
     /// A milestone rather than part of the reply, for the same reason [`Self::Committed`] is: it
     /// says something the supervisor has to act on *before* the `Done` it precedes. The two travel
     /// the same ordered channel and are processed in order, so by the time the abandon call
-    /// returns, the session already knows a rollback is under way — which is what lets the
-    /// teardown hold its grace open for that one session and no other. Absent, the ordinary short
-    /// grace stands.
-    RollingBack { id: u64 },
+    /// returns, the session already knows how long to hold its grace open — for that one session
+    /// and no other. Absent, the ordinary short grace stands.
+    ///
+    /// The figure is a **field, not a sentence in the reply**, because the supervisor computes a
+    /// deadline from it, and it is the worker's to compute: only that process knows what budget the
+    /// batch is running under and how much of it is spent. It covers the step in flight as well as
+    /// the rollback, since the signal cannot reach a step already inside DbgEng — a grace sized for
+    /// the rollback alone would expire mid-step, which is the whole failure being fixed, arriving a
+    /// little later.
+    RollingBack { id: u64, within_ms: u32 },
     /// The op finished. `Err` is a debugger-level failure with the engine's own text.
     Done {
         id: u64,

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -116,23 +116,28 @@ pub enum EngineOp {
     /// deadline. Splitting it into per-step round trips would put the client back in the middle
     /// of it, which is the design this replaces.
     Batch(BatchOp),
-    /// Abandon a running [`Self::Batch`]: stop before the next step and go straight to its
-    /// `always` block. Sent by a teardown — a client disconnect, or `end_session` — so the
-    /// rollback runs before the worker is asked to let the target go.
-    ///
-    /// **The one op the worker does not run on its engine thread.** Every other variant here is a
-    /// job for that thread, and this one exists precisely because that thread is busy: it is
-    /// inside the batch being abandoned. So the worker's *request reader* handles it where it
-    /// reads it, which it can, because the reader is never blocked by the engine — it drains this
-    /// channel into an in-process queue and nothing more.
-    ///
-    /// It does not interrupt a step already inside DbgEng; the batch stops at the next step
-    /// boundary, and the worker says how long that leaves it ([`WorkerMessage::RollingBack`]) so
-    /// the teardown can wait for the step as well as the rollback. Interrupting the engine itself
-    /// is a different mechanism (`SetInterrupt`, bound to job identity) and is not this.
-    AbandonBatch,
     /// Release the target. The supervisor tears the worker down afterwards — under
     /// process-per-session a worker outlives its target for no reason.
+    ///
+    /// **The one op that acts before it is dequeued.** Every other variant is nothing until the
+    /// engine thread reaches it, but a [`Self::Batch`] can be running when this arrives, and this
+    /// would then queue behind every step it has left — so the grace would expire mid-transaction
+    /// and the worker be terminated with the target still patched. The worker's *request reader*
+    /// therefore acts on this one where it reads it: it tells any running batch to stop at its
+    /// next step and roll back ([`WorkerMessage::RollingBack`], which says how long that leaves),
+    /// and only then queues the op for the engine thread, which reaches it with the transaction
+    /// already unwound. The reader can do that because it is never blocked by the engine — it
+    /// drains this channel into an in-process queue and nothing more.
+    ///
+    /// Carrying the signal on *this* op rather than on one of its own is what keeps it honest: a
+    /// request the session's gate refuses never reaches the worker, so nothing can tell a batch to
+    /// stop except a teardown that is really happening — and every request that does reach the
+    /// worker is followed by the supervisor terminating it, so the flag it sets cannot outlive the
+    /// session it belongs to.
+    ///
+    /// It does not interrupt a step already inside DbgEng; the batch stops at the next step
+    /// boundary. Interrupting the engine itself is a different mechanism (`SetInterrupt`, bound to
+    /// job identity) and is not this.
     EndSession,
 }
 
@@ -228,15 +233,15 @@ pub enum WorkerMessage {
     /// that report. This is also what moves a kernel attach out of the state it can park in
     /// forever.
     Opened { id: u64 },
-    /// An [`EngineOp::AbandonBatch`] found a batch in flight, and it will be done — stopped,
-    /// rolled back and reported — within `within_ms`. `id` is the abandon request's, like every
+    /// An [`EngineOp::EndSession`] found a batch in flight and told it to stop; it will be done —
+    /// stopped, rolled back and reported — within `within_ms`. `id` is that request's, like every
     /// other message here.
     ///
     /// A milestone rather than part of the reply, for the same reason [`Self::Committed`] is: it
-    /// says something the supervisor has to act on *before* the `Done` it precedes. The two travel
-    /// the same ordered channel and are processed in order, so by the time the abandon call
-    /// returns, the session already knows how long to hold its grace open — for that one session
-    /// and no other. Absent, the ordinary short grace stands.
+    /// says something the supervisor has to act on while the op it belongs to is still running.
+    /// The teardown is already waiting on that op's `Done` when this arrives, and extends its wait
+    /// by what this says — for that one session and no other. Absent, the ordinary short grace
+    /// stands.
     ///
     /// The figure is a **field, not a sentence in the reply**, because the supervisor computes a
     /// deadline from it, and it is the worker's to compute: only that process knows what budget the

--- a/src/server.rs
+++ b/src/server.rs
@@ -2107,6 +2107,10 @@ impl WindbgServer {
     /// within a short grace period — a live-kernel attach whose target never dialed in cannot,
     /// since nothing can interrupt that wait — its engine process is terminated outright. The
     /// session ends either way, and no other session is affected.
+    ///
+    /// A `debug_batch` running on the session is told to stop at its next step and run its
+    /// rollback before the target is released, and the batch's own call reports that; the grace
+    /// covers the rollback.
     #[rmcp::tool(annotations(
         title = "End debug session",
         read_only_hint = false,
@@ -2163,11 +2167,12 @@ impl WindbgServer {
     /// call that times out. The result names every step that ran, the exact one that failed, what
     /// each changed, whether the rollback completed, and whether the target is left stopped,
     /// running, detached, or uncertain (the last when the debugger could not be asked — which is
-    /// reported as not knowing, never guessed at). Two edges: a step that overruns far enough to
-    /// consume the reserved cleanup budget too leaves the rollback unrun, and the result says
-    /// `rollback: INCOMPLETE`;
-    /// and a client *disconnect* is not a safe way to abort a batch — it is treated as
-    /// `end_session` everywhere and gives only a few seconds' grace, so end the session instead.
+    /// reported as not knowing, never guessed at). Tearing the session down while a batch runs —
+    /// `end_session`, or a client disconnect — stops it at its next step and runs the rollback
+    /// first, reported as `BATCH: ABANDONED`; what that cannot do is cut short a step already
+    /// inside the debugger, so a batch of long steps still waits for the current one. One edge
+    /// remains: a step that overruns far enough to consume the reserved cleanup budget too leaves
+    /// the rollback unrun, and the result says `rollback: INCOMPLETE`.
     #[rmcp::tool(annotations(
         title = "Run a transactional debugger batch",
         read_only_hint = false,

--- a/src/server.rs
+++ b/src/server.rs
@@ -2110,7 +2110,7 @@ impl WindbgServer {
     ///
     /// A `debug_batch` running on the session is told to stop at its next step and run its
     /// rollback before the target is released, and the batch's own call reports that; the grace
-    /// covers the rollback.
+    /// covers the step in flight and the rollback after it.
     #[rmcp::tool(annotations(
         title = "End debug session",
         read_only_hint = false,
@@ -2169,10 +2169,11 @@ impl WindbgServer {
     /// running, detached, or uncertain (the last when the debugger could not be asked — which is
     /// reported as not knowing, never guessed at). Tearing the session down while a batch runs —
     /// `end_session`, or a client disconnect — stops it at its next step and runs the rollback
-    /// first, reported as `BATCH: ABANDONED`; what that cannot do is cut short a step already
-    /// inside the debugger, so a batch of long steps still waits for the current one. One edge
-    /// remains: a step that overruns far enough to consume the reserved cleanup budget too leaves
-    /// the rollback unrun, and the result says `rollback: INCOMPLETE`.
+    /// first, reported as `BATCH: ABANDONED`; the teardown waits for the step in flight as well as
+    /// the rollback, but it cannot cut that step short, so a batch of long steps unwinds only once
+    /// the current one ends. One edge remains: a step that overruns far enough to consume the
+    /// reserved cleanup budget too leaves the rollback unrun, and the result says
+    /// `rollback: INCOMPLETE`.
     #[rmcp::tool(annotations(
         title = "Run a transactional debugger batch",
         read_only_hint = false,

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -287,15 +287,15 @@ pub fn run(args: &[String]) -> ! {
             continue;
         }
         match serde_json::from_str::<WorkerRequest>(&line) {
-            // Answered here rather than queued, because the thread that would run it is the one
-            // this is about: it is inside the batch being abandoned. This loop is never blocked by
-            // the engine — it reads a line and hands it on — which is the whole reason the signal
-            // can arrive at all. See [`EngineOp::AbandonBatch`].
-            Ok(WorkerRequest {
-                id,
-                op: EngineOp::AbandonBatch,
-            }) => abandon_batch(id),
             Ok(request) => {
+                // Acted on here, before it is queued, because the thread that will run it is the
+                // one it is about: a batch on that thread has to be told to stop *now* if the
+                // release behind it is not to wait out every step it has left. This loop is never
+                // blocked by the engine — it reads a line and hands it on — which is the whole
+                // reason the signal can arrive at all. See [`EngineOp::EndSession`].
+                if matches!(request.op, EngineOp::EndSession) {
+                    announce_teardown(request.id);
+                }
                 if tx.send(Job::Run(Instant::now(), request)).is_err() {
                     break; // the engine thread is gone; nothing can run any more
                 }
@@ -506,29 +506,20 @@ fn emit(message: &WorkerMessage) -> Emit {
     }
 }
 
-/// Answers an [`EngineOp::AbandonBatch`] from the request reader.
+/// Tells any running batch that its session is going away, from the request reader — see
+/// [`EngineOp::EndSession`] for why this happens here rather than on the engine thread.
 ///
-/// The order of the two messages is the contract: [`WorkerMessage::RollingBack`] says the grace has
-/// to be held open, and it must be on the wire before the `Done` that releases the supervisor's
-/// waiter, or the teardown would read the flag before it was set and size its grace as though
-/// nothing were running.
-fn abandon_batch(id: u64) {
-    let what = match BATCH.abandon() {
-        Some(within) => {
-            emit(&WorkerMessage::RollingBack {
-                id,
-                within_ms: within.as_millis().min(u128::from(u32::MAX)) as u32,
-            });
-            format!(
-                "a batch was running; it will stop at its next step and run its `always` block, \
-                 within {within:?}"
-            )
-        }
-        None => "no batch was running; none can start on this session now".to_string(),
+/// The message it may send is a promise about time, so it goes out *before* the release is queued:
+/// the supervisor is waiting on that release, and this is what tells it how long the wait is worth.
+/// Sent only when there is a batch to stop, so an ordinary teardown says nothing and costs nothing.
+fn announce_teardown(id: u64) {
+    let Some(within) = BATCH.abandon() else {
+        return;
     };
-    emit(&WorkerMessage::Done {
+    tracing::info!("worker: session ending with a batch in flight; it has {within:?} to unwind");
+    emit(&WorkerMessage::RollingBack {
         id,
-        result: Ok(what),
+        within_ms: within.as_millis().min(u128::from(u32::MAX)) as u32,
     });
 }
 
@@ -707,14 +698,8 @@ fn execute(e: &DebugEngine, id: u64, op: EngineOp, queued: Duration) -> Result<S
         EngineOp::Reachability(args) => reachable(e, args),
         EngineOp::Pool(args) => pool(e, args),
         EngineOp::Batch(op) => run_batch(e, op, queued),
-        // Handled by the request reader, which is the only place it can be handled: reaching this
-        // thread means it queued behind the very batch it was meant to cut short. Answered rather
-        // than ignored, because a request without a reply costs the caller its session.
-        EngineOp::AbandonBatch => Err(
-            "the abandon signal reached the engine thread, which means it was queued rather than \
-             delivered — nothing was abandoned. This is a bug in the worker's request reader."
-                .to_string(),
-        ),
+        // Reaching here means any batch has already been told to stop and has finished unwinding —
+        // the reader saw this request go past and said so, and this thread runs one job at a time.
         EngineOp::EndSession => e
             .end_session()
             .map(|_| "session ended".to_string())

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -143,20 +143,41 @@ struct BatchSignal {
     /// started must not start, or the session's last act would be a fresh set of mutations run for
     /// a caller who is already gone.
     abandon: AtomicBool,
-    /// When the batch on the engine thread must be finished by, or `None` when none is running.
+    /// The mutable half, under one lock so the deadline and the teardown that is waiting on it
+    /// cannot be read out of step with each other.
     ///
-    /// A `Mutex` rather than an atomic because it carries an `Instant`, and because the lock is
-    /// what orders it against [`Self::abandon`] — see there. Uncontended in practice: it is taken
-    /// twice per batch and once per teardown.
-    finish_by: Mutex<Option<Instant>>,
+    /// A `Mutex` rather than atomics because it carries an `Instant`, and because the lock is what
+    /// orders it against [`Self::abandon`] — see there. Uncontended in practice: taken twice per
+    /// batch and once per teardown.
+    state: Mutex<SignalState>,
+}
+
+/// What [`BatchSignal`] knows about the batch on the engine thread and about who is waiting for it.
+#[derive(Default)]
+struct SignalState {
+    /// When the running batch must be finished by, or `None` when none is running. This *is* the
+    /// "is one running" answer rather than a second flag beside it, so the two can never disagree
+    /// about a batch that started or finished in between.
+    finish_by: Option<Instant>,
+    /// The request id of the teardown that told the batch to stop, once one has. Kept so the
+    /// promise made to that teardown can be *retracted* when the batch finishes — see
+    /// [`BatchGuard::drop`].
+    told_by: Option<u64>,
 }
 
 impl BatchSignal {
     const fn new() -> Self {
         Self {
             abandon: AtomicBool::new(false),
-            finish_by: Mutex::new(None),
+            state: Mutex::new(SignalState {
+                finish_by: None,
+                told_by: None,
+            }),
         }
+    }
+
+    fn state(&self) -> std::sync::MutexGuard<'_, SignalState> {
+        self.state.lock().unwrap_or_else(|e| e.into_inner())
     }
 
     /// Tells any batch to stop at its next step boundary, and reports **how long it may still
@@ -174,20 +195,40 @@ impl BatchSignal {
     /// loads. If this sees `None` because it got the lock first, its store is already visible to
     /// the load `enter` makes after taking the lock — so that batch refuses to start. Both sides
     /// seeing each other is fine, and costs a teardown a grace it did not need.
-    fn abandon(&self) -> Option<Duration> {
+    fn abandon(&self, told_by: u64) -> Option<Duration> {
         self.abandon.store(true, Ordering::SeqCst);
-        let finish_by = *self.finish_by.lock().unwrap_or_else(|e| e.into_inner());
-        finish_by.map(|by| by.saturating_duration_since(Instant::now()))
+        let mut state = self.state();
+        state.told_by = Some(told_by);
+        state
+            .finish_by
+            .map(|by| by.saturating_duration_since(Instant::now()))
     }
 
     fn abandoned(&self) -> bool {
         self.abandon.load(Ordering::SeqCst)
     }
 
+    /// Ends the claim, and reports the teardown that is owed a **retraction** — the one told, back
+    /// when it arrived, that this batch might need up to N.
+    ///
+    /// The retraction is not tidiness. That promise was measured when the teardown arrived, and a
+    /// rollback usually finishes in a fraction of it. Left standing, a teardown whose *release*
+    /// then hangs — a live kernel that will not detach, the case the short grace exists for —
+    /// would wait out the rest of a batch budget that was spent long ago: minutes, for a
+    /// transaction already safely unwound. A fresh promise of zero says the only thing still worth
+    /// waiting for is the release itself.
+    ///
+    /// Owed once: whoever takes it here sends it.
+    fn finish(&self) -> Option<u64> {
+        let mut state = self.state();
+        state.finish_by = None;
+        state.told_by.take()
+    }
+
     /// Claims the engine thread for a batch that must be done within `budget`, for as long as the
     /// guard lives, and answers whether it may start at all.
     fn enter(&self, budget: Duration) -> (BatchGuard<'_>, bool) {
-        *self.finish_by.lock().unwrap_or_else(|e| e.into_inner()) = Some(Instant::now() + budget);
+        self.state().finish_by = Some(Instant::now() + budget);
         let guard = BatchGuard { signal: self };
         // After the lock above is released, so a teardown that observes this batch at all observes
         // its deadline too. See [`Self::abandon`].
@@ -196,20 +237,19 @@ impl BatchSignal {
     }
 }
 
-/// Clears the deadline however the batch ends — including by unwinding, which `engine_thread`'s
-/// guard catches one frame further out. A teardown after this point has nothing to wait for, and
-/// gets the ordinary grace.
+/// Ends the batch's claim however it ends — including by unwinding, which `engine_thread`'s guard
+/// catches one frame further out.
 struct BatchGuard<'a> {
     signal: &'a BatchSignal,
 }
 
 impl Drop for BatchGuard<'_> {
     fn drop(&mut self) {
-        *self
-            .signal
-            .finish_by
-            .lock()
-            .unwrap_or_else(|e| e.into_inner()) = None;
+        // Outside the lock `finish` takes: `emit` takes one of its own, and nothing here should
+        // hold two at once.
+        if let Some(id) = self.signal.finish() {
+            emit(&WorkerMessage::RollingBack { id, within_ms: 0 });
+        }
     }
 }
 
@@ -341,7 +381,9 @@ pub fn run(args: &[String]) -> ! {
     // behind every step it has left, on the one path where nobody is left to have asked for
     // anything — and this process is leaving either way, so the choice is between a rollback and
     // no rollback, not between finishing the batch and not.
-    let grace = match BATCH.abandon() {
+    // No teardown request to answer here — the supervisor is gone — so the id is immaterial; what
+    // matters is that the batch is told, and that this process waits for it.
+    let grace = match BATCH.abandon(0) {
         Some(within) => {
             tracing::info!(
                 "worker: a batch is running; giving it up to {within:?} to stop and roll back \
@@ -513,7 +555,7 @@ fn emit(message: &WorkerMessage) -> Emit {
 /// the supervisor is waiting on that release, and this is what tells it how long the wait is worth.
 /// Sent only when there is a batch to stop, so an ordinary teardown says nothing and costs nothing.
 fn announce_teardown(id: u64) {
-    let Some(within) = BATCH.abandon() else {
+    let Some(within) = BATCH.abandon(id) else {
         return;
     };
     tracing::info!("worker: session ending with a batch in flight; it has {within:?} to unwind");
@@ -2028,6 +2070,9 @@ mod tests {
     /// this machine runs a test.
     const A_LONG_BATCH: Duration = Duration::from_secs(120);
 
+    /// Stands in for the request id of the teardown doing the telling.
+    const TEARDOWN: u64 = 42;
+
     /// The property the signal exists to hold: a batch never runs with a teardown believing there
     /// is nothing to wait for.
     ///
@@ -2038,7 +2083,7 @@ mod tests {
     fn a_batch_and_the_signal_that_stops_it_cannot_both_miss() {
         // The signal arrives first: the batch must not start.
         let waiting = BatchSignal::new();
-        assert_eq!(waiting.abandon(), None, "nothing is running yet");
+        assert_eq!(waiting.abandon(TEARDOWN), None, "nothing is running yet");
         let (_running, may_start) = waiting.enter(A_LONG_BATCH);
         assert!(
             !may_start,
@@ -2049,7 +2094,7 @@ mod tests {
         let started = BatchSignal::new();
         let (_running, may_start) = started.enter(A_LONG_BATCH);
         assert!(may_start, "an ordinary batch runs");
-        let within = started.abandon().expect(
+        let within = started.abandon(TEARDOWN).expect(
             "a signal that found a batch running has to say so, or the teardown waits five \
              seconds and kills it mid-transaction",
         );
@@ -2070,10 +2115,40 @@ mod tests {
         let (_running, may_start) = signal.enter(Duration::ZERO);
         assert!(may_start);
         assert_eq!(
-            signal.abandon(),
+            signal.abandon(TEARDOWN),
             Some(Duration::ZERO),
             "its budget is spent, so the teardown owes it only the ordinary grace"
         );
+    }
+
+    /// A batch that finishes retracts what it was promised for, so a teardown stops waiting on a
+    /// transaction that is already unwound.
+    ///
+    /// Without this the promise stands at the figure it had when the teardown arrived — and if the
+    /// *release* behind it then hangs, which is exactly what the short grace exists to bound, the
+    /// teardown waits out the rest of a batch budget that was spent long ago. Minutes, for a
+    /// rollback that finished in seconds.
+    #[test]
+    fn a_finished_batch_retracts_the_promise_it_was_given() {
+        // Nobody was told, so nobody is owed an answer.
+        let untold = BatchSignal::new();
+        let (guard, _) = untold.enter(A_LONG_BATCH);
+        drop(guard);
+        assert_eq!(untold.finish(), None);
+
+        let signal = BatchSignal::new();
+        let (guard, _) = signal.enter(A_LONG_BATCH);
+        assert!(
+            signal.abandon(TEARDOWN).is_some(),
+            "the teardown is told this batch may need time"
+        );
+        assert_eq!(
+            signal.finish(),
+            Some(TEARDOWN),
+            "so it is owed the news when that stops being true"
+        );
+        assert_eq!(signal.finish(), None, "and owed it once");
+        drop(guard);
     }
 
     /// Once the batch is over, a teardown gets the short grace again — the extra wait is for a
@@ -2086,7 +2161,7 @@ mod tests {
             assert!(may_start);
         }
         assert_eq!(
-            signal.abandon(),
+            signal.abandon(TEARDOWN),
             None,
             "the batch is done; there is nothing to unwind"
         );

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -222,7 +222,7 @@ impl BatchSignal {
     fn finish(&self) -> Option<(u64, u32)> {
         let mut state = self.state();
         state.finish_by = None;
-        state.told_by.take().map(|id| (id, RELEASE_STILL_NEEDS))
+        state.told_by.take().map(|id| (id, RETRACTED))
     }
 
     /// Claims the engine thread for a batch that will be done by `bound` — everything it may start
@@ -262,17 +262,15 @@ impl Drop for BatchGuard<'_> {
     }
 }
 
-/// What a retraction promises instead of the batch's remaining budget: the transaction is over, and
-/// what is left is the release, which has not started yet.
+/// What a retraction says: **nothing more**, because the transaction is over.
 ///
-/// **Not zero**, which is what "the batch is done" first became. The release was queued *behind*
-/// the batch, so at the moment the batch ends it has not run at all — and a teardown whose grace
-/// expires just then would terminate the worker in the middle of the resume-and-detach a live
-/// kernel needs, leaving the target halted. It would also be non-monotonic, since a batch finishing
-/// a moment later would keep its whole extension. A release gets what an idle engine takes to let
-/// go, which is the same figure this process waits when it has to do it unasked
-/// ([`ABRUPT_EXIT_RELEASE`]).
-const RELEASE_STILL_NEEDS: u32 = ABRUPT_EXIT_RELEASE.as_millis() as u32;
+/// A retraction names the moment the batch ended, and zero is how a deadline says "now". What the
+/// release still needs is not the worker's to name — the supervisor grants it from this moment,
+/// out of the same grace it would have given a session that never ran a batch at all. Naming a
+/// release interval here as well, which is what this first was, adds one: the supervisor waits the
+/// interval out and *then* starts the grace, so a disconnect took two of them after a batch ended
+/// rather than one.
+const RETRACTED: u32 = 0;
 
 /// This process's one batch signal. Global for the same reason [`MESSAGES`] is: the reader thread
 /// sets it, the engine thread reads it, and there is exactly one engine here to be talking about.
@@ -2170,15 +2168,18 @@ mod tests {
         assert_eq!(signal.finish(), None, "and owed it once");
         drop(guard);
 
-        // What it is told is not "stop waiting": the release was queued *behind* the batch, so at
-        // this moment it has not run at all. Retracting to nothing would let a teardown whose
-        // grace expires right here terminate the worker mid-detach — and would be non-monotonic,
-        // since a batch finishing a moment later keeps its whole extension.
-        assert!(
-            within_ms > 0,
-            "a finished transaction still leaves a release that has not started"
+        // What it is told is "now": the batch is done, and the moment it ended is the only thing
+        // the worker knows that the supervisor does not. How long the release then gets is the
+        // supervisor's to decide, out of the grace it would have given any session — naming an
+        // interval here as well would be added to that rather than replacing it.
+        // Against `0`, not against `RETRACTED`: comparing the constant with itself would hold
+        // whatever it was changed to, which is exactly how a retraction quietly became a second
+        // helping of grace once before.
+        assert_eq!(
+            within_ms, 0,
+            "a retraction names the moment the batch ended, not an interval — what the release \
+             then gets is the supervisor's own grace, measured from that moment"
         );
-        assert_eq!(u128::from(within_ms), ABRUPT_EXIT_RELEASE.as_millis());
     }
 
     /// Once the batch is over, a teardown gets the short grace again — the extra wait is for a

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -133,76 +133,83 @@ fn watchdog_budget_ms(patience: Duration, queued: Duration) -> u32 {
 /// the case that matters: exiting without it leaves the target machine halted.
 const ABRUPT_EXIT_RELEASE: Duration = Duration::from_secs(5);
 
-/// The same, for a process whose engine is in the middle of a [`crate::batch`] transaction.
+/// Whether the batch on this worker's engine thread has been told to stop, and — the part a
+/// teardown actually needs — how long it can still be running.
 ///
-/// The release queues *behind* the batch, so waiting the bare grace above would exit with the
-/// rollback half-run — and on this path there is no supervisor left to have asked for anything
-/// better. The abandon flag is set alongside, so what is being waited on is one step finishing plus
-/// the `always` block, which is exactly [`batch::ROLLBACK_RESERVE`] at the outside.
-const ABRUPT_EXIT_ROLLBACK: Duration =
-    Duration::from_secs(ABRUPT_EXIT_RELEASE.as_secs() + batch::ROLLBACK_RESERVE.as_secs());
-
-/// Whether the batch on this worker's engine thread has been told to stop, and whether there is
-/// one to tell.
-///
-/// Two flags rather than one because the two questions have different owners: the *reader* sets
-/// `abandon` and needs an answer for the supervisor, the *engine thread* sets `running` and needs
-/// to know whether to stop. What matters is that they cannot both say "no" at once — see
-/// [`Self::abandon`].
+/// The deadline *is* the "is one running" answer rather than a second flag beside it, so the two
+/// can never disagree about a batch that started or finished in between.
 struct BatchSignal {
     /// Set by a teardown, and never cleared. Sticky on purpose: after it a batch that has not
     /// started must not start, or the session's last act would be a fresh set of mutations run for
     /// a caller who is already gone.
     abandon: AtomicBool,
-    /// Set while [`batch::run`] owns the engine thread.
-    running: AtomicBool,
+    /// When the batch on the engine thread must be finished by, or `None` when none is running.
+    ///
+    /// A `Mutex` rather than an atomic because it carries an `Instant`, and because the lock is
+    /// what orders it against [`Self::abandon`] — see there. Uncontended in practice: it is taken
+    /// twice per batch and once per teardown.
+    finish_by: Mutex<Option<Instant>>,
 }
 
 impl BatchSignal {
     const fn new() -> Self {
         Self {
             abandon: AtomicBool::new(false),
-            running: AtomicBool::new(false),
+            finish_by: Mutex::new(None),
         }
     }
 
-    /// Tells any batch to stop at its next step boundary, and reports whether one is running — the
-    /// answer a teardown sizes its grace from.
+    /// Tells any batch to stop at its next step boundary, and reports **how long it may still
+    /// need** — which is what a teardown sizes its grace from.
     ///
-    /// The store precedes the load, and [`Self::enter`] does the opposite, so at least one of the
-    /// two sees the other: either the batch has already started and this reports it, or it has not
-    /// and refuses to start. Both may happen, which costs a teardown a grace it did not need;
-    /// *neither* would be a batch running with the short grace behind it, which is the one outcome
-    /// this pairing exists to exclude. `SeqCst` because that guarantee is exactly what the weaker
-    /// orderings do not give across two locations.
-    fn abandon(&self) -> bool {
+    /// That figure is the batch's own remaining budget, not the rollback's reserve, and the
+    /// difference is the whole point: the signal cannot reach a step already inside DbgEng, so what
+    /// the teardown waits out is the step in flight *and* the `always` block after it. A batch is
+    /// finished inside its budget however it ends (`batch::run`), and that budget was already
+    /// clamped to the caller's patience, so this is a bound the worker can actually keep rather
+    /// than a guess that holds until a step runs long.
+    ///
+    /// **The one interleaving that must not happen** is a batch running while this reports nothing
+    /// to wait for. It cannot: the store precedes this lock, and [`Self::enter`] locks before it
+    /// loads. If this sees `None` because it got the lock first, its store is already visible to
+    /// the load `enter` makes after taking the lock — so that batch refuses to start. Both sides
+    /// seeing each other is fine, and costs a teardown a grace it did not need.
+    fn abandon(&self) -> Option<Duration> {
         self.abandon.store(true, Ordering::SeqCst);
-        self.running.load(Ordering::SeqCst)
+        let finish_by = *self.finish_by.lock().unwrap_or_else(|e| e.into_inner());
+        finish_by.map(|by| by.saturating_duration_since(Instant::now()))
     }
 
     fn abandoned(&self) -> bool {
         self.abandon.load(Ordering::SeqCst)
     }
 
-    /// Marks a batch as running for as long as the guard lives, and answers whether it may start
-    /// at all. See [`Self::abandon`] for why the store comes first.
-    fn enter(&self) -> (BatchGuard<'_>, bool) {
-        self.running.store(true, Ordering::SeqCst);
+    /// Claims the engine thread for a batch that must be done within `budget`, for as long as the
+    /// guard lives, and answers whether it may start at all.
+    fn enter(&self, budget: Duration) -> (BatchGuard<'_>, bool) {
+        *self.finish_by.lock().unwrap_or_else(|e| e.into_inner()) = Some(Instant::now() + budget);
         let guard = BatchGuard { signal: self };
+        // After the lock above is released, so a teardown that observes this batch at all observes
+        // its deadline too. See [`Self::abandon`].
         let may_start = !self.abandon.load(Ordering::SeqCst);
         (guard, may_start)
     }
 }
 
-/// Clears [`BatchSignal::running`] however the batch ends — including by unwinding, which
-/// `engine_thread`'s guard catches one frame further out.
+/// Clears the deadline however the batch ends — including by unwinding, which `engine_thread`'s
+/// guard catches one frame further out. A teardown after this point has nothing to wait for, and
+/// gets the ordinary grace.
 struct BatchGuard<'a> {
     signal: &'a BatchSignal,
 }
 
 impl Drop for BatchGuard<'_> {
     fn drop(&mut self) {
-        self.signal.running.store(false, Ordering::SeqCst);
+        *self
+            .signal
+            .finish_by
+            .lock()
+            .unwrap_or_else(|e| e.into_inner()) = None;
     }
 }
 
@@ -317,8 +324,8 @@ pub fn run(args: &[String]) -> ! {
     // supervisor without it running its own shutdown — nobody has, and exiting here would leave a
     // live kernel *halted*, because DbgEng needs an explicit resume-and-detach. So ask for one,
     // bounded: an idle engine obliges in milliseconds, a parked one never will, and either way
-    // this process is gone within `ABRUPT_EXIT_RELEASE` — or within `ABRUPT_EXIT_ROLLBACK`, when a
-    // batch is being unwound first.
+    // this process is gone within `ABRUPT_EXIT_RELEASE` — or, when a batch is being unwound first,
+    // within that plus what the batch itself has left to run.
     //
     // Ctrl+C only reaches this path because a worker is spawned into its own process group
     // (`engine::CREATE_NEW_PROCESS_GROUP`). Without that it would be delivered here too, and the
@@ -334,12 +341,15 @@ pub fn run(args: &[String]) -> ! {
     // behind every step it has left, on the one path where nobody is left to have asked for
     // anything — and this process is leaving either way, so the choice is between a rollback and
     // no rollback, not between finishing the batch and not.
-    let rolling_back = BATCH.abandon();
-    let grace = if rolling_back {
-        tracing::info!("worker: a batch was running; letting it roll back before exit");
-        ABRUPT_EXIT_ROLLBACK
-    } else {
-        ABRUPT_EXIT_RELEASE
+    let grace = match BATCH.abandon() {
+        Some(within) => {
+            tracing::info!(
+                "worker: a batch is running; giving it up to {within:?} to stop and roll back \
+                 before exit"
+            );
+            ABRUPT_EXIT_RELEASE + within
+        }
+        None => ABRUPT_EXIT_RELEASE,
     };
     let (ack, released) = mpsc::channel();
     if tx.send(Job::Release(ack)).is_err() {
@@ -503,18 +513,22 @@ fn emit(message: &WorkerMessage) -> Emit {
 /// waiter, or the teardown would read the flag before it was set and size its grace as though
 /// nothing were running.
 fn abandon_batch(id: u64) {
-    let rolling_back = BATCH.abandon();
-    if rolling_back {
-        emit(&WorkerMessage::RollingBack { id });
-    }
-    let what = if rolling_back {
-        "a batch was running; it will stop at its next step and run its `always` block"
-    } else {
-        "no batch was running; none can start on this session now"
+    let what = match BATCH.abandon() {
+        Some(within) => {
+            emit(&WorkerMessage::RollingBack {
+                id,
+                within_ms: within.as_millis().min(u128::from(u32::MAX)) as u32,
+            });
+            format!(
+                "a batch was running; it will stop at its next step and run its `always` block, \
+                 within {within:?}"
+            )
+        }
+        None => "no batch was running; none can start on this session now".to_string(),
     };
     emit(&WorkerMessage::Done {
         id,
-        result: Ok(what.to_string()),
+        result: Ok(what),
     });
 }
 
@@ -811,22 +825,6 @@ impl Debuggee for BatchEngine<'_> {
 /// and whether the rollback ran would be worse than no report at all. `Err` only chooses how
 /// [`crate::server`] renders it: a tool-execution error the model can read and act on.
 fn run_batch(e: &DebugEngine, op: BatchOp, queued: Duration) -> Result<String, String> {
-    // Claimed before the budget is worked out, so that from here on an abandon signal either finds
-    // this batch running or is found by it — never neither. See [`BatchSignal::abandon`].
-    let (_running, may_start) = BATCH.enter();
-    if !may_start {
-        // The same answer as an unaffordable budget below, and for the same reason: nothing ran, so
-        // there is nothing to undo and resubmitting is safe. This is the queue-wait case — the
-        // teardown that set the flag arrived while this batch was still behind other work.
-        return Err(
-            "This batch was not started: the session it names is being torn down (the client \
-             disconnected, or the session was ended) and was already doing so when this batch \
-             reached the engine. Nothing was run and nothing was changed — no step, no assertion, \
-             no rollback — so the target is exactly as it was. Open a session again and resubmit \
-             the whole batch."
-                .to_string(),
-        );
-    }
     let Some(budget) = batch_budget(
         op.budget_ms,
         Duration::from_millis(u64::from(op.patience_ms)),
@@ -849,6 +847,24 @@ fn run_batch(e: &DebugEngine, op: BatchOp, queued: Duration) -> Result<String, S
             queued.as_secs(),
         ));
     };
+    // Claimed only now, because the claim carries the deadline: a teardown that finds this batch
+    // has to be told how long it may still run, and that is not known until the budget is. From
+    // here an abandon signal either finds this batch or is found by it — never neither. See
+    // [`BatchSignal::abandon`].
+    let (_running, may_start) = BATCH.enter(budget);
+    if !may_start {
+        // The same answer as an unaffordable budget above, and for the same reason: nothing ran, so
+        // there is nothing to undo and resubmitting is safe. This is the queue-wait case — the
+        // teardown that set the flag arrived while this batch was still behind other work.
+        return Err(
+            "This batch was not started: the session it names is being torn down (the client \
+             disconnected, or the session was ended) and was already doing so when this batch \
+             reached the engine. Nothing was run and nothing was changed — no step, no assertion, \
+             no rollback — so the target is exactly as it was. Open a session again and resubmit \
+             the whole batch."
+                .to_string(),
+        );
+    }
     let mut engine = BatchEngine {
         e,
         started: Instant::now(),
@@ -2023,18 +2039,22 @@ mod tests {
     // below can be staged, which against the real one would mean disconnecting a client at an
     // exact instant.
 
-    /// The property the two flags exist to hold: a batch never runs with a teardown believing
-    /// there is nothing to wait for.
+    /// A budget long enough that the remaining-time assertions below are not measuring how fast
+    /// this machine runs a test.
+    const A_LONG_BATCH: Duration = Duration::from_secs(120);
+
+    /// The property the signal exists to hold: a batch never runs with a teardown believing there
+    /// is nothing to wait for.
     ///
     /// Whichever way the race falls, at least one side sees the other — the batch refuses to start,
-    /// or the signal reports it running. The forbidden outcome is *both* saying no, which is a
-    /// worker terminated mid-transaction on the five-second grace.
+    /// or the signal reports it and says how long it may still take. The forbidden outcome is
+    /// *both* missing, which is a worker terminated mid-transaction on the five-second grace.
     #[test]
     fn a_batch_and_the_signal_that_stops_it_cannot_both_miss() {
         // The signal arrives first: the batch must not start.
         let waiting = BatchSignal::new();
-        assert!(!waiting.abandon(), "nothing is running yet");
-        let (_running, may_start) = waiting.enter();
+        assert_eq!(waiting.abandon(), None, "nothing is running yet");
+        let (_running, may_start) = waiting.enter(A_LONG_BATCH);
         assert!(
             !may_start,
             "a batch that reached the engine after the teardown must not run its mutations"
@@ -2042,38 +2062,51 @@ mod tests {
 
         // The batch got there first: the signal must report it, so the grace is held open.
         let started = BatchSignal::new();
-        let (_running, may_start) = started.enter();
+        let (_running, may_start) = started.enter(A_LONG_BATCH);
         assert!(may_start, "an ordinary batch runs");
-        assert!(
-            started.abandon(),
+        let within = started.abandon().expect(
             "a signal that found a batch running has to say so, or the teardown waits five \
-             seconds and kills it mid-transaction"
+             seconds and kills it mid-transaction",
         );
         assert!(started.abandoned(), "and the batch has to see it");
+        // What it reports is what the batch has left, which is what covers the step in flight as
+        // well as the rollback after it.
+        assert!(
+            within <= A_LONG_BATCH && within > A_LONG_BATCH - Duration::from_secs(5),
+            "a batch just started should have nearly its whole budget left, not {within:?}"
+        );
+    }
+
+    /// A batch already past its deadline asks for nothing, rather than reporting a negative
+    /// remainder as a huge positive one.
+    #[test]
+    fn a_batch_that_is_out_of_time_asks_a_teardown_for_none() {
+        let signal = BatchSignal::new();
+        let (_running, may_start) = signal.enter(Duration::ZERO);
+        assert!(may_start);
+        assert_eq!(
+            signal.abandon(),
+            Some(Duration::ZERO),
+            "its budget is spent, so the teardown owes it only the ordinary grace"
+        );
     }
 
     /// Once the batch is over, a teardown gets the short grace again — the extra wait is for a
-    /// rollback in flight, not for a session that has ever run one.
+    /// transaction in flight, not for a session that has ever run one.
     #[test]
     fn a_finished_batch_leaves_nothing_for_a_teardown_to_wait_on() {
         let signal = BatchSignal::new();
         {
-            let (_running, may_start) = signal.enter();
+            let (_running, may_start) = signal.enter(A_LONG_BATCH);
             assert!(may_start);
         }
-        assert!(
-            !signal.abandon(),
+        assert_eq!(
+            signal.abandon(),
+            None,
             "the batch is done; there is nothing to unwind"
         );
         // Still sticky, though: this session is on its way out and must not start another.
-        let (_running, may_start) = signal.enter();
+        let (_running, may_start) = signal.enter(A_LONG_BATCH);
         assert!(!may_start);
-    }
-
-    /// The exit grace has to cover the rollback the abandon signal sets in motion, not just the
-    /// release queued behind it.
-    #[test]
-    fn the_abrupt_exit_grace_covers_a_rollback() {
-        assert!(ABRUPT_EXIT_ROLLBACK >= ABRUPT_EXIT_RELEASE + batch::ROLLBACK_RESERVE);
     }
 }

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -20,6 +20,7 @@
 use std::io::{BufRead, BufReader, PipeReader, PipeWriter, Write};
 use std::os::windows::io::{AsRawHandle, FromRawHandle, RawHandle};
 use std::panic::{AssertUnwindSafe, catch_unwind};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Mutex, OnceLock, mpsc};
 use std::thread;
 use std::time::{Duration, Instant};
@@ -132,6 +133,83 @@ fn watchdog_budget_ms(patience: Duration, queued: Duration) -> u32 {
 /// the case that matters: exiting without it leaves the target machine halted.
 const ABRUPT_EXIT_RELEASE: Duration = Duration::from_secs(5);
 
+/// The same, for a process whose engine is in the middle of a [`crate::batch`] transaction.
+///
+/// The release queues *behind* the batch, so waiting the bare grace above would exit with the
+/// rollback half-run — and on this path there is no supervisor left to have asked for anything
+/// better. The abandon flag is set alongside, so what is being waited on is one step finishing plus
+/// the `always` block, which is exactly [`batch::ROLLBACK_RESERVE`] at the outside.
+const ABRUPT_EXIT_ROLLBACK: Duration =
+    Duration::from_secs(ABRUPT_EXIT_RELEASE.as_secs() + batch::ROLLBACK_RESERVE.as_secs());
+
+/// Whether the batch on this worker's engine thread has been told to stop, and whether there is
+/// one to tell.
+///
+/// Two flags rather than one because the two questions have different owners: the *reader* sets
+/// `abandon` and needs an answer for the supervisor, the *engine thread* sets `running` and needs
+/// to know whether to stop. What matters is that they cannot both say "no" at once — see
+/// [`Self::abandon`].
+struct BatchSignal {
+    /// Set by a teardown, and never cleared. Sticky on purpose: after it a batch that has not
+    /// started must not start, or the session's last act would be a fresh set of mutations run for
+    /// a caller who is already gone.
+    abandon: AtomicBool,
+    /// Set while [`batch::run`] owns the engine thread.
+    running: AtomicBool,
+}
+
+impl BatchSignal {
+    const fn new() -> Self {
+        Self {
+            abandon: AtomicBool::new(false),
+            running: AtomicBool::new(false),
+        }
+    }
+
+    /// Tells any batch to stop at its next step boundary, and reports whether one is running — the
+    /// answer a teardown sizes its grace from.
+    ///
+    /// The store precedes the load, and [`Self::enter`] does the opposite, so at least one of the
+    /// two sees the other: either the batch has already started and this reports it, or it has not
+    /// and refuses to start. Both may happen, which costs a teardown a grace it did not need;
+    /// *neither* would be a batch running with the short grace behind it, which is the one outcome
+    /// this pairing exists to exclude. `SeqCst` because that guarantee is exactly what the weaker
+    /// orderings do not give across two locations.
+    fn abandon(&self) -> bool {
+        self.abandon.store(true, Ordering::SeqCst);
+        self.running.load(Ordering::SeqCst)
+    }
+
+    fn abandoned(&self) -> bool {
+        self.abandon.load(Ordering::SeqCst)
+    }
+
+    /// Marks a batch as running for as long as the guard lives, and answers whether it may start
+    /// at all. See [`Self::abandon`] for why the store comes first.
+    fn enter(&self) -> (BatchGuard<'_>, bool) {
+        self.running.store(true, Ordering::SeqCst);
+        let guard = BatchGuard { signal: self };
+        let may_start = !self.abandon.load(Ordering::SeqCst);
+        (guard, may_start)
+    }
+}
+
+/// Clears [`BatchSignal::running`] however the batch ends — including by unwinding, which
+/// `engine_thread`'s guard catches one frame further out.
+struct BatchGuard<'a> {
+    signal: &'a BatchSignal,
+}
+
+impl Drop for BatchGuard<'_> {
+    fn drop(&mut self) {
+        self.signal.running.store(false, Ordering::SeqCst);
+    }
+}
+
+/// This process's one batch signal. Global for the same reason [`MESSAGES`] is: the reader thread
+/// sets it, the engine thread reads it, and there is exactly one engine here to be talking about.
+static BATCH: BatchSignal = BatchSignal::new();
+
 /// What the request reader hands to the engine thread.
 enum Job {
     /// A request from the supervisor, stamped when it was read.
@@ -202,6 +280,14 @@ pub fn run(args: &[String]) -> ! {
             continue;
         }
         match serde_json::from_str::<WorkerRequest>(&line) {
+            // Answered here rather than queued, because the thread that would run it is the one
+            // this is about: it is inside the batch being abandoned. This loop is never blocked by
+            // the engine — it reads a line and hands it on — which is the whole reason the signal
+            // can arrive at all. See [`EngineOp::AbandonBatch`].
+            Ok(WorkerRequest {
+                id,
+                op: EngineOp::AbandonBatch,
+            }) => abandon_batch(id),
             Ok(request) => {
                 if tx.send(Job::Run(Instant::now(), request)).is_err() {
                     break; // the engine thread is gone; nothing can run any more
@@ -231,7 +317,8 @@ pub fn run(args: &[String]) -> ! {
     // supervisor without it running its own shutdown — nobody has, and exiting here would leave a
     // live kernel *halted*, because DbgEng needs an explicit resume-and-detach. So ask for one,
     // bounded: an idle engine obliges in milliseconds, a parked one never will, and either way
-    // this process is gone within `ABRUPT_EXIT_RELEASE`.
+    // this process is gone within `ABRUPT_EXIT_RELEASE` — or within `ABRUPT_EXIT_ROLLBACK`, when a
+    // batch is being unwound first.
     //
     // Ctrl+C only reaches this path because a worker is spawned into its own process group
     // (`engine::CREATE_NEW_PROCESS_GROUP`). Without that it would be delivered here too, and the
@@ -243,6 +330,17 @@ pub fn run(args: &[String]) -> ! {
     // Logged because it is otherwise invisible: this is the teardown nobody asked for, and an
     // operator looking at a target that came back fine wants to see which path did it.
     tracing::info!("worker: supervisor is gone; releasing the target before exit");
+    // Same signal, sent to ourselves. A batch still running would otherwise hold the release
+    // behind every step it has left, on the one path where nobody is left to have asked for
+    // anything — and this process is leaving either way, so the choice is between a rollback and
+    // no rollback, not between finishing the batch and not.
+    let rolling_back = BATCH.abandon();
+    let grace = if rolling_back {
+        tracing::info!("worker: a batch was running; letting it roll back before exit");
+        ABRUPT_EXIT_ROLLBACK
+    } else {
+        ABRUPT_EXIT_RELEASE
+    };
     let (ack, released) = mpsc::channel();
     if tx.send(Job::Release(ack)).is_err() {
         // The engine thread died before this could be asked, so nothing was even attempted --
@@ -255,12 +353,11 @@ pub fn run(args: &[String]) -> ! {
         // Whichever way this ends the process does, but *which* way is the difference between a
         // target let go and a target still attached to a debugger that no longer exists. Silence
         // here would leave that to be inferred from a guest that never came back.
-        match released.recv_timeout(ABRUPT_EXIT_RELEASE) {
+        match released.recv_timeout(grace) {
             Ok(()) => {}
             Err(mpsc::RecvTimeoutError::Timeout) => tracing::warn!(
-                "worker: the engine did not finish releasing within {ABRUPT_EXIT_RELEASE:?} \
-                 (parked in DbgEng, most likely); exiting anyway, so a live kernel target may be \
-                 left halted"
+                "worker: the engine did not finish releasing within {grace:?} (parked in DbgEng, \
+                 most likely); exiting anyway, so a live kernel target may be left halted"
             ),
             Err(mpsc::RecvTimeoutError::Disconnected) => {
                 tracing::error!("worker: the engine thread is gone, so nothing released the target")
@@ -397,6 +494,28 @@ fn emit(message: &WorkerMessage) -> Emit {
             Emit::Unwritable
         }
     }
+}
+
+/// Answers an [`EngineOp::AbandonBatch`] from the request reader.
+///
+/// The order of the two messages is the contract: [`WorkerMessage::RollingBack`] says the grace has
+/// to be held open, and it must be on the wire before the `Done` that releases the supervisor's
+/// waiter, or the teardown would read the flag before it was set and size its grace as though
+/// nothing were running.
+fn abandon_batch(id: u64) {
+    let rolling_back = BATCH.abandon();
+    if rolling_back {
+        emit(&WorkerMessage::RollingBack { id });
+    }
+    let what = if rolling_back {
+        "a batch was running; it will stop at its next step and run its `always` block"
+    } else {
+        "no batch was running; none can start on this session now"
+    };
+    emit(&WorkerMessage::Done {
+        id,
+        result: Ok(what.to_string()),
+    });
 }
 
 /// Runs one op against this worker's engine. `queued` is how long it waited its turn here, which
@@ -574,6 +693,14 @@ fn execute(e: &DebugEngine, id: u64, op: EngineOp, queued: Duration) -> Result<S
         EngineOp::Reachability(args) => reachable(e, args),
         EngineOp::Pool(args) => pool(e, args),
         EngineOp::Batch(op) => run_batch(e, op, queued),
+        // Handled by the request reader, which is the only place it can be handled: reaching this
+        // thread means it queued behind the very batch it was meant to cut short. Answered rather
+        // than ignored, because a request without a reply costs the caller its session.
+        EngineOp::AbandonBatch => Err(
+            "the abandon signal reached the engine thread, which means it was queued rather than \
+             delivered — nothing was abandoned. This is a bug in the worker's request reader."
+                .to_string(),
+        ),
         EngineOp::EndSession => e
             .end_session()
             .map(|_| "session ended".to_string())
@@ -645,6 +772,7 @@ fn batch_budget(requested_ms: u32, patience: Duration, queued: Duration) -> Opti
 struct BatchEngine<'a> {
     e: &'a DebugEngine,
     started: Instant,
+    signal: &'a BatchSignal,
 }
 
 impl Debuggee for BatchEngine<'_> {
@@ -671,6 +799,10 @@ impl Debuggee for BatchEngine<'_> {
     fn elapsed(&self) -> Duration {
         self.started.elapsed()
     }
+
+    fn abandoned(&self) -> bool {
+        self.signal.abandoned()
+    }
 }
 
 /// Runs a batch and renders its report.
@@ -679,6 +811,22 @@ impl Debuggee for BatchEngine<'_> {
 /// and whether the rollback ran would be worse than no report at all. `Err` only chooses how
 /// [`crate::server`] renders it: a tool-execution error the model can read and act on.
 fn run_batch(e: &DebugEngine, op: BatchOp, queued: Duration) -> Result<String, String> {
+    // Claimed before the budget is worked out, so that from here on an abandon signal either finds
+    // this batch running or is found by it — never neither. See [`BatchSignal::abandon`].
+    let (_running, may_start) = BATCH.enter();
+    if !may_start {
+        // The same answer as an unaffordable budget below, and for the same reason: nothing ran, so
+        // there is nothing to undo and resubmitting is safe. This is the queue-wait case — the
+        // teardown that set the flag arrived while this batch was still behind other work.
+        return Err(
+            "This batch was not started: the session it names is being torn down (the client \
+             disconnected, or the session was ended) and was already doing so when this batch \
+             reached the engine. Nothing was run and nothing was changed — no step, no assertion, \
+             no rollback — so the target is exactly as it was. Open a session again and resubmit \
+             the whole batch."
+                .to_string(),
+        );
+    }
     let Some(budget) = batch_budget(
         op.budget_ms,
         Duration::from_millis(u64::from(op.patience_ms)),
@@ -704,9 +852,24 @@ fn run_batch(e: &DebugEngine, op: BatchOp, queued: Duration) -> Result<String, S
     let mut engine = BatchEngine {
         e,
         started: Instant::now(),
+        signal: &BATCH,
     };
     let report = batch::run(&mut engine, &op, budget);
     let rendered = batch::render(&report);
+    // The one outcome whose report is written for nobody: a batch is abandoned by a teardown, so
+    // the caller is already gone and the `Done` this becomes answers a waiter that is being failed
+    // out anyway. The log is where it can still be read, and an operator looking at a target that
+    // was patched wants to know the patch came off.
+    if matches!(report.outcome, batch::BatchOutcome::Abandoned { .. }) {
+        tracing::info!(
+            "worker: batch abandoned mid-flight; rollback {}",
+            if report.rollback_complete() {
+                "complete"
+            } else {
+                "INCOMPLETE — the target may still be patched"
+            }
+        );
+    }
     if report.committed() && report.rollback_complete() {
         Ok(rendered)
     } else {
@@ -1851,5 +2014,66 @@ mod tests {
             batch_budget(120_000, least - Duration::from_millis(1), Duration::ZERO),
             None
         );
+    }
+
+    // ---- the abandon signal -----------------------------------------------
+    //
+    // Against a local `BatchSignal` rather than the process-wide `BATCH`, so these say nothing
+    // about the order the test binary happens to run them in — and so that both sides of the race
+    // below can be staged, which against the real one would mean disconnecting a client at an
+    // exact instant.
+
+    /// The property the two flags exist to hold: a batch never runs with a teardown believing
+    /// there is nothing to wait for.
+    ///
+    /// Whichever way the race falls, at least one side sees the other — the batch refuses to start,
+    /// or the signal reports it running. The forbidden outcome is *both* saying no, which is a
+    /// worker terminated mid-transaction on the five-second grace.
+    #[test]
+    fn a_batch_and_the_signal_that_stops_it_cannot_both_miss() {
+        // The signal arrives first: the batch must not start.
+        let waiting = BatchSignal::new();
+        assert!(!waiting.abandon(), "nothing is running yet");
+        let (_running, may_start) = waiting.enter();
+        assert!(
+            !may_start,
+            "a batch that reached the engine after the teardown must not run its mutations"
+        );
+
+        // The batch got there first: the signal must report it, so the grace is held open.
+        let started = BatchSignal::new();
+        let (_running, may_start) = started.enter();
+        assert!(may_start, "an ordinary batch runs");
+        assert!(
+            started.abandon(),
+            "a signal that found a batch running has to say so, or the teardown waits five \
+             seconds and kills it mid-transaction"
+        );
+        assert!(started.abandoned(), "and the batch has to see it");
+    }
+
+    /// Once the batch is over, a teardown gets the short grace again — the extra wait is for a
+    /// rollback in flight, not for a session that has ever run one.
+    #[test]
+    fn a_finished_batch_leaves_nothing_for_a_teardown_to_wait_on() {
+        let signal = BatchSignal::new();
+        {
+            let (_running, may_start) = signal.enter();
+            assert!(may_start);
+        }
+        assert!(
+            !signal.abandon(),
+            "the batch is done; there is nothing to unwind"
+        );
+        // Still sticky, though: this session is on its way out and must not start another.
+        let (_running, may_start) = signal.enter();
+        assert!(!may_start);
+    }
+
+    /// The exit grace has to cover the rollback the abandon signal sets in motion, not just the
+    /// release queued behind it.
+    #[test]
+    fn the_abrupt_exit_grace_covers_a_rollback() {
+        assert!(ABRUPT_EXIT_ROLLBACK >= ABRUPT_EXIT_RELEASE + batch::ROLLBACK_RESERVE);
     }
 }

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -218,22 +218,30 @@ impl BatchSignal {
     /// transaction already safely unwound. A fresh promise of zero says the only thing still worth
     /// waiting for is the release itself.
     ///
-    /// Owed once: whoever takes it here sends it.
-    fn finish(&self) -> Option<u64> {
+    /// Owed once: whoever takes it here sends it, to the id and with the figure this returns.
+    fn finish(&self) -> Option<(u64, u32)> {
         let mut state = self.state();
         state.finish_by = None;
-        state.told_by.take()
+        state.told_by.take().map(|id| (id, RELEASE_STILL_NEEDS))
     }
 
     /// Claims the engine thread for a batch that must be done within `budget`, for as long as the
-    /// guard lives, and answers whether it may start at all.
-    fn enter(&self, budget: Duration) -> (BatchGuard<'_>, bool) {
-        self.state().finish_by = Some(Instant::now() + budget);
-        let guard = BatchGuard { signal: self };
-        // After the lock above is released, so a teardown that observes this batch at all observes
-        // its deadline too. See [`Self::abandon`].
-        let may_start = !self.abandon.load(Ordering::SeqCst);
-        (guard, may_start)
+    /// guard lives — or refuses, when a teardown has already been through.
+    ///
+    /// Checking and publishing under the **one** lock acquisition is what keeps a refused batch
+    /// from ever being visible: published first and withdrawn after, there is a window in which a
+    /// second teardown reads a whole batch budget for a batch that will not run, and waits it out
+    /// before killing a worker that is doing nothing.
+    fn enter(&self, budget: Duration) -> Option<BatchGuard<'_>> {
+        let mut state = self.state();
+        // Under the lock, which is what pairs it with [`Self::abandon`]: that one stores before it
+        // takes this lock, so a teardown that got here first is visible to this load, and a batch
+        // that got here first is visible to that read. Never neither.
+        if self.abandon.load(Ordering::SeqCst) {
+            return None;
+        }
+        state.finish_by = Some(Instant::now() + budget);
+        Some(BatchGuard { signal: self })
     }
 }
 
@@ -247,11 +255,23 @@ impl Drop for BatchGuard<'_> {
     fn drop(&mut self) {
         // Outside the lock `finish` takes: `emit` takes one of its own, and nothing here should
         // hold two at once.
-        if let Some(id) = self.signal.finish() {
-            emit(&WorkerMessage::RollingBack { id, within_ms: 0 });
+        if let Some((id, within_ms)) = self.signal.finish() {
+            emit(&WorkerMessage::RollingBack { id, within_ms });
         }
     }
 }
+
+/// What a retraction promises instead of the batch's remaining budget: the transaction is over, and
+/// what is left is the release, which has not started yet.
+///
+/// **Not zero**, which is what "the batch is done" first became. The release was queued *behind*
+/// the batch, so at the moment the batch ends it has not run at all — and a teardown whose grace
+/// expires just then would terminate the worker in the middle of the resume-and-detach a live
+/// kernel needs, leaving the target halted. It would also be non-monotonic, since a batch finishing
+/// a moment later would keep its whole extension. A release gets what an idle engine takes to let
+/// go, which is the same figure this process waits when it has to do it unasked
+/// ([`ABRUPT_EXIT_RELEASE`]).
+const RELEASE_STILL_NEEDS: u32 = ABRUPT_EXIT_RELEASE.as_millis() as u32;
 
 /// This process's one batch signal. Global for the same reason [`MESSAGES`] is: the reader thread
 /// sets it, the engine thread reads it, and there is exactly one engine here to be talking about.
@@ -878,8 +898,7 @@ fn run_batch(e: &DebugEngine, op: BatchOp, queued: Duration) -> Result<String, S
     // has to be told how long it may still run, and that is not known until the budget is. From
     // here an abandon signal either finds this batch or is found by it — never neither. See
     // [`BatchSignal::abandon`].
-    let (_running, may_start) = BATCH.enter(budget);
-    if !may_start {
+    let Some(_running) = BATCH.enter(budget) else {
         // The same answer as an unaffordable budget above, and for the same reason: nothing ran, so
         // there is nothing to undo and resubmitting is safe. This is the queue-wait case — the
         // teardown that set the flag arrived while this batch was still behind other work.
@@ -891,7 +910,7 @@ fn run_batch(e: &DebugEngine, op: BatchOp, queued: Duration) -> Result<String, S
              the whole batch."
                 .to_string(),
         );
-    }
+    };
     let mut engine = BatchEngine {
         e,
         started: Instant::now(),
@@ -2084,16 +2103,14 @@ mod tests {
         // The signal arrives first: the batch must not start.
         let waiting = BatchSignal::new();
         assert_eq!(waiting.abandon(TEARDOWN), None, "nothing is running yet");
-        let (_running, may_start) = waiting.enter(A_LONG_BATCH);
         assert!(
-            !may_start,
+            waiting.enter(A_LONG_BATCH).is_none(),
             "a batch that reached the engine after the teardown must not run its mutations"
         );
 
         // The batch got there first: the signal must report it, so the grace is held open.
         let started = BatchSignal::new();
-        let (_running, may_start) = started.enter(A_LONG_BATCH);
-        assert!(may_start, "an ordinary batch runs");
+        let _running = started.enter(A_LONG_BATCH).expect("an ordinary batch runs");
         let within = started.abandon(TEARDOWN).expect(
             "a signal that found a batch running has to say so, or the teardown waits five \
              seconds and kills it mid-transaction",
@@ -2112,8 +2129,7 @@ mod tests {
     #[test]
     fn a_batch_that_is_out_of_time_asks_a_teardown_for_none() {
         let signal = BatchSignal::new();
-        let (_running, may_start) = signal.enter(Duration::ZERO);
-        assert!(may_start);
+        let _running = signal.enter(Duration::ZERO).expect("it may start");
         assert_eq!(
             signal.abandon(TEARDOWN),
             Some(Duration::ZERO),
@@ -2132,23 +2148,31 @@ mod tests {
     fn a_finished_batch_retracts_the_promise_it_was_given() {
         // Nobody was told, so nobody is owed an answer.
         let untold = BatchSignal::new();
-        let (guard, _) = untold.enter(A_LONG_BATCH);
-        drop(guard);
+        drop(untold.enter(A_LONG_BATCH).expect("it may start"));
         assert_eq!(untold.finish(), None);
 
         let signal = BatchSignal::new();
-        let (guard, _) = signal.enter(A_LONG_BATCH);
+        let guard = signal.enter(A_LONG_BATCH).expect("it may start");
         assert!(
             signal.abandon(TEARDOWN).is_some(),
             "the teardown is told this batch may need time"
         );
-        assert_eq!(
-            signal.finish(),
-            Some(TEARDOWN),
-            "so it is owed the news when that stops being true"
-        );
+        let (told, within_ms) = signal
+            .finish()
+            .expect("so it is owed the news when that stops being true");
+        assert_eq!(told, TEARDOWN);
         assert_eq!(signal.finish(), None, "and owed it once");
         drop(guard);
+
+        // What it is told is not "stop waiting": the release was queued *behind* the batch, so at
+        // this moment it has not run at all. Retracting to nothing would let a teardown whose
+        // grace expires right here terminate the worker mid-detach — and would be non-monotonic,
+        // since a batch finishing a moment later keeps its whole extension.
+        assert!(
+            within_ms > 0,
+            "a finished transaction still leaves a release that has not started"
+        );
+        assert_eq!(u128::from(within_ms), ABRUPT_EXIT_RELEASE.as_millis());
     }
 
     /// Once the batch is over, a teardown gets the short grace again — the extra wait is for a
@@ -2156,17 +2180,13 @@ mod tests {
     #[test]
     fn a_finished_batch_leaves_nothing_for_a_teardown_to_wait_on() {
         let signal = BatchSignal::new();
-        {
-            let (_running, may_start) = signal.enter(A_LONG_BATCH);
-            assert!(may_start);
-        }
+        drop(signal.enter(A_LONG_BATCH).expect("it may start"));
         assert_eq!(
             signal.abandon(TEARDOWN),
             None,
             "the batch is done; there is nothing to unwind"
         );
         // Still sticky, though: this session is on its way out and must not start another.
-        let (_running, may_start) = signal.enter(A_LONG_BATCH);
-        assert!(!may_start);
+        assert!(signal.enter(A_LONG_BATCH).is_none());
     }
 }

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -225,14 +225,15 @@ impl BatchSignal {
         state.told_by.take().map(|id| (id, RELEASE_STILL_NEEDS))
     }
 
-    /// Claims the engine thread for a batch that must be done within `budget`, for as long as the
-    /// guard lives — or refuses, when a teardown has already been through.
+    /// Claims the engine thread for a batch that will be done by `bound` — everything it may start
+    /// plus everything that may still be finishing — for as long as the guard lives, or refuses
+    /// when a teardown has already been through.
     ///
     /// Checking and publishing under the **one** lock acquisition is what keeps a refused batch
     /// from ever being visible: published first and withdrawn after, there is a window in which a
     /// second teardown reads a whole batch budget for a batch that will not run, and waits it out
     /// before killing a worker that is doing nothing.
-    fn enter(&self, budget: Duration) -> Option<BatchGuard<'_>> {
+    fn enter(&self, bound: Duration) -> Option<BatchGuard<'_>> {
         let mut state = self.state();
         // Under the lock, which is what pairs it with [`Self::abandon`]: that one stores before it
         // takes this lock, so a teardown that got here first is visible to this load, and a batch
@@ -240,7 +241,7 @@ impl BatchSignal {
         if self.abandon.load(Ordering::SeqCst) {
             return None;
         }
-        state.finish_by = Some(Instant::now() + budget);
+        state.finish_by = Some(Instant::now() + bound);
         Some(BatchGuard { signal: self })
     }
 }
@@ -898,7 +899,12 @@ fn run_batch(e: &DebugEngine, op: BatchOp, queued: Duration) -> Result<String, S
     // has to be told how long it may still run, and that is not known until the budget is. From
     // here an abandon signal either finds this batch or is found by it — never neither. See
     // [`BatchSignal::abandon`].
-    let Some(_running) = BATCH.enter(budget) else {
+    //
+    // What is advertised is the budget **plus what the executor is allowed to overrun it by**: the
+    // budget bounds what a batch may start, and an operation started a moment before it still gets
+    // a watchdog floor. Advertising the bare budget would have a teardown terminate this worker
+    // while the last restore was still running — see [`batch::OVERRUN_ALLOWANCE`].
+    let Some(_running) = BATCH.enter(budget + batch::OVERRUN_ALLOWANCE) else {
         // The same answer as an unaffordable budget above, and for the same reason: nothing ran, so
         // there is nothing to undo and resubmitting is safe. This is the queue-wait case — the
         // teardown that set the flag arrived while this batch was still behind other work.

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -1277,7 +1277,7 @@ fn ending_a_session_stops_a_running_batch_and_rolls_it_back() {
     let session_id = session_id_of(&text_of(&response["result"]));
 
     let mut steps = vec![
-        json!({ "op": "command", "command": format!(".logopen {}", running.display()) }),
+        json!({ "op": "command", "command": format!(".logopen \"{}\"", running.display()) }),
         json!({ "op": "command", "command": ".echo BATCH-RUNNING" }),
         json!({ "op": "command", "command": ".logclose" }),
     ];
@@ -1368,7 +1368,7 @@ fn a_disconnect_lets_a_running_batch_roll_back_first() {
     // Steps: announce that the batch is running, then spend twenty seconds so the disconnect
     // lands squarely inside it. `always` leaves the second marker, and is the thing under test.
     let mut steps = vec![
-        json!({ "op": "command", "command": format!(".logopen {}", running.display()) }),
+        json!({ "op": "command", "command": format!(".logopen \"{}\"", running.display()) }),
         json!({ "op": "command", "command": ".echo BATCH-RUNNING" }),
         json!({ "op": "command", "command": ".logclose" }),
     ];
@@ -1385,7 +1385,7 @@ fn a_disconnect_lets_a_running_batch_roll_back_first() {
                 "session_id": session_id,
                 "steps": steps,
                 "always": [
-                    { "op": "command", "command": format!(".logopen {}", rolled_back.display()) },
+                    { "op": "command", "command": format!(".logopen \"{}\"", rolled_back.display()) },
                     { "op": "command", "command": ".echo ROLLBACK-RAN" },
                     { "op": "command", "command": ".logclose" },
                 ],

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -16,7 +16,8 @@
 //!   symbols, no network.
 //! * **Target** (`WINDBG_MCP_SMOKE_DUMP=1`) — opens the sample crash dump through DbgEng, so
 //!   it needs `dbgeng.dll` and may reach a symbol server. Off by default; this is the tier
-//!   that catches a `win-kexp` regression. It also runs a `debug_batch` to both outcomes,
+//!   that catches a `win-kexp` regression. It also runs a `debug_batch` to both outcomes, and
+//!   through both teardowns — an `end_session` and a client disconnect landing mid-transaction —
 //!   because "the rollback ran inside the worker" is a claim only a real engine can settle.
 //! * **Bounded command** (`#[ignore]`d, run by hand) — deliberately runs away and waits out a
 //!   watchdog, so it is measured in minutes rather than seconds. It lives here rather than
@@ -41,7 +42,7 @@ use std::panic::{AssertUnwindSafe, catch_unwind, resume_unwind};
 use std::process::{Child, ChildStdin, Command, Stdio};
 use std::sync::mpsc::{Receiver, RecvTimeoutError, channel};
 use std::sync::{Arc, Mutex};
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime};
 
 use serde_json::{Value, json};
 
@@ -1254,6 +1255,200 @@ fn a_batch_commits_or_fails_and_its_rollback_runs_either_way() {
         json!({ "session_id": session_id }),
         TARGET_STEP,
     );
+}
+
+/// `end_session` on a session that is running a batch: the batch stops at its next step, rolls
+/// back, and *reports* — which is what makes ending the session the documented way to abort one.
+///
+/// The client is still here for this one, so unlike the disconnect below it can be asked what
+/// happened, and the answer is the point: an `ABANDONED` report with the rollback complete, rather
+/// than a session that goes quiet for as long as the batch had left. Both calls are outstanding at
+/// once, deliberately — a teardown that had to queue behind the work it is tearing down would be no
+/// use for the case it exists for.
+#[test]
+fn ending_a_session_stops_a_running_batch_and_rolls_it_back() {
+    let Some(dump) = target_tier() else { return };
+    let running = marker_path("end-session-batch-running");
+    let _ = std::fs::remove_file(&running);
+
+    let mut server = Server::started();
+    let response = server.call_tool("open_dump", json!({ "path": dump }), TARGET_STEP);
+    assert_no_error(&response, "open_dump");
+    let session_id = session_id_of(&text_of(&response["result"]));
+
+    let mut steps = vec![
+        json!({ "op": "command", "command": format!(".logopen {}", running.display()) }),
+        json!({ "op": "command", "command": ".echo BATCH-RUNNING" }),
+        json!({ "op": "command", "command": ".logclose" }),
+    ];
+    steps.extend(std::iter::repeat_n(
+        json!({ "op": "command", "command": ".sleep 1000" }),
+        20,
+    ));
+    let batch = server.send_request(
+        "tools/call",
+        json!({
+            "name": "debug_batch",
+            "arguments": {
+                "session_id": session_id,
+                "steps": steps,
+                "always": [{ "op": "command", "command": "version", "name": "cleanup" }],
+            }
+        }),
+    );
+
+    // As below: end the session only once the batch is demonstrably inside it, or this would be
+    // testing the refuse-to-start path instead and passing just as green.
+    let deadline = Instant::now() + TARGET_STEP;
+    while !running.exists() {
+        assert!(
+            Instant::now() < deadline,
+            "the batch never reached its first step\n--- stderr ---\n{}",
+            server.stderr()
+        );
+        std::thread::sleep(Duration::from_millis(100));
+    }
+
+    let asked = Instant::now();
+    let ended = server.tool_text(
+        "end_session",
+        json!({ "session_id": session_id }),
+        TARGET_STEP,
+    );
+    let took = asked.elapsed();
+    assert!(!ended.trim().is_empty(), "end_session said nothing");
+    assert!(
+        took < Duration::from_secs(15),
+        "end_session took {took:?}: it waited out the batch instead of cutting it short"
+    );
+
+    // The batch's own reply, which the client is still here to receive.
+    let report = text_of(&server.await_id(batch, "debug_batch", TARGET_STEP)["result"]);
+    assert!(
+        report.contains("BATCH: ABANDONED"),
+        "the batch should say it was cut short, not that it failed or timed out:\n{report}"
+    );
+    assert!(
+        report.contains("rollback: COMPLETE"),
+        "the rollback is the reason for stopping early:\n{report}"
+    );
+
+    let _ = std::fs::remove_file(&running);
+}
+
+/// A batch still running when the client disconnects has to finish its rollback before its worker
+/// goes — the one guarantee `debug_batch` used to make only against a call *timeout*.
+///
+/// The teardown is the adversary here: a disconnect is `end_session` on every session, the
+/// `EndSession` op queues *behind* the batch, and the grace it waits is deliberately short. So the
+/// worker used to be terminated mid-transaction, with whatever the batch had patched still
+/// patched — on a live kernel, the exact loss the tool exists to prevent, arriving by the path
+/// where nobody is watching.
+///
+/// Both facts it asserts need a real engine and a real disconnect, which is why this is here rather
+/// than in `src/batch.rs`: the abandon signal has to cross the worker's channel and be answered by
+/// its *reader* while its engine thread is busy, and the rollback has to leave something behind
+/// after the client, the supervisor and the worker are all gone. That last part is what the log
+/// files are for — a side effect on this machine outlives every process involved, where a tool
+/// result has nobody left to be returned to. A dump has nothing worth restoring, so the mutation is
+/// stood in for by writing a file; the byte-level version belongs in the live-kernel tier.
+#[test]
+fn a_disconnect_lets_a_running_batch_roll_back_first() {
+    let Some(dump) = target_tier() else { return };
+    let running = marker_path("batch-running");
+    let rolled_back = marker_path("batch-rolled-back");
+    let _ = std::fs::remove_file(&running);
+    let _ = std::fs::remove_file(&rolled_back);
+
+    let mut server = Server::started();
+    let response = server.call_tool("open_dump", json!({ "path": dump }), TARGET_STEP);
+    assert_no_error(&response, "open_dump");
+    let session_id = session_id_of(&text_of(&response["result"]));
+
+    // Steps: announce that the batch is running, then spend twenty seconds so the disconnect
+    // lands squarely inside it. `always` leaves the second marker, and is the thing under test.
+    let mut steps = vec![
+        json!({ "op": "command", "command": format!(".logopen {}", running.display()) }),
+        json!({ "op": "command", "command": ".echo BATCH-RUNNING" }),
+        json!({ "op": "command", "command": ".logclose" }),
+    ];
+    steps.extend(std::iter::repeat_n(
+        json!({ "op": "command", "command": ".sleep 1000" }),
+        20,
+    ));
+    // Sent without waiting: nobody is left to read the answer, which is the whole scenario.
+    server.send_request(
+        "tools/call",
+        json!({
+            "name": "debug_batch",
+            "arguments": {
+                "session_id": session_id,
+                "steps": steps,
+                "always": [
+                    { "op": "command", "command": format!(".logopen {}", rolled_back.display()) },
+                    { "op": "command", "command": ".echo ROLLBACK-RAN" },
+                    { "op": "command", "command": ".logclose" },
+                ],
+            }
+        }),
+    );
+
+    // Disconnect only once the batch is demonstrably inside its steps. Timing it with a sleep
+    // instead would make a slow machine into a test that proves nothing: the batch would not have
+    // started, and refusing to start is a *different* correct behaviour with the same green tick.
+    let deadline = Instant::now() + TARGET_STEP;
+    while !running.exists() {
+        assert!(
+            Instant::now() < deadline,
+            "the batch never reached its first step, so the disconnect below would prove \
+             nothing\n--- stderr ---\n{}",
+            server.stderr()
+        );
+        std::thread::sleep(Duration::from_millis(100));
+    }
+
+    let disconnected = Instant::now();
+    assert_eq!(
+        server.shutdown(),
+        Some(0),
+        "clean disconnect should be a clean exit"
+    );
+    let took = disconnected.elapsed();
+
+    let rollback = std::fs::read_to_string(&rolled_back).unwrap_or_else(|e| {
+        panic!(
+            "the `always` block left nothing at {} ({e}) — the batch was terminated \
+             mid-transaction, which on a live kernel would leave the patch in place",
+            rolled_back.display()
+        )
+    });
+    assert!(
+        rollback.contains("ROLLBACK-RAN"),
+        "the rollback started but did not finish; it left:\n{rollback}"
+    );
+    // The steps had twenty seconds left to run. Waiting them out would be a rollback that happened
+    // for the wrong reason — the batch finishing normally — and would say nothing about abandoning
+    // one.
+    assert!(
+        took < Duration::from_secs(15),
+        "the disconnect took {took:?}: the batch ran on instead of stopping at its next step"
+    );
+
+    let _ = std::fs::remove_file(&running);
+    let _ = std::fs::remove_file(&rolled_back);
+}
+
+/// A path in the temp directory nothing else in this run will pick, for tests that need a side
+/// effect outliving the server process.
+fn marker_path(what: &str) -> std::path::PathBuf {
+    let unique = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or_default();
+    std::env::temp_dir().join(format!(
+        "windbg-mcp-smoke-{what}-{}-{unique:x}.log",
+        std::process::id()
+    ))
 }
 
 /// The `session_id` a tool result carries, if it carries one.


### PR DESCRIPTION
Closes [`FOLLOWUPS.md`](https://github.com/glslang/windbg-mcp/blob/main/FOLLOWUPS.md) item 18, the last thing #82 left owed on the rollback guarantee.

## Why

`debug_batch` made its guarantee totally against a call **timeout** — the budget is clamped to the caller's remaining patience, so `always` has run and the report is written before the wait expires — and not at all against a **teardown**.

A client disconnect is `end_session` on every session, `end_session` is itself the documented way to abort a batch, and both queue their `EndSession` *behind* the batch on the engine thread. So the grace expired with the transaction still open and the worker was terminated mid-patch. On a live kernel that is the exact loss the tool exists to prevent, arriving by the path where nobody is watching. `end_session` was the same shape with a longer number on it: it waited out the whole batch, or killed it at 20s.

Item 18 recorded why neither obvious fix was worth taking, and both still hold. A longer `SHUTDOWN_RELEASE_TIMEOUT` is paid on **every** disconnect, including the parked kernel attach the five seconds were tuned against; a supervisor that tracks what each worker is running is a change to the path every session's teardown depends on, with the failure mode "the client hangs on disconnect".

## What

The teardown asks instead.

**`EngineOp::AbandonBatch` is answered by the worker's request *reader*, not its engine thread** — the one op that must be, since the thread it concerns is inside the batch being abandoned. Item 18 expected this to need item 7's side channel; it does not, and that is the one thing the item got wrong. A worker busy in DbgEng **is** draining its request queue: the reader lives on the main thread and only hands work to the engine thread, so it is never blocked. It only ever drains the pipe into an in-process queue.

**`batch::run` reads the flag between steps**, which is where every failure path already fell through to `always` from. The batch stops there, rolls back, and reports a new outcome:

```
BATCH: ABANDONED at step 7 of 23 — the session was being torn down (the client
disconnected, or the session was ended), so the batch stopped there and ran its
rollback. Nothing was wrong with the steps or the budget; resubmit the whole
batch on a fresh session.
rollback: COMPLETE — all 3 `always` step(s) ran
```

Its own outcome rather than a timeout or a failure, because the steps that did not run were not *refused* — nothing was wrong with the target or the budget, and resubmitting from the top is the right next move, which is not what a caller should conclude from either of the other two.

**The grace is conditional without the supervisor tracking anything.** The worker answers the signal with `WorkerMessage::RollingBack` — a milestone like `Committed`, so it rides *ahead* of the reply on the same ordered channel, and the flag is set by the time the abandon call returns. `engine::release_grace` then adds `batch::ROLLBACK_RESERVE` for that session alone. Derived from the reserve rather than picked to look sufficient: an abandoned batch holds its rollback to exactly that reserve, so the worker's own bound and the supervisor's grace cannot drift apart when one of them changes.

An ordinary disconnect is untouched, and not merely by arithmetic — **the signal is skipped entirely when a worker owes no reply**, which is every idle session.

Three smaller pieces fall out of the same mechanism:

- A batch reaching the engine *after* the signal does not start at all — the same "nothing ran, no step, no assertion, no rollback, resubmitting is safe" answer an unaffordable budget already gets.
- The two flags are ordered store-then-load on both sides, so a batch and the signal that stops it can never **both** miss. Both may see each other, which costs a teardown a grace it did not need; neither seeing the other would be a batch running with the five-second grace behind it, and that is what the pairing excludes.
- The worker's own EOF path signals itself, so a supervisor killed outright (Ctrl+C, a crash) also leaves a rolled-back target rather than a truncated transaction.

## What this still cannot do

No signal reaches a step already inside DbgEng, so a batch stops at its **next** step, and one step longer than the grace is still terminated mid-transaction. That is item 7 — `SetInterrupt` as a typed win-kexp method, bound to job identity — and it is now the only part of this that needs it. Item 7 has been updated to say which half of it item 18 built.

Documented as the boundary it is in `README.md`, the skill playbook and the tool description, all three of which previously said a disconnect was simply not a safe way to abort a batch.

## Proof

Two altitudes, as the rest of `batch.rs` is:

- **`src/batch.rs`** — the executor stops where it is and still rolls back, with each skipped step saying the session went away rather than that something failed or the clock ran out; and the rollback is held to the reserve rather than to a budget nobody is waiting out any more.
- **`src/worker.rs`** — the flag pairing, staged from both sides against a local `BatchSignal` (the real one is process-wide, and a test that depended on run order would prove nothing).
- **`tests/mcp_smoke.rs`, dump tier** — both teardowns end to end, each with a batch parked in twenty seconds of `.sleep` steps. `end_session` returns in seconds instead of waiting the batch out, and the batch's own call comes back `BATCH: ABANDONED` with the rollback complete. The **disconnect** version has nobody left to report to — client, supervisor and worker are all gone by the time it is checked — so the rollback writes a file and the assertion is made against the filesystem afterwards, which is as close as a dump gets to the byte a live target would have restored. Both wait for a marker the batch's *first* step writes before tearing anything down: timed with a sleep instead, a slow machine would test the refuse-to-start path and pass just as green.

The disconnect test was run with the signal patched out and **fails** there — `the always block left nothing at …` — so it catches the defect rather than merely passing.

`cargo test` with `WINDBG_MCP_SMOKE_DUMP=1`: 198 unit + 27 smoke, clippy and markdownlint clean.

## Still owed on batches

Unchanged by this: pool steps (item 17, the one gap the CTF transcript found) and a live-kernel exercise of a *mutating* batch (item 16) — a dump has nothing worth restoring. Item 16 now also asks for the teardown paths against a real target: patch a byte, disconnect mid-batch, read it back over a fresh attach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Active batches are safely abandoned during session termination or client disconnection.
  * Running batches stop at the next step, execute rollback, and report `BATCH: ABANDONED`.
  * Additional grace time is reserved for rollback during teardown.
  * Queued batches no longer start when teardown is requested.

* **Bug Fixes**
  * Improved cleanup reporting, including incomplete rollback when long-running steps exceed available grace.

* **Documentation**
  * Updated guidance and smoke-test coverage for teardown, rollback, and known limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->