### PR TITLE
Stop a running call without throwing the target away

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,9 @@ For local iteration while an MCP client may have the release executable locked, 
 
 ## Coding Style & Naming Conventions
 
-Use Rust 2024 idioms and `rustfmt` defaults. Keep DbgEng access inside the worker process and on its engine thread; do not add ad hoc cross-thread or cross-process calls. The supervisor must never touch a `DebugEngine`. Prefer typed Rust APIs and structured JSON over parsing debugger text unless the command surface only exposes text. Use `snake_case` for functions, modules, fields, and tests; use `PascalCase` for types. Keep comments short and focused on non-obvious debugger behavior.
+Use Rust 2024 idioms and `rustfmt` defaults. Keep DbgEng access inside the worker process and on its engine thread; do not add ad hoc cross-thread or cross-process calls. The supervisor must never touch a `DebugEngine`.
+
+**There is exactly one approved exception, and it is not a precedent for a second.** `SetInterrupt` is the single DbgEng entry point Microsoft documents as safe to call from any thread, and it is the only call made off the engine thread: from `worker::interrupt_running` on the request reader, and from win-kexp's two watchdog threads, which have always done it. It is unavoidable rather than convenient — an interrupt exists to stop an operation that is running, so the engine thread is busy by definition, and a request routed through it would be read only once there was nothing left to interrupt. Adding any *other* cross-thread DbgEng call is a design change, not a local one: raise it before writing it. See the `DECISIONS.md` entry "An interrupt is bound to a job, not to a moment" and the `worker.rs` module docs. Prefer typed Rust APIs and structured JSON over parsing debugger text unless the command surface only exposes text. Use `snake_case` for functions, modules, fields, and tests; use `PascalCase` for types. Keep comments short and focused on non-obvious debugger behavior.
 
 ## Testing Guidelines
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,9 +48,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   told separately rather than inferring it from the step, and that is not a detail: an interrupted
   step *succeeds*. Preserving the output reached up to the break is the whole point, so the debugger
   returns `Ok` and a step whose assertions still hold is indistinguishable from one that ran — the
-  batch would carry on applying later mutations for a caller who had just asked it to stop. A second
-  `interrupt` while one is already stopping is a no-op that says so, because the rollback runs as
-  part of the same job and a second break could land on a restore.
+  batch would carry on applying later mutations for a caller who had just asked it to stop.
+
+  **A batch's rollback is not interruptible.** Cleanup runs as part of the same call and is reached
+  on every path, so a break landing there hits a restore command — which returns `Ok` with partial
+  output like any interrupted command, and would be recorded as a step that worked: `rollback:
+  COMPLETE` with the target still changed. The executor announces the block before running it, and
+  the worker then refuses breaks for that call and drains any already pending, both under the lock a
+  raise has to take. An `interrupt` aimed at a batch that is unwinding says so and sends nothing.
+  A break landing during the **last** step is caught too, on a re-check once the steps end: it
+  cannot be seen between steps, and the batch would otherwise report `COMMITTED` of a transaction
+  whose final step was cut short — directly above the note saying it had been.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   never exceeds the caller's patience. A walk cut short still answers, and every pool result already
   reports how much of the pool it reached.
 
+  Where it parts company with a bounded command is at the bottom of the range: that one *floors* its
+  budget, because zero disables its watchdog and an unbounded command is the worse outcome. A walk
+  has no such cliff — zero simply stops it at the first check — so there is no floor here, and a
+  query that reaches the engine with nothing left to spend is refused rather than run. Flooring it
+  would reintroduce the bug at the small end (a 10s call budget yielding a 15s walk) and buy nothing
+  for it, since win-kexp caches complete snapshots only: a budget-truncated walk is discarded, so the
+  work would be spent for a caller who has gone and the next query would walk from scratch anyway.
+  Only a query that *must* walk is refused; one that can be served from the session's cached snapshot
+  is still answered, because a cache read costs nothing that even an exhausted caller cannot afford.
+
   Which slot the pump fills is now named on `EngineOp` itself rather than matched inside the pump,
   because the failure it prevents is silent — that is exactly how `Pool` came to carry no patience
   at all — and is checked against the serialized form, so an op with a `patience_ms` that does not

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,13 +42,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   an operation that never polls for the break is not reached, and neither is an `attach_kernel`
   whose target has not connected — `end_session` remains the only end to that one.
 
-  A `debug_batch` interrupted this way stops at its **next step** and runs its `always` block,
-  reporting `BATCH: INTERRUPTED` — a distinct outcome from `ABANDONED`, because the session is still
-  open and still holds its target, so the same batch can be resubmitted against it. The executor is
-  told separately rather than inferring it from the step, and that is not a detail: an interrupted
-  step *succeeds*. Preserving the output reached up to the break is the whole point, so the debugger
-  returns `Ok` and a step whose assertions still hold is indistinguishable from one that ran — the
-  batch would carry on applying later mutations for a caller who had just asked it to stop.
+  A `debug_batch` interrupted this way stops and runs its `always` block, reporting
+  `BATCH: INTERRUPTED` at the step the break reached — a distinct outcome from `ABANDONED`, because
+  the session is still open and still holds its target, so the same batch can be resubmitted against
+  it. It has to be told rather than left to infer it, and that is not a detail: **an interrupted
+  command succeeds**. Preserving the output reached up to the break is the whole point, so a step
+  whose assertions still hold is indistinguishable from one that ran, and the batch would carry on
+  applying later mutations for a caller who had just asked it to stop.
+
+  So the debugger reports *both* facts. `execute_command_bounded` returns the output **and** whether
+  the command finished (`CommandRun { output, cut_short }`), the shape `run_to_address` already had,
+  rather than a bare `String` that cannot say "this did not finish" — every place that reads a result
+  gets the fact with the value instead of having to remember to ask for it. That is the difference
+  between a step that reports itself cut short and a batch that has to guess: the last step of a
+  batch, and a step whose assertion stops holding *because* the output was truncated, are both just
+  "the step says so" rather than two more special cases.
 
   **A batch's rollback is not interruptible.** Cleanup runs as part of the same call and is reached
   on every path, so a break landing there hits a restore command — which returns `Ok` with partial
@@ -56,14 +64,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   COMPLETE` with the target still changed. The executor announces the block before running it, and
   the worker then refuses breaks for that call and drains any already pending, both under the lock a
   raise has to take. An `interrupt` aimed at a batch that is unwinding says so and sends nothing.
-  A break landing during the **last** step is caught too, on a re-check once the steps end: it
-  cannot be seen between steps, and the batch would otherwise report `COMMITTED` of a transaction
-  whose final step was cut short — directly above the note saying it had been. And a step that
-  *fails* because the break truncated its output — a `contains` that stops holding, an `eval` that
-  stops parsing, which is the likeliest shape of an interrupted step — reports `INTERRUPTED` rather
-  than `FAILED`, so the caller is not sent to debug a step that was fine. Attributable rather than
-  guessed: the between-steps check runs before every step, so a break outstanding when one fails can
-  only have been raised during it.
+  Two readings that were wrong in the same direction come right for free once the step carries the
+  fact. A break landing during the **last** step has no next step to be caught before, so the batch
+  reported `COMMITTED` of a transaction whose final step was cut short — directly above the note
+  saying it had been. And a step that *fails* because the break truncated its output — a `contains`
+  that stops holding, an `eval` that stops parsing, the likeliest shape of an interrupted step —
+  reported `FAILED`, sending the caller to debug a step that was fine. Both are now `INTERRUPTED`,
+  named at the step the break actually reached.
 
   Every op now keeps the output an interrupted command reached, not only the bounded ones. The plain
   path (`modules`, `index_trace` and the other typed commands) went through `execute_command`, where

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,70 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`interrupt`: stop the operation a session is running, keeping the session and its target**
+  (FOLLOWUPS item 7).
+
+  A runaway call used to have exactly one way out: `end_session`, which ends it by throwing away
+  the target it was running against. On a live kernel that is a machine to re-attach, and often a
+  guest to reboot. `interrupt` is the graceful one — a Ctrl+Break, exactly as at a WinDbg prompt.
+  The interrupted operation ends at the debugger's next poll and returns **whatever it had reached
+  to the call that started it**, marked as cut short, and the session takes the next call
+  immediately. Partial output is preserved rather than discarded: `SetInterrupt` makes `Execute`
+  fail, so an aborted search used to be indistinguishable from a failed one and lost every line it
+  had already produced.
+
+  The primitive existed but was only ever *timeout-driven* — win-kexp's watchdog threads
+  Ctrl+Break when a deadline passes, and no caller could ask for the same. `SetInterrupt` is now a
+  public win-kexp method on a `Send` handle taken from a `&DebugEngine`, which needs no new
+  threading model: it is the one DbgEng call documented as safe from another thread, so the engine
+  stays confined to its own.
+
+  **Bound to a job, not to a moment.** `SetInterrupt` addresses an *engine*, so raised a moment
+  late it stops whatever started next — a caller's `go` aborted by a cancel meant for the search
+  before it. The worker tracks which job its engine thread is running, and the request reader reads
+  that job and raises the interrupt under one lock, while the engine thread claims and releases the
+  job under the same one. So an interrupt reaches the job that was running when it arrived or
+  nothing at all, and the job it reached spends it: a pending break left over is drained before the
+  next job starts, and only the interrupted caller is told their result was cut short.
+
+  Like the abandon-a-batch signal, the request is **answered by the worker's request reader** rather
+  than queued for its engine thread — queued, it could only be read once the operation it means to
+  stop had ended. So it does not wait behind the busy session: issue it while the slow call is still
+  outstanding. With nothing running it says so and does nothing. Two limits carry over from DbgEng:
+  an operation that never polls for the break is not reached, and neither is an `attach_kernel`
+  whose target has not connected — `end_session` remains the only end to that one.
+
+  A `debug_batch` interrupted this way fails the step that was running, which stops the transaction
+  and runs its `always` block, so the rollback still happens and the batch's own result reports it.
+
+### Changed
+
+- **The pool tools take the caller's own deadline instead of win-kexp's default walk budget**
+  ([#75](https://github.com/glslang/windbg-mcp/issues/75)).
+
+  A pool walk enforces a wall-clock ceiling of its own, so `pool_find_tag` and friends can no
+  longer run for minutes after their caller has given up and leave every later call to that session
+  queued behind them. But they took the walker's **default** — 120s — which knows nothing about
+  this server's deadline, and was wrong in both directions. A host configured with
+  `WINDBG_MCP_CALL_TIMEOUT_SECS=60` got a 120s walk against a 60s budget: the call timed out and
+  the engine kept walking, which is precisely the wedge the walk budget was added to fix, arriving
+  from this side. And with the 300s default the walk stopped at 120s and handed back a partial
+  snapshot with three minutes still to spend.
+
+  `EngineOp::Pool` now carries the caller's remaining patience exactly as a bounded command and a
+  batch do — filled in by the supervisor's pump as the request is written, with the worker deriving
+  the deadline, because only the worker knows how long the request then sat in *its* queue. The
+  arithmetic is the bounded command's, so the invariant is the same: queue wait plus walk budget
+  never exceeds the caller's patience. A walk cut short still answers, and every pool result already
+  reports how much of the pool it reached.
+
+  Which slot the pump fills is now named on `EngineOp` itself rather than matched inside the pump,
+  because the failure it prevents is silent — that is exactly how `Pool` came to carry no patience
+  at all — and is checked against the serialized form, so an op with a `patience_ms` that does not
+  hand it out fails a test rather than shipping with an unset deadline.
+
 ## [0.6.0] - 2026-08-10
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   raise has to take. An `interrupt` aimed at a batch that is unwinding says so and sends nothing.
   A break landing during the **last** step is caught too, on a re-check once the steps end: it
   cannot be seen between steps, and the batch would otherwise report `COMMITTED` of a transaction
-  whose final step was cut short — directly above the note saying it had been.
+  whose final step was cut short — directly above the note saying it had been. And a step that
+  *fails* because the break truncated its output — a `contains` that stops holding, an `eval` that
+  stops parsing, which is the likeliest shape of an interrupted step — reports `INTERRUPTED` rather
+  than `FAILED`, so the caller is not sent to debug a step that was fine. Attributable rather than
+  guessed: the between-steps check runs before every step, so a break outstanding when one fails can
+  only have been raised during it.
+
+  Every op now keeps the output an interrupted command reached, not only the bounded ones. The plain
+  path (`modules`, `index_trace` and the other typed commands) went through `execute_command`, where
+  a break makes `Execute` fail and the captured buffer is discarded with the error — a bare failure
+  plus a note promising partial output that was not there. They take `execute_command_bounded` with
+  a zero deadline instead, which is the same call plus that recovery: zero spawns no watchdog, so
+  they stay unbounded, as `index_trace` in particular must.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,8 +42,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   an operation that never polls for the break is not reached, and neither is an `attach_kernel`
   whose target has not connected — `end_session` remains the only end to that one.
 
-  A `debug_batch` interrupted this way fails the step that was running, which stops the transaction
-  and runs its `always` block, so the rollback still happens and the batch's own result reports it.
+  A `debug_batch` interrupted this way stops at its **next step** and runs its `always` block,
+  reporting `BATCH: INTERRUPTED` — a distinct outcome from `ABANDONED`, because the session is still
+  open and still holds its target, so the same batch can be resubmitted against it. The executor is
+  told separately rather than inferring it from the step, and that is not a detail: an interrupted
+  step *succeeds*. Preserving the output reached up to the break is the whole point, so the debugger
+  returns `Ok` and a step whose assertions still hold is indistinguishable from one that ran — the
+  batch would carry on applying later mutations for a caller who had just asked it to stop. A second
+  `interrupt` while one is already stopping is a no-op that says so, because the rollback runs as
+  part of the same job and a second break could land on a restore.
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -884,7 +884,7 @@ dependencies = [
 [[package]]
 name = "win-kexp"
 version = "0.1.0"
-source = "git+https://github.com/glslang/win-kexp?branch=main#65d8ec3e17de3b27daecb6d0bf947af31c093b3b"
+source = "git+https://github.com/glslang/win-kexp?branch=main#13b6b9570179eb5117c226e266b08da61d511738"
 dependencies = [
  "byte-strings",
  "goblin",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -884,7 +884,7 @@ dependencies = [
 [[package]]
 name = "win-kexp"
 version = "0.1.0"
-source = "git+https://github.com/glslang/win-kexp?branch=main#ae958fbe33f2076322b148239f5ddfffe8032db3"
+source = "git+https://github.com/glslang/win-kexp?branch=main#65d8ec3e17de3b27daecb6d0bf947af31c093b3b"
 dependencies = [
  "byte-strings",
  "goblin",

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -37,6 +37,22 @@ failed one **without being the thread that asked**. Without it an interrupt on r
 search is worth. The watchdog's explanatory note stays the watchdog's: it exists because nobody saw
 that deadline pass, whereas this caller is the one who asked.
 
+**A batch has to be told, because an interrupted step succeeds.** Preserving the output a command
+reached up to the break is the point of an on-request interrupt, so the debugger returns `Ok` rather
+than the error the break provoked — and a `debug_batch` step whose assertions still hold is then
+indistinguishable from one that ran to completion. Left to infer it, the executor carried on
+applying later mutations for a caller who had just asked it to stop. So `batch::run` checks between
+steps, exactly where it checks for a teardown, and stops with its own outcome: `Interrupted` rather
+than `Abandoned`, because the session is *staying* — telling a caller to resubmit on a fresh session
+when the one they hold is fine is the same class of wrong answer that keeps `Abandoned` apart from a
+timeout. The signal it reads is the per-job record ([`Running`]), not the batch abandon flag: that
+one is sticky by design, and a sticky flag on a session that survives would refuse every later batch.
+
+One consequence worth naming: the rollback runs as part of the same job, so a *second* interrupt
+while a batch is already stopping could land on a restore command — a cut-short `Execute` that still
+reports `Ok`, which is a mutation left applied and reported as undone. So at most one break is
+raised per job; a repeat is answered with "already interrupted, it is stopping".
+
 **This is the approved exception to engine-thread confinement** (`AGENTS.md`), and worth being
 explicit about, because the rule is otherwise absolute and the code visibly departs from it.
 `SetInterrupt` is the one DbgEng entry point Microsoft documents as safe from any thread; it is the

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -67,12 +67,26 @@ holding, an `eval` that stops parsing — reported `FAILED`, sending the caller 
 was fine. Both are attributions this executor can actually make: the between-steps check runs before
 every step, so a break outstanding when one fails can only have been raised during that step.
 
-The general shape, worth keeping because it is what four rounds of review kept finding: **an
-interrupted operation is indistinguishable from a successful one to everything downstream**, so
-every place that reads a result has to be told separately. The places are enumerable — between
+**The root cause was the return type, and it is now fixed rather than worked around.** Four rounds
+of review each found a different place that had to be told an interrupt had happened — between
 steps, after the last step, when a step fails, and the plain-command path that discarded its output
-entirely — and each was wrong in the same direction, reporting the caller's own interrupt as a fact
-about their target.
+entirely — and every one was wrong in the same direction, reporting the caller's own interrupt as a
+fact about their target. They were all the same defect: `execute_command_bounded` returned
+`Result<String, _>`, an interrupt is not an error (the output is worth keeping), so it returned
+`Ok(text)` — and a `String` cannot say "this did not finish". The fact then had to travel by side
+channel, and a side channel is something each reader must remember to consult.
+
+It now returns `CommandRun { output, cut_short: Option<Interruption> }`, the shape `run_to_address`
+had all along — a structured verdict *and* the text, which is what should have been copied in the
+first place. Two of the four special cases disappeared rather than being fixed: the last-step case
+and the failed-assertion case are both just "the step says it was cut short", read where the step's
+result is already interpreted. `Debuggee::interrupted` survives for the one case a step genuinely
+cannot carry — a break landing between steps — and the batch outcome now names the step the break
+actually *reached* rather than the one that never started.
+
+The general lesson, since it cost four rounds: **a value that omits how it was produced makes every
+reader responsible for finding out**, and readers are added over time. `Ok` for "interrupted" bought
+partial output at the price of an invariant nobody could see from the type.
 
 **This is the approved exception to engine-thread confinement** (`AGENTS.md`), and worth being
 explicit about, because the rule is otherwise absolute and the code visibly departs from it.

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -88,6 +88,14 @@ flag is collected across its assertions too: an `eval` check is two further engi
 break landing in one can leave a value that still parses and still matches, so nothing else in the
 step would ever say anything was wrong.
 
+And the seam has **no** "this finished" constructor, which is the part that stops the class coming
+back. There was one, used at the dispatch to wrap the three actions that are not commands — `run_to`,
+`read_memory` and the pool steps — and it made *finished* their silent default. Two of those are
+interruptible in fact (a pool walk polls the same flag win-kexp's walker does), and the engine
+cannot report it for any of them, since only the worker knows a break was raised. So every method on
+the trait returns the same type and every implementor has to say what it saw: there is now no way to
+claim a call finished without deciding that it did.
+
 The general lesson, since it cost four rounds: **a value that omits how it was produced makes every
 reader responsible for finding out**, and readers are added over time. `Ok` for "interrupted" bought
 partial output at the price of an invariant nobody could see from the type.

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -5,6 +5,45 @@ status. Keep entries short; link to code with `file:line` where it helps a futur
 
 ---
 
+## An interrupt is bound to a job, not to a moment (2026-08-10, FOLLOWUPS item 7)
+
+**Context.** A runaway call had one way out: `end_session`, which ends it by discarding the target.
+The primitive for a gentler one existed but was only ever *timeout-driven* — win-kexp's watchdog
+threads Ctrl+Break when a deadline passes, and no caller could ask for the same. What stopped it
+being a five-line change is that `SetInterrupt` addresses an **engine**, not an operation.
+
+**Decision.** `interrupt` is a per-session tool, and the binding to a job is made **in the worker,
+under one lock**. The request reader reads which job the engine thread is claiming and raises the
+interrupt while holding `RUNNING`; the engine thread claims and releases that job under the same
+lock (`src/worker.rs`). So an interrupt reaches the job that was running when it arrived, or nothing
+at all — it can never land on the one after it — and the job it reached *spends* it: any break the
+engine did not consume is drained before the next job starts, and only that caller's reply is marked
+cut short.
+
+**Why the lock rather than a check.** Read-then-raise without it is a race against an ordinary job
+boundary, and losing it means a caller's `go` aborted by a cancel meant for the search before it,
+with nothing in the record to say why. That is a rare accident today and the *normal* case under
+tasks (FOLLOWUPS item 8), where several calls in flight is the point — which is why this was built
+now rather than deferred with it.
+
+**Answered by the reader, never queued**, exactly like the abandon-a-batch signal (2026-08-09
+above), and here it is the whole mechanism rather than an ordering detail: queued, the request would
+be read only once the operation it means to stop had ended.
+
+**One thing had to change in win-kexp**, and it is not the `SetInterrupt` call. The handle and the
+engine share a "raised" flag, so `execute_command_bounded` can tell an aborted `Execute` from a
+failed one **without being the thread that asked**. Without it an interrupt on request is a
+`CommandFailed` and the output captured up to the break goes with it — most of what an interrupted
+search is worth. The watchdog's explanatory note stays the watchdog's: it exists because nobody saw
+that deadline pass, whereas this caller is the one who asked.
+
+**Status.** Adopted. What it deliberately does **not** do: drop a *queued* job (nothing can name one
+— a tool call names a session, so that variant belongs with `tasks/cancel`), and reach a live-kernel
+wait whose target has not connected (`SetInterrupt` cannot, so the tool says so instead of reporting
+a success that does nothing). `end_session` remains the answer to that one.
+
+---
+
 ## The rollback belongs to the worker, not the client (2026-08-09, #82)
 
 **Context.** Multi-step debugger work that mutates a target — patch a byte, arm a breakpoint,
@@ -108,9 +147,11 @@ never ran a batch. When the worker named a release interval too, the supervisor 
 its advertised bound raced the wait's last look and could be killed as the release began.
 
 A session with nothing to unwind says nothing and costs exactly what it always did, so an ordinary
-disconnect is untouched. What none of this can do is *shorten* a step already inside DbgEng — that
-is `SetInterrupt` bound to job identity, FOLLOWUPS item 7 — so a batch stops at its next step
-boundary, not where it stands.
+disconnect is untouched. What none of this can do is *shorten* a step already inside DbgEng, so a
+batch stops at its next step boundary, not where it stands. The primitive for that now exists —
+FOLLOWUPS item 7 landed as `interrupt` (see the entry above) — and a teardown still does not raise
+it, because what it would buy is latency rather than safety: the grace already covers the step in
+flight, and Ctrl+Breaking it would turn a step that was about to succeed into a failed one.
 
 **Status.** Adopted, and the two things it owed are now paid (2026-08-10). **Pool steps** (FOLLOWUPS
 item 17) landed as one `StepAction` variant per question rather than a generic "call a tool" step,
@@ -118,7 +159,9 @@ which would have put every tool's arguments in the batch schema twice; the part 
 anticipated is that a walk needs a deadline *from the batch*, because win-kexp bounds one at 120s and
 an ordinary batch's whole budget is shorter — a refreshed pool step taking that default would spend
 the rollback's reserve and overrun the bound advertised to a teardown, which is the failure above
-arriving through the one step that is not a command. And the **mutating batch** (item 16) is now
+arriving through the one step that is not a command. The pool *tools* went on taking that default
+until [#75](https://github.com/glslang/windbg-mcp/issues/75) gave them the call's own patience, on
+the same arithmetic as a bounded command. And the **mutating batch** (item 16) is now
 exercised on a live kernel, which is the only place the claim can be false: a byte patched in a dump
 is patched in a file nobody reads again, so a rollback that silently did nothing satisfies every
 assertion the dump tier can make.

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -58,14 +58,15 @@ lock a raise has to take. Every break is therefore either lodged before the seal
 there, or refused after it. A repeat while a batch is merely *stopping* is refused for the same
 reason one step earlier.
 
-**And the same fact distorts the report in two more places, both fixed by attributing rather than
-guessing.** An interrupt during the *last* step is invisible between steps — there is no next step
-to stop before — so every step had run and the report said `COMMITTED` of a transaction whose final
-step was cut short, directly above the note saying it had been; the outcome is re-checked once the
-loop ends. And a step that *fails* because the break truncated its output — a `contains` that stops
-holding, an `eval` that stops parsing — reported `FAILED`, sending the caller to debug a step that
-was fine. Both are attributions this executor can actually make: the between-steps check runs before
-every step, so a break outstanding when one fails can only have been raised during that step.
+**And the same fact distorted the report in two more places.** An interrupt during the *last* step
+is invisible between steps — there is no next step to stop before — so every step had run and the
+report said `COMMITTED` of a transaction whose final step was cut short, directly above the note
+saying it had been. And a step that *failed* because the break truncated its output — a `contains`
+that stops holding, an `eval` that stops parsing — reported `FAILED`, sending the caller to debug a
+step that was fine. Both were first fixed as further special cases (a re-check after the loop, and a
+reclassification arm), and both then *deleted* by the return-type change below, which is the reason
+that change was worth making: they are the same fact arriving at two more readers, and the fix that
+scales is to stop asking readers to remember.
 
 **The root cause was the return type, and it is now fixed rather than worked around.** Four rounds
 of review each found a different place that had to be told an interrupt had happened — between

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -48,10 +48,21 @@ when the one they hold is fine is the same class of wrong answer that keeps `Aba
 timeout. The signal it reads is the per-job record ([`Running`]), not the batch abandon flag: that
 one is sticky by design, and a sticky flag on a session that survives would refuse every later batch.
 
-One consequence worth naming: the rollback runs as part of the same job, so a *second* interrupt
-while a batch is already stopping could land on a restore command — a cut-short `Execute` that still
-reports `Ok`, which is a mutation left applied and reported as undone. So at most one break is
-raised per job; a repeat is answered with "already interrupted, it is stopping".
+**The rollback is not interruptible, and that is the sharper end of the same fact.** Cleanup runs as
+part of the same job and is reached on *every* path, so a break landing there — the first one, not
+merely a repeat — hits a restore command, which returns `Ok` with partial output like any
+interrupted command and is recorded as a step that worked: `rollback: COMPLETE` with the target
+still changed. So the executor announces the block before it runs it (`Debuggee::rolling_back`), and
+the worker seals the job against further breaks *and* drains any already pending, both under the
+lock a raise has to take. Every break is therefore either lodged before the seal and consumed
+there, or refused after it. A repeat while a batch is merely *stopping* is refused for the same
+reason one step earlier.
+
+**And an interrupt during the last step is not a commit.** The between-steps check cannot see it —
+there is no next step to stop before — so every step has run and every assertion has held, and the
+report said `COMMITTED` of a transaction whose final step was cut short, directly above the note
+saying the operation was interrupted. The outcome is re-checked once the loop ends, and only from
+`Committed`: a step that failed or timed out has news the caller must act on first.
 
 **This is the approved exception to engine-thread confinement** (`AGENTS.md`), and worth being
 explicit about, because the rule is otherwise absolute and the code visibly departs from it.

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -82,7 +82,10 @@ first place. Two of the four special cases disappeared rather than being fixed: 
 and the failed-assertion case are both just "the step says it was cut short", read where the step's
 result is already interpreted. `Debuggee::interrupted` survives for the one case a step genuinely
 cannot carry — a break landing between steps — and the batch outcome now names the step the break
