### PR TITLE
Let a batch step ask the pool, and prove a mutating batch on a live kernel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   A batch is submitted as one op and executed inside the session's worker process. Steps are
   `command` (raw), `resume` (a command that moves the target, plus the wait), `run_to` (a
-  HIT/STOPPED ELSEWHERE/TIMEOUT verdict), `eval` (a MASM expression's value) and `read_memory`.
-  Each may carry assertions — `contains`, `not_contains`, or `eval`, which compares two MASM
+  HIT/STOPPED ELSEWHERE/TIMEOUT verdict), `eval` (a MASM expression's value) and `read_memory`,
+  plus `pool_chunk`, `pool_find_tag` and `pool_census`, which ask the kernel pool exactly what the
+  tools of those names ask. Those three are here because they are the only typed tools that are
+  *not* debugger commands — they are win-kexp walks over the allocator's descriptors, so no
+  `command` step can stand in for them, and a transaction that needed one had to be split around
+  it. Inside a batch their walk is bounded by the step's share of the budget rather than by the
+  walker's own 120s default, so a `refresh` cannot spend the reserve the rollback lives on; a walk
+  cut short still reports the coverage it reached.
+  Each step may carry assertions — `contains`, `not_contains`, or `eval`, which compares two MASM
   expressions and so covers registers, memory and any relation between them — and an `eval` step
   may `capture` its value under a name later steps interpolate as `{{name}}`.
 
@@ -82,6 +89,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   to both teardowns — a real disconnect mid-batch, whose rollback has to leave a mark on the machine
   because there is no client left to report to, and an `end_session` mid-batch, where there is.
 
+  The claim itself — *a write that is then restored* — is settled where it can be false, on a live
+  KDNET kernel: a byte of the running kernel is patched inside a batch and read back afterwards,
+  through a failing assertion, through a call budget shorter than the batch asked for, through a
+  disconnect (read back by a **new server process** over a fresh attach) and through an
+  `end_session`. A crash dump cannot make that claim at all — a byte patched in a dump is patched in
+  a file nobody reads again, so a rollback that silently did nothing passes every assertion the dump
+  tier can make. Each of those tests probes the byte before it starts, because a guest with memory
+  integrity enabled accepts a debugger write to an image page and drops it, which would otherwise
+  leave the whole tier passing for the wrong reason.
+
   Two limits are documented rather than papered over. DbgEng reports most command failures by
   printing them and returning success, so a raw step that prints an error is a step that
   *succeeded* — assert on its output if that matters. And what a step "changed" is a best-effort
@@ -90,10 +107,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   Validated against the workflow it was filed for, not against a guess at it: the CTF session's own
   transcript records all 18 revisions of the throwaway client and all 188 of its invocations — 1,681
-  steps, of which 1,672 are shapes the step language covers. The 9 that are not are pool-tool calls
-  (`pool_chunk`, `pool_census`, `pool_find_tag`), which are win-kexp walks rather than debugger
-  commands and so have no `execute` to fall back on; that gap is [`FOLLOWUPS.md`](./FOLLOWUPS.md)
-  item 17. Two of the client's revisions exist only to work around gaps this closes — a compound
+  steps, every one of them a shape the step language covers. The 9 that motivated the pool steps are
+  the reason those exist: the client's `@chunkt1` read a pseudo-register with `execute`,
+  regex-scraped the value out of the debugger's prose and handed it to `pool_chunk`, and it sat
+  *inside* the 32-step transaction, between a code patch and its restore — so a batch without it
+  would have had to drop the query or split the transaction. It is now a `capture` and a step.
+  Two of the client's revisions exist only to work around gaps this closes — a compound
   assertion rewritten as three pseudo-register assignments and three regexes, and a duplicate of its
   run-to verb whose only difference was restoring a patch "on both hit and timeout". The longest
   single invocation, 32 steps, is transcribed as a regression test.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,8 +105,11 @@ cargo test --test mcp_smoke -- --ignored --nocapture --test-threads=1 bounded
 
 A fourth tier drives a **real KDNET target** through a full session lifecycle — attach, work
 alongside a second session, detach gracefully — separately checks that a client *disconnect*
-releases a live kernel session rather than killing its worker, and covers the **pool walk**
-(`pool_find_tag`/`pool_census`), whose cost only exists over a live link. It is gated on the
+releases a live kernel session rather than killing its worker, covers the **pool walk**
+(`pool_find_tag`/`pool_census`), whose cost only exists over a live link, and runs a **`debug_batch`
+that patches a byte of the running kernel** and has to put it back (through a failing assertion, a
+clamped call budget, a disconnect and an `end_session`) — the one claim a crash dump cannot test,
+because a byte patched in a dump is patched in a file nobody reads again. It is gated on the
 connection string (which nobody can guess) *and* `#[ignore]`d, so a stale variable can never freeze
 a VM during an ordinary `cargo test`. Run it last, on its own:
 
@@ -115,7 +118,7 @@ $env:WINDBG_MCP_SMOKE_KERNEL = "net:port=50000,key=<w.x.y.z>"
 cargo test --test mcp_smoke -- --ignored --nocapture --test-threads=1 live_kernel
 ```
 
-`--test-threads=1` is not optional: the filter matches **three** tests, and the KD transport is
+`--test-threads=1` is not optional: the filter matches **eight** tests, and the KD transport is
 single-owner, so in parallel the second attach fails and can leave the target halted.
 
 ## Live kernel + driver IOCTL gotchas (learned driving HEVD over KDNET)

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -111,9 +111,16 @@ disconnect is untouched. What none of this can do is *shorten* a step already in
 is `SetInterrupt` bound to job identity, FOLLOWUPS item 7 — so a batch stops at its next step
 boundary, not where it stands.
 
-**Status.** Adopted. Two things are still owed: pool steps (FOLLOWUPS item 17, the one gap the
-transcript found) and a live-kernel exercise of a *mutating* batch (item 16) — the dump tier proves
-the wiring and both outcomes, but a dump has nothing worth restoring.
+**Status.** Adopted, and the two things it owed are now paid (2026-08-10). **Pool steps** (FOLLOWUPS
+item 17) landed as one `StepAction` variant per question rather than a generic "call a tool" step,
+which would have put every tool's arguments in the batch schema twice; the part nobody had
+anticipated is that a walk needs a deadline *from the batch*, because win-kexp bounds one at 120s and
+an ordinary batch's whole budget is shorter — a refreshed pool step taking that default would spend
+the rollback's reserve and overrun the bound advertised to a teardown, which is the failure above
+arriving through the one step that is not a command. And the **mutating batch** (item 16) is now
+exercised on a live kernel, which is the only place the claim can be false: a byte patched in a dump
+is patched in a file nobody reads again, so a rollback that silently did nothing satisfies every
+assertion the dump tier can make.
 
 ---
 

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -47,9 +47,10 @@ tools already learned not to make.
 
 **Validated against the workflow it was filed for.** The CTF session's own transcript
 (`~/.codex/sessions/2026/08/08`) records all 18 revisions of the throwaway client and all 188 of its
-invocations — 1,681 individual steps. Classified against the step language: 1,672 of them are
-`command`, `run_to`, `resume` or `eval` shapes, and **9 are pool-tool calls a batch cannot reach**
-(`@chunkt1`, `@census`, `@find`, `@findr`). Two of the client's revisions exist only to work around
+invocations — 1,681 individual steps. Classified against the step language *as adopted*: 1,672 of
+them are `command`, `run_to`, `resume` or `eval` shapes, and **9 were pool-tool calls a batch could
+not then reach** (`@chunkt1`, `@census`, `@find`, `@findr`) — the gap that became FOLLOWUPS item 17
+and is closed below. Two of the client's revisions exist only to work around
 gaps this design closes — its eighth replaced a compound `.if` assertion with three pseudo-register
 assignments and three regexes over printed output, and its sixteenth added a duplicate of `@run`
 whose only difference was restoring a patch "on both hit and timeout", which is `always` hand-rolled.

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -13,8 +13,10 @@ and the 2026-08-02 entries that items 13–14 and item 10 extend.
 Items are roughly ordered by how soon they're worth doing, within each cluster. **Item 10 has
 landed** (process-per-session, 2026-08-02); it is kept here rather than deleted because items 7, 8
 and 9 were all written against the single-engine design it replaced, and each now says what moved.
-**Item 18 has landed** (2026-08-10) and is kept for the opposite reason: it turned out to need much
-less of item 7 than it claimed to, and item 7 should be read knowing which half of it is still owed.
+**Items 16, 17 and 18 have landed** (2026-08-10) and are kept for the opposite reason: each turned
+out to need something its entry did not anticipate — item 18 needed much less of item 7 than it
+claimed to (item 7 should be read knowing which half of it is still owed), item 17 needed a walk
+deadline nothing had asked for, and item 16 needed a probe before it could measure anything at all.
 
 ## 1. [win-kexp] Managed breakpoint lifecycle for `run_to_address` — **done upstream**
 
@@ -350,51 +352,60 @@ and no other spawn site needs to know the rule exists.
   function. The convention is pinned rather than merely documented, which is what makes this an
   improvement to *how* the property is held rather than a fix to a live hole.
 
-## 16. [windbg-mcp] Exercise a *mutating* `debug_batch` against a live kernel target
+## 16. [windbg-mcp] Exercise a *mutating* `debug_batch` against a live kernel target — **done**
 
-`debug_batch` (#82) is proved at two altitudes: `src/batch.rs` drives the executor over a scripted
+`debug_batch` (#82) was proved at two altitudes: `src/batch.rs` drives the executor over a scripted
 debuggee with a virtual clock (assertion failure, a command failure after a mutation, deadline
 expiry, a rollback that itself fails), and the debugger tier drives a real engine to both outcomes
-over the wire. Neither covers the case the tool was built for — a **write that is then restored**
+over the wire. Neither covered the case the tool was built for — a **write that is then restored**
 on a target that would notice.
 
-- **Why deferred:** a crash dump has nothing worth restoring, and the live-kernel tier is
-  `#[ignore]`d and gated on a connection string precisely so an ordinary `cargo test` can never
-  reach a VM. So this belongs beside the existing `live_kernel` tests, run by hand.
-- **What it should assert:** save a byte with an `eval`+`capture`, patch it, fail an assertion
-  deliberately, and confirm from a *later, separate* call that the `always` block put the original
-  back — the point being that nothing after the batch had to be sent for that to happen. Then the
-  same batch with the call budget shortened (`WINDBG_MCP_CALL_TIMEOUT_SECS`) below the batch's own
-  deadline, to check the clamp in `worker::batch_budget` really keeps the report ahead of the
-  caller's timeout on a target where steps take real time.
-- **And now the teardown paths too** (item 18, landed): patch a byte, disconnect mid-batch, and
-  read the byte back over a *fresh* attach — the dump tier proves the rollback ran by the file it
-  wrote, which is the shape of the claim but not the substance of it. Same again for `end_session`
-  arriving mid-batch, where the batch's own `BATCH: ABANDONED` report comes back to the client.
-- **Where it picks up:** `tests/mcp_smoke.rs`, the `live_kernel` filter; the harness for setting and
-  reading back a byte already exists in the MessageManager tier.
+Landed (2026-08-10) as five tests in the `live_kernel` filter of `tests/mcp_smoke.rs`: a failing
+batch whose `always` block restores a patched byte (confirmed by a *later, separate* call, so
+nothing after the batch had to be sent for it to happen); the same under a
+`WINDBG_MCP_CALL_TIMEOUT_SECS` shorter than the batch's own deadline, where the clamp in
+`worker::batch_budget` is what keeps the report ahead of the caller; a disconnect mid-batch, read
+back by a **new server process** over a fresh attach; an `end_session` mid-batch, where the client is
+still there to receive `BATCH: ABANDONED` *and* a second attach agrees about the byte; and a pool
+step inside a batch (item 17).
 
-## 17. [windbg-mcp] Let a `debug_batch` step call a typed tool, starting with the pool queries
+Two things the writing of it settled, both worth keeping:
+
+- **What to patch.** `nt`'s DOS-header `e_res2` field (`nt+0x28`) — reserved by the format, read by
+  nothing at runtime, and stable across a detach and re-attach, which the teardown tests need and a
+  stack address could not give. Anything with a *purpose* satisfies the first two conditions and
+  bugchecks the guest on the third.
+- **The probe is not optional.** A guest with memory integrity (HVCI) enabled accepts a debugger
+  write to an image page and silently drops it, so every one of these tests reads, writes, reads
+  back and restores the byte *before* it opens a transaction. Without that, a rollback that did
+  nothing and a patch that never landed are the same green tick.
+
+## 17. [windbg-mcp] Let a `debug_batch` step call a typed tool, starting with the pool queries — **done**
 
 The one gap the MessageManager transcript found in `debug_batch` (#82). Its step vocabulary reaches
 anything that is a *debugger command*, which is almost every typed tool in this server — but not the
 ones that are not commands at all. The pool tools are win-kexp walks over the allocator's own
-structures, so `pool_find_tag`, `pool_chunk` and `pool_census` have no `execute` equivalent to fall
-back on.
+structures, so `pool_find_tag`, `pool_chunk` and `pool_census` had no `execute` equivalent to fall
+back on. It cost the workflow this is measured against 9 of 1,681 steps (`@chunkt1`, `@census`,
+`@find`, `@findr`) — small, but not incidental: `@chunkt1` sat *inside* the 32-step transaction,
+between a code patch and its restore.
 
-- **How much it cost the workflow it is measured against:** 9 of 1,681 steps (`@chunkt1`, `@census`,
-  `@find`, `@findr`). Small, but not incidental — `@chunkt1` sat *inside* the 32-step transaction,
-  between a code patch and its restore, so a batch expressing that sequence today has to drop it.
-- **Why deferred:** the shape is a design question, not a missing wire. `PoolOp` already crosses to
-  the worker and `worker::pool` already renders it, so the plumbing is short; what needs deciding is
-  whether a step names a *tool* generically (open-ended, and every tool's arguments then have to
-  exist in the batch schema twice) or whether the batch grows one variant per typed tool worth
-  having in a transaction. The second is smaller and matches how `StepAction` is already justified —
-  variants exist for what a raw command cannot express — but it is a list that will keep growing.
-- **Where it picks up:** `StepAction` in `src/batch.rs`, `PoolOp` in `src/proto.rs`, and
-  `batch::Debuggee`, which would gain one method per capability so the executor stays engine-free.
-  `@chunkt1`'s real shape is the test case: capture a register with `eval`, then ask `pool_chunk`
-  about `{{that}}` — the capture half already works.
+Landed (2026-08-10) as **one `StepAction` variant per question** — `pool_chunk`, `pool_find_tag`,
+`pool_census` — rather than a generic "call a tool" step, for the reason this item guessed at: the
+generic form would have every tool's arguments living in the batch schema twice. `pool_diagnostics`
+is deliberately not among them; it explains a *walk* rather than the target, and belongs to the
+interactive look that follows a batch. `batch::Debuggee` gained one method, `pool`, so the executor
+stays engine-free, and the defaults and caps moved onto `PoolOp` constructors in `src/proto.rs` so a
+step and a tool cannot drift apart on what `limit` means.
+
+The design question the item did *not* anticipate, and the part worth remembering: **a walk needs a
+deadline from the batch.** win-kexp bounds a walk at `DEFAULT_WALK_BUDGET` (120s), which is longer
+than an ordinary batch's whole budget — so a `refresh` step taking that default could spend the
+reserve the rollback lives on and overrun the bound the worker advertises to a teardown (item 18),
+which is a worker terminated mid-transaction. `PoolWalk::within` already existed for exactly this
+("a host that knows its own deadline should pass that instead of taking this"), so a pool step now
+passes its own step budget and a walk cut short reports its coverage as it always did. The pool
+*tools* still take the default; giving them the call's patience is [#75](https://github.com/glslang/windbg-mcp/issues/75).
 
 ## 18. [windbg-mcp] Let a running batch finish its rollback when the client disconnects — **done**
 

--- a/README.md
+++ b/README.md
@@ -419,12 +419,23 @@ step that ran to its own deadline is nothing.
 }
 ```
 
-Five step kinds: `command` (raw), `resume` (a command that moves the target, plus the wait),
-`run_to` (a HIT/STOPPED ELSEWHERE/TIMEOUT verdict), `eval` (a MASM expression's value), and
-`read_memory`. Assertions are `contains`, `not_contains`, and `eval` — the last compares two MASM
-expressions, so registers, memory and relations between them are all one check. An `eval` step may
-`capture` its value under a name that later steps interpolate as `{{name}}`; a reference that names
-no earlier capture is refused before anything runs.
+Eight step kinds. Five are the debugger itself: `command` (raw), `resume` (a command that moves the
+target, plus the wait), `run_to` (a HIT/STOPPED ELSEWHERE/TIMEOUT verdict), `eval` (a MASM
+expression's value), and `read_memory`. Three ask the kernel pool the questions the `pool_*` tools
+ask — `pool_chunk`, `pool_find_tag`, `pool_census` — because those are walks over the allocator's own
+descriptors rather than debugger commands, so no `command` step can stand in for them:
+
+```jsonc
+{ "op": "eval", "expr": "@$t1", "capture": "obj" },                    // what the target handed us
+{ "op": "pool_chunk", "address": "{{obj}}", "refresh": true }          // what the allocator says it is
+```
+
+Inside a batch a walk is bounded by the *step's* share of the budget rather than by the walker's own
+120s default, so a `refresh` cannot spend the reserve the rollback lives on; a walk cut short still
+reports how much of the pool it covered. Assertions are `contains`, `not_contains`, and `eval` — the
+last compares two MASM expressions, so registers, memory and relations between them are all one
+check. An `eval` step may `capture` its value under a name that later steps interpolate as
+`{{name}}`; a reference that names no earlier capture is refused before anything runs.
 
 **A field this tool does not know is an error, not something to ignore** — the one place in this
 server where that is true. Serde drops unknown fields silently, so `"aways"` for `always` would be a

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -22,7 +22,7 @@ connected MCP client holds a lock on (see [`CLAUDE.md`](../CLAUDE.md)). Whole su
 | **Protocol** | always | nothing — no debugger, no target, no network | transport, revision negotiation, tool-surface drift |
 | **Debugger** | `WINDBG_MCP_SMOKE_DUMP=1` | `dbgeng.dll`, the checked-in sample dump | `win-kexp` / DbgEng regressions |
 | **Bounded command** | `--ignored` | `dbgeng.dll`, the sample dump, ~1 minute | the watchdog wiring, which now spans two processes |
-| **Live kernel** | `--ignored` + `WINDBG_MCP_SMOKE_KERNEL` | a KDNET target you can freeze | that a kernel attach *lands*, coexists, and is let go — by `end_session` and by a disconnect |
+| **Live kernel** | `--ignored` + `WINDBG_MCP_SMOKE_KERNEL` | a KDNET target you can freeze | that a kernel attach *lands*, coexists, and is let go — by `end_session` and by a disconnect; and that a `debug_batch` which patches a byte of the running kernel puts it back |
 | **MessageManager CTF** | `--ignored` + live-kernel gate + `WINDBG_MCP_SMOKE_CTF=1` | the challenge VM, WinRM, full `nt` symbols | the real driver and retained `Tgsm` pool objects through the shipped MCP transport |
 | **Live (other)** | manual | TTD engine, elevation, a test driver | see [Manual checklist](#manual-checklist) |
 
@@ -220,7 +220,7 @@ $env:WINDBG_MCP_SMOKE_KERNEL = "net:port=50000,key=<w.x.y.z>"
 cargo test --test mcp_smoke -- --ignored --nocapture --test-threads=1 live_kernel
 ```
 
-`--test-threads=1` is required, not tidiness: the filter matches **three** tests, and the KD
+`--test-threads=1` is required, not tidiness: the filter matches **eight** tests, and the KD
 transport is single-owner. Run them in parallel and the later attaches fail, which can leave the
 target halted.
 
@@ -313,6 +313,47 @@ a *dump* costs nothing. Both tests therefore collect their evidence and assert o
 target has been released: an earlier draft asserted as it went, failed at the release check, and
 left the target halted. A test for a bug that freezes a machine must not freeze the machine when
 it fails.
+
+### A `debug_batch` that really mutates the target
+
+Five of the eight tests are about a batch that **patches a byte of the running kernel and puts it
+back**, which is the thing the tool exists for and the thing no dump can test: a byte "patched" in a
+crash dump is patched in a file nobody reads again, so a rollback that silently did nothing would
+satisfy every assertion the debugger tier can make. Here the byte either reads back as it was or it
+does not.
+
+The byte is `nt`'s DOS-header `e_res2` field (`nt+0x28`) — reserved by the PE format, zero in every
+image MSVC has linked, read by nothing at runtime, and stable across a detach and re-attach because
+the image does not move without a reboot. Each test **probes it first**: read, write a different
+value, read it back, restore. That probe decides whether the run can prove anything at all, and it
+is the one place a guest with memory integrity (HVCI) enabled announces itself — such a guest
+accepts a debugger write to an image page and drops it, which would leave every assertion below
+passing for the wrong reason. When the probe cannot write, the test says so loudly and stops rather
+than measuring a patch that never landed.
+
+- **A failing batch restores its patch** — the assertion that cannot hold is step 4 of 5, the batch
+  stops there, and a **separate later call** finds the original byte. The step after the failure
+  writes a third distinct value, so "SKIPPED" is checked against the target and not only against the
+  report.
+- **A batch reports and rolls back inside its caller's timeout.** The server's per-call budget is
+  pinned to 60s, the batch asks for ten minutes and is given nearly a minute of work; the clamp in
+  `worker::batch_budget` is what makes the report arrive before the call gives up. The steps are
+  many short `.sleep`s rather than a few long ones deliberately: the deadline is then crossed
+  *between* steps, so the outcome does not depend on whether DbgEng honours an interrupt inside a
+  `.sleep`.
+- **A disconnect lets the rollback finish first**, verified from a **new server process** over a
+  fresh attach — the byte outlives every process that was involved in patching it. This is the
+  substance the debugger tier's version can only approximate with a log file.
+- **`end_session` mid-batch does the same with a client still listening**: the batch's own call
+  comes back `BATCH: ABANDONED` with the rollback complete, *and* a second attach agrees about the
+  byte. Both attaches check `nt`'s base, so a guest that rebooted in between fails loudly instead of
+  comparing a byte to a different byte.
+- **A batch step queries the pool.** `pool_chunk`, `pool_find_tag` and `pool_census` are the only
+  typed tools that are not debugger commands, so a batch that could not call them could not express
+  the CTF workflow's `@chunkt1` — which sat inside the transaction, between a patch and its restore.
+  The test captures `@$proc` with an `eval` step and asks `pool_chunk` about `{{proc}}`; it needs the
+  same full `nt` symbols the pool tier does. Either pool answer is correct (a chunk, or an address
+  the walk did not cover) and they are different facts, so both are accepted by name.
 
 ## MessageManager CTF regression
 

--- a/skills/windbg-debugging/SKILL.md
+++ b/skills/windbg-debugging/SKILL.md
@@ -50,7 +50,11 @@ the engine process on every path, including a failed assertion and an expired de
 the budget is reserved so it has time to run; the report names the exact failing step, what each
 step changed, whether the rollback completed, and whether the target is left stopped, running or
 gone. Save what you are about to overwrite with an `eval` step's `capture`, and restore it in
-`always` as `{{name}}`.
+`always` as `{{name}}`. A step can also ask the kernel pool what the `pool_*` tools ask —
+`pool_chunk`, `pool_find_tag`, `pool_census` — so "capture the pointer, ask the allocator what it
+is" stays *inside* the transaction instead of splitting it in two; a `refresh` there is bounded by
+the step's share of the batch budget rather than by the walker's own, and says how much of the pool
+it reached.
 
 Two edges to keep in mind. If a step overruns far enough to consume the reserve too, cleanup is
 skipped and the result says `rollback: INCOMPLETE` — believe it rather than the intent. And a

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -39,6 +39,7 @@ use std::time::Duration;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
+use crate::proto::PoolOp;
 use crate::server::{
     EXEC_WAIT_MS, Quotes, changes_debug_target, fmt_addr, parse_eval, reject_command_breakers,
 };
@@ -135,6 +136,20 @@ const FAILED_OUTPUT_CHARS: usize = 8_000;
 /// `execute_command`, so [`Self::Command`] already covers them, and the variants that exist beside
 /// it are the ones a raw command genuinely cannot express as a single unit — a wait for the target
 /// to stop, a run-to verdict, a value this batch can bind a name to.
+///
+/// The pool variants are the same rule reaching its other end. `pool_find_tag`, `pool_chunk` and
+/// `pool_census` are not commands at all — they are win-kexp walks over the allocator's own
+/// descriptors, with no `!pool` text a `command` step could stand in for — so a batch without them
+/// simply cannot ask what a chunk is, which is what the MessageManager workflow found: its
+/// `@chunkt1` sat *inside* the transaction, between a code patch and its restore, so the sequence
+/// could not be expressed with it left out. `pool_diagnostics` is deliberately absent: it explains
+/// a *walk*, not the target, and belongs to the interactive look that follows a batch rather than
+/// to the transaction.
+///
+/// `refresh` is what makes a pool step expensive — it re-walks every committed page — and inside a
+/// batch that walk is bounded by the *step's* share of the budget rather than by win-kexp's own
+/// default, which is longer than most batches. A walk cut short says how much of the pool it
+/// covered, so the answer stays honest; see [`Debuggee::pool`].
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(tag = "op", rename_all = "snake_case")]
 pub enum StepAction {
@@ -169,6 +184,34 @@ pub enum StepAction {
     /// `0x`-hex, so `@rsp` or `poi(@rbx+8)` is one `eval` with a `capture` and then `{{name}}`
     /// here.
     ReadMemory { address: String, size: u32 },
+    /// Identify the pool chunk containing `address` and its neighbours — the `pool_chunk` tool.
+    ///
+    /// The step the transaction shape needs: an `eval` captures a pointer the target just handed
+    /// over, and this asks the allocator what it is. `address` takes the same forms the tool does,
+    /// and a `{{capture}}` is one of them.
+    PoolChunk {
+        address: String,
+        #[serde(default)]
+        refresh: Option<bool>,
+    },
+    /// Every allocated chunk carrying `tag` — the `pool_find_tag` tool.
+    PoolFindTag {
+        tag: String,
+        /// true = paged only, false = nonpaged only, omitted = both.
+        #[serde(default)]
+        paged: Option<bool>,
+        #[serde(default)]
+        refresh: Option<bool>,
+        #[serde(default)]
+        limit: Option<u32>,
+    },
+    /// Per-tag totals across the pool, heaviest first — the `pool_census` tool.
+    PoolCensus {
+        #[serde(default)]
+        refresh: Option<bool>,
+        #[serde(default)]
+        limit: Option<u32>,
+    },
 }
 
 impl StepAction {
@@ -185,6 +228,9 @@ impl StepAction {
             Self::RunTo { .. } => &["address", "timeout_ms"],
             Self::Eval { .. } => &["expr"],
             Self::ReadMemory { .. } => &["address", "size"],
+            Self::PoolChunk { .. } => &["address", "refresh"],
+            Self::PoolFindTag { .. } => &["tag", "paged", "refresh", "limit"],
+            Self::PoolCensus { .. } => &["refresh", "limit"],
         };
         key == "op" || fields.contains(&key)
     }
@@ -197,6 +243,27 @@ impl StepAction {
             Self::RunTo { address, .. } => format!("run to {address}"),
             Self::Eval { expr } => format!("? {expr}"),
             Self::ReadMemory { address, size } => format!("read {size} bytes at {address}"),
+            // A refreshed walk is the expensive half of a pool step and the one that can dominate
+            // a batch's clock, so the report says which kind ran rather than leaving a reader to
+            // wonder where the time went.
+            Self::PoolChunk { address, refresh } => {
+                format!("pool chunk containing {address}{}", walk_kind(*refresh))
+            }
+            Self::PoolFindTag {
+                tag,
+                paged,
+                refresh,
+                ..
+            } => format!(
+                "pool chunks tagged {tag}{}{}",
+                match paged {
+                    Some(true) => " in paged pool",
+                    Some(false) => " in nonpaged pool",
+                    None => "",
+                },
+                walk_kind(*refresh)
+            ),
+            Self::PoolCensus { refresh, .. } => format!("pool census{}", walk_kind(*refresh)),
         }
     }
 
@@ -230,7 +297,40 @@ impl StepAction {
                 address: substitute(address, resolve)?,
                 size: *size,
             },
+            Self::PoolChunk { address, refresh } => Self::PoolChunk {
+                address: substitute(address, resolve)?,
+                refresh: *refresh,
+            },
+            // The tag is substituted too, though no capture can produce a plausible one: a
+            // `{{name}}` left to pass through would be sent to the allocator index as four
+            // literal bytes and answer "no such tag", which is a wrong answer where an
+            // unresolvable reference is meant to be an error.
+            Self::PoolFindTag {
+                tag,
+                paged,
+                refresh,
+                limit,
+            } => Self::PoolFindTag {
+                tag: substitute(tag, resolve)?,
+                paged: *paged,
+                refresh: *refresh,
+                limit: *limit,
+            },
+            Self::PoolCensus { refresh, limit } => Self::PoolCensus {
+                refresh: *refresh,
+                limit: *limit,
+            },
         })
+    }
+}
+
+/// How a pool step's walk is rendered in the report: a fresh walk is worth naming, a cached
+/// lookup is not.
+fn walk_kind(refresh: Option<bool>) -> &'static str {
+    if refresh.unwrap_or(false) {
+        " (fresh walk)"
+    } else {
+        ""
     }
 }
 