-actually *reached* rather than the one that never started.
+actually *reached* rather than the one that never started. A step is more than its action, so the
+flag is collected across its assertions too: an `eval` check is two further engine calls, and a
+break landing in one can leave a value that still parses and still matches, so nothing else in the
+step would ever say anything was wrong.
 
 The general lesson, since it cost four rounds: **a value that omits how it was produced makes every
 reader responsible for finding out**, and readers are added over time. `Ok` for "interrupted" bought

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -58,11 +58,21 @@ lock a raise has to take. Every break is therefore either lodged before the seal
 there, or refused after it. A repeat while a batch is merely *stopping* is refused for the same
 reason one step earlier.
 
-**And an interrupt during the last step is not a commit.** The between-steps check cannot see it —
-there is no next step to stop before — so every step has run and every assertion has held, and the
-report said `COMMITTED` of a transaction whose final step was cut short, directly above the note
-saying the operation was interrupted. The outcome is re-checked once the loop ends, and only from
-`Committed`: a step that failed or timed out has news the caller must act on first.
+**And the same fact distorts the report in two more places, both fixed by attributing rather than
+guessing.** An interrupt during the *last* step is invisible between steps — there is no next step
+to stop before — so every step had run and the report said `COMMITTED` of a transaction whose final
+step was cut short, directly above the note saying it had been; the outcome is re-checked once the
+loop ends. And a step that *fails* because the break truncated its output — a `contains` that stops
+holding, an `eval` that stops parsing — reported `FAILED`, sending the caller to debug a step that
+was fine. Both are attributions this executor can actually make: the between-steps check runs before
+every step, so a break outstanding when one fails can only have been raised during that step.
+
+The general shape, worth keeping because it is what four rounds of review kept finding: **an
+interrupted operation is indistinguishable from a successful one to everything downstream**, so
+every place that reads a result has to be told separately. The places are enumerable — between
+steps, after the last step, when a step fails, and the plain-command path that discarded its output
+entirely — and each was wrong in the same direction, reporting the caller's own interrupt as a fact
+about their target.
 
 **This is the approved exception to engine-thread confinement** (`AGENTS.md`), and worth being
 explicit about, because the rule is otherwise absolute and the code visibly departs from it.

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -37,6 +37,27 @@ failed one **without being the thread that asked**. Without it an interrupt on r
 search is worth. The watchdog's explanatory note stays the watchdog's: it exists because nobody saw
 that deadline pass, whereas this caller is the one who asked.
 
+**This is the approved exception to engine-thread confinement** (`AGENTS.md`), and worth being
+explicit about, because the rule is otherwise absolute and the code visibly departs from it.
+`SetInterrupt` is the one DbgEng entry point Microsoft documents as safe from any thread; it is the
+only call this server makes off the engine thread, from exactly one place (`worker::interrupt_running`
+on the request reader). The engine is still created on the engine thread, never sent anywhere, and
+every other call is made there. The exception is unavoidable rather than convenient: an interrupt
+exists to stop an operation that is *running*, so the engine thread is busy by definition, and a
+request routed through it would be read only once there was nothing left to interrupt — the
+alternative is not a safer interrupt but no interrupt. It is also not new. win-kexp's two watchdogs
+have Ctrl+Broken the engine from threads of their own on every bounded command and every go/step
+since the bounded path existed; what changed is that a caller can now ask for the same thing.
+
+Validated where it can be: `execute_command_bounded`'s watchdog is the same call from the same
+kind of thread and is exercised by the bounded tier; win-kexp's
+`test_command_interrupted_on_request_keeps_its_output` drives the new caller against a live engine;
+and the dump tier's `a_running_command_is_interrupted_on_request_and_frees_its_session` drives it
+through the shipped binary, with the session used again afterwards — which is what would fail if
+the cross-thread call had corrupted engine state rather than merely raising a flag. The only other
+cross-thread touch is the handle's own refcount, and the handle windbg-mcp holds lives in a
+`OnceLock` for the life of the process, so it is never released at all.
+
 **Status.** Adopted. What it deliberately does **not** do: drop a *queued* job (nothing can name one
 — a tool call names a session, so that variant belongs with `tasks/cancel`), and reach a live-kernel
 wait whose target has not connected (`SetInterrupt` cannot, so the tool says so instead of reporting

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -11,12 +11,14 @@ why it was deferred, and where it picks up. See [`DECISIONS.md`](./DECISIONS.md)
 and the 2026-08-02 entries that items 13–14 and item 10 extend.
 
 Items are roughly ordered by how soon they're worth doing, within each cluster. **Item 10 has
-landed** (process-per-session, 2026-08-02); it is kept here rather than deleted because items 7, 8
-and 9 were all written against the single-engine design it replaced, and each now says what moved.
+landed** (process-per-session, 2026-08-02); it is kept here rather than deleted because items 8 and
+9 were both written against the single-engine design it replaced, and each now says what moved.
 **Items 16, 17 and 18 have landed** (2026-08-10) and are kept for the opposite reason: each turned
 out to need something its entry did not anticipate — item 18 needed much less of item 7 than it
-claimed to (item 7 should be read knowing which half of it is still owed), item 17 needed a walk
-deadline nothing had asked for, and item 16 needed a probe before it could measure anything at all.
+claimed to, item 17 needed a walk deadline nothing had asked for, and item 16 needed a probe before
+it could measure anything at all. **Item 7 has landed** too (2026-08-10, the `interrupt` tool), and
+is kept because item 8 rests on it: what it built is the job binding, and what it deliberately did
+not build is the queued-job half that only `tasks/cancel` can ask for.
 
 ## 1. [win-kexp] Managed breakpoint lifecycle for `run_to_address` — **done upstream**
 
@@ -78,52 +80,68 @@ than the human/LLM-readable recipe emitted today.
   debugger memory snapshot rather than building an in-house solver — kernel state modeling, loops,
   hashing, and stateful protocols make it brittle and a separate project.
 
-## 7. [win-kexp + windbg-mcp] On-demand engine interrupt
+## 7. [win-kexp + windbg-mcp] On-demand engine interrupt — **done** (2026-08-10)
 
 Expose `SetInterrupt` as a public win-kexp method (and a `Send` handle obtainable from a
-`&DebugEngine`), then plumb it through to a per-session `interrupt()`. Today the primitive exists
-but is only ever *timeout-driven*: `execute_command_bounded` (win-kexp `src/dbgeng.rs:607`) and
-`wait_for_event_bounded` (`:716`) each spawn a watchdog thread holding an `InterruptHandle` and
-Ctrl+Break the engine when a deadline passes. There is no way for a caller to ask for that now.
+`&DebugEngine`), then plumb it through to a per-session `interrupt()`. The primitive existed but was
+only ever *timeout-driven*: `execute_command_bounded` and `wait_for_event_bounded` each spawn a
+watchdog thread holding an `InterruptHandle` and Ctrl+Break the engine when a deadline passes, and
+no caller could ask for the same.
 
-`InterruptHandle` (`src/dbgeng.rs:115-119`) already carries the reasoning: `SetInterrupt` is the one
-DbgEng call documented as safe from another thread, so this needs no new threading model — the
-engine stays confined to its one thread (`src/worker.rs`) and the interrupt arrives from outside it,
-exactly as it does today.
+`InterruptHandle` already carried the reasoning: `SetInterrupt` is the one DbgEng call documented as
+safe from another thread, so this needed no new threading model — the engine stays confined to its
+one thread (`src/worker.rs`) and the interrupt arrives from outside it, exactly as it always did.
 
-**Reshaped by item 10.** The interrupt is now a *per-session* concern: it has to reach one worker's
-engine, and it cannot travel as an ordinary op, because a worker whose engine is wedged is exactly
-the one not draining its *engine* queue — it needs a request the worker's reader thread acts on
-where it reads it.
+**Reshaped by item 10, half-built by item 18.** The interrupt is a *per-session* concern: it has to
+reach one worker's engine, and it cannot travel as an ordinary op, because it would be read only
+once the operation it means to stop had ended. Item 18 built that half — `worker::run`'s reader acts
+on a request where it reads it — and settled the channel question: no side channel was needed,
+because the reader was never blocked.
 
-**Item 18 built that half.** `worker::run`'s reader loop acts on `EngineOp::EndSession` where it
-reads it, before queueing it, so the signal lands while the engine is busy. What is left for this
-item is the part that touches DbgEng — `SetInterrupt` as a public win-kexp method, bound to job
-identity so a cancel cannot Ctrl+Break an unrelated job. The channel question is settled; no side
-channel was needed, because the reader was never blocked.
-The urgency dropped with the same change: `end_session` already ends any call by terminating the
-session, so an interrupt is no longer the only way out of a runaway command, just the graceful one
-that keeps the target.
+Landed as the `interrupt` tool. What each half turned out to be:
 
-- **Why it comes first:** it is what would give item 8's `tasks/cancel` anything to do — the spec's
+- **win-kexp:** `InterruptHandle` is public, `Send + Sync`, and holds an owned `IDebugControl4`
+  rather than a borrowed pointer — a handle a host can keep would otherwise dangle past the engine
+  it came from. Both watchdogs now go through it, which is what makes the second part work: the
+  handle and the engine share a `raised` flag, so `execute_command_bounded` can tell an aborted
+  `Execute` from a failed one **without being the thread that asked**. Without that, an interrupt on
+  request came back as `CommandFailed` and threw away every line the command had produced — most of
+  what an interrupted search is worth. No note is appended for a requested interrupt, unlike the
+  watchdog's: that one explains a deadline nobody saw pass, whereas this caller is the one who
+  asked.
+- **windbg-mcp:** the reader answers `EngineOp::Interrupt` outright and never queues it. Job
+  identity is a `Running { job, interrupted }` under one lock: the reader reads the running job and
+  raises under it, the engine thread claims and releases under it, so an interrupt reaches the job
+  that was running when it arrived or nothing at all. The job it reached **spends** it — a pending
+  break is drained before the next job starts, and only that caller's reply is marked cut short.
+
+- **Why it came first:** it is what would give item 8's `tasks/cancel` anything to do — the spec's
   cancellation is cooperative, so acknowledging one conforms, but a session blocked inside DbgEng
-  cannot act on it at all *without being thrown away*. It stands alone too: it gives an operator a
-  way to abort a runaway `execute` before `ENGINE_CALL_TIMEOUT` (`src/main.rs`, 300s) elapses,
-  keeping the target that `end_session` would discard.
-- **A bare `interrupt()` would hit the wrong job.** `SetInterrupt` addresses one engine, meaning
-  whichever operation that session is *currently running* — but each session's queue is FIFO with
-  one consumer, and item 8 makes several calls in flight at once the normal case rather than the
-  exception. Cancelling a task whose job is still queued would then Ctrl+Break an unrelated
-  task's running operation, and the cancelled job would go on to execute anyway when its turn came:
-  `Sessions::call` already documents that a timeout abandons the wait and that the job itself is
-  *not* cancelled. So the interrupt has to be bound to job identity — the engine tracks which job
-  is active, a cancel for a queued job drops it from the queue, and `SetInterrupt` fires only when
-  the cancelled job is the running one. That is the substance of this item, not an add-on to it.
-- **Known limit, carried from win-kexp `src/dbgeng.rs:726`:** `SetInterrupt` cannot unblock a
-  live-kernel wait until the target is *connected*. So the `attach_kernel` KDNET park documented in
-  `CLAUDE.md` — the case that most wants cancelling — is not cancellable this way; only tearing down
-  the process ends it. That limit is what motivated item 10, which has since landed and made that
-  teardown a supported, in-band operation (`end_session`).
+  cannot act on it at all *without being thrown away*. It stands alone too, which is how it shipped:
+  an operator can abort a runaway `execute` before `ENGINE_CALL_TIMEOUT` (`src/main.rs`, 300s)
+  elapses, keeping the target that `end_session` would discard.
+- **A bare `interrupt()` would hit the wrong job**, and this is the part that needed designing
+  rather than plumbing. `SetInterrupt` addresses one engine, meaning whichever operation that
+  session is *currently running* — so raised a moment late it Ctrl+Breaks whatever started next.
+  Today that is a race against a job boundary; under item 8, with several calls in flight as the
+  normal case, it is the ordinary outcome of cancelling a task whose job is still queued. The lock
+  above closes the race and is the foundation the queued case needs: `tasks/cancel` for a job that
+  has not started should drop it from the queue rather than raise anything, and that is a *second*
+  variant of this request (one naming a job id) rather than a change to what landed. It is not
+  built, because nothing can name a job id yet — a tool call names a session.
+- **Known limit, unchanged:** `SetInterrupt` cannot unblock a live-kernel wait until the target is
+  *connected*. So the `attach_kernel` KDNET park documented in `CLAUDE.md` — the case that most
+  wants cancelling — is not cancellable this way; only tearing down the process ends it, which
+  item 10 made an in-band operation (`end_session`). The tool says so rather than reporting a
+  success that does nothing.
+- **Proof:** win-kexp's `test_command_interrupted_on_request_keeps_its_output` (live, `#[ignore]`d)
+  holds the partial-output-as-`Ok` claim the shared flag exists for; `src/worker.rs` unit-tests the
+  binding against a local `Running` (both orderings of the race, staged — which against the real
+  one would mean interrupting an engine at an exact instant); and `tests/mcp_smoke.rs`'s
+  `a_running_command_is_interrupted_on_request_and_frees_its_session` drives the whole thing through
+  the shipped binary, which is the only place both halves exist. That last one is in the ordinary
+  dump tier rather than the ignored one: the interrupt lands in milliseconds, so nothing waits out a
+  deadline — measured at 203ms against a `.for` sized to run for hours.
 
 ## 8. [windbg-mcp] Tasks extension (`io.modelcontextprotocol/tasks`, SEP-2663)
 
@@ -152,11 +170,15 @@ Suggested order, chosen so the protocol work is proved before it touches DbgEng:
    pure protocol work with no debugger risk.
 2. `open_dump` / `open_trace` / `index_trace` / `attach_kernel` — where the pain actually is, and
    where `session_status` can shrink to a thin adapter over `tasks/get`.
-3. `go` / `run_to_address` / `execute` — best held until item 7 lands. `tasks/cancel` is
-   *cooperative* by spec: acknowledging it while the work runs on to some terminal state is
-   conformant, so these are implementable without an interrupt. But for exactly these three the
-   session's engine is blocked inside DbgEng, so until item 7 the only effort the server can make
-   is ending the session outright — a heavier answer than a cancel should be.
+3. `go` / `run_to_address` / `execute` — these were held for item 7, which has landed. `tasks/cancel`
+   is *cooperative* by spec, so they were implementable without an interrupt; what they lacked was
+   any way to make an effort short of ending the session outright, since for exactly these three the
+   engine is blocked inside DbgEng. Now a cancel for the *running* job can raise the interrupt item 7
+   built, and the job returns what it reached. A cancel for a job still **queued** is the half item 7
+   did not build, and this is what would ask for it: drop it from the queue and answer its waiter,
+   rather than raise anything — a bare interrupt would Ctrl+Break the unrelated job that is actually
+   running. It needs a second request variant naming a job id, and the lock item 7 put in is what
+   makes both safe together.
 
 Fast, pure tools (`decode_ioctl`, `registers`, `read_memory`, `modules`, `threads`, `disassemble`,
 `backtrace`, `session_status`) should stay synchronous.
@@ -166,8 +188,9 @@ Fast, pure tools (`decode_ioctl`, `registers`, `read_memory`, `modules`, `thread
     `failed`; a kernel attach waits indefinitely by design. Attaches need `ttl_ms: None`, or the task
     reports a failure while the attach is still genuinely pending — the exact false report the
     conversion was meant to remove.
-  - **An `attach_kernel` task must not report `cancelled`.** Item 7's interrupt cannot unblock a
-    KDNET wait before the target connects, so a cancel cannot end that job — and the job is not
+  - **An `attach_kernel` task must not report `cancelled`.** Item 7's interrupt does not unblock a
+    KDNET wait before the target connects — `SetInterrupt` cannot reach it — so a cancel cannot end
+    that job — and the job is not
     inert while it runs: the attach self-heals and *lands* the moment the target dials in, replacing
     the current target. A task that went `cancelled` on request would therefore have the session
     swapped underneath a client that believes the operation is over. Cooperative cancellation is the
@@ -405,7 +428,10 @@ reserve the rollback lives on and overrun the bound the worker advertises to a t
 which is a worker terminated mid-transaction. `PoolWalk::within` already existed for exactly this
 ("a host that knows its own deadline should pass that instead of taking this"), so a pool step now
 passes its own step budget and a walk cut short reports its coverage as it always did. The pool
-*tools* still take the default; giving them the call's patience is [#75](https://github.com/glslang/windbg-mcp/issues/75).
+*tools* took the default until [#75](https://github.com/glslang/windbg-mcp/issues/75) gave them the
+call's patience on the same arithmetic (2026-08-10); `None` — the walker's own default — is now
+reachable from neither caller, which is right, because neither is a human at a prompt who could
+Ctrl+C a walk that ran long.
 
 ## 18. [windbg-mcp] Let a running batch finish its rollback when the client disconnects — **done**
 

--- a/README.md
+++ b/README.md
@@ -527,7 +527,10 @@ timeline). For anything else, `dx` evaluates arbitrary data-model/LINQ expressio
   (`WINDBG_MCP_CALL_TIMEOUT_SECS`, less what the query waited its turn on the session), so it can
   neither outlive the call that asked for it nor stop early while that call is still waiting; a walk
   cut short still answers, and every result says how much of the pool it reached. `interrupt` ends
-  one sooner. Two semantics worth knowing: only *allocated* chunks are indexed by tag (a freed
+  one sooner. A query that reaches the engine with no time left to walk in — a call timeout at or
+  under the 15s the reply itself reserves, or a long wait behind other work on the session — is
+  *refused* rather than run, since a truncated walk is discarded rather than cached; without
+  `refresh` it is still answered from the cached snapshot if there is one. Two semantics worth knowing: only *allocated* chunks are indexed by tag (a freed
   chunk's tag is not reliably preserved, so `pool_find_tag` never reports freed memory — ask about a
   specific address with `pool_chunk` instead), and `pool_chunk` reports three outcomes that are
   easy to conflate. A chunk in an explicitly free state (`ReusableFree` or `CachedFree`) is the

--- a/README.md
+++ b/README.md
@@ -293,6 +293,12 @@ was running when it arrived, so it can never land on the one after it; with noth
 so and does nothing. Two things it cannot reach, both properties of the debugger: an operation that
 never polls for the break, and the parked kernel attach below.
 
+A `debug_batch` is the one call that stops *itself*: it checks between steps and, when interrupted,
+runs its `always` block and reports `BATCH: INTERRUPTED` — so no step after the interrupt is applied
+and the session keeps its target, unlike `end_session`, which also stops a batch but takes the
+session with it. Repeating `interrupt` while one is already stopping is a no-op that says so, since
+the rollback runs as part of the same call and a second break could land on a restore.
+
 **Recovering a session that is stuck.** A per-call timeout abandons the *wait*, not the job, so a
 call that reports a timeout may still be running. The case that matters is `attach_kernel`: it waits
 for the target to dial in with no timeout, and DbgEng cannot interrupt a wait that has not yet

--- a/README.md
+++ b/README.md
@@ -296,8 +296,10 @@ never polls for the break, and the parked kernel attach below.
 A `debug_batch` is the one call that stops *itself*: it checks between steps and, when interrupted,
 runs its `always` block and reports `BATCH: INTERRUPTED` — so no step after the interrupt is applied
 and the session keeps its target, unlike `end_session`, which also stops a batch but takes the
-session with it. Repeating `interrupt` while one is already stopping is a no-op that says so, since
-the rollback runs as part of the same call and a second break could land on a restore.
+session with it. Its **rollback is not interruptible**: cleanup runs as part of the same call, and a
+restore cut short would come back `Ok` with partial output and be reported as a rollback that
+completed while the target was still changed — so an `interrupt` aimed at a batch that is unwinding
+says so and sends nothing, as does one repeated while a batch is still stopping.
 
 **Recovering a session that is stuck.** A per-call timeout abandons the *wait*, not the job, so a
 call that reports a timeout may still be running. The case that matters is `attach_kernel`: it waits

--- a/README.md
+++ b/README.md
@@ -38,7 +38,9 @@ process. Two things follow, and they are why it is built this way:
 - **`worker.rs`** — the child process. The `DebugEngine` is created on, and confined to, one OS
   thread inside it (DbgEng requires serialized, single-thread access, and `WaitForEvent` must run on
   the session-owning thread). A `catch_unwind` guard turns a panic in one operation into a failed
-  call rather than a dead session.
+  call rather than a dead session. The *request reader* is a second thread that only ever reads and
+  hands on, so it is never blocked by the engine — which is what makes `interrupt` and the
+  abandon-a-batch signal deliverable to a worker that is busy.
 - **`proto.rs`** — the line-delimited JSON protocol between the two. A closure cannot cross a
   process boundary, so what used to be closures marshalled onto the engine thread are now
   serializable operations — deliberately *tool*-shaped rather than DbgEng-shaped, so a tool that is
@@ -246,7 +248,7 @@ gh attestation verify <zip> --repo glslang/windbg-mcp `
 
 | Group | Tools |
 |-------|-------|
-| Session | `open_dump`, `open_trace`, `attach_kernel_local`, `attach_kernel`, `attach_process`, `launch`, `end_session`, `session_status` |
+| Session | `open_dump`, `open_trace`, `attach_kernel_local`, `attach_kernel`, `attach_process`, `launch`, `interrupt`, `end_session`, `session_status` |
 | State   | `registers`, `read_memory`, `backtrace`, `modules`, `threads`, `disassemble`, `dx` |
 | Control | `go`, `step_over`, `step_into`, `set_breakpoint`, `run_to_address` |
 | Transaction | `debug_batch` — an ordered sequence with assertions and a rollback the engine process runs on every path |
@@ -280,6 +282,16 @@ is that the call can never land on a target you did not open — it fails loudly
 `session_status` lists every session — what it is, what state it is in, how long it has been there,
 and which one is current — or reports on one you name. It never queues on any worker, so it answers
 even while a session is parked.
+
+**Stopping a call that is taking too long.** `interrupt` Ctrl+Breaks a session's engine, exactly as
+Ctrl+Break does at a WinDbg prompt, and leaves the session and its target alone. Call it while the
+slow call is still outstanding — it travels on the session's queue but is answered by the worker's
+*request reader*, so it does not queue behind the operation it is meant to stop. That operation ends
+at the debugger's next poll and returns whatever it had reached **to the call that started it**,
+marked as cut short, and the session takes the next call immediately. It is bound to the job that
+was running when it arrived, so it can never land on the one after it; with nothing running it says
+so and does nothing. Two things it cannot reach, both properties of the debugger: an operation that
+never polls for the break, and the parked kernel attach below.
 
 **Recovering a session that is stuck.** A per-call timeout abandons the *wait*, not the job, so a
 call that reports a timeout may still be running. The case that matters is `attach_kernel`: it waits
@@ -430,9 +442,9 @@ descriptors rather than debugger commands, so no `command` step can stand in for
 { "op": "pool_chunk", "address": "{{obj}}", "refresh": true }          // what the allocator says it is
 ```
 
-Inside a batch a walk is bounded by the *step's* share of the budget rather than by the walker's own
-120s default, so a `refresh` cannot spend the reserve the rollback lives on; a walk cut short still
-reports how much of the pool it covered. Assertions are `contains`, `not_contains`, and `eval` — the
+Inside a batch a walk is bounded by the *step's* share of the budget rather than by the whole call's,
+so a `refresh` cannot spend the reserve the rollback lives on; a walk cut short still reports how
+much of the pool it covered. Assertions are `contains`, `not_contains`, and `eval` — the
 last compares two MASM expressions, so registers, memory and relations between them are all one
 check. An `eval` step may `capture` its value under a name that later steps interpolate as
 `{{name}}`; a reference that names no earlier capture is refused before anything runs.
@@ -511,7 +523,11 @@ timeline). For anything else, `dx` evaluates arbitrary data-model/LINQ expressio
   one snapshot and cannot disagree with each other. They need a **broken-in x64 kernel** target.
   Walking every pool page is expensive, so the snapshot is **cached per session** and reused; pass
   `refresh: true` after letting the target run, or you are reading a photograph of a target that has
-  since moved. Two semantics worth knowing: only *allocated* chunks are indexed by tag (a freed
+  since moved. A walk that does happen is bounded by **what is left of the caller's own timeout**
+  (`WINDBG_MCP_CALL_TIMEOUT_SECS`, less what the query waited its turn on the session), so it can
+  neither outlive the call that asked for it nor stop early while that call is still waiting; a walk
+  cut short still answers, and every result says how much of the pool it reached. `interrupt` ends
+  one sooner. Two semantics worth knowing: only *allocated* chunks are indexed by tag (a freed
   chunk's tag is not reliably preserved, so `pool_find_tag` never reports freed memory — ask about a
   specific address with `pool_chunk` instead), and `pool_chunk` reports three outcomes that are
   easy to conflate. A chunk in an explicitly free state (`ReusableFree` or `CachedFree`) is the

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -162,6 +162,12 @@ processes, so they need real ones:
   break provoked, so the interrupted step comes back `Ok` with its assertions intact and the executor
   saw a step that simply ran. `src/batch.rs` pins the executor's half against a scripted debuggee,
   which answers `Ok` to the interrupted step for exactly this reason.
+- *Interrupting a batch during its **rollback** is refused.* The severe half of the same problem,
+  and it needs no earlier interrupt to set up: cleanup is reached on every path, so a *first* break
+  landing there hits a restore command — recorded as a step that worked, reported as `rollback:
+  COMPLETE`, with the target still changed. The batch's `always` block writes a marker when it
+  starts and another when it finishes, so the interrupt is staged on the first and the second is the
+  proof the rollback ran whole; the refusal has to say it is a rollback, or it reads as a bug.
 
 This tier is also the only end-to-end check of the **protocol channel** — the inherited pipe pair a
 worker speaks on ([`proto.rs`](../src/proto.rs)). Handles are passed on the worker's command line

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -119,6 +119,30 @@ processes, so they need real ones:
   from one step and interpolated into the next) and one to `FAILED at step 2 of 3`, with the same
   `always` block on both. The claim only a real engine can settle is the second one: the rollback
   ran **inside the worker process**, on the failing path, before the tool call returned.
+- *A pool walk takes this server's deadline, not the walker's default.* Asserted against the
+  worker's log (`RUST_LOG=windbg_mcp=debug`) rather than against the answer, because on a dump the
+  number has no visible consequence — the pool is local memory, so every budget from 15s to 120s
+  produces the identical result. That is exactly why it shipped wrong
+  ([#75](https://github.com/glslang/windbg-mcp/issues/75)): the query carried no deadline at all and
+  quietly took win-kexp's 120s however long its caller was willing to wait, and nothing that looked
+  at results could see it. The test shrinks the call budget to 60s and checks the worker derived
+  ~45s — a range, since the milliseconds already spent come off the patience, and one that contains
+  neither the 15s floor nor the 120s default. The query itself is allowed to fail: the sample dump
+  has no pool-layout symbols on a bare machine (that is the live tier's business), and the budget is
+  derived before the first page is read.
+- *A running command is interrupted on request.* A `.for` sized to run for hours is stopped by
+  `interrupt` while its `execute` call is still outstanding, comes back **as a result** carrying
+  what it reached, and the session serves the next call. It belongs in this tier rather than the
+  bounded one below because nothing waits out a deadline: the break lands in milliseconds
+  (measured: 203ms), and the test bounds the session's call budget to 30s so a *failure* fails fast
+  — anything at the watchdog's 15s floor means the deadline did the work and the run proves nothing
+  about the request path, which the assertions say. The claim only the shipped binary can settle is
+  that the interrupt is answered by the worker's **request reader** rather than queued for its
+  engine thread: queued, it would be read only once the command had ended, and every other
+  assertion here would still pass. The test retries the interrupt until it reports it reached
+  something, because the worker claims the job a moment after the request is written and an
+  interrupt landing in that gap correctly binds to nothing — racing it is the test's problem, not
+  the server's. Proof it was cut short is the loop counter in `$t0`, as in the bounded tier.
 - *A teardown mid-batch rolls it back first.* Two tests, one per teardown, both with a batch parked
   in twenty seconds of `.sleep` steps. `end_session` gets the version with a client still attached:
   it returns in seconds rather than waiting the batch out, and the batch's own call comes back
@@ -279,8 +303,11 @@ about. This is the other half — an attach that lands:
   expected one on a busy kernel — so the test never asserts the walk was complete, only that it said
   which it was, and it prints the walk's own diagnostic categories when it fell short, which is the
   part worth reading. **Measured against Server 26100 over KDNET: a forced walk returned in ~52s,
-  indexed 530,680 chunks (306,227 allocated), and reported INCOMPLETE.** That is still inside the
-  120s budget, so on that target the coverage gap is not the deadline — which is why scoping the
+  indexed 530,680 chunks (306,227 allocated), and reported INCOMPLETE.** That was inside the 120s
+  the walker used to default to, and is inside the caller-derived budget it takes now
+  ([#75](https://github.com/glslang/windbg-mcp/issues/75) — 285s under the default call timeout, and
+  the figure to re-read if you shrink `WINDBG_MCP_CALL_TIMEOUT_SECS`), so on that target the
+  coverage gap is not the deadline — which is why scoping the
   walk to one side of the pool was closed unbuilt (glslang/win-kexp#89): it would have bought a
   faster query at the cost of a cache that keys on scope, against better than two-fold headroom
   that already exists. That margin is worth re-reading rather than assuming: the same walk cost

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -223,8 +223,9 @@ case.
 - `a_bounded_runaway_command_aborts_and_leaves_its_session_usable` — a `.for` loop sized to run for
   hours is cut short by the watchdog, and the session executes the *next* command normally. This is
   the wedge that used to need a server restart. Proof of interruption is the loop counter left in
-  `$t0`, not the clock and not the "interrupted after" note (which is appended whenever the watchdog
-  *attempted* an interrupt, even one the engine ignored).
+  `$t0`, not the clock and not the "interrupted after" note (which the worker renders whenever the
+  watchdog *attempted* an interrupt, even one the engine ignored — win-kexp reports the reason as a
+  field, and prose for a human is this server's to add).
 - `a_bounded_command_queued_behind_another_job_still_beats_its_caller` — the same, from behind a
   `.sleep` that occupies the session for half the call budget. This is the half win-kexp cannot
   cover, because the queue belongs to this crate: budgeting from the patience as sent, instead of

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -152,6 +152,16 @@ processes, so they need real ones:
   afterwards, which is as close as a dump gets to the byte a live target would have restored. Both
   wait for a marker the batch's *first* step writes before tearing anything down: timed with a sleep
   instead, a slow machine would test the refuse-to-start path and pass just as green.
+- *Interrupting a batch stops it and rolls it back, keeping the session.* The same twenty-second
+  batch, stopped with `interrupt` instead: `BATCH: INTERRUPTED`, rollback complete, and the session
+  still usable afterwards — which is the whole difference from the `end_session` version above.
+  The assertion that carries it is a **second marker file** written by a step *after* the sleeps: a
+  batch that ignored the interrupt reaches it, and the file says so independently of what the report
+  claims about itself. That is the bug the interrupt itself created, and it needs a real engine to
+  reproduce: an on-request interrupt returns the output the command reached rather than the error the
+  break provoked, so the interrupted step comes back `Ok` with its assertions intact and the executor
+  saw a step that simply ran. `src/batch.rs` pins the executor's half against a scripted debuggee,
+  which answers `Ok` to the interrupted step for exactly this reason.
 
 This tier is also the only end-to-end check of the **protocol channel** — the inherited pipe pair a
 worker speaks on ([`proto.rs`](../src/proto.rs)). Handles are passed on the worker's command line

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -1052,6 +1052,13 @@ pub fn run(d: &mut impl Debuggee, op: &BatchOp, budget: Duration) -> BatchReport
         let done = run_step(d, step, position, steps_deadline, &mut bound);
         if !done.ok() {
             outcome = match &done.result {
+                // A step that failed while a break was landing on it failed *because* of the
+                // break, and saying otherwise sends the caller to debug their own step: an
+                // interrupt truncates the output, so a `contains` assertion stops holding and an
+                // `eval` capture stops parsing. Attributable rather than guessed — the check
+                // above runs before every step, so a break outstanding *here* can only have been
+                // raised during this one.
+                _ if d.interrupted() => BatchOutcome::Interrupted { at: position },
                 // An assertion that did not hold is a verdict about the target, and stays one
                 // however long the step took to reach it.
                 StepResult::Unmet(_) => BatchOutcome::Failed { at: position },
@@ -2005,6 +2012,50 @@ mod tests {
         let text = render(&report);
         assert!(text.contains("BATCH: INTERRUPTED at step 2 of 3"), "{text}");
         assert!(text.contains("rollback: COMPLETE"), "{text}");
+    }
+
+    /// A step whose assertion fails *because* the break truncated its output reports `INTERRUPTED`,
+    /// not `FAILED`.
+    ///
+    /// The most likely shape of an interrupted step, and the one that sends a caller furthest
+    /// wrong: an interrupt cuts the output short, so a `contains` stops holding — and the report
+    /// then tells them to go and debug a step that was fine. Attributable rather than guessed,
+    /// because the between-steps check runs before every step: a break outstanding when *this* one
+    /// fails can only have been raised during it.
+    #[test]
+    fn a_step_that_failed_because_it_was_cut_short_is_not_a_failure() {
+        let mut d = stopped()
+            .on("first", Ok("truncated"))
+            .on("eb restore", Ok(""))
+            .interrupted_after(1);
+        let batch = op(
+            vec![
+                BatchStep {
+                    expect: vec![Check::Contains {
+                        text: "the whole output".to_string(),
+                    }],
+                    ..cmd("first step")
+                },
+                cmd("second step"),
+            ],
+            vec![cmd("eb restore 41")],
+        );
+
+        let report = run(&mut d, &batch, BUDGET);
+
+        assert_eq!(
+            report.outcome,
+            BatchOutcome::Interrupted { at: 1 },
+            "the assertion did not hold because the break truncated the output, so the batch was \
+             interrupted rather than wrong"
+        );
+        assert!(!d.ran("second"), "and it still stops there");
+        assert!(d.ran("eb restore"));
+        // The step's own entry keeps the assertion detail — reclassifying the *batch* outcome does
+        // not hide which assertion did not hold.
+        assert!(matches!(report.steps[0].result, StepResult::Unmet(_)));
+        let text = render(&report);
+        assert!(text.contains("BATCH: INTERRUPTED at step 1 of 2"), "{text}");
     }
 
     /// A break landing during the **last** step must not leave the batch reporting `COMMITTED`.

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -755,15 +755,11 @@ pub struct Ran {
     pub interrupted: bool,
 }
 
-impl Ran {
-    /// A call that finished.
-    pub fn whole(output: String) -> Self {
-        Self {
-            output,
-            interrupted: false,
-        }
-    }
-}
+// Deliberately no `Ran::whole` constructor. There was one, used at the dispatch to wrap the actions
+// whose calls returned a bare `String` — and it made "this finished" the silent default for three
+// of them, including a pool walk, which is genuinely interruptible (win-kexp's walker polls the same
+// flag). Every implementor now has to say what it saw, because there is no way to say it without
+// deciding.
 
 /// What [`run`] needs from a debugger. Implemented over a real engine by the worker, and over a
 /// script by the tests — see the module docs for why that seam is where it is.
@@ -773,9 +769,9 @@ pub trait Debuggee {
     /// Run a command that moves the target, waiting up to `timeout_ms` for the next stop.
     fn resume(&mut self, command: &str, timeout_ms: u32) -> Result<Ran, String>;
     /// Run to `address` and report a verdict.
-    fn run_to(&mut self, address: &str, timeout_ms: u32) -> Result<String, String>;
+    fn run_to(&mut self, address: &str, timeout_ms: u32) -> Result<Ran, String>;
     /// Hex-dump `size` bytes at `address`.
-    fn read_memory(&mut self, address: &str, size: u32) -> Result<String, String>;
+    fn read_memory(&mut self, address: &str, size: u32) -> Result<Ran, String>;
     /// Answer a pool question — the one capability here that is not a debugger command at all,
     /// but a walk over the allocator's own descriptors.
     ///
@@ -785,7 +781,7 @@ pub trait Debuggee {
     /// it the bound the worker advertises to a teardown, which is what stops a worker being
     /// terminated mid-transaction. A walk stopped by the budget reports how much of the pool it
     /// reached, so a short step degrades to a partial answer that says so rather than to a failure.
-    fn pool(&mut self, query: &PoolOp, budget_ms: u32) -> Result<String, String>;
+    fn pool(&mut self, query: &PoolOp, budget_ms: u32) -> Result<Ran, String>;
     /// How long this batch has been running.
     fn elapsed(&self) -> Duration;
     /// Whether something outside the batch has asked it to stop early and roll back — a client
@@ -1206,28 +1202,26 @@ fn run_step(
         StepAction::RunTo {
             address,
             timeout_ms,
-        } => d.run_to(address, wait_ms(*timeout_ms)).map(Ran::whole),
+        } => d.run_to(address, wait_ms(*timeout_ms)),
         StepAction::Eval { expr } => d.command(&format!("? {expr}"), budget_ms),
-        StepAction::ReadMemory { address, size } => d.read_memory(address, *size).map(Ran::whole),
+        StepAction::ReadMemory { address, size } => d.read_memory(address, *size),
         // Through the same constructors the pool *tools* use, so a step and a tool cannot drift
         // apart on what a default or a cap means — see [`PoolOp`].
-        StepAction::PoolChunk { address, refresh } => d
-            .pool(&PoolOp::chunk(address.clone(), *refresh), budget_ms)
-            .map(Ran::whole),
+        StepAction::PoolChunk { address, refresh } => {
+            d.pool(&PoolOp::chunk(address.clone(), *refresh), budget_ms)
+        }
         StepAction::PoolFindTag {
             tag,
             paged,
             refresh,
             limit,
-        } => d
-            .pool(
-                &PoolOp::find_tag(tag.clone(), *paged, *refresh, *limit),
-                budget_ms,
-            )
-            .map(Ran::whole),
-        StepAction::PoolCensus { refresh, limit } => d
-            .pool(&PoolOp::census(*refresh, *limit), budget_ms)
-            .map(Ran::whole),
+        } => d.pool(
+            &PoolOp::find_tag(tag.clone(), *paged, *refresh, *limit),
+            budget_ms,
+        ),
+        StepAction::PoolCensus { refresh, limit } => {
+            d.pool(&PoolOp::census(*refresh, *limit), budget_ms)
+        }
     });
 
     let (output, mut cut_short) = match ran {
@@ -1799,17 +1793,17 @@ mod tests {
         fn resume(&mut self, command: &str, _timeout_ms: u32) -> Result<Ran, String> {
             self.answer_run(command)
         }
-        fn run_to(&mut self, address: &str, _timeout_ms: u32) -> Result<String, String> {
-            self.answer(&format!("run to {address}"))
+        fn run_to(&mut self, address: &str, _timeout_ms: u32) -> Result<Ran, String> {
+            self.answer_run(&format!("run to {address}"))
         }
-        fn read_memory(&mut self, address: &str, size: u32) -> Result<String, String> {
-            self.answer(&format!("read {size} at {address}"))
+        fn read_memory(&mut self, address: &str, size: u32) -> Result<Ran, String> {
+            self.answer_run(&format!("read {size} at {address}"))
         }
-        fn pool(&mut self, query: &PoolOp, budget_ms: u32) -> Result<String, String> {
+        fn pool(&mut self, query: &PoolOp, budget_ms: u32) -> Result<Ran, String> {
             // The budget is part of the call text, not swallowed: a pool step's whole hazard is
             // taking longer than the batch can afford, so a test that could not see what the walk
             // was armed with could not tell the fix from the bug.
-            self.answer(&format!("pool {query:?} within {budget_ms}ms"))
+            self.answer_run(&format!("pool {query:?} within {budget_ms}ms"))
         }
         fn elapsed(&self) -> Duration {
             self.clock
@@ -2085,6 +2079,64 @@ mod tests {
         let text = render(&report);
         assert!(text.contains("BATCH: INTERRUPTED at step 1 of 3"), "{text}");
         assert!(text.contains("rollback: COMPLETE"), "{text}");
+    }
+
+    /// Every kind of step reports a break that reached it — not only the command-shaped ones.
+    ///
+    /// `run_to`, `read_memory` and the pool steps do not go through `execute_command_bounded`, so
+    /// the engine has no interruption to report for them and the worker's own record is the
+    /// authority. They were wrapped as "finished" at the dispatch, which made a `run_to` cut short
+    /// look like a target that had merely stopped somewhere else — and a pool walk is *genuinely*
+    /// interruptible, since win-kexp's walker polls the same flag.
+    #[test]
+    fn a_break_is_reported_by_every_shape_of_step() {
+        for (action, matching) in [
+            (
+                StepAction::RunTo {
+                    address: "nt!NtCreateFile".to_string(),
+                    timeout_ms: None,
+                },
+                "run to",
+            ),
+            (
+                StepAction::ReadMemory {
+                    address: "0x1000".to_string(),
+                    size: 16,
+                },
+                "read 16",
+            ),
+            (
+                StepAction::PoolCensus {
+                    refresh: None,
+                    limit: None,
+                },
+                "pool",
+            ),
+        ] {
+            let mut d = stopped()
+                .on(matching, Ok("whatever it had reached"))
+                .on("second", Ok(""))
+                .on("eb restore", Ok(""))
+                .interrupted_after(1);
+            let batch = op(
+                vec![step(action), cmd("second step")],
+                vec![cmd("eb restore 41")],
+            );
+
+            let report = run(&mut d, &batch, BUDGET);
+
+            assert_eq!(
+                report.outcome,
+                BatchOutcome::Interrupted { at: 1 },
+                "a `{matching}` step cut short reported {:?}",
+                report.outcome
+            );
+            assert!(!d.ran("second"), "`{matching}`: a later mutation still ran");
+            assert!(
+                d.ran("eb restore"),
+                "`{matching}`: the rollback did not run"
+            );
+        }
     }
 
     /// A break landing while an **assertion** is being evaluated belongs to the step too.

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -740,11 +740,40 @@ fn action_mutation(action: &StepAction) -> Option<String> {
 
 /// What [`run`] needs from a debugger. Implemented over a real engine by the worker, and over a
 /// script by the tests — see the module docs for why that seam is where it is.
+/// What a step's engine call produced: its output, and whether it actually finished.
+///
+/// Both, because either alone is a lie in the case that matters. Output alone cannot say a command
+/// was cut short, and an interrupted command's output looks exactly like a complete one — a search
+/// prints the hits it reached and nothing to say there were more. An error alone throws that output
+/// away, which is the whole reason to interrupt a call rather than end its session.
+#[derive(Debug, Clone)]
+pub struct Ran {
+    pub output: String,
+    /// The operation was stopped by a break somebody asked for, before it finished.
+    ///
+    /// A *deadline*-driven abort is deliberately not this: that is the step's own `timeout_ms`
+    /// doing its job, the output says so, and the step's assertions are the right place to judge
+    /// it. This is the one a caller outside the batch caused.
+    pub interrupted: bool,
+}
+
+impl Ran {
+    /// A call that finished.
+    pub fn whole(output: String) -> Self {
+        Self {
+            output,
+            interrupted: false,
+        }
+    }
+}
+
+/// What [`run`] needs from a debugger. Implemented over a real engine by the worker, and over a
+/// script by the tests — see the module docs for why that seam is where it is.
 pub trait Debuggee {
     /// Run a command to completion, self-aborting after `budget_ms`.
-    fn command(&mut self, command: &str, budget_ms: u32) -> Result<String, String>;
+    fn command(&mut self, command: &str, budget_ms: u32) -> Result<Ran, String>;
     /// Run a command that moves the target, waiting up to `timeout_ms` for the next stop.
-    fn resume(&mut self, command: &str, timeout_ms: u32) -> Result<String, String>;
+    fn resume(&mut self, command: &str, timeout_ms: u32) -> Result<Ran, String>;
     /// Run to `address` and report a verdict.
     fn run_to(&mut self, address: &str, timeout_ms: u32) -> Result<String, String>;
     /// Hex-dump `size` bytes at `address`.
@@ -772,21 +801,21 @@ pub trait Debuggee {
     /// has to be shortened to fit a teardown.
     fn abandoned(&self) -> bool;
     /// Whether someone has asked this batch's *call* to stop — the `interrupt` tool, aimed at the
-    /// job this batch is running as. Read between steps, with the same limit as
-    /// [`Self::abandoned`]: it cannot reach a call already inside DbgEng.
+    /// job this batch is running as.
     ///
-    /// Separate from `abandoned` because the two say opposite things about the session: a teardown
-    /// means it is going away, this means it is staying.
+    /// Separate from [`Self::abandoned`] because the two say opposite things about the session: a
+    /// teardown means it is going away, this means it is staying.
     ///
-    /// **The executor has to be told, because an interrupted step succeeds.** The break makes the
-    /// debugger return early with whatever it had produced — preserving that is the point — so a
-    /// step whose assertions still hold is indistinguishable from one that ran. See `DECISIONS.md`.
+    /// Only for a break that landed while **no step was running**. One that lands during a step is
+    /// carried back by that step, in [`Ran::interrupted`], which is where it belongs: the step is
+    /// what the break actually reached, and a fact travelling with the value it is about cannot be
+    /// forgotten at one of the places that reads it.
     fn interrupted(&self) -> bool;
     /// Announces that the main steps are over and the `always` block is about to run.
     ///
     /// A safety boundary, not bookkeeping: cleanup must not be interruptible, because a restore cut
-    /// short returns `Ok` like any other interrupted command and would be reported as a rollback
-    /// that completed. Implementations refuse interrupts from here on.
+    /// short comes back as a step that ran and would be reported as a rollback that completed.
+    /// Implementations refuse interrupts from here on.
     fn rolling_back(&mut self);
 }
 
@@ -795,7 +824,7 @@ pub trait Debuggee {
 /// Needed because the only other guard is `worker::engine_thread`'s, which wraps a whole op — an
 /// unwind from a step would pass straight through the rollback. Not hypothetical: several win-kexp
 /// methods use `.expect`, and a step calls into them.
-fn guarded(call: impl FnOnce() -> Result<String, String>) -> Result<String, String> {
+fn guarded<T>(call: impl FnOnce() -> Result<T, String>) -> Result<T, String> {
     catch_unwind(AssertUnwindSafe(call)).unwrap_or_else(|payload| {
         // The message, when the payload carries one. A bare "panicked" would tell a caller that
         // their transaction stopped without telling them what stopped it, and this is a report
@@ -856,6 +885,14 @@ pub struct StepOutcome {
     pub changes: Option<String>,
     pub result: StepResult,
     pub output: String,
+    /// A break somebody asked for landed while this step was running, so its output is what the
+    /// step had reached rather than what it would have produced.
+    ///
+    /// Travels with the step rather than being asked for separately, which is the point: this is
+    /// the fact that made an interrupted step indistinguishable from a completed one, and carrying
+    /// it on the value means every reader of the step has it — the outcome classification, the
+    /// renderer, and whatever comes next — instead of each having to remember to ask.
+    pub cut_short: bool,
 }
 
 impl StepOutcome {
@@ -867,6 +904,7 @@ impl StepOutcome {
             changes: None,
             result: StepResult::Skipped(why.into()),
             output: String::new(),
+            cut_short: false,
         }
     }
 
@@ -1050,15 +1088,23 @@ pub fn run(d: &mut impl Debuggee, op: &BatchOp, budget: Duration) -> BatchReport
             continue;
         }
         let done = run_step(d, step, position, steps_deadline, &mut bound);
-        if !done.ok() {
+        // The step says whether a break reached it, so this needs no separate question and covers
+        // every shape at once: a step cut short that still succeeded (including the *last* one,
+        // which no between-steps check can ever see), and one whose assertions stopped holding
+        // *because* the output was truncated — which would otherwise read as `FAILED` and send the
+        // caller to debug a step that was fine.
+        if done.cut_short {
+            // A teardown outranks a break that reached the same step: the session is going away,
+            // so "resubmit on a fresh session" is the advice, and `Interrupted` would send the
+            // caller back to one that will not be there. Only asked here, where both can be true
+            // of the same step — an ordinary teardown is still caught before the *next* step.
+            outcome = if d.abandoned() {
+                BatchOutcome::Abandoned { at: position }
+            } else {
+                BatchOutcome::Interrupted { at: position }
+            };
+        } else if !done.ok() {
             outcome = match &done.result {
-                // A step that failed while a break was landing on it failed *because* of the
-                // break, and saying otherwise sends the caller to debug their own step: an
-                // interrupt truncates the output, so a `contains` assertion stops holding and an
-                // `eval` capture stops parsing. Attributable rather than guessed — the check
-                // above runs before every step, so a break outstanding *here* can only have been
-                // raised during this one.
-                _ if d.interrupted() => BatchOutcome::Interrupted { at: position },
                 // An assertion that did not hold is a verdict about the target, and stays one
                 // however long the step took to reach it.
                 StepResult::Unmet(_) => BatchOutcome::Failed { at: position },
@@ -1069,22 +1115,6 @@ pub fn run(d: &mut impl Debuggee, op: &BatchOp, budget: Duration) -> BatchReport
             };
         }
         steps.push(done);
-    }
-
-    // The between-steps check above cannot see a break that lands during the **last** step: there is
-    // no next step to stop before. Left there, every step has run and every assertion has held, so
-    // the batch reports `COMMITTED` — of a transaction whose final step was cut short, with only the
-    // generic cut-short note beneath to contradict it. Contradicting itself is worse than either
-    // reading alone, so the outcome is corrected here.
-    //
-    // Only from `Committed`. A step that failed or ran out of time has news the caller must act on
-    // first, and an interrupt does not change what it says.
-    if outcome == BatchOutcome::Committed && d.interrupted() {
-        // One past the end, which is what `at` means everywhere it appears — the first step not
-        // attempted — and here says there is no such step. `render` reads it back and says so.
-        outcome = BatchOutcome::Interrupted {
-            at: op.steps.len() + 1,
-        };
     }
 
     // The rollback block, on every path. Its own deadline is the *whole* budget, which is what the
@@ -1178,30 +1208,32 @@ fn run_step(
         StepAction::RunTo {
             address,
             timeout_ms,
-        } => d.run_to(address, wait_ms(*timeout_ms)),
+        } => d.run_to(address, wait_ms(*timeout_ms)).map(Ran::whole),
         StepAction::Eval { expr } => d.command(&format!("? {expr}"), budget_ms),
-        StepAction::ReadMemory { address, size } => d.read_memory(address, *size),
+        StepAction::ReadMemory { address, size } => d.read_memory(address, *size).map(Ran::whole),
         // Through the same constructors the pool *tools* use, so a step and a tool cannot drift
         // apart on what a default or a cap means — see [`PoolOp`].
-        StepAction::PoolChunk { address, refresh } => {
-            d.pool(&PoolOp::chunk(address.clone(), *refresh), budget_ms)
-        }
+        StepAction::PoolChunk { address, refresh } => d
+            .pool(&PoolOp::chunk(address.clone(), *refresh), budget_ms)
+            .map(Ran::whole),
         StepAction::PoolFindTag {
             tag,
             paged,
             refresh,
             limit,
-        } => d.pool(
-            &PoolOp::find_tag(tag.clone(), *paged, *refresh, *limit),
-            budget_ms,
-        ),
-        StepAction::PoolCensus { refresh, limit } => {
-            d.pool(&PoolOp::census(*refresh, *limit), budget_ms)
-        }
+        } => d
+            .pool(
+                &PoolOp::find_tag(tag.clone(), *paged, *refresh, *limit),
+                budget_ms,
+            )
+            .map(Ran::whole),
+        StepAction::PoolCensus { refresh, limit } => d
+            .pool(&PoolOp::census(*refresh, *limit), budget_ms)
+            .map(Ran::whole),
     });
 
-    let output = match ran {
-        Ok(output) => output,
+    let (output, cut_short) = match ran {
+        Ok(ran) => (ran.output, ran.interrupted),
         Err(why) => {
             return StepOutcome {
                 position,
@@ -1210,6 +1242,7 @@ fn run_step(
                 changes,
                 result: StepResult::Failed(why),
                 output: String::new(),
+                cut_short: false,
             };
         }
     };
@@ -1280,6 +1313,7 @@ fn run_step(
         changes,
         result,
         output: clip(&output, cap),
+        cut_short,
     }
 }
 
@@ -1320,8 +1354,11 @@ fn eval_value(d: &mut impl Debuggee, expr: &str, deadline: Duration) -> Result<u
     let budget_ms = step_budget_ms(d.elapsed(), deadline).max(MIN_STEP_BUDGET_MS);
     // Parenthesized, so a relational expression (`@rcx > 0x1000`) is evaluated as one value
     // rather than losing its precedence against whatever `?` does with the rest of the line.
-    let text = guarded(|| d.command(&format!("? ({expr})"), budget_ms))
-        .map_err(|why| CheckFailed::Unmet(format!("`? ({expr})` failed: {why}")))?;
+    let text = guarded(|| {
+        d.command(&format!("? ({expr})"), budget_ms)
+            .map(|ran| ran.output)
+    })
+    .map_err(|why| CheckFailed::Unmet(format!("`? ({expr})` failed: {why}")))?;
     parse_eval(&text).ok_or_else(|| {
         CheckFailed::Unmet(format!(
             "`? ({expr})` printed no value; the debugger answered: {}",
@@ -1418,7 +1455,7 @@ fn probe_state(
     });
 
     let budget_ms = step_budget_ms(d.elapsed(), budget).max(MIN_STEP_BUDGET_MS);
-    match guarded(|| d.command("? @$ip", budget_ms)) {
+    match guarded(|| d.command("? @$ip", budget_ms).map(|ran| ran.output)) {
         Ok(text) => match parse_eval(&text) {
             Some(ip) => SessionAfter::Stopped { ip: fmt_addr(ip) },
             None => SessionAfter::Uncertain {
@@ -1517,21 +1554,16 @@ pub fn render(report: &BatchReport) -> String {
              its rollback. Nothing was wrong with the steps or the budget; resubmit the whole \
              batch on a fresh session.\n"
         ),
-        // `at` past the end means no step was skipped: the break landed during the last one, so
-        // every step ran but the last one's result is whatever it had reached. Reported as its own
-        // sentence, because "stopped at step N" would claim a step did not run when they all did —
-        // and `COMMITTED`, which this replaces, claimed the opposite and worse.
-        BatchOutcome::Interrupted { at } if *at > total => format!(
-            "BATCH: INTERRUPTED during step {total} of {total} — every step ran, but `interrupt` \
-             was called on this session while the last one was still going, so what it reported is \
-             what it had reached rather than a completed step. The rollback ran. The session is \
-             still open and still holds its target.\n"
-        ),
+        // One form, because `at` now has one meaning: the step the break reached — which is the
+        // step it landed *during*, or the one it stopped from starting. The step list says which,
+        // and says it more precisely than a second sentence here could: that step is either a step
+        // with a result and output, or a skipped one.
         BatchOutcome::Interrupted { at } => format!(
             "BATCH: INTERRUPTED at step {at} of {total} — `interrupt` was called on this session, \
-             so the batch stopped there and ran its rollback. Nothing was wrong with the steps or \
-             the budget, and the session is still open and still holds its target; resubmit the \
-             whole batch on it once whatever prompted the interrupt is dealt with.\n"
+             so the batch stopped there and ran its rollback. The step list says whether step {at} \
+             was cut short mid-flight or never started. Nothing was wrong with the steps or the \
+             budget, and the session is still open and still holds its target; resubmit the whole \
+             batch on it once whatever prompted the interrupt is dealt with.\n"
         ),
     };
 
@@ -1630,6 +1662,10 @@ mod tests {
         /// The same, for an interrupt aimed at this batch's own call; see
         /// [`Script::interrupted_after`].
         interrupt_after: Option<usize>,
+        /// How many calls before an answered call reports *itself* cut short. Separate from
+        /// `interrupt_after` because the two are separately reachable on a real engine: a break
+        /// landing during a call comes back on the call, and one landing between calls does not.
+        cut_short_after: Option<usize>,
         /// Whether the executor announced its rollback — the notification a host turns into "no
         /// break may reach this job any more".
         sealed: bool,
@@ -1679,6 +1715,15 @@ mod tests {
         /// be testing the failure path that already worked.
         fn interrupted_after(mut self, calls: usize) -> Self {
             self.interrupt_after = Some(calls);
+            self.cut_short_after = Some(calls);
+            self
+        }
+
+        /// A break that lands in the gap *between* calls: the host knows, but no call carries it.
+        /// The narrow case `Debuggee::interrupted` still exists for, now that a break during a call
+        /// travels back on the call.
+        fn interrupted_between_calls(mut self, calls: usize) -> Self {
+            self.interrupt_after = Some(calls);
             self
         }
 
@@ -1717,17 +1762,30 @@ mod tests {
             }
         }
 
+        /// [`Self::answer`], as the call a *step* makes — carrying whether the break reached this
+        /// call, which is how a real engine reports it.
+        fn answer_run(&mut self, call: &str) -> Result<Ran, String> {
+            let output = self.answer(call)?;
+            let interrupted = self
+                .cut_short_after
+                .is_some_and(|after| self.calls.len() >= after);
+            Ok(Ran {
+                output,
+                interrupted,
+            })
+        }
+
         fn ran(&self, matching: &str) -> bool {
             self.calls.iter().any(|c| c.contains(matching))
         }
     }
 
     impl Debuggee for Script {
-        fn command(&mut self, command: &str, _budget_ms: u32) -> Result<String, String> {
-            self.answer(command)
+        fn command(&mut self, command: &str, _budget_ms: u32) -> Result<Ran, String> {
+            self.answer_run(command)
         }
-        fn resume(&mut self, command: &str, _timeout_ms: u32) -> Result<String, String> {
-            self.answer(command)
+        fn resume(&mut self, command: &str, _timeout_ms: u32) -> Result<Ran, String> {
+            self.answer_run(command)
         }
         fn run_to(&mut self, address: &str, _timeout_ms: u32) -> Result<String, String> {
             self.answer(&format!("run to {address}"))
@@ -1986,7 +2044,10 @@ mod tests {
 
         let report = run(&mut d, &batch, BUDGET);
 
-        assert_eq!(report.outcome, BatchOutcome::Interrupted { at: 2 });
+        // Step 1, not 2: the break reached that step, and the step is what reports it. Before the
+        // fact travelled with the value it could only be inferred *between* steps, so it was
+        // attributed to the step that never started.
+        assert_eq!(report.outcome, BatchOutcome::Interrupted { at: 1 });
         assert!(
             !d.ran("second"),
             "a mutation after the interrupt must not run — this is the whole finding"
@@ -2010,8 +2071,39 @@ mod tests {
             assert!(!why.contains("torn down"), "{why}");
         }
         let text = render(&report);
-        assert!(text.contains("BATCH: INTERRUPTED at step 2 of 3"), "{text}");
+        assert!(text.contains("BATCH: INTERRUPTED at step 1 of 3"), "{text}");
         assert!(text.contains("rollback: COMPLETE"), "{text}");
+    }
+
+    /// A break landing in the gap *between* steps still stops the batch.
+    ///
+    /// The narrow case [`Debuggee::interrupted`] still exists for, now that a break landing during
+    /// a step travels back on the step. It is reachable on a real engine: the break is raised after
+    /// a command has returned and accounted for its own interrupt state, but before the next step
+    /// starts — so no step carries it, and only the host's own record has it.
+    #[test]
+    fn a_break_between_steps_stops_the_batch_too() {
+        let mut d = stopped()
+            .on("first", Ok(""))
+            .on("second", Ok(""))
+            .on("eb restore", Ok(""))
+            .interrupted_between_calls(1);
+        let batch = op(
+            vec![cmd("first step"), cmd("second step")],
+            vec![cmd("eb restore 41")],
+        );
+
+        let report = run(&mut d, &batch, BUDGET);
+
+        // The step that never started, since no step was running when the break landed.
+        assert_eq!(report.outcome, BatchOutcome::Interrupted { at: 2 });
+        assert!(
+            report.steps[0].ok(),
+            "the first step ran and was not cut short"
+        );
+        assert!(!d.ran("second"));
+        assert!(d.ran("eb restore"));
+        assert!(report.rollback_complete());
     }
 
     /// A step whose assertion fails *because* the break truncated its output reports `INTERRUPTED`,
@@ -2078,20 +2170,16 @@ mod tests {
 
         assert_eq!(
             report.outcome,
-            BatchOutcome::Interrupted { at: 2 },
-            "one past the end: every step ran, so none was skipped"
+            BatchOutcome::Interrupted { at: 1 },
+            "the break reached step 1, and step 1 is what says so — no between-steps check could              have seen this one, because there is no step after it"
         );
         assert!(d.ran("eb restore"), "the rollback runs on this path too");
         assert!(report.rollback_complete());
         let text = render(&report);
-        assert!(
-            text.contains("BATCH: INTERRUPTED during step 1 of 1"),
-            "{text}"
-        );
-        assert!(
-            !text.contains("stopped there"),
-            "no step was skipped, so nothing should claim one was: {text}"
-        );
+        assert!(text.contains("BATCH: INTERRUPTED at step 1 of 1"), "{text}");
+        // The step is not skipped — it ran and was cut short — and the report says to read the
+        // step list for which of the two it was.
+        assert!(!matches!(report.steps[0].result, StepResult::Skipped(_)));
     }
 
     /// The rollback is announced before it runs, so a host can close the job to further breaks.
@@ -2131,7 +2219,7 @@ mod tests {
 
         let report = run(&mut d, &batch, BUDGET);
 
-        assert_eq!(report.outcome, BatchOutcome::Abandoned { at: 2 });
+        assert_eq!(report.outcome, BatchOutcome::Abandoned { at: 1 });
         assert!(report.rollback_complete());
     }
 

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -771,6 +771,22 @@ pub trait Debuggee {
     /// `always` block after it — the batch's whole remaining budget, which is why nothing here
     /// has to be shortened to fit a teardown.
     fn abandoned(&self) -> bool;
+    /// Whether someone has asked this batch's *call* to stop — the `interrupt` tool, aimed at the
+    /// job this batch is running as.
+    ///
+    /// Separate from [`Self::abandoned`] because the two say opposite things about the session: a
+    /// teardown means it is going away, this means it is staying and the caller simply wants the
+    /// transaction to end. Folding them together would tell a caller to resubmit on a fresh session
+    /// when the one they have is fine.
+    ///
+    /// **Why the executor has to be told at all**, when an interrupt already stops the step: it
+    /// stops the step by making the debugger return early, and — since the whole point of an
+    /// on-request interrupt is that partial output is preserved rather than thrown away — that
+    /// return is a *success*. A step whose assertions still hold therefore reads as a step that
+    /// ran, and the batch would carry on applying later mutations for a caller who has asked it to
+    /// stop. Read between steps, with the same limit as `abandoned`: a call already inside DbgEng
+    /// runs to its own end.
+    fn interrupted(&self) -> bool;
 }
 
 /// Runs one engine call, turning a panic into a step failure so [`run`] still reaches `always`.
@@ -876,6 +892,14 @@ pub enum BatchOutcome {
     /// batch has no quarrel with. Resubmitting from the top is the right next move, which is not
     /// what a caller should conclude from either of the other two.
     Abandoned { at: usize },
+    /// Someone called `interrupt` on this batch's session, so it stopped and went to its rollback.
+    /// `at` is the 1-based position of the first step not attempted.
+    ///
+    /// Distinct from [`Self::Abandoned`] for the same reason that one is distinct from a timeout:
+    /// the next move differs. Nothing is wrong with the steps, the budget, or the *session* — which
+    /// is still open and still holds its target — so this batch can be resubmitted as it stands, on
+    /// the same session, once whatever prompted the interrupt has been dealt with.
+    Interrupted { at: usize },
 }
 
 /// What the session holds once the batch is done — the question a caller cannot answer from the
@@ -974,6 +998,17 @@ pub fn run(d: &mut impl Debuggee, op: &BatchOp, budget: Duration) -> BatchReport
                 ));
                 continue;
             }
+            BatchOutcome::Interrupted { at } => {
+                steps.push(StepOutcome::skipped(
+                    position,
+                    step,
+                    format!(
+                        "the batch was interrupted while it was running, so it stopped at step \
+                         {at} and went to its rollback"
+                    ),
+                ));
+                continue;
+            }
         }
         // Before the deadline check, because the two are not the same news and this one is the
         // more urgent: something is tearing this session down and the rollback is what is left
@@ -984,6 +1019,23 @@ pub fn run(d: &mut impl Debuggee, op: &BatchOp, budget: Duration) -> BatchReport
                 position,
                 step,
                 "the session was torn down before this step started",
+            ));
+            continue;
+        }
+        // After the teardown check and before the deadline, which is where it belongs on both
+        // sides: a session going away outranks a caller who merely wants this call to stop, and a
+        // caller who has asked it to stop outranks a clock that has not run out yet.
+        //
+        // Checked here rather than inferred from the step's result, because an interrupted step
+        // *succeeds*: preserving the output reached up to the break is the whole point of an
+        // on-request interrupt, so the debugger returns `Ok` and the batch would otherwise run on
+        // through every later mutation. See [`Debuggee::interrupted`].
+        if d.interrupted() {
+            outcome = BatchOutcome::Interrupted { at: position };
+            steps.push(StepOutcome::skipped(
+                position,
+                step,
+                "the batch was interrupted before this step started",
             ));
             continue;
         }
@@ -1433,6 +1485,12 @@ pub fn render(report: &BatchReport) -> String {
              its rollback. Nothing was wrong with the steps or the budget; resubmit the whole \
              batch on a fresh session.\n"
         ),
+        BatchOutcome::Interrupted { at } => format!(
+            "BATCH: INTERRUPTED at step {at} of {total} — `interrupt` was called on this session, \
+             so the batch stopped there and ran its rollback. Nothing was wrong with the steps or \
+             the budget, and the session is still open and still holds its target; resubmit the \
+             whole batch on it once whatever prompted the interrupt is dealt with.\n"
+        ),
     };
 
     let mutations = report.mutations();
@@ -1527,6 +1585,9 @@ mod tests {
         /// How many calls this debuggee answers before it starts reporting itself abandoned; see
         /// [`Script::abandoned_after`].
         abandon_after: Option<usize>,
+        /// The same, for an interrupt aimed at this batch's own call; see
+        /// [`Script::interrupted_after`].
+        interrupt_after: Option<usize>,
     }
 
     /// The message a scripted panic carries, so the report can be asserted to have kept it.
@@ -1563,6 +1624,16 @@ mod tests {
         /// disconnecting a client from a real worker.
         fn abandoned_after(mut self, calls: usize) -> Self {
             self.abandon_after = Some(calls);
+            self
+        }
+
+        /// Reports the batch interrupted once `calls` calls have been answered — the scripted
+        /// stand-in for someone calling `interrupt` mid-transaction. Deliberately *not* expressed
+        /// as a failing step, because the whole difficulty is that an interrupted step succeeds:
+        /// the debugger returns the output it reached, so a script that answered `Err` here would
+        /// be testing the failure path that already worked.
+        fn interrupted_after(mut self, calls: usize) -> Self {
+            self.interrupt_after = Some(calls);
             self
         }
 
@@ -1630,6 +1701,10 @@ mod tests {
         }
         fn abandoned(&self) -> bool {
             self.abandon_after
+                .is_some_and(|after| self.calls.len() >= after)
+        }
+        fn interrupted(&self) -> bool {
+            self.interrupt_after
                 .is_some_and(|after| self.calls.len() >= after)
         }
     }
@@ -1829,6 +1904,85 @@ mod tests {
         let text = render(&report);
         assert!(text.contains("BATCH: ABANDONED at step 2 of 3"), "{text}");
         assert!(text.contains("rollback: COMPLETE"), "{text}");
+    }
+
+    /// An `interrupt` arriving mid-transaction stops the batch and unwinds it, exactly as a teardown
+    /// does — and this is the case that does **not** announce itself through a failing step.
+    ///
+    /// An interrupted step *succeeds*. Preserving whatever output the debugger reached is the whole
+    /// point of an on-request interrupt, so `execute_command_bounded` returns `Ok` rather than the
+    /// error the break provoked, and a step whose assertions still hold is indistinguishable from
+    /// one that ran to completion. Without the executor being told separately, the batch would carry
+    /// on applying later mutations for a caller who has asked it to stop — which is why the script
+    /// here answers `Ok` to every step rather than failing the interrupted one.
+    #[test]
+    fn an_interrupted_batch_stops_where_it_is_and_still_rolls_back() {
+        let mut d = stopped()
+            .on("eb fffff800", Ok(""))
+            .on("second", Ok(""))
+            .on("third", Ok(""))
+            .on("eb restore", Ok(""))
+            // Lands after the first step's command — which still answers `Ok`, as a real
+            // interrupted command does.
+            .interrupted_after(1);
+        let batch = op(
+            vec![
+                cmd("eb fffff800`00001000 90"),
+                cmd("second step"),
+                cmd("third step"),
+            ],
+            vec![cmd("eb restore 41")],
+        );
+
+        let report = run(&mut d, &batch, BUDGET);
+
+        assert_eq!(report.outcome, BatchOutcome::Interrupted { at: 2 });
+        assert!(
+            !d.ran("second"),
+            "a mutation after the interrupt must not run — this is the whole finding"
+        );
+        assert!(!d.ran("third"), "nor any step after that one");
+        assert!(
+            d.ran("eb restore"),
+            "and the rollback still runs, as on every other path"
+        );
+        assert!(report.rollback_complete());
+        // The skipped steps must not say the session was torn down: it was not, and a caller told
+        // so would open a new session to resubmit against when the one they have is fine.
+        for step in &report.steps[1..] {
+            let StepResult::Skipped(why) = &step.result else {
+                panic!(
+                    "step {} should have been skipped: {:?}",
+                    step.position, step
+                );
+            };
+            assert!(why.contains("interrupted"), "{why}");
+            assert!(!why.contains("torn down"), "{why}");
+        }
+        let text = render(&report);
+        assert!(text.contains("BATCH: INTERRUPTED at step 2 of 3"), "{text}");
+        assert!(text.contains("rollback: COMPLETE"), "{text}");
+    }
+
+    /// A teardown outranks an interrupt when both are in play: the session is going away, and that
+    /// is the news the caller needs — resubmit on a *fresh* session, not on this one.
+    #[test]
+    fn a_teardown_outranks_an_interrupt_for_the_same_batch() {
+        let mut d = stopped()
+            .on("first", Ok(""))
+            .on("second", Ok(""))
+            .on("eb restore", Ok(""))
+            .abandoned_after(1)
+            .interrupted_after(1);
+        let batch = op(
+            vec![cmd("first step"), cmd("second step")],
+            vec![cmd("eb restore 41")],
+        );
+
+        let report = run(&mut d, &batch, BUDGET);
+
+        assert_eq!(report.outcome, BatchOutcome::Abandoned { at: 2 });
+        assert!(report.rollback_complete());
     }
 
     /// **The bound the worker advertises to a teardown has to be one this executor keeps.**

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -738,8 +738,6 @@ fn action_mutation(action: &StepAction) -> Option<String> {
 
 // ---- the engine seam ------------------------------------------------------
 
-/// What [`run`] needs from a debugger. Implemented over a real engine by the worker, and over a
-/// script by the tests — see the module docs for why that seam is where it is.
 /// What a step's engine call produced: its output, and whether it actually finished.
 ///
 /// Both, because either alone is a lie in the case that matters. Output alone cannot say a command
@@ -1232,7 +1230,7 @@ fn run_step(
             .map(Ran::whole),
     });
 