@@ -513,11 +613,19 @@ fn validate_operands(step: &BatchStep, where_: &str) -> Result<(), String> {
             .map_err(|e| format!("{where_}: {e}"))
     };
     match &step.action {
-        StepAction::RunTo { address, .. } | StepAction::ReadMemory { address, .. } => {
+        StepAction::RunTo { address, .. }
+        | StepAction::ReadMemory { address, .. }
+        | StepAction::PoolChunk { address, .. } => {
             operand("address", address)?;
         }
         StepAction::Eval { expr } => operand("expr", expr)?,
-        StepAction::Command { .. } | StepAction::Resume { .. } => {}
+        // A pool `tag` is exempt, and deliberately: it is 1..4 arbitrary ASCII bytes handed to an
+        // index lookup, never interpolated into a command, so there is no command to break — and
+        // refusing a quote here would refuse a tag the `pool_find_tag` tool itself accepts.
+        StepAction::Command { .. }
+        | StepAction::Resume { .. }
+        | StepAction::PoolFindTag { .. }
+        | StepAction::PoolCensus { .. } => {}
     }
     for check in &step.expect {
         if let Check::Eval { expr, equals } = check {
@@ -618,7 +726,13 @@ fn action_mutation(action: &StepAction) -> Option<String> {
             _ => "execution".to_string(),
         }),
         StepAction::RunTo { .. } => Some("execution".to_string()),
-        StepAction::Eval { .. } | StepAction::ReadMemory { .. } => None,
+        // A pool query reads the allocator's own descriptors and writes nothing, however long it
+        // takes to do it.
+        StepAction::Eval { .. }
+        | StepAction::ReadMemory { .. }
+        | StepAction::PoolChunk { .. }
+        | StepAction::PoolFindTag { .. }
+        | StepAction::PoolCensus { .. } => None,
     }
 }
 