-    let (output, cut_short) = match ran {
+    let (output, mut cut_short) = match ran {
         Ok(ran) => (ran.output, ran.interrupted),
         Err(why) => {
             return StepOutcome {
@@ -1260,7 +1258,7 @@ fn run_step(
             );
             break;
         }
-        match evaluate(d, check, &output, deadline) {
+        match evaluate(d, check, &output, deadline, &mut cut_short) {
             Ok(()) => {}
             Err(CheckFailed::Unmet(why)) => {
                 result = StepResult::Unmet(why);
@@ -1345,7 +1343,12 @@ enum CheckFailed {
 /// falling back on [`MIN_STEP_BUDGET_MS`] when nothing is left: that floor exists so a query which
 /// *has* to run is never armed with a disabled watchdog, and using it to start a query that did
 /// not have to run would spend the rollback's reserve on an assertion.
-fn eval_value(d: &mut impl Debuggee, expr: &str, deadline: Duration) -> Result<u64, CheckFailed> {
+fn eval_value(
+    d: &mut impl Debuggee,
+    expr: &str,
+    deadline: Duration,
+    cut_short: &mut bool,
+) -> Result<u64, CheckFailed> {
     if d.elapsed() >= deadline {
         return Err(CheckFailed::Expired(format!(
             "the batch ran out of time before `? ({expr})` could be evaluated"
@@ -1355,8 +1358,13 @@ fn eval_value(d: &mut impl Debuggee, expr: &str, deadline: Duration) -> Result<u
     // Parenthesized, so a relational expression (`@rcx > 0x1000`) is evaluated as one value
     // rather than losing its precedence against whatever `?` does with the rest of the line.
     let text = guarded(|| {
-        d.command(&format!("? ({expr})"), budget_ms)
-            .map(|ran| ran.output)
+        d.command(&format!("? ({expr})"), budget_ms).map(|ran| {
+            // An assertion is engine calls too, so a break can land in one — and it belongs to the
+            // step just as much as one landing in the step's action. Dropped here, an interrupted
+            // assertion that still parses reports the step, and the batch, as having succeeded.
+            *cut_short |= ran.interrupted;
+            ran.output
+        })
     })
     .map_err(|why| CheckFailed::Unmet(format!("`? ({expr})` failed: {why}")))?;
     parse_eval(&text).ok_or_else(|| {
@@ -1373,6 +1381,10 @@ fn evaluate(
     check: &Check,
     output: &str,
     deadline: Duration,
+    // `cut_short` is set when a break landed while this assertion was being evaluated. An
+    // out-parameter because an assertion can be *both* interrupted and conclusive — a truncated
+    // value that still parses and still matches — so it cannot ride on the `Result`.
+    cut_short: &mut bool,
 ) -> Result<(), CheckFailed> {
     match check {
         Check::Contains { text } => {
@@ -1402,8 +1414,8 @@ fn evaluate(
             }
         }
         Check::Eval { expr, equals } => {
-            let left = eval_value(d, expr, deadline)?;
-            let right = eval_value(d, equals, deadline)?;
+            let left = eval_value(d, expr, deadline, cut_short)?;
+            let right = eval_value(d, equals, deadline, cut_short)?;
             if left == right {
                 Ok(())
             } else {
@@ -2073,6 +2085,48 @@ mod tests {
         let text = render(&report);
         assert!(text.contains("BATCH: INTERRUPTED at step 1 of 3"), "{text}");
         assert!(text.contains("rollback: COMPLETE"), "{text}");
+    }
+
+    /// A break landing while an **assertion** is being evaluated belongs to the step too.
+    ///
+    /// The nastiest shape of it, which is why the assertion here *holds*: an `eval` check is two
+    /// more engine calls, and a break landing in one leaves a value that may still parse and still
+    /// match. Nothing fails, so nothing else in the step says anything is wrong — and on a last
+    /// step, with no next iteration to notice, the batch reported `COMMITTED`.
+    #[test]
+    fn a_break_during_an_assertion_is_the_steps_too() {
+        let mut d = stopped()
+            .on("only", Ok(""))
+            .on("? (1)", Ok("Evaluate expression: 1 = 00000000`00000001"))
+            .on("eb restore", Ok(""))
+            // Call 1 is the step's own command; the break lands on call 2, which is the first of
+            // the assertion's two evaluations.
+            .interrupted_after(2);
+        let batch = op(
+            vec![BatchStep {
+                expect: vec![Check::Eval {
+                    expr: "1".to_string(),
+                    equals: "1".to_string(),
+                }],
+                ..cmd("only step")
+            }],
+            vec![cmd("eb restore 41")],
+        );
+
+        let report = run(&mut d, &batch, BUDGET);
+
+        assert!(
+            report.steps[0].ok(),
+            "the assertion held — this is the case where nothing looks wrong: {:?}",
+            report.steps[0].result
+        );
+        assert_eq!(
+            report.outcome,
+            BatchOutcome::Interrupted { at: 1 },
+            "a break during the step's assertions is a break during the step"
+        );
+        assert!(d.ran("eb restore"));
+        assert!(report.rollback_complete());
     }
 
     /// A break landing in the gap *between* steps still stops the batch.

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -772,21 +772,22 @@ pub trait Debuggee {
     /// has to be shortened to fit a teardown.
     fn abandoned(&self) -> bool;
     /// Whether someone has asked this batch's *call* to stop — the `interrupt` tool, aimed at the
-    /// job this batch is running as.
+    /// job this batch is running as. Read between steps, with the same limit as
+    /// [`Self::abandoned`]: it cannot reach a call already inside DbgEng.
     ///
-    /// Separate from [`Self::abandoned`] because the two say opposite things about the session: a
-    /// teardown means it is going away, this means it is staying and the caller simply wants the
-    /// transaction to end. Folding them together would tell a caller to resubmit on a fresh session
-    /// when the one they have is fine.
+    /// Separate from `abandoned` because the two say opposite things about the session: a teardown
+    /// means it is going away, this means it is staying.
     ///
-    /// **Why the executor has to be told at all**, when an interrupt already stops the step: it
-    /// stops the step by making the debugger return early, and — since the whole point of an
-    /// on-request interrupt is that partial output is preserved rather than thrown away — that
-    /// return is a *success*. A step whose assertions still hold therefore reads as a step that
-    /// ran, and the batch would carry on applying later mutations for a caller who has asked it to
-    /// stop. Read between steps, with the same limit as `abandoned`: a call already inside DbgEng
-    /// runs to its own end.
+    /// **The executor has to be told, because an interrupted step succeeds.** The break makes the
+    /// debugger return early with whatever it had produced — preserving that is the point — so a
+    /// step whose assertions still hold is indistinguishable from one that ran. See `DECISIONS.md`.
     fn interrupted(&self) -> bool;
+    /// Announces that the main steps are over and the `always` block is about to run.
+    ///
+    /// A safety boundary, not bookkeeping: cleanup must not be interruptible, because a restore cut
+    /// short returns `Ok` like any other interrupted command and would be reported as a rollback
+    /// that completed. Implementations refuse interrupts from here on.
+    fn rolling_back(&mut self);
 }
 
 /// Runs one engine call, turning a panic into a step failure so [`run`] still reaches `always`.
@@ -1063,11 +1064,35 @@ pub fn run(d: &mut impl Debuggee, op: &BatchOp, budget: Duration) -> BatchReport
         steps.push(done);
     }
 
+    // The between-steps check above cannot see a break that lands during the **last** step: there is
+    // no next step to stop before. Left there, every step has run and every assertion has held, so
+    // the batch reports `COMMITTED` — of a transaction whose final step was cut short, with only the
+    // generic cut-short note beneath to contradict it. Contradicting itself is worse than either
+    // reading alone, so the outcome is corrected here.
+    //
+    // Only from `Committed`. A step that failed or ran out of time has news the caller must act on
+    // first, and an interrupt does not change what it says.
+    if outcome == BatchOutcome::Committed && d.interrupted() {
+        // One past the end, which is what `at` means everywhere it appears — the first step not
+        // attempted — and here says there is no such step. `render` reads it back and says so.
+        outcome = BatchOutcome::Interrupted {
+            at: op.steps.len() + 1,
+        };
+    }
+
     // The rollback block, on every path. Its own deadline is the *whole* budget, which is what the
     // reserve above bought it — and that holds when the batch is abandoned too, rather than the
     // rollback being cut short to fit a teardown's grace. The grace is sized from this budget
     // instead (`worker::BatchSignal::abandon`), so shortening the block here would only mean
     // skipping cleanup the teardown was already waiting for.
+    //
+    // Announced first, and this is a safety boundary rather than bookkeeping: from here the host
+    // must not let a Ctrl+Break reach the engine. An interrupted command returns `Ok` with whatever
+    // it had produced, so a *restore* that is cut short reports success — a patch left applied and
+    // reported as undone, which is the one outcome this whole tool exists to prevent. The host
+    // refuses interrupts from this point and clears any already pending
+    // (`worker::BatchEngine::rolling_back`).
+    d.rolling_back();
     let mut always: Vec<StepOutcome> = Vec::with_capacity(op.always.len());
     for (index, step) in op.always.iter().enumerate() {
         let position = index + 1;
@@ -1485,6 +1510,16 @@ pub fn render(report: &BatchReport) -> String {
              its rollback. Nothing was wrong with the steps or the budget; resubmit the whole \
              batch on a fresh session.\n"
         ),
+        // `at` past the end means no step was skipped: the break landed during the last one, so
+        // every step ran but the last one's result is whatever it had reached. Reported as its own
+        // sentence, because "stopped at step N" would claim a step did not run when they all did —
+        // and `COMMITTED`, which this replaces, claimed the opposite and worse.
+        BatchOutcome::Interrupted { at } if *at > total => format!(
+            "BATCH: INTERRUPTED during step {total} of {total} — every step ran, but `interrupt` \
+             was called on this session while the last one was still going, so what it reported is \
+             what it had reached rather than a completed step. The rollback ran. The session is \
+             still open and still holds its target.\n"
+        ),
         BatchOutcome::Interrupted { at } => format!(
             "BATCH: INTERRUPTED at step {at} of {total} — `interrupt` was called on this session, \
              so the batch stopped there and ran its rollback. Nothing was wrong with the steps or \
@@ -1588,6 +1623,9 @@ mod tests {
         /// The same, for an interrupt aimed at this batch's own call; see
         /// [`Script::interrupted_after`].
         interrupt_after: Option<usize>,
+        /// Whether the executor announced its rollback — the notification a host turns into "no
+        /// break may reach this job any more".
+        sealed: bool,
     }
 
     /// The message a scripted panic carries, so the report can be asserted to have kept it.
@@ -1706,6 +1744,11 @@ mod tests {
         fn interrupted(&self) -> bool {
             self.interrupt_after
                 .is_some_and(|after| self.calls.len() >= after)
+        }
+        fn rolling_back(&mut self) {
+            // A real host seals the job against further breaks here; the script only records that
+            // it was told, which is what the executor owes it.
+            self.sealed = true;
         }
     }
 
@@ -1962,6 +2005,62 @@ mod tests {
         let text = render(&report);
         assert!(text.contains("BATCH: INTERRUPTED at step 2 of 3"), "{text}");
         assert!(text.contains("rollback: COMPLETE"), "{text}");
+    }
+
+    /// A break landing during the **last** step must not leave the batch reporting `COMMITTED`.
+    ///
+    /// The between-steps check cannot see this one: there is no next step to stop before, so every
+    /// step has run and every assertion has held. The report would then say the transaction
+    /// committed while the note beneath it said the operation was cut short — and a report that
+    /// contradicts itself is worse than either reading alone. It says `INTERRUPTED` instead, in the
+    /// form that admits every step ran.
+    #[test]
+    fn an_interrupt_during_the_last_step_is_not_a_commit() {
+        let mut d = stopped()
+            .on("only", Ok(""))
+            .on("eb restore", Ok(""))
+            // After the one and only step's command — so the loop never looks again.
+            .interrupted_after(1);
+        let batch = op(vec![cmd("only step")], vec![cmd("eb restore 41")]);
+
+        let report = run(&mut d, &batch, BUDGET);
+
+        assert_eq!(
+            report.outcome,
+            BatchOutcome::Interrupted { at: 2 },
+            "one past the end: every step ran, so none was skipped"
+        );
+        assert!(d.ran("eb restore"), "the rollback runs on this path too");
+        assert!(report.rollback_complete());
+        let text = render(&report);
+        assert!(
+            text.contains("BATCH: INTERRUPTED during step 1 of 1"),
+            "{text}"
+        );
+        assert!(
+            !text.contains("stopped there"),
+            "no step was skipped, so nothing should claim one was: {text}"
+        );
+    }
+
+    /// The rollback is announced before it runs, so a host can close the job to further breaks.
+    ///
+    /// Without it the *first* interrupt of a batch can land on a restore — cleanup is reached on
+    /// every path, including paths no interrupt was involved in — and an interrupted restore
+    /// returns `Ok` with partial output, so it is recorded as a step that worked and the report
+    /// says `rollback: COMPLETE` with the target still changed.
+    #[test]
+    fn the_rollback_is_announced_before_it_runs() {
+        let mut d = stopped().on("only", Ok("")).on("eb restore", Ok(""));
+        let batch = op(vec![cmd("only step")], vec![cmd("eb restore 41")]);
+
+        run(&mut d, &batch, BUDGET);
+
+        assert!(
+            d.sealed,
+            "the executor must tell its host that cleanup is starting, or the host cannot know \
+             when to stop letting breaks through"
+        );
     }
 
     /// A teardown outranks an interrupt when both are in play: the session is going away, and that

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -37,7 +37,6 @@ use tokio::process::{Child, ChildStdout, Command};
 use tokio::sync::{mpsc, oneshot};
 use windows_sys::Win32::Foundation::{HANDLE_FLAG_INHERIT, SetHandleInformation};
 
-use crate::batch::BatchOp;
 use crate::kdconn;
 use crate::proto::{EngineOp, WorkerMessage, WorkerRequest};
 use crate::worker::{MESSAGES_FLAG, REQUESTS_FLAG, WORKER_FLAG};
@@ -66,6 +65,14 @@ const WORKER_READY_TIMEOUT: Duration = Duration::from_secs(30);
 /// that a live target with real teardown work (a detach that has to resume threads) finishes
 /// gracefully, short enough that recovering a parked attach is not a wait.
 const END_SESSION_TIMEOUT: Duration = Duration::from_secs(20);
+
+/// How long to wait for a worker to acknowledge an interrupt.
+///
+/// Not a bound on the operation being interrupted: that one ends when the engine next polls, and it
+/// reports to its own caller on its own clock. This bounds only the round trip to the worker's
+/// *request reader*, which does no debugging and is by construction never blocked behind the engine
+/// — so it is short, and a wait that reaches it means the worker has stopped reading altogether.
+const INTERRUPT_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// The same grace, but at shutdown, where it competes with the client's expectation that closing
 /// stdin ends the process promptly.
@@ -1053,6 +1060,27 @@ impl Sessions {
         outcome
     }
 
+    /// Ctrl+Breaks whatever a session's engine is running, leaving the session and its target
+    /// alone.
+    ///
+    /// The graceful counterpart to [`Self::end`], and the reason both exist: `end_session` also
+    /// ends a runaway command, but by throwing away the target it was running against. Here the
+    /// operation returns to *its own* caller — with whatever it had reached — and the session is
+    /// ready for the next call.
+    ///
+    /// Its own short budget rather than the call timeout, because this waits on nothing that can
+    /// run long. The worker answers from its request reader, which is never blocked by the engine
+    /// (that is what makes an interrupt deliverable at all), so anything slower than this is a
+    /// worker that has stopped reading rather than one that is thinking.
+    pub async fn interrupt(
+        &self,
+        session: &Arc<Session>,
+        named: bool,
+    ) -> Result<String, EngineError> {
+        let call = Call::new(EngineOp::Interrupt).named(named);
+        self.call_within(session, call, INTERRUPT_TIMEOUT).await
+    }
+
     /// Ends a session: asks the worker to release its target, then terminates it.
     ///
     /// The kill is not a fallback for tidiness — it is the recovery path. A worker parked in a
@@ -2035,15 +2063,12 @@ fn pump(
         }
 
         let mut op = job.op;
-        // The two ops whose own deadline is derived from the caller's: what is written here is how
+        // For the ops whose own deadline is derived from the caller's: what is written here is how
         // much patience the caller had left when this job reached the front of the queue, and the
-        // worker sizes its watchdog (or its batch budget) from it. See `EngineOp::BoundedCommand`.
-        match &mut op {
-            EngineOp::BoundedCommand { patience_ms, .. }
-            | EngineOp::Batch(BatchOp { patience_ms, .. }) => {
-                *patience_ms = remaining_patience_ms(call_timeout, job.submitted);
-            }
-            _ => {}
+        // worker sizes its watchdog (or its walk, or its batch budget) from it. See
+        // `EngineOp::BoundedCommand` for why the derivation itself belongs to the worker.
+        if let Some(patience_ms) = op.patience_slot() {
+            *patience_ms = remaining_patience_ms(call_timeout, job.submitted);
         }
         let request = WorkerRequest { id: job.id, op };
         let Ok(mut line) = serde_json::to_string(&request) else {

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -106,7 +106,18 @@ pub enum EngineOp {
     /// A pool query. Like [`Self::Reachability`] this is one indivisible job: a query may have
     /// to walk every pool page, and letting another call for the same session interleave would
     /// let the walk describe a target that moved underneath it.
-    Pool(PoolOp),
+    ///
+    /// `patience_ms` is the caller's remaining patience, filled in and derived exactly as
+    /// [`Self::BoundedCommand`]'s is, and for the same reason: a walk that outlives its caller is a
+    /// walk nobody is waiting for holding a session nobody can use. Without it the walk takes
+    /// win-kexp's `DEFAULT_WALK_BUDGET`, which knows nothing about this server's deadline and is
+    /// wrong in both directions — too long for a host configured with a short
+    /// `WINDBG_MCP_CALL_TIMEOUT_SECS`, and needlessly short for the default one, where it stops
+    /// with minutes still to spend and hands back a partial snapshot.
+    Pool {
+        query: PoolOp,
+        patience_ms: u32,
+    },
     /// A whole transaction: ordered steps, their assertions, and the rollback block that runs
     /// whatever happens to them ([`crate::batch`]).
     ///
@@ -116,6 +127,26 @@ pub enum EngineOp {
     /// deadline. Splitting it into per-step round trips would put the client back in the middle
     /// of it, which is the design this replaces.
     Batch(BatchOp),
+    /// Ctrl+Break whatever this worker's engine is running, and answer without going near the
+    /// engine thread.
+    ///
+    /// **The second op the reader acts on where it reads it**, and here it is the entire point
+    /// rather than an ordering detail: an interrupt queued behind the operation it is meant to stop
+    /// would be read after that operation ended, which is a request that can never do anything.
+    /// So this one is answered by the reader outright and never queued at all.
+    ///
+    /// It carries no job id, because the id that matters is not the caller's to know. A tool call
+    /// names a *session*, and which job that session is running is decided inside the worker
+    /// between the request being written and it being read — so the binding is made where the
+    /// answer is: the reader reads the running job and raises the interrupt under one lock, and the
+    /// engine thread clears that job under the same lock and drains anything still pending before
+    /// it starts the next one. An interrupt therefore reaches the job that was running when it
+    /// arrived, or nothing at all; it can never land on the one after it.
+    ///
+    /// What it cannot do is bounded by `SetInterrupt` itself: a live-kernel wait whose target has
+    /// never connected does not poll, so an `attach_kernel` parked on a dead link is unreachable
+    /// this way and only [`Self::EndSession`] ends it.
+    Interrupt,
     /// Release the target. The supervisor tears the worker down afterwards — under
     /// process-per-session a worker outlives its target for no reason.
     ///
@@ -142,6 +173,23 @@ pub enum EngineOp {
 }
 
 impl EngineOp {
+    /// The `patience_ms` this op carries, for the supervisor's pump to fill in as it writes the
+    /// request — or `None` for an op that derives no deadline from its caller's.
+    ///
+    /// Named here, next to the variants, rather than as a `match` inside [`crate::engine::pump`],
+    /// because the failure it prevents is silent: a variant that grows a `patience_ms` and is not
+    /// added to that `match` compiles, ships, and takes whatever the field's default happens to
+    /// be. That is exactly what [`Self::Pool`] did — it carried none at all and quietly took
+    /// win-kexp's default walk budget instead of this server's deadline.
+    pub fn patience_slot(&mut self) -> Option<&mut u32> {
+        match self {
+            Self::BoundedCommand { patience_ms, .. }
+            | Self::Pool { patience_ms, .. }
+            | Self::Batch(BatchOp { patience_ms, .. }) => Some(patience_ms),
+            _ => None,
+        }
+    }
+
     /// Whether this op creates the worker's target, and so reports the `Committed`/`Opened`
     /// milestones below.
     pub fn is_opener(&self) -> bool {
@@ -268,6 +316,70 @@ impl PoolOp {
             refresh: refresh.unwrap_or(false),
             limit: Self::rows(limit, Self::DIAGNOSTIC_LINES),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every op that *carries* a caller's patience must hand it out, and no other op may claim to.
+    ///
+    /// Checked against the serialized form rather than against a second list, because that is the
+    /// one thing a hand-written `match` cannot get out of step with: the field is either in the
+    /// JSON this op crosses the pipe as, or it is not. `Pool` is the reason — it reached the worker
+    /// with no patience at all, and the walk took win-kexp's 120s default however long its caller
+    /// was actually willing to wait ([#75](https://github.com/glslang/windbg-mcp/issues/75)).
+    #[test]
+    fn an_op_that_carries_a_deadline_hands_it_to_the_pump() {
+        let mut ops = vec![
+            EngineOp::Command {
+                command: "lm".into(),
+            },
+            EngineOp::BoundedCommand {
+                command: "s -b 0 L?0x1000 41".into(),
+                patience_ms: 0,
+            },
+            EngineOp::Registers,
+            EngineOp::Pool {
+                query: PoolOp::census(None, None),
+                patience_ms: 0,
+            },
+            EngineOp::Batch(BatchOp {
+                budget_ms: 1_000,
+                patience_ms: 0,
+                steps: Vec::new(),
+                always: Vec::new(),
+            }),
+            EngineOp::Interrupt,
+            EngineOp::EndSession,
+        ];
+        for op in &mut ops {
+            let carries = serde_json::to_string(&op)
+                .expect("every op is plain data")
+                .contains("patience_ms");
+            let handed = op.patience_slot().is_some();
+            assert_eq!(
+                carries, handed,
+                "{op:?} carries patience_ms={carries} but hands it out={handed}; the supervisor \
+                 fills in exactly what this returns, so the two disagreeing is a deadline that is \
+                 never set"
+            );
+        }
+    }
+
+    /// And what it hands out is the field the worker then reads, not a copy of it.
+    #[test]
+    fn the_slot_the_pump_writes_is_the_one_that_crosses_the_pipe() {
+        let mut op = EngineOp::Pool {
+            query: PoolOp::find_tag("Tgsm".into(), None, None, None),
+            patience_ms: 0,
+        };
+        *op.patience_slot().expect("a pool query carries one") = 42_000;
+        let EngineOp::Pool { patience_ms, .. } = op else {
+            unreachable!("still a pool query")
+        };
+        assert_eq!(patience_ms, 42_000);
     }
 }
 

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -317,6 +317,22 @@ impl PoolOp {
             limit: Self::rows(limit, Self::DIAGNOSTIC_LINES),
         }
     }
+
+    /// Whether this query **must** walk, rather than possibly being served from the session's
+    /// cached snapshot.
+    ///
+    /// The distinction matters only when there is no time to walk in: a query that can be answered
+    /// from the cache costs nothing and should be, while one that has to walk and cannot finish
+    /// produces a truncated snapshot that win-kexp discards rather than caches — so it is work for
+    /// nobody, twice over. The worker refuses that one instead of doing it.
+    pub fn refreshes(&self) -> bool {
+        match self {
+            Self::FindTag { refresh, .. }
+            | Self::Chunk { refresh, .. }
+            | Self::Census { refresh, .. }
+            | Self::Diagnostics { refresh, .. } => *refresh,
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/server.rs
+++ b/src/server.rs
@@ -2127,8 +2127,11 @@ impl WindbgServer {
     /// A `debug_batch` interrupted this way stops at its next step and runs its `always` block, and
     /// its own result reports `BATCH: INTERRUPTED` with the rollback state — so no step after the
     /// interrupt is applied, and the session keeps its target (unlike `end_session`, which also
-    /// stops a batch but takes the session with it). A second `interrupt` while one is already
-    /// stopping is a no-op that says so, rather than a break that could land on the rollback.
+    /// stops a batch but takes the session with it). Its **rollback cannot be interrupted**: a
+    /// restore cut short would report success while leaving the target changed, so a call aimed at
+    /// a batch that is unwinding, or repeated while one is still stopping, says so and sends
+    /// nothing. If a rollback will not end, `end_session` is the way out, at the cost of the
+    /// target.
     // `idempotent_hint = false`, which is not the intuitive reading: raising the same Ctrl+Break
     // twice on the same operation plainly has no second effect. But the hint is about *repeating
     // the call*, and what a repeat addresses is whichever job is running when it arrives — which

--- a/src/server.rs
+++ b/src/server.rs
@@ -65,6 +65,20 @@ fn engine_result(r: Result<String, EngineError>) -> Result<CallToolResult, Error
     }
 }
 
+/// Wraps a pool question as an engine op.
+///
+/// `patience_ms` is filled in by the supervisor's pump when the job reaches the front of its
+/// session's queue, so the zero here is never what the worker reads — see [`EngineOp::Pool`]. It
+/// lives in one place rather than at each of the four call sites for the reason the `PoolOp`
+/// constructors do: a tool that spelled it out and got it wrong would silently take a walk budget
+/// of nothing.
+fn pool_op(query: PoolOp) -> EngineOp {
+    EngineOp::Pool {
+        query,
+        patience_ms: 0,
+    }
+}
+
 /// Parses a decimal or `0x`-prefixed hex integer.
 pub(crate) fn parse_u64(s: &str) -> Result<u64, String> {
     let t = s.trim();
@@ -1885,7 +1899,7 @@ impl WindbgServer {
         let out = self
             .run(
                 args.session_id.as_deref(),
-                EngineOp::Pool(PoolOp::find_tag(
+                pool_op(PoolOp::find_tag(
                     args.tag,
                     args.paged,
                     args.refresh,
@@ -1922,7 +1936,7 @@ impl WindbgServer {
         let out = self
             .run(
                 args.session_id.as_deref(),
-                EngineOp::Pool(PoolOp::chunk(args.address, args.refresh)),
+                pool_op(PoolOp::chunk(args.address, args.refresh)),
             )
             .await;
         engine_result(out)
@@ -1949,7 +1963,7 @@ impl WindbgServer {
         let out = self
             .run(
                 args.session_id.as_deref(),
-                EngineOp::Pool(PoolOp::diagnostics(args.filter, args.refresh, args.limit)),
+                pool_op(PoolOp::diagnostics(args.filter, args.refresh, args.limit)),
             )
             .await;
         engine_result(out)
@@ -1974,7 +1988,7 @@ impl WindbgServer {
         let out = self
             .run(
                 args.session_id.as_deref(),
-                EngineOp::Pool(PoolOp::census(args.refresh, args.limit)),
+                pool_op(PoolOp::census(args.refresh, args.limit)),
             )
             .await;
         engine_result(out)
@@ -2085,6 +2099,49 @@ impl WindbgServer {
             ));
         };
         text_result(describe_session(session))
+    }
+
+    /// Stop the operation a session is currently running, **keeping the session and its target**.
+    /// The graceful way out of a call that is taking too long — a broad `s` search, a `go` that
+    /// has not hit anything, a pool walk over a slow KD link.
+    ///
+    /// This is a Ctrl+Break, exactly as at a WinDbg prompt. The interrupted operation ends at the
+    /// debugger's next poll and returns whatever it had reached *to the call that started it*, not
+    /// to this one — so partial output is preserved, marked as cut short, and the session takes the
+    /// next call immediately. This call answers as soon as the break is raised.
+    ///
+    /// Issue it while the other call is still outstanding; it does not queue behind it. With
+    /// nothing running it reports exactly that and does nothing.
+    ///
+    /// Two things it cannot reach, both properties of the debugger rather than of this server: an
+    /// operation that never polls for the break, and a live-kernel `attach_kernel` whose target has
+    /// not connected yet (the documented case — see `session_status`). `end_session` is what ends
+    /// those, at the cost of the target.
+    ///
+    /// A `debug_batch` interrupted this way fails the step that was running, which stops the
+    /// transaction and runs its `always` block — the rollback still happens, and the batch's own
+    /// result reports it.
+    #[rmcp::tool(annotations(
+        title = "Interrupt the running operation",
+        read_only_hint = false,
+        destructive_hint = false,
+        idempotent_hint = true,
+        open_world_hint = true
+    ))]
+    async fn interrupt(
+        &self,
+        Parameters(args): Parameters<SessionArgs>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let session_id = args.session_id.as_deref();
+        let session = match self.sessions.resolve(session_id) {
+            Ok(session) => session,
+            Err(e) => return engine_result(Err(e)),
+        };
+        engine_result(
+            self.sessions
+                .interrupt(&session, session_id.is_some())
+                .await,
+        )
     }
 
     /// End a debug session: release its target and shut down its engine process. Pass
@@ -2982,9 +3039,12 @@ Open a dump or .run trace, attach to a process or the kernel, inspect registers/
 Each open target is a separate session in its own engine process, so several can be open at once (up to 4) without \
 disturbing each other; pass the `session_id` an opener returns on later calls to route them to that target, and \
 `end_session` when done. `session_status` lists what is open and what state each session is in — ask it when an open \
-reports a timeout rather than re-running the open, which would attach or launch a second time. A live kernel attach \
-waits for its target indefinitely and cannot be interrupted; if it has been waiting far longer than a healthy link \
-takes, `end_session` reclaims that session (and only that session) by terminating its engine process. \
+reports a timeout rather than re-running the open, which would attach or launch a second time. To stop a call that is \
+taking too long without losing the target, call `interrupt` on its session while it is still outstanding: it Ctrl+Breaks \
+the engine, the running call returns whatever it had reached, and the session is free for the next one. A live kernel \
+attach is the exception — it waits for its target indefinitely and cannot be interrupted; if it has been waiting far \
+longer than a healthy link takes, `end_session` reclaims that session (and only that session) by terminating its engine \
+process. \
 Navigate a TTD trace in both directions: go/step_over/step_into forward, and reverse_go/step_over_back/step_back backward, \
 or jump with goto_position. Analyze a trace with the data-model tools ttd_calls (calls to a function), ttd_memory (accesses \
 to an address range), and ttd_events (module/thread/exception events), or run any data-model query with dx. Record new traces \

--- a/src/server.rs
+++ b/src/server.rs
@@ -2113,6 +2113,12 @@ impl WindbgServer {
     /// Issue it while the other call is still outstanding; it does not queue behind it. With
     /// nothing running it reports exactly that and does nothing.
     ///
+    /// **Not safe to retry blind.** Each call stops whatever is running *at the moment it arrives*,
+    /// and this one returns as soon as the break is raised, while the operation it stopped runs on
+    /// to its next poll. So a second call sent after the first has answered can land on the next
+    /// operation instead of the one you meant. Read the reply — it says whether it reached anything
+    /// — rather than repeating the call.
+    ///
     /// Two things it cannot reach, both properties of the debugger rather than of this server: an
     /// operation that never polls for the break, and a live-kernel `attach_kernel` whose target has
     /// not connected yet (the documented case — see `session_status`). `end_session` is what ends
@@ -2121,11 +2127,17 @@ impl WindbgServer {
     /// A `debug_batch` interrupted this way fails the step that was running, which stops the
     /// transaction and runs its `always` block — the rollback still happens, and the batch's own
     /// result reports it.
+    // `idempotent_hint = false`, which is not the intuitive reading: raising the same Ctrl+Break
+    // twice on the same operation plainly has no second effect. But the hint is about *repeating
+    // the call*, and what a repeat addresses is whichever job is running when it arrives — which
+    // after the first call has answered may well be the next one. So a client retrying this on a
+    // timeout can stop an operation nobody asked it to. See the note above, and the smoke test that
+    // has to loop until it reaches something, which is the same property from the other side.
     #[rmcp::tool(annotations(
         title = "Interrupt the running operation",
         read_only_hint = false,
         destructive_hint = false,
-        idempotent_hint = true,
+        idempotent_hint = false,
         open_world_hint = true
     ))]
     async fn interrupt(

--- a/src/server.rs
+++ b/src/server.rs
@@ -2124,9 +2124,11 @@ impl WindbgServer {
     /// not connected yet (the documented case — see `session_status`). `end_session` is what ends
     /// those, at the cost of the target.
     ///
-    /// A `debug_batch` interrupted this way fails the step that was running, which stops the
-    /// transaction and runs its `always` block — the rollback still happens, and the batch's own
-    /// result reports it.
+    /// A `debug_batch` interrupted this way stops at its next step and runs its `always` block, and
+    /// its own result reports `BATCH: INTERRUPTED` with the rollback state — so no step after the
+    /// interrupt is applied, and the session keeps its target (unlike `end_session`, which also
+    /// stops a batch but takes the session with it). A second `interrupt` while one is already
+    /// stopping is a no-op that says so, rather than a break that could land on the rollback.
     // `idempotent_hint = false`, which is not the intuitive reading: raising the same Ctrl+Break
     // twice on the same operation plainly has no second effect. But the hint is about *repeating
     // the call*, and what a repeat addresses is whichever job is running when it arrives — which

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -354,6 +354,15 @@ impl Running {
         self.interrupted = self.job;
     }
 
+    /// Whether an interrupt has been raised for `id` and not yet spent.
+    ///
+    /// A peek, where [`Self::release`] takes: a long-running job that can stop *itself* — a
+    /// [`crate::batch`], between its steps — has to be able to see the request without consuming
+    /// the record that its reply is owed an explanation.
+    fn interrupt_pending(&self, id: u64) -> bool {
+        self.interrupted == Some(id)
+    }
+
     /// Ends `id`'s claim, reporting whether an interrupt was bound to it.
     ///
     /// Taken rather than read, so an interrupt is spent by the job it reached: the next job starts
@@ -380,6 +389,11 @@ static INTERRUPT: OnceLock<InterruptHandle> = OnceLock::new();
 /// [`Running::claim`] on this process's one tracker.
 fn claim(id: u64) {
     running().claim(id);
+}
+
+/// [`Running::interrupt_pending`] on this process's one tracker.
+fn interrupt_pending(id: u64) -> bool {
+    running().interrupt_pending(id)
 }
 
 /// [`Running::release`] on this process's one tracker.
@@ -769,6 +783,23 @@ fn interrupt_running() -> Result<String, String> {
                 .to_string(),
         );
     };
+    // At most one break per job, and the reason is a `debug_batch`: its rollback runs as part of
+    // the same job, so a second interrupt aimed at a batch that is already stopping would land on
+    // a restore command instead — a cut-short `Execute` that still reports `Ok`, which is a
+    // mutation left applied and reported as undone. The one thing this subsystem exists to prevent.
+    //
+    // Costs nothing anywhere else: a repeat only ever meant "that same operation, again", and it
+    // is already stopping. A *later* job is a different id and is interrupted normally, which is
+    // why this is not idempotence — see the tool's annotation.
+    if running.interrupt_pending(job) {
+        return Ok(format!(
+            "Already interrupted. Ctrl+Break was raised on this session's engine for the \
+             operation it is running (job {job}) and it is stopping; nothing further was sent. If \
+             it does not end, it is one of the cases an interrupt cannot reach — a command that \
+             never polls, or a live-kernel attach whose target has not connected — and \
+             `end_session` is what ends those, at the cost of the target."
+        ));
+    }
     let Some(handle) = INTERRUPT.get() else {
         // Only reachable before the engine exists, and the supervisor is told `Ready` after that,
         // so no session can be routed here. Reported rather than unwrapped all the same.
@@ -1012,7 +1043,9 @@ fn execute(e: &DebugEngine, id: u64, op: EngineOp, queued: Duration) -> Result<S
                 None => pool(e, query, Duration::ZERO),
             }
         }
-        EngineOp::Batch(op) => run_batch(e, op, queued),
+        // `id` is passed because a batch is the one op that can stop *itself*: it checks between
+        // steps whether an interrupt has been raised for the job it is running as.
+        EngineOp::Batch(op) => run_batch(e, id, op, queued),
         // Answered by the request reader, which is the only way it could reach a busy engine at
         // all, so it is never queued and never arrives here. See [`EngineOp::Interrupt`].
         EngineOp::Interrupt => Err(
@@ -1094,6 +1127,9 @@ struct BatchEngine<'a> {
     e: &'a DebugEngine,
     started: Instant,
     signal: &'a BatchSignal,
+    /// The request id this batch is running as, so it can see an interrupt aimed at *it* — see
+    /// [`Debuggee::interrupted`].
+    job: u64,
 }
 
 impl Debuggee for BatchEngine<'_> {
@@ -1136,6 +1172,10 @@ impl Debuggee for BatchEngine<'_> {
     fn abandoned(&self) -> bool {
         self.signal.abandoned()
     }
+
+    fn interrupted(&self) -> bool {
+        interrupt_pending(self.job)
+    }
 }
 
 /// Runs a batch and renders its report.
@@ -1143,7 +1183,7 @@ impl Debuggee for BatchEngine<'_> {
 /// The report is the result either way — a failed transaction that did not say which step failed
 /// and whether the rollback ran would be worse than no report at all. `Err` only chooses how
 /// [`crate::server`] renders it: a tool-execution error the model can read and act on.
-fn run_batch(e: &DebugEngine, op: BatchOp, queued: Duration) -> Result<String, String> {
+fn run_batch(e: &DebugEngine, job: u64, op: BatchOp, queued: Duration) -> Result<String, String> {
     let Some(budget) = batch_budget(
         op.budget_ms,
         Duration::from_millis(u64::from(op.patience_ms)),
@@ -1192,6 +1232,7 @@ fn run_batch(e: &DebugEngine, op: BatchOp, queued: Duration) -> Result<String, S
         e,
         started: Instant::now(),
         signal: &BATCH,
+        job,
     };
     let report = batch::run(&mut engine, &op, budget);
     let rendered = batch::render(&report);

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -16,6 +16,22 @@
 //! Which is why the request reader lives on the *main* thread and exits the process outright on
 //! EOF instead of joining the engine thread: at EOF the engine thread may be parked forever,
 //! and waiting for it would recreate the very wedge this design removes.
+//!
+//! **The one call that crosses that line, and why it is not a hole in it.** `SetInterrupt` is the
+//! single DbgEng entry point Microsoft documents as safe from any thread, and it is the only one
+//! this process ever makes off the engine thread — from exactly one place, [`interrupt_running`],
+//! on the request reader. Everything else about the engine stays where it always was: it is created
+//! on the engine thread, never sent anywhere, and every other call is made there.
+//!
+//! The exception is not optional and not an optimisation. An interrupt exists to stop an operation
+//! that is *running*, which means the engine thread is by definition busy; routed through that
+//! thread it would be read only once there was nothing left to interrupt. So the alternative to
+//! reaching the engine from outside is not a safer interrupt, it is no interrupt at all.
+//!
+//! It is also not new here — win-kexp's two watchdogs have always Ctrl+Broken the engine from a
+//! thread of their own, on every bounded command and every go/step. What this adds is a caller who
+//! can ask for the same thing, and the binding ([`Running`]) that decides *which job* the request
+//! reaches. See `AGENTS.md` and the `DECISIONS.md` entry for the invariant and its boundary.
 
 use std::io::{BufRead, BufReader, PipeReader, PipeWriter, Write};
 use std::os::windows::io::{AsRawHandle, FromRawHandle, RawHandle};

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -1145,16 +1145,6 @@ fn told(run: CommandRun) -> String {
     out
 }
 
-/// A [`CommandRun`] as the batch executor sees it: the output, and whether a break somebody asked
-/// for reached it. A deadline is not that — it is the step's own `timeout_ms` doing its job, which
-/// the step's output and assertions already speak to. See [`batch::Ran`].
-fn ran(run: CommandRun) -> Ran {
-    Ran {
-        interrupted: matches!(run.cut_short, Some(Interruption::OnRequest)),
-        output: told(run),
-    }
-}
-
 /// Reads target memory and renders it as a hex dump.
 ///
 /// Free function rather than an inline arm because a batch step reads memory the same way, and a
@@ -1220,41 +1210,79 @@ struct BatchEngine<'a> {
     job: u64,
 }
 
+impl BatchEngine<'_> {
+    /// Whether a break has been raised for this batch's job.
+    ///
+    /// Which, at the moment a call returns, means it was raised *during that call*: the executor
+    /// checks between steps, so a break outstanding from an earlier one would have stopped the
+    /// batch before this step began.
+    ///
+    /// This is the authority for the calls win-kexp cannot answer for. A command knows its own
+    /// interruption — the engine clears and reads a flag around `Execute` — but a `run_to` verdict,
+    /// a typed memory read and a pool walk have no such notion, and a walk in particular *is*
+    /// interruptible: win-kexp's walker polls the same Ctrl+C flag and stops. Left unasked, they
+    /// reported every result as whole.
+    fn broken(&self) -> bool {
+        interrupt_pending(self.job)
+    }
+
+    /// A command's result as the executor sees it: the text with any deadline note, and whether a
+    /// break reached it — from the engine, which knows, or from this worker, which raised it.
+    fn ran(&self, run: CommandRun) -> Ran {
+        Ran {
+            interrupted: matches!(run.cut_short, Some(Interruption::OnRequest)) || self.broken(),
+            output: told(run),
+        }
+    }
+}
+
 impl Debuggee for BatchEngine<'_> {
     fn command(&mut self, command: &str, budget_ms: u32) -> Result<Ran, String> {
         // Bounded, always. A batch is the one place a runaway command would also strand a
         // rollback, so the step self-aborts rather than eating the reserve.
         self.e
             .execute_command_bounded(command, budget_ms)
-            .map(ran)
+            .map(|run| self.ran(run))
             .map_err(es)
     }
 
     fn resume(&mut self, command: &str, timeout_ms: u32) -> Result<Ran, String> {
         self.e
             .execute_and_wait(command, timeout_ms)
-            .map(ran)
+            .map(|run| self.ran(run))
             .map_err(es)
     }
 
-    fn run_to(&mut self, address: &str, timeout_ms: u32) -> Result<String, String> {
-        run_to_address(self.e, address, timeout_ms)
+    fn run_to(&mut self, address: &str, timeout_ms: u32) -> Result<Ran, String> {
+        let output = run_to_address(self.e, address, timeout_ms)?;
+        Ok(Ran {
+            output,
+            interrupted: self.broken(),
+        })
     }
 
-    fn read_memory(&mut self, address: &str, size: u32) -> Result<String, String> {
-        read_memory(self.e, address, size)
+    fn read_memory(&mut self, address: &str, size: u32) -> Result<Ran, String> {
+        let output = read_memory(self.e, address, size)?;
+        Ok(Ran {
+            output,
+            interrupted: self.broken(),
+        })
     }
 
-    fn pool(&mut self, query: &PoolOp, budget_ms: u32) -> Result<String, String> {
+    fn pool(&mut self, query: &PoolOp, budget_ms: u32) -> Result<Ran, String> {
         // The step's own budget, handed to the walker. Bounded, always, for the same reason a
         // command step is: this is the one step that can spend minutes without a runaway anywhere
         // — a full pool walk is every committed page over the KD wire — and the reserve the
         // rollback lives on is what it would spend.
-        pool(
+        let output = pool(
             self.e,
             query.clone(),
             Duration::from_millis(u64::from(budget_ms)),
-        )
+        )?;
+        Ok(Ran {
+            output,
+            interrupted: self.broken(),
+        })
     }
 
     fn elapsed(&self) -> Duration {

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -41,12 +41,12 @@ use std::sync::{Mutex, OnceLock, mpsc};
 use std::thread;
 use std::time::{Duration, Instant};
 
-use win_kexp::dbgeng::{DebugEngine, InterruptHandle, RunToOutcome};
+use win_kexp::dbgeng::{CommandRun, DebugEngine, InterruptHandle, Interruption, RunToOutcome};
 use win_kexp::pool::query::{self, PoolPageFilter, PoolWalk};
 use win_kexp::pool::{DiagnosticShape, PoolDiagnostics, PoolSpan, PoolState};
 use windows_sys::Win32::Foundation::{HANDLE_FLAG_INHERIT, SetHandleInformation};
 
-use crate::batch::{self, BatchOp, Debuggee};
+use crate::batch::{self, BatchOp, Debuggee, Ran};
 use crate::proto::{EngineOp, PoolOp, ReachabilityOp, WorkerMessage, WorkerRequest};
 use crate::server::{
     fmt_addr, format_recipe, format_report, hexdump, parse_eval, parse_lm_base, parse_u64,
@@ -1014,18 +1014,25 @@ fn execute(e: &DebugEngine, id: u64, op: EngineOp, queued: Duration) -> Result<S
         // Zero costs nothing to say. It spawns no watchdog at all — which is the whole reason these
         // ops are off the bounded path (DECISIONS.md, 2026-08-02: arming one rounds a command up to
         // a multiple of 200ms) — so this stays unbounded, as `index_trace` in particular must.
-        EngineOp::Command { command } => e.execute_command_bounded(&command, 0).map_err(es),
+        EngineOp::Command { command } => {
+            e.execute_command_bounded(&command, 0).map(told).map_err(es)
+        }
         EngineOp::BoundedCommand {
             command,
             patience_ms,
         } => {
             let budget = watchdog_budget_ms(Duration::from_millis(u64::from(patience_ms)), queued);
-            e.execute_command_bounded(&command, budget).map_err(es)
+            e.execute_command_bounded(&command, budget)
+                .map(told)
+                .map_err(es)
         }
         EngineOp::CommandAndWait {
             command,
             timeout_ms,
-        } => e.execute_and_wait(&command, timeout_ms).map_err(es),
+        } => e
+            .execute_and_wait(&command, timeout_ms)
+            .map(told)
+            .map_err(es),
         EngineOp::Registers => e.registers().map_err(es),
         EngineOp::ReadMemory { address, size } => read_memory(e, &address, size),
         EngineOp::SymbolPath {
@@ -1118,6 +1125,36 @@ fn es<E: ToString>(e: E) -> String {
     e.to_string()
 }
 
+/// A command's text, with the deadline's explanation appended when there is one.
+///
+/// The note lives here rather than in win-kexp because it is prose for whoever reads the tool's
+/// output, and a return value is the wrong place to put prose: the caller before this one had to
+/// string-match for it. Only the deadline earns one — an interrupt *on request* is explained to
+/// the caller by [`cut_short`], and to the one who asked by their own reply.
+fn told(run: CommandRun) -> String {
+    let mut out = run.output;
+    if let Some(Interruption::Deadline { after_ms }) = run.cut_short {
+        if !out.is_empty() && !out.ends_with('\n') {
+            out.push('\n');
+        }
+        out.push_str(&format!(
+            "[windbg-mcp] command interrupted after {after_ms} ms (Ctrl+Break) — it was taking \
+             too long. Scope it (e.g. a bounded memory range) and retry."
+        ));
+    }
+    out
+}
+
+/// A [`CommandRun`] as the batch executor sees it: the output, and whether a break somebody asked
+/// for reached it. A deadline is not that — it is the step's own `timeout_ms` doing its job, which
+/// the step's output and assertions already speak to. See [`batch::Ran`].
+fn ran(run: CommandRun) -> Ran {
+    Ran {
+        interrupted: matches!(run.cut_short, Some(Interruption::OnRequest)),
+        output: told(run),
+    }
+}
+
 /// Reads target memory and renders it as a hex dump.
 ///
 /// Free function rather than an inline arm because a batch step reads memory the same way, and a
@@ -1184,16 +1221,20 @@ struct BatchEngine<'a> {
 }
 
 impl Debuggee for BatchEngine<'_> {
-    fn command(&mut self, command: &str, budget_ms: u32) -> Result<String, String> {
+    fn command(&mut self, command: &str, budget_ms: u32) -> Result<Ran, String> {
         // Bounded, always. A batch is the one place a runaway command would also strand a
         // rollback, so the step self-aborts rather than eating the reserve.
         self.e
             .execute_command_bounded(command, budget_ms)
+            .map(ran)
             .map_err(es)
     }
 
-    fn resume(&mut self, command: &str, timeout_ms: u32) -> Result<String, String> {
-        self.e.execute_and_wait(command, timeout_ms).map_err(es)
+    fn resume(&mut self, command: &str, timeout_ms: u32) -> Result<Ran, String> {
+        self.e
+            .execute_and_wait(command, timeout_ms)
+            .map(ran)
+            .map_err(es)
     }
 
     fn run_to(&mut self, address: &str, timeout_ms: u32) -> Result<String, String> {

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -125,22 +125,27 @@ fn watchdog_budget_ms(patience: Duration, queued: Duration) -> u32 {
         .min(u32::MAX as u128) as u32
 }
 
-/// How long a pool walk may run, on the same terms.
+/// How long a pool walk may run: the same arithmetic as [`watchdog_budget_ms`] and the same
+/// headroom, but **no floor** — `None` when the caller's clock has nothing left to give it.
 ///
-/// The same question as [`watchdog_budget_ms`] — how much of the caller's clock is this operation
-/// entitled to spend — so the same answer, rather than a second constant that would drift from it.
-/// What differs is only what runs out of time: win-kexp's walker checks the deadline between reads
-/// and returns the snapshot it has, so a short budget costs *coverage*, and every rendering here
-/// already says how much of the pool the walk reached.
+/// The same question as the watchdog's, so deliberately the same answer rather than a second
+/// constant that would drift from it. What differs is what running out of time *does*. There, zero
+/// disables the bound outright, so a command dequeued past the deadline would be the one command
+/// that runs unbounded, and a floor that overruns the caller by a headroom is the lesser evil. Here
+/// zero merely stops the walk at its first check — so the floor buys nothing and costs the one thing
+/// this budget exists to prevent, a walk still running after its caller gave up. That is #75 in
+/// miniature: with `WINDBG_MCP_CALL_TIMEOUT_SECS=10`, a floored 15s walk outlives *every* call.
 ///
-/// The floor matters for a different reason than the watchdog's, and matters less. There, zero
-/// would disable the bound outright; here it would simply stop the walk on its first check. Keeping
-/// the floor is still the better of the two, because the snapshot a walk builds is cached for the
-/// session: a walk dequeued past its caller's deadline that runs for one headroom leaves the *next*
-/// query something to answer from, where one that gives up immediately leaves it the same walk to
-/// do again.
-fn walk_budget(patience: Duration, queued: Duration) -> Duration {
-    Duration::from_millis(u64::from(watchdog_budget_ms(patience, queued)))
+/// **And it really does buy nothing**, which is the part worth writing down, because the first cut
+/// of this reasoned the other way: a walk cut short by its budget clears `complete`, and
+/// win-kexp caches only complete snapshots — an incomplete one invalidates the entry instead. So a
+/// floored walk for a caller who has gone does 15s of work that is then *discarded*, and the next
+/// query walks from scratch anyway. There is no cache to warm.
+fn walk_budget(patience: Duration, queued: Duration) -> Option<Duration> {
+    let left = patience
+        .saturating_sub(queued)
+        .saturating_sub(WATCHDOG_HEADROOM);
+    (!left.is_zero()).then_some(left)
 }
 
 /// How long the worker gives its engine to let go of the target when the supervisor disappears
@@ -949,14 +954,47 @@ fn execute(e: &DebugEngine, id: u64, op: EngineOp, queued: Duration) -> Result<S
         // outlives its caller holds this session against nobody. Taking win-kexp's default instead
         // was wrong in both directions — see [`EngineOp::Pool`].
         EngineOp::Pool { query, patience_ms } => {
-            let budget = walk_budget(Duration::from_millis(u64::from(patience_ms)), queued);
-            // Logged because a truncated walk otherwise says only *that* it was truncated, and the
-            // two explanations — this deadline, or a target the walk could not read — want
-            // opposite responses. It is also the only place the number is observable, which is
-            // what `tests/mcp_smoke.rs` asserts against: the previous bug was that no number
-            // crossed the pipe at all.
-            tracing::debug!("worker: pool walk budget {budget:?} (queued {queued:?})");
-            pool(e, query, budget)
+            let patience = Duration::from_millis(u64::from(patience_ms));
+            match walk_budget(patience, queued) {
+                Some(budget) => {
+                    // Logged because a truncated walk otherwise says only *that* it was truncated,
+                    // and the two explanations — this deadline, or a target the walk could not
+                    // read — want opposite responses. It is also the only place the figure is
+                    // observable, which is what `tests/mcp_smoke.rs` asserts against: the bug this
+                    // fixed was that no figure crossed the pipe at all.
+                    tracing::debug!("worker: pool walk budget {budget:?} (queued {queued:?})");
+                    pool(e, query, budget)
+                }
+                // Nothing left to walk in. A query that *must* walk is refused rather than
+                // attempted, because attempting it cannot produce an answer: the walk would be cut
+                // short at its first check, and a truncated snapshot is discarded rather than
+                // cached, so the work would be spent for nobody and the next query would walk from
+                // scratch regardless.
+                None if query.refreshes() => {
+                    tracing::debug!(
+                        "worker: no pool walk budget left (queued {queued:?}); refusing a query \
+                         that must walk"
+                    );
+                    Err(format!(
+                        "This pool query was not run: it reached the engine with {}s of its \
+                         caller's timeout left, which is not enough to walk the pool and report \
+                         back before that timeout expires. It asked for `refresh`, so it cannot \
+                         be answered from the snapshot cached for this session either. Nothing \
+                         was read and nothing changed. It waited {}s behind other work on this \
+                         session; issue it when the session is idle, or raise the server's call \
+                         timeout (WINDBG_MCP_CALL_TIMEOUT_SECS — a pool walk needs more than the \
+                         {}s of headroom the reply itself reserves).",
+                        patience.saturating_sub(queued).as_secs(),
+                        queued.as_secs(),
+                        WATCHDOG_HEADROOM.as_secs(),
+                    ))
+                }
+                // Without `refresh` the session's cached snapshot may well answer this outright, and
+                // a caller with no time left can certainly afford a cache read. Passed zero rather
+                // than refused: if a walk *is* needed it stops at once and the answer says its
+                // coverage was nil, which every rendering below already does.
+                None => pool(e, query, Duration::ZERO),
+            }
         }
         EngineOp::Batch(op) => run_batch(e, op, queued),
         // Answered by the request reader, which is the only way it could reach a busy engine at
@@ -2536,7 +2574,7 @@ mod tests {
         const WIN_KEXP_DEFAULT: Duration = Duration::from_secs(120);
 
         let short = Duration::from_secs(60);
-        let budget = walk_budget(short, Duration::ZERO);
+        let budget = walk_budget(short, Duration::ZERO).expect("60s leaves time to walk in");
         assert!(
             budget < short,
             "a walk under a {short:?} call budget got {budget:?}; it would still be walking when \
@@ -2549,7 +2587,7 @@ mod tests {
 
         let generous = Duration::from_secs(300);
         assert!(
-            walk_budget(generous, Duration::ZERO) > WIN_KEXP_DEFAULT,
+            walk_budget(generous, Duration::ZERO).expect("300s does too") > WIN_KEXP_DEFAULT,
             "a caller who can wait five minutes should not be handed a partial snapshot at two"
         );
     }
@@ -2557,17 +2595,79 @@ mod tests {
     /// The same invariant the bounded command holds, for the same reason: **queue wait + walk
     /// budget must not exceed the caller's patience**. A pool query can sit behind another job on
     /// its session, and a budget derived from the patience as sent would spend it all again.
+    ///
+    /// Checked down to patiences *below* the headroom, which is where the first cut of this failed:
+    /// it borrowed the watchdog's floor, so every patience under 15s got a 15s walk. A 10s call
+    /// budget yielded a walk allowed to run half again as long as the call — #75's own complaint,
+    /// arriving at the small end.
     #[test]
     fn a_queued_pool_walk_still_stops_before_its_caller_gives_up() {
-        let patience = Duration::from_secs(300);
-        for waited in [0, 1, 30, 100, 240, 269] {
-            let waited = Duration::from_secs(waited);
-            let budget = walk_budget(patience, waited);
-            assert!(
-                waited + budget <= patience,
-                "a walk dequeued after {waited:?} got {budget:?} — it would still be walking at \
-                 the {patience:?} mark"
-            );
+        for patience in [10, 15, 20, 60, 300] {
+            let patience = Duration::from_secs(patience);
+            for waited in [0, 1, 5, 30, 100, 240, 269, 400] {
+                let waited = Duration::from_secs(waited);
+                // No budget means no walk, which trivially cannot outlive anybody.
+                let Some(budget) = walk_budget(patience, waited) else {
+                    continue;
+                };
+                assert!(
+                    waited + budget <= patience,
+                    "a walk dequeued after {waited:?} of a {patience:?} budget got {budget:?} — it \
+                     would still be walking after its caller gave up"
+                );
+            }
         }
+    }
+
+    /// A caller who cannot be answered gets **no walk at all**, rather than one floored to a
+    /// headroom.
+    ///
+    /// Two ways in, and both are real: a server configured with a call timeout at or under the
+    /// headroom, and a query dequeued after its caller has given up. Neither can be answered, and
+    /// the work would not even leave a cache behind — win-kexp caches complete snapshots only, so a
+    /// budget-truncated walk is discarded and the next query walks again regardless.
+    #[test]
+    fn a_pool_walk_with_no_time_left_is_not_run_at_all() {
+        assert_eq!(
+            walk_budget(Duration::from_secs(10), Duration::ZERO),
+            None,
+            "a 10s call budget is entirely reply headroom; there is no walk to be had"
+        );
+        assert_eq!(
+            walk_budget(WATCHDOG_HEADROOM, Duration::ZERO),
+            None,
+            "and the headroom itself is the boundary, not the first affordable value"
+        );
+        assert_eq!(
+            walk_budget(WATCHDOG_HEADROOM + Duration::from_millis(1), Duration::ZERO),
+            Some(Duration::from_millis(1)),
+            "one millisecond past it is a walk, however short"
+        );
+        // The queue-wait route to the same place: patience that was ample when the request was
+        // written and is spent by the time the engine reaches it.
+        assert_eq!(
+            walk_budget(Duration::from_secs(300), Duration::from_secs(290)),
+            None
+        );
+        assert_eq!(
+            walk_budget(Duration::from_secs(300), Duration::from_secs(400)),
+            None,
+            "and a wait past the whole budget saturates rather than wrapping to a huge one"
+        );
+    }
+
+    /// The refusal applies to a query that **must** walk. One that may be served from the cached
+    /// snapshot is still worth trying, because a cache read costs nothing that a caller with no time
+    /// left cannot afford.
+    #[test]
+    fn only_a_query_that_must_walk_is_refused_for_want_of_time() {
+        assert!(PoolOp::census(Some(true), None).refreshes());
+        assert!(PoolOp::find_tag("Tgsm".into(), None, Some(true), None).refreshes());
+        assert!(PoolOp::chunk("0x1000".into(), Some(true)).refreshes());
+        assert!(PoolOp::diagnostics(None, Some(true), None).refreshes());
+
+        // The default, and the reason the distinction is worth making at all.
+        assert!(!PoolOp::census(None, None).refreshes());
+        assert!(!PoolOp::chunk("0x1000".into(), Some(false)).refreshes());
     }
 }

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -1006,7 +1006,15 @@ fn execute(e: &DebugEngine, id: u64, op: EngineOp, queued: Duration) -> Result<S
         ),
 
         // ---- ordinary work ----
-        EngineOp::Command { command } => e.execute_command(&command).map_err(es),
+        // Bounded with a zero deadline, which is `execute_command` plus one thing: the recovery
+        // that keeps the output an *interrupted* command had already produced. Without it a break
+        // makes `Execute` fail and the captured buffer goes with the error, so the caller of a long
+        // `index_trace` gets a bare failure and a note promising partial output that is not there.
+        //
+        // Zero costs nothing to say. It spawns no watchdog at all — which is the whole reason these
+        // ops are off the bounded path (DECISIONS.md, 2026-08-02: arming one rounds a command up to
+        // a multiple of 200ms) — so this stays unbounded, as `index_trace` in particular must.
+        EngineOp::Command { command } => e.execute_command_bounded(&command, 0).map_err(es),
         EngineOp::BoundedCommand {
             command,
             patience_ms,

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -334,11 +334,21 @@ struct Running {
     /// drain whatever the engine did not consume. An interrupt lodged just as a command finishes
     /// leaves a Ctrl+Break pending with nothing running, and the next job would wear it.
     interrupted: Option<u64>,
+    /// The job that has entered a phase no break may reach — a [`crate::batch`] running its
+    /// `always` block.
+    ///
+    /// Cleanup is the one thing an interrupt must never touch. A restore cut short returns `Ok`
+    /// with partial output like any other interrupted command, so `run_step` records it as a step
+    /// that worked and the report says `rollback: COMPLETE` with the patch still applied — the
+    /// exact loss the whole transaction machinery exists to prevent, arriving through the tool
+    /// meant to be the gentle way out.
+    uninterruptible: Option<u64>,
 }
 
 static RUNNING: Mutex<Running> = Mutex::new(Running {
     job: None,
     interrupted: None,
+    uninterruptible: None,
 });
 
 impl Running {
@@ -363,6 +373,16 @@ impl Running {
         self.interrupted == Some(id)
     }
 
+    /// Closes `id` to interrupts for the rest of its life. See [`Self::uninterruptible`].
+    fn seal(&mut self, id: u64) {
+        self.uninterruptible = Some(id);
+    }
+
+    /// Whether a break may still be raised for `id`.
+    fn sealed(&self, id: u64) -> bool {
+        self.uninterruptible == Some(id)
+    }
+
     /// Ends `id`'s claim, reporting whether an interrupt was bound to it.
     ///
     /// Taken rather than read, so an interrupt is spent by the job it reached: the next job starts
@@ -370,6 +390,7 @@ impl Running {
     /// to the one before it.
     fn release(&mut self, id: u64) -> bool {
         self.job = None;
+        self.uninterruptible = None;
         self.interrupted.take() == Some(id)
     }
 }
@@ -394,6 +415,19 @@ fn claim(id: u64) {
 /// [`Running::interrupt_pending`] on this process's one tracker.
 fn interrupt_pending(id: u64) -> bool {
     running().interrupt_pending(id)
+}
+
+/// Closes `id` to further interrupts and consumes anything already pending on the engine.
+///
+/// Both under the one lock, which is what makes it a boundary rather than a hope: a raise takes the
+/// same lock, so every break is either lodged before this — and drained here, before the first
+/// cleanup command runs — or refused after it. Called by a batch as it enters its `always` block.
+fn seal_against_interrupts(e: &DebugEngine, id: u64) {
+    let mut running = running();
+    running.seal(id);
+    // Under the lock deliberately: a break raised between the seal and the drain would survive
+    // both and land on the first restore command.
+    let _ = e.interrupted();
 }
 
 /// [`Running::release`] on this process's one tracker.
@@ -783,10 +817,19 @@ fn interrupt_running() -> Result<String, String> {
                 .to_string(),
         );
     };
-    // At most one break per job, and the reason is a `debug_batch`: its rollback runs as part of
-    // the same job, so a second interrupt aimed at a batch that is already stopping would land on
-    // a restore command instead — a cut-short `Execute` that still reports `Ok`, which is a
-    // mutation left applied and reported as undone. The one thing this subsystem exists to prevent.
+    // A batch that has reached its `always` block is closed to breaks, whether or not one has been
+    // raised for it before. Cleanup is the one thing an interrupt must not reach: a restore cut
+    // short returns `Ok` with partial output like any other interrupted command, so it would be
+    // recorded as a step that worked and reported as `rollback: COMPLETE` with the patch still
+    // applied.
+    if running.sealed(job) {
+        return Ok(format!(
+            "Not interrupted. The operation on this session (job {job}) is a `debug_batch` that              has finished its steps and is running its rollback, which is deliberately not              interruptible — a restore stopped halfway would report success while leaving the              target changed. It is bounded by the batch's own budget and will return shortly. If              it does not, `end_session` ends the session outright, at the cost of the target."
+        ));
+    }
+    // At most one break per job otherwise, for the same reason one step later: a batch told to stop
+    // runs its rollback as part of this same job, so a second interrupt aimed at it would land on a
+    // restore command.
     //
     // Costs nothing anywhere else: a repeat only ever meant "that same operation, again", and it
     // is already stopping. A *later* job is a different id and is interrupted normally, which is
@@ -1175,6 +1218,10 @@ impl Debuggee for BatchEngine<'_> {
 
     fn interrupted(&self) -> bool {
         interrupt_pending(self.job)
+    }
+
+    fn rolling_back(&mut self) {
+        seal_against_interrupts(self.e, self.job);
     }
 }
 
@@ -2537,6 +2584,7 @@ mod tests {
         Running {
             job: None,
             interrupted: None,
+            uninterruptible: None,
         }
     }
 
@@ -2568,6 +2616,28 @@ mod tests {
             !running.release(8),
             "the next job inherited an interrupt meant for the one before it"
         );
+    }
+
+    /// A job that has sealed itself takes no break at all — not a second one, and **not a first**.
+    ///
+    /// The first is the case that matters and the one the seal exists for. A `debug_batch` reaches
+    /// its `always` block on every path, including paths no interrupt was ever involved in, so an
+    /// interrupt arriving for the first time while cleanup runs would land on a restore command.
+    /// That returns `Ok` with partial output like any interrupted command, so it is recorded as a
+    /// step that worked: `rollback: COMPLETE` with the target still changed.
+    #[test]
+    fn a_sealed_job_takes_no_interrupt_at_all() {
+        let mut running = idle();
+        running.claim(7);
+        assert!(!running.sealed(7), "an ordinary job is interruptible");
+
+        running.seal(7);
+        assert!(running.sealed(7));
+        // And the seal is the job's, not the process's: it goes when the job does, or the next
+        // batch on this session could never be interrupted.
+        assert!(!running.release(7), "no interrupt was ever raised for it");
+        running.claim(8);
+        assert!(!running.sealed(8), "the next job starts interruptible");
     }
 
     /// The other side of the same race: an interrupt that arrives between jobs binds to nothing, so

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -25,7 +25,7 @@ use std::sync::{Mutex, OnceLock, mpsc};
 use std::thread;
 use std::time::{Duration, Instant};
 
-use win_kexp::dbgeng::{DebugEngine, RunToOutcome};
+use win_kexp::dbgeng::{DebugEngine, InterruptHandle, RunToOutcome};
 use win_kexp::pool::query::{self, PoolPageFilter, PoolWalk};
 use win_kexp::pool::{DiagnosticShape, PoolDiagnostics, PoolSpan, PoolState};
 use windows_sys::Win32::Foundation::{HANDLE_FLAG_INHERIT, SetHandleInformation};
@@ -123,6 +123,24 @@ fn watchdog_budget_ms(patience: Duration, queued: Duration) -> u32 {
         .max(WATCHDOG_HEADROOM)
         .as_millis()
         .min(u32::MAX as u128) as u32
+}
+
+/// How long a pool walk may run, on the same terms.
+///
+/// The same question as [`watchdog_budget_ms`] — how much of the caller's clock is this operation
+/// entitled to spend — so the same answer, rather than a second constant that would drift from it.
+/// What differs is only what runs out of time: win-kexp's walker checks the deadline between reads
+/// and returns the snapshot it has, so a short budget costs *coverage*, and every rendering here
+/// already says how much of the pool the walk reached.
+///
+/// The floor matters for a different reason than the watchdog's, and matters less. There, zero
+/// would disable the bound outright; here it would simply stop the walk on its first check. Keeping
+/// the floor is still the better of the two, because the snapshot a walk builds is cached for the
+/// session: a walk dequeued past its caller's deadline that runs for one headroom leaves the *next*
+/// query something to answer from, where one that gives up immediately leaves it the same walk to
+/// do again.
+fn walk_budget(patience: Duration, queued: Duration) -> Duration {
+    Duration::from_millis(u64::from(watchdog_budget_ms(patience, queued)))
 }
 
 /// How long the worker gives its engine to let go of the target when the supervisor disappears
@@ -276,6 +294,83 @@ const RETRACTED: u32 = 0;
 /// sets it, the engine thread reads it, and there is exactly one engine here to be talking about.
 static BATCH: BatchSignal = BatchSignal::new();
 
+/// Which job the engine thread is running, and whether an interrupt has been raised for it.
+///
+/// The two live under one lock because the property that matters is a relation between them: an
+/// interrupt must reach *the job that was running when it arrived*, or nothing. `SetInterrupt`
+/// addresses an engine rather than an operation, so raised a moment late it Ctrl+Breaks whatever
+/// started next — a caller's `go` aborted by a cancel meant for the search before it, with nothing
+/// in the record to say why.
+///
+/// Holding the lock across the raise is what closes that: the engine thread takes the same lock to
+/// clear `job`, so an interrupt either finds the job still claimed (and the engine thread then
+/// waits behind it) or finds `None` and does nothing. It is never held *across* a job — only around
+/// its two ends — so the reader is not blocked by the work it may be about to interrupt.
+struct Running {
+    /// The request id the engine thread is executing, or `None` between jobs.
+    job: Option<u64>,
+    /// The job an interrupt was raised for, kept until that job ends so the engine thread knows to
+    /// drain whatever the engine did not consume. An interrupt lodged just as a command finishes
+    /// leaves a Ctrl+Break pending with nothing running, and the next job would wear it.
+    interrupted: Option<u64>,
+}
+
+static RUNNING: Mutex<Running> = Mutex::new(Running {
+    job: None,
+    interrupted: None,
+});
+
+impl Running {
+    /// Claims the engine thread for `id`.
+    fn claim(&mut self, id: u64) {
+        self.job = Some(id);
+    }
+
+    /// Records that an interrupt has been raised for the job running *now* — which is the binding
+    /// itself, and why it takes no id: the only job an interrupt can ever reach is the one claimed
+    /// at the moment it is raised, and this is called under the lock that makes that true.
+    fn interrupt_raised(&mut self) {
+        self.interrupted = self.job;
+    }
+
+    /// Ends `id`'s claim, reporting whether an interrupt was bound to it.
+    ///
+    /// Taken rather than read, so an interrupt is spent by the job it reached: the next job starts
+    /// with nothing outstanding and cannot inherit a cut-short label — or a drain — that belongs
+    /// to the one before it.
+    fn release(&mut self, id: u64) -> bool {
+        self.job = None;
+        self.interrupted.take() == Some(id)
+    }
+}
+
+fn running() -> std::sync::MutexGuard<'static, Running> {
+    RUNNING.lock().unwrap_or_else(|e| e.into_inner())
+}
+
+/// The engine's interrupt handle, published by the engine thread once the engine exists.
+///
+/// A `OnceLock` rather than a field somewhere, because the two threads that need it are the only
+/// two this process has: the engine thread creates the engine, and the request reader is the one
+/// that ever asks for a break. Set before [`WorkerMessage::Ready`], so a supervisor that has been
+/// told this worker is usable is never then told there is no handle.
+static INTERRUPT: OnceLock<InterruptHandle> = OnceLock::new();
+
+/// [`Running::claim`] on this process's one tracker.
+fn claim(id: u64) {
+    running().claim(id);
+}
+
+/// [`Running::release`] on this process's one tracker.
+///
+/// `true` is the engine thread's cue to do two things before the next job: drain whatever
+/// Ctrl+Break the engine did not consume, and tell the caller their result was cut short. Paired
+/// with [`claim`] around the `catch_unwind` rather than inside it, so an op that panics still gives
+/// the claim back.
+fn release(id: u64) -> bool {
+    running().release(id)
+}
+
 /// What the request reader hands to the engine thread.
 enum Job {
     /// A request from the supervisor, stamped when it was read.
@@ -354,6 +449,16 @@ pub fn run(args: &[String]) -> ! {
                 // reason the signal can arrive at all. See [`EngineOp::EndSession`].
                 if matches!(request.op, EngineOp::EndSession) {
                     announce_teardown(request.id);
+                }
+                // The one request that is *answered* here rather than queued. Queueing it would
+                // put it behind the operation it exists to stop, so it could only ever run once
+                // there was nothing left to interrupt. See [`EngineOp::Interrupt`].
+                if matches!(request.op, EngineOp::Interrupt) {
+                    emit(&WorkerMessage::Done {
+                        id: request.id,
+                        result: interrupt_running(),
+                    });
+                    continue;
                 }
                 if tx.send(Job::Run(Instant::now(), request)).is_err() {
                     break; // the engine thread is gone; nothing can run any more
@@ -455,6 +560,8 @@ fn engine_thread(rx: mpsc::Receiver<Job>) {
             std::process::exit(1);
         }
     };
+    // Published before `Ready`, so the request reader can never be handed work it cannot interrupt.
+    let _ = INTERRUPT.set(engine.interrupt_handle());
     emit(&WorkerMessage::Ready);
 
     while let Ok(job) = rx.recv() {
@@ -488,14 +595,28 @@ fn engine_thread(rx: mpsc::Receiver<Job>) {
         // Measured here, at the front of the queue: this is the wait only this process can see,
         // and the bounded path needs it to size the watchdog.
         let queued = arrived.elapsed();
+        let id = request.id;
+        // Claimed around the whole op, so an interrupt arriving while it runs names *this* job.
+        // Outside the `catch_unwind` below, so a panicking op gives the claim back too.
+        claim(id);
         // A panic inside a win-kexp method (several use `.expect`) must not kill the session —
         // surface it as an error for this one op. The engine survives, so this stays a
         // debugger-level failure the model can work around by trying something else.
         let result = catch_unwind(AssertUnwindSafe(|| {
-            execute(&engine, request.id, request.op, queued)
+            execute(&engine, id, request.op, queued)
         }))
         .unwrap_or_else(|_| Err("debugger operation panicked".to_string()));
-        let id = request.id;
+        let result = if release(id) {
+            // The engine may have consumed the Ctrl+Break, or the request may have been lodged as
+            // the operation was already returning — in which case it is still pending with nothing
+            // running, and the next job would be the one to stop. Draining is cheap and this is
+            // the only moment it is unambiguous: this job's claim is gone and the next has not
+            // been made, so nothing else can be raising one.
+            let _ = engine.interrupted();
+            cut_short(result)
+        } else {
+            result
+        };
         // A `Done` is what removes the supervisor's waiter, so one that never arrives costs the
         // caller its session rather than its result: the call times out, the waiter stays, and
         // the session counts as busy — and so stays unreclaimable — for the life of the server.
@@ -582,6 +703,73 @@ fn announce_teardown(id: u64) {
         id,
         within_ms: within.as_millis().min(u128::from(u32::MAX)) as u32,
     });
+}
+
+/// Marks a result as one that was cut short by an interrupt somebody asked for.
+///
+/// Said on *this* reply because this is the caller who cannot otherwise find out. The one who asked
+/// for the interrupt was answered when they asked; this one gets back a search that found nothing,
+/// or a `go` that stopped somewhere unremarkable, and would read either as a fact about the target
+/// rather than about a request made behind their back.
+///
+/// Appended rather than substituted, both ways round: the partial output is the point of
+/// interrupting rather than ending the session, and a failure keeps its debugger text because
+/// "this is why it stopped" is not the same claim as "this is what it would have said".
+fn cut_short(result: Result<String, String>) -> Result<String, String> {
+    const NOTE: &str = "[windbg-mcp] This operation was interrupted on request (Ctrl+Break) \
+                        before it finished, so this is what it had reached, not a complete \
+                        result. Nothing about the target failed. Re-run it — scoped more \
+                        narrowly, if it was interrupted for taking too long.";
+    match result {
+        Ok(text) if text.is_empty() => Ok(NOTE.to_string()),
+        Ok(text) if text.ends_with('\n') => Ok(format!("{text}\n{NOTE}")),
+        Ok(text) => Ok(format!("{text}\n\n{NOTE}")),
+        Err(text) => Err(format!("{text}\n\n{NOTE}")),
+    }
+}
+
+/// Ctrl+Breaks the job the engine thread is running, from the request reader — see
+/// [`EngineOp::Interrupt`] for why this happens here rather than on the engine thread.
+///
+/// The whole decision is made under [`RUNNING`]'s lock: which job is running, and the raise itself.
+/// That is what binds the interrupt to a job rather than to a moment — the engine thread cannot
+/// finish that job and start another in between, because clearing the claim needs the same lock.
+///
+/// Says which job it reached, in a reply the *interrupting* caller reads. That caller is not the
+/// one running the operation, so "an operation was interrupted" and "there was nothing to
+/// interrupt" are the two answers it needs, and they are indistinguishable from the outside.
+fn interrupt_running() -> Result<String, String> {
+    let mut running = running();
+    let Some(job) = running.job else {
+        return Ok(
+            "Nothing was running on this session's engine, so nothing was interrupted. \
+                   Whatever you meant to stop had already finished — its own reply says how it \
+                   ended."
+                .to_string(),
+        );
+    };
+    let Some(handle) = INTERRUPT.get() else {
+        // Only reachable before the engine exists, and the supervisor is told `Ready` after that,
+        // so no session can be routed here. Reported rather than unwrapped all the same.
+        return Err(
+            "this engine worker has no interrupt handle yet — its engine is still \
+                    starting up"
+                .to_string(),
+        );
+    };
+    handle.interrupt().map_err(es)?;
+    // Recorded only once the raise succeeded: a failed one has left nothing pending, and claiming
+    // otherwise would have the engine thread drain an interrupt that was never lodged and label a
+    // complete result as cut short.
+    running.interrupt_raised();
+    tracing::info!("worker: interrupt raised for job {job}");
+    Ok(
+        "Interrupted. Ctrl+Break was raised on this session's engine, so the operation it was \
+         running stops at its next poll and returns whatever it had reached — to the call that \
+         started it, not to this one. A command that never polls, and a live-kernel attach whose \
+         target has not connected, cannot be reached this way; `end_session` is what ends those."
+            .to_string(),
+    )
 }
 
 /// Runs one op against this worker's engine. `queued` is how long it waited its turn here, which
@@ -757,11 +945,27 @@ fn execute(e: &DebugEngine, id: u64, op: EngineOp, queued: Duration) -> Result<S
             timeout_ms,
         } => run_to_address(e, &address, timeout_ms),
         EngineOp::Reachability(args) => reachable(e, args),
-        // No deadline of our own: a pool *tool* call takes win-kexp's `DEFAULT_WALK_BUDGET`, which
-        // is sized to fit inside a typical per-call budget (this server's own is #75). A pool
-        // *step* is different — it has a batch's clock to keep — so that path passes one.
-        EngineOp::Pool(args) => pool(e, args, None),
+        // The caller's own deadline, on the same arithmetic as a bounded command's: a walk that
+        // outlives its caller holds this session against nobody. Taking win-kexp's default instead
+        // was wrong in both directions — see [`EngineOp::Pool`].
+        EngineOp::Pool { query, patience_ms } => {
+            let budget = walk_budget(Duration::from_millis(u64::from(patience_ms)), queued);
+            // Logged because a truncated walk otherwise says only *that* it was truncated, and the
+            // two explanations — this deadline, or a target the walk could not read — want
+            // opposite responses. It is also the only place the number is observable, which is
+            // what `tests/mcp_smoke.rs` asserts against: the previous bug was that no number
+            // crossed the pipe at all.
+            tracing::debug!("worker: pool walk budget {budget:?} (queued {queued:?})");
+            pool(e, query, budget)
+        }
         EngineOp::Batch(op) => run_batch(e, op, queued),
+        // Answered by the request reader, which is the only way it could reach a busy engine at
+        // all, so it is never queued and never arrives here. See [`EngineOp::Interrupt`].
+        EngineOp::Interrupt => Err(
+            "an interrupt reached the engine thread, which cannot act on \
+                                    one; this is a bug in the worker's request reader"
+                .to_string(),
+        ),
         // Reaching here means any batch has already been told to stop and has finished unwinding —
         // the reader saw this request go past and said so, and this thread runs one job at a time.
         EngineOp::EndSession => e
@@ -867,7 +1071,7 @@ impl Debuggee for BatchEngine<'_> {
         pool(
             self.e,
             query.clone(),
-            Some(Duration::from_millis(u64::from(budget_ms))),
+            Duration::from_millis(u64::from(budget_ms)),
         )
     }
 
@@ -1108,20 +1312,17 @@ fn render_walk_report(report: &query::PoolSnapshotReport) -> String {
 
 /// Answers one pool question, walking the pool if the cached snapshot will not do.
 ///
-/// `within` is the caller's own deadline for a walk that actually happens, or `None` to take
-/// win-kexp's default. It is `Some` for a [`crate::batch`] step, whose budget is both shorter than
-/// that default and load-bearing: the batch reserves part of it for the rollback and advertises the
-/// whole of it to a teardown, so a walk that ran to the *walker's* default could overrun both. A
-/// walk stopped by a budget still answers — every rendering below carries how much of the pool the
-/// walk reached — so the cost of a short deadline is coverage, not an error.
-fn pool(e: &DebugEngine, args: PoolOp, within: Option<Duration>) -> Result<String, String> {
-    let walk = |refresh: bool| {
-        let walk = PoolWalk::from(refresh);
-        match within {
-            Some(budget) => walk.within(budget),
-            None => walk,
-        }
-    };
+/// `within` is the caller's own deadline for a walk that actually happens, and is **required** —
+/// win-kexp's `DEFAULT_WALK_BUDGET` is reachable from neither caller here, which is right, because
+/// neither is a human at a prompt who could Ctrl+C a walk that ran long. A [`crate::batch`] step
+/// passes its step budget; a pool *tool* call passes what is left of its caller's patience
+/// ([`walk_budget`]). For a batch the deadline is load-bearing beyond the caller: it reserves part
+/// of its budget for the rollback and advertises the whole of it to a teardown, so a walk running to
+/// the *walker's* default could overrun both. A walk stopped by a budget still answers — every
+/// rendering below carries how much of the pool the walk reached — so the cost of a short deadline
+/// is coverage, not an error.
+fn pool(e: &DebugEngine, args: PoolOp, within: Duration) -> Result<String, String> {
+    let walk = |refresh: bool| PoolWalk::from(refresh).within(within);
     match args {
         PoolOp::FindTag {
             tag,
@@ -2227,5 +2428,146 @@ mod tests {
         );
         // Still sticky, though: this session is on its way out and must not start another.
         assert!(signal.enter(A_LONG_BATCH).is_none());
+    }
+
+    // ---- binding an interrupt to a job -------------------------------------
+    //
+    // Against a local `Running` rather than the process-wide `RUNNING`, for the reason above: these
+    // stage both orderings of a race that against the real one would mean interrupting a real
+    // engine at an exact instant. What is *wired* to it — that the reader raises under this lock
+    // and the engine thread claims and releases under it — is `src/worker.rs`'s own code above and
+    // the smoke tier's business; what is checked here is that the bookkeeping cannot misattribute.
+
+    fn idle() -> Running {
+        Running {
+            job: None,
+            interrupted: None,
+        }
+    }
+
+    /// The everyday case: an interrupt raised while a job runs is reported to *that* job, so its
+    /// caller is told their result was cut short and the engine's pending break is drained.
+    #[test]
+    fn an_interrupt_reaches_the_job_that_was_running() {
+        let mut running = idle();
+        running.claim(7);
+        running.interrupt_raised();
+        assert!(running.release(7));
+    }
+
+    /// The failure the binding exists to prevent, stated as the property: an interrupt is spent by
+    /// the job it reached and can never be charged to the next one.
+    ///
+    /// `SetInterrupt` addresses an engine, not an operation. Without the pairing, a cancel landing
+    /// as a search ends would leave a Ctrl+Break pending for whatever ran next — and the caller of
+    /// *that* would be told their `go` had been interrupted on request, which nobody asked for.
+    #[test]
+    fn an_interrupt_is_spent_by_the_job_it_reached() {
+        let mut running = idle();
+        running.claim(7);
+        running.interrupt_raised();
+        assert!(running.release(7));
+
+        running.claim(8);
+        assert!(
+            !running.release(8),
+            "the next job inherited an interrupt meant for the one before it"
+        );
+    }
+
+    /// The other side of the same race: an interrupt that arrives between jobs binds to nothing, so
+    /// the job that starts next is not the one it stops.
+    ///
+    /// This is what the reader's early return reports as "nothing was running". The engine may
+    /// still hold a pending break from it — that is what the drain after each job is for — but no
+    /// caller is told their complete result was cut short.
+    #[test]
+    fn an_interrupt_between_jobs_binds_to_nothing() {
+        let mut running = idle();
+        running.interrupt_raised();
+        assert_eq!(running.interrupted, None, "there was no job to bind it to");
+
+        running.claim(9);
+        assert!(
+            !running.release(9),
+            "a job that started after the interrupt must not answer for it"
+        );
+    }
+
+    // ---- what an interrupted caller is told --------------------------------
+
+    /// A cut-short result keeps what it reached and gains the reason — which is the whole point of
+    /// interrupting rather than ending the session.
+    #[test]
+    fn a_cut_short_result_keeps_its_output_and_says_why() {
+        let out = cut_short(Ok("0x1000  41 42 43\n".to_string())).expect("still a result");
+        assert!(out.starts_with("0x1000  41 42 43"), "{out}");
+        assert!(out.contains("interrupted on request"), "{out}");
+
+        // And a failure keeps its debugger text: "this is why it stopped" is not a claim about
+        // what it would otherwise have said.
+        let err = cut_short(Err("Memory access error".to_string())).expect_err("still a failure");
+        assert!(err.starts_with("Memory access error"), "{err}");
+        assert!(err.contains("interrupted on request"), "{err}");
+    }
+
+    /// An operation interrupted before it printed anything still explains itself, rather than
+    /// coming back as an empty success the caller would read as "found nothing".
+    #[test]
+    fn a_cut_short_result_with_no_output_is_still_an_explanation() {
+        let out = cut_short(Ok(String::new())).expect("still a result");
+        assert!(out.contains("interrupted on request"), "{out}");
+        assert!(
+            !out.starts_with('\n'),
+            "no blank lead-in when there is nothing above it: {out:?}"
+        );
+    }
+
+    // ---- the pool walk budget (#75) ----------------------------------------
+
+    /// A pool walk is bounded by the *caller's* deadline, not by win-kexp's default.
+    ///
+    /// Both directions matter, which is why this checks a short call budget and the default one.
+    /// Taking `DEFAULT_WALK_BUDGET` (120s) meant a host configured with a 60s call timeout got a
+    /// walk that outlived its caller — the wedge, reintroduced from this side — while the 300s
+    /// default stopped at 120s and handed back a partial snapshot with minutes left to spend.
+    #[test]
+    fn a_pool_walk_is_bounded_by_the_call_that_asked_for_it() {
+        const WIN_KEXP_DEFAULT: Duration = Duration::from_secs(120);
+
+        let short = Duration::from_secs(60);
+        let budget = walk_budget(short, Duration::ZERO);
+        assert!(
+            budget < short,
+            "a walk under a {short:?} call budget got {budget:?}; it would still be walking when \
+             its caller gave up"
+        );
+        assert!(
+            budget < WIN_KEXP_DEFAULT,
+            "which is what taking the walker's own default did"
+        );
+
+        let generous = Duration::from_secs(300);
+        assert!(
+            walk_budget(generous, Duration::ZERO) > WIN_KEXP_DEFAULT,
+            "a caller who can wait five minutes should not be handed a partial snapshot at two"
+        );
+    }
+
+    /// The same invariant the bounded command holds, for the same reason: **queue wait + walk
+    /// budget must not exceed the caller's patience**. A pool query can sit behind another job on
+    /// its session, and a budget derived from the patience as sent would spend it all again.
+    #[test]
+    fn a_queued_pool_walk_still_stops_before_its_caller_gives_up() {
+        let patience = Duration::from_secs(300);
+        for waited in [0, 1, 30, 100, 240, 269] {
+            let waited = Duration::from_secs(waited);
+            let budget = walk_budget(patience, waited);
+            assert!(
+                waited + budget <= patience,
+                "a walk dequeued after {waited:?} got {budget:?} — it would still be walking at \
+                 the {patience:?} mark"
+            );
+        }
     }
 }

--- a/tests/golden/tools_list.json
+++ b/tests/golden/tools_list.json
@@ -242,7 +242,7 @@
     {
       "hints": {
         "destructive": false,
-        "idempotent": true,
+        "idempotent": false,
         "openWorld": true,
         "readOnly": false
       },

--- a/tests/golden/tools_list.json
+++ b/tests/golden/tools_list.json
@@ -3,7 +3,7 @@
     "(none)",
     "https://json-schema.org/draft/2020-12/schema"
   ],
-  "toolCount": 42,
+  "toolCount": 43,
   "tools": [
     {
       "hints": {
@@ -238,6 +238,20 @@
       ],
       "required": [],
       "title": "Build TTD trace index"
+    },
+    {
+      "hints": {
+        "destructive": false,
+        "idempotent": true,
+        "openWorld": true,
+        "readOnly": false
+      },
+      "name": "interrupt",
+      "params": [
+        "session_id: string|null"
+      ],
+      "required": [],
+      "title": "Interrupt the running operation"
     },
     {
       "hints": {

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -1867,6 +1867,203 @@ fn a_failed_debugger_operation_is_a_tool_error_not_a_protocol_error() {
     );
 }
 
+/// A pool query's walk is bounded by **this server's** deadline, not by the walker's own default
+/// ([#75](https://github.com/glslang/windbg-mcp/issues/75)).
+///
+/// Asserted against the worker's log rather than against the answer, because on a dump the number
+/// has no visible consequence: the pool is local memory and any walk finishes in well under a
+/// second, so every budget from 15s to 120s produces the identical result. Only a live kernel makes
+/// the difference observable in an answer — which is exactly why this shipped wrong. `Pool` carried
+/// no patience at all and quietly took 120s however long its caller was willing to wait, and no
+/// test that looked at results could have seen it.
+///
+/// So this checks the one thing that *is* observable here: the figure the worker derived, which is
+/// the whole chain — the supervisor filling the slot in as it writes the request, and the worker
+/// turning it into a walk deadline. The query itself is allowed to fail (the sample dump has no
+/// symbols for the pool layout on a CI machine, and resolving them is the live tier's job); the
+/// budget is computed and logged before any of that is attempted.
+#[test]
+fn a_pool_walk_takes_this_servers_deadline_not_the_walkers_default() {
+    let Some(dump) = target_tier() else { return };
+    // 60s of call budget: enough that the 15s headroom leaves a distinctive 45s, and short enough
+    // that taking the walker's 120s default would be the bug this pins — a walk outliving its
+    // caller.
+    let mut server = Server::started_with(&[
+        ("WINDBG_MCP_CALL_TIMEOUT_SECS", "60"),
+        ("RUST_LOG", "windbg_mcp=debug"),
+    ]);
+    let session =
+        session_id_of(&server.tool_text("open_dump", json!({ "path": dump }), TARGET_STEP));
+
+    // Not `tool_text`: whether the walk itself succeeds depends on symbols this tier does not
+    // require, and the budget is derived before the first pool page is read either way.
+    let _ = server.call_tool(
+        "pool_census",
+        json!({ "session_id": session, "refresh": true }),
+        TARGET_STEP,
+    );
+
+    assert!(
+        server.wait_for_stderr("pool walk budget", Duration::from_secs(20)),
+        "the worker logged no walk budget at all, so the query reached the walker without one \
+         and took its 120s default:\n--- stderr ---\n{}",
+        server.stderr()
+    );
+    let log = server.stderr();
+    let budget = log
+        .lines()
+        .find_map(|line| line.split("pool walk budget ").nth(1))
+        .and_then(|rest| rest.split_whitespace().next())
+        .unwrap_or_else(|| panic!("no budget on the line that carries it:\n{log}"));
+    // A range, not the exact figure: the patience the supervisor sends is what is left of the 60s
+    // when the request is *written*, so the milliseconds already spent come off it. Wide enough to
+    // ignore those, narrow enough that neither the 15s floor nor the walker's 120s default is
+    // inside it. Parsed from `Duration`'s own rendering, so a budget in milliseconds or
+    // microseconds fails to parse rather than passing as a small number of seconds.
+    let seconds: f64 = budget
+        .strip_suffix('s')
+        .and_then(|n| n.parse().ok())
+        .unwrap_or_else(|| panic!("`{budget}` is not a whole-seconds walk budget"));
+    assert!(
+        (40.0..=46.0).contains(&seconds),
+        "the worker derived a {seconds}s walk budget; the 60s call timeout less the 15s headroom \
+         the reply needs is ~45s. 120s means the walker's default, 15s means no patience arrived."
+    );
+    server.tool_text("end_session", json!({ "session_id": session }), TARGET_STEP);
+}
+
+/// The interrupt, end to end: a command that would run for hours is stopped **on request**, the
+/// call that started it gets its partial output back as a result, and the session takes the next
+/// call at once.
+///
+/// This is the only place the whole mechanism exists. win-kexp proves `SetInterrupt` reaches a
+/// running command; what is unproven there is everything that makes it usable from a client — that
+/// the interrupt travels on the session's queue and is *answered by the worker's request reader*
+/// rather than queued behind the very operation it means to stop, and that the binding to the
+/// running job survives the round trip. Queue it like an ordinary op and every assertion below
+/// still passes except the one that matters: the interrupt would be read after the command ended.
+///
+/// Fast by construction — the interrupt lands in milliseconds, so this stays in the tier that runs
+/// on a `WINDBG_MCP_SMOKE_DUMP=1` push rather than in the ignored one that waits out deadlines. It
+/// borrows that tier's runaway helpers (below) because the probe is the same: a `.for` that polls
+/// for the break and leaves its progress in `$t0`.
+#[test]
+fn a_running_command_is_interrupted_on_request_and_frees_its_session() {
+    let Some(dump) = target_tier() else { return };
+    // A short call budget so a failure fails *fast*: if the interrupt never lands, the watchdog
+    // ends the runaway at the 15s floor and the assertions below say so, instead of this test
+    // sitting out five minutes of the default timeout.
+    let mut server = Server::started_with(&[("WINDBG_MCP_CALL_TIMEOUT_SECS", "30")]);
+    let session =
+        session_id_of(&server.tool_text("open_dump", json!({ "path": dump }), TARGET_STEP));
+
+    // An idle session says so and does nothing. Deterministic: the open above has been answered
+    // and nothing else is outstanding.
+    let idle = server.tool_text(
+        "interrupt",
+        json!({ "session_id": session }),
+        Duration::from_secs(20),
+    );
+    assert!(
+        idle.contains("Nothing was running"),
+        "an idle session has nothing to interrupt, and should say so rather than raise a break \
+         the next call would wear:\n{idle}"
+    );
+
+    // Now the real thing. Sent without waiting, because the interrupt has to reach a session that
+    // is *busy* — which is the arrangement the whole design is about.
+    let started = Instant::now();
+    let runaway = server.send_request(
+        "tools/call",
+        json!({
+            "name": "execute",
+            "arguments": { "command": runaway_command("$t0"), "session_id": session },
+        }),
+    );
+
+    // Retried until it reports it reached something, rather than sent once after a sleep: the
+    // command is queued the instant the request is written, but the worker claims it a moment
+    // later, and an interrupt that arrives in that gap correctly binds to nothing. Racing it is
+    // the test's problem, not the server's.
+    let interrupt_deadline = Instant::now() + Duration::from_secs(10);
+    let raised = loop {
+        std::thread::sleep(Duration::from_millis(100));
+        let reply = server.tool_text(
+            "interrupt",
+            json!({ "session_id": session }),
+            Duration::from_secs(20),
+        );
+        if reply.contains("Interrupted") {
+            break reply;
+        }
+        assert!(
+            Instant::now() < interrupt_deadline,
+            "10s of interrupts all found the session idle while a command that runs for hours was \
+             outstanding — the interrupt is being queued behind it instead of answered by the \
+             reader:\n{reply}"
+        );
+    };
+    // The interrupt answers while the command it stopped is still outstanding. That is the part
+    // that cannot be true if the request is queued.
+    assert!(
+        raised.contains("Ctrl+Break"),
+        "the interrupt should say what it did:\n{raised}"
+    );
+
+    let response = server.await_id(runaway, "the interrupted command", Duration::from_secs(60));
+    let elapsed = started.elapsed();
+    assert_no_error(&response, "an interrupted command");
+    let out = text_of(&response["result"]);
+    assert!(
+        !is_tool_error(&response),
+        "an interrupted command must come back as a result carrying what it reached, not as a \
+         failure — the interrupt is not an error condition ({elapsed:?}):\n{out}"
+    );
+    assert!(
+        out.contains("interrupted on request"),
+        "the caller of the interrupted command is the one who cannot otherwise know why their \
+         result is short, so it has to say:\n{out}"
+    );
+    // The watchdog's floor is 15s (30s call budget less the headroom), so anything under that
+    // could only have been the request. Without this the test would pass on a run where the
+    // interrupt did nothing and the deadline did all the work.
+    assert!(
+        elapsed < Duration::from_secs(14),
+        "the command took {elapsed:?}, which is the watchdog's floor rather than the interrupt — \
+         this run proves nothing about the request path"
+    );
+    assert!(
+        !out.contains("interrupted after"),
+        "and it carries the watchdog's note, so it was the deadline that ended it:\n{out}"
+    );
+
+    // Proof it was cut short rather than having finished: the loop counter, as in the bounded
+    // tier. A note alone would be produced by an interrupt the engine ignored.
+    let counter = server.tool_text(
+        "execute",
+        json!({ "command": "r $t0", "session_id": session }),
+        TARGET_STEP,
+    );
+    let t0 = pseudo_register(&counter, "$t0")
+        .unwrap_or_else(|| panic!("could not read $t0 back from:\n{counter}"));
+    println!("interrupted after {elapsed:?}, $t0 = {t0:#x} of {RUNAWAY_ITERATIONS:#x}");
+    assert!(t0 > 0, "the loop never started ($t0 = {t0:#x})");
+    assert!(
+        t0 < RUNAWAY_ITERATIONS,
+        "the loop ran to completion ($t0 = {t0:#x}) — nothing cut it short"
+    );
+
+    // And the session is genuinely free, not merely answering: `r $t0` above already ran on it,
+    // and this is the call that would have been aborted had the break been left pending.
+    let after = server.call_tool("modules", json!({ "session_id": session }), TARGET_STEP);
+    assert!(
+        !is_tool_error(&after),
+        "the session was not usable after the interrupt:\n{}",
+        text_of(&after["result"])
+    );
+    server.tool_text("end_session", json!({ "session_id": session }), TARGET_STEP);
+}
+
 // ---- tier 3: the bounded-command path -----------------------------------------
 //
 // These deliberately run a command that would take hours and wait for a watchdog to cut it short,

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -1338,6 +1338,118 @@ fn ending_a_session_stops_a_running_batch_and_rolls_it_back() {
     let _ = std::fs::remove_file(&running);
 }
 
+/// `interrupt` on a session that is running a batch: the batch stops at its next step, rolls back,
+/// and reports `BATCH: INTERRUPTED` — while the **session stays open**, which is what separates it
+/// from the `end_session` case above.
+///
+/// The bug this pins is one an interrupt *created*. An on-request interrupt deliberately returns the
+/// output the command reached rather than the error the break provoked — that is what makes partial
+/// output survivable — so the interrupted step comes back `Ok`, its assertions still hold, and the
+/// batch executor sees a step that ran. Without being told separately it carried straight on into
+/// the next mutation, for a caller who had just asked it to stop. `src/batch.rs` pins the executor's
+/// half against a scripted debuggee; only here is the whole path real, because only a real engine
+/// turns a Ctrl+Break into that deceptively successful step.
+#[test]
+fn interrupting_a_running_batch_stops_it_and_rolls_it_back() {
+    let Some(dump) = target_tier() else { return };
+    let running = marker_path("interrupt-batch-running");
+    let reached_later = marker_path("interrupt-batch-later-step");
+    let _ = std::fs::remove_file(&running);
+    let _ = std::fs::remove_file(&reached_later);
+
+    let mut server = Server::started();
+    let response = server.call_tool("open_dump", json!({ "path": dump }), TARGET_STEP);
+    assert_no_error(&response, "open_dump");
+    let session_id = session_id_of(&text_of(&response["result"]));
+
+    // Announce that the batch is inside its steps, spend long enough to be interrupted, and then —
+    // the assertion that matters — write a second marker. A batch that carries on past the
+    // interrupt reaches that step; one that stops does not, and the file is the evidence either
+    // way, independent of what the report says about itself.
+    let mut steps = vec![
+        json!({ "op": "command", "command": format!(".logopen \"{}\"", running.display()) }),
+        json!({ "op": "command", "command": ".echo BATCH-RUNNING" }),
+        json!({ "op": "command", "command": ".logclose" }),
+    ];
+    steps.extend(std::iter::repeat_n(
+        json!({ "op": "command", "command": ".sleep 1000" }),
+        20,
+    ));
+    steps.extend([
+        json!({ "op": "command", "command": format!(".logopen \"{}\"", reached_later.display()) }),
+        json!({ "op": "command", "command": ".echo REACHED-A-LATER-STEP" }),
+        json!({ "op": "command", "command": ".logclose" }),
+    ]);
+    let batch = server.send_request(
+        "tools/call",
+        json!({
+            "name": "debug_batch",
+            "arguments": {
+                "session_id": session_id,
+                "steps": steps,
+                "always": [{ "op": "command", "command": "version", "name": "cleanup" }],
+            }
+        }),
+    );
+
+    // Wait for the batch to be demonstrably inside its steps, as the teardown tests do: timed with
+    // a sleep instead, a slow machine would interrupt before the batch started and take the
+    // refuse-to-start path, passing just as green.
+    let deadline = Instant::now() + TARGET_STEP;
+    while !running.exists() {
+        assert!(
+            Instant::now() < deadline,
+            "the batch never reached its first step\n--- stderr ---\n{}",
+            server.stderr()
+        );
+        std::thread::sleep(Duration::from_millis(100));
+    }
+
+    let raised = server.tool_text(
+        "interrupt",
+        json!({ "session_id": session_id }),
+        Duration::from_secs(20),
+    );
+    assert!(
+        raised.contains("Interrupted"),
+        "the batch was running, so the interrupt should have reached it:\n{raised}"
+    );
+
+    let report = text_of(&server.await_id(batch, "debug_batch", TARGET_STEP)["result"]);
+    assert!(
+        report.contains("BATCH: INTERRUPTED"),
+        "an interrupted batch should say so — not COMMITTED, which is what it reported while the \
+         interrupt was invisible to the executor, and not ABANDONED, which would send the caller \
+         to a new session:\n{report}"
+    );
+    assert!(
+        report.contains("rollback: COMPLETE"),
+        "the rollback runs on this path like every other:\n{report}"
+    );
+    assert!(
+        !reached_later.exists(),
+        "the batch ran a step *after* the interrupt — the executor was never told, so it treated \
+         the interrupted step as one that simply succeeded:\n{report}"
+    );
+
+    // And the session is still open, which is the whole difference from `end_session`: the same
+    // batch can be resubmitted against it.
+    let after = server.call_tool("modules", json!({ "session_id": session_id }), TARGET_STEP);
+    assert!(
+        !is_tool_error(&after),
+        "interrupting a batch must not cost the session:\n{}",
+        text_of(&after["result"])
+    );
+    server.tool_text(
+        "end_session",
+        json!({ "session_id": session_id }),
+        TARGET_STEP,
+    );
+
+    let _ = std::fs::remove_file(&running);
+    let _ = std::fs::remove_file(&reached_later);
+}
+
 /// A batch still running when the client disconnects has to finish its rollback before its worker
 /// goes — the one guarantee `debug_batch` used to make only against a call *timeout*.
 ///

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -1932,6 +1932,61 @@ fn a_pool_walk_takes_this_servers_deadline_not_the_walkers_default() {
     server.tool_text("end_session", json!({ "session_id": session }), TARGET_STEP);
 }
 
+/// A pool query with no time left to walk in is **refused**, not floored to a headroom and run for
+/// a caller who has already gone.
+///
+/// The budget borrowed the bounded command's floor at first, which is right *there* — zero disables
+/// that watchdog, so an unbounded command is the worse outcome — and wrong here, where zero merely
+/// stops the walk at its first check. Floored, a 10s call budget bought a 15s walk: #75's own
+/// complaint at the small end. And it bought nothing for it, since win-kexp caches complete
+/// snapshots only, so the truncated result is discarded and the next query walks from scratch
+/// regardless.
+///
+/// A 10s call budget is entirely reply headroom, so this needs no queue wait to stage — which is
+/// what keeps it in the tier that runs on a push. The open has to land inside that budget too; if
+/// it does not, the test skips rather than reporting a failure about the wrong thing.
+#[test]
+fn a_pool_query_with_no_time_to_walk_is_refused_rather_than_run() {
+    let Some(dump) = target_tier() else { return };
+    let mut server = Server::started_with(&[("WINDBG_MCP_CALL_TIMEOUT_SECS", "10")]);
+
+    let opened = server.call_tool("open_dump", json!({ "path": dump }), TARGET_STEP);
+    assert_no_error(&opened, "open_dump");
+    if is_tool_error(&opened) {
+        skip("the sample dump did not open inside a 10s call budget on this machine");
+        return;
+    }
+    let session = session_id_of(&text_of(&opened["result"]));
+
+    // `refresh`, so the cached snapshot cannot answer it and a walk is unavoidable.
+    let response = server.call_tool(
+        "pool_census",
+        json!({ "session_id": session, "refresh": true }),
+        TARGET_STEP,
+    );
+    assert_no_error(&response, "pool_census with no walk budget");
+    let text = text_of(&response["result"]);
+    assert!(
+        is_tool_error(&response) && text.contains("was not run"),
+        "a pool query that must walk, reaching the engine with no time to walk in, should be \
+         refused with an explanation naming the call timeout — not floored to a headroom and run \
+         for nobody:\n{text}"
+    );
+    assert!(
+        text.contains("WINDBG_MCP_CALL_TIMEOUT_SECS"),
+        "and the refusal has to name the knob that fixes it:\n{text}"
+    );
+
+    // The session is untouched by the refusal — nothing was read, so nothing is in a odd state.
+    let after = server.call_tool("modules", json!({ "session_id": session }), TARGET_STEP);
+    assert!(
+        !is_tool_error(&after),
+        "the session should be unaffected by a refused query:\n{}",
+        text_of(&after["result"])
+    );
+    server.tool_text("end_session", json!({ "session_id": session }), TARGET_STEP);
+}
+
 /// The interrupt, end to end: a command that would run for hours is stopped **on request**, the
 /// call that started it gets its partial output back as a result, and the session takes the next
 /// call at once.

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -1450,6 +1450,102 @@ fn interrupting_a_running_batch_stops_it_and_rolls_it_back() {
     let _ = std::fs::remove_file(&reached_later);
 }
 
+/// An `interrupt` that arrives while a batch is running its **rollback** is refused, and the
+/// rollback finishes.
+///
+/// The severe half of the same problem. Cleanup is reached on every path, including paths no
+/// interrupt was involved in, so this needs no earlier interrupt to set it up — a *first* break
+/// landing here would hit a restore command, and an interrupted command returns `Ok` with whatever
+/// it had produced. The restore would then be recorded as a step that worked and the report would
+/// say `rollback: COMPLETE` with the target still changed, which is the one outcome the whole
+/// transaction machinery exists to prevent, arriving through the tool meant to be the gentle way
+/// out.
+///
+/// Staged with markers rather than timing, like the teardown tests: the first cleanup step
+/// announces that the rollback has begun, and the last one records that it finished. Interrupting
+/// on a sleep instead would sometimes land in the steps block and pass for the wrong reason.
+#[test]
+fn interrupting_a_batch_during_its_rollback_is_refused() {
+    let Some(dump) = target_tier() else { return };
+    let unwinding = marker_path("interrupt-batch-unwinding");
+    let unwound = marker_path("interrupt-batch-unwound");
+    let _ = std::fs::remove_file(&unwinding);
+    let _ = std::fs::remove_file(&unwound);
+
+    let mut server = Server::started();
+    let response = server.call_tool("open_dump", json!({ "path": dump }), TARGET_STEP);
+    assert_no_error(&response, "open_dump");
+    let session_id = session_id_of(&text_of(&response["result"]));
+
+    let batch = server.send_request(
+        "tools/call",
+        json!({
+            "name": "debug_batch",
+            "arguments": {
+                "session_id": session_id,
+                "steps": [{ "op": "command", "command": "version" }],
+                "always": [
+                    { "op": "command", "command": format!(".logopen \"{}\"", unwinding.display()) },
+                    { "op": "command", "command": ".echo ROLLBACK-RUNNING" },
+                    { "op": "command", "command": ".logclose" },
+                    // The window the interrupt has to land in.
+                    { "op": "command", "command": ".sleep 0n5000" },
+                    { "op": "command", "command": format!(".logopen \"{}\"", unwound.display()) },
+                    { "op": "command", "command": ".echo ROLLBACK-FINISHED" },
+                    { "op": "command", "command": ".logclose" },
+                ],
+            }
+        }),
+    );
+
+    let deadline = Instant::now() + TARGET_STEP;
+    while !unwinding.exists() {
+        assert!(
+            Instant::now() < deadline,
+            "the batch never reached its rollback\n--- stderr ---\n{}",
+            server.stderr()
+        );
+        std::thread::sleep(Duration::from_millis(100));
+    }
+
+    let refused = server.tool_text(
+        "interrupt",
+        json!({ "session_id": session_id }),
+        Duration::from_secs(20),
+    );
+    assert!(
+        refused.contains("Not interrupted"),
+        "a break must not be raised against a rollback — cleanup cut short reports success:\n{refused}"
+    );
+    assert!(
+        refused.contains("rollback"),
+        "and the refusal has to say why, or it reads as a bug:\n{refused}"
+    );
+
+    let report = text_of(&server.await_id(batch, "debug_batch", TARGET_STEP)["result"]);
+    assert!(
+        report.contains("rollback: COMPLETE"),
+        "the rollback had to finish, which is what refusing the break was for:\n{report}"
+    );
+    assert!(
+        unwound.exists(),
+        "the last cleanup step never ran, so the rollback was cut short after all:\n{report}"
+    );
+    // Nothing was interrupted, so nothing should claim it was.
+    assert!(
+        !report.contains("INTERRUPTED"),
+        "the break was refused, so the batch was not interrupted:\n{report}"
+    );
+
+    server.tool_text(
+        "end_session",
+        json!({ "session_id": session_id }),
+        TARGET_STEP,
+    );
+    let _ = std::fs::remove_file(&unwinding);
+    let _ = std::fs::remove_file(&unwound);
+}
+
 /// A batch still running when the client disconnects has to finish its rollback before its worker
 /// goes — the one guarantee `debug_batch` used to make only against a call *timeout*.
 ///


### PR DESCRIPTION
Two pieces, both about a deadline nobody could reach. FOLLOWUPS item 7 and
[#75](https://github.com/glslang/windbg-mcp/issues/75).

## `interrupt`: stop the operation a session is running, keeping the session

A runaway call had exactly one way out — `end_session`, which ends it by discarding the target it
was running against. On a live kernel that is a machine to re-attach and often a guest to reboot.
This is the graceful one: a Ctrl+Break, exactly as at a WinDbg prompt. The interrupted operation
ends at the debugger's next poll and returns **whatever it had reached to the call that started
it**, marked as cut short, and the session takes the next call at once.

**The part that needed designing is that `SetInterrupt` addresses an *engine*, not an operation.**
Raised a moment late it stops whatever started next — a caller's `go` aborted by a cancel meant for
the search before it, with nothing in the record to say why. The worker now tracks which job its
engine thread is running, and the request reader raises the interrupt under the same lock the engine
thread claims and releases that job under. So an interrupt reaches the job that was running when it
arrived or nothing at all, and the job it reached *spends* it: any break the engine did not consume
is drained before the next job starts, and only that caller's reply is marked. That is a rare
accident today and the *normal* case under tasks (FOLLOWUPS item 8), which is why it was built now
rather than deferred with it.

Like the abandon-a-batch signal, the request is **answered by the worker's request reader** rather
than queued for its engine thread — queued, it could only ever be read once there was nothing left
to interrupt. So it does not wait behind the busy session.

**win-kexp** ([glslang/win-kexp@65d8ec3](https://github.com/glslang/win-kexp/commit/65d8ec3), on
`main`, pin bumped here) makes `InterruptHandle` public, `Send + Sync`, and holds an owned
`IDebugControl4` rather than a borrowed pointer — a handle a host can keep can outlive the engine it
came from. The less obvious half: the handle and the engine share a "raised" flag, so
`execute_command_bounded` can tell an aborted `Execute` from a failed one *without* being the thread
that asked. Without it an interrupt on request is a `CommandFailed` that discards every line the
command had already produced, which on an interrupted search is the whole of what it was going to
say. No note is appended for a requested interrupt, unlike the watchdog's: that one explains a
deadline nobody saw pass, whereas this caller is the one who asked.

**Unchanged, and now said out loud in the tool:** an `attach_kernel` whose target has not connected
is not reachable this way — `SetInterrupt` cannot reach that wait — and neither is an operation that
never polls. `end_session` remains the answer to those. Dropping a *queued* job is deliberately not
built: nothing can name one (a tool call names a session), so that variant belongs with
`tasks/cancel`.

## The pool tools take this server's deadline, not the walker's default (#75)

A pool walk bounds itself now, but the tools took win-kexp's **default** — 120s, which knows nothing
about our call budget, and was wrong in both directions. Under `WINDBG_MCP_CALL_TIMEOUT_SECS=60` the
call timed out and the engine kept walking, which is precisely the wedge the walk budget exists to
prevent, arriving from this side; under the 300s default the walk stopped at 120s and handed back a
partial snapshot with three minutes still to spend.

`EngineOp::Pool` now carries the caller's remaining patience the way `BoundedCommand` and `Batch`
do — filled in by the supervisor's pump as the request is written, with the worker deriving the
deadline, because only the worker knows how long the request then sat in *its* queue. Same
arithmetic, so the same invariant: queue wait plus walk budget never exceeds the caller's patience.

Which ops carry a deadline is now named on `EngineOp` itself rather than matched inside the pump,
because that omission is silent — it is exactly how `Pool` came to have none — and a test checks the
accessor against the serialized form, so an op with a `patience_ms` that does not hand it out fails
rather than shipping with an unset deadline.

## Verification

Against a real engine, not only in arithmetic.

- **win-kexp** `test_command_interrupted_on_request_keeps_its_output` (live, `#[ignore]`d as that
  family is): a `.for` sized to run for hours, interrupted from another thread, returns `Ok` with
  its partial output and no watchdog note, and leaves the next command unaffected. Measured at
  78,949 of 16,777,216 iterations.
- **Dump tier** (29 tests, ~66s, `WINDBG_MCP_SMOKE_DUMP=1`) gains two:
  - `a_running_command_is_interrupted_on_request_and_frees_its_session` — **203ms**, `$t0` = 0x2508
    of 0x40000000, session usable afterwards. In this tier rather than the ignored one because the
    break lands in milliseconds; the call budget is shrunk to 30s so a *failure* fails fast, and
    anything at the watchdog's 15s floor is asserted against as "the deadline did the work".
  - `a_pool_walk_takes_this_servers_deadline_not_the_walkers_default` — reads the derived budget out
    of the worker's log (44.998s from a 60s call timeout), which is the only place the number is
    observable on a dump, where every budget from 15s to 120s produces the identical answer. That is
    why this shipped wrong: nothing looking at results could have seen it.
- **Unit**: the job binding against a local `Running` (both orderings of the race, staged — which
  against the real one would mean interrupting an engine at an exact instant), the cut-short reply
  shaping, the walk budget in both directions, and the patience-slot agreement.
- **Unmoved**: the bounded-command tier and win-kexp's own `test_next_command_survives_a_bounded_timeout`
  pass unchanged, which is the check that the deadline path did not shift under the shared flag.

Docs: `README.md` (tool table, a section on stopping a slow call, the pool budget), `CHANGELOG.md`,
`DECISIONS.md` (a new entry for the job binding), `FOLLOWUPS.md` (item 7 closed, item 8 told what it
inherits and what it still owes, item 17's open question closed), `docs/smoke-test.md`.

Closes #75.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an `interrupt` tool to stop the active session operation while preserving the session and target.
  - Interrupted operations retain partial output and clearly report interruption.
  - Active batches can be interrupted between steps, with rollback and completed results preserved.

- **Improvements**
  - Pool operations now honour caller, queue and batch-step time budgets.
  - Walks refuse to start when insufficient time remains.
  - Interrupted sessions remain available for subsequent commands.

- **Documentation**
  - Added guidance on interruption behaviour, limitations, deadlines and smoke-test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->