@@ -635,6 +749,16 @@ pub trait Debuggee {
     fn run_to(&mut self, address: &str, timeout_ms: u32) -> Result<String, String>;
     /// Hex-dump `size` bytes at `address`.
     fn read_memory(&mut self, address: &str, size: u32) -> Result<String, String>;
+    /// Answer a pool question — the one capability here that is not a debugger command at all,
+    /// but a walk over the allocator's own descriptors.
+    ///
+    /// `budget_ms` bounds *the walk*, not a command, and that is why it is passed rather than left
+    /// to win-kexp's own default: that default (120s) is longer than a whole ordinary batch, so a
+    /// refreshed pool step taking it could overrun the deadline the rollback depends on — and with
+    /// it the bound the worker advertises to a teardown, which is what stops a worker being
+    /// terminated mid-transaction. A walk stopped by the budget reports how much of the pool it
+    /// reached, so a short step degrades to a partial answer that says so rather than to a failure.
+    fn pool(&mut self, query: &PoolOp, budget_ms: u32) -> Result<String, String>;
     /// How long this batch has been running.
     fn elapsed(&self) -> Duration;
     /// Whether something outside the batch has asked it to stop early and roll back — a client
@@ -973,6 +1097,23 @@ fn run_step(
         } => d.run_to(address, wait_ms(*timeout_ms)),
         StepAction::Eval { expr } => d.command(&format!("? {expr}"), budget_ms),
         StepAction::ReadMemory { address, size } => d.read_memory(address, *size),
+        // Through the same constructors the pool *tools* use, so a step and a tool cannot drift
+        // apart on what a default or a cap means — see [`PoolOp`].
+        StepAction::PoolChunk { address, refresh } => {
+            d.pool(&PoolOp::chunk(address.clone(), *refresh), budget_ms)
+        }
+        StepAction::PoolFindTag {
+            tag,
+            paged,
+            refresh,
+            limit,
+        } => d.pool(
+            &PoolOp::find_tag(tag.clone(), *paged, *refresh, *limit),
+            budget_ms,
+        ),
+        StepAction::PoolCensus { refresh, limit } => {
+            d.pool(&PoolOp::census(*refresh, *limit), budget_ms)
+        }
     });
 
     let output = match ran {
@@ -1477,6 +1618,12 @@ mod tests {
         }
         fn read_memory(&mut self, address: &str, size: u32) -> Result<String, String> {
             self.answer(&format!("read {size} at {address}"))
+        }
+        fn pool(&mut self, query: &PoolOp, budget_ms: u32) -> Result<String, String> {
+            // The budget is part of the call text, not swallowed: a pool step's whole hazard is
+            // taking longer than the batch can afford, so a test that could not see what the walk
+            // was armed with could not tell the fix from the bug.
+            self.answer(&format!("pool {query:?} within {budget_ms}ms"))
         }
         fn elapsed(&self) -> Duration {
             self.clock
@@ -2162,6 +2309,124 @@ mod tests {
         );
     }
 
+    // ---- pool steps ---------------------------------------------------------
+
+    /// `@chunkt1`, the workflow verb these variants were added for: capture the pointer the target
+    /// is holding, then ask the allocator what it is — inside the transaction, between a patch and
+    /// its restore, which is where the CTF client had to do it and where a batch previously could
+    /// not follow.
+    #[test]
+    fn a_captured_pointer_becomes_a_pool_question() {
+        let mut d = stopped()
+            .on("? @$t1", Ok("Evaluate expression: 1 = ffffc00f`6ec02f90"))
+            .on(
+                "pool Chunk",
+                Ok("ffffc00f`6ec02f90 is 0x0 byte(s) into a 0x70-byte chunk tagged `Tgsm`"),
+            );
+        let batch = op(
+            vec![
+                BatchStep {
+                    capture: Some("reclaimed".to_string()),
+                    ..step(StepAction::Eval {
+                        expr: "@$t1".to_string(),
+                    })
+                },
+                step(StepAction::PoolChunk {
+                    address: "{{reclaimed}}".to_string(),
+                    refresh: Some(true),
+                }),
+            ],
+            vec![],
+        );
+
+        let report = run(&mut d, &batch, BUDGET);
+
+        assert!(report.committed(), "{}", render(&report));
+        // The capture reached the *query*, not a command line: this step never becomes text the
+        // debugger parses, which is the whole reason it exists.
+        assert!(
+            d.ran("address: \"0xffffc00f6ec02f90\""),
+            "the captured pointer must arrive as the query's address: {:?}",
+            d.calls
+        );
+        assert!(
+            d.ran("refresh: true"),
+            "the step asked for a fresh walk: {:?}",
+            d.calls
+        );
+        let text = render(&report);
+        assert!(
+            text.contains("pool chunk containing 0xffffc00f6ec02f90 (fresh walk)"),
+            "{text}"
+        );
+        assert!(text.contains("tagged `Tgsm`"), "{text}");
+        // A walk reads the allocator's descriptors and writes nothing, so a batch of pool queries
+        // must not be reported as having changed the target.
+        assert!(text.contains("mutations: none recognised"), "{text}");
+    }
+
+    /// A pool step is armed with what the *batch* has left, not with the walker's own default.
+    ///
+    /// The one hazard these variants introduce: a refreshed walk is every committed page over the
+    /// KD wire and win-kexp bounds it at 120s, which is longer than an ordinary batch's whole
+    /// budget. A step that took that default could spend the reserve the rollback lives on, and
+    /// overrun the bound the worker advertises to a teardown — which is a worker terminated
+    /// mid-transaction, the failure the `always` block exists to prevent, arriving through the one
+    /// step that is not a command.
+    #[test]
+    fn a_pool_step_is_armed_with_what_the_batch_has_left() {
+        let mut d = stopped()
+            .slow("first", Ok(""), Duration::from_secs(25))
+            .on("pool Census", Ok("3 distinct tag(s) allocated"));
+        let batch = op(
+            vec![
+                cmd("first step"),
+                step(StepAction::PoolCensus {
+                    refresh: Some(true),
+                    limit: None,
+                }),
+            ],
+            vec![],
+        );
+
+        // 60s budget, 30s reserved → the steps have 30s, and the first one spends 25 of them.
+        let report = run(&mut d, &batch, BUDGET);
+
+        assert!(report.committed(), "{}", render(&report));
+        assert!(
+            d.ran("within 5000ms"),
+            "the walk must be bounded by what the batch has left, not by the walker's default: \
+             {:?}",
+            d.calls
+        );
+        // And the defaults are the pool *tools'* defaults, because both come from the same
+        // constructor: a census prints 40 rows unless asked otherwise.
+        assert!(d.ran("limit: 40"), "{:?}", d.calls);
+    }
+
+    /// A `{{name}}` is resolved in a pool tag as well as in an address — no field of a step is a
+    /// place where an unresolvable reference quietly becomes literal text. Here that would be four
+    /// bytes the allocator index has never seen, answered as "no such tag": a wrong answer, where
+    /// every other unbound reference is an error.
+    #[test]
+    fn an_unbound_reference_in_a_pool_step_is_refused_in_either_field() {
+        for action in [
+            StepAction::PoolFindTag {
+                tag: "{{nope}}".to_string(),
+                paged: None,
+                refresh: None,
+                limit: None,
+            },
+            StepAction::PoolChunk {
+                address: "{{nope}}".to_string(),
+                refresh: None,
+            },
+        ] {
+            let why = validate(&[step(action)], &[]).unwrap_err();
+            assert!(why.contains("`{{nope}}` is not bound"), "{why}");
+        }
+    }
+
     // ---- validation --------------------------------------------------------
 
     /// The catch-all must take *only* what the schema does not name. If serde routed a variant's
@@ -2178,6 +2443,12 @@ mod tests {
             serde_json::json!({"op": "eval", "expr": "@rcx", "capture": "x"}),
             serde_json::json!({"op": "read_memory", "address": "0x1000", "size": 64}),
             serde_json::json!({"op": "resume", "command": "g"}),
+            serde_json::json!({"op": "pool_chunk", "address": "0xffffc00f6ec02f90"}),
+            serde_json::json!({"op": "pool_chunk", "address": "{{obj}}", "refresh": true}),
+            serde_json::json!({
+                "op": "pool_find_tag", "tag": "Tgsm", "paged": false, "refresh": true, "limit": 32
+            }),
+            serde_json::json!({"op": "pool_census", "refresh": true, "limit": 200}),
         ] {
             let step: BatchStep = serde_json::from_value(json.clone()).expect("valid step");
             assert!(
@@ -2382,10 +2653,12 @@ mod tests {
     /// (`@asserttarget`), a structure assertion over three memory words (`@assertfake`), code
     /// patches and their restores, and `bc *`.
     ///
-    /// Two of the script's verbs are **not** here and cannot be: `@chunkt1` and `@census` call the
-    /// `pool_chunk`/`pool_census` tools, and a batch step cannot reach a typed tool that is not a
-    /// debugger command. Nine of the workflow's 1,681 steps were pool queries; the other 1,672 are
-    /// the shapes below.
+    /// The script's two pool verbs are here as well, and they are why the pool steps exist:
+    /// `@chunkt1` read the pseudo-register `@$t1` with `execute`, regex-scraped the value out of
+    /// the debugger's answer, and passed it to `pool_chunk` — a round trip through the client
+    /// that a `capture` plus a `pool_chunk` step now says in two lines. It sat *inside* the
+    /// transaction, between a code patch and its restore, so a batch that could not express it
+    /// would have had to drop it or split the transaction in half.
     fn messagemanager_sequence() -> (Vec<BatchStep>, Vec<BatchStep>) {
         // The verdict check the script open-coded as `if ($verdict -notmatch 'VERDICT: HIT')`.
         let run_to = |address: &str, ms: u32| BatchStep {
@@ -2429,6 +2702,24 @@ mod tests {
             cmd("bc *"),
             cmd("eb @$t7+1f00 f3 90 eb fc e9 27 f3 ff ff; eb @$t7+1230 e9 cb 0c 00 00"),
             run_to("fffff80615951210", 90_000),
+            // `@chunkt1`, in the two steps it always was: the value the target is holding, and
+            // the allocator's account of it. `refresh`, because the target has run since the
+            // last walk — which is the case the flag exists for.
+            BatchStep {
+                capture: Some("reclaimed".to_string()),
+                ..step(StepAction::Eval {
+                    expr: "@$t1".to_string(),
+                })
+            },
+            step(StepAction::PoolChunk {
+                address: "{{reclaimed}}".to_string(),
+                refresh: Some(true),
+            }),
+            // `@census`, with the limit the script settled on.
+            step(StepAction::PoolCensus {
+                refresh: Some(true),
+                limit: Some(200),
+            }),
             cmd("bc *"),
             cmd("eb @$t7+1230 48 89 5c 24 08"),
             run_to("fffff80615951560", 30_000),
@@ -2473,7 +2764,7 @@ mod tests {
     #[test]
     fn the_messagemanager_sequence_is_a_valid_batch() {
         let (steps, always) = messagemanager_sequence();
-        assert_eq!(steps.len(), 25);
+        assert_eq!(steps.len(), 28);
         validate(&steps, &always).expect("the sequence the tool was filed for must validate");
         // It patches code and clears breakpoints, so it must not be mistaken for inspection.
         assert!(
@@ -2483,6 +2774,15 @@ mod tests {
                 .any(|m| m.contains("memory")),
             "the code patches must be recognised as mutations"
         );
+        // And the pool queries in the middle of it change nothing, however long they take.
+        for step in &steps {
+            if matches!(
+                step.action,
+                StepAction::PoolChunk { .. } | StepAction::PoolCensus { .. }
+            ) {
+                assert_eq!(action_mutation(&step.action), None, "{:?}", step.action);
+            }
+        }
     }
 
     /// The failure the client hand-rolled a rollback for: the race breakpoint fires for a
@@ -2520,7 +2820,7 @@ mod tests {
             d.calls
         );
         let text = render(&report);
-        assert!(text.contains("BATCH: FAILED at step 3 of 25"), "{text}");
+        assert!(text.contains("BATCH: FAILED at step 3 of 28"), "{text}");
         assert!(text.contains("ffffb08e`e358c080"), "{text}");
         assert!(text.contains("ffffb08e`e358d100"), "{text}");
     }

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -180,6 +180,11 @@ pub struct ReachabilityOp {
 /// snapshot is cached per session and invalidated when the debugger reports the session
 /// changed. Pass it after resuming the target, when the cached view is a photograph of a
 /// target that has since moved.
+///
+/// **Built through the constructors below, never by hand.** Two callers now ask these questions —
+/// the pool tools and a [`crate::batch`] step — and the defaults are part of the *answer's* shape
+/// rather than of one tool's argument parsing. Spelling them out at each call site is how the two
+/// come to disagree about what `limit` means.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum PoolOp {
     /// Every *allocated* chunk carrying `tag`.
@@ -205,6 +210,65 @@ pub enum PoolOp {
         refresh: bool,
         limit: usize,
     },
+}
+
+impl PoolOp {
+    /// Most rows or lines a pool answer will render in one response.
+    ///
+    /// The worker builds the whole reply as a single `String` before it crosses the pipe, so an
+    /// unbounded `limit` is a request to allocate a snapshot-sized buffer — hundreds of thousands
+    /// of chunks, or ~19k diagnostic lines on an idle machine. Clamping costs a caller nothing
+    /// they can act on; a worker killed mid-session costs them the session.
+    pub const MAX_ROWS: u32 = 2000;
+
+    /// Rows each question prints when the caller names no `limit`.
+    const FIND_TAG_ROWS: u32 = 64;
+    const CENSUS_ROWS: u32 = 40;
+    const DIAGNOSTIC_LINES: u32 = 60;
+
+    fn rows(limit: Option<u32>, default: u32) -> usize {
+        limit.unwrap_or(default).min(Self::MAX_ROWS) as usize
+    }
+
+    /// Every allocated chunk carrying `tag`.
+    pub fn find_tag(
+        tag: String,
+        paged: Option<bool>,
+        refresh: Option<bool>,
+        limit: Option<u32>,
+    ) -> Self {
+        Self::FindTag {
+            tag,
+            paged,
+            refresh: refresh.unwrap_or(false),
+            limit: Self::rows(limit, Self::FIND_TAG_ROWS),
+        }
+    }
+
+    /// The chunk containing `address`, with its immediate neighbours.
+    pub fn chunk(address: String, refresh: Option<bool>) -> Self {
+        Self::Chunk {
+            address,
+            refresh: refresh.unwrap_or(false),
+        }
+    }
+
+    /// Per-tag totals across the whole snapshot.
+    pub fn census(refresh: Option<bool>, limit: Option<u32>) -> Self {
+        Self::Census {
+            refresh: refresh.unwrap_or(false),
+            limit: Self::rows(limit, Self::CENSUS_ROWS),
+        }
+    }
+
+    /// The walk's own diagnostics, optionally narrowed.
+    pub fn diagnostics(filter: Option<String>, refresh: Option<bool>, limit: Option<u32>) -> Self {
+        Self::Diagnostics {
+            filter,
+            refresh: refresh.unwrap_or(false),
+            limit: Self::rows(limit, Self::DIAGNOSTIC_LINES),
+        }
+    }
 }
 
 /// A request down the worker's stdin. `id` is echoed on every message the op produces.

--- a/src/server.rs
+++ b/src/server.rs
@@ -1193,14 +1193,6 @@ pub struct SymbolPathArgs {
     pub session_id: Option<String>,
 }
 
-/// Most rows or lines a pool tool will render in one response.
-///
-/// The worker builds the whole reply as a single `String` before it crosses the pipe, so an
-/// unbounded `limit` is a request to allocate a snapshot-sized buffer — hundreds of thousands
-/// of chunks, or ~19k diagnostic lines on an idle machine. Clamping costs a caller nothing
-/// they can act on; a worker killed mid-session costs them the session.
-const MAX_POOL_ROWS: u32 = 2000;
-
 #[derive(Deserialize, JsonSchema)]
 pub struct PoolFindTagArgs {
     /// Pool tag to find: 1..4 ASCII bytes, e.g. "Tgsm". This is the tag as the debugger
@@ -1384,7 +1376,12 @@ pub struct DebugBatchArgs {
     /// verdict; `{"op": "eval", "expr": "@rcx"}` reads a value; `{"op": "read_memory",
     /// "address": "0xfffff8000012c000", "size": 64}` hex-dumps memory — this one takes a *number*
     /// (decimal or `0x`-hex), not an expression, so for `@rsp` or `poi(...)` put an `eval` step in
-    /// front of it and read the capture. Add `"expect"` to assert on the result and `"capture"`
+    /// front of it and read the capture. Three more ask the kernel pool the same questions the
+    /// `pool_*` tools do, because those are allocator walks rather than debugger commands and no
+    /// `command` step can stand in for them: `{"op": "pool_chunk", "address": "{{obj}}"}`,
+    /// `{"op": "pool_find_tag", "tag": "Tgsm", "paged": false}` and `{"op": "pool_census"}`, each
+    /// taking `refresh` (re-walk rather than reuse this session's snapshot) and the last two a
+    /// `limit`. Add `"expect"` to assert on the result and `"capture"`
     /// (on an `eval` step) to bind its value for later steps as `{{name}}`.
     /// The batch stops at the first step that fails or whose assertions do not hold.
     pub steps: Vec<batch::BatchStep>,
@@ -1888,12 +1885,12 @@ impl WindbgServer {
         let out = self
             .run(
                 args.session_id.as_deref(),
-                EngineOp::Pool(PoolOp::FindTag {
-                    tag: args.tag,
-                    paged: args.paged,
-                    refresh: args.refresh.unwrap_or(false),
-                    limit: args.limit.unwrap_or(64).min(MAX_POOL_ROWS) as usize,
-                }),
+                EngineOp::Pool(PoolOp::find_tag(
+                    args.tag,
+                    args.paged,
+                    args.refresh,
+                    args.limit,
+                )),
             )
             .await;
         engine_result(out)
@@ -1925,10 +1922,7 @@ impl WindbgServer {
         let out = self
             .run(
                 args.session_id.as_deref(),
-                EngineOp::Pool(PoolOp::Chunk {
-                    address: args.address,
-                    refresh: args.refresh.unwrap_or(false),
-                }),
+                EngineOp::Pool(PoolOp::chunk(args.address, args.refresh)),
             )
             .await;
         engine_result(out)
@@ -1955,11 +1949,7 @@ impl WindbgServer {
         let out = self
             .run(
                 args.session_id.as_deref(),
-                EngineOp::Pool(PoolOp::Diagnostics {
-                    filter: args.filter,
-                    refresh: args.refresh.unwrap_or(false),
-                    limit: args.limit.unwrap_or(60).min(MAX_POOL_ROWS) as usize,
-                }),
+                EngineOp::Pool(PoolOp::diagnostics(args.filter, args.refresh, args.limit)),
             )
             .await;
         engine_result(out)
@@ -1984,10 +1974,7 @@ impl WindbgServer {
         let out = self
             .run(
                 args.session_id.as_deref(),
-                EngineOp::Pool(PoolOp::Census {
-                    refresh: args.refresh.unwrap_or(false),
-                    limit: args.limit.unwrap_or(40).min(MAX_POOL_ROWS) as usize,
-                }),
+                EngineOp::Pool(PoolOp::census(args.refresh, args.limit)),
             )
             .await;
         engine_result(out)

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -26,7 +26,7 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use win_kexp::dbgeng::{DebugEngine, RunToOutcome};
-use win_kexp::pool::query::{self, PoolPageFilter};
+use win_kexp::pool::query::{self, PoolPageFilter, PoolWalk};
 use win_kexp::pool::{DiagnosticShape, PoolDiagnostics, PoolSpan, PoolState};
 use windows_sys::Win32::Foundation::{HANDLE_FLAG_INHERIT, SetHandleInformation};
 
@@ -757,7 +757,10 @@ fn execute(e: &DebugEngine, id: u64, op: EngineOp, queued: Duration) -> Result<S
             timeout_ms,
         } => run_to_address(e, &address, timeout_ms),
         EngineOp::Reachability(args) => reachable(e, args),
-        EngineOp::Pool(args) => pool(e, args),
+        // No deadline of our own: a pool *tool* call takes win-kexp's `DEFAULT_WALK_BUDGET`, which
+        // is sized to fit inside a typical per-call budget (this server's own is #75). A pool
+        // *step* is different — it has a batch's clock to keep — so that path passes one.
+        EngineOp::Pool(args) => pool(e, args, None),
         EngineOp::Batch(op) => run_batch(e, op, queued),
         // Reaching here means any batch has already been told to stop and has finished unwinding —
         // the reader saw this request go past and said so, and this thread runs one job at a time.
@@ -854,6 +857,18 @@ impl Debuggee for BatchEngine<'_> {
 
     fn read_memory(&mut self, address: &str, size: u32) -> Result<String, String> {
         read_memory(self.e, address, size)
+    }
+
+    fn pool(&mut self, query: &PoolOp, budget_ms: u32) -> Result<String, String> {
+        // The step's own budget, handed to the walker. Bounded, always, for the same reason a
+        // command step is: this is the one step that can spend minutes without a runaway anywhere
+        // — a full pool walk is every committed page over the KD wire — and the reserve the
+        // rollback lives on is what it would spend.
+        pool(
+            self.e,
+            query.clone(),
+            Some(Duration::from_millis(u64::from(budget_ms))),
+        )
     }
 
     fn elapsed(&self) -> Duration {
@@ -1091,7 +1106,22 @@ fn render_walk_report(report: &query::PoolSnapshotReport) -> String {
     out
 }
 
-fn pool(e: &DebugEngine, args: PoolOp) -> Result<String, String> {
+/// Answers one pool question, walking the pool if the cached snapshot will not do.
+///
+/// `within` is the caller's own deadline for a walk that actually happens, or `None` to take
+/// win-kexp's default. It is `Some` for a [`crate::batch`] step, whose budget is both shorter than
+/// that default and load-bearing: the batch reserves part of it for the rollback and advertises the
+/// whole of it to a teardown, so a walk that ran to the *walker's* default could overrun both. A
+/// walk stopped by a budget still answers — every rendering below carries how much of the pool the
+/// walk reached — so the cost of a short deadline is coverage, not an error.
+fn pool(e: &DebugEngine, args: PoolOp, within: Option<Duration>) -> Result<String, String> {
+    let walk = |refresh: bool| {
+        let walk = PoolWalk::from(refresh);
+        match within {
+            Some(budget) => walk.within(budget),
+            None => walk,
+        }
+    };
     match args {
         PoolOp::FindTag {
             tag,
@@ -1106,8 +1136,10 @@ fn pool(e: &DebugEngine, args: PoolOp) -> Result<String, String> {
                     PoolPageFilter::NonPaged
                 }
             });
-            let spans = query::find_tag(e, &tag, filter, refresh).map_err(es)?;
+            let spans = query::find_tag(e, &tag, filter, walk(refresh)).map_err(es)?;
             let mut out = render_find_tag(&tag, filter, &spans, limit);
+            // Both branches read the snapshot `find_tag` has just taken or reused — hence the bare
+            // `false` below, which cannot start a walk of its own whatever budget this query had.
             if spans.is_empty() {
                 append_walk_report(&mut out, e);
             } else if let Ok(report) = query::snapshot_report(e, false)
@@ -1119,7 +1151,7 @@ fn pool(e: &DebugEngine, args: PoolOp) -> Result<String, String> {
         }
         PoolOp::Chunk { address, refresh } => {
             let address = parse_pool_addr(&address)?;
-            match query::chunk_at(e, address, refresh).map_err(es)? {
+            match query::chunk_at(e, address, walk(refresh)).map_err(es)? {
                 Some(found) => Ok(render_chunk(address, &found)),
                 // "Not in the snapshot" and "free" are different answers, and reporting this one
                 // as free would manufacture a dangling pointer out of a gap in the walk.
@@ -1143,12 +1175,12 @@ fn pool(e: &DebugEngine, args: PoolOp) -> Result<String, String> {
             refresh,
             limit,
         } => {
-            let report = query::snapshot_report(e, refresh).map_err(es)?;
+            let report = query::snapshot_report(e, walk(refresh)).map_err(es)?;
             Ok(render_diagnostics(&report, filter.as_deref(), limit))
         }
         // The census *is* the state of the walk, so it always carries the report.
         PoolOp::Census { refresh, limit } => {
-            let census = query::tag_census(e, refresh).map_err(es)?;
+            let census = query::tag_census(e, walk(refresh)).map_err(es)?;
             let mut out = render_census(&census, limit);
             append_walk_report(&mut out, e);
             Ok(out)

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -3374,15 +3374,24 @@ fn kernel_scratch(server: &mut Server, session: &str) -> Option<KernelScratch> {
 
     // Write it, read it back, put it back — the shortest thing that distinguishes "the debugger
     // can write here" from "the debugger accepted a write here and nothing happened".
-    server.tool_text(
-        "execute",
-        json!({
-            "command": format!("eb {} {:#x}", scratch.addr(), scratch.patched()),
-            "session_id": session,
-        }),
-        TARGET_STEP,
-    );
-    let wrote = eval_expr(server, session, &format!("by({})", scratch.addr()));
+    //
+    // Under `catch_unwind`, because between the write and the restore is the one window in this
+    // whole tier where a panic leaves the *guest* changed rather than merely halted: a call that
+    // times out in transit has still reached DbgEng, so the byte is patched and the reply that
+    // would have let this function continue never arrives. The restore below then has to run
+    // anyway — the outer handlers end the session, which puts a halted kernel back but not a
+    // patched one.
+    let wrote = catch_unwind(AssertUnwindSafe(|| {
+        server.tool_text(
+            "execute",
+            json!({
+                "command": format!("eb {} {:#x}", scratch.addr(), scratch.patched()),
+                "session_id": session,
+            }),
+            TARGET_STEP,
+        );
+        eval_expr(server, session, &format!("by({})", scratch.addr()))
+    }));
     // Restore before judging the result: the assertion is the caller's business, the byte is the
     // target's, and a failed probe must not be the reason a guest is left modified.
     server.tool_text(
@@ -3402,6 +3411,12 @@ fn kernel_scratch(server: &mut Server, session: &str) -> Option<KernelScratch> {
         scratch.addr(),
         scratch.original
     );
+    // Only now, with the byte confirmed back: whatever went wrong above is worth reporting, and
+    // it is worth reporting *after* the guest is whole rather than instead of making it whole.
+    let wrote = match wrote {
+        Ok(wrote) => wrote,
+        Err(panic) => resume_unwind(panic),
+    };
     if wrote != Some(scratch.patched()) {
         eprintln!(
             "NOTE: writing {} was accepted and did not take (read back {wrote:?}, wanted {:#x}), \
@@ -3990,6 +4005,11 @@ fn a_live_kernel_batch_step_can_ask_the_pool_about_a_captured_pointer() {
     };
     let engine = ensure_engine_beside_test_binary();
     println!("engine: {engine}");
+    // Pinned below `POOL_CALL_BUDGET`, exactly as the pool tier is, and that ordering is not
+    // adjustable: the server has to answer before the *harness* gives up, or the `end_session` in
+    // the cleanup queues behind a walk that is still running, misses its grace, and the worker is
+    // killed — which on a broken-in kernel leaves the guest halted. Raising this above the harness
+    // budget to buy the batch more room would buy it by inverting that.
     let mut server = Server::started_with(&[(
         "WINDBG_MCP_CALL_TIMEOUT_SECS",
         &SERVER_CALL_TIMEOUT.as_secs().to_string(),
@@ -4012,7 +4032,9 @@ fn a_live_kernel_batch_step_can_ask_the_pool_about_a_captured_pointer() {
                 "session_id": session,
                 // The walk is the expensive part and it is inside the batch, so give the batch
                 // room for it — the point is that the *step* bounds the walk, not that nothing
-                // ever has to wait.
+                // ever has to wait. Asking for the whole call budget is deliberate and the clamp
+                // to it (minus the reply's headroom) is the expected outcome: what the steps then
+                // have is ~255s, against a walk measured at ~52s over KDNET.
                 "timeout_ms": 300_000,
                 "steps": [
                     { "op": "eval", "expr": "@$proc", "capture": "proc",

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -26,9 +26,11 @@
 //!   worker — so the only place the wiring exists as a whole is the shipped binary.
 //! * **Live kernel** (`#[ignore]`d **and** `WINDBG_MCP_SMOKE_KERNEL=<connection string>`) — a
 //!   real KDNET target. The only tier that touches another machine, and the only one that can
-//!   prove a kernel attach still *lands* and lets go cleanly rather than merely parks, or that a
-//!   pool walk stays inside its budget when every page it reads crosses a wire. Run it last, on
-//!   its own.
+//!   prove a kernel attach still *lands* and lets go cleanly rather than merely parks, that a
+//!   pool walk stays inside its budget when every page it reads crosses a wire, or that a
+//!   `debug_batch` which patches a byte of the running kernel puts it back — a dump has nothing
+//!   worth restoring, so a rollback that did nothing would pass every check the tier above can
+//!   make. Run it last, on its own.
 //! * **MessageManager CTF** (`#[ignore]`d, `WINDBG_MCP_SMOKE_CTF=1`, and the live-kernel gate)
 //!   — deploys a benign allocation fixture over WinRM, then verifies that the real driver and its
 //!   pool objects are visible through the structured MCP tools. The PowerShell orchestrator owns
@@ -3261,6 +3263,799 @@ fn a_live_kernel_pool_walk_is_bounded_and_leaves_its_session_usable() {
         (Ok(()), Some(why)) => panic!("{why}"),
         (Ok(()), None) => {}
     }
+}
+
+// ---- tier 4b: a batch that actually mutates a live kernel ---------------------
+//
+// `debug_batch` is proved at two altitudes elsewhere: `src/batch.rs` drives the executor over a
+// scripted debuggee with a virtual clock, and the dump tier drives a real engine to both outcomes
+// and through both teardowns. Neither covers the case the tool exists for — **a write that is then
+// restored, on a target that would notice**. A crash dump has nothing worth restoring: a byte
+// "patched" in it is patched in a file nobody reads again, so a rollback that silently did nothing
+// would pass every assertion the dump tier can make. The disconnect test there proves the rollback
+// ran by the *file it wrote*, which is the shape of the claim rather than its substance.
+//
+// Here the claim is settled by reading the byte back — from a later call, from a re-attached
+// session, or from a whole new server process — and the value either is the original or it is not.
+
+/// The byte this tier patches, and what it was.
+///
+/// `nt`'s DOS header `e_res2` field: reserved by the PE format, zero in every image MSVC has ever
+/// linked, read by the loader never and by Windows never. It is real kernel memory, it is stable
+/// across a detach and re-attach (the image does not move without a reboot), and nothing in the
+/// running system can observe it changing — which is exactly the combination this tier needs, since
+/// the whole point is to leave the target patched for a while and then prove something put it back.
+/// Anything with a *purpose* would satisfy the first two and bugcheck the machine on the third.
+struct KernelScratch {
+    address: u64,
+    original: u64,
+}
+
+impl KernelScratch {
+    /// The address as the debugger and the tools both take it.
+    fn addr(&self) -> String {
+        format!("{:#x}", self.address)
+    }
+
+    /// A byte value that is definitely not the original, so "the patch landed" is a real check
+    /// rather than a comparison that would hold either way.
+    fn patched(&self) -> u64 {
+        self.original ^ 0xa5
+    }
+
+    /// A third value, distinct from both of the others, for the step that must **not** run: with
+    /// two values a "it never wrote this" check could pass by coinciding with the original.
+    fn never(&self) -> u64 {
+        self.original ^ 0x5a
+    }
+}
+
+/// `nt`'s load base, from the module list.
+fn nt_base(server: &mut Server, session: &str) -> u64 {
+    let modules = server.tool_text("modules", json!({ "session_id": session }), TARGET_STEP);
+    let start = modules
+        .lines()
+        .find(|line| line.split_whitespace().nth(2) == Some("nt"))
+        .and_then(|line| line.split_whitespace().next())
+        .unwrap_or_else(|| panic!("no `nt` in the module list:\n{modules}"))
+        .replace('`', "");
+    u64::from_str_radix(&start, 16)
+        .unwrap_or_else(|e| panic!("`{start}` is not a module base ({e}):\n{modules}"))
+}
+
+/// What the debugger makes of a MASM expression, or `None` if it would not say.
+///
+/// Deliberately *not* `tool_text`: several callers below use this on paths where a failure is
+/// possible and must not panic, because a panic there would skip a detach and leave a kernel
+/// halted.
+fn eval_expr(server: &mut Server, session: &str, expr: &str) -> Option<u64> {
+    let call = server.call_tool(
+        "execute",
+        json!({ "command": format!("? {expr}"), "session_id": session }),
+        TARGET_STEP,
+    );
+    if !call["error"].is_null() || is_tool_error(&call) {
+        eprintln!(
+            "NOTE: `? {expr}` failed: {}",
+            text_of(&call["result"]).trim()
+        );
+        return None;
+    }
+    // `Evaluate expression: 84 = 00000000`00000054` — the value is what follows the last `=`.
+    let text = text_of(&call["result"]);
+    let (_, value) = text.rsplit_once('=')?;
+    u64::from_str_radix(&value.replace('`', "").trim().replace(' ', ""), 16).ok()
+}
+
+/// Reads the scratch byte and proves this target lets a debugger write it, leaving it as found.
+///
+/// A probe rather than an assumption, and it runs *before* any batch does, because the two ways
+/// this can be unavailable are both about the host being debugged rather than about this code:
+/// a header page that is not resident cannot be read, and a guest with memory integrity enabled
+/// refuses debugger writes to image pages outright. Finding that out from a batch would mean
+/// finding it out with a transaction already open.
+///
+/// `None` means the check could not be made here — reported loudly, and the caller stops. What it
+/// must never do is carry on: a batch whose patch never landed would "restore" a byte that was
+/// never changed and pass every assertion below while proving nothing at all.
+fn kernel_scratch(server: &mut Server, session: &str) -> Option<KernelScratch> {
+    // +0x28 is `e_res2[0]`; `e_lfanew` (the one header field anything reads at runtime) is at
+    // +0x3c, well clear of it.
+    let address = nt_base(server, session) + 0x28;
+    let Some(original) = eval_expr(server, session, &format!("by({address:#x})")) else {
+        eprintln!(
+            "NOTE: {address:#x} (nt's DOS header) could not be read, so this run cannot patch and \
+             restore a byte. Skipped rather than failed: an unreadable header page is a fact \
+             about the guest, not about the server."
+        );
+        return None;
+    };
+    let scratch = KernelScratch { address, original };
+
+    // Write it, read it back, put it back — the shortest thing that distinguishes "the debugger
+    // can write here" from "the debugger accepted a write here and nothing happened".
+    server.tool_text(
+        "execute",
+        json!({
+            "command": format!("eb {} {:#x}", scratch.addr(), scratch.patched()),
+            "session_id": session,
+        }),
+        TARGET_STEP,
+    );
+    let wrote = eval_expr(server, session, &format!("by({})", scratch.addr()));
+    // Restore before judging the result: the assertion is the caller's business, the byte is the
+    // target's, and a failed probe must not be the reason a guest is left modified.
+    server.tool_text(
+        "execute",
+        json!({
+            "command": format!("eb {} {:#x}", scratch.addr(), scratch.original),
+            "session_id": session,
+        }),
+        TARGET_STEP,
+    );
+    let back = eval_expr(server, session, &format!("by({})", scratch.addr()));
+    assert_eq!(
+        back,
+        Some(scratch.original),
+        "the probe could not put {} back the way it found it ({:#x}) — stop and look at the \
+         guest before running anything else here",
+        scratch.addr(),
+        scratch.original
+    );
+    if wrote != Some(scratch.patched()) {
+        eprintln!(
+            "NOTE: writing {} was accepted and did not take (read back {wrote:?}, wanted {:#x}), \
+             so this guest does not let a debugger patch image pages — memory integrity (HVCI) \
+             does exactly this. Skipped: nothing below could tell a rollback that worked from a \
+             patch that never landed.",
+            scratch.addr(),
+            scratch.patched()
+        );
+        return None;
+    }
+    Some(scratch)
+}
+
+/// Attaches, runs `body` against the session, and **releases the target whatever `body` did**.
+///
+/// The ceremony every test in this tier needs and none of them may skip: from the attach onward
+/// the guest is broken in, so a panic that escaped before the detach would leave someone's machine
+/// frozen because an assertion failed. The ordering at the end is deliberate — a failed detach is
+/// reported *first*, even when the body already failed, because it is the only outcome that needs
+/// action now and the earlier failure keeps.
+fn with_live_kernel_session<R>(
+    server: &mut Server,
+    connection: &str,
+    body: impl FnOnce(&mut Server, &str) -> R,
+) -> R {
+    let attached = server.call_tool(
+        "attach_kernel",
+        json!({ "connection": connection }),
+        TARGET_STEP,
+    );
+    let report = text_of(&attached["result"]);
+    // The handle decides whether there is anything to clean up, not `isError`: an attach that
+    // claimed its target and then failed the wait comes back as a tool error carrying a live,
+    // halted session.
+    let Some(session) = maybe_session_id(&report) else {
+        assert_no_error(&attached, "attach_kernel");
+        panic!(
+            "the attach did not land, and left no session behind. The target must be booted with \
+             debugging enabled and dialling this host, and the KD transport is single-owner:\n\
+             {report}"
+        );
+    };
+    let outcome = catch_unwind(AssertUnwindSafe(|| {
+        assert_no_error(&attached, "attach_kernel");
+        assert!(
+            !is_tool_error(&attached),
+            "the attach claimed its target and then failed:\n{report}"
+        );
+        body(server, &session)
+    }));
+    let ended = server.call_tool("end_session", json!({ "session_id": session }), TARGET_STEP);
+    let ended_text = text_of(&ended["result"]);
+    match (outcome, ungraceful_detach(&ended, &ended_text)) {
+        (Err(_), Some(why)) => panic!(
+            "THE TARGET MAY STILL BE HALTED — {why}\n\nThis run had already failed, for the \
+             reason printed above; that is what to investigate, but check the machine first."
+        ),
+        (Err(panic), None) => resume_unwind(panic),
+        (Ok(_), Some(why)) => panic!("{why}"),
+        (Ok(value), None) => value,
+    }
+}
+
+/// The steps that save a byte, patch it, and prove the patch landed — the opening of every
+/// mutating batch below, and the part that has to be true before a rollback means anything.
+fn patch_steps(scratch: &KernelScratch) -> Vec<Value> {
+    vec![
+        json!({
+            "op": "eval", "expr": format!("by({})", scratch.addr()), "capture": "orig",
+            "name": "save the byte we are about to overwrite",
+        }),
+        json!({
+            "op": "command", "command": format!("eb {} {:#x}", scratch.addr(), scratch.patched()),
+            "name": "patch it",
+        }),
+        // An assertion, because DbgEng reports most write failures by printing them and returning
+        // success — so "the `eb` step succeeded" is not the same claim as "the byte changed", and
+        // only the second one makes the restore below worth measuring.
+        json!({
+            "op": "eval", "expr": format!("by({})", scratch.addr()),
+            "name": "the patch is really in the target",
+            "expect": [{
+                "check": "eval",
+                "expr": format!("by({})", scratch.addr()),
+                "equals": format!("{:#x}", scratch.patched()),
+            }],
+        }),
+    ]
+}
+
+/// The `always` block: put the captured byte back, whatever happened.
+fn restore_steps(scratch: &KernelScratch) -> Vec<Value> {
+    vec![json!({
+        "op": "command", "command": format!("eb {} {{{{orig}}}}", scratch.addr()),
+        "name": "restore the byte",
+    })]
+}
+
+/// A batch that patches a live kernel and then fails: the `always` block has to put the byte back,
+/// and a **later, separate call** has to see it back.
+///
+/// This is the claim `debug_batch` was built for, made where it can actually be false. Everything
+/// the dump tier can say about a rollback is about control flow — the block ran, its steps reported
+/// OK. Here the target holds a byte that either changed back or did not, and nothing in the batch's
+/// own report is trusted to settle it: the verification is a separate tool call, made after the
+/// batch has returned, exactly as a caller would make it.
+#[test]
+#[ignore = "needs a live KDNET target and its connection string; run manually, last"]
+fn a_mutating_batch_on_a_live_kernel_restores_its_patch_when_a_step_fails() {
+    let Some(connection) = kernel_tier() else {
+        return;
+    };
+    let mut server = Server::started_with(&[(
+        "WINDBG_MCP_CALL_TIMEOUT_SECS",
+        &SERVER_CALL_TIMEOUT.as_secs().to_string(),
+    )]);
+
+    with_live_kernel_session(&mut server, &connection, |server, session| {
+        let Some(scratch) = kernel_scratch(server, session) else {
+            return;
+        };
+        println!(
+            "scratch byte {} reads {:#x}",
+            scratch.addr(),
+            scratch.original
+        );
+
+        let mut steps = patch_steps(&scratch);
+        steps.push(json!({
+            "op": "command", "command": "version",
+            "name": "an assertion that cannot hold",
+            "expect": [{ "check": "contains", "text": "no version banner says this" }],
+        }));
+        steps.push(json!({
+            "op": "command", "command": format!("eb {} {:#x}", scratch.addr(), scratch.never()),
+            "name": "must not run",
+        }));
+        let call = server.call_tool(
+            "debug_batch",
+            json!({
+                "session_id": session,
+                "steps": steps,
+                "always": restore_steps(&scratch),
+            }),
+            TARGET_STEP,
+        );
+        let report = text_of(&call["result"]);
+        assert_no_error(&call, "debug_batch on a live kernel");
+        assert!(
+            is_tool_error(&call),
+            "a batch that did not commit must come back as a tool error:\n{report}"
+        );
+        assert!(
+            report.contains("BATCH: FAILED at step 4 of 5"),
+            "the batch had to stop at the assertion that cannot hold:\n{report}"
+        );
+        assert!(
+            report.contains("rollback: COMPLETE"),
+            "the `always` block must run on the failing path — that is the whole point:\n{report}"
+        );
+
+        // The claim, from outside the batch: the byte is what it was before any of this ran.
+        let now = eval_expr(server, session, &format!("by({})", scratch.addr()));
+        assert_eq!(
+            now,
+            Some(scratch.original),
+            "the rollback reported COMPLETE and {} still reads {now:?} rather than {:#x} — the \
+             restore ran and did not take, which is worse than not running:\n{report}",
+            scratch.addr(),
+            scratch.original
+        );
+        // And the step after the failure never wrote its own value, so "SKIPPED" is a fact about
+        // the target and not only about the report.
+        assert_ne!(
+            now,
+            Some(scratch.never()),
+            "the step after the failure ran anyway"
+        );
+        println!("the patch was applied inside the batch and restored by its rollback");
+    });
+}
+
+/// The same batch under a **call budget shorter than the batch asks for**: the clamp in
+/// `worker::batch_budget` has to keep the whole report — steps, rollback and all — inside the
+/// caller's own timeout.
+///
+/// Only a live target can test this honestly. Against a dump every step returns in microseconds, so
+/// a batch never reaches its deadline and the clamp is arithmetic nobody exercises; here the steps
+/// take real time and the batch is deliberately given more of it than the call has. What must come
+/// back is a *report* — not a timeout from the server, and not silence — with the byte restored.
+#[test]
+#[ignore = "needs a live KDNET target and its connection string; run manually, last"]
+fn a_live_kernel_batch_reports_and_rolls_back_before_its_callers_timeout() {
+    let Some(connection) = kernel_tier() else {
+        return;
+    };
+    /// Short enough that a batch of real steps runs out of time inside it, long enough that the
+    /// attach and the probe are unaffected.
+    const CALL_BUDGET: Duration = Duration::from_secs(60);
+    let mut server = Server::started_with(&[(
+        "WINDBG_MCP_CALL_TIMEOUT_SECS",
+        &CALL_BUDGET.as_secs().to_string(),
+    )]);
+
+    with_live_kernel_session(&mut server, &connection, |server, session| {
+        let Some(scratch) = kernel_scratch(server, session) else {
+            return;
+        };
+
+        let mut steps = patch_steps(&scratch);
+        // Nearly a minute of work in a budget that will be clamped to well under it, so the
+        // deadline is certain to expire. Many short steps rather than a few long ones on purpose:
+        // the clock is then crossed *between* steps, where the executor stops cleanly, instead of
+        // inside one, where the outcome depends on whether the engine honours an interrupt during
+        // a `.sleep` — a property of DbgEng that this test has no business asserting.
+        steps.extend(std::iter::repeat_n(
+            json!({ "op": "command", "command": ".sleep 1000" }),
+            55,
+        ));
+        let started = Instant::now();
+        let call = server.call_tool(
+            "debug_batch",
+            json!({
+                "session_id": session,
+                "steps": steps,
+                // Ten minutes, which this call does not have. The clamp is what stops that being
+                // a rollback report nobody is left to read.
+                "timeout_ms": 600_000,
+                "always": restore_steps(&scratch),
+            }),
+            TARGET_STEP,
+        );
+        let took = started.elapsed();
+        let report = text_of(&call["result"]);
+        assert_no_error(&call, "debug_batch under a short call budget");
+        assert!(
+            report.contains("BATCH: TIMED OUT"),
+            "the batch should have run out of its (clamped) time and said so:\n{report}"
+        );
+        assert!(
+            report.contains("rollback: COMPLETE"),
+            "the reserve exists so the rollback still runs when the steps use the clock up:\n\
+             {report}"
+        );
+        assert!(
+            took < CALL_BUDGET,
+            "the report took {took:?}, past the {CALL_BUDGET:?} its caller was waiting — the \
+             batch outlived the call it belongs to, which is what the clamp exists to prevent"
+        );
+        println!("a 10-minute batch reported in {took:?}, inside a {CALL_BUDGET:?} call budget");
+
+        let now = eval_expr(server, session, &format!("by({})", scratch.addr()));
+        assert_eq!(
+            now,
+            Some(scratch.original),
+            "the byte was not restored when the batch ran out of time:\n{report}"
+        );
+    });
+}
+
+/// A client **disconnect** while a live kernel batch holds a patch: the rollback has to run before
+/// the worker goes, and the byte has to be back when somebody else looks.
+///
+/// The dump tier proves this by the log file the `always` block writes, because by then there is no
+/// client, no supervisor and no worker left to ask. That proves the block *ran*; it cannot prove
+/// what it did to a target, because a dump has nothing to do anything to. Here the evidence is the
+/// guest's own memory, read by a **new server process** over a fresh attach — the byte outlives
+/// every process that was involved in patching it.
+#[test]
+#[ignore = "needs a live KDNET target and its connection string; run manually, last"]
+fn a_disconnect_lets_a_live_kernel_batch_restore_its_patch_first() {
+    let Some(connection) = kernel_tier() else {
+        return;
+    };
+    let running = marker_path("live-kernel-batch-running");
+    let _ = std::fs::remove_file(&running);
+
+    let mut server = Server::started_with(&[(
+        "WINDBG_MCP_CALL_TIMEOUT_SECS",
+        &SERVER_CALL_TIMEOUT.as_secs().to_string(),
+    )]);
+    let attached = server.call_tool(
+        "attach_kernel",
+        json!({ "connection": connection }),
+        TARGET_STEP,
+    );
+    let report = text_of(&attached["result"]);
+    assert_no_error(&attached, "attach_kernel");
+    let session = maybe_session_id(&report)
+        .unwrap_or_else(|| panic!("the attach left no session behind:\n{report}"));
+    assert!(
+        !is_tool_error(&attached),
+        "the attach claimed its target and then failed; this test needs one that landed:\n{report}"
+    );
+    // Everything up to the disconnect runs under `catch_unwind`: from the attach onward the guest
+    // is broken in, and the release is the disconnect itself, so a panic before it would leave the
+    // machine frozen for the sake of a failed assertion. That includes the two lines below, which
+    // look harmless and would still cost a VM.
+    let ready = catch_unwind(AssertUnwindSafe(|| {
+        // Read now, because the re-attach below has to wait for this process to be gone: the KD
+        // transport is single-owner, so a second attach that races the first worker's exit fails
+        // on the port rather than on anything this test is about.
+        let status = server.tool_text("session_status", json!({}), STEP);
+        let worker = engine_pid_of(&status, &session);
+        let scratch = kernel_scratch(&mut server, &session)?;
+
+        // Patch, announce, then spend twenty seconds so the disconnect lands squarely inside the
+        // batch with the byte already changed. The marker is written *after* the patch for exactly
+        // that reason: waiting on it means waiting for a target that is genuinely modified.
+        let mut steps = patch_steps(&scratch);
+        steps.push(
+            json!({ "op": "command", "command": format!(".logopen \"{}\"", running.display()) }),
+        );
+        steps.push(json!({ "op": "command", "command": ".echo BATCH-RUNNING" }));
+        steps.push(json!({ "op": "command", "command": ".logclose" }));
+        steps.extend(std::iter::repeat_n(
+            json!({ "op": "command", "command": ".sleep 1000" }),
+            20,
+        ));
+        // Sent without waiting: nobody will be here to read the answer, which is the whole
+        // scenario.
+        server.send_request(
+            "tools/call",
+            json!({
+                "name": "debug_batch",
+                "arguments": {
+                    "session_id": session,
+                    "steps": steps,
+                    "always": restore_steps(&scratch),
+                }
+            }),
+        );
+
+        // Disconnect only once the patch is demonstrably in the target. Timing it with a sleep
+        // would make a slow machine into a test that proves nothing: the batch would not have
+        // started, and refusing to start is a *different* correct behaviour with the same green
+        // tick.
+        let deadline = Instant::now() + TARGET_STEP;
+        while !running.exists() {
+            assert!(
+                Instant::now() < deadline,
+                "the batch never got past its patch steps, so the disconnect below would prove \
+                 nothing\n--- stderr ---\n{}",
+                server.stderr()
+            );
+            std::thread::sleep(Duration::from_millis(100));
+        }
+        Some((scratch, worker))
+    }));
+    let (scratch, worker) = match ready {
+        Ok(Some(ready)) => ready,
+        // Either nothing to prove (no writable scratch byte) or an assertion failed. Both leave a
+        // halted kernel that has to be released the ordinary way, since the disconnect below is
+        // now not going to happen.
+        other => {
+            let ended =
+                server.call_tool("end_session", json!({ "session_id": session }), TARGET_STEP);
+            let text = text_of(&ended["result"]);
+            if let Some(why) = ungraceful_detach(&ended, &text) {
+                panic!("THE TARGET MAY STILL BE HALTED — {why}");
+            }
+            match other {
+                Err(panic) => resume_unwind(panic),
+                _ => return,
+            }
+        }
+    };
+    let (base, expected) = (scratch.address, scratch.original);
+
+    let disconnected = Instant::now();
+    let exit = catch_unwind(AssertUnwindSafe(|| server.shutdown()));
+    let took = disconnected.elapsed();
+
+    // The worker outlives the supervisor by however long its rollback and release take, and it
+    // owns the KD endpoint until it exits.
+    let deadline = Instant::now() + Duration::from_secs(20);
+    while process_alive(worker) && Instant::now() < deadline {
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    let worker_gone = !process_alive(worker);
+
+    // Re-attach from a *new server process* and ask the guest what the byte says now. Everything
+    // is collected rather than asserted until the target has been released again.
+    let mut again = Server::started_with(&[(
+        "WINDBG_MCP_CALL_TIMEOUT_SECS",
+        &SERVER_CALL_TIMEOUT.as_secs().to_string(),
+    )]);
+    let (base_now, byte_now) =
+        with_live_kernel_session(&mut again, &connection, |server, session| {
+            (
+                nt_base(server, session),
+                eval_expr(server, session, &format!("by({:#x})", base)),
+            )
+        });
+
+    match exit {
+        Ok(code) => assert_eq!(code, Some(0), "a disconnect should still be a clean exit"),
+        Err(panic) => resume_unwind(panic),
+    }
+    assert!(
+        worker_gone,
+        "engine worker pid {worker} outlived the connection"
+    );
+    assert_eq!(
+        base_now + 0x28,
+        base,
+        "the guest rebooted between the two attaches, so the byte read back is not the byte that \
+         was patched and this run can say nothing about the rollback"
+    );
+    assert_eq!(
+        byte_now,
+        Some(expected),
+        "{:#x} still reads {byte_now:?} rather than {expected:#x} after a disconnect — the batch \
+         was terminated with its patch in place, which on a real target is the loss this tool \
+         exists to prevent",
+        base
+    );
+    // The steps had twenty seconds left. Waiting them out would be a rollback that happened for
+    // the wrong reason — the batch finishing normally — and would say nothing about abandoning one.
+    assert!(
+        took < Duration::from_secs(15),
+        "the disconnect took {took:?}: the batch ran on instead of stopping at its next step"
+    );
+    println!(
+        "a disconnect mid-patch left {:#x} restored to {expected:#x}",
+        base
+    );
+    let _ = std::fs::remove_file(&running);
+}
+
+/// `end_session` while a live kernel batch holds a patch — the same guarantee with a client still
+/// present to be told about it.
+///
+/// Two things have to be true at once here, and only the first is testable against a dump: the
+/// batch's own call comes back saying `BATCH: ABANDONED` with the rollback complete, *and* the
+/// guest's memory agrees. The session is gone by then, so the byte is read over a second attach.
+#[test]
+#[ignore = "needs a live KDNET target and its connection string; run manually, last"]
+fn ending_a_live_kernel_session_mid_batch_restores_its_patch() {
+    let Some(connection) = kernel_tier() else {
+        return;
+    };
+    let running = marker_path("live-kernel-end-session-batch");
+    let _ = std::fs::remove_file(&running);
+
+    let mut server = Server::started_with(&[(
+        "WINDBG_MCP_CALL_TIMEOUT_SECS",
+        &SERVER_CALL_TIMEOUT.as_secs().to_string(),
+    )]);
+
+    // The first session is ended *by the test itself*, mid-batch, so it cannot use the helper —
+    // but everything it does before that still has to be unwound if it fails.
+    let attached = server.call_tool(
+        "attach_kernel",
+        json!({ "connection": connection }),
+        TARGET_STEP,
+    );
+    let report = text_of(&attached["result"]);
+    assert_no_error(&attached, "attach_kernel");
+    let session = maybe_session_id(&report)
+        .unwrap_or_else(|| panic!("the attach left no session behind:\n{report}"));
+    assert!(
+        !is_tool_error(&attached),
+        "the attach claimed its target and then failed:\n{report}"
+    );
+    // Under `catch_unwind` from here: the guest is broken in, and the `end_session` below is what
+    // releases it — so nothing in between may propagate a panic past it, including the two
+    // bookkeeping calls that open this block.
+    let outcome = catch_unwind(AssertUnwindSafe(|| {
+        // The second attach has to wait for this worker to exit before it can claim the KD
+        // transport, which is single-owner.
+        let status = server.tool_text("session_status", json!({}), STEP);
+        let worker = engine_pid_of(&status, &session);
+        let scratch = kernel_scratch(&mut server, &session)?;
+        let mut steps = patch_steps(&scratch);
+        steps.push(
+            json!({ "op": "command", "command": format!(".logopen \"{}\"", running.display()) }),
+        );
+        steps.push(json!({ "op": "command", "command": ".echo BATCH-RUNNING" }));
+        steps.push(json!({ "op": "command", "command": ".logclose" }));
+        steps.extend(std::iter::repeat_n(
+            json!({ "op": "command", "command": ".sleep 1000" }),
+            20,
+        ));
+        let batch = server.send_request(
+            "tools/call",
+            json!({
+                "name": "debug_batch",
+                "arguments": {
+                    "session_id": session,
+                    "steps": steps,
+                    "always": restore_steps(&scratch),
+                }
+            }),
+        );
+
+        let deadline = Instant::now() + TARGET_STEP;
+        while !running.exists() {
+            assert!(
+                Instant::now() < deadline,
+                "the batch never got past its patch steps\n--- stderr ---\n{}",
+                server.stderr()
+            );
+            std::thread::sleep(Duration::from_millis(100));
+        }
+        Some((scratch, batch, worker))
+    }));
+
+    // Whatever happened above, this session is ending now — it is either the act under test or the
+    // cleanup, and on a broken-in kernel it is not optional.
+    let asked = Instant::now();
+    let ended = server.call_tool("end_session", json!({ "session_id": session }), TARGET_STEP);
+    let ended_text = text_of(&ended["result"]);
+    let took = asked.elapsed();
+    if let Some(why) = ungraceful_detach(&ended, &ended_text) {
+        panic!("THE TARGET MAY STILL BE HALTED — {why}");
+    }
+    let started = match outcome {
+        Ok(started) => started,
+        Err(panic) => resume_unwind(panic),
+    };
+    let Some((scratch, batch, worker)) = started else {
+        return;
+    };
+
+    // The batch's own reply, which the client is still here to receive.
+    let report = text_of(&server.await_id(batch, "debug_batch", TARGET_STEP)["result"]);
+    assert!(
+        report.contains("BATCH: ABANDONED"),
+        "the batch should say it was cut short, not that it failed or timed out:\n{report}"
+    );
+    assert!(
+        report.contains("rollback: COMPLETE"),
+        "the rollback is the reason for stopping early:\n{report}"
+    );
+    assert!(
+        took < Duration::from_secs(15),
+        "end_session took {took:?}: it waited out the batch instead of stopping it at its next step"
+    );
+
+    // The KD transport is single-owner, so the second attach has to wait for the first worker to
+    // be gone rather than race it.
+    let deadline = Instant::now() + Duration::from_secs(20);
+    while process_alive(worker) && Instant::now() < deadline {
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    assert!(
+        !process_alive(worker),
+        "engine worker pid {worker} outlived the session that was ended"
+    );
+
+    let byte_now = with_live_kernel_session(&mut server, &connection, |server, session| {
+        assert_eq!(
+            nt_base(server, session) + 0x28,
+            scratch.address,
+            "the guest rebooted between the two attaches, so nothing below is about the byte that \
+             was patched"
+        );
+        eval_expr(server, session, &format!("by({})", scratch.addr()))
+    });
+    assert_eq!(
+        byte_now,
+        Some(scratch.original),
+        "the batch reported its rollback complete, but {} reads {byte_now:?} rather than {:#x} on \
+         a fresh attach:\n{report}",
+        scratch.addr(),
+        scratch.original
+    );
+    println!("`end_session` mid-batch left the guest with its byte restored");
+    let _ = std::fs::remove_file(&running);
+}
+
+/// A batch step that asks the **pool** about a pointer it just captured — the one shape the CTF
+/// workflow needed and `debug_batch` could not express (`FOLLOWUPS.md` item 17).
+///
+/// Live-only, and not incidentally: the pool tools walk the allocator's own descriptors, which
+/// needs a broken-in x64 kernel with `nt` private symbols. What it proves beyond the unit tests is
+/// the part that only exists over a wire — that a step's walk is armed with the *batch's* budget
+/// rather than the walker's own default, and still answers.
+#[test]
+#[ignore = "needs a live KDNET target and its connection string; run manually, last"]
+fn a_live_kernel_batch_step_can_ask_the_pool_about_a_captured_pointer() {
+    let Some(connection) = kernel_tier() else {
+        return;
+    };
+    let engine = ensure_engine_beside_test_binary();
+    println!("engine: {engine}");
+    let mut server = Server::started_with(&[(
+        "WINDBG_MCP_CALL_TIMEOUT_SECS",
+        &SERVER_CALL_TIMEOUT.as_secs().to_string(),
+    )]);
+
+    with_live_kernel_session(&mut server, &connection, |server, session| {
+        let symbols = load_kernel_symbols(server, session);
+        assert!(
+            symbols.loaded.contains("pdb symbols") && !symbols.probe.is_empty(),
+            "a pool step needs full `nt` symbols and the pool-root global, same as the pool tools. \
+             If a known-good path exists, set {SYMBOLS_ENV}. Engine setup said: {engine}\n{}",
+            symbols.transcript
+        );
+
+        // `@$proc` is the current process's EPROCESS — a real pool allocation, and a pointer the
+        // debugger will hand over without any of this having to know an address in advance.
+        let call = server.call_tool(
+            "debug_batch",
+            json!({
+                "session_id": session,
+                // The walk is the expensive part and it is inside the batch, so give the batch
+                // room for it — the point is that the *step* bounds the walk, not that nothing
+                // ever has to wait.
+                "timeout_ms": 300_000,
+                "steps": [
+                    { "op": "eval", "expr": "@$proc", "capture": "proc",
+                      "name": "the EPROCESS the target is running on" },
+                    { "op": "pool_chunk", "address": "{{proc}}", "refresh": true,
+                      "name": "what the allocator says that pointer is" },
+                    { "op": "pool_census", "limit": 8, "name": "and what the pool holds overall",
+                      "expect": [{ "check": "contains", "text": "chunks walked:" }] }
+                ]
+            }),
+            POOL_CALL_BUDGET,
+        );
+        let report = text_of(&call["result"]);
+        assert_no_error(&call, "debug_batch with pool steps");
+        assert!(
+            !is_tool_error(&call),
+            "the pool steps failed inside the batch:\n{report}\n\nsymbol setup said:{}",
+            symbols.transcript
+        );
+        assert!(
+            report.contains("BATCH: COMMITTED"),
+            "a read-only batch of pool queries should commit:\n{report}"
+        );
+        // Nothing was written, and the report must not claim otherwise: a pool walk reads
+        // descriptors, however long it takes to do it.
+        assert!(
+            report.contains("mutations: none recognised"),
+            "pool queries change nothing:\n{report}"
+        );
+        // The captured pointer reached the query — a `{{proc}}` surviving into the report would
+        // mean nothing was bound.
+        assert!(
+            !report.contains("{{proc}}"),
+            "the capture was not interpolated into the pool step:\n{report}"
+        );
+        // Either answer is correct and they are different facts, so accept both by name rather
+        // than asserting the walk covered this particular chunk.
+        assert!(
+            report.contains("chunk tagged") || report.contains("not covered by the pool snapshot"),
+            "the pool_chunk step answered neither of the two things it can say:\n{report}"
+        );
+        println!("a pool query inside a live-kernel batch:\n{report}");
+    });
 }
 
 /// End-to-end CTF regression: a real MessageManager image and its retained `Tgsm` objects must be


### PR DESCRIPTION
Closes the two things `debug_batch` (#82) still owed — [`FOLLOWUPS.md`](../blob/main/FOLLOWUPS.md) items 17 and 16.

## Pool steps (item 17)

A batch step reaches anything that is a *debugger command*, which is almost every typed tool here — but the pool tools are win-kexp walks over the allocator's own descriptors, so there is no `execute` to fall back on. The CTF workflow's `@chunkt1` is exactly that shape: read a pseudo-register with `execute`, regex-scrape the value out of the debugger's prose, hand it to `pool_chunk` — and it sat *inside* the 32-step transaction, between a code patch and its restore, so a batch that could not express it had to drop the query or split the transaction.

```jsonc
{ "op": "eval", "expr": "@$t1", "capture": "obj" },
{ "op": "pool_chunk", "address": "{{obj}}", "refresh": true }
```

**One variant per question** (`pool_chunk`, `pool_find_tag`, `pool_census`) rather than a generic "call a tool" step, which would put every tool's arguments in the batch schema twice. `pool_diagnostics` is deliberately absent: it explains a *walk*, not the target, and belongs to the interactive look that follows a batch.

**The part that is not plumbing: a walk needs a deadline from the batch.** win-kexp bounds one at `DEFAULT_WALK_BUDGET` (120s), which is longer than an ordinary batch's whole budget — so a refreshed pool step taking that default would spend the reserve the rollback lives on *and* overrun the bound the worker advertises to a teardown, which is a worker terminated mid-transaction: the failure #82 exists to prevent, arriving through the one step that is not a command. `PoolWalk::within` already existed for this ("a host that knows its own deadline should pass that instead of taking this"), so a step passes its own budget and a walk cut short reports its coverage as it always did. The pool *tools* keep the default; giving them the call's real patience is still #75.

Defaults and caps moved onto `PoolOp` constructors so a step and a tool cannot disagree about what `limit` means, and `batch::Debuggee` gained one method so the executor stays engine-free.

## A mutating batch on a live kernel (item 16)

`debug_batch` was proved over a scripted debuggee with a virtual clock, and against a real engine holding a crash dump — both outcomes, both teardowns. Neither covers the case the tool exists for: **a write that is then restored.** A byte "patched" in a dump is patched in a file nobody reads again, so a rollback that silently did nothing satisfies every assertion that tier can make.

Five tests in the `live_kernel` filter:

| test | what only a live target can show |
|---|---|
| `a_mutating_batch_on_a_live_kernel_restores_its_patch_when_a_step_fails` | the byte is back, per a **later, separate** call |
| `a_live_kernel_batch_reports_and_rolls_back_before_its_callers_timeout` | the clamp in `worker::batch_budget` keeps a 10-minute batch inside a 60s call |
| `a_disconnect_lets_a_live_kernel_batch_restore_its_patch_first` | read back by a **new server process** over a fresh attach |
| `ending_a_live_kernel_session_mid_batch_restores_its_patch` | `BATCH: ABANDONED` to the client **and** a second attach agreeing about the byte |
| `a_live_kernel_batch_step_can_ask_the_pool_about_a_captured_pointer` | item 17 over a wire, walk bounded by the batch |

**What gets patched:** `nt`'s DOS-header `e_res2` field — reserved by the format, read by nothing at runtime, and stable across a detach and re-attach, which the teardown tests need and a stack address could not give. Anything with a *purpose* meets the first two conditions and bugchecks the guest on the third.

**The probe is not optional.** A guest with memory integrity (HVCI) enabled accepts a debugger write to an image page and silently drops it, so each test reads, writes, reads back and restores the byte *before* opening a transaction. Without it, "the rollback worked" and "the patch never landed" are the same green tick.

## Verification

- `cargo test` — 206 unit + 27 smoke, and the debugger tier (`WINDBG_MCP_SMOKE_DUMP=1`) green.
- **The live-kernel tier was run against a real KDNET target: 8 passed, 0 failed, 294s**, including `a disconnect mid-patch left 0xfffff801e8800028 restored to 0x0` — the patch landed and the rollback put it back, rather than the probe skipping.
- `--list` confirms the `live_kernel` filter matches exactly 8 tests, which is the count `CLAUDE.md` and `docs/smoke-test.md` now state.
- clippy, rustfmt, markdownlint clean.

Docs: CHANGELOG (folded into the unreleased `debug_batch` entry — the tool has not shipped), README, SKILL.md, `docs/smoke-test.md` runbook, DECISIONS.md's status line, CLAUDE.md, and FOLLOWUPS 16/17 marked done with what each needed that its entry had not foreseen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added pool inspection steps to debugging batches: chunk lookup, tag search and pool census.
  - Added refresh and result-limit options, with bounded output and progress reporting.
  - Pool results can now use captured values within batch workflows.
  - Added support for safely restoring changes after failures, timeouts, disconnects and session teardown.

- **Documentation**
  - Expanded guidance and examples for pool operations, batch budgets and restoration behaviour.
  - Updated live-kernel smoke-test coverage and documented supported batch step types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->