### PR TITLE
Return typed results beside the text (closes #84)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Typed results: `structuredContent` and `outputSchema` for the session, execution, register,
+  module, breakpoint and pool tools** ([#84](https://github.com/glslang/windbg-mcp/issues/84)).
+
+  Every tool answered in prose, so anything driving this server programmatically had to parse it.
+  The MessageManager batch client and its regression test matched on `VERDICT: HIT`, on
+  `allocation(s)`, on module-name substrings and on the exact spelling of the `session_id:` line —
+  which means a rewording here broke automation there without any debugger behaviour changing at
+  all. Twenty-two tools now return the same text **and** a typed result beside it, with a schema in
+  `tools/list` describing it. The text is unchanged: this adds a channel rather than replacing one.
+
+  What is typed, and why each one earns it: an opener's `session_id` (previously recoverable only
+  by finding a line in the report) and, when an open fails, **whether a target was created** — the
+  field that decides whether opening again is a recovery or a second attach; `session_status`'s
+  per-session `state`, with `waits_indefinitely` and `overdue` for the attach that can park for
+  ever; `end_session`'s `released` / `worker_terminated`; `run_to_address`'s verdict; where a
+  `go`/step left the target; the register set and the module list as records; the breakpoint a
+  `bp` just set, which prints *nothing at all* on success; and the four pool answers.
+
+  **One address representation**, documented once and used everywhere: a `0x`-prefixed, lowercase,
+  16-digit zero-padded hex string. A string because a `u64` past 2^53 does not survive a JSON
+  parser that reads numbers as doubles, and zero-padded so lexical order matches numeric order.
+
+  **A pool answer now says what its walk covered** — `complete`, `deadline_truncated` or `partial`
+  — because those need opposite responses and "incomplete" alone cannot tell them apart: more time
+  reaches more of the pool in the first case and changes nothing in the second. A walk that failed
+  or was interrupted is not a coverage state but an error, and an *interrupted* one no longer
+  reports itself as a debugger failure.
+
+  **Failures carry a category** (`invalid_argument`, `debugger`, `timeout`, `interrupted`,
+  `not_run`, `stale_session`, `worker_lost`, `capacity`) in the error branch of the same schema, so
+  a caller branches on a value rather than on wording. `not_run` is new information rather than a
+  renaming: a pool query refused for want of budget never touched the target, which is the opposite
+  of `timeout`, where the work may well still be running.
+
+  Nothing here is parsed out of debugger output. Each value is built from a value — which is why
+  `win-kexp` grew typed `register_values`, `modules` and `breakpoints` readers, and why its pool
+  walk now reports *why* it stopped rather than only that it did. Where the answer is the
+  supervisor's rather than the engine's, it is built from the session registry, not from the
+  sentence describing it.
+
 - **`interrupt`: stop the operation a session is running, keeping the session and its target**
   (FOLLOWUPS item 7).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `allocation(s)`, on module-name substrings and on the exact spelling of the `session_id:` line —
   which means a rewording here broke automation there without any debugger behaviour changing at
   all. Twenty-two tools now return the same text **and** a typed result beside it, with a schema in
-  `tools/list` describing it. The text is unchanged: this adds a channel rather than replacing one.
+  `tools/list` describing it. The text is unchanged with one exception, which is an improvement
+  rather than a break: a successful `bp` prints nothing at all, so `set_breakpoint` used to answer
+  with an empty string and now renders the breakpoints the session holds beneath the command's own
+  (usually empty) output.
 
   What is typed, and why each one earns it: an opener's `session_id` (previously recoverable only
   by finding a line in the report) and, when an open fails, **whether a target was created** — the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,10 +47,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   of `timeout`, where the work may well still be running.
 
   Nothing here is parsed out of debugger output. Each value is built from a value — which is why
-  `win-kexp` grew typed `register_values`, `modules` and `breakpoints` readers, and why its pool
-  walk now reports *why* it stopped rather than only that it did. Where the answer is the
-  supervisor's rather than the engine's, it is built from the session registry, not from the
-  sentence describing it.
+  `win-kexp` grew typed `register_values`, `modules` and `breakpoints` readers, why its pool walk
+  now reports *why* it stopped rather than only that it did, and why its pool queries hand back
+  the walk their answer came from (`PoolAnswer`) instead of leaving a caller to ask separately:
+  an incomplete walk is deliberately not cached, so the second question could be answered by a
+  *different* walk, and the count and the coverage beside it would then describe two things.
+  Where the answer is the supervisor's rather than the engine's, it is built from the session
+  registry, not from the sentence describing it.
 
 - **`interrupt`: stop the operation a session is running, keeping the session and its target**
   (FOLLOWUPS item 7).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -884,7 +884,7 @@ dependencies = [
 [[package]]
 name = "win-kexp"
 version = "0.1.0"
-source = "git+https://github.com/glslang/win-kexp?branch=main#96444a0dbc25d1966d585e7c4f90f1d640f2e552"
+source = "git+https://github.com/glslang/win-kexp?branch=main#7b0137c22127c16eb07251143592efa4c58a3302"
 dependencies = [
  "byte-strings",
  "goblin",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -884,7 +884,7 @@ dependencies = [
 [[package]]
 name = "win-kexp"
 version = "0.1.0"
-source = "git+https://github.com/glslang/win-kexp?branch=main#13b6b9570179eb5117c226e266b08da61d511738"
+source = "git+https://github.com/glslang/win-kexp?branch=main#96444a0dbc25d1966d585e7c4f90f1d640f2e552"
 dependencies = [
  "byte-strings",
  "goblin",

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -5,6 +5,40 @@ status. Keep entries short; link to code with `file:line` where it helps a futur
 
 ---
 
+## A typed result is a second channel, not a replacement (2026-08-12, issue #84)
+
+**Context.** Every tool answered in prose, so the only way to drive this server programmatically was
+to parse it — `VERDICT: HIT`, `allocation(s)`, the `session_id:` line at the foot of an opener's
+report. A rewording here broke automation elsewhere with no debugger behaviour changing at all.
+
+**Decision.** The tools in #84 return the same text **and** MCP `structuredContent`, with an
+`outputSchema` in `tools/list`. The text is byte-for-byte what it was: adding a channel, not
+migrating one. A tool with no typed shape yet carries none, and is untouched.
+
+**One schema covers both outcomes.** Every result is internally tagged on `status` (`"ok"` /
+`"error"`), so a failure conforms to the same schema a success does. The alternative — structured
+content on success only — leaves the one question a caller most needs answered ("did this work?")
+readable only in prose, and risks a client that validates results rejecting the failure case.
+Failures carry a coarse `ErrorCategory`; the categories are the distinctions that change what a
+caller *does*, because one nobody can act on differently will drift.
+
+**Values are built where the values are, never re-derived from a rendering** — the same rule as
+#77, pointed at results. The worker builds its half from win-kexp types while it still holds them
+(`crate::structured`, carried over the pipe by `proto::Output`); the supervisor builds the session
+answers from its own registry. Where a value did not exist upstream it was added there first, which
+is why win-kexp grew `register_values`, `modules`, `breakpoints`, and a pool walk that reports *why*
+it stopped rather than only that it did.
+
+**Addresses are strings, in one form.** `0x`-prefixed, lowercase, 16-digit zero-padded. A JSON
+number cannot hold a kernel pointer past 2^53 through a parser that reads numbers as doubles, and
+fixed width means lexical order matches numeric order. The debugger's backtick form stays in the
+text, where it belongs.
+
+**Status.** Done for the twenty-two tools #84 lists. `reachable_from_dispatch`,
+`driver_object`/`device_object` and the TTD query tools remain text-only (FOLLOWUPS item 11).
+
+---
+
 ## An interrupt is bound to a job, not to a moment (2026-08-10, FOLLOWUPS item 7)
 
 **Context.** A runaway call had one way out: `end_session`, which ends it by discarding the target.

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -12,8 +12,10 @@ to parse it — `VERDICT: HIT`, `allocation(s)`, the `session_id:` line at the f
 report. A rewording here broke automation elsewhere with no debugger behaviour changing at all.
 
 **Decision.** The tools in #84 return the same text **and** MCP `structuredContent`, with an
-`outputSchema` in `tools/list`. The text is byte-for-byte what it was: adding a channel, not
-migrating one. A tool with no typed shape yet carries none, and is untouched.
+`outputSchema` in `tools/list`. The text is byte-for-byte what it was — adding a channel, not
+migrating one — with one deliberate exception: `set_breakpoint`, whose success case printed the
+empty string, now renders the breakpoints the session holds. A tool with no typed shape yet carries
+none, and is untouched.
 
 **One schema covers both outcomes.** Every result is internally tagged on `status` (`"ok"` /
 `"error"`), so a failure conforms to the same schema a success does. The alternative — structured

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -280,6 +280,12 @@ iframe host.
   (events on a trace-position axis).
 - **Cheaper alternative, if those three ever need it:** `structuredContent` + `outputSchema`. Same
   data, lossless to the model, works in every client, no UI runtime. Do that before any HTML.
+- **Since done, for a different set of tools** ([#84](https://github.com/glslang/windbg-mcp/issues/84),
+  DECISIONS 2026-08-12): sessions, execution control, registers, modules, breakpoints and the pool
+  answers now carry both channels. The three outputs named above are *not* among them and are still
+  text — they are the ones whose structure is a graph or a tree rather than a record, which is the
+  same reason they were the candidates for Apps. The plumbing they would need now exists
+  (`src/structured.rs`, `proto::Output`), so the remaining work is their shapes, not the seam.
 
 ## 12. [win-kexp] Validate the opener split against a live KDNET target
 

--- a/README.md
+++ b/README.md
@@ -500,7 +500,7 @@ matching `outputSchema` in `tools/list`, so a program can read a field instead o
 | `open_dump`, `open_trace`, `attach_kernel`, `attach_kernel_local`, `attach_process`, `launch` | `session_id`, `kind`, `target`, `report` — and on failure, whether a target was created (`target: no \| yes \| pending`), which is what decides whether opening again is a recovery or a second attach |
 | `session_status` | each session's `state` (`opening`/`attaching`/`open`/`failed`/`retired`/`closed`), `engine_pid`, `in_state_for_ms`, and — for an attach — `waits_indefinitely` and `overdue` |
 | `end_session` | `released`, `worker_terminated`, `waited_ms` |
-| `registers` | `registers[]` as `{name, kind, …}` plus `instruction_pointer` — `kind: int` and `kind: float` carry `value`, `kind: bytes` carries `bytes` (an x87 or vector register, which no number holds), `kind: unavailable` carries neither; pass `all: true` for the x87/vector registers and subregister views |
+| `registers` | `registers[]` as `{name, kind, …}` plus `instruction_pointer` — `kind: int` and `kind: float` carry `value`, `kind: bytes` carries `bytes` (an x87 or vector register, which no number holds), `kind: non_finite` names a NaN or infinity that JSON has no literal for and carries its bits, `kind: unavailable` carries neither; pass `all: true` for the x87/vector registers and subregister views |
 | `modules` | `modules[]` with `start`/`end`, `size` and a typed `symbols` state (`deferred` is *not* `none`) |
 | `set_breakpoint` | the ids this call `added`, and every breakpoint now set — a successful `bp` prints nothing at all |
 | `run_to_address` | `verdict` (`hit`/`stopped_elsewhere`/`timeout`), `target`, `stopped_at` |

--- a/README.md
+++ b/README.md
@@ -489,6 +489,37 @@ Four honest limits, none of them hidden in the report:
   of long steps stops at the end of the current one rather than where it stands — and it cannot undo
   what the batch never recorded, since `always` is still the only thing that puts anything back.
 
+### Structured results
+
+Every tool returns the same readable text it always has. The tools below **also** return MCP
+[`structuredContent`](https://modelcontextprotocol.io/specification/2025-06-18/server/tools), with a
+matching `outputSchema` in `tools/list`, so a program can read a field instead of parsing prose:
+
+| Tool | Typed answer |
+|------|--------------|
+| `open_dump`, `open_trace`, `attach_kernel`, `attach_kernel_local`, `attach_process`, `launch` | `session_id`, `kind`, `target`, `report` — and on failure, whether a target was created (`target: no \| yes \| pending`), which is what decides whether opening again is a recovery or a second attach |
+| `session_status` | each session's `state` (`opening`/`attaching`/`open`/`failed`/`retired`/`closed`), `engine_pid`, `in_state_for_ms`, and — for an attach — `waits_indefinitely` and `overdue` |
+| `end_session` | `released`, `worker_terminated`, `waited_ms` |
+| `registers` | `registers[]` as `{name, kind, value}` plus `instruction_pointer`; pass `all: true` for the x87/vector registers and subregister views |
+| `modules` | `modules[]` with `start`/`end`, `size` and a typed `symbols` state (`deferred` is *not* `none`) |
+| `set_breakpoint` | the ids this call `added`, and every breakpoint now set — a successful `bp` prints nothing at all |
+| `run_to_address` | `verdict` (`hit`/`stopped_elsewhere`/`timeout`), `target`, `stopped_at` |
+| `go`, `step_over`, `step_into`, `step_back`, `step_over_back`, `reverse_go` | `stopped_at` |
+| `pool_find_tag`, `pool_chunk`, `pool_census`, `pool_diagnostics` | the chunks/totals/diagnostics as values, each carrying the `walk` behind them |
+
+Two conventions hold across all of them:
+
+- **One address representation.** Every address, and every register-sized value, is a `0x`-prefixed,
+  lowercase, 16-digit zero-padded hex **string** — `"0xfffff8031ab10000"`. A string because a `u64`
+  past 2^53 does not survive a JSON parser that reads numbers as doubles; zero-padded so lexical
+  order matches numeric order. The debugger's backtick form (``fffff803`1ab10000``) appears only in
+  the text.
+- **A pool answer says what the walk covered.** `walk.coverage` is `complete`, `deadline_truncated`
+  (the call's budget ran out — more time reaches more of the pool) or `partial` (unreadable regions
+  or a traversal cap — more time changes nothing). Counts from anything but `complete` are floors,
+  not totals. A walk that failed outright, or was stopped by `interrupt`, is not a coverage state at
+  all: it is the error branch below, with category `debugger` or `interrupted`.
+
 ### Error reporting
 
 Anything scoped to a session comes back as a normal tool result with `isError: true` and the text
@@ -496,6 +527,13 @@ intact, so the model can read it and correct itself: a failed *debugger operatio
 symbol, an unreadable address, a target that never stopped), a refused handle, a timeout, a session
 whose worker is gone. Each has a next move. The only JSON-RPC protocol error is the one failure that
 is the server's rather than a session's — no engine worker could be started at all.
+
+For the tools listed above, a failure also carries structured content — the `error` branch of the
+same output schema — so a caller can branch on a stable category instead of on wording:
+`invalid_argument`, `debugger`, `timeout`, `interrupted`, `not_run` (the work never started, so
+nothing changed — unlike `timeout`, where it may still be running), `stale_session`, `worker_lost`,
+`capacity`. Both branches carry a `status` discriminator (`"ok"` / `"error"`), which is what lets one
+schema describe a result whichever way it went.
 
 The forward (`go`/`step_over`/`step_into`) and reverse (`reverse_go`/`step_over_back`/`step_back`)
 control tools mirror a debugger UI's F9/F8/F7 and Shift+F9/F8/F7, so an agent can drive a trace in

--- a/README.md
+++ b/README.md
@@ -500,7 +500,7 @@ matching `outputSchema` in `tools/list`, so a program can read a field instead o
 | `open_dump`, `open_trace`, `attach_kernel`, `attach_kernel_local`, `attach_process`, `launch` | `session_id`, `kind`, `target`, `report` — and on failure, whether a target was created (`target: no \| yes \| pending`), which is what decides whether opening again is a recovery or a second attach |
 | `session_status` | each session's `state` (`opening`/`attaching`/`open`/`failed`/`retired`/`closed`), `engine_pid`, `in_state_for_ms`, and — for an attach — `waits_indefinitely` and `overdue` |
 | `end_session` | `released`, `worker_terminated`, `waited_ms` |
-| `registers` | `registers[]` as `{name, kind, value}` plus `instruction_pointer`; pass `all: true` for the x87/vector registers and subregister views |
+| `registers` | `registers[]` as `{name, kind, …}` plus `instruction_pointer` — `kind: int` and `kind: float` carry `value`, `kind: bytes` carries `bytes` (an x87 or vector register, which no number holds), `kind: unavailable` carries neither; pass `all: true` for the x87/vector registers and subregister views |
 | `modules` | `modules[]` with `start`/`end`, `size` and a typed `symbols` state (`deferred` is *not* `none`) |
 | `set_breakpoint` | the ids this call `added`, and every breakpoint now set — a successful `bp` prints nothing at all |
 | `run_to_address` | `verdict` (`hit`/`stopped_elsewhere`/`timeout`), `target`, `stopped_at` |

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -59,10 +59,12 @@ suppress it — not ship an advertisement clients will call into a dead end.
 **Tool surface golden.** `tests/golden/tools_list.json` records the *structural* `tools/list`
 surface as it appears on the wire: JSON Schema dialect, `$defs` usage (`true` since `debug_batch`
 introduced the first nested schema), tool count, and per tool its
-name, title, four behaviour hints, required arguments, and each parameter's type/format/enum. It
-deliberately excludes descriptions, so prose edits do not churn it while a `schemars` dialect
-switch, an `rmcp` annotation-casing change, or an accidental tool rename all land as a readable
-line diff.
+name, title, four behaviour hints, required arguments, each parameter's type/format/enum, and — for
+the tools that declare one — the shape of its `outputSchema`: the dialect, and for each branch of
+the result union its `status` const, the payload type it references, and what that branch requires.
+It deliberately excludes descriptions, so prose edits do not churn it while a `schemars` dialect
+switch, an `rmcp` annotation-casing change, a discriminator that stops being emitted, or an
+accidental tool rename all land as a readable line diff.
 
 Re-record after an *intended* change, and read the diff before committing:
 
@@ -93,6 +95,14 @@ session-handle contract on the wire (a stale handle is refused; the handle stops
 which DbgEng implements only in user mode, so on a kernel dump it must come back as a **tool error
 carrying the engine's message** — not a JSON-RPC error, and not a dead session. Read-only
 throughout, and it needs no symbols, so it runs offline.
+
+Those checks are made against **typed fields** wherever a tool has them (issue #84): the handle is
+read from `structuredContent`, not from a `session_id:` line; `nt` and `hal` are matched as module
+records rather than as the third token of a rendered row, which is what used to break on a column
+shift and name the wrong cause; the stale-handle refusal is checked by its `stale_session` category
+rather than by its wording. A field is a contract; the text beside it is a rendering, and rewording
+it must not fail a test. The one exception is deliberate: `tool_text` still exists and is still used
+where the *rendering* is the thing under test (a batch report, an interrupted call's note).
 
 It also covers process-per-session, which cannot be checked any other way — the claims are about
 processes, so they need real ones:

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -38,7 +38,7 @@ use tokio::sync::{mpsc, oneshot};
 use windows_sys::Win32::Foundation::{HANDLE_FLAG_INHERIT, SetHandleInformation};
 
 use crate::kdconn;
-use crate::proto::{EngineOp, WorkerMessage, WorkerRequest};
+use crate::proto::{EngineOp, Output, WorkerMessage, WorkerRequest};
 use crate::worker::{MESSAGES_FLAG, REQUESTS_FLAG, WORKER_FLAG};
 
 /// How many sessions may be open at once.
@@ -183,6 +183,13 @@ pub enum EngineError {
     /// The worker holding this session is gone — it crashed, or it was terminated to reclaim it.
     /// The session is unrecoverable, but the server is not: opening again gets a fresh worker.
     Lost(String),
+    /// The work was stopped on request. Not a failure of the target, and reported as one for as
+    /// long as the worker could only send a message: somebody asked for this.
+    Interrupted(String),
+    /// The work was never started — too little of the caller's budget was left to do it and
+    /// report back. Distinct from [`Self::Timeout`] in the way that matters: nothing ran, so
+    /// nothing changed, and a retry is unambiguous.
+    NotRun(String),
 }
 
 // Note what is *not* here any more: an "engine is unusable" variant. Under process-per-session
@@ -195,8 +202,27 @@ pub enum EngineError {
 impl fmt::Display for EngineError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::Debugger(m) | Self::Timeout(m) | Self::Stale(m) | Self::Lost(m) => f.write_str(m),
+            Self::Debugger(m)
+            | Self::Timeout(m)
+            | Self::Stale(m)
+            | Self::Lost(m)
+            | Self::Interrupted(m)
+            | Self::NotRun(m) => f.write_str(m),
         }
+    }
+}
+
+/// Lifts a worker's failure into this side's error type, keeping the kind the worker named.
+///
+/// The default is [`EngineError::Debugger`], because for almost every op that is what a failure
+/// is. The two exceptions are the ones the worker can see and the supervisor cannot: an operation
+/// that was interrupted, and one that was never started for want of budget.
+fn engine_error(failed: crate::proto::Failed) -> EngineError {
+    use crate::structured::ErrorCategory;
+    match failed.category {
+        Some(ErrorCategory::Interrupted) => EngineError::Interrupted(failed.message),
+        Some(ErrorCategory::NotRun) => EngineError::NotRun(failed.message),
+        _ => EngineError::Debugger(failed.message),
     }
 }
 
@@ -375,7 +401,7 @@ pub struct Session {
     child: Mutex<Option<Child>>,
 }
 
-type Waiters = Arc<Mutex<HashMap<u64, oneshot::Sender<Result<String, EngineError>>>>>;
+type Waiters = Arc<Mutex<HashMap<u64, oneshot::Sender<Result<Output, EngineError>>>>>;
 
 impl Session {
     fn state(&self) -> SessionState {
@@ -840,7 +866,7 @@ impl Sessions {
     }
 
     /// Runs `call` against `session`, awaiting the result with the configured timeout.
-    pub async fn call(&self, session: &Arc<Session>, call: Call) -> Result<String, EngineError> {
+    pub async fn call(&self, session: &Arc<Session>, call: Call) -> Result<Output, EngineError> {
         self.call_within(session, call, self.call_timeout).await
     }
 
@@ -849,7 +875,7 @@ impl Sessions {
         session: &Arc<Session>,
         call: Call,
         budget: Duration,
-    ) -> Result<String, EngineError> {
+    ) -> Result<Output, EngineError> {
         let id = session.next_id.fetch_add(1, Ordering::Relaxed);
         self.call_as(session, call, budget, id, Wait::Fixed).await
     }
@@ -863,7 +889,7 @@ impl Sessions {
         budget: Duration,
         id: u64,
         wait: Wait,
-    ) -> Result<String, EngineError> {
+    ) -> Result<Output, EngineError> {
         let (tx, rx) = oneshot::channel();
         // Registered before the job is queued, so the session counts as busy from the moment the
         // call is submitted rather than from the moment it is written to the worker.
@@ -900,7 +926,7 @@ impl Sessions {
         let mut rx = rx;
         // The sender is dropped only when the worker's reader gives up on it, which it does by
         // answering first — so `Err` here is the residual case, not the normal one.
-        let settled = |reply: Result<Result<String, EngineError>, oneshot::error::RecvError>| {
+        let settled = |reply: Result<Result<Output, EngineError>, oneshot::error::RecvError>| {
             reply.unwrap_or_else(|_| Err(EngineError::Lost(worker_gone(&session.id))))
         };
         if let Ok(reply) = tokio::time::timeout(budget, &mut rx).await {
@@ -1006,7 +1032,10 @@ impl Sessions {
                 // the overage is more than one. The caller is owed the handle for a target that
                 // is already open.
                 self.reconcile_capacity(&session);
-                Ok(OpenReport { id, report })
+                Ok(OpenReport {
+                    id,
+                    report: report.text,
+                })
             }
             Err(EngineError::Timeout(message)) => Err(OpenError::Timeout { id, message }),
             Err(e) => {
@@ -1076,7 +1105,7 @@ impl Sessions {
         &self,
         session: &Arc<Session>,
         named: bool,
-    ) -> Result<String, EngineError> {
+    ) -> Result<Output, EngineError> {
         let call = Call::new(EngineOp::Interrupt).named(named);
         self.call_within(session, call, INTERRUPT_TIMEOUT).await
     }
@@ -1087,9 +1116,25 @@ impl Sessions {
     /// kernel attach that will never connect cannot answer, cannot be interrupted, and would
     /// otherwise hold its session forever; killing it is the only thing that ends that wait, and
     /// under process-per-session it costs nothing else.
-    pub async fn end(&self, session: &Arc<Session>, named: bool) -> Result<String, EngineError> {
+    pub async fn end(&self, session: &Arc<Session>, named: bool) -> Result<Output, EngineError> {
         let call = Call::new(EngineOp::EndSession).named(named);
-        let (reason, message) = match self.release(session, call, END_SESSION_TIMEOUT).await {
+        let outcome = self.release(session, call, END_SESSION_TIMEOUT).await;
+        // Read before the rendering, from the outcome rather than from the message it produces:
+        // "did the worker let go, or was it killed still holding the target?" is the question a
+        // caller has to act on, and it was previously only answerable by reading which paragraph
+        // came back.
+        let ended = crate::structured::SessionEnded {
+            session_id: session.id.clone(),
+            released: matches!(outcome, Release::Released(_)),
+            worker_terminated: !matches!(outcome, Release::AlreadyGone | Release::Stale(_)),
+            waited_ms: match &outcome {
+                Release::Parked { waited } => {
+                    Some(waited.as_millis().min(u128::from(u64::MAX)) as u64)
+                }
+                _ => None,
+            },
+        };
+        let (reason, message) = match outcome {
             // A refused handle is the mechanism working, not a session to tear down.
             Release::Stale(why) => return Err(EngineError::Stale(why)),
             Release::Released(text) => (
@@ -1140,7 +1185,7 @@ impl Sessions {
             ),
         };
         session.set_state(SessionState::Closed(reason));
-        Ok(message)
+        Ok(Output::typed(message, ended))
     }
 
     /// Asks a worker to release its target and then terminates it, without deciding *why* the
@@ -1184,7 +1229,7 @@ impl Sessions {
         session.fail_outstanding(&format!("session `{}` was ended", session.id));
         session.kill();
         match out {
-            Ok(text) => Release::Released(text),
+            Ok(out) => Release::Released(out.text),
             // Carries what it actually waited, because that is no longer one constant: a session
             // unwinding a transaction is given the extra time it asked for, and a report naming
             // the base grace would understate what was allowed before the worker was terminated.
@@ -1628,7 +1673,7 @@ fn settle_uncommitted(session: &Session, why: &str) -> bool {
 ///
 /// Returns whether the session was left **live**: its worker still holds a target, so it still
 /// owes its slot and capacity has to be reconciled against it.
-fn settle_open(session: &Session, result: &Result<String, EngineError>) -> bool {
+fn settle_open(session: &Session, result: &Result<Output, EngineError>) -> bool {
     // The same discriminator `open` uses, and for the same reason: the *phase* says whether a
     // target was created, while the state may since have been retired by a command queued behind
     // the open.
@@ -2042,7 +2087,7 @@ fn pump(
         let Some(session) = session.upgrade() else {
             return;
         };
-        let answer = |result: Result<String, EngineError>| {
+        let answer = |result: Result<Output, EngineError>| {
             let waiter = waiters
                 .lock()
                 .unwrap_or_else(|e| e.into_inner())
@@ -2154,7 +2199,7 @@ async fn reader(
                 // `Opening` or `Attaching` for the life of the process — `session_status` would
                 // keep reporting an open that finished long ago, and `busy()` would keep the
                 // worker from ever being reclaimed.
-                if let Err(unreceived) = waiter.send(result.map_err(EngineError::Debugger))
+                if let Err(unreceived) = waiter.send(result.map_err(engine_error))
                     && id == OPENER_JOB
                     && settle_open(&session, &unreceived)
                 {
@@ -2799,7 +2844,7 @@ mod tests {
         assert_eq!(committed.state(), SessionState::Open);
 
         let landed = dormant("sess-3", SessionState::Attaching);
-        settle_open(&landed, &Ok("vertarget".into()));
+        settle_open(&landed, &Ok(Output::text("vertarget")));
         assert_eq!(landed.state(), SessionState::Open);
     }
 
@@ -3216,7 +3261,7 @@ mod tests {
     #[test]
     fn settling_never_reopens_a_session_that_is_already_over() {
         let closed = dormant("sess-1", SessionState::Closed("ended".into()));
-        assert!(!settle_open(&closed, &Ok("vertarget".into())));
+        assert!(!settle_open(&closed, &Ok(Output::text("vertarget"))));
         assert_eq!(closed.state(), SessionState::Closed("ended".into()));
     }
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -190,6 +190,11 @@ pub enum EngineError {
     /// report back. Distinct from [`Self::Timeout`] in the way that matters: nothing ran, so
     /// nothing changed, and a retry is unambiguous.
     NotRun(String),
+    /// The **worker** refused the call on its arguments, before the debugger saw them — an
+    /// address that will not parse, say. The same class of mistake this server rejects on its own
+    /// side, and it has to read the same way from both: a caller told "the debugger failed" for a
+    /// malformed argument goes looking at the target.
+    InvalidArgument(String),
 }
 
 // Note what is *not* here any more: an "engine is unusable" variant. Under process-per-session
@@ -207,7 +212,8 @@ impl fmt::Display for EngineError {
             | Self::Stale(m)
             | Self::Lost(m)
             | Self::Interrupted(m)
-            | Self::NotRun(m) => f.write_str(m),
+            | Self::NotRun(m)
+            | Self::InvalidArgument(m) => f.write_str(m),
         }
     }
 }
@@ -215,13 +221,19 @@ impl fmt::Display for EngineError {
 /// Lifts a worker's failure into this side's error type, keeping the kind the worker named.
 ///
 /// The default is [`EngineError::Debugger`], because for almost every op that is what a failure
-/// is. The two exceptions are the ones the worker can see and the supervisor cannot: an operation
-/// that was interrupted, and one that was never started for want of budget.
+/// is. The exceptions are the kinds the worker can tell apart and the supervisor cannot: an
+/// operation that was interrupted, one that was never started for want of budget, and one refused
+/// on its arguments before the debugger ever saw them.
+///
+/// Every named category gets a variant rather than being folded into the default. Folding is how
+/// a category becomes decorative: the worker went to the trouble of saying "this was the caller's
+/// mistake, not the target's", and a `_` arm here quietly restates it as the target's.
 fn engine_error(failed: crate::proto::Failed) -> EngineError {
     use crate::structured::ErrorCategory;
     match failed.category {
         Some(ErrorCategory::Interrupted) => EngineError::Interrupted(failed.message),
         Some(ErrorCategory::NotRun) => EngineError::NotRun(failed.message),
+        Some(ErrorCategory::InvalidArgument) => EngineError::InvalidArgument(failed.message),
         _ => EngineError::Debugger(failed.message),
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ mod engine;
 mod kdconn;
 mod proto;
 mod server;
+mod structured;
 mod ttd;
 mod worker;
 

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -88,7 +88,26 @@ pub enum EngineOp {
         command: String,
         timeout_ms: u32,
     },
-    Registers,
+    /// The target's registers, as text (`r`) *and* as values.
+    ///
+    /// `all` is the caller's choice between the integer registers — which is what `r` prints, and
+    /// what almost every question is about — and the whole bank including x87, vector and
+    /// subregister views, which on x64 is several hundred entries and would otherwise ride along
+    /// with every single call.
+    Registers {
+        all: bool,
+    },
+    /// The loaded modules, as text (`lm`) *and* as values.
+    Modules,
+    /// Set a breakpoint (`bp <expression>`) and report what the session now holds.
+    ///
+    /// A command rather than a typed `AddBreakpoint` because `bp`'s syntax is the point: a
+    /// condition, a command string to run on each hit, `/1` for one-shot. What the typed side
+    /// adds is the *answer* — a successful `bp` prints nothing at all, so "did that work, and
+    /// what is it now?" was previously only answerable with a second `bl`.
+    SetBreakpoint {
+        expression: String,
+    },
     ReadMemory {
         address: String,
         size: u32,
@@ -356,7 +375,7 @@ mod tests {
                 command: "s -b 0 L?0x1000 41".into(),
                 patience_ms: 0,
             },
-            EngineOp::Registers,
+            EngineOp::Registers { all: false },
             EngineOp::Pool {
                 query: PoolOp::census(None, None),
                 patience_ms: 0,
@@ -442,9 +461,112 @@ pub enum WorkerMessage {
     /// the rollback alone would expire mid-step, which is the whole failure being fixed, arriving a
     /// little later.
     RollingBack { id: u64, within_ms: u32 },
-    /// The op finished. `Err` is a debugger-level failure with the engine's own text.
+    /// The op finished. `Err` is a failure with the engine's own text, and — where the worker
+    /// knows better than "the debugger said no" — what kind of failure it was.
     Done {
         id: u64,
-        result: Result<String, String>,
+        result: Result<Output, Failed>,
     },
+}
+
+/// A failed op, as it crosses the pipe.
+///
+/// The message was once the whole of it, and a supervisor reading only a message has to call
+/// every failure a debugger failure. Two are emphatically not: a walk stopped because somebody
+/// asked it to stop, and a query that was **never run** because too little of the caller's budget
+/// was left to run it in. Both used to arrive looking like a target that had misbehaved, which is
+/// the opposite of what each one means.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Failed {
+    pub message: String,
+    /// `None` means the ordinary case: the debugger ran it and it failed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub category: Option<crate::structured::ErrorCategory>,
+}
+
+impl Failed {
+    /// A failure of a kind the worker can name.
+    pub fn categorised(
+        category: crate::structured::ErrorCategory,
+        message: impl Into<String>,
+    ) -> Self {
+        Self {
+            message: message.into(),
+            category: Some(category),
+        }
+    }
+}
+
+/// The ordinary case, so a bare `Err(message)?` keeps reading as it did.
+///
+/// Spelled out for the two string types rather than blanket over `ToString`, which cannot be
+/// written: it would overlap the reflexive `From<Failed> for Failed`.
+impl From<String> for Failed {
+    fn from(message: String) -> Self {
+        Self {
+            message,
+            category: None,
+        }
+    }
+}
+
+impl From<&str> for Failed {
+    fn from(message: &str) -> Self {
+        Self::from(message.to_string())
+    }
+}
+
+/// What an op produced: the text every client has always received, plus the typed answer for
+/// the tools that have one.
+///
+/// Two channels rather than one, because they answer to different readers and neither is a
+/// projection of the other. The text is a rendering — aligned columns, caveats, advice on what
+/// to do next — and a program reading it is parsing prose that exists to be reworded. `data` is
+/// the same answer as values, and it is built **here**, on the side of the pipe where the engine's
+/// own types are still in hand ([`crate::structured`]). Sending only the text and re-deriving
+/// values on the supervisor's side would be the mistake
+/// [#77](https://github.com/glslang/windbg-mcp/issues/77) was: a figure recovered from a
+/// rendering measures the rendering.
+///
+/// `data` is already the *whole* structured result — `{"status": "ok", …}` — rather than a bare
+/// payload, so the supervisor forwards it untouched and never has to know which tool asked.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Output {
+    pub text: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub data: Option<serde_json::Value>,
+}
+
+impl Output {
+    /// A reply with text only — every op that has no typed shape yet.
+    pub fn text(text: impl Into<String>) -> Self {
+        Self {
+            text: text.into(),
+            data: None,
+        }
+    }
+
+    /// A reply carrying both, from a payload that is serialized here so no caller can forget
+    /// the `status` discriminator that makes an outcome one shape.
+    pub fn typed<T: Serialize>(text: impl Into<String>, payload: T) -> Self {
+        let data = serde_json::to_value(crate::structured::Outcome::Ok(payload));
+        Self {
+            text: text.into(),
+            // A payload that will not serialize is a bug in a `structured` type, not a debugger
+            // failure, and it must not cost the caller the text they asked for.
+            data: match data {
+                Ok(value) => Some(value),
+                Err(error) => {
+                    tracing::error!("structured payload did not serialize: {error}");
+                    None
+                }
+            },
+        }
+    }
+}
+
+impl From<String> for Output {
+    fn from(text: String) -> Self {
+        Self::text(text)
+    }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -9,6 +9,7 @@ use std::collections::{HashMap, HashSet, VecDeque};
 use std::time::Duration;
 
 use rmcp::ErrorData;
+use rmcp::handler::server::tool::schema_for_output;
 use rmcp::handler::server::wrapper::Parameters;
 use rmcp::model::{CallToolResult, ContentBlock};
 use schemars::JsonSchema;
@@ -20,7 +21,8 @@ use crate::engine::{
     SessionState, Sessions,
 };
 use crate::kdconn;
-use crate::proto::{EngineOp, PoolOp, ReachabilityOp};
+use crate::proto::{EngineOp, Output, PoolOp, ReachabilityOp};
+use crate::structured::{self, ErrorCategory, Outcome, TargetCreated};
 use crate::ttd;
 
 /// How long to wait for an execution-control command (go/step/reverse) to reach its
@@ -50,6 +52,121 @@ fn tool_error(s: String) -> Result<CallToolResult, ErrorData> {
     Ok(CallToolResult::error(vec![ContentBlock::text(s)]))
 }
 
+/// A tool-execution error carrying a typed reason beside the text.
+///
+/// The text is what it always was. The structured half exists so a caller can branch on
+/// [`ErrorCategory`] instead of on wording, and it conforms to the same `outputSchema` the
+/// success branch does — see [`crate::structured`] for why both branches are one shape.
+fn typed_error(
+    category: ErrorCategory,
+    message: String,
+    session_id: Option<String>,
+) -> Result<CallToolResult, ErrorData> {
+    let structured: Outcome<()> = Outcome::failed_in(category, message.clone(), session_id);
+    Ok(with_structured(
+        CallToolResult::error(vec![ContentBlock::text(message)]),
+        serde_json::to_value(structured).ok(),
+    ))
+}
+
+/// Attaches structured content to a result, if there is any.
+fn with_structured(mut result: CallToolResult, data: Option<serde_json::Value>) -> CallToolResult {
+    result.structured_content = data;
+    result
+}
+
+/// A success carrying both halves: the text a person reads, and the payload a program does.
+///
+/// For the tools the supervisor answers by itself — `session_status`, the openers, `end_session`
+/// — where there is no worker to have built the typed half.
+fn structured_result<T: serde::Serialize>(
+    text: String,
+    payload: T,
+) -> Result<CallToolResult, ErrorData> {
+    outcome_result(text, Outcome::Ok(payload))
+}
+
+/// [`structured_result`] for a payload that is already an outcome of its own — the openers,
+/// whose success and failure branches carry different fields and so have their own enum.
+fn outcome_result<T: serde::Serialize>(
+    text: String,
+    outcome: T,
+) -> Result<CallToolResult, ErrorData> {
+    Ok(with_structured(
+        CallToolResult::success(vec![ContentBlock::text(text)]),
+        serde_json::to_value(outcome).ok(),
+    ))
+}
+
+/// The typed view of what `session_status` was asked and what it found.
+///
+/// `asked`/`unknown_handle` exist because an empty list is three different answers — nothing is
+/// open, the handle you named is gone, the handle you named was never issued — and prose was the
+/// only thing telling them apart.
+fn sessions_report(
+    sessions: &[&SessionSnapshot],
+    asked: Option<&str>,
+    unknown_handle: bool,
+) -> structured::SessionsReport {
+    structured::SessionsReport {
+        sessions: sessions
+            .iter()
+            .map(|s| structured::SessionInfo {
+                session_id: s.id.clone(),
+                kind: s.kind.into(),
+                target: s.what.clone(),
+                engine_pid: s.pid,
+                // The two derived facts a caller cannot compute: whether this wait can end on its
+                // own, and whether it has already gone on longer than a healthy one ever does.
+                // Both come from the same constants the text is written against.
+                state: structured::SessionStateInfo::of(
+                    &s.state,
+                    s.kind.waits_indefinitely(),
+                    s.in_state_for >= OPEN_TAKING_TOO_LONG,
+                ),
+                in_state_for_ms: ms(s.in_state_for),
+                age_ms: ms(s.age),
+                current: s.current,
+                live: s.state.is_live(),
+            })
+            .collect(),
+        max_sessions: MAX_SESSIONS as u32,
+        asked: asked.map(str::to_string),
+        unknown_handle,
+    }
+}
+
+/// A duration in whole milliseconds, saturating rather than wrapping.
+fn ms(d: Duration) -> u64 {
+    d.as_millis().min(u128::from(u64::MAX)) as u64
+}
+
+/// A failed open, with the two things a caller has to act on as fields.
+///
+/// `session_id` because an open that failed *after* creating its target hands back the only
+/// handle that reaches it — text that had to be scraped for a `session_id:` line before — and
+/// `target` because "was anything created?" is what decides whether opening again is a recovery
+/// or a second process.
+fn open_failure(
+    category: ErrorCategory,
+    message: String,
+    session_id: Option<String>,
+    target: TargetCreated,
+) -> Result<CallToolResult, ErrorData> {
+    let structured = structured::OpenOutcome::Error(structured::OpenFailure {
+        error: structured::FailureDetail {
+            category,
+            message: message.clone(),
+            session_id,
+        },
+        target,
+    });
+    Ok(with_structured(
+        CallToolResult::error(vec![ContentBlock::text(message)]),
+        serde_json::to_value(structured).ok(),
+    ))
+}
+
 /// Renders a session-scoped engine outcome using the MCP error model.
 ///
 /// Everything that can go wrong here is feedback the model can act on — a failed debugger
@@ -58,10 +175,35 @@ fn tool_error(s: String) -> Result<CallToolResult, ErrorData> {
 /// intact, never as a JSON-RPC error the model never really sees. The one failure that is the
 /// *server's* rather than a session's is "no engine worker could be started", and only an opener
 /// can hit it; [`WindbgServer::opened`] renders that one.
-fn engine_result(r: Result<String, EngineError>) -> Result<CallToolResult, ErrorData> {
+///
+/// Both branches carry whatever typed answer exists: the worker's, on success ([`Output::data`]),
+/// and the failure's category otherwise. A tool with no typed shape yet simply has none, and is
+/// unchanged.
+fn engine_result(r: Result<Output, EngineError>) -> Result<CallToolResult, ErrorData> {
     match r {
-        Ok(out) => text_result(out),
-        Err(e) => tool_error(e.to_string()),
+        Ok(out) => Ok(with_structured(
+            CallToolResult::success(vec![ContentBlock::text(out.text)]),
+            out.data,
+        )),
+        Err(e) => typed_error(ErrorCategory::of(&e), e.to_string(), None),
+    }
+}
+
+/// [`engine_result`] for a call that named a session, so a failure can say which one it was.
+fn engine_result_for(
+    session_id: Option<&str>,
+    r: Result<Output, EngineError>,
+) -> Result<CallToolResult, ErrorData> {
+    match r {
+        Ok(out) => Ok(with_structured(
+            CallToolResult::success(vec![ContentBlock::text(out.text)]),
+            out.data,
+        )),
+        Err(e) => typed_error(
+            ErrorCategory::of(&e),
+            e.to_string(),
+            session_id.map(str::to_string),
+        ),
     }
 }
 
@@ -1036,6 +1178,21 @@ pub struct SessionArgs {
     pub session_id: Option<String>,
 }
 
+/// Parameters for `registers`.
+#[derive(Deserialize, JsonSchema)]
+pub struct RegistersArgs {
+    /// Include every register the engine knows, not just the integer ones: x87 and vector
+    /// registers, and subregister views such as `eax` within `rax`. Off by default because on
+    /// x64 that is several hundred entries — the `r` text is unaffected either way.
+    #[serde(default)]
+    pub all: Option<bool>,
+    /// Session handle returned by open_dump/open_trace/attach_*/launch. Optional: omit it
+    /// to act on whatever session is current, or pass it to have the call refuse to run if
+    /// this server's debug target has been replaced since you opened it.
+    #[serde(default)]
+    pub session_id: Option<String>,
+}
+
 #[derive(Deserialize, JsonSchema)]
 pub struct PathArgs {
     /// Filesystem path to the dump (.dmp) or TTD trace (.run) file.
@@ -1658,7 +1815,7 @@ impl WindbgServer {
     /// worker and cannot be ordered against this call at all. What still has to be re-checked
     /// at the front of the session's own queue is whether the handle survived work queued ahead
     /// of it, and that is `engine::Gate`'s job.
-    async fn run_call(&self, session_id: Option<&str>, call: Call) -> Result<String, EngineError> {
+    async fn run_call(&self, session_id: Option<&str>, call: Call) -> Result<Output, EngineError> {
         let session = self.sessions.resolve(session_id)?;
         self.sessions
             .call(&session, call.named(session_id.is_some()))
@@ -1666,7 +1823,7 @@ impl WindbgServer {
     }
 
     /// The common case: one op, no handle retirement.
-    async fn run(&self, session_id: Option<&str>, op: EngineOp) -> Result<String, EngineError> {
+    async fn run(&self, session_id: Option<&str>, op: EngineOp) -> Result<Output, EngineError> {
         self.run_call(session_id, Call::new(op)).await
     }
 
@@ -1682,42 +1839,71 @@ impl WindbgServer {
         what: String,
         op: EngineOp,
     ) -> Result<CallToolResult, ErrorData> {
+        // Kept for the typed answer, which describes what was asked for rather than re-deriving
+        // it from the report the debugger printed.
+        let target = what.clone();
         match self.sessions.open(kind, what, op).await {
-            Ok(OpenReport { id, report }) => text_result(format!(
-                "{report}\n\nsession_id: {id}\nPass this as `session_id` on later calls to route \
-                 them to this session and to fail loudly rather than act on a different target."
-            )),
+            Ok(OpenReport { id, report }) => outcome_result(
+                format!(
+                    "{report}\n\nsession_id: {id}\nPass this as `session_id` on later calls to \
+                     route them to this session and to fail loudly rather than act on a different \
+                     target."
+                ),
+                structured::OpenOutcome::Ok(structured::OpenedSession {
+                    session_id: id,
+                    kind: kind.into(),
+                    target,
+                    report,
+                }),
+            ),
             // No worker, so no session — and no argument the model can change fixes that.
             Err(OpenError::Unavailable(m)) => Err(ErrorData::internal_error(m, None)),
-            Err(OpenError::NoRoom(m)) => tool_error(m),
-            Err(OpenError::Clean(m)) => tool_error(m),
+            Err(OpenError::NoRoom(m)) => {
+                open_failure(ErrorCategory::Capacity, m, None, TargetCreated::No)
+            }
+            Err(OpenError::Clean(m)) => {
+                open_failure(ErrorCategory::Debugger, m, None, TargetCreated::No)
+            }
             Err(OpenError::PostCommit {
                 id,
                 message,
                 report_only,
-            }) => tool_error(if report_only {
-                format!(
-                    "{message}\n\nsession_id: {id}\nThe target opened; only this follow-up report \
-                     failed, so the handle above is valid and usable."
-                )
-            } else {
-                post_commit_failure(&message, &id)
-            }),
+            }) => open_failure(
+                ErrorCategory::Debugger,
+                if report_only {
+                    format!(
+                        "{message}\n\nsession_id: {id}\nThe target opened; only this follow-up \
+                         report failed, so the handle above is valid and usable."
+                    )
+                } else {
+                    post_commit_failure(&message, &id)
+                },
+                Some(id),
+                // Both halves of this branch created a target; that is what "post commit" means,
+                // and it is the fact that makes re-opening the wrong move.
+                TargetCreated::Yes,
+            ),
             // A timeout abandons the *wait*, not the job: this open may still be running and may
             // still land. The handle exists from the moment the session is registered, so it can
             // be named now — which is what makes recovery via `session_status` sound.
             // The `session_id:` line is the same one a successful open emits, deliberately: this
             // is the result a caller most needs to get a handle *out* of, and prose alone would
             // make it the one opener outcome they cannot parse the id from.
-            Err(OpenError::Timeout { id, message }) => tool_error(format!(
-                "{message}\n\nsession_id: {id}\nThe wait was abandoned, but this open was not: it \
-                 is still running in the session above, and may still land. Ask `session_status \
-                 {{ \"session_id\": \"{id}\" }}` — it reports whether the open is still going, \
-                 how long it has been going, and whether that is longer than a healthy one takes. \
-                 Do not re-run the open while it is still going, which would attach to, or start, \
-                 a second target; `end_session {{ \"session_id\": \"{id}\" }}` ends it outright, \
-                 terminating the worker process if it will not unwind."
-            )),
+            Err(OpenError::Timeout { id, message }) => open_failure(
+                ErrorCategory::Timeout,
+                format!(
+                    "{message}\n\nsession_id: {id}\nThe wait was abandoned, but this open was \
+                     not: it is still running in the session above, and may still land. Ask \
+                     `session_status {{ \"session_id\": \"{id}\" }}` — it reports whether the \
+                     open is still going, how long it has been going, and whether that is longer \
+                     than a healthy one takes. Do not re-run the open while it is still going, \
+                     which would attach to, or start, a second target; `end_session \
+                     {{ \"session_id\": \"{id}\" }}` ends it outright, terminating the worker \
+                     process if it will not unwind."
+                ),
+                Some(id),
+                TargetCreated::Pending,
+            ),
         }
     }
 }
@@ -1745,13 +1931,16 @@ impl WindbgServer {
     /// Open a crash dump (.dmp) or a Time Travel Debugging trace (.run) and wait for it to load.
     /// Opens a new session in its own engine process — sessions already open are left alone —
     /// and returns a `session_id` that routes later calls to it. End it with `end_session`.
-    #[rmcp::tool(annotations(
-        title = "Open crash dump or TTD trace",
-        read_only_hint = false,
-        destructive_hint = true,
-        idempotent_hint = false,
-        open_world_hint = true
-    ))]
+    #[rmcp::tool(
+        annotations(
+            title = "Open crash dump or TTD trace",
+            read_only_hint = false,
+            destructive_hint = true,
+            idempotent_hint = false,
+            open_world_hint = true
+        ),
+        output_schema = schema_for_output::<structured::OpenOutcome>()
+    )]
     async fn open_dump(
         &self,
         Parameters(args): Parameters<PathArgs>,
@@ -1767,13 +1956,16 @@ impl WindbgServer {
     /// Open a TTD trace (.run); alias of open_dump. Enables time-travel navigation and TTD queries.
     /// Opens a new session in its own engine process — sessions already open are left alone —
     /// and returns a `session_id` that routes later calls to it. End it with `end_session`.
-    #[rmcp::tool(annotations(
-        title = "Open TTD trace",
-        read_only_hint = false,
-        destructive_hint = true,
-        idempotent_hint = false,
-        open_world_hint = true
-    ))]
+    #[rmcp::tool(
+        annotations(
+            title = "Open TTD trace",
+            read_only_hint = false,
+            destructive_hint = true,
+            idempotent_hint = false,
+            open_world_hint = true
+        ),
+        output_schema = schema_for_output::<structured::OpenOutcome>()
+    )]
     async fn open_trace(
         &self,
         Parameters(args): Parameters<PathArgs>,
@@ -1789,13 +1981,16 @@ impl WindbgServer {
     /// Attach to the local kernel (live local kernel debugging).
     /// Opens a new session in its own engine process — sessions already open are left alone —
     /// and returns a `session_id` that routes later calls to it. End it with `end_session`.
-    #[rmcp::tool(annotations(
-        title = "Attach to local kernel",
-        read_only_hint = false,
-        destructive_hint = true,
-        idempotent_hint = false,
-        open_world_hint = true
-    ))]
+    #[rmcp::tool(
+        annotations(
+            title = "Attach to local kernel",
+            read_only_hint = false,
+            destructive_hint = true,
+            idempotent_hint = false,
+            open_world_hint = true
+        ),
+        output_schema = schema_for_output::<structured::OpenOutcome>()
+    )]
     async fn attach_kernel_local(&self) -> Result<CallToolResult, ErrorData> {
         self.opened(
             SessionKind::KernelLocal,
@@ -1819,13 +2014,16 @@ impl WindbgServer {
     /// unaffected — and `session_status` says how long it has been waiting. Recover with
     /// `end_session`, which terminates the session's engine process; do NOT re-attach while it
     /// is still waiting.
-    #[rmcp::tool(annotations(
-        title = "Attach to kernel target",
-        read_only_hint = false,
-        destructive_hint = true,
-        idempotent_hint = false,
-        open_world_hint = true
-    ))]
+    #[rmcp::tool(
+        annotations(
+            title = "Attach to kernel target",
+            read_only_hint = false,
+            destructive_hint = true,
+            idempotent_hint = false,
+            open_world_hint = true
+        ),
+        output_schema = schema_for_output::<structured::OpenOutcome>()
+    )]
     async fn attach_kernel(
         &self,
         Parameters(args): Parameters<ConnectionArgs>,
@@ -1836,7 +2034,11 @@ impl WindbgServer {
         // `session_status` without holding the key anywhere but in the op below.
         let selected = match kdconn::select(args.connection, args.profile) {
             Ok(selected) => selected,
-            Err(why) => return tool_error(why),
+            // Typed like every other refusal from a tool that declares an output schema: the
+            // result has to conform whichever way it went, and "fix the argument" is a category.
+            Err(why) => {
+                return open_failure(ErrorCategory::InvalidArgument, why, None, TargetCreated::No);
+            }
         };
         self.opened(
             SessionKind::Kernel,
@@ -1885,13 +2087,16 @@ impl WindbgServer {
     /// Only allocated chunks are indexed by tag — a freed chunk's tag is not reliably
     /// preserved by the allocator, so this never reports freed memory. To ask whether one
     /// specific address has been freed, use `pool_chunk`.
-    #[rmcp::tool(annotations(
-        title = "Find pool chunks by tag",
-        read_only_hint = true,
-        destructive_hint = false,
-        idempotent_hint = true,
-        open_world_hint = true
-    ))]
+    #[rmcp::tool(
+        annotations(
+            title = "Find pool chunks by tag",
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
+        output_schema = schema_for_output::<Outcome<structured::PoolTagMatches>>()
+    )]
     async fn pool_find_tag(
         &self,
         Parameters(args): Parameters<PoolFindTagArgs>,
@@ -1907,7 +2112,7 @@ impl WindbgServer {
                 )),
             )
             .await;
-        engine_result(out)
+        engine_result_for(args.session_id.as_deref(), out)
     }
 
     /// Identify the pool chunk containing an address, **with its immediate neighbours**.
@@ -1922,13 +2127,16 @@ impl WindbgServer {
     /// prints before reading it as "never was pool". A third state, `Unreadable`, is neither:
     /// the walk could not read the span (a Verifier guard page reads exactly this way), so it
     /// says nothing about whether the chunk is live.
-    #[rmcp::tool(annotations(
-        title = "Locate a pool chunk by address",
-        read_only_hint = true,
-        destructive_hint = false,
-        idempotent_hint = true,
-        open_world_hint = true
-    ))]
+    #[rmcp::tool(
+        annotations(
+            title = "Locate a pool chunk by address",
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
+        output_schema = schema_for_output::<Outcome<structured::PoolChunkAt>>()
+    )]
     async fn pool_chunk(
         &self,
         Parameters(args): Parameters<PoolChunkArgs>,
@@ -1939,7 +2147,7 @@ impl WindbgServer {
                 pool_op(PoolOp::chunk(args.address, args.refresh)),
             )
             .await;
-        engine_result(out)
+        engine_result_for(args.session_id.as_deref(), out)
     }
 
     /// The pool walk's own diagnostics, verbatim, optionally narrowed by substring.
@@ -1949,13 +2157,16 @@ impl WindbgServer {
     /// hundred-plus categories, so the summaries the other tools print are necessarily
     /// truncated — and the one line explaining a specific heap is reliably not in the
     /// truncated head. Filter by a heap address or a phrase to get at it.
-    #[rmcp::tool(annotations(
-        title = "Filter pool walk diagnostics",
-        read_only_hint = true,
-        destructive_hint = false,
-        idempotent_hint = true,
-        open_world_hint = true
-    ))]
+    #[rmcp::tool(
+        annotations(
+            title = "Filter pool walk diagnostics",
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
+        output_schema = schema_for_output::<Outcome<structured::PoolDiagnosticsReport>>()
+    )]
     async fn pool_diagnostics(
         &self,
         Parameters(args): Parameters<PoolDiagnosticsArgs>,
@@ -1966,7 +2177,7 @@ impl WindbgServer {
                 pool_op(PoolOp::diagnostics(args.filter, args.refresh, args.limit)),
             )
             .await;
-        engine_result(out)
+        engine_result_for(args.session_id.as_deref(), out)
     }
 
     /// Per-tag census of the kernel pool: allocation counts and bytes, heaviest first.
@@ -1974,13 +2185,16 @@ impl WindbgServer {
     /// The structured answer to what `!poolused` renders as text, taken from the same walk
     /// as `pool_find_tag` and `pool_chunk` so the three cannot disagree. Useful for spotting
     /// which tag a driver's allocations are landing under before querying it by name.
-    #[rmcp::tool(annotations(
-        title = "Census pool usage by tag",
-        read_only_hint = true,
-        destructive_hint = false,
-        idempotent_hint = true,
-        open_world_hint = true
-    ))]
+    #[rmcp::tool(
+        annotations(
+            title = "Census pool usage by tag",
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
+        output_schema = schema_for_output::<Outcome<structured::PoolCensus>>()
+    )]
     async fn pool_census(
         &self,
         Parameters(args): Parameters<PoolCensusArgs>,
@@ -1991,19 +2205,22 @@ impl WindbgServer {
                 pool_op(PoolOp::census(args.refresh, args.limit)),
             )
             .await;
-        engine_result(out)
+        engine_result_for(args.session_id.as_deref(), out)
     }
 
     /// Attach to an existing user-mode process by PID and break in.
     /// Opens a new session in its own engine process — sessions already open are left alone —
     /// and returns a `session_id` that routes later calls to it. End it with `end_session`.
-    #[rmcp::tool(annotations(
-        title = "Attach to process",
-        read_only_hint = false,
-        destructive_hint = true,
-        idempotent_hint = false,
-        open_world_hint = true
-    ))]
+    #[rmcp::tool(
+        annotations(
+            title = "Attach to process",
+            read_only_hint = false,
+            destructive_hint = true,
+            idempotent_hint = false,
+            open_world_hint = true
+        ),
+        output_schema = schema_for_output::<structured::OpenOutcome>()
+    )]
     async fn attach_process(
         &self,
         Parameters(args): Parameters<PidArgs>,
@@ -2019,13 +2236,16 @@ impl WindbgServer {
     /// Launch a new user-mode process under the debugger, stopping at the initial breakpoint.
     /// Opens a new session in its own engine process — sessions already open are left alone —
     /// and returns a `session_id` that routes later calls to it. End it with `end_session`.
-    #[rmcp::tool(annotations(
-        title = "Launch process under debugger",
-        read_only_hint = false,
-        destructive_hint = true,
-        idempotent_hint = false,
-        open_world_hint = true
-    ))]
+    #[rmcp::tool(
+        annotations(
+            title = "Launch process under debugger",
+            read_only_hint = false,
+            destructive_hint = true,
+            idempotent_hint = false,
+            open_world_hint = true
+        ),
+        output_schema = schema_for_output::<structured::OpenOutcome>()
+    )]
     async fn launch(
         &self,
         Parameters(args): Parameters<CommandLineArgs>,
@@ -2055,11 +2275,14 @@ impl WindbgServer {
     ///
     /// Answers even while a session is parked: it reads this server's own bookkeeping and never
     /// queues on any session's engine.
-    #[rmcp::tool(annotations(
-        title = "List debug sessions",
-        read_only_hint = true,
-        open_world_hint = false
-    ))]
+    #[rmcp::tool(
+        annotations(
+            title = "List debug sessions",
+            read_only_hint = true,
+            open_world_hint = false
+        ),
+        output_schema = schema_for_output::<Outcome<structured::SessionsReport>>()
+    )]
     async fn session_status(
         &self,
         Parameters(args): Parameters<SessionArgs>,
@@ -2070,15 +2293,19 @@ impl WindbgServer {
         let sessions = self.sessions.snapshot();
 
         let Some(asked) = args.session_id.as_deref() else {
-            if sessions.iter().all(|s| !s.state.is_live()) {
-                return text_result(
+            let live: Vec<&SessionSnapshot> =
+                sessions.iter().filter(|s| s.state.is_live()).collect();
+            let report = sessions_report(&live, None, false);
+            if live.is_empty() {
+                return structured_result(
                     "No debug session is open. Start one with open_dump / open_trace / \
                      attach_process / attach_kernel / attach_kernel_local / launch."
                         .to_string(),
+                    report,
                 );
             }
             let mut out = String::new();
-            for s in sessions.iter().filter(|s| s.state.is_live()) {
+            for s in &live {
                 out.push_str(&describe_session(s));
                 out.push('\n');
             }
@@ -2088,17 +2315,26 @@ impl WindbgServer {
                  `session_id` on a call to route it to a specific session; omit it and the \
                  session marked (current) is used.",
             ));
-            return text_result(out);
+            return structured_result(out, report);
         };
 
         let Some(session) = sessions.iter().find(|s| s.id == asked) else {
-            return text_result(format!(
-                "`{asked}` is not a handle this server is holding. Either it was never issued \
-                 here, or it closed a while ago and has aged out of the session history. A \
-                 session that still exists is never forgotten, so opening again is safe."
-            ));
+            // Not an error: asking after a handle that has aged out is a fair question with a
+            // definite answer. `unknown_handle` is how a caller tells that answer from "the
+            // session exists, here it is", which an empty list on its own cannot.
+            return structured_result(
+                format!(
+                    "`{asked}` is not a handle this server is holding. Either it was never issued \
+                     here, or it closed a while ago and has aged out of the session history. A \
+                     session that still exists is never forgotten, so opening again is safe."
+                ),
+                sessions_report(&[], Some(asked), true),
+            );
         };
-        text_result(describe_session(session))
+        structured_result(
+            describe_session(session),
+            sessions_report(&[session], Some(asked), false),
+        )
     }
 
     /// Stop the operation a session is currently running, **keeping the session and its target**.
@@ -2172,13 +2408,16 @@ impl WindbgServer {
     /// A `debug_batch` running on the session is told to stop at its next step and run its
     /// rollback before the target is released, and the batch's own call reports that; the grace
     /// covers the step in flight and the rollback after it.
-    #[rmcp::tool(annotations(
-        title = "End debug session",
-        read_only_hint = false,
-        destructive_hint = true,
-        idempotent_hint = true,
-        open_world_hint = true
-    ))]
+    #[rmcp::tool(
+        annotations(
+            title = "End debug session",
+            read_only_hint = false,
+            destructive_hint = true,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
+        output_schema = schema_for_output::<Outcome<structured::SessionEnded>>()
+    )]
     async fn end_session(
         &self,
         Parameters(args): Parameters<SessionArgs>,
@@ -2186,9 +2425,12 @@ impl WindbgServer {
         let session_id = args.session_id.as_deref();
         let session = match self.sessions.resolve(session_id) {
             Ok(session) => session,
-            Err(e) => return engine_result(Err(e)),
+            Err(e) => return engine_result_for(session_id, Err(e)),
         };
-        engine_result(self.sessions.end(&session, session_id.is_some()).await)
+        engine_result_for(
+            session_id,
+            self.sessions.end(&session, session_id.is_some()).await,
+        )
     }
 
     /// Run a raw debugger command and return its full output. The universal escape hatch.
@@ -2275,32 +2517,49 @@ impl WindbgServer {
         engine_result(self.run_call(args.session_id.as_deref(), call).await)
     }
 
-    /// Show the current register set.
-    #[rmcp::tool(annotations(
-        title = "Show registers",
-        read_only_hint = true,
-        open_world_hint = true
-    ))]
+    /// Show the current register set, as `r` prints it and as typed values beside it.
+    /// By default the structured half carries the **integer** registers (what `r` prints,
+    /// plus any control registers the target has); pass `all: true` for the whole bank,
+    /// including x87/vector registers and subregister views such as `eax` within `rax`.
+    #[rmcp::tool(
+        annotations(
+            title = "Show registers",
+            read_only_hint = true,
+            open_world_hint = true
+        ),
+        output_schema = schema_for_output::<Outcome<structured::RegisterSet>>()
+    )]
     async fn registers(
         &self,
-        Parameters(args): Parameters<SessionArgs>,
+        Parameters(args): Parameters<RegistersArgs>,
     ) -> Result<CallToolResult, ErrorData> {
         let out = self
-            .run(args.session_id.as_deref(), EngineOp::Registers)
+            .run(
+                args.session_id.as_deref(),
+                EngineOp::Registers {
+                    all: args.all.unwrap_or(false),
+                },
+            )
             .await;
         // DbgEng prints nothing for `r` when there is no live thread context (e.g. a
-        // module-load break, or a bare goto_position to the very start of a trace).
-        let out = out.map(|s| {
-            if s.trim().is_empty() {
-                "(no thread register context at this position — e.g. a module-load break or \
-                 the start of a trace. Travel to a settled position after a go/breakpoint, or \
-                 read a specific register with execute { \"command\": \"r rip\" }.)"
-                    .to_string()
+        // module-load break, or a bare goto_position to the very start of a trace). The
+        // structured half says the same thing by carrying no registers, so this replaces only
+        // the text — and only when the text is the empty one.
+        let out = out.map(|out| {
+            if out.text.trim().is_empty() {
+                Output {
+                    text: "(no thread register context at this position — e.g. a module-load \
+                           break or the start of a trace. Travel to a settled position after a \
+                           go/breakpoint, or read a specific register with execute \
+                           { \"command\": \"r rip\" }.)"
+                        .to_string(),
+                    data: out.data,
+                }
             } else {
-                s
+                out
             }
         });
-        engine_result(out)
+        engine_result_for(args.session_id.as_deref(), out)
     }
 
     /// Read process/kernel virtual memory and return a hex dump.
@@ -2346,25 +2605,26 @@ impl WindbgServer {
         engine_result(out)
     }
 
-    /// List loaded modules (`lm`).
-    #[rmcp::tool(annotations(
-        title = "List modules",
-        read_only_hint = true,
-        open_world_hint = true
-    ))]
+    /// List loaded modules, as `lm` prints them and as typed values beside it: each module's
+    /// name, image name, start/end addresses and **symbol state** — `deferred` (not fetched
+    /// yet) is not the same as `none` (this module has no symbols), which the `lm` text
+    /// renders as an easily-missed parenthesis.
+    #[rmcp::tool(
+        annotations(
+            title = "List modules",
+            read_only_hint = true,
+            open_world_hint = true
+        ),
+        output_schema = schema_for_output::<Outcome<structured::ModuleList>>()
+    )]
     async fn modules(
         &self,
         Parameters(args): Parameters<SessionArgs>,
     ) -> Result<CallToolResult, ErrorData> {
         let out = self
-            .run(
-                args.session_id.as_deref(),
-                EngineOp::Command {
-                    command: "lm".to_string(),
-                },
-            )
+            .run(args.session_id.as_deref(), EngineOp::Modules)
             .await;
-        engine_result(out)
+        engine_result_for(args.session_id.as_deref(), out)
     }
 
     /// List threads (`~`).
@@ -2543,39 +2803,49 @@ impl WindbgServer {
         engine_result(out)
     }
 
-    /// Set a breakpoint at a symbol, address, or expression (`bp`).
-    #[rmcp::tool(annotations(
-        title = "Set breakpoint",
-        read_only_hint = false,
-        destructive_hint = false,
-        idempotent_hint = false,
-        open_world_hint = true
-    ))]
+    /// Set a breakpoint at a symbol, address, or expression (`bp`), and report every
+    /// breakpoint the session then holds. A successful `bp` prints nothing at all, so the
+    /// structured result is where "it was set, and here is its id" actually lives — along with
+    /// whether it resolved to an address or is deferred until its module loads.
+    #[rmcp::tool(
+        annotations(
+            title = "Set breakpoint",
+            read_only_hint = false,
+            destructive_hint = false,
+            idempotent_hint = false,
+            open_world_hint = true
+        ),
+        output_schema = schema_for_output::<Outcome<structured::BreakpointSet>>()
+    )]
     async fn set_breakpoint(
         &self,
         Parameters(args): Parameters<BreakpointArgs>,
     ) -> Result<CallToolResult, ErrorData> {
         if let Err(e) = reject_command_breakers("expression", &args.expression, Quotes::Rejected) {
-            return tool_error(e);
+            return typed_error(ErrorCategory::InvalidArgument, e, args.session_id);
         }
-        let cmd = format!("bp {}", args.expression);
         let out = self
             .run(
                 args.session_id.as_deref(),
-                EngineOp::Command { command: cmd },
+                EngineOp::SetBreakpoint {
+                    expression: args.expression,
+                },
             )
             .await;
-        engine_result(out)
+        engine_result_for(args.session_id.as_deref(), out)
     }
 
     /// Continue execution (`g`). Runs to the next breakpoint, or the end of a TTD trace.
-    #[rmcp::tool(annotations(
-        title = "Continue execution",
-        read_only_hint = false,
-        destructive_hint = true,
-        idempotent_hint = false,
-        open_world_hint = true
-    ))]
+    #[rmcp::tool(
+        annotations(
+            title = "Continue execution",
+            read_only_hint = false,
+            destructive_hint = true,
+            idempotent_hint = false,
+            open_world_hint = true
+        ),
+        output_schema = schema_for_output::<Outcome<structured::StopReport>>()
+    )]
     async fn go(
         &self,
         Parameters(args): Parameters<SessionArgs>,
@@ -2589,7 +2859,7 @@ impl WindbgServer {
                 },
             )
             .await;
-        engine_result(out)
+        engine_result_for(args.session_id.as_deref(), out)
     }
 
     /// Run the target until it reaches `address` (a one-shot `g <addr>` that doesn't
@@ -2598,19 +2868,22 @@ impl WindbgServer {
     /// reached in time). Confirms *live* that the current input/state drives execution to
     /// a block — e.g. one from `reachable_from_dispatch`. Needs a real KDNET/VM kernel
     /// target (a local kernel can't set code breakpoints).
-    #[rmcp::tool(annotations(
-        title = "Run to address",
-        read_only_hint = false,
-        destructive_hint = true,
-        idempotent_hint = false,
-        open_world_hint = true
-    ))]
+    #[rmcp::tool(
+        annotations(
+            title = "Run to address",
+            read_only_hint = false,
+            destructive_hint = true,
+            idempotent_hint = false,
+            open_world_hint = true
+        ),
+        output_schema = schema_for_output::<Outcome<structured::RunToReport>>()
+    )]
     async fn run_to_address(
         &self,
         Parameters(args): Parameters<RunToAddressArgs>,
     ) -> Result<CallToolResult, ErrorData> {
         if let Err(e) = reject_command_breakers("address", &args.address, Quotes::Rejected) {
-            return tool_error(e);
+            return typed_error(ErrorCategory::InvalidArgument, e, args.session_id);
         }
         let out = self
             .run(
@@ -2621,17 +2894,20 @@ impl WindbgServer {
                 },
             )
             .await;
-        engine_result(out)
+        engine_result_for(args.session_id.as_deref(), out)
     }
 
     /// Step over one source/instruction step (`p`).
-    #[rmcp::tool(annotations(
-        title = "Step over",
-        read_only_hint = false,
-        destructive_hint = true,
-        idempotent_hint = false,
-        open_world_hint = true
-    ))]
+    #[rmcp::tool(
+        annotations(
+            title = "Step over",
+            read_only_hint = false,
+            destructive_hint = true,
+            idempotent_hint = false,
+            open_world_hint = true
+        ),
+        output_schema = schema_for_output::<Outcome<structured::StopReport>>()
+    )]
     async fn step_over(
         &self,
         Parameters(args): Parameters<SessionArgs>,
@@ -2645,17 +2921,20 @@ impl WindbgServer {
                 },
             )
             .await;
-        engine_result(out)
+        engine_result_for(args.session_id.as_deref(), out)
     }
 
     /// Step into one instruction (`t`).
-    #[rmcp::tool(annotations(
-        title = "Step into",
-        read_only_hint = false,
-        destructive_hint = true,
-        idempotent_hint = false,
-        open_world_hint = true
-    ))]
+    #[rmcp::tool(
+        annotations(
+            title = "Step into",
+            read_only_hint = false,
+            destructive_hint = true,
+            idempotent_hint = false,
+            open_world_hint = true
+        ),
+        output_schema = schema_for_output::<Outcome<structured::StopReport>>()
+    )]
     async fn step_into(
         &self,
         Parameters(args): Parameters<SessionArgs>,
@@ -2669,19 +2948,22 @@ impl WindbgServer {
                 },
             )
             .await;
-        engine_result(out)
+        engine_result_for(args.session_id.as_deref(), out)
     }
 
     /// Step backward one instruction in a TTD trace (`t-`). Reverse of step_into.
     // The reverse-navigation tools only work on a TTD trace, which is a recorded replay:
     // moving through it cannot destroy state, unlike stepping a live target.
-    #[rmcp::tool(annotations(
-        title = "Step back (TTD)",
-        read_only_hint = false,
-        destructive_hint = false,
-        idempotent_hint = false,
-        open_world_hint = true
-    ))]
+    #[rmcp::tool(
+        annotations(
+            title = "Step back (TTD)",
+            read_only_hint = false,
+            destructive_hint = false,
+            idempotent_hint = false,
+            open_world_hint = true
+        ),
+        output_schema = schema_for_output::<Outcome<structured::StopReport>>()
+    )]
     async fn step_back(
         &self,
         Parameters(args): Parameters<SessionArgs>,
@@ -2695,17 +2977,20 @@ impl WindbgServer {
                 },
             )
             .await;
-        engine_result(out)
+        engine_result_for(args.session_id.as_deref(), out)
     }
 
     /// Step over one call backward in a TTD trace (`p-`). Reverse of step_over.
-    #[rmcp::tool(annotations(
-        title = "Step over back (TTD)",
-        read_only_hint = false,
-        destructive_hint = false,
-        idempotent_hint = false,
-        open_world_hint = true
-    ))]
+    #[rmcp::tool(
+        annotations(
+            title = "Step over back (TTD)",
+            read_only_hint = false,
+            destructive_hint = false,
+            idempotent_hint = false,
+            open_world_hint = true
+        ),
+        output_schema = schema_for_output::<Outcome<structured::StopReport>>()
+    )]
     async fn step_over_back(
         &self,
         Parameters(args): Parameters<SessionArgs>,
@@ -2719,17 +3004,20 @@ impl WindbgServer {
                 },
             )
             .await;
-        engine_result(out)
+        engine_result_for(args.session_id.as_deref(), out)
     }
 
     /// Reverse-continue: run the TTD trace backward until a breakpoint or its start (`g-`).
-    #[rmcp::tool(annotations(
-        title = "Reverse continue (TTD)",
-        read_only_hint = false,
-        destructive_hint = false,
-        idempotent_hint = false,
-        open_world_hint = true
-    ))]
+    #[rmcp::tool(
+        annotations(
+            title = "Reverse continue (TTD)",
+            read_only_hint = false,
+            destructive_hint = false,
+            idempotent_hint = false,
+            open_world_hint = true
+        ),
+        output_schema = schema_for_output::<Outcome<structured::StopReport>>()
+    )]
     async fn reverse_go(
         &self,
         Parameters(args): Parameters<SessionArgs>,
@@ -2743,7 +3031,7 @@ impl WindbgServer {
                 },
             )
             .await;
-        engine_result(out)
+        engine_result_for(args.session_id.as_deref(), out)
     }
 
     /// Travel to a specific position in a TTD trace (`!tt <position>`).
@@ -3729,8 +4017,54 @@ mod tests {
 
     #[test]
     fn successful_output_is_not_flagged_as_an_error() {
-        let r = engine_result(Ok("rax=0000000000000000".into())).unwrap();
+        let r = engine_result(Ok(Output::text("rax=0000000000000000"))).unwrap();
         assert_eq!(r.is_error, Some(false));
+    }
+
+    /// A failure carries its category as a value beside the same text it always had.
+    ///
+    /// The point of the pair: the text is what the model reads and may be reworded at any time,
+    /// while `category` is what a program branches on. A client that had to tell a stale handle
+    /// from a debugger error by matching prose was one rewording away from breaking.
+    #[test]
+    fn a_failure_carries_its_category_beside_the_text() {
+        let r = engine_result_for(
+            Some("sess-7"),
+            Err(EngineError::Stale("`sess-7` was retired".into())),
+        )
+        .unwrap();
+        assert_eq!(r.is_error, Some(true));
+        let structured = r.structured_content.expect("a failure is structured too");
+        assert_eq!(structured["status"], "error");
+        assert_eq!(structured["error"]["category"], "stale_session");
+        assert_eq!(structured["error"]["session_id"], "sess-7");
+        assert_eq!(structured["error"]["message"], "`sess-7` was retired");
+        // And the text content is unchanged — the whole point of adding a channel rather than
+        // replacing one.
+        assert_eq!(
+            r.content.first().and_then(|c| c.as_text()).map(|t| &t.text),
+            Some(&"`sess-7` was retired".to_string())
+        );
+    }
+
+    /// The typed half of a success is the worker's, forwarded rather than re-derived.
+    #[test]
+    fn a_success_forwards_the_workers_typed_answer() {
+        let r = engine_result(Ok(Output::typed(
+            "VERDICT: HIT",
+            structured::RunToReport {
+                verdict: structured::RunToVerdict::Hit,
+                target: structured::addr(0xfffff803_1ab10000),
+                stopped_at: Some(structured::addr(0xfffff803_1ab10000)),
+                timeout_ms: 60_000,
+                output: String::new(),
+            },
+        )))
+        .unwrap();
+        let structured = r.structured_content.expect("carried through");
+        assert_eq!(structured["status"], "ok");
+        assert_eq!(structured["verdict"], "hit");
+        assert_eq!(structured["target"], "0xfffff8031ab10000");
     }
 
     #[test]

--- a/src/server.rs
+++ b/src/server.rs
@@ -65,8 +65,24 @@ fn typed_error(
     let structured: Outcome<()> = Outcome::failed_in(category, message.clone(), session_id);
     Ok(with_structured(
         CallToolResult::error(vec![ContentBlock::text(message)]),
-        serde_json::to_value(structured).ok(),
+        payload(structured),
     ))
+}
+
+/// Serializes a structured payload, saying so if it cannot.
+///
+/// A tool that declares an `outputSchema` and answers with text alone is a contract broken, and
+/// silently: the client sees a schema-bearing tool return nothing to validate and has nothing to
+/// go on. It cannot happen — these are plain data types — which is exactly why the one place it
+/// could must not swallow it. [`Output::typed`] logs the same failure on the worker's side.
+fn payload<T: serde::Serialize>(value: T) -> Option<serde_json::Value> {
+    match serde_json::to_value(value) {
+        Ok(value) => Some(value),
+        Err(error) => {
+            tracing::error!("structured payload did not serialize: {error}");
+            None
+        }
+    }
 }
 
 /// Attaches structured content to a result, if there is any.
@@ -94,7 +110,7 @@ fn outcome_result<T: serde::Serialize>(
 ) -> Result<CallToolResult, ErrorData> {
     Ok(with_structured(
         CallToolResult::success(vec![ContentBlock::text(text)]),
-        serde_json::to_value(outcome).ok(),
+        payload(outcome),
     ))
 }
 
@@ -163,7 +179,7 @@ fn open_failure(
     });
     Ok(with_structured(
         CallToolResult::error(vec![ContentBlock::text(message)]),
-        serde_json::to_value(structured).ok(),
+        payload(structured),
     ))
 }
 
@@ -180,13 +196,7 @@ fn open_failure(
 /// and the failure's category otherwise. A tool with no typed shape yet simply has none, and is
 /// unchanged.
 fn engine_result(r: Result<Output, EngineError>) -> Result<CallToolResult, ErrorData> {
-    match r {
-        Ok(out) => Ok(with_structured(
-            CallToolResult::success(vec![ContentBlock::text(out.text)]),
-            out.data,
-        )),
-        Err(e) => typed_error(ErrorCategory::of(&e), e.to_string(), None),
-    }
+    engine_result_for(None, r)
 }
 
 /// [`engine_result`] for a call that named a session, so a failure can say which one it was.
@@ -4045,6 +4055,44 @@ mod tests {
             r.content.first().and_then(|c| c.as_text()).map(|t| &t.text),
             Some(&"`sess-7` was retired".to_string())
         );
+    }
+
+    /// A failed open says whether a target exists, because that is what decides the next move.
+    ///
+    /// The most consequential field in this PR: `no` means opening again is the recovery, `yes`
+    /// means it would attach a second time or start a second process, and `pending` means the
+    /// open is still running. A future edit that returned the wrong one here would invert the
+    /// advice while every other assertion stayed green — the text carries the same distinction,
+    /// but only in prose, which is what this replaces.
+    #[test]
+    fn a_post_commit_open_failure_reports_that_a_target_exists() {
+        let r = open_failure(
+            ErrorCategory::Debugger,
+            "the target never broke in".to_string(),
+            Some("sess-3".to_string()),
+            TargetCreated::Yes,
+        )
+        .unwrap();
+        assert_eq!(r.is_error, Some(true));
+        let structured = r
+            .structured_content
+            .expect("a failed open is structured too");
+        assert_eq!(structured["status"], "error");
+        assert_eq!(structured["target"], "yes");
+        assert_eq!(structured["error"]["session_id"], "sess-3");
+
+        // And the clean case says the opposite, which is the pair that matters: these two
+        // failures read alike and want opposite responses.
+        let clean = open_failure(
+            ErrorCategory::Debugger,
+            "the dump could not be opened".to_string(),
+            None,
+            TargetCreated::No,
+        )
+        .unwrap();
+        let clean = clean.structured_content.expect("structured");
+        assert_eq!(clean["target"], "no");
+        assert!(clean["error"].get("session_id").is_none());
     }
 
     /// The typed half of a success is the worker's, forwarded rather than re-derived.

--- a/src/structured.rs
+++ b/src/structured.rs
@@ -395,8 +395,19 @@ pub struct RegisterInfo {
 pub enum RegisterValue {
     /// An integer register, in this module's one address representation.
     Int { value: String },
-    /// A floating-point register that an `f64` holds exactly.
+    /// A floating-point register that a JSON number holds exactly.
     Float { value: f64 },
+    /// A floating-point register holding a value JSON has **no literal for**: a NaN or an
+    /// infinity, which a register legitimately holds and which `serde_json` renders as `null` —
+    /// neither the value nor anything this schema allows, and not something that reads back.
+    /// Its own kind rather than a `null` inside `float`, so the field a consumer reads is a
+    /// number whenever it is present at all.
+    NonFinite {
+        value: NonFinite,
+        /// The exact bits, as lowercase hex, little-endian. A register the engine reported as
+        /// 32-bit was widened to 64 first — exact for every value except the payload of a NaN.
+        bytes: String,
+    },
     /// An x87 or vector register, as lowercase hex bytes in the engine's own order. Not
     /// narrowed to a number, because there is no number that holds it.
     Bytes { bytes: String },
@@ -405,12 +416,31 @@ pub enum RegisterValue {
     Unavailable,
 }
 
+/// Which value JSON could not express.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum NonFinite {
+    Nan,
+    Infinity,
+    NegativeInfinity,
+}
+
 impl From<&win_kexp::dbgeng::RegisterValue> for RegisterValue {
     fn from(value: &win_kexp::dbgeng::RegisterValue) -> Self {
         use win_kexp::dbgeng::RegisterValue as Engine;
         match value {
             Engine::Int(v) => Self::Int { value: addr(*v) },
-            Engine::Float(v) => Self::Float { value: *v },
+            Engine::Float(v) if v.is_finite() => Self::Float { value: *v },
+            Engine::Float(v) => Self::NonFinite {
+                value: if v.is_nan() {
+                    NonFinite::Nan
+                } else if v.is_sign_positive() {
+                    NonFinite::Infinity
+                } else {
+                    NonFinite::NegativeInfinity
+                },
+                bytes: v.to_le_bytes().iter().map(|b| format!("{b:02x}")).collect(),
+            },
             Engine::Bytes(bytes) => Self::Bytes {
                 bytes: bytes.iter().map(|b| format!("{b:02x}")).collect(),
             },
@@ -955,6 +985,42 @@ mod tests {
             serde_json::to_value(&missing).unwrap(),
             serde_json::json!({ "kind": "unavailable" })
         );
+    }
+
+    /// A register holding a NaN or an infinity must not answer with `null`.
+    ///
+    /// JSON has no literal for either, and `serde_json` renders both as `null` — silently, so
+    /// nothing on the server sees it happen. What reaches the client is then a `float` whose
+    /// `value` is null: not the value, not valid against the schema this tool declares, and not
+    /// something that deserializes back into the type it came from. A register legitimately holds
+    /// these (uninitialised x87 state, an ARM64 `d0`), so they get a kind of their own with the
+    /// exact bits beside the name.
+    #[test]
+    fn a_register_that_json_cannot_express_says_so_rather_than_saying_null() {
+        use win_kexp::dbgeng::RegisterValue as Engine;
+        let wire = |v: f64| serde_json::to_value(RegisterValue::from(&Engine::Float(v))).unwrap();
+
+        let nan = wire(f64::NAN);
+        assert_eq!(nan["kind"], "non_finite");
+        assert_eq!(nan["value"], "nan");
+        assert!(nan.get("value").is_some_and(|v| !v.is_null()));
+        assert_eq!(wire(f64::INFINITY)["value"], "infinity");
+        assert_eq!(wire(f64::NEG_INFINITY)["value"], "negative_infinity");
+        // The bits are kept, so nothing about the register is lost in the retelling.
+        assert_eq!(
+            wire(f64::INFINITY)["bytes"],
+            f64::INFINITY
+                .to_le_bytes()
+                .iter()
+                .map(|b| format!("{b:02x}"))
+                .collect::<String>()
+        );
+
+        // A finite float is untouched — it stays a number, which is the whole point of not
+        // making every float a string.
+        let finite = wire(1.5);
+        assert_eq!(finite["kind"], "float");
+        assert_eq!(finite["value"], 1.5);
     }
 
     /// The three coverage states stay distinct across the seam: collapsing `deadline_truncated`

--- a/src/structured.rs
+++ b/src/structured.rs
@@ -152,6 +152,7 @@ impl ErrorCategory {
             EngineError::Lost(_) => Self::WorkerLost,
             EngineError::Interrupted(_) => Self::Interrupted,
             EngineError::NotRun(_) => Self::NotRun,
+            EngineError::InvalidArgument(_) => Self::InvalidArgument,
         }
     }
 }
@@ -376,6 +377,7 @@ pub struct RegisterSet {
     pub all_registers: bool,
 }
 
+/// One register: its name, and its value tagged by what kind of value it is.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct RegisterInfo {
     /// The engine's own name for it (`rax`, `xmm0`, `efl`).
@@ -425,6 +427,10 @@ pub struct ModuleList {
     pub loaded: usize,
 }
 
+/// One loaded module.
+///
+/// Carries its own description because a flattened enum's would otherwise be hoisted onto the
+/// struct: `symbols` is flattened in, and schemars merges its documentation with this object's.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct ModuleInfo {
     /// The name symbols are qualified by — the `nt` in `nt!KeBugCheckEx`.
@@ -438,6 +444,7 @@ pub struct ModuleInfo {
     /// One past the last byte, matching the `start end` pair `lm` prints.
     pub end: String,
     pub size: u64,
+    #[serde(flatten)]
     pub symbols: SymbolState,
     pub user_mode: bool,
     pub timestamp: u32,
@@ -445,8 +452,14 @@ pub struct ModuleInfo {
 }
 
 /// How much symbol information the engine has for a module.
+///
+/// Internally tagged on `symbols` and flattened into [`ModuleInfo`], so the field is **always a
+/// string** — including for a symbol type this build does not name, which adds a sibling
+/// `symbol_type_code` rather than turning `symbols` into an object. A field whose JSON type
+/// depends on its value is one a consumer parses correctly right up until the first target that
+/// reports something new.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "snake_case")]
+#[serde(tag = "symbols", rename_all = "snake_case")]
 pub enum SymbolState {
     None,
     /// Not loaded *yet* — the engine fetches them when something needs them. Emphatically not
@@ -459,9 +472,9 @@ pub enum SymbolState {
     Export,
     Sym,
     Dia,
-    /// A symbol type this build does not name; `code` is the engine's own.
+    /// A symbol type this build does not name. `symbol_type_code` is the engine's own value.
     Other {
-        code: u32,
+        symbol_type_code: u32,
     },
 }
 
@@ -477,7 +490,9 @@ impl From<win_kexp::dbgeng::SymbolKind> for SymbolState {
             Engine::Export => Self::Export,
             Engine::Sym => Self::Sym,
             Engine::Dia => Self::Dia,
-            Engine::Other(code) => Self::Other { code },
+            Engine::Other(code) => Self::Other {
+                symbol_type_code: code,
+            },
         }
     }
 }
@@ -510,10 +525,12 @@ pub struct BreakpointSet {
     pub breakpoints: Vec<BreakpointInfo>,
 }
 
+/// One breakpoint the session holds.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct BreakpointInfo {
     /// The id the debugger prints, and that `bc`/`bd`/`be` take.
     pub id: u32,
+    #[serde(flatten)]
     pub kind: BreakpointKind,
     /// Where it will fire. Absent while it is deferred — its module is not loaded, so it has no
     /// address yet, which is not the same as an address of zero.
@@ -538,16 +555,20 @@ pub struct BreakpointInfo {
     pub passes_remaining: u32,
 }
 
+/// What a breakpoint watches for.
+///
+/// Tagged and flattened for the reason [`SymbolState`] is: `kind` is always a string, and the one
+/// case this build cannot name adds `kind_code` beside it instead of changing the field's type.
+/// Not hypothetical — DbgEng also has time and inline breakpoint types.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "snake_case")]
+#[serde(tag = "kind", rename_all = "snake_case")]
 pub enum BreakpointKind {
     /// Execution reaching an address (`bp`).
     Code,
     /// Access to a range of memory (`ba`).
     Data,
-    Other {
-        code: u32,
-    },
+    /// A type this build does not name. `kind_code` is the engine's own value.
+    Other { kind_code: u32 },
 }
 
 impl From<&win_kexp::dbgeng::BreakpointInfo> for BreakpointInfo {
@@ -558,7 +579,7 @@ impl From<&win_kexp::dbgeng::BreakpointInfo> for BreakpointInfo {
             kind: match bp.kind {
                 Engine::Code => BreakpointKind::Code,
                 Engine::Data => BreakpointKind::Data,
-                Engine::Other(code) => BreakpointKind::Other { code },
+                Engine::Other(code) => BreakpointKind::Other { kind_code: code },
             },
             address: bp.address.map(addr),
             expression: bp.expression.clone(),
@@ -878,6 +899,21 @@ mod tests {
                 ErrorCategory::WorkerLost,
                 "worker_lost",
             ),
+            (
+                EngineError::Interrupted("no".into()),
+                ErrorCategory::Interrupted,
+                "interrupted",
+            ),
+            (
+                EngineError::NotRun("no".into()),
+                ErrorCategory::NotRun,
+                "not_run",
+            ),
+            (
+                EngineError::InvalidArgument("no".into()),
+                ErrorCategory::InvalidArgument,
+                "invalid_argument",
+            ),
         ];
         for (error, expected, wire) in cases {
             assert_eq!(ErrorCategory::of(&error), expected);
@@ -925,6 +961,60 @@ mod tests {
             assert_eq!(PoolCoverage::from(engine), expected);
             assert_eq!(serde_json::to_value(expected).unwrap(), wire);
         }
+    }
+
+    /// A field's JSON type must not depend on its value.
+    ///
+    /// `symbols` and `kind` each have a branch for a code this build does not name, and the
+    /// obvious spelling makes those branches objects while every other is a string. A consumer
+    /// then reads the field correctly until the first target that reports something new — which
+    /// is the worst possible moment to change shape. Both are tagged and flattened instead, so
+    /// the field stays a string and the unnamed code arrives beside it.
+    #[test]
+    fn a_named_state_is_a_string_whether_or_not_it_is_one_we_know() {
+        let module = |symbols| {
+            serde_json::to_value(ModuleInfo {
+                name: "nt".into(),
+                image_name: "ntkrnlmp.exe".into(),
+                loaded_image_name: None,
+                start: addr(0xfffff803_1ab10000),
+                end: addr(0xfffff803_1ab1b000),
+                size: 0xb000,
+                symbols,
+                user_mode: false,
+                timestamp: 0,
+                checksum: 0,
+            })
+            .expect("serializes")
+        };
+        assert_eq!(module(SymbolState::Pdb)["symbols"], "pdb");
+        assert_eq!(module(SymbolState::Deferred)["symbols"], "deferred");
+        let unknown = module(SymbolState::Other {
+            symbol_type_code: 9,
+        });
+        assert_eq!(unknown["symbols"], "other");
+        assert_eq!(unknown["symbol_type_code"], 9);
+
+        let breakpoint = |kind| {
+            serde_json::to_value(BreakpointInfo {
+                id: 0,
+                kind,
+                address: Some(addr(0x1000)),
+                expression: None,
+                command: None,
+                thread: None,
+                enabled: true,
+                deferred: false,
+                one_shot: false,
+                pass_count: 1,
+                passes_remaining: 1,
+            })
+            .expect("serializes")
+        };
+        assert_eq!(breakpoint(BreakpointKind::Code)["kind"], "code");
+        let inline = breakpoint(BreakpointKind::Other { kind_code: 3 });
+        assert_eq!(inline["kind"], "other");
+        assert_eq!(inline["kind_code"], 3);
     }
 
     /// A chunk's state is four named values, and the fourth is not a kind of free.

--- a/src/structured.rs
+++ b/src/structured.rs
@@ -1,0 +1,943 @@
+//! The typed half of a tool result: what a program reads, beside the text a person reads.
+//!
+//! Every tool in this server has always answered with prose — a rendered pool table, a
+//! `VERDICT: HIT` line, a `session_id:` line at the bottom of an opener's report. That is the
+//! right answer for a model and for a human, and it is a bad API: the MessageManager batch
+//! client and its regression test had to match on `allocation(s)`, on module-name substrings and
+//! on the exact spelling of a session line, so a rewording here broke automation there without
+//! any debugger behaviour changing at all ([#84](https://github.com/glslang/windbg-mcp/issues/84)).
+//!
+//! So the tools listed in that issue now emit **both**: the same text as before, plus MCP
+//! `structuredContent` built from the types below, and an `outputSchema` in `tools/list`
+//! describing it. The text is unchanged, deliberately — this adds a channel rather than
+//! replacing one.
+//!
+//! # Where the values come from
+//!
+//! Nothing here is parsed out of debugger output. Each type is built from a value: win-kexp's
+//! `RunToOutcome`, `Register`, `Module`, `BreakpointInfo`, `PoolSpan` and `WalkCoverage` on the
+//! worker side, and this server's own `SessionSnapshot`/`Release` on the supervisor side. That is
+//! the rule the counts in [#77](https://github.com/glslang/windbg-mcp/issues/77) were fixed by,
+//! pointed at results instead of at counts: a figure re-derived from a rendering measures the
+//! rendering. Where a value did not exist upstream it was added there first — this is why
+//! `win-kexp` grew `register_values`, `modules`, `breakpoints` and `WalkCoverage`.
+//!
+//! # One address representation
+//!
+//! Every address, and every register-sized value, is a **`0x`-prefixed, lowercase, 16-digit
+//! zero-padded hex string** — `"0xfffff8031ab10000"`. One representation, everywhere, and a
+//! string rather than a JSON number because a `u64` above 2^53 does not survive a JSON parser
+//! that reads numbers as doubles, which is most of them. Zero-padded because clients sort and
+//! group these, and `0x9f` sorting after `0xfffff803…` is a bug waiting in every consumer. The
+//! debugger's own backtick form (`fffff803`1ab10000`) stays in the text and appears nowhere here.
+//!
+//! # Errors
+//!
+//! A failing tool still returns an MCP tool-execution error carrying the same text. It also
+//! carries structured content — the `error` branch of [`Outcome`] — so a caller can branch on
+//! [`ErrorCategory`] rather than on wording. Both branches are described by the one output
+//! schema, which is why the discriminator exists: a client validating results against the schema
+//! finds an error result conforms too.
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::engine::{EngineError, SessionKind, SessionState};
+
+/// Renders a value in this module's one address representation.
+///
+/// See the module docs: `0x`-prefixed, lowercase, zero-padded to 16 digits.
+pub fn addr(value: u64) -> String {
+    format!("{value:#018x}")
+}
+
+/// A tool's typed answer: the payload, or why there is none.
+///
+/// Internally tagged on `status`, so both branches are objects of the same schema and a client
+/// switches on one field. The alternative — omitting structured content on failure — leaves the
+/// one case a caller most needs to branch on (did this work?) answerable only by reading prose.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum Outcome<T> {
+    /// The tool did what was asked; the payload is the answer.
+    Ok(T),
+    /// It did not, and `error` says what kind of failure it was.
+    Error(Failure),
+}
+
+impl<T> Outcome<T> {
+    /// The error branch, naming the session the failure is about (where there is one).
+    pub fn failed_in(
+        category: ErrorCategory,
+        message: impl Into<String>,
+        session_id: Option<String>,
+    ) -> Self {
+        Self::Error(Failure {
+            error: FailureDetail {
+                category,
+                message: message.into(),
+                session_id,
+            },
+        })
+    }
+}
+
+/// The `error` branch of [`Outcome`].
+///
+/// One level of nesting so the payload's own fields can never collide with the failure's: a
+/// success and a failure are the same JSON object here, and a payload with a `message` field
+/// would otherwise silently shadow this one.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct Failure {
+    pub error: FailureDetail,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct FailureDetail {
+    /// What kind of failure this is. Stable across rewordings of `message`.
+    pub category: ErrorCategory,
+    /// The full human-readable failure, identical to the text content of the same result.
+    pub message: String,
+    /// The session the failure is about, where the failure has one — including the openers
+    /// that fail *after* creating a target, where this handle is the only way to reach it.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+}
+
+/// Why a tool call failed, as a value a caller can branch on.
+///
+/// Deliberately coarse. These are the distinctions that change what a caller *does* next, and
+/// nothing finer: a category nobody can act on differently is a category that will drift.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ErrorCategory {
+    /// The call was refused here, before it reached a debugger: a malformed number, an operand
+    /// carrying a command separator, two arguments that cannot both be given. Fix the argument.
+    InvalidArgument,
+    /// The debugger ran it and it failed — an unresolvable symbol, an unreadable address, a
+    /// target in the wrong state. Actionable, but by changing what is asked, not how.
+    Debugger,
+    /// The wait for this call's result expired. The job was abandoned by the *waiter*, not by
+    /// the worker: it may still be running, and anything whose retry has side effects must
+    /// treat it as possibly-done. `session_status` says what became of it.
+    Timeout,
+    /// The work was stopped on request — an `interrupt`, or a Ctrl+Break reaching the engine.
+    /// Not a failure of the target: somebody asked for this.
+    Interrupted,
+    /// The work was never started, because too little of the call's budget was left to do it and
+    /// report back. Nothing was read and nothing changed — which is what separates this from
+    /// [`Self::Timeout`], where the job may well still be running. Retry on an idle session, or
+    /// raise the server's call timeout.
+    NotRun,
+    /// The handle named no session this server will run the call against: it was ended, its
+    /// target was replaced under it, it never existed, or nothing is open at all.
+    StaleSession,
+    /// The engine process holding this session is gone. The session is unrecoverable; opening
+    /// again gets a fresh one.
+    WorkerLost,
+    /// No session slot was free, so nothing was opened. End a session and retry.
+    Capacity,
+}
+
+impl ErrorCategory {
+    /// The category an engine-level failure falls into.
+    ///
+    /// A `match` rather than a string test, so a new [`EngineError`] variant is a compile error
+    /// here instead of an `internal` that quietly swallows it.
+    pub fn of(error: &EngineError) -> Self {
+        match error {
+            EngineError::Debugger(_) => Self::Debugger,
+            EngineError::Timeout(_) => Self::Timeout,
+            EngineError::Stale(_) => Self::StaleSession,
+            EngineError::Lost(_) => Self::WorkerLost,
+            EngineError::Interrupted(_) => Self::Interrupted,
+            EngineError::NotRun(_) => Self::NotRun,
+        }
+    }
+}
+
+// ---- sessions -------------------------------------------------------------
+
+/// What an opener produced.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum OpenOutcome {
+    Ok(OpenedSession),
+    Error(OpenFailure),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct OpenedSession {
+    /// The handle to pass as `session_id` on later calls. Previously recoverable only by
+    /// finding the `session_id:` line in the report text.
+    pub session_id: String,
+    pub kind: SessionKindName,
+    /// What was opened — a path, a pid, a redacted connection label. Never carries a debug key.
+    pub target: String,
+    /// The opener's own diagnostic (`lm`, `vertarget`, `r`, the TTD lifetime query), verbatim.
+    pub report: String,
+}
+
+/// A failed open, and the one thing a caller must know about it.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct OpenFailure {
+    pub error: FailureDetail,
+    /// Whether a target was created or claimed. This is the field that decides whether opening
+    /// again is a recovery or a second attach: getting it wrong means two processes, or two
+    /// dials at one KD link.
+    pub target: TargetCreated,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum TargetCreated {
+    /// Nothing was created or claimed. The slate is clean and opening again is correct.
+    No,
+    /// The target exists — the dump is loaded, the process is spawned, the connection is taken
+    /// — and something after that failed. Do not open again; use the handle, or `end_session`.
+    Yes,
+    /// The wait was abandoned but the open was not: it is still running and may still land.
+    /// `session_status` on the handle says which it became.
+    Pending,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum SessionKindName {
+    Dump,
+    Trace,
+    Kernel,
+    KernelLocal,
+    Process,
+    Launch,
+}
+
+impl From<SessionKind> for SessionKindName {
+    fn from(kind: SessionKind) -> Self {
+        match kind {
+            SessionKind::Dump => Self::Dump,
+            SessionKind::Trace => Self::Trace,
+            SessionKind::Kernel => Self::Kernel,
+            SessionKind::KernelLocal => Self::KernelLocal,
+            SessionKind::Process => Self::Process,
+            SessionKind::Launch => Self::Launch,
+        }
+    }
+}
+
+/// What `session_status` reports.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct SessionsReport {
+    /// The live sessions, or the single session asked about. Empty when nothing is open.
+    pub sessions: Vec<SessionInfo>,
+    /// How many sessions this server will hold at once.
+    pub max_sessions: u32,
+    /// The handle this call asked about, when it named one.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub asked: Option<String>,
+    /// True when `asked` names no session this server is holding — never issued here, or closed
+    /// long enough ago to have aged out of the history. `sessions` is then empty, which on its
+    /// own is indistinguishable from "it closed".
+    pub unknown_handle: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct SessionInfo {
+    pub session_id: String,
+    pub kind: SessionKindName,
+    /// What this session holds, as it can safely be described: a kernel connection appears with
+    /// its key redacted, exactly as in the text.
+    pub target: String,
+    /// The pid of the engine process that owns it — one process per session.
+    pub engine_pid: u32,
+    pub state: SessionStateInfo,
+    /// How long it has been in that state.
+    pub in_state_for_ms: u64,
+    /// How long since it was opened.
+    pub age_ms: u64,
+    /// Whether a call that names no session is routed here.
+    pub current: bool,
+    /// Whether it will still accept work.
+    pub live: bool,
+}
+
+/// A session's state, with the one derived fact a caller cannot compute for itself.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "state", rename_all = "snake_case")]
+pub enum SessionStateInfo {
+    /// The open has started; nothing has been created or claimed yet.
+    Opening,
+    /// The target has been created or claimed and the debugger is waiting for it to break in.
+    Attaching {
+        /// Whether this wait has no timeout and cannot be interrupted — true for a live kernel
+        /// attach, which parks until its target dials in or the session is reclaimed.
+        waits_indefinitely: bool,
+        /// Whether it has been waiting longer than a healthy open ever takes. The state alone
+        /// cannot distinguish a KD link coming up from a guest that was never booted in debug
+        /// mode; how long it has been waiting can, and the two need opposite responses.
+        overdue: bool,
+    },
+    /// Open and ready for work.
+    Open,
+    /// The open failed and never created anything.
+    Failed { why: String },
+    /// The handle was retired: the engine process still holds a target, but not this one.
+    Retired { why: String },
+    /// Ended.
+    Closed { why: String },
+}
+
+impl SessionStateInfo {
+    /// Builds the state, given the two facts only the server knows.
+    pub fn of(state: &SessionState, waits_indefinitely: bool, overdue: bool) -> Self {
+        match state {
+            SessionState::Opening => Self::Opening,
+            SessionState::Attaching => Self::Attaching {
+                waits_indefinitely,
+                overdue,
+            },
+            SessionState::Open => Self::Open,
+            SessionState::Failed(why) => Self::Failed { why: why.clone() },
+            SessionState::Retired(why) => Self::Retired { why: why.clone() },
+            SessionState::Closed(why) => Self::Closed { why: why.clone() },
+        }
+    }
+}
+
+/// What `end_session` did.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct SessionEnded {
+    pub session_id: String,
+    /// Whether the worker let go of the target itself. False when it had to be killed holding
+    /// it — the live-kernel attach that cannot be interrupted is the case this exists for.
+    pub released: bool,
+    /// Whether the engine process was terminated rather than exiting on its own.
+    pub worker_terminated: bool,
+    /// How long the worker was given to let go before it was terminated, when it was.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub waited_ms: Option<u64>,
+}
+
+// ---- execution ------------------------------------------------------------
+
+/// What `run_to_address` established.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct RunToReport {
+    pub verdict: RunToVerdict,
+    /// The address asked for, after resolution.
+    pub target: String,
+    /// Where the target actually stopped, when it stopped somewhere else.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stopped_at: Option<String>,
+    /// The wait this verdict was reached under.
+    pub timeout_ms: u32,
+    /// The debugger text captured across the run.
+    pub output: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum RunToVerdict {
+    /// Execution reached the address.
+    Hit,
+    /// Another breakpoint or an exception stopped it first. `stopped_at` says where.
+    StoppedElsewhere,
+    /// It did not stop within the wait — the current input/state does not drive execution here.
+    Timeout,
+}
+
+/// Where a target ended up after a command that moves it (`g`, `p`, `t`, and the TTD reverses).
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct StopReport {
+    /// The debugger command that was run.
+    pub command: String,
+    /// The instruction pointer after it, when the engine could be asked. Absent for a target
+    /// that is running, gone, or has no thread context — which is not the same as zero.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stopped_at: Option<String>,
+    /// Whether the target was broken into **on request** rather than stopping on its own. The
+    /// position is real either way, but it is where an `interrupt` landed rather than where the
+    /// target was going, which is a different answer to "where did this stop?".
+    pub interrupted: bool,
+    /// The debugger's own output for the command.
+    pub output: String,
+}
+
+// ---- registers, modules, breakpoints --------------------------------------
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct RegisterSet {
+    pub registers: Vec<RegisterInfo>,
+    /// The instruction pointer, called out because it is the register most callers came for.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub instruction_pointer: Option<String>,
+    /// Whether x87/vector registers and subregister views were included — see the tool's
+    /// `include` argument. False means this is the integer set only.
+    pub all_registers: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct RegisterInfo {
+    /// The engine's own name for it (`rax`, `xmm0`, `efl`).
+    pub name: String,
+    #[serde(flatten)]
+    pub value: RegisterValue,
+    /// Whether this register is a view of another (`eax` within `rax`) rather than storage of
+    /// its own. Only ever true when the whole set was asked for.
+    pub subregister: bool,
+}
+
+/// One register's value, tagged by what kind of value it is.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum RegisterValue {
+    /// An integer register, in this module's one address representation.
+    Int { value: String },
+    /// A floating-point register that an `f64` holds exactly.
+    Float { value: f64 },
+    /// An x87 or vector register, as lowercase hex bytes in the engine's own order. Not
+    /// narrowed to a number, because there is no number that holds it.
+    Bytes { bytes: String },
+    /// The engine holds no value for this register in this target — a minidump carrying no
+    /// floating-point state answers this way. Distinct from zero.
+    Unavailable,
+}
+
+impl From<&win_kexp::dbgeng::RegisterValue> for RegisterValue {
+    fn from(value: &win_kexp::dbgeng::RegisterValue) -> Self {
+        use win_kexp::dbgeng::RegisterValue as Engine;
+        match value {
+            Engine::Int(v) => Self::Int { value: addr(*v) },
+            Engine::Float(v) => Self::Float { value: *v },
+            Engine::Bytes(bytes) => Self::Bytes {
+                bytes: bytes.iter().map(|b| format!("{b:02x}")).collect(),
+            },
+            Engine::Unavailable => Self::Unavailable,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct ModuleList {
+    pub modules: Vec<ModuleInfo>,
+    /// How many modules are loaded. Equal to `modules.len()`; carried so a truncated listing
+    /// could never be read as a total.
+    pub loaded: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct ModuleInfo {
+    /// The name symbols are qualified by — the `nt` in `nt!KeBugCheckEx`.
+    pub name: String,
+    /// The image's own name (`ntkrnlmp.exe`).
+    pub image_name: String,
+    /// Where the engine loaded the image from, where it has a path.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub loaded_image_name: Option<String>,
+    pub start: String,
+    /// One past the last byte, matching the `start end` pair `lm` prints.
+    pub end: String,
+    pub size: u64,
+    pub symbols: SymbolState,
+    pub user_mode: bool,
+    pub timestamp: u32,
+    pub checksum: u32,
+}
+
+/// How much symbol information the engine has for a module.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum SymbolState {
+    None,
+    /// Not loaded *yet* — the engine fetches them when something needs them. Emphatically not
+    /// "this module has no symbols", which is the reading that makes `lm` output misleading.
+    Deferred,
+    Coff,
+    CodeView,
+    Pdb,
+    /// Names from the export table only: enough for `module!Export`, nothing more.
+    Export,
+    Sym,
+    Dia,
+    /// A symbol type this build does not name; `code` is the engine's own.
+    Other {
+        code: u32,
+    },
+}
+
+impl From<win_kexp::dbgeng::SymbolKind> for SymbolState {
+    fn from(kind: win_kexp::dbgeng::SymbolKind) -> Self {
+        use win_kexp::dbgeng::SymbolKind as Engine;
+        match kind {
+            Engine::None => Self::None,
+            Engine::Deferred => Self::Deferred,
+            Engine::Coff => Self::Coff,
+            Engine::CodeView => Self::CodeView,
+            Engine::Pdb => Self::Pdb,
+            Engine::Export => Self::Export,
+            Engine::Sym => Self::Sym,
+            Engine::Dia => Self::Dia,
+            Engine::Other(code) => Self::Other { code },
+        }
+    }
+}
+
+impl From<&win_kexp::dbgeng::Module> for ModuleInfo {
+    fn from(module: &win_kexp::dbgeng::Module) -> Self {
+        Self {
+            name: module.name.clone(),
+            image_name: module.image_name.clone(),
+            loaded_image_name: Some(module.loaded_image_name.clone())
+                .filter(|name| !name.is_empty()),
+            start: addr(module.base),
+            end: addr(module.end()),
+            size: u64::from(module.size),
+            symbols: module.symbols.into(),
+            user_mode: module.user_mode,
+            timestamp: module.timestamp,
+            checksum: module.checksum,
+        }
+    }
+}
+
+/// The breakpoints a session holds, after a `set_breakpoint`.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct BreakpointSet {
+    /// The ids this call added. Empty when the command set nothing — which `bp` reports by
+    /// printing an error and is otherwise invisible, since a successful `bp` prints nothing.
+    pub added: Vec<u32>,
+    /// Every breakpoint the session now holds, added or not.
+    pub breakpoints: Vec<BreakpointInfo>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct BreakpointInfo {
+    /// The id the debugger prints, and that `bc`/`bd`/`be` take.
+    pub id: u32,
+    pub kind: BreakpointKind,
+    /// Where it will fire. Absent while it is deferred — its module is not loaded, so it has no
+    /// address yet, which is not the same as an address of zero.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub address: Option<String>,
+    /// The expression the engine is still holding it as, in practice only for a deferred one:
+    /// a breakpoint that resolved when it was set keeps its address instead.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expression: Option<String>,
+    /// The command string the debugger runs each time it fires (what `ioctl_trace` installs).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub command: Option<String>,
+    /// The thread it is restricted to, or absent for any thread.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub thread: Option<u32>,
+    pub enabled: bool,
+    pub deferred: bool,
+    pub one_shot: bool,
+    /// How many times it must be reached before it stops the target (1 = every time).
+    pub pass_count: u32,
+    /// How many of those passes are still to go.
+    pub passes_remaining: u32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum BreakpointKind {
+    /// Execution reaching an address (`bp`).
+    Code,
+    /// Access to a range of memory (`ba`).
+    Data,
+    Other {
+        code: u32,
+    },
+}
+
+impl From<&win_kexp::dbgeng::BreakpointInfo> for BreakpointInfo {
+    fn from(bp: &win_kexp::dbgeng::BreakpointInfo) -> Self {
+        use win_kexp::dbgeng::BreakpointKind as Engine;
+        Self {
+            id: bp.id,
+            kind: match bp.kind {
+                Engine::Code => BreakpointKind::Code,
+                Engine::Data => BreakpointKind::Data,
+                Engine::Other(code) => BreakpointKind::Other { code },
+            },
+            address: bp.address.map(addr),
+            expression: bp.expression.clone(),
+            command: bp.command.clone(),
+            thread: bp.thread,
+            enabled: bp.enabled,
+            deferred: bp.deferred,
+            one_shot: bp.one_shot,
+            pass_count: bp.pass_count,
+            passes_remaining: bp.passes_remaining,
+        }
+    }
+}
+
+// ---- pool -----------------------------------------------------------------
+
+/// How much of the pool the walk behind an answer actually covered.
+///
+/// Every pool answer carries this, because every one of them is drawn from a snapshot and a
+/// count taken from a partial snapshot is a floor rather than a total. The three ways of falling
+/// short are separate values because they need different responses; a fourth — the walk failing
+/// outright, or being interrupted — is not a coverage state at all but the `error` branch of
+/// [`Outcome`], with category [`ErrorCategory::Debugger`] or [`ErrorCategory::Interrupted`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum PoolCoverage {
+    /// The walk covered everything it set out to. Counts here are totals.
+    Complete,
+    /// It stopped because its deadline — what was left of this call's budget — ran out. What it
+    /// found was really there; what is missing is unknown rather than absent, and a longer
+    /// budget (a larger `WINDBG_MCP_CALL_TIMEOUT_SECS`, or an idle session) reaches more.
+    DeadlineTruncated,
+    /// It ran to the end without covering all of it: unreadable regions, a region that stopped
+    /// mid-chunk, a traversal cap. `pool_diagnostics` says which. Unlike `deadline_truncated`,
+    /// more time changes nothing.
+    Partial,
+}
+
+impl From<win_kexp::pool::query::WalkCoverage> for PoolCoverage {
+    fn from(coverage: win_kexp::pool::query::WalkCoverage) -> Self {
+        use win_kexp::pool::query::WalkCoverage as Engine;
+        match coverage {
+            Engine::Complete => Self::Complete,
+            Engine::BudgetExpired => Self::DeadlineTruncated,
+            Engine::Partial => Self::Partial,
+        }
+    }
+}
+
+/// The state of the walk an answer was drawn from.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct WalkInfo {
+    pub coverage: PoolCoverage,
+    /// Chunks the walk indexed, allocated and free.
+    pub chunks_walked: usize,
+    pub allocated_chunks: usize,
+    /// How many complaints the walk made — every one, not the capped sample it kept verbatim.
+    pub diagnostics_emitted: usize,
+    /// How many distinct kinds of complaint those fell into.
+    pub diagnostic_categories: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct PoolChunkInfo {
+    /// What the allocation call returned, and so what the target's own pointers hold.
+    pub address: String,
+    /// Where the allocator's bookkeeping starts. Rarely what a caller is holding.
+    pub header_address: String,
+    pub size: u64,
+    pub state: PoolChunkState,
+    pub tag: String,
+    pub pool: PoolKindName,
+    pub backend: PoolBackendName,
+    pub numa_node: u16,
+    /// Whether this chunk sits in Driver Verifier special pool — a whole page against a guard
+    /// page, so an overflow or a touch after free faults at once.
+    pub special_pool: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum PoolChunkState {
+    Allocated,
+    /// Freed and available for reuse: a pointer the target still holds to it is dangling.
+    ReusableFree,
+    /// Freed into a cache: likewise dangling.
+    CachedFree,
+    /// The walk could not read the span. A limit of the walk, not a fact about lifetime — a
+    /// Verifier guard page reads exactly this way.
+    Unreadable,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum PoolKindName {
+    NonPagedExecutable,
+    NonPagedNx,
+    Paged,
+    PrototypePaged,
+    SpecialNonPaged,
+    SpecialNonPagedNx,
+    SpecialPaged,
+    SpecialPrototypePaged,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum PoolBackendName {
+    Lfh,
+    Vs,
+    Segment,
+    Large,
+}
+
+impl From<&win_kexp::pool::PoolSpan> for PoolChunkInfo {
+    fn from(span: &win_kexp::pool::PoolSpan) -> Self {
+        use win_kexp::pool::{PoolBackend, PoolKind, PoolState};
+        Self {
+            address: addr(span.usable_address),
+            header_address: addr(span.header_address),
+            size: span.size,
+            state: match span.state {
+                PoolState::Allocated => PoolChunkState::Allocated,
+                PoolState::ReusableFree => PoolChunkState::ReusableFree,
+                PoolState::CachedFree => PoolChunkState::CachedFree,
+                PoolState::Unreadable => PoolChunkState::Unreadable,
+            },
+            tag: span.display_tag.clone(),
+            pool: match span.pool_kind {
+                PoolKind::NonPagedExecutable => PoolKindName::NonPagedExecutable,
+                PoolKind::NonPagedNx => PoolKindName::NonPagedNx,
+                PoolKind::Paged => PoolKindName::Paged,
+                PoolKind::PrototypePaged => PoolKindName::PrototypePaged,
+                PoolKind::SpecialNonPaged => PoolKindName::SpecialNonPaged,
+                PoolKind::SpecialNonPagedNx => PoolKindName::SpecialNonPagedNx,
+                PoolKind::SpecialPaged => PoolKindName::SpecialPaged,
+                PoolKind::SpecialPrototypePaged => PoolKindName::SpecialPrototypePaged,
+            },
+            backend: match span.backend {
+                PoolBackend::Lfh => PoolBackendName::Lfh,
+                PoolBackend::Vs => PoolBackendName::Vs,
+                PoolBackend::Segment => PoolBackendName::Segment,
+                PoolBackend::Large => PoolBackendName::Large,
+            },
+            numa_node: span.numa_node,
+            special_pool: span.heap.special,
+        }
+    }
+}
+
+/// What `pool_find_tag` found.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct PoolTagMatches {
+    pub tag: String,
+    pub scope: PoolScope,
+    /// How many allocated chunks carry the tag. A floor rather than a total unless
+    /// `walk.coverage` is `complete`.
+    pub matches: usize,
+    /// Their total size in bytes, over all matches — not only the ones listed.
+    pub total_bytes: u64,
+    /// The matches themselves, capped by the call's `limit`; `matches` is the full count.
+    pub chunks: Vec<PoolChunkInfo>,
+    pub walk: WalkInfo,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum PoolScope {
+    Both,
+    Paged,
+    NonPaged,
+}
+
+/// What `pool_chunk` found at an address.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct PoolChunkAt {
+    /// The address asked about.
+    pub address: String,
+    /// Whether the snapshot covers this address at all. False is *not* "free": it means the
+    /// address is not pool, or sits in a region this walk never reached — check `walk.coverage`
+    /// before reading it as either.
+    pub covered: bool,
+    /// The chunk containing the address, when one covers it.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub chunk: Option<PoolChunkInfo>,
+    /// How far into that chunk the address sits.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub offset: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub previous: Option<PoolChunkInfo>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub next: Option<PoolChunkInfo>,
+    pub walk: WalkInfo,
+}
+
+/// What `pool_census` totalled.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct PoolCensus {
+    /// How many distinct tags are allocated. The listing below is capped by `limit`.
+    pub distinct_tags: usize,
+    pub tags: Vec<PoolTagTotals>,
+    pub walk: WalkInfo,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct PoolTagTotals {
+    pub tag: String,
+    pub allocations: usize,
+    pub total_bytes: u64,
+    pub paged_allocations: usize,
+    pub nonpaged_allocations: usize,
+}
+
+/// What `pool_diagnostics` selected.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct PoolDiagnosticsReport {
+    /// The substring the listing was narrowed to, when it was.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub filter: Option<String>,
+    /// Categories matching the filter, commonest first, capped by `limit`.
+    pub categories: Vec<DiagnosticCategory>,
+    /// Verbatim messages matching the filter, capped by `limit`. A *sample*: the walk keeps
+    /// only a few per category, so their number says nothing about volume — `categories` does.
+    pub examples: Vec<String>,
+    /// How many categories matched, before the cap.
+    pub matched_categories: usize,
+    /// How many kept messages matched, before the cap.
+    pub matched_examples: usize,
+    pub walk: WalkInfo,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct DiagnosticCategory {
+    /// The message with its addresses and numbers generalised away — which is what lets it
+    /// carry a count, and why a filter naming a concrete address never matches one.
+    pub shape: String,
+    /// Every message of this shape the walk emitted, not just the ones kept verbatim.
+    pub total: usize,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// One address representation, and it is the lossless one.
+    ///
+    /// The three properties a consumer relies on: it round-trips a full 64-bit value (a JSON
+    /// number would not, above 2^53), it is fixed width so lexical order matches numeric order,
+    /// and it never carries the debugger's backtick — that form is text, and text is the other
+    /// channel.
+    #[test]
+    fn addresses_have_one_lossless_representation() {
+        assert_eq!(addr(0), "0x0000000000000000");
+        assert_eq!(addr(0x9f), "0x000000000000009f");
+        assert_eq!(addr(u64::MAX), "0xffffffffffffffff");
+        // A kernel pointer past 2^53, which is where a JSON number starts lying.
+        assert_eq!(addr(0xffff_8000_dead_beef), "0xffff8000deadbeef");
+        assert_eq!(
+            u64::from_str_radix(addr(0xffff_8000_dead_beef).trim_start_matches("0x"), 16),
+            Ok(0xffff_8000_dead_beef)
+        );
+        assert!(addr(0xfffff803_1ab10000) < addr(0xffffffff_00000000));
+        assert!(!addr(0xfffff803_1ab10000).contains('`'));
+    }
+
+    /// Both branches of an outcome are objects carrying `status`, which is what lets one output
+    /// schema describe a result whichever way it went.
+    #[test]
+    fn an_outcome_is_discriminated_on_status() {
+        let ok = serde_json::to_value(Outcome::Ok(SessionEnded {
+            session_id: "sess-1".into(),
+            released: true,
+            worker_terminated: false,
+            waited_ms: None,
+        }))
+        .expect("serializes");
+        assert_eq!(ok["status"], "ok");
+        assert_eq!(ok["session_id"], "sess-1");
+        assert_eq!(ok["released"], true);
+        // Absent rather than null: a consumer reading `waited_ms` gets "no answer", not "0ms".
+        assert!(ok.get("waited_ms").is_none());
+
+        let failed: Outcome<SessionEnded> = Outcome::failed_in(
+            ErrorCategory::StaleSession,
+            "`sess-9` is not a handle this server is holding",
+            Some("sess-9".into()),
+        );
+        let failed = serde_json::to_value(failed).expect("serializes");
+        assert_eq!(failed["status"], "error");
+        assert_eq!(failed["error"]["category"], "stale_session");
+        assert_eq!(failed["error"]["session_id"], "sess-9");
+    }
+
+    /// The category is a value, and every engine failure maps to one — checked here rather than
+    /// left to a `_` arm, because a new failure kind silently becoming "debugger" is exactly the
+    /// drift this field exists to prevent.
+    #[test]
+    fn every_engine_failure_has_a_category() {
+        let cases = [
+            (
+                EngineError::Debugger("no".into()),
+                ErrorCategory::Debugger,
+                "debugger",
+            ),
+            (
+                EngineError::Timeout("no".into()),
+                ErrorCategory::Timeout,
+                "timeout",
+            ),
+            (
+                EngineError::Stale("no".into()),
+                ErrorCategory::StaleSession,
+                "stale_session",
+            ),
+            (
+                EngineError::Lost("no".into()),
+                ErrorCategory::WorkerLost,
+                "worker_lost",
+            ),
+        ];
+        for (error, expected, wire) in cases {
+            assert_eq!(ErrorCategory::of(&error), expected);
+            assert_eq!(serde_json::to_value(expected).unwrap(), wire);
+        }
+    }
+
+    /// A register's kind travels with its value, so a consumer never has to guess whether a
+    /// string is a number or bytes.
+    #[test]
+    fn a_register_value_says_what_kind_of_value_it_is() {
+        use win_kexp::dbgeng::RegisterValue as Engine;
+        let int = RegisterValue::from(&Engine::Int(0xffff_8000_dead_beef));
+        let json = serde_json::to_value(&int).unwrap();
+        assert_eq!(json["kind"], "int");
+        assert_eq!(json["value"], "0xffff8000deadbeef");
+
+        let bytes = RegisterValue::from(&Engine::Bytes(vec![0x00, 0x1f, 0xff]));
+        let json = serde_json::to_value(&bytes).unwrap();
+        assert_eq!(json["kind"], "bytes");
+        assert_eq!(json["bytes"], "001fff");
+
+        let missing = RegisterValue::from(&Engine::Unavailable);
+        assert_eq!(
+            serde_json::to_value(&missing).unwrap(),
+            serde_json::json!({ "kind": "unavailable" })
+        );
+    }
+
+    /// The three coverage states stay distinct across the seam: collapsing `deadline_truncated`
+    /// into `partial` would tell a caller that waiting longer cannot help, when it is the one
+    /// thing that would.
+    #[test]
+    fn pool_coverage_keeps_the_walks_own_reason() {
+        use win_kexp::pool::query::WalkCoverage as Engine;
+        for (engine, expected, wire) in [
+            (Engine::Complete, PoolCoverage::Complete, "complete"),
+            (
+                Engine::BudgetExpired,
+                PoolCoverage::DeadlineTruncated,
+                "deadline_truncated",
+            ),
+            (Engine::Partial, PoolCoverage::Partial, "partial"),
+        ] {
+            assert_eq!(PoolCoverage::from(engine), expected);
+            assert_eq!(serde_json::to_value(expected).unwrap(), wire);
+        }
+    }
+
+    /// A chunk's state is four named values, and the fourth is not a kind of free.
+    ///
+    /// `Unreadable` is a limit of the walk — a Verifier guard page reads exactly that way — so a
+    /// consumer testing "is this a use-after-free?" must be able to see it as neither allocated
+    /// nor freed. Collapsing it either way turns "could not read" into a verdict.
+    #[test]
+    fn a_chunk_state_names_the_unreadable_case_separately() {
+        let wire = |state| serde_json::to_value(state).unwrap();
+        assert_eq!(wire(PoolChunkState::Allocated), "allocated");
+        assert_eq!(wire(PoolChunkState::ReusableFree), "reusable_free");
+        assert_eq!(wire(PoolChunkState::CachedFree), "cached_free");
+        assert_eq!(wire(PoolChunkState::Unreadable), "unreadable");
+    }
+}

--- a/src/structured.rs
+++ b/src/structured.rs
@@ -520,9 +520,23 @@ impl From<&win_kexp::dbgeng::Module> for ModuleInfo {
 pub struct BreakpointSet {
     /// The ids this call added. Empty when the command set nothing — which `bp` reports by
     /// printing an error and is otherwise invisible, since a successful `bp` prints nothing.
+    ///
+    /// When `listed` is false this is empty because it is **unknown**, not because nothing was
+    /// added.
     pub added: Vec<u32>,
     /// Every breakpoint the session now holds, added or not.
     pub breakpoints: Vec<BreakpointInfo>,
+    /// Whether the breakpoints above are the session's real list.
+    ///
+    /// False does **not** mean the breakpoint was not set. The `bp` succeeded — that is why this
+    /// is a success and not an error — and the follow-up inspection is what failed. Reporting an
+    /// inspection failure as the mutation failing invites the one recovery that must not happen:
+    /// `bp` is not idempotent, so a caller who retries sets a second breakpoint. `bl` through
+    /// `execute` is the way to find out what is there.
+    pub listed: bool,
+    /// Why the listing is missing or incomplete, when it is.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub listing_error: Option<String>,
 }
 
 /// One breakpoint the session holds.

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -1696,6 +1696,13 @@ fn render_walk_report(report: &query::PoolSnapshotReport) -> String {
 /// rendering below carries how much of the pool the walk reached — so the cost of a short deadline
 /// is coverage, not an error.
 fn pool(e: &DebugEngine, args: PoolOp, within: Duration) -> Result<Output, Failed> {
+    // `within` is a duration, and the walk report below is read *after* the query has spent most
+    // of it — so handing it `within` again would grant a second full-length walk (which is a real
+    // possibility, not a theoretical one: an incomplete snapshot is not cached, so the report can
+    // find nothing to read and start one). Anchored to a deadline here, and what is left of it is
+    // what the report gets.
+    let started = Instant::now();
+    let left = move || within.saturating_sub(started.elapsed());
     let walk = |refresh: bool| PoolWalk::from(refresh).within(within);
     match args {
         PoolOp::FindTag {
@@ -1715,7 +1722,7 @@ fn pool(e: &DebugEngine, args: PoolOp, within: Duration) -> Result<Output, Faile
             let mut out = render_find_tag(&tag, filter, &spans, limit);
             // Reads the snapshot `find_tag` has just taken or reused — hence `refresh: false`,
             // which cannot start a walk of its own whatever budget this query had.
-            let report = walk_report(e, within);
+            let report = walk_report(e, left());
             if spans.is_empty() {
                 // An empty answer has to explain itself, or "the pool holds no such chunk" and
                 // "the walk reached almost none of the pool" read identically.
@@ -1772,7 +1779,7 @@ fn pool(e: &DebugEngine, args: PoolOp, within: Duration) -> Result<Output, Faile
             // Read once and spent twice: the text below and the typed answer describe the same
             // walk, and asking again could start a second one — an incomplete snapshot is not
             // cached, so a re-read is a re-walk.
-            let report = walk_report(e, within);
+            let report = walk_report(e, left());
             if found.is_none() {
                 append_walk_report(&mut out, report.as_ref());
             }
@@ -1839,7 +1846,7 @@ fn pool(e: &DebugEngine, args: PoolOp, within: Duration) -> Result<Output, Faile
         PoolOp::Census { refresh, limit } => {
             let census = query::tag_census(e, walk(refresh)).map_err(pool_failure)?;
             let mut out = render_census(&census, limit);
-            let report = walk_report(e, within);
+            let report = walk_report(e, left());
             append_walk_report(&mut out, report.as_ref());
             Ok(Output::typed(
                 out,
@@ -1865,14 +1872,15 @@ fn pool(e: &DebugEngine, args: PoolOp, within: Duration) -> Result<Output, Faile
 
 /// The walk's own state, for an answer that has already been computed from it.
 ///
-/// `refresh: false`, so this reads the snapshot the query just took or reused. It is bounded by
-/// the caller's remaining `within` all the same: an *incomplete* walk is not cached, so this can
-/// find no snapshot and start one, and win-kexp's 120s default is not this call's to spend.
+/// `refresh: false`, so this reads the snapshot the query just took or reused. It is bounded all
+/// the same, and by what is **left** of the caller's patience rather than by the whole of it: an
+/// *incomplete* walk is not cached, so this can find no snapshot and start one — and neither
+/// win-kexp's 120s default nor a second helping of a budget already spent is this call's to give.
 fn walk_report(
     e: &DebugEngine,
-    within: Duration,
+    left: Duration,
 ) -> Result<query::PoolSnapshotReport, query::PoolQueryError> {
-    query::snapshot_report(e, PoolWalk::from(false).within(within))
+    query::snapshot_report(e, PoolWalk::from(false).within(left))
 }
 
 /// The walk state every pool answer carries.

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -1269,29 +1269,121 @@ fn modules(e: &DebugEngine) -> Result<Output, Failed> {
 /// be right until the first time it was not.
 ///
 /// A successful `bp` prints nothing at all, so the text alone cannot distinguish "set" from
-/// "silently did nothing" — which is the gap this fills.
+/// "silently did nothing" — which is the gap this fills, in **both** channels: the listing is
+/// rendered into the text too, or a client that reads only text is left with the empty string
+/// this was meant to fix.
+///
+/// **Only the `bp` itself can fail this call.** The listing either side of it is an inspection,
+/// and an inspection that fails after a mutation must not be reported as the mutation failing:
+/// the breakpoint is set, and a caller who retries on that error sets a second one. So a listing
+/// failure comes back as a success that says the listing is missing —
+/// [`structured::BreakpointSet::listed`] — which is the same distinction `OpenError::PostCommit`
+/// draws for an opener, at a much smaller scale.
 fn set_breakpoint(e: &DebugEngine, expression: &str) -> Result<Output, Failed> {
-    let before: HashSet<u32> = e
+    // Best-effort, and taken first: a session whose breakpoint list cannot be read must still be
+    // able to set a breakpoint, so this cannot be a `?`.
+    let before: Option<HashSet<u32>> = e
         .breakpoints()
-        .map_err(failed)?
-        .iter()
-        .map(|breakpoint| breakpoint.id)
-        .collect();
-    let text = e
+        .ok()
+        .map(|held| held.iter().map(|breakpoint| breakpoint.id).collect());
+    let mut text = e
         .execute_command(&format!("bp {expression}"))
         .map_err(failed)?;
-    let after = e.breakpoints().map_err(failed)?;
-    Ok(Output::typed(
-        text,
-        structured::BreakpointSet {
+    // Past this point the breakpoint exists.
+    let set = match (e.breakpoints(), before) {
+        (Ok(after), Some(before)) => structured::BreakpointSet {
             added: after
                 .iter()
                 .map(|breakpoint| breakpoint.id)
                 .filter(|id| !before.contains(id))
                 .collect(),
             breakpoints: after.iter().map(structured::BreakpointInfo::from).collect(),
+            listed: true,
+            listing_error: None,
         },
-    ))
+        // The list read, but not the one before it — so what is set can be reported and which of
+        // them is new cannot. `added` is empty because it is unknown, and `listed` says so.
+        (Ok(after), None) => structured::BreakpointSet {
+            added: Vec::new(),
+            breakpoints: after.iter().map(structured::BreakpointInfo::from).collect(),
+            listed: false,
+            listing_error: Some(
+                "the breakpoints held before this call could not be read, so which of the \
+                 breakpoints below is the new one is unknown"
+                    .to_string(),
+            ),
+        },
+        (Err(why), _) => structured::BreakpointSet {
+            added: Vec::new(),
+            breakpoints: Vec::new(),
+            listed: false,
+            listing_error: Some(why.to_string()),
+        },
+    };
+    text.push_str(&render_breakpoints(&set));
+    Ok(Output::typed(text, set))
+}
+
+/// Renders what a `set_breakpoint` left the session holding, for the text channel.
+///
+/// Appended to the command's own output rather than replacing it: `bp` prints nothing when it
+/// succeeds and an error when it does not, and both are worth keeping.
+fn render_breakpoints(set: &structured::BreakpointSet) -> String {
+    if !set.listed && set.breakpoints.is_empty() {
+        return format!(
+            "\nThe breakpoint command ran and the breakpoint is set, but the session's breakpoint \
+             list could not be read: {}\n\nDo **not** re-run this call to find out what it did — \
+             `bp` is not idempotent and a second call sets a second breakpoint. Use `execute \
+             {{ \"command\": \"bl\" }}` instead.\n",
+            set.listing_error.as_deref().unwrap_or("no reason given")
+        );
+    }
+    let mut out = format!(
+        "\n{} breakpoint(s) set{}:\n",
+        set.breakpoints.len(),
+        match set.added.len() {
+            0 if set.listed => " (this call added none)".to_string(),
+            0 => String::new(),
+            n => format!(" ({n} added by this call, marked *)"),
+        }
+    );
+    for breakpoint in &set.breakpoints {
+        // Trimmed at the end, because the columns are padded for alignment and the last one on a
+        // row is usually empty — trailing spaces on every line of a tool result are noise.
+        let row = format!(
+            "{} {:<3} {:<18} {:<9}{}{}",
+            if set.added.contains(&breakpoint.id) {
+                "*"
+            } else {
+                " "
+            },
+            breakpoint.id,
+            // A deferred breakpoint has no address *yet*; printing a zero would name the null
+            // page as the place it will fire.
+            breakpoint.address.as_deref().unwrap_or("(unresolved)"),
+            if breakpoint.enabled {
+                "enabled"
+            } else {
+                "disabled"
+            },
+            breakpoint
+                .expression
+                .as_deref()
+                .map(|expression| format!("  {expression}"))
+                .unwrap_or_default(),
+            if breakpoint.deferred {
+                "  (deferred)"
+            } else {
+                ""
+            },
+        );
+        out.push_str(row.trim_end());
+        out.push('\n');
+    }
+    if let Some(why) = &set.listing_error {
+        out.push_str(&format!("\nNote: {why}.\n"));
+    }
+    out
 }
 
 /// Reads target memory and renders it as a hex dump.
@@ -3034,6 +3126,71 @@ mod tests {
         assert!(
             !running.release(9),
             "a job that started after the interrupt must not answer for it"
+        );
+    }
+
+    // ---- what a set_breakpoint caller is told -------------------------------
+
+    fn breakpoint(id: u32, address: Option<&str>) -> structured::BreakpointInfo {
+        structured::BreakpointInfo {
+            id,
+            kind: structured::BreakpointKind::Code,
+            address: address.map(str::to_string),
+            expression: address.is_none().then(|| "nosuchmod!Sym".to_string()),
+            command: None,
+            thread: None,
+            enabled: true,
+            deferred: address.is_none(),
+            one_shot: false,
+            pass_count: 1,
+            passes_remaining: 1,
+        }
+    }
+
+    /// A successful `bp` prints **nothing**, so a text-only client saw an empty result and could
+    /// not tell it from silence. The listing goes into the text as well as into the typed answer,
+    /// or the fix only reaches half the clients it was written for.
+    #[test]
+    fn a_breakpoint_that_was_set_says_so_in_the_text_too() {
+        let out = render_breakpoints(&structured::BreakpointSet {
+            added: vec![1],
+            breakpoints: vec![
+                breakpoint(0, Some("0x00007ffb6e6a0e10")),
+                breakpoint(1, None),
+            ],
+            listed: true,
+            listing_error: None,
+        });
+        assert!(out.contains("2 breakpoint(s) set"), "{out}");
+        assert!(out.contains("1 added by this call"), "{out}");
+        // The new one is marked, and the deferred one says it has no address rather than
+        // printing a zero — which would name the null page as where it will fire.
+        assert!(out.lines().any(|l| l.starts_with("* 1")), "{out}");
+        assert!(out.lines().any(|l| l.starts_with("  0")), "{out}");
+        assert!(
+            out.contains("(unresolved)") && out.contains("nosuchmod!Sym"),
+            "{out}"
+        );
+    }
+
+    /// A listing that failed *after* the `bp` must not read as a breakpoint that was not set.
+    ///
+    /// This is the whole reason that case is a success rather than an error: `bp` is not
+    /// idempotent, so a caller who reads "failed" and retries ends up with two breakpoints. The
+    /// text has to say both things — it is set, and do not re-run this to find out what it did.
+    #[test]
+    fn a_listing_that_failed_after_the_bp_still_says_the_breakpoint_is_set() {
+        let out = render_breakpoints(&structured::BreakpointSet {
+            added: Vec::new(),
+            breakpoints: Vec::new(),
+            listed: false,
+            listing_error: Some("the engine refused: 0x80004005".to_string()),
+        });
+        assert!(out.contains("the breakpoint is set"), "{out}");
+        assert!(out.contains("0x80004005"), "{out}");
+        assert!(
+            out.contains("second breakpoint"),
+            "must warn against the retry: {out}"
         );
     }
 

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -33,6 +33,7 @@
 //! can ask for the same thing, and the binding ([`Running`]) that decides *which job* the request
 //! reaches. See `AGENTS.md` and the `DECISIONS.md` entry for the invariant and its boundary.
 
+use std::collections::HashSet;
 use std::io::{BufRead, BufReader, PipeReader, PipeWriter, Write};
 use std::os::windows::io::{AsRawHandle, FromRawHandle, RawHandle};
 use std::panic::{AssertUnwindSafe, catch_unwind};
@@ -47,11 +48,14 @@ use win_kexp::pool::{DiagnosticShape, PoolDiagnostics, PoolSpan, PoolState};
 use windows_sys::Win32::Foundation::{HANDLE_FLAG_INHERIT, SetHandleInformation};
 
 use crate::batch::{self, BatchOp, Debuggee, Ran};
-use crate::proto::{EngineOp, PoolOp, ReachabilityOp, WorkerMessage, WorkerRequest};
+use crate::proto::{
+    EngineOp, Failed, Output, PoolOp, ReachabilityOp, WorkerMessage, WorkerRequest,
+};
 use crate::server::{
     fmt_addr, format_recipe, format_report, hexdump, parse_eval, parse_lm_base, parse_u64,
     parse_windbg_addr, path_recipe, reachability,
 };
+use crate::structured;
 
 /// The argument that turns this executable into a worker. Not a documented CLI: the supervisor
 /// re-executes itself with it, and nothing else should.
@@ -525,7 +529,7 @@ pub fn run(args: &[String]) -> ! {
                 if matches!(request.op, EngineOp::Interrupt) {
                     emit(&WorkerMessage::Done {
                         id: request.id,
-                        result: interrupt_running(),
+                        result: interrupt_running().map(Output::text).map_err(Failed::from),
                     });
                     continue;
                 }
@@ -650,7 +654,7 @@ fn engine_thread(rx: mpsc::Receiver<Job>) {
                     Ok(Err(e)) => tracing::error!(
                         "worker: the debugger refused to release the target ({}); a live kernel \
                          target may be left halted",
-                        es(e)
+                        e
                     ),
                     Err(_) => tracing::error!(
                         "worker: releasing the target panicked; a live kernel target may be left \
@@ -674,7 +678,7 @@ fn engine_thread(rx: mpsc::Receiver<Job>) {
         let result = catch_unwind(AssertUnwindSafe(|| {
             execute(&engine, id, request.op, queued)
         }))
-        .unwrap_or_else(|_| Err("debugger operation panicked".to_string()));
+        .unwrap_or_else(|_| Err(Failed::from("debugger operation panicked")));
         let result = if release(id) {
             // The engine may have consumed the Ctrl+Break, or the request may have been lodged as
             // the operation was already returning — in which case it is still pending with nothing
@@ -695,9 +699,9 @@ fn engine_thread(rx: mpsc::Receiver<Job>) {
             // in the same shape. The caller loses the output, not the session.
             emit(&WorkerMessage::Done {
                 id,
-                result: Err(
-                    "the debugger's result could not be encoded for the supervisor".to_string(),
-                ),
+                result: Err(Failed::from(
+                    "the debugger's result could not be encoded for the supervisor",
+                )),
             });
         }
         // `Unwritable` gets no retry, and needs none: the supervisor holds the only read end, so
@@ -784,16 +788,31 @@ fn announce_teardown(id: u64) {
 /// Appended rather than substituted, both ways round: the partial output is the point of
 /// interrupting rather than ending the session, and a failure keeps its debugger text because
 /// "this is why it stopped" is not the same claim as "this is what it would have said".
-fn cut_short(result: Result<String, String>) -> Result<String, String> {
+fn cut_short(result: Result<Output, Failed>) -> Result<Output, Failed> {
     const NOTE: &str = "[windbg-mcp] This operation was interrupted on request (Ctrl+Break) \
                         before it finished, so this is what it had reached, not a complete \
                         result. Nothing about the target failed. Re-run it — scoped more \
                         narrowly, if it was interrupted for taking too long.";
     match result {
-        Ok(text) if text.is_empty() => Ok(NOTE.to_string()),
-        Ok(text) if text.ends_with('\n') => Ok(format!("{text}\n{NOTE}")),
-        Ok(text) => Ok(format!("{text}\n\n{NOTE}")),
-        Err(text) => Err(format!("{text}\n\n{NOTE}")),
+        // The note lands on the text and the typed payload is left as it was: the interruption is
+        // a fact about this *call*, and rewriting an answer the engine did produce — a stop
+        // position, a chunk listing — to say it did not would throw away the very thing that
+        // makes interrupting better than ending the session.
+        Ok(out) => Ok(Output {
+            text: match out.text {
+                text if text.is_empty() => NOTE.to_string(),
+                text if text.ends_with('\n') => format!("{text}\n{NOTE}"),
+                text => format!("{text}\n\n{NOTE}"),
+            },
+            data: out.data,
+        }),
+        // The category matters as much as the note: an interrupted operation reported as a
+        // debugger failure tells its caller the target misbehaved, when what happened is that
+        // somebody — quite possibly that same caller — asked for it to stop.
+        Err(failed) => Err(Failed::categorised(
+            structured::ErrorCategory::Interrupted,
+            format!("{}\n\n{NOTE}", failed.message),
+        )),
     }
 }
 
@@ -869,7 +888,7 @@ fn interrupt_running() -> Result<String, String> {
 
 /// Runs one op against this worker's engine. `queued` is how long it waited its turn here, which
 /// only the bounded-command path cares about.
-fn execute(e: &DebugEngine, id: u64, op: EngineOp, queued: Duration) -> Result<String, String> {
+fn execute(e: &DebugEngine, id: u64, op: EngineOp, queued: Duration) -> Result<Output, Failed> {
     match op {
         // ---- openers ----
         //
@@ -1014,27 +1033,29 @@ fn execute(e: &DebugEngine, id: u64, op: EngineOp, queued: Duration) -> Result<S
         // Zero costs nothing to say. It spawns no watchdog at all — which is the whole reason these
         // ops are off the bounded path (DECISIONS.md, 2026-08-02: arming one rounds a command up to
         // a multiple of 200ms) — so this stays unbounded, as `index_trace` in particular must.
-        EngineOp::Command { command } => {
-            e.execute_command_bounded(&command, 0).map(told).map_err(es)
-        }
+        EngineOp::Command { command } => e
+            .execute_command_bounded(&command, 0)
+            .map(|run| Output::text(told(run)))
+            .map_err(failed),
         EngineOp::BoundedCommand {
             command,
             patience_ms,
         } => {
             let budget = watchdog_budget_ms(Duration::from_millis(u64::from(patience_ms)), queued);
             e.execute_command_bounded(&command, budget)
-                .map(told)
-                .map_err(es)
+                .map(|run| Output::text(told(run)))
+                .map_err(failed)
         }
         EngineOp::CommandAndWait {
             command,
             timeout_ms,
-        } => e
-            .execute_and_wait(&command, timeout_ms)
-            .map(told)
-            .map_err(es),
-        EngineOp::Registers => e.registers().map_err(es),
-        EngineOp::ReadMemory { address, size } => read_memory(e, &address, size),
+        } => resumed(e, &command, timeout_ms),
+        EngineOp::Registers { all } => registers(e, all),
+        EngineOp::Modules => modules(e),
+        EngineOp::SetBreakpoint { expression } => set_breakpoint(e, &expression),
+        EngineOp::ReadMemory { address, size } => read_memory(e, &address, size)
+            .map(Output::text)
+            .map_err(Failed::from),
         EngineOp::SymbolPath {
             path,
             append,
@@ -1048,13 +1069,15 @@ fn execute(e: &DebugEngine, id: u64, op: EngineOp, queued: Duration) -> Result<S
             // Reload so the new path takes effect (default: all deferred modules).
             e.reload_symbols(&reload).map_err(es)?;
             // Echo the effective path so the caller can confirm what resolved.
-            e.execute_command(".sympath").map_err(es)
+            e.execute_command(".sympath")
+                .map(Output::text)
+                .map_err(failed)
         }
         EngineOp::RunToAddress {
             address,
             timeout_ms,
         } => run_to_address(e, &address, timeout_ms),
-        EngineOp::Reachability(args) => reachable(e, args),
+        EngineOp::Reachability(args) => reachable(e, args).map(Output::text).map_err(Failed::from),
         // The caller's own deadline, on the same arithmetic as a bounded command's: a walk that
         // outlives its caller holds this session against nobody. Taking win-kexp's default instead
         // was wrong in both directions — see [`EngineOp::Pool`].
@@ -1080,18 +1103,25 @@ fn execute(e: &DebugEngine, id: u64, op: EngineOp, queued: Duration) -> Result<S
                         "worker: no pool walk budget left (queued {queued:?}); refusing a query \
                          that must walk"
                     );
-                    Err(format!(
-                        "This pool query was not run: it reached the engine with {}s of its \
-                         caller's timeout left, which is not enough to walk the pool and report \
-                         back before that timeout expires. It asked for `refresh`, so it cannot \
-                         be answered from the snapshot cached for this session either. Nothing \
-                         was read and nothing changed. It waited {}s behind other work on this \
-                         session; issue it when the session is idle, or raise the server's call \
-                         timeout (WINDBG_MCP_CALL_TIMEOUT_SECS — a pool walk needs more than the \
-                         {}s of headroom the reply itself reserves).",
-                        patience.saturating_sub(queued).as_secs(),
-                        queued.as_secs(),
-                        WATCHDOG_HEADROOM.as_secs(),
+                    // Categorised, because "nothing ran" is the whole content of this answer and
+                    // a caller that reads it as an ordinary debugger failure learns the opposite
+                    // of what happened: nothing about the target is wrong, and nothing changed.
+                    Err(Failed::categorised(
+                        structured::ErrorCategory::NotRun,
+                        format!(
+                            "This pool query was not run: it reached the engine with {}s of its \
+                             caller's timeout left, which is not enough to walk the pool and \
+                             report back before that timeout expires. It asked for `refresh`, so \
+                             it cannot be answered from the snapshot cached for this session \
+                             either. Nothing was read and nothing changed. It waited {}s behind \
+                             other work on this session; issue it when the session is idle, or \
+                             raise the server's call timeout (WINDBG_MCP_CALL_TIMEOUT_SECS — a \
+                             pool walk needs more than the {}s of headroom the reply itself \
+                             reserves).",
+                            patience.saturating_sub(queued).as_secs(),
+                            queued.as_secs(),
+                            WATCHDOG_HEADROOM.as_secs(),
+                        ),
                     ))
                 }
                 // Without `refresh` the session's cached snapshot may well answer this outright, and
@@ -1103,26 +1133,36 @@ fn execute(e: &DebugEngine, id: u64, op: EngineOp, queued: Duration) -> Result<S
         }
         // `id` is passed because a batch is the one op that can stop *itself*: it checks between
         // steps whether an interrupt has been raised for the job it is running as.
-        EngineOp::Batch(op) => run_batch(e, id, op, queued),
+        EngineOp::Batch(op) => run_batch(e, id, op, queued)
+            .map(Output::text)
+            .map_err(Failed::from),
         // Answered by the request reader, which is the only way it could reach a busy engine at
         // all, so it is never queued and never arrives here. See [`EngineOp::Interrupt`].
-        EngineOp::Interrupt => Err(
-            "an interrupt reached the engine thread, which cannot act on \
-                                    one; this is a bug in the worker's request reader"
-                .to_string(),
-        ),
+        EngineOp::Interrupt => Err(Failed::from(
+            "an interrupt reached the engine thread, which cannot act on one; this is a bug in \
+             the worker's request reader",
+        )),
         // Reaching here means any batch has already been told to stop and has finished unwinding —
         // the reader saw this request go past and said so, and this thread runs one job at a time.
         EngineOp::EndSession => e
             .end_session()
-            .map(|_| "session ended".to_string())
-            .map_err(es),
+            .map(|_| Output::text("session ended"))
+            .map_err(failed),
     }
 }
 
 /// Maps any error to a `String` for the wire.
 fn es<E: ToString>(e: E) -> String {
     e.to_string()
+}
+
+/// Maps any error onto the wire as the ordinary case: the debugger ran it and it failed.
+///
+/// The two failures that are *not* that — interrupted, and never started — say so where they
+/// happen, through [`Failed::categorised`]. Everything else reaching a caller as a debugger
+/// failure is right: that is what it is.
+fn failed<E: ToString>(e: E) -> Failed {
+    Failed::from(e.to_string())
 }
 
 /// A command's text, with the deadline's explanation appended when there is one.
@@ -1143,6 +1183,115 @@ fn told(run: CommandRun) -> String {
         ));
     }
     out
+}
+
+/// Runs a command that moves the target, and reports where it ended up.
+///
+/// The text is exactly what it always was. What is added is the *position*, read typed from the
+/// engine rather than left for a caller to find in the stop banner — which is a different shape
+/// for a breakpoint, an exception and the end of a trace.
+///
+/// A position that cannot be read is reported as absent, never as zero: after a `g` that left the
+/// target running, or on a module-load break with no thread context, there is no instruction
+/// pointer to report and saying `0` would name the null page as the answer.
+fn resumed(e: &DebugEngine, command: &str, timeout_ms: u32) -> Result<Output, Failed> {
+    let run = e.execute_and_wait(command, timeout_ms).map_err(failed)?;
+    let stopped_at = e.instruction_pointer().ok().map(structured::addr);
+    let interrupted = run.cut_short.is_some();
+    let text = told(run.clone());
+    Ok(Output::typed(
+        text,
+        structured::StopReport {
+            command: command.to_string(),
+            stopped_at,
+            interrupted,
+            output: run.output,
+        },
+    ))
+}
+
+/// The register set, as `r` renders it and as values beside it.
+///
+/// Two reads of the same context rather than one parsed twice — and they cannot disagree, because
+/// this is one indivisible job on the engine thread, so nothing can move the target between them.
+///
+/// `all` decides how much of the bank travels. The integer registers are what `r` prints and what
+/// nearly every question is about; the x87/vector registers and the subregister views are several
+/// hundred more entries, and including them unasked would put ~20x the payload on every call for
+/// `rsp`.
+fn registers(e: &DebugEngine, all: bool) -> Result<Output, Failed> {
+    let text = e.registers().map_err(failed)?;
+    let registers = e.register_values().map_err(failed)?;
+    let selected: Vec<structured::RegisterInfo> = registers
+        .iter()
+        .filter(|register| {
+            all || (!register.subregister
+                && matches!(register.value, win_kexp::dbgeng::RegisterValue::Int(_)))
+        })
+        .map(|register| structured::RegisterInfo {
+            name: register.name.clone(),
+            value: (&register.value).into(),
+            subregister: register.subregister,
+        })
+        .collect();
+    Ok(Output::typed(
+        // DbgEng prints nothing for `r` when there is no live thread context (a module-load
+        // break, or a bare `goto_position` to the very start of a trace). The explanation is the
+        // supervisor's to add — it is advice about which tool to call next — so the text crosses
+        // as the engine gave it.
+        text,
+        structured::RegisterSet {
+            instruction_pointer: e.instruction_pointer().ok().map(structured::addr),
+            registers: selected,
+            all_registers: all,
+        },
+    ))
+}
+
+/// The loaded modules, as `lm` renders them and as values beside them.
+fn modules(e: &DebugEngine) -> Result<Output, Failed> {
+    let text = e.execute_command("lm").map_err(failed)?;
+    let modules = e.modules().map_err(failed)?;
+    Ok(Output::typed(
+        text,
+        structured::ModuleList {
+            loaded: modules.len(),
+            modules: modules.iter().map(structured::ModuleInfo::from).collect(),
+        },
+    ))
+}
+
+/// Sets a breakpoint and reports what the session holds afterwards.
+///
+/// The ids are diffed across the `bp` rather than assumed, because `bp` is not the only thing
+/// that can produce one: a command string on an existing breakpoint can add another, and DbgEng
+/// reuses ids freed by a `bc`. Diffing says what *this call* did; guessing "the highest id" would
+/// be right until the first time it was not.
+///
+/// A successful `bp` prints nothing at all, so the text alone cannot distinguish "set" from
+/// "silently did nothing" — which is the gap this fills.
+fn set_breakpoint(e: &DebugEngine, expression: &str) -> Result<Output, Failed> {
+    let before: HashSet<u32> = e
+        .breakpoints()
+        .map_err(failed)?
+        .iter()
+        .map(|breakpoint| breakpoint.id)
+        .collect();
+    let text = e
+        .execute_command(&format!("bp {expression}"))
+        .map_err(failed)?;
+    let after = e.breakpoints().map_err(failed)?;
+    Ok(Output::typed(
+        text,
+        structured::BreakpointSet {
+            added: after
+                .iter()
+                .map(|breakpoint| breakpoint.id)
+                .filter(|id| !before.contains(id))
+                .collect(),
+            breakpoints: after.iter().map(structured::BreakpointInfo::from).collect(),
+        },
+    ))
 }
 
 /// Reads target memory and renders it as a hex dump.
@@ -1254,9 +1403,11 @@ impl Debuggee for BatchEngine<'_> {
     }
 
     fn run_to(&mut self, address: &str, timeout_ms: u32) -> Result<Ran, String> {
-        let output = run_to_address(self.e, address, timeout_ms)?;
+        // The typed half is dropped here, deliberately: a batch's product is its own report,
+        // which renders every step into one narrative, and a step does not answer separately.
+        let output = run_to_address(self.e, address, timeout_ms).map_err(|error| error.message)?;
         Ok(Ran {
-            output,
+            output: output.text,
             interrupted: self.broken(),
         })
     }
@@ -1278,9 +1429,10 @@ impl Debuggee for BatchEngine<'_> {
             self.e,
             query.clone(),
             Duration::from_millis(u64::from(budget_ms)),
-        )?;
+        )
+        .map_err(|error| error.message)?;
         Ok(Ran {
-            output,
+            output: output.text,
             interrupted: self.broken(),
         })
     }
@@ -1445,7 +1597,7 @@ fn diagnostic_categories(diagnostics: &PoolDiagnostics) -> Vec<&DiagnosticShape>
 /// drawn from what the walk indexed, so under partial coverage a count is a floor. Saying so
 /// is the difference between "there are three of these" and "these are the three I could see".
 fn coverage_caveat(report: &query::PoolSnapshotReport) -> Option<String> {
-    if report.complete {
+    if report.coverage.complete() {
         return None;
     }
     Some(format!(
@@ -1466,9 +1618,12 @@ fn coverage_caveat(report: &query::PoolSnapshotReport) -> Option<String> {
 /// thousands, and the first forty of those are a sample of whichever heap happened to be
 /// walked first, not of the problem. Counts per category say which failures actually
 /// dominate; the verbatim tail keeps concrete addresses available.
-fn append_walk_report(out: &mut String, e: &DebugEngine) {
-    match query::snapshot_report(e, false) {
-        Ok(report) => out.push_str(&render_walk_report(&report)),
+fn append_walk_report(
+    out: &mut String,
+    report: Result<&query::PoolSnapshotReport, &query::PoolQueryError>,
+) {
+    match report {
+        Ok(report) => out.push_str(&render_walk_report(report)),
         Err(error) => out.push_str(&format!("\n(could not summarise the walk: {error})\n")),
     }
 }
@@ -1482,7 +1637,7 @@ fn render_walk_report(report: &query::PoolSnapshotReport) -> String {
         "\n--- pool walk ---\nchunks walked: {} ({} allocated), coverage: {}\n",
         report.total_chunks,
         report.allocated_chunks,
-        if report.complete {
+        if report.coverage.complete() {
             "complete"
         } else {
             "INCOMPLETE - the walk did not reach everything it set out to"
@@ -1540,7 +1695,7 @@ fn render_walk_report(report: &query::PoolSnapshotReport) -> String {
 /// the *walker's* default could overrun both. A walk stopped by a budget still answers — every
 /// rendering below carries how much of the pool the walk reached — so the cost of a short deadline
 /// is coverage, not an error.
-fn pool(e: &DebugEngine, args: PoolOp, within: Duration) -> Result<String, String> {
+fn pool(e: &DebugEngine, args: PoolOp, within: Duration) -> Result<Output, Failed> {
     let walk = |refresh: bool| PoolWalk::from(refresh).within(within);
     match args {
         PoolOp::FindTag {
@@ -1556,55 +1711,205 @@ fn pool(e: &DebugEngine, args: PoolOp, within: Duration) -> Result<String, Strin
                     PoolPageFilter::NonPaged
                 }
             });
-            let spans = query::find_tag(e, &tag, filter, walk(refresh)).map_err(es)?;
+            let spans = query::find_tag(e, &tag, filter, walk(refresh)).map_err(pool_failure)?;
             let mut out = render_find_tag(&tag, filter, &spans, limit);
-            // Both branches read the snapshot `find_tag` has just taken or reused — hence the bare
-            // `false` below, which cannot start a walk of its own whatever budget this query had.
+            // Reads the snapshot `find_tag` has just taken or reused — hence `refresh: false`,
+            // which cannot start a walk of its own whatever budget this query had.
+            let report = walk_report(e, within);
             if spans.is_empty() {
-                append_walk_report(&mut out, e);
-            } else if let Ok(report) = query::snapshot_report(e, false)
-                && let Some(caveat) = coverage_caveat(&report)
+                // An empty answer has to explain itself, or "the pool holds no such chunk" and
+                // "the walk reached almost none of the pool" read identically.
+                append_walk_report(&mut out, report.as_ref());
+            } else if let Ok(report) = &report
+                && let Some(caveat) = coverage_caveat(report)
             {
                 out.push_str(&caveat);
             }
-            Ok(out)
+            Ok(Output::typed(
+                out,
+                structured::PoolTagMatches {
+                    tag,
+                    scope: match filter {
+                        None => structured::PoolScope::Both,
+                        Some(PoolPageFilter::Paged) => structured::PoolScope::Paged,
+                        Some(PoolPageFilter::NonPaged) => structured::PoolScope::NonPaged,
+                    },
+                    matches: spans.len(),
+                    // Summed over every match, not over the listed ones: `limit` bounds the
+                    // rows a reply carries and must never bound what it *says* is there.
+                    total_bytes: spans.iter().map(|span| span.size).sum(),
+                    chunks: spans
+                        .iter()
+                        .take(limit)
+                        .map(structured::PoolChunkInfo::from)
+                        .collect(),
+                    walk: walk_info(report.as_ref()),
+                },
+            ))
         }
         PoolOp::Chunk { address, refresh } => {
-            let address = parse_pool_addr(&address)?;
-            match query::chunk_at(e, address, walk(refresh)).map_err(es)? {
-                Some(found) => Ok(render_chunk(address, &found)),
+            // The caller's own mistake, and named as one: an unparseable address never reached
+            // the debugger, so reporting it as a debugger failure would send them looking at the
+            // target.
+            let address = parse_pool_addr(&address).map_err(|why| {
+                Failed::categorised(structured::ErrorCategory::InvalidArgument, why)
+            })?;
+            let found = query::chunk_at(e, address, walk(refresh)).map_err(pool_failure)?;
+            let mut out = match &found {
+                Some(found) => render_chunk(address, found),
                 // "Not in the snapshot" and "free" are different answers, and reporting this one
                 // as free would manufacture a dangling pointer out of a gap in the walk.
-                None => {
-                    let mut out = format!(
-                        "{} is not covered by the pool snapshot.\n\nThat is not the same as \
-                         \"free\": a free hole inside a walked region comes back as a chunk in \
-                         an explicitly free state (ReusableFree or CachedFree). An address \
-                         outside every region is either not pool at all, or sits in a region \
-                         this walk did not reach. If the target has run since the snapshot was \
-                         taken, retry with refresh=true.",
-                        fmt_addr(address)
-                    );
-                    append_walk_report(&mut out, e);
-                    Ok(out)
-                }
+                None => format!(
+                    "{} is not covered by the pool snapshot.\n\nThat is not the same as \
+                     \"free\": a free hole inside a walked region comes back as a chunk in \
+                     an explicitly free state (ReusableFree or CachedFree). An address \
+                     outside every region is either not pool at all, or sits in a region \
+                     this walk did not reach. If the target has run since the snapshot was \
+                     taken, retry with refresh=true.",
+                    fmt_addr(address)
+                ),
+            };
+            // Read once and spent twice: the text below and the typed answer describe the same
+            // walk, and asking again could start a second one — an incomplete snapshot is not
+            // cached, so a re-read is a re-walk.
+            let report = walk_report(e, within);
+            if found.is_none() {
+                append_walk_report(&mut out, report.as_ref());
             }
+            Ok(Output::typed(
+                out,
+                structured::PoolChunkAt {
+                    address: structured::addr(address),
+                    covered: found.is_some(),
+                    offset: found
+                        .as_ref()
+                        .map(|found| address.saturating_sub(found.chunk.usable_address)),
+                    chunk: found
+                        .as_ref()
+                        .map(|found| structured::PoolChunkInfo::from(&found.chunk)),
+                    previous: found
+                        .as_ref()
+                        .and_then(|found| found.previous.as_ref())
+                        .map(structured::PoolChunkInfo::from),
+                    next: found
+                        .as_ref()
+                        .and_then(|found| found.next.as_ref())
+                        .map(structured::PoolChunkInfo::from),
+                    walk: walk_info(report.as_ref()),
+                },
+            ))
         }
         PoolOp::Diagnostics {
             filter,
             refresh,
             limit,
         } => {
-            let report = query::snapshot_report(e, walk(refresh)).map_err(es)?;
-            Ok(render_diagnostics(&report, filter.as_deref(), limit))
+            let report = query::snapshot_report(e, walk(refresh)).map_err(pool_failure)?;
+            let out = render_diagnostics(&report, filter.as_deref(), limit);
+            let examples = select_examples(&report.diagnostics, filter.as_deref());
+            let categories = select_categories(&report.diagnostics, filter.as_deref());
+            let (example_rows, category_rows) =
+                split_row_budget(limit, examples.len(), categories.len());
+            Ok(Output::typed(
+                out,
+                structured::PoolDiagnosticsReport {
+                    filter,
+                    matched_categories: categories.len(),
+                    matched_examples: examples.len(),
+                    categories: categories
+                        .iter()
+                        .take(category_rows)
+                        .map(|category| structured::DiagnosticCategory {
+                            shape: category.shape.trim().to_string(),
+                            // The walk's own total for this shape, not the number of messages
+                            // that survived its sampling — see #77.
+                            total: category.total,
+                        })
+                        .collect(),
+                    examples: examples
+                        .iter()
+                        .take(example_rows)
+                        .map(|line| (*line).clone())
+                        .collect(),
+                    walk: walk_info(Ok(&report)),
+                },
+            ))
         }
         // The census *is* the state of the walk, so it always carries the report.
         PoolOp::Census { refresh, limit } => {
-            let census = query::tag_census(e, walk(refresh)).map_err(es)?;
+            let census = query::tag_census(e, walk(refresh)).map_err(pool_failure)?;
             let mut out = render_census(&census, limit);
-            append_walk_report(&mut out, e);
-            Ok(out)
+            let report = walk_report(e, within);
+            append_walk_report(&mut out, report.as_ref());
+            Ok(Output::typed(
+                out,
+                structured::PoolCensus {
+                    distinct_tags: census.len(),
+                    tags: census
+                        .iter()
+                        .take(limit)
+                        .map(|entry| structured::PoolTagTotals {
+                            tag: entry.display_tag.clone(),
+                            allocations: entry.allocations,
+                            total_bytes: entry.total_bytes,
+                            paged_allocations: entry.paged_allocations,
+                            nonpaged_allocations: entry.nonpaged_allocations,
+                        })
+                        .collect(),
+                    walk: walk_info(report.as_ref()),
+                },
+            ))
         }
+    }
+}
+
+/// The walk's own state, for an answer that has already been computed from it.
+///
+/// `refresh: false`, so this reads the snapshot the query just took or reused. It is bounded by
+/// the caller's remaining `within` all the same: an *incomplete* walk is not cached, so this can
+/// find no snapshot and start one, and win-kexp's 120s default is not this call's to spend.
+fn walk_report(
+    e: &DebugEngine,
+    within: Duration,
+) -> Result<query::PoolSnapshotReport, query::PoolQueryError> {
+    query::snapshot_report(e, PoolWalk::from(false).within(within))
+}
+
+/// The walk state every pool answer carries.
+///
+/// A walk whose own summary could not be read reports `Partial` with nothing counted, which is
+/// the honest reading: something is not being covered here, and it is certainly not complete.
+fn walk_info(
+    report: Result<&query::PoolSnapshotReport, &query::PoolQueryError>,
+) -> structured::WalkInfo {
+    match report {
+        Ok(report) => structured::WalkInfo {
+            coverage: report.coverage.into(),
+            chunks_walked: report.total_chunks,
+            allocated_chunks: report.allocated_chunks,
+            diagnostics_emitted: report.diagnostics.emitted(),
+            diagnostic_categories: report.diagnostics.shapes().len(),
+        },
+        Err(_) => structured::WalkInfo {
+            coverage: structured::PoolCoverage::Partial,
+            chunks_walked: 0,
+            allocated_chunks: 0,
+            diagnostics_emitted: 0,
+            diagnostic_categories: 0,
+        },
+    }
+}
+
+/// A pool query's failure, with the one kind of stop that is not a failure kept apart from it.
+///
+/// A walk that was interrupted did exactly what it was told; reporting it as a debugger failure
+/// sends a caller looking for a broken target.
+fn pool_failure(error: query::PoolQueryError) -> Failed {
+    match error {
+        query::PoolQueryError::Interrupted => {
+            Failed::categorised(structured::ErrorCategory::Interrupted, error.to_string())
+        }
+        other => Failed::from(other.to_string()),
     }
 }
 
@@ -1764,7 +2069,7 @@ fn render_diagnostics(
             "No diagnostics{scope}.\n\nThe walk was {}. It emitted {} diagnostic(s) in total over {} \
              chunk(s) ({} allocated). If you expected a match, check the spelling — the \
              filter is a plain case-insensitive substring, not a pattern.",
-            if report.complete {
+            if report.coverage.complete() {
                 "complete"
             } else {
                 "INCOMPLETE"
@@ -1887,7 +2192,7 @@ fn render_census(census: &[query::PoolTagSummary], limit: usize) -> String {
 /// win-kexp's openers expose the first seam as `x_begin()` returning a `PendingTarget` guard,
 /// which cannot exist unless the side effect succeeded — so `commit()` between the guard and its
 /// `wait()` is enforced by the type rather than by convention (glslang/win-kexp#71).
-fn open<T, R>(id: u64, transition: T, report: R) -> Result<String, String>
+fn open<T, R>(id: u64, transition: T, report: R) -> Result<Output, Failed>
 where
     T: FnOnce(&dyn Fn()) -> Result<(), String>,
     R: FnOnce() -> Result<String, String>,
@@ -1896,7 +2201,10 @@ where
         emit(&WorkerMessage::Committed { id });
     })?;
     emit(&WorkerMessage::Opened { id });
-    report()
+    // The opener's *typed* answer is assembled by the supervisor, which is the only side that
+    // knows the handle it minted and the state it settled the session into; this side owns the
+    // report text and nothing else.
+    report().map(Output::text).map_err(Failed::from)
 }
 
 /// The post-attach diagnostic shared by both kernel openers.
@@ -1922,10 +2230,10 @@ fn resolve(e: &DebugEngine, expr: &str) -> Option<u64> {
         .or_else(|| parse_u64(expr).ok())
 }
 
-fn run_to_address(e: &DebugEngine, address: &str, wait: u32) -> Result<String, String> {
+fn run_to_address(e: &DebugEngine, address: &str, wait: u32) -> Result<Output, Failed> {
     let target =
         resolve(e, address).ok_or_else(|| format!("could not resolve address `{address}`"))?;
-    let res = e.run_to_address(target, wait).map_err(es)?;
+    let res = e.run_to_address(target, wait).map_err(failed)?;
     let mut msg = match res.outcome {
         RunToOutcome::Hit => format!("VERDICT: HIT — execution reached {}\n", fmt_addr(target)),
         RunToOutcome::StoppedElsewhere { stopped_at } => format!(
@@ -1944,7 +2252,25 @@ fn run_to_address(e: &DebugEngine, address: &str, wait: u32) -> Result<String, S
         msg.push_str("---- debugger output ----\n");
         msg.push_str(&res.output);
     }
-    Ok(msg)
+    // The verdict was a value in win-kexp and became a `VERDICT:` line here, which is what every
+    // caller then matched on. It travels as a value again; the line stays for the reader.
+    let (verdict, stopped_at) = match res.outcome {
+        RunToOutcome::Hit => (structured::RunToVerdict::Hit, Some(target)),
+        RunToOutcome::StoppedElsewhere { stopped_at } => {
+            (structured::RunToVerdict::StoppedElsewhere, Some(stopped_at))
+        }
+        RunToOutcome::Timeout => (structured::RunToVerdict::Timeout, None),
+    };
+    Ok(Output::typed(
+        msg,
+        structured::RunToReport {
+            verdict,
+            target: structured::addr(target),
+            stopped_at: stopped_at.map(structured::addr),
+            timeout_ms: wait,
+            output: res.output,
+        },
+    ))
 }
 
 fn reachable(e: &DebugEngine, args: ReachabilityOp) -> Result<String, String> {
@@ -2021,8 +2347,19 @@ mod tests {
         query::PoolSnapshotReport {
             total_chunks: 4211,
             allocated_chunks: 3007,
-            complete,
+            coverage: coverage(complete),
             diagnostics: diagnostics.iter().map(|line| line.to_string()).collect(),
+        }
+    }
+
+    /// A walk that covered everything, or one that stopped short for a reason other than the
+    /// clock. The deadline case is a value of its own and is exercised where it becomes an
+    /// answer — in `structured`.
+    fn coverage(complete: bool) -> query::WalkCoverage {
+        if complete {
+            query::WalkCoverage::Complete
+        } else {
+            query::WalkCoverage::Partial
         }
     }
 
@@ -2036,7 +2373,7 @@ mod tests {
         query::PoolSnapshotReport {
             total_chunks: 4211,
             allocated_chunks: 3007,
-            complete: false,
+            coverage: coverage(false),
             diagnostics: lines.into_iter().collect(),
         }
     }
@@ -2144,7 +2481,7 @@ mod tests {
         query::PoolSnapshotReport {
             total_chunks: 4211,
             allocated_chunks: 3007,
-            complete: true,
+            coverage: coverage(true),
             diagnostics: lines.into_iter().collect(),
         }
     }
@@ -2742,22 +3079,28 @@ mod tests {
     /// interrupting rather than ending the session.
     #[test]
     fn a_cut_short_result_keeps_its_output_and_says_why() {
-        let out = cut_short(Ok("0x1000  41 42 43\n".to_string())).expect("still a result");
+        let out = cut_short(Ok(Output::text("0x1000  41 42 43\n")))
+            .expect("still a result")
+            .text;
         assert!(out.starts_with("0x1000  41 42 43"), "{out}");
         assert!(out.contains("interrupted on request"), "{out}");
 
         // And a failure keeps its debugger text: "this is why it stopped" is not a claim about
-        // what it would otherwise have said.
-        let err = cut_short(Err("Memory access error".to_string())).expect_err("still a failure");
-        assert!(err.starts_with("Memory access error"), "{err}");
-        assert!(err.contains("interrupted on request"), "{err}");
+        // what it would otherwise have said. It also stops calling itself a *debugger* failure,
+        // which is the half a caller acts on rather than reads.
+        let err = cut_short(Err(Failed::from("Memory access error"))).expect_err("still a failure");
+        assert!(err.message.starts_with("Memory access error"), "{err:?}");
+        assert!(err.message.contains("interrupted on request"), "{err:?}");
+        assert_eq!(err.category, Some(structured::ErrorCategory::Interrupted));
     }
 
     /// An operation interrupted before it printed anything still explains itself, rather than
     /// coming back as an empty success the caller would read as "found nothing".
     #[test]
     fn a_cut_short_result_with_no_output_is_still_an_explanation() {
-        let out = cut_short(Ok(String::new())).expect("still a result");
+        let out = cut_short(Ok(Output::text(String::new())))
+            .expect("still a result")
+            .text;
         assert!(out.contains("interrupted on request"), "{out}");
         assert!(
             !out.starts_with('\n'),

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -1197,7 +1197,13 @@ fn told(run: CommandRun) -> String {
 fn resumed(e: &DebugEngine, command: &str, timeout_ms: u32) -> Result<Output, Failed> {
     let run = e.execute_and_wait(command, timeout_ms).map_err(failed)?;
     let stopped_at = e.instruction_pointer().ok().map(structured::addr);
-    let interrupted = run.cut_short.is_some();
+    // Matched on the variant rather than on "was it cut short at all", even though
+    // `execute_and_wait` produces only `OnRequest` today: a go/step that hits its own deadline is
+    // a *forced break at the bound*, which win-kexp deliberately does not report as a cut-short
+    // because the target simply had not stopped yet. That is an invariant of another crate and is
+    // invisible here, so naming the variant this field means keeps the two from drifting apart in
+    // silence — the field says "somebody asked", and only `OnRequest` is somebody asking.
+    let interrupted = matches!(run.cut_short, Some(Interruption::OnRequest));
     let text = told(run.clone());
     Ok(Output::typed(
         text,

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -1608,27 +1608,17 @@ fn coverage_caveat(report: &query::PoolSnapshotReport) -> Option<String> {
     ))
 }
 
-/// Appends what the walk itself managed, so an empty answer explains itself.
+/// What the walk itself managed, so an empty answer explains itself.
 ///
-/// Without this, an empty result is ambiguous in the worst way: "the pool holds no such
-/// chunk" and "the walk reached almost none of the pool" render identically. The snapshot
-/// is already cached by the time this runs, so the extra query costs nothing.
+/// Without it, an empty result is ambiguous in the worst way: "the pool holds no such chunk" and
+/// "the walk reached almost none of the pool" render identically. The report rendered here is the
+/// one the query handed back *with* its answer, so this describes the walk that produced the list
+/// above it rather than whichever walk a later question happened to provoke.
 ///
-/// The diagnostics are *categorised* rather than listed: a real walk emits tens of
-/// thousands, and the first forty of those are a sample of whichever heap happened to be
-/// walked first, not of the problem. Counts per category say which failures actually
-/// dominate; the verbatim tail keeps concrete addresses available.
-fn append_walk_report(
-    out: &mut String,
-    report: Result<&query::PoolSnapshotReport, &query::PoolQueryError>,
-) {
-    match report {
-        Ok(report) => out.push_str(&render_walk_report(report)),
-        Err(error) => out.push_str(&format!("\n(could not summarise the walk: {error})\n")),
-    }
-}
-
-/// The body of [`append_walk_report`], split out so the counts can be tested without an engine.
+/// The diagnostics are *categorised* rather than listed: a real walk emits tens of thousands, and
+/// the first forty of those are a sample of whichever heap happened to be walked first, not of the
+/// problem. Counts per category say which failures actually dominate; the verbatim tail keeps
+/// concrete addresses available.
 fn render_walk_report(report: &query::PoolSnapshotReport) -> String {
     // `complete` is not implied by an empty diagnostics list: a walk can end partway
     // through without saying anything. Report it explicitly, or a caller reads a truncated
@@ -1696,13 +1686,10 @@ fn render_walk_report(report: &query::PoolSnapshotReport) -> String {
 /// rendering below carries how much of the pool the walk reached — so the cost of a short deadline
 /// is coverage, not an error.
 fn pool(e: &DebugEngine, args: PoolOp, within: Duration) -> Result<Output, Failed> {
-    // `within` is a duration, and the walk report below is read *after* the query has spent most
-    // of it — so handing it `within` again would grant a second full-length walk (which is a real
-    // possibility, not a theoretical one: an incomplete snapshot is not cached, so the report can
-    // find nothing to read and start one). Anchored to a deadline here, and what is left of it is
-    // what the report gets.
-    let started = Instant::now();
-    let left = move || within.saturating_sub(started.elapsed());
+    // Every answer below carries `answer.walk` — the state of the walk it was *itself* drawn
+    // from, handed back by the query. Asking separately would be a second call, and an incomplete
+    // walk is deliberately not cached, so that call could walk again and report the coverage of a
+    // different walk as this one's (win-kexp's `PoolAnswer`).
     let walk = |refresh: bool| PoolWalk::from(refresh).within(within);
     match args {
         PoolOp::FindTag {
@@ -1718,18 +1705,14 @@ fn pool(e: &DebugEngine, args: PoolOp, within: Duration) -> Result<Output, Faile
                     PoolPageFilter::NonPaged
                 }
             });
-            let spans = query::find_tag(e, &tag, filter, walk(refresh)).map_err(pool_failure)?;
-            let mut out = render_find_tag(&tag, filter, &spans, limit);
-            // Reads the snapshot `find_tag` has just taken or reused — hence `refresh: false`,
-            // which cannot start a walk of its own whatever budget this query had.
-            let report = walk_report(e, left());
+            let answer = query::find_tag(e, &tag, filter, walk(refresh)).map_err(pool_failure)?;
+            let spans = &answer.found;
+            let mut out = render_find_tag(&tag, filter, spans, limit);
             if spans.is_empty() {
                 // An empty answer has to explain itself, or "the pool holds no such chunk" and
                 // "the walk reached almost none of the pool" read identically.
-                append_walk_report(&mut out, report.as_ref());
-            } else if let Ok(report) = &report
-                && let Some(caveat) = coverage_caveat(report)
-            {
+                out.push_str(&render_walk_report(&answer.walk));
+            } else if let Some(caveat) = coverage_caveat(&answer.walk) {
                 out.push_str(&caveat);
             }
             Ok(Output::typed(
@@ -1750,7 +1733,7 @@ fn pool(e: &DebugEngine, args: PoolOp, within: Duration) -> Result<Output, Faile
                         .take(limit)
                         .map(structured::PoolChunkInfo::from)
                         .collect(),
-                    walk: walk_info(report.as_ref()),
+                    walk: walk_info(&answer.walk),
                 },
             ))
         }
@@ -1761,8 +1744,9 @@ fn pool(e: &DebugEngine, args: PoolOp, within: Duration) -> Result<Output, Faile
             let address = parse_pool_addr(&address).map_err(|why| {
                 Failed::categorised(structured::ErrorCategory::InvalidArgument, why)
             })?;
-            let found = query::chunk_at(e, address, walk(refresh)).map_err(pool_failure)?;
-            let mut out = match &found {
+            let answer = query::chunk_at(e, address, walk(refresh)).map_err(pool_failure)?;
+            let found = &answer.found;
+            let mut out = match found {
                 Some(found) => render_chunk(address, found),
                 // "Not in the snapshot" and "free" are different answers, and reporting this one
                 // as free would manufacture a dangling pointer out of a gap in the walk.
@@ -1776,12 +1760,8 @@ fn pool(e: &DebugEngine, args: PoolOp, within: Duration) -> Result<Output, Faile
                     fmt_addr(address)
                 ),
             };
-            // Read once and spent twice: the text below and the typed answer describe the same
-            // walk, and asking again could start a second one — an incomplete snapshot is not
-            // cached, so a re-read is a re-walk.
-            let report = walk_report(e, left());
             if found.is_none() {
-                append_walk_report(&mut out, report.as_ref());
+                out.push_str(&render_walk_report(&answer.walk));
             }
             Ok(Output::typed(
                 out,
@@ -1802,7 +1782,7 @@ fn pool(e: &DebugEngine, args: PoolOp, within: Duration) -> Result<Output, Faile
                         .as_ref()
                         .and_then(|found| found.next.as_ref())
                         .map(structured::PoolChunkInfo::from),
-                    walk: walk_info(report.as_ref()),
+                    walk: walk_info(&answer.walk),
                 },
             ))
         }
@@ -1838,16 +1818,16 @@ fn pool(e: &DebugEngine, args: PoolOp, within: Duration) -> Result<Output, Faile
                         .take(example_rows)
                         .map(|line| (*line).clone())
                         .collect(),
-                    walk: walk_info(Ok(&report)),
+                    walk: walk_info(&report),
                 },
             ))
         }
         // The census *is* the state of the walk, so it always carries the report.
         PoolOp::Census { refresh, limit } => {
-            let census = query::tag_census(e, walk(refresh)).map_err(pool_failure)?;
-            let mut out = render_census(&census, limit);
-            let report = walk_report(e, left());
-            append_walk_report(&mut out, report.as_ref());
+            let answer = query::tag_census(e, walk(refresh)).map_err(pool_failure)?;
+            let census = &answer.found;
+            let mut out = render_census(census, limit);
+            out.push_str(&render_walk_report(&answer.walk));
             Ok(Output::typed(
                 out,
                 structured::PoolCensus {
@@ -1863,48 +1843,24 @@ fn pool(e: &DebugEngine, args: PoolOp, within: Duration) -> Result<Output, Faile
                             nonpaged_allocations: entry.nonpaged_allocations,
                         })
                         .collect(),
-                    walk: walk_info(report.as_ref()),
+                    walk: walk_info(&answer.walk),
                 },
             ))
         }
     }
 }
 
-/// The walk's own state, for an answer that has already been computed from it.
-///
-/// `refresh: false`, so this reads the snapshot the query just took or reused. It is bounded all
-/// the same, and by what is **left** of the caller's patience rather than by the whole of it: an
-/// *incomplete* walk is not cached, so this can find no snapshot and start one — and neither
-/// win-kexp's 120s default nor a second helping of a budget already spent is this call's to give.
-fn walk_report(
-    e: &DebugEngine,
-    left: Duration,
-) -> Result<query::PoolSnapshotReport, query::PoolQueryError> {
-    query::snapshot_report(e, PoolWalk::from(false).within(left))
-}
-
 /// The walk state every pool answer carries.
 ///
-/// A walk whose own summary could not be read reports `Partial` with nothing counted, which is
-/// the honest reading: something is not being covered here, and it is certainly not complete.
-fn walk_info(
-    report: Result<&query::PoolSnapshotReport, &query::PoolQueryError>,
-) -> structured::WalkInfo {
-    match report {
-        Ok(report) => structured::WalkInfo {
-            coverage: report.coverage.into(),
-            chunks_walked: report.total_chunks,
-            allocated_chunks: report.allocated_chunks,
-            diagnostics_emitted: report.diagnostics.emitted(),
-            diagnostic_categories: report.diagnostics.shapes().len(),
-        },
-        Err(_) => structured::WalkInfo {
-            coverage: structured::PoolCoverage::Partial,
-            chunks_walked: 0,
-            allocated_chunks: 0,
-            diagnostics_emitted: 0,
-            diagnostic_categories: 0,
-        },
+/// Infallible, because the report is no longer something to go and ask for: it arrives with the
+/// answer, from the same snapshot. There is no "could not read the walk" case left to render.
+fn walk_info(report: &query::PoolSnapshotReport) -> structured::WalkInfo {
+    structured::WalkInfo {
+        coverage: report.coverage.into(),
+        chunks_walked: report.total_chunks,
+        allocated_chunks: report.allocated_chunks,
+        diagnostics_emitted: report.diagnostics.emitted(),
+        diagnostic_categories: report.diagnostics.shapes().len(),
     }
 }
 

--- a/tests/golden/tools_list.json
+++ b/tests/golden/tools_list.json
@@ -13,6 +13,25 @@
         "readOnly": false
       },
       "name": "attach_kernel",
+      "output": {
+        "branches": [
+          {
+            "payload": "#/$defs/OpenedSession",
+            "required": [
+              "status"
+            ],
+            "status": "ok"
+          },
+          {
+            "payload": "#/$defs/OpenFailure",
+            "required": [
+              "status"
+            ],
+            "status": "error"
+          }
+        ],
+        "dialect": "https://json-schema.org/draft/2020-12/schema"
+      },
       "params": [
         "connection: string|null",
         "profile: string|null"
@@ -28,6 +47,25 @@
         "readOnly": false
       },
       "name": "attach_kernel_local",
+      "output": {
+        "branches": [
+          {
+            "payload": "#/$defs/OpenedSession",
+            "required": [
+              "status"
+            ],
+            "status": "ok"
+          },
+          {
+            "payload": "#/$defs/OpenFailure",
+            "required": [
+              "status"
+            ],
+            "status": "error"
+          }
+        ],
+        "dialect": "https://json-schema.org/draft/2020-12/schema"
+      },
       "params": [],
       "required": [],
       "title": "Attach to local kernel"
@@ -40,6 +78,25 @@
         "readOnly": false
       },
       "name": "attach_process",
+      "output": {
+        "branches": [
+          {
+            "payload": "#/$defs/OpenedSession",
+            "required": [
+              "status"
+            ],
+            "status": "ok"
+          },
+          {
+            "payload": "#/$defs/OpenFailure",
+            "required": [
+              "status"
+            ],
+            "status": "error"
+          }
+        ],
+        "dialect": "https://json-schema.org/draft/2020-12/schema"
+      },
       "params": [
         "pid: integer/uint32"
       ],
@@ -56,6 +113,7 @@
         "readOnly": true
       },
       "name": "backtrace",
+      "output": null,
       "params": [
         "session_id: string|null"
       ],
@@ -70,6 +128,7 @@
         "readOnly": false
       },
       "name": "debug_batch",
+      "output": null,
       "params": [
         "always: array<ref(#/$defs/BatchStep)>",
         "session_id: string|null",
@@ -89,6 +148,7 @@
         "readOnly": true
       },
       "name": "decode_ioctl",
+      "output": null,
       "params": [
         "code: string"
       ],
@@ -105,6 +165,7 @@
         "readOnly": true
       },
       "name": "device_object",
+      "output": null,
       "params": [
         "device: string",
         "session_id: string|null"
@@ -122,6 +183,7 @@
         "readOnly": true
       },
       "name": "disassemble",
+      "output": null,
       "params": [
         "address: string|null",
         "session_id: string|null"
@@ -137,6 +199,7 @@
         "readOnly": true
       },
       "name": "driver_object",
+      "output": null,
       "params": [
         "name: string",
         "session_id: string|null"
@@ -154,6 +217,7 @@
         "readOnly": false
       },
       "name": "dx",
+      "output": null,
       "params": [
         "expression: string",
         "session_id: string|null"
@@ -171,6 +235,25 @@
         "readOnly": false
       },
       "name": "end_session",
+      "output": {
+        "branches": [
+          {
+            "payload": "#/$defs/SessionEnded",
+            "required": [
+              "status"
+            ],
+            "status": "ok"
+          },
+          {
+            "payload": "#/$defs/Failure",
+            "required": [
+              "status"
+            ],
+            "status": "error"
+          }
+        ],
+        "dialect": "https://json-schema.org/draft/2020-12/schema"
+      },
       "params": [
         "session_id: string|null"
       ],
@@ -185,6 +268,7 @@
         "readOnly": false
       },
       "name": "execute",
+      "output": null,
       "params": [
         "command: string",
         "session_id: string|null"
@@ -202,6 +286,25 @@
         "readOnly": false
       },
       "name": "go",
+      "output": {
+        "branches": [
+          {
+            "payload": "#/$defs/StopReport",
+            "required": [
+              "status"
+            ],
+            "status": "ok"
+          },
+          {
+            "payload": "#/$defs/Failure",
+            "required": [
+              "status"
+            ],
+            "status": "error"
+          }
+        ],
+        "dialect": "https://json-schema.org/draft/2020-12/schema"
+      },
       "params": [
         "session_id: string|null"
       ],
@@ -216,6 +319,7 @@
         "readOnly": false
       },
       "name": "goto_position",
+      "output": null,
       "params": [
         "position: string",
         "session_id: string|null"
@@ -233,6 +337,7 @@
         "readOnly": false
       },
       "name": "index_trace",
+      "output": null,
       "params": [
         "session_id: string|null"
       ],
@@ -247,6 +352,7 @@
         "readOnly": false
       },
       "name": "interrupt",
+      "output": null,
       "params": [
         "session_id: string|null"
       ],
@@ -261,6 +367,7 @@
         "readOnly": false
       },
       "name": "ioctl_trace",
+      "output": null,
       "params": [
         "dispatch: string",
         "session_id: string|null"
@@ -278,6 +385,7 @@
         "readOnly": true
       },
       "name": "irp_stack",
+      "output": null,
       "params": [
         "irp: string|null",
         "session_id: string|null"
@@ -293,6 +401,25 @@
         "readOnly": false
       },
       "name": "launch",
+      "output": {
+        "branches": [
+          {
+            "payload": "#/$defs/OpenedSession",
+            "required": [
+              "status"
+            ],
+            "status": "ok"
+          },
+          {
+            "payload": "#/$defs/OpenFailure",
+            "required": [
+              "status"
+            ],
+            "status": "error"
+          }
+        ],
+        "dialect": "https://json-schema.org/draft/2020-12/schema"
+      },
       "params": [
         "command_line: string"
       ],
@@ -309,6 +436,25 @@
         "readOnly": true
       },
       "name": "modules",
+      "output": {
+        "branches": [
+          {
+            "payload": "#/$defs/ModuleList",
+            "required": [
+              "status"
+            ],
+            "status": "ok"
+          },
+          {
+            "payload": "#/$defs/Failure",
+            "required": [
+              "status"
+            ],
+            "status": "error"
+          }
+        ],
+        "dialect": "https://json-schema.org/draft/2020-12/schema"
+      },
       "params": [
         "session_id: string|null"
       ],
@@ -323,6 +469,25 @@
         "readOnly": false
       },
       "name": "open_dump",
+      "output": {
+        "branches": [
+          {
+            "payload": "#/$defs/OpenedSession",
+            "required": [
+              "status"
+            ],
+            "status": "ok"
+          },
+          {
+            "payload": "#/$defs/OpenFailure",
+            "required": [
+              "status"
+            ],
+            "status": "error"
+          }
+        ],
+        "dialect": "https://json-schema.org/draft/2020-12/schema"
+      },
       "params": [
         "path: string"
       ],
@@ -339,6 +504,25 @@
         "readOnly": false
       },
       "name": "open_trace",
+      "output": {
+        "branches": [
+          {
+            "payload": "#/$defs/OpenedSession",
+            "required": [
+              "status"
+            ],
+            "status": "ok"
+          },
+          {
+            "payload": "#/$defs/OpenFailure",
+            "required": [
+              "status"
+            ],
+            "status": "error"
+          }
+        ],
+        "dialect": "https://json-schema.org/draft/2020-12/schema"
+      },
       "params": [
         "path: string"
       ],
@@ -355,6 +539,25 @@
         "readOnly": true
       },
       "name": "pool_census",
+      "output": {
+        "branches": [
+          {
+            "payload": "#/$defs/PoolCensus",
+            "required": [
+              "status"
+            ],
+            "status": "ok"
+          },
+          {
+            "payload": "#/$defs/Failure",
+            "required": [
+              "status"
+            ],
+            "status": "error"
+          }
+        ],
+        "dialect": "https://json-schema.org/draft/2020-12/schema"
+      },
       "params": [
         "limit: integer|null/uint32",
         "refresh: boolean|null",
@@ -371,6 +574,25 @@
         "readOnly": true
       },
       "name": "pool_chunk",
+      "output": {
+        "branches": [
+          {
+            "payload": "#/$defs/PoolChunkAt",
+            "required": [
+              "status"
+            ],
+            "status": "ok"
+          },
+          {
+            "payload": "#/$defs/Failure",
+            "required": [
+              "status"
+            ],
+            "status": "error"
+          }
+        ],
+        "dialect": "https://json-schema.org/draft/2020-12/schema"
+      },
       "params": [
         "address: string",
         "refresh: boolean|null",
@@ -389,6 +611,25 @@
         "readOnly": true
       },
       "name": "pool_diagnostics",
+      "output": {
+        "branches": [
+          {
+            "payload": "#/$defs/PoolDiagnosticsReport",
+            "required": [
+              "status"
+            ],
+            "status": "ok"
+          },
+          {
+            "payload": "#/$defs/Failure",
+            "required": [
+              "status"
+            ],
+            "status": "error"
+          }
+        ],
+        "dialect": "https://json-schema.org/draft/2020-12/schema"
+      },
       "params": [
         "filter: string|null",
         "limit: integer|null/uint32",
@@ -406,6 +647,25 @@
         "readOnly": true
       },
       "name": "pool_find_tag",
+      "output": {
+        "branches": [
+          {
+            "payload": "#/$defs/PoolTagMatches",
+            "required": [
+              "status"
+            ],
+            "status": "ok"
+          },
+          {
+            "payload": "#/$defs/Failure",
+            "required": [
+              "status"
+            ],
+            "status": "error"
+          }
+        ],
+        "dialect": "https://json-schema.org/draft/2020-12/schema"
+      },
       "params": [
         "limit: integer|null/uint32",
         "paged: boolean|null",
@@ -426,6 +686,7 @@
         "readOnly": true
       },
       "name": "reachable_from_dispatch",
+      "output": null,
       "params": [
         "address: string|null",
         "from: string",
@@ -449,6 +710,7 @@
         "readOnly": true
       },
       "name": "read_memory",
+      "output": null,
       "params": [
         "address: string",
         "session_id: string|null",
@@ -468,6 +730,7 @@
         "readOnly": false
       },
       "name": "record_trace",
+      "output": null,
       "params": [
         "env: array<string>",
         "out_dir: string",
@@ -488,7 +751,27 @@
         "readOnly": true
       },
       "name": "registers",
+      "output": {
+        "branches": [
+          {
+            "payload": "#/$defs/RegisterSet",
+            "required": [
+              "status"
+            ],
+            "status": "ok"
+          },
+          {
+            "payload": "#/$defs/Failure",
+            "required": [
+              "status"
+            ],
+            "status": "error"
+          }
+        ],
+        "dialect": "https://json-schema.org/draft/2020-12/schema"
+      },
       "params": [
+        "all: boolean|null",
         "session_id: string|null"
       ],
       "required": [],
@@ -502,6 +785,25 @@
         "readOnly": false
       },
       "name": "reverse_go",
+      "output": {
+        "branches": [
+          {
+            "payload": "#/$defs/StopReport",
+            "required": [
+              "status"
+            ],
+            "status": "ok"
+          },
+          {
+            "payload": "#/$defs/Failure",
+            "required": [
+              "status"
+            ],
+            "status": "error"
+          }
+        ],
+        "dialect": "https://json-schema.org/draft/2020-12/schema"
+      },
       "params": [
         "session_id: string|null"
       ],
@@ -516,6 +818,25 @@
         "readOnly": false
       },
       "name": "run_to_address",
+      "output": {
+        "branches": [
+          {
+            "payload": "#/$defs/RunToReport",
+            "required": [
+              "status"
+            ],
+            "status": "ok"
+          },
+          {
+            "payload": "#/$defs/Failure",
+            "required": [
+              "status"
+            ],
+            "status": "error"
+          }
+        ],
+        "dialect": "https://json-schema.org/draft/2020-12/schema"
+      },
       "params": [
         "address: string",
         "session_id: string|null",
@@ -534,6 +855,25 @@
         "readOnly": true
       },
       "name": "session_status",
+      "output": {
+        "branches": [
+          {
+            "payload": "#/$defs/SessionsReport",
+            "required": [
+              "status"
+            ],
+            "status": "ok"
+          },
+          {
+            "payload": "#/$defs/Failure",
+            "required": [
+              "status"
+            ],
+            "status": "error"
+          }
+        ],
+        "dialect": "https://json-schema.org/draft/2020-12/schema"
+      },
       "params": [
         "session_id: string|null"
       ],
@@ -548,6 +888,25 @@
         "readOnly": false
       },
       "name": "set_breakpoint",
+      "output": {
+        "branches": [
+          {
+            "payload": "#/$defs/BreakpointSet",
+            "required": [
+              "status"
+            ],
+            "status": "ok"
+          },
+          {
+            "payload": "#/$defs/Failure",
+            "required": [
+              "status"
+            ],
+            "status": "error"
+          }
+        ],
+        "dialect": "https://json-schema.org/draft/2020-12/schema"
+      },
       "params": [
         "expression: string",
         "session_id: string|null"
@@ -565,6 +924,7 @@
         "readOnly": false
       },
       "name": "set_symbol_path",
+      "output": null,
       "params": [
         "append: boolean|null",
         "path: string",
@@ -584,6 +944,25 @@
         "readOnly": false
       },
       "name": "step_back",
+      "output": {
+        "branches": [
+          {
+            "payload": "#/$defs/StopReport",
+            "required": [
+              "status"
+            ],
+            "status": "ok"
+          },
+          {
+            "payload": "#/$defs/Failure",
+            "required": [
+              "status"
+            ],
+            "status": "error"
+          }
+        ],
+        "dialect": "https://json-schema.org/draft/2020-12/schema"
+      },
       "params": [
         "session_id: string|null"
       ],
@@ -598,6 +977,25 @@
         "readOnly": false
       },
       "name": "step_into",
+      "output": {
+        "branches": [
+          {
+            "payload": "#/$defs/StopReport",
+            "required": [
+              "status"
+            ],
+            "status": "ok"
+          },
+          {
+            "payload": "#/$defs/Failure",
+            "required": [
+              "status"
+            ],
+            "status": "error"
+          }
+        ],
+        "dialect": "https://json-schema.org/draft/2020-12/schema"
+      },
       "params": [
         "session_id: string|null"
       ],
@@ -612,6 +1010,25 @@
         "readOnly": false
       },
       "name": "step_over",
+      "output": {
+        "branches": [
+          {
+            "payload": "#/$defs/StopReport",
+            "required": [
+              "status"
+            ],
+            "status": "ok"
+          },
+          {
+            "payload": "#/$defs/Failure",
+            "required": [
+              "status"
+            ],
+            "status": "error"
+          }
+        ],
+        "dialect": "https://json-schema.org/draft/2020-12/schema"
+      },
       "params": [
         "session_id: string|null"
       ],
@@ -626,6 +1043,25 @@
         "readOnly": false
       },
       "name": "step_over_back",
+      "output": {
+        "branches": [
+          {
+            "payload": "#/$defs/StopReport",
+            "required": [
+              "status"
+            ],
+            "status": "ok"
+          },
+          {
+            "payload": "#/$defs/Failure",
+            "required": [
+              "status"
+            ],
+            "status": "error"
+          }
+        ],
+        "dialect": "https://json-schema.org/draft/2020-12/schema"
+      },
       "params": [
         "session_id: string|null"
       ],
@@ -640,6 +1076,7 @@
         "readOnly": true
       },
       "name": "threads",
+      "output": null,
       "params": [
         "session_id: string|null"
       ],
@@ -654,6 +1091,7 @@
         "readOnly": true
       },
       "name": "ttd_calls",
+      "output": null,
       "params": [
         "function: string",
         "session_id: string|null"
@@ -671,6 +1109,7 @@
         "readOnly": true
       },
       "name": "ttd_events",
+      "output": null,
       "params": [
         "session_id: string|null"
       ],
@@ -685,6 +1124,7 @@
         "readOnly": true
       },
       "name": "ttd_memory",
+      "output": null,
       "params": [
         "address: string",
         "mode: string|null",

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -938,6 +938,12 @@ fn tool_schemas_declare_one_dialect_and_are_self_contained() {
 /// Driven with no session open, so every session-scoped tool takes its refusal path without a
 /// debugger anywhere near it — which is what keeps this in the default tier.
 ///
+/// The **openers** are the exception, and are handled rather than excluded: each fails on
+/// something that cannot exist (a path, a pid, an image), but reaching that failure spawns a
+/// worker, and a worker needs DbgEng. On a host without it there is no session at all — the one
+/// failure this server reports as a JSON-RPC error — so those rows are skipped by *error code*,
+/// visibly, rather than by matching the message or by dropping them from the table.
+///
 /// The table is checked *against* `tools/list` in both directions: a tool that grows a schema and
 /// is not listed here fails, so this cannot quietly stop covering the surface it is about.
 #[test]
@@ -1014,6 +1020,15 @@ fn every_tool_with_an_output_schema_answers_with_structured_content() {
 
     for (name, args, expected) in cases {
         let response = server.call_tool(name, args.clone(), STEP);
+        // `-32603` is `ErrorData::internal_error`, which this server emits for exactly one thing:
+        // no engine worker could be started. Every other failure is a tool result by design, so
+        // this cannot swallow the case the test is for.
+        if response["error"]["code"] == -32603 {
+            skip(&format!(
+                "`{name}` needs an engine worker and none could be started (no DbgEng on this                  host?), so its structured-result contract was not checked"
+            ));
+            continue;
+        }
         assert_no_error(&response, &format!("tools/call {name}"));
         let result = &response["result"];
         let data = &result["structuredContent"];
@@ -2061,21 +2076,28 @@ fn two_sessions_coexist_and_do_not_disturb_each_other() {
         text_of(&response["result"])
     );
 
-    // Both are listed, and the newest is the one an omitted handle routes to.
-    let status = server.tool_text("session_status", json!({}), TARGET_STEP);
-    for id in [&first, &second] {
-        assert!(
-            status.contains(id.as_str()),
-            "`{id}` should be listed:\n{status}"
-        );
-    }
-    let current_line = status
-        .lines()
-        .find(|l| l.contains("(current)"))
-        .unwrap_or_else(|| panic!("some session must be current:\n{status}"));
-    assert!(
-        current_line.contains(&second),
-        "the newest session should be current, got:\n{current_line}"
+    // Both are listed, and the newest is the one an omitted handle routes to. Read as `current`
+    // rather than by finding a line containing `(current)`: that marker is a rendering, and which
+    // session it sits on is the routing rule this test is actually about.
+    let status = server.tool_data("session_status", json!({}), TARGET_STEP);
+    let listed = |id: &str| -> Value {
+        status["sessions"]
+            .as_array()
+            .into_iter()
+            .flatten()
+            .find(|s| s["session_id"] == id)
+            .cloned()
+            .unwrap_or_else(|| panic!("`{id}` should be listed: {status}"))
+    };
+    assert_eq!(
+        listed(&first)["current"],
+        false,
+        "the older session is not the default target: {status}"
+    );
+    assert_eq!(
+        listed(&second)["current"],
+        true,
+        "the newest session should be the one an omitted handle routes to: {status}"
     );
 
     // Ending one leaves the other alone — the failure mode that made `end_session` unusable as a
@@ -3891,9 +3913,12 @@ fn a_live_kernel_pool_walk_is_bounded_and_leaves_its_session_usable() {
                 json!({ "session_id": session, "limit": 40 }),
                 POOL_CALL_BUDGET,
             );
+            // The categories, which is what the extra call was made for — the census text says
+            // only *that* the walk fell short, and this tier runs on a machine an operator had to
+            // set up, so losing the one output that explains it wastes the whole run.
             println!(
-                "why the walk fell short: {}",
-                text_of(&census_call["result"])
+                "why the walk fell short ({} diagnostic(s)): {}",
+                diagnostics["walk"]["diagnostics_emitted"], diagnostics["categories"]
             );
             assert_diagnostic_total_covers_its_categories(&diagnostics);
         }

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -316,6 +316,61 @@ impl Server {
         text
     }
 
+    /// The **structured** result of a tool call that worked.
+    ///
+    /// The typed counterpart of [`Self::tool_text`], and the one to reach for: a field is a
+    /// contract, where the text it accompanies is a rendering that may be reworded at any time.
+    /// Asserts the outcome is the `ok` branch, so a test asking for `matches` cannot silently
+    /// read a failure that has no such field.
+    fn tool_data(&mut self, name: &str, args: Value, budget: Duration) -> Value {
+        let response = self.call_tool(name, args, budget);
+        assert_no_error(&response, &format!("tools/call {name}"));
+        let result = &response["result"];
+        let data = result["structuredContent"].clone();
+        assert!(
+            !data.is_null(),
+            "`{name}` declares an outputSchema, so every result must carry structuredContent; \
+             got:\n{}",
+            text_of(result)
+        );
+        assert_eq!(
+            data["status"],
+            "ok",
+            "`{name}` did not succeed: {}",
+            text_of(result)
+        );
+        data
+    }
+
+    /// Opens a target and hands back the handle, read as a field.
+    ///
+    /// The handle used to be recovered from the `session_id:` line an opener prints, which is the
+    /// single most-parsed piece of prose this server emits — and the one every client needs.
+    fn open_session(&mut self, tool: &str, args: Value, budget: Duration) -> String {
+        let data = self.tool_data(tool, args, budget);
+        data["session_id"]
+            .as_str()
+            .unwrap_or_else(|| panic!("`{tool}` opened without minting a handle: {data}"))
+            .to_string()
+    }
+
+    /// The structured result of a call that was **expected** to fail, with its category checked.
+    fn tool_failure(&mut self, name: &str, args: Value, budget: Duration) -> Value {
+        let response = self.call_tool(name, args, budget);
+        assert_no_error(&response, &format!("tools/call {name}"));
+        assert!(
+            is_tool_error(&response),
+            "`{name}` was expected to fail but did not:\n{}",
+            text_of(&response["result"])
+        );
+        let data = response["result"]["structuredContent"].clone();
+        assert_eq!(
+            data["status"], "error",
+            "a failing `{name}` must carry the error branch of its own output schema, got: {data}"
+        );
+        data
+    }
+
     /// Terminates the supervisor outright, giving it no chance to run its own shutdown.
     ///
     /// Stdin is *not* closed first — that would be the graceful path this is the opposite of. The
@@ -670,6 +725,52 @@ fn digest_tool(tool: &Value) -> Value {
         },
         "required": required,
         "params": params,
+        "output": digest_output_schema(&tool["outputSchema"]),
+    })
+}
+
+/// The shape of a tool's declared `outputSchema`, or `null` for a tool that declares none.
+///
+/// Recorded because this is the half of the contract a client validates *results* against, and
+/// it is generated rather than written: a `schemars` bump that changed how a discriminated union
+/// is emitted would otherwise land silently on every consumer. The digest keeps the branch shape
+/// rather than the whole schema — the point is that the discriminator and its branches survive,
+/// not the wording of every field's description.
+fn digest_output_schema(schema: &Value) -> Value {
+    if schema.is_null() {
+        return Value::Null;
+    }
+    // Every result schema here is a `oneOf` over the outcome's branches; each branch pins
+    // `status` to a const and lists what that branch requires.
+    let branches: Vec<Value> = schema["oneOf"]
+        .as_array()
+        .map(|branches| {
+            branches
+                .iter()
+                .map(|branch| {
+                    let mut required: Vec<String> = branch["required"]
+                        .as_array()
+                        .map(|r| {
+                            r.iter()
+                                .filter_map(|v| v.as_str().map(String::from))
+                                .collect()
+                        })
+                        .unwrap_or_default();
+                    required.sort();
+                    json!({
+                        "status": branch["properties"]["status"]["const"],
+                        // The payload rides in on a `$ref` beside the discriminator, so the
+                        // reference is what names *which* result this branch describes.
+                        "payload": branch["$ref"],
+                        "required": required,
+                    })
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+    json!({
+        "dialect": schema["$schema"],
+        "branches": branches,
     })
 }
 
@@ -823,6 +924,124 @@ fn tool_schemas_declare_one_dialect_and_are_self_contained() {
             "tools/list mixes JSON Schema dialects: `{first_tool}` declares {first_dialect}, \
              `{other_tool}` declares {other}"
         );
+    }
+}
+
+/// A tool that declares an `outputSchema` must return `structuredContent` — on **both** paths.
+///
+/// The spec's requirement is on the success path, and the failure path is where this would break
+/// in practice: every migrated tool has a validation refusal or a session check that returns long
+/// before the typed answer is built, and each is a separate `return` a future edit can add without
+/// the payload. A client that validates results against the schema then rejects the very message
+/// telling it what went wrong.
+///
+/// Driven with no session open, so every session-scoped tool takes its refusal path without a
+/// debugger anywhere near it — which is what keeps this in the default tier.
+///
+/// The table is checked *against* `tools/list` in both directions: a tool that grows a schema and
+/// is not listed here fails, so this cannot quietly stop covering the surface it is about.
+#[test]
+fn every_tool_with_an_output_schema_answers_with_structured_content() {
+    // `attach_kernel_local` is deliberately absent: it is the one schema-bearing tool whose
+    // failure path cannot be reached without trying the thing itself, and on a machine booted
+    // with debugging enabled it would *succeed* and leave this test holding the local kernel.
+    const UNREACHED: &[&str] = &["attach_kernel_local"];
+    let cases: &[(&str, Value, &str)] = &[
+        // Openers, each failing before anything is created: a path that does not exist, a pid
+        // that cannot be attached, an image that cannot be launched, a selector with neither
+        // half given.
+        ("open_dump", json!({ "path": "Z:\\no\\such.dmp" }), "error"),
+        ("open_trace", json!({ "path": "Z:\\no\\such.run" }), "error"),
+        ("attach_process", json!({ "pid": 0xffff_fffeu32 }), "error"),
+        (
+            "launch",
+            json!({ "command_line": "Z:\\no\\such\\image.exe" }),
+            "error",
+        ),
+        ("attach_kernel", json!({}), "error"),
+        // Answered from this server's own bookkeeping, so it succeeds with nothing open.
+        ("session_status", json!({}), "ok"),
+        // Everything else needs a session, and there is none.
+        ("end_session", json!({}), "error"),
+        ("registers", json!({}), "error"),
+        ("modules", json!({}), "error"),
+        (
+            "set_breakpoint",
+            json!({ "expression": "nt!KeBugCheckEx" }),
+            "error",
+        ),
+        (
+            "run_to_address",
+            json!({ "address": "nt!KeBugCheckEx" }),
+            "error",
+        ),
+        ("go", json!({}), "error"),
+        ("step_over", json!({}), "error"),
+        ("step_into", json!({}), "error"),
+        ("step_back", json!({}), "error"),
+        ("step_over_back", json!({}), "error"),
+        ("reverse_go", json!({}), "error"),
+        ("pool_find_tag", json!({ "tag": "Tgsm" }), "error"),
+        (
+            "pool_chunk",
+            json!({ "address": "0xffff800000000000" }),
+            "error",
+        ),
+        ("pool_census", json!({}), "error"),
+        ("pool_diagnostics", json!({}), "error"),
+    ];
+
+    let mut server = Server::started();
+    let response = server.request("tools/list", json!({}), STEP);
+    let tools = response["result"]["tools"]
+        .as_array()
+        .expect("tools/list returns an array")
+        .clone();
+    let mut declared: Vec<&str> = tools
+        .iter()
+        .filter(|t| !t["outputSchema"].is_null())
+        .filter_map(|t| t["name"].as_str())
+        .filter(|name| !UNREACHED.contains(name))
+        .collect();
+    declared.sort_unstable();
+    let mut covered: Vec<&str> = cases.iter().map(|(name, _, _)| *name).collect();
+    covered.sort_unstable();
+    assert_eq!(
+        declared, covered,
+        "every tool declaring an outputSchema has to be exercised here (or listed in UNREACHED \
+         with a reason), or this test stops covering the surface it is named for"
+    );
+
+    for (name, args, expected) in cases {
+        let response = server.call_tool(name, args.clone(), STEP);
+        assert_no_error(&response, &format!("tools/call {name}"));
+        let result = &response["result"];
+        let data = &result["structuredContent"];
+        assert!(
+            !data.is_null(),
+            "`{name}` declares an outputSchema but answered with text alone:\n{}",
+            text_of(result)
+        );
+        assert_eq!(
+            data["status"], *expected,
+            "`{name}` should have answered `{expected}`: {data}"
+        );
+        if *expected == "error" {
+            assert!(
+                is_tool_error(&response),
+                "`{name}` reported a structured error but did not set isError: {result}"
+            );
+            assert!(
+                data["error"]["category"].is_string(),
+                "`{name}` must name a category a caller can branch on: {data}"
+            );
+            // The text and the typed message are the same failure, not two accounts of it.
+            assert_eq!(
+                data["error"]["message"].as_str().unwrap_or_default(),
+                text_of(result),
+                "`{name}`'s structured message and its text should be one string"
+            );
+        }
     }
 }
 
@@ -1072,17 +1291,22 @@ fn a_dump_session_opens_reads_and_closes() {
     );
 
     // The handle is what routes every later call, so the open has to mint one.
-    let session_id = session_id_of(&opened);
+    let session_id = session_id_of(&response["result"]);
     assert!(
         session_id.starts_with("sess-"),
         "session handles are minted as `sess-…`, got `{session_id}` in:\n{opened}"
     );
 
-    let status = server.tool_text("session_status", json!({}), TARGET_STEP);
-    assert!(
-        status.contains(&session_id),
-        "session_status should report the open session `{session_id}`, got:\n{status}"
-    );
+    let status = server.tool_data("session_status", json!({}), TARGET_STEP);
+    let listed_session = status["sessions"]
+        .as_array()
+        .into_iter()
+        .flatten()
+        .find(|s| s["session_id"] == session_id.as_str())
+        .unwrap_or_else(|| panic!("session_status omitted the open session: {status}"));
+    assert_eq!(listed_session["kind"], "dump");
+    assert_eq!(listed_session["state"]["state"], "open");
+    assert_eq!(listed_session["current"], true);
 
     // Read-only inspection through the engine thread. These are the calls that break when a
     // DbgEng binding changes shape.
@@ -1090,30 +1314,95 @@ fn a_dump_session_opens_reads_and_closes() {
     // anchors — not `ntdll`. Symbols are not needed: the rows come from the dump's own module
     // list, which keeps this tier runnable offline.
     //
-    // Matched as whitespace-separated tokens rather than by column position: `lm` lays out its
-    // columns from the address width and the longest module name, so a layout shift would
-    // otherwise fail here and name the wrong cause.
-    let modules = server.tool_text("modules", json!({ "session_id": session_id }), TARGET_STEP);
-    let listed: Vec<&str> = modules
-        .lines()
-        // `start end name [flags]` — the module name is the third token on a row.
-        .filter_map(|line| line.split_whitespace().nth(2))
-        .collect();
+    // Read as module *records*, not as tokens on a rendered row: `lm` lays its columns out from
+    // the address width and the longest module name, so the third-token rule this replaces
+    // failed on a layout shift and named the wrong cause.
+    let modules = server.tool_data("modules", json!({ "session_id": session_id }), TARGET_STEP);
+    let by_name = |want: &str| -> Value {
+        modules["modules"]
+            .as_array()
+            .into_iter()
+            .flatten()
+            .find(|m| m["name"] == want)
+            .cloned()
+            .unwrap_or_else(|| panic!("the module list should include `{want}`: {modules}"))
+    };
     for expected in ["nt", "hal"] {
+        let module = by_name(expected);
+        // The addresses are this server's one representation, and they bound a real image.
+        let start = address_of(&module["start"]);
+        let end = address_of(&module["end"]);
         assert!(
-            listed.contains(&expected),
-            "the module list should include `{expected}`, got:\n{modules}"
+            start != 0 && end > start,
+            "`{expected}` should span a real range, got {module}"
+        );
+        assert!(
+            module["symbols"].is_string(),
+            "symbol state is a value, not a parenthesis in a line: {module}"
         );
     }
-    for tool in ["registers", "backtrace"] {
-        let response = server.call_tool(tool, json!({ "session_id": session_id }), TARGET_STEP);
-        assert_no_error(&response, tool);
-        let text = text_of(&response["result"]);
-        assert!(
-            !is_tool_error(&response) && !text.trim().is_empty(),
-            "`{tool}` failed against the sample dump:\n{text}"
+    assert_eq!(
+        modules["loaded"].as_u64().unwrap_or_default() as usize,
+        modules["modules"].as_array().map_or(0, Vec::len),
+        "the count and the list have to be the same walk: {modules}"
+    );
+
+    // Registers come back as values too, with the instruction pointer called out.
+    let registers = server.tool_data(
+        "registers",
+        json!({ "session_id": session_id }),
+        TARGET_STEP,
+    );
+    assert_eq!(
+        registers["all_registers"], false,
+        "the integer set by default"
+    );
+    let rip = registers["instruction_pointer"]
+        .as_str()
+        .unwrap_or_else(|| panic!("a stopped dump has an instruction pointer: {registers}"));
+    let named = |want: &str| -> Value {
+        registers["registers"]
+            .as_array()
+            .into_iter()
+            .flatten()
+            .find(|r| r["name"] == want)
+            .cloned()
+            .unwrap_or_else(|| panic!("`{want}` should be in the integer set: {registers}"))
+    };
+    assert_eq!(named("rip")["value"], rip, "the two must be the same read");
+    for name in ["rsp", "rax", "efl"] {
+        let register = named(name);
+        assert_eq!(register["kind"], "int", "{register}");
+        assert_eq!(
+            register["value"].as_str().map(str::len),
+            Some(18),
+            "one address representation, zero-padded: {register}"
         );
     }
+    // The whole bank is opt-in, and it is a superset.
+    let everything = server.tool_data(
+        "registers",
+        json!({ "session_id": session_id, "all": true }),
+        TARGET_STEP,
+    );
+    assert_eq!(everything["all_registers"], true);
+    assert!(
+        everything["registers"].as_array().map_or(0, Vec::len)
+            > registers["registers"].as_array().map_or(0, Vec::len),
+        "`all` should add the x87/vector registers and the subregister views"
+    );
+
+    let response = server.call_tool(
+        "backtrace",
+        json!({ "session_id": session_id }),
+        TARGET_STEP,
+    );
+    assert_no_error(&response, "backtrace");
+    assert!(
+        !is_tool_error(&response) && !text_of(&response["result"]).trim().is_empty(),
+        "`backtrace` failed against the sample dump:\n{}",
+        text_of(&response["result"])
+    );
 
     // `threads` is `~`, which DbgEng only implements in user mode — against this kernel dump
     // it fails, and that is the point: a real engine failure has to come back as a *tool*
@@ -1130,23 +1419,26 @@ fn a_dump_session_opens_reads_and_closes() {
     );
 
     // A handle this server never issued must be refused rather than silently answered against
-    // whatever happens to be open — the contract `Sessions::resolve` owns.
-    let stale = server.call_tool(
+    // whatever happens to be open — the contract `Sessions::resolve` owns. The refusal says so
+    // as a category, which is what lets a client tell it from a debugger error without reading.
+    let stale = server.tool_failure(
         "modules",
         json!({ "session_id": "sess-not-a-real-handle" }),
         TARGET_STEP,
     );
-    assert!(
-        is_tool_error(&stale) || !stale["error"].is_null(),
-        "a stale session handle must be refused, got {stale}"
-    );
+    assert_eq!(stale["error"]["category"], "stale_session", "{stale}");
+    assert_eq!(stale["error"]["session_id"], "sess-not-a-real-handle");
 
-    let ended = server.tool_text(
+    let ended = server.tool_data(
         "end_session",
         json!({ "session_id": session_id }),
         TARGET_STEP,
     );
-    assert!(!ended.trim().is_empty(), "end_session said nothing");
+    assert_eq!(ended["session_id"], session_id.as_str());
+    assert_eq!(
+        ended["released"], true,
+        "a dump session lets go of its target: {ended}"
+    );
 
     // After the session is gone, the old handle must not be honoured.
     let after = server.call_tool("modules", json!({ "session_id": session_id }), TARGET_STEP);
@@ -1173,7 +1465,7 @@ fn a_batch_commits_or_fails_and_its_rollback_runs_either_way() {
 
     let response = server.call_tool("open_dump", json!({ "path": dump }), TARGET_STEP);
     assert_no_error(&response, "open_dump");
-    let session_id = session_id_of(&text_of(&response["result"]));
+    let session_id = session_id_of(&response["result"]);
 
     // A batch that should commit: a capture bound from one step and interpolated into the next,
     // which is the whole of the "named values" contract in three steps.
@@ -1276,7 +1568,7 @@ fn ending_a_session_stops_a_running_batch_and_rolls_it_back() {
     let mut server = Server::started();
     let response = server.call_tool("open_dump", json!({ "path": dump }), TARGET_STEP);
     assert_no_error(&response, "open_dump");
-    let session_id = session_id_of(&text_of(&response["result"]));
+    let session_id = session_id_of(&response["result"]);
 
     let mut steps = vec![
         json!({ "op": "command", "command": format!(".logopen \"{}\"", running.display()) }),
@@ -1360,7 +1652,7 @@ fn interrupting_a_running_batch_stops_it_and_rolls_it_back() {
     let mut server = Server::started();
     let response = server.call_tool("open_dump", json!({ "path": dump }), TARGET_STEP);
     assert_no_error(&response, "open_dump");
-    let session_id = session_id_of(&text_of(&response["result"]));
+    let session_id = session_id_of(&response["result"]);
 
     // Announce that the batch is inside its steps, spend long enough to be interrupted, and then —
     // the assertion that matters — write a second marker. A batch that carries on past the
@@ -1475,7 +1767,7 @@ fn interrupting_a_batch_during_its_rollback_is_refused() {
     let mut server = Server::started();
     let response = server.call_tool("open_dump", json!({ "path": dump }), TARGET_STEP);
     assert_no_error(&response, "open_dump");
-    let session_id = session_id_of(&text_of(&response["result"]));
+    let session_id = session_id_of(&response["result"]);
 
     let batch = server.send_request(
         "tools/call",
@@ -1573,7 +1865,7 @@ fn a_disconnect_lets_a_running_batch_roll_back_first() {
     let mut server = Server::started();
     let response = server.call_tool("open_dump", json!({ "path": dump }), TARGET_STEP);
     assert_no_error(&response, "open_dump");
-    let session_id = session_id_of(&text_of(&response["result"]));
+    let session_id = session_id_of(&response["result"]);
 
     // Steps: announce that the batch is running, then spend twenty seconds so the disconnect
     // lands squarely inside it. `always` leaves the second marker, and is the thing under test.
@@ -1671,15 +1963,23 @@ fn marker_path(what: &str) -> std::path::PathBuf {
 /// A **failed** opener can carry one too, and that is the case worth remembering: an open that
 /// fails *after* claiming its target hands the handle back deliberately, because the session
 /// exists and needs cleaning up. So cleanup must key on this, never on `isError`.
-fn maybe_session_id(text: &str) -> Option<String> {
-    text.lines()
-        .find_map(|line| line.trim().strip_prefix("session_id:"))
-        .map(|id| id.trim().to_string())
+fn maybe_session_id(result: &Value) -> Option<String> {
+    let data = &result["structuredContent"];
+    data["session_id"]
+        .as_str()
+        .or_else(|| data["error"]["session_id"].as_str())
+        .map(str::to_string)
 }
 
 /// [`maybe_session_id`], for a call that must have opened something.
-fn session_id_of(text: &str) -> String {
-    maybe_session_id(text).unwrap_or_else(|| panic!("expected a session_id in:\n{text}"))
+fn session_id_of(result: &Value) -> String {
+    maybe_session_id(result).unwrap_or_else(|| {
+        panic!(
+            "expected a session_id in the structured result:\n{}\n--- text ---\n{}",
+            result["structuredContent"],
+            text_of(result)
+        )
+    })
 }
 
 /// Whether a process is still running. Windows-only, like everything else here.
@@ -1692,19 +1992,49 @@ fn process_alive(pid: u32) -> bool {
     String::from_utf8_lossy(&out.stdout).contains(&pid.to_string())
 }
 
-/// The `pid` `session_status` reports for a session, from its `[engine pid N, …]` line.
-fn engine_pid_of(status: &str, session_id: &str) -> u32 {
-    let line = status
-        .lines()
-        .find(|l| l.contains(session_id) && l.contains("engine pid"))
-        .unwrap_or_else(|| panic!("no engine pid reported for `{session_id}` in:\n{status}"));
-    let after = line.split("engine pid ").nth(1).expect("checked above");
-    after
-        .chars()
-        .take_while(char::is_ascii_digit)
-        .collect::<String>()
-        .parse()
-        .unwrap_or_else(|e| panic!("unreadable engine pid in {line:?}: {e}"))
+/// Reads one of this server's addresses back to a number, checking the representation on the way.
+///
+/// Every address in a structured result is documented as a `0x`-prefixed, lowercase, 16-digit
+/// hex string, and it is documented because clients depend on it: the whole reason it is a string
+/// and not a JSON number is that a kernel pointer past 2^53 does not survive a parser that reads
+/// numbers as doubles. So the shape is asserted at every point a test reads one.
+fn address_of(value: &Value) -> u64 {
+    let text = value
+        .as_str()
+        .unwrap_or_else(|| panic!("an address is a string, got {value}"));
+    let digits = text
+        .strip_prefix("0x")
+        .unwrap_or_else(|| panic!("addresses carry a `0x` prefix, got {text:?}"));
+    assert_eq!(
+        digits.len(),
+        16,
+        "addresses are zero-padded to 16 digits so they sort: {text:?}"
+    );
+    assert!(
+        digits
+            .chars()
+            .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()),
+        "addresses are lowercase hex with no backtick: {text:?}"
+    );
+    u64::from_str_radix(digits, 16).unwrap_or_else(|e| panic!("unreadable address {text:?}: {e}"))
+}
+
+/// The pid of the engine process holding a session, from `session_status`'s typed report.
+///
+/// A field rather than the `[engine pid N, …]` fragment of a rendered line: these tests kill that
+/// process and then assert it is gone, so a misread number would make the whole check pass
+/// against a process nobody touched.
+fn engine_pid_of(status: &Value, session_id: &str) -> u32 {
+    let sessions = status["sessions"]
+        .as_array()
+        .unwrap_or_else(|| panic!("session_status reports a session list, got: {status}"));
+    let session = sessions
+        .iter()
+        .find(|s| s["session_id"] == session_id)
+        .unwrap_or_else(|| panic!("`{session_id}` is not in the report: {status}"));
+    session["engine_pid"]
+        .as_u64()
+        .unwrap_or_else(|| panic!("`{session_id}` reports no engine pid: {session}")) as u32
 }
 
 /// Sessions are independent processes, so opening a second target must not disturb the first.
@@ -1718,9 +2048,8 @@ fn two_sessions_coexist_and_do_not_disturb_each_other() {
     let Some(dump) = target_tier() else { return };
     let mut server = Server::started();
 
-    let first = session_id_of(&server.tool_text("open_dump", json!({ "path": dump }), TARGET_STEP));
-    let second =
-        session_id_of(&server.tool_text("open_dump", json!({ "path": dump }), TARGET_STEP));
+    let first = server.open_session("open_dump", json!({ "path": dump }), TARGET_STEP);
+    let second = server.open_session("open_dump", json!({ "path": dump }), TARGET_STEP);
     assert_ne!(first, second, "each open must get its own session");
 
     // The claim: the first handle still names a live target after the second open landed.
@@ -1791,11 +2120,18 @@ fn a_kernel_attach_that_never_connects_costs_one_session_and_can_be_ended() {
         }),
     );
 
-    // Wait for it to reach the parked state rather than assuming a timing.
+    // Wait for it to reach the parked state rather than assuming a timing. Read as a state, not
+    // as a phrase: "attaching" is what the session *is*, where the sentence describing it is
+    // several sentences long and rewritten whenever the advice changes.
     let deadline = Instant::now() + Duration::from_secs(30);
     let parked = loop {
-        let status = server.tool_text("session_status", json!({}), STEP);
-        if status.contains("waiting") && status.contains("kernel target") {
+        let status = server.tool_data("session_status", json!({}), STEP);
+        let attaching = status["sessions"]
+            .as_array()
+            .into_iter()
+            .flatten()
+            .any(|s| s["kind"] == "kernel" && s["state"]["state"] == "attaching");
+        if attaching {
             break Some(status);
         }
         if Instant::now() >= deadline {
@@ -1809,11 +2145,14 @@ fn a_kernel_attach_that_never_connects_costs_one_session_and_can_be_ended() {
         skip("attach_kernel did not reach the parked state (port 50007 busy?)");
         return;
     };
-    let kernel_session = status
-        .lines()
-        .find(|l| l.contains("kernel target"))
-        .map(|l| l.split_whitespace().next().unwrap_or_default().to_string())
-        .expect("the kernel session should be listed");
+    let kernel_session = status["sessions"]
+        .as_array()
+        .into_iter()
+        .flatten()
+        .find(|s| s["kind"] == "kernel")
+        .and_then(|s| s["session_id"].as_str())
+        .expect("the kernel session should be listed")
+        .to_string();
 
     // The point. A parked session used to be the *server's* engine thread; now it is one worker,
     // and everything else carries on.
@@ -1824,30 +2163,41 @@ fn a_kernel_attach_that_never_connects_costs_one_session_and_can_be_ended() {
         "a parked kernel attach must not block another session:\n{}",
         text_of(&opened["result"])
     );
-    let dump_session = session_id_of(&text_of(&opened["result"]));
+    let dump_session = session_id_of(&opened["result"]);
 
     // …and the parked session reports itself honestly rather than as an ordinary pending open.
-    let asked = server.tool_text(
+    // The distinction is two fields: the target has been claimed (`attaching`, not `opening`),
+    // and this particular wait has no timeout and cannot be interrupted.
+    let asked = server.tool_data(
         "session_status",
         json!({ "session_id": kernel_session }),
         STEP,
     );
-    assert!(
-        asked.contains("Do not re-run the open"),
-        "the target exists, so re-attaching would be a second attach:\n{asked}"
+    let parked = &asked["sessions"][0]["state"];
+    assert_eq!(
+        parked["state"], "attaching",
+        "the target exists, so re-attaching would be a second attach: {asked}"
+    );
+    assert_eq!(
+        parked["waits_indefinitely"], true,
+        "a live kernel attach is the wait that cannot end on its own: {asked}"
     );
 
     // The recovery that did not exist before: `end_session` cannot be answered by a worker that
     // is parked, so the worker is killed. It has to come back, and the process has to be gone.
     let worker = engine_pid_of(&status, &kernel_session);
-    let ended = server.tool_text(
+    let ended = server.tool_data(
         "end_session",
         json!({ "session_id": kernel_session }),
         Duration::from_secs(120),
     );
-    assert!(
-        ended.contains("terminated"),
-        "a parked session ends by terminating its worker:\n{ended}"
+    assert_eq!(
+        ended["released"], false,
+        "a parked worker cannot let go of its target: {ended}"
+    );
+    assert_eq!(
+        ended["worker_terminated"], true,
+        "a parked session ends by terminating its worker: {ended}"
     );
     assert!(
         !process_alive(worker),
@@ -1961,9 +2311,8 @@ fn a_profile_attach_names_its_target_without_disclosing_the_key() {
 fn engine_workers_do_not_outlive_the_connection() {
     let Some(dump) = target_tier() else { return };
     let mut server = Server::started();
-    let session =
-        session_id_of(&server.tool_text("open_dump", json!({ "path": dump }), TARGET_STEP));
-    let status = server.tool_text("session_status", json!({}), TARGET_STEP);
+    let session = server.open_session("open_dump", json!({ "path": dump }), TARGET_STEP);
+    let status = server.tool_data("session_status", json!({}), TARGET_STEP);
     let worker = engine_pid_of(&status, &session);
     assert!(process_alive(worker), "the worker should be running");
 
@@ -2002,9 +2351,8 @@ fn engine_workers_do_not_outlive_the_connection() {
 fn a_worker_lets_go_and_exits_when_its_supervisor_is_killed_outright() {
     let Some(dump) = target_tier() else { return };
     let mut server = Server::started();
-    let session =
-        session_id_of(&server.tool_text("open_dump", json!({ "path": dump }), TARGET_STEP));
-    let status = server.tool_text("session_status", json!({}), TARGET_STEP);
+    let session = server.open_session("open_dump", json!({ "path": dump }), TARGET_STEP);
+    let status = server.tool_data("session_status", json!({}), TARGET_STEP);
     let worker = engine_pid_of(&status, &session);
     assert!(process_alive(worker), "the worker should be running");
 
@@ -2052,8 +2400,7 @@ fn a_failed_debugger_operation_is_a_tool_error_not_a_protocol_error() {
 
     // And the other half: a real engine failure, carrying the engine's own text. `~` is
     // user-mode-only, so DbgEng rejects it against this kernel dump.
-    let session_id =
-        session_id_of(&server.tool_text("open_dump", json!({ "path": dump }), TARGET_STEP));
+    let session_id = server.open_session("open_dump", json!({ "path": dump }), TARGET_STEP);
     let unsupported = server.call_tool("threads", json!({ "session_id": session_id }), TARGET_STEP);
     assert_no_error(&unsupported, "threads on a kernel dump");
     assert!(
@@ -2100,8 +2447,7 @@ fn a_pool_walk_takes_this_servers_deadline_not_the_walkers_default() {
         ("WINDBG_MCP_CALL_TIMEOUT_SECS", "60"),
         ("RUST_LOG", "windbg_mcp=debug"),
     ]);
-    let session =
-        session_id_of(&server.tool_text("open_dump", json!({ "path": dump }), TARGET_STEP));
+    let session = server.open_session("open_dump", json!({ "path": dump }), TARGET_STEP);
 
     // Not `tool_text`: whether the walk itself succeeds depends on symbols this tier does not
     // require, and the budget is derived before the first pool page is read either way.
@@ -2164,7 +2510,7 @@ fn a_pool_query_with_no_time_to_walk_is_refused_rather_than_run() {
         skip("the sample dump did not open inside a 10s call budget on this machine");
         return;
     }
-    let session = session_id_of(&text_of(&opened["result"]));
+    let session = session_id_of(&opened["result"]);
 
     // `refresh`, so the cached snapshot cannot answer it and a walk is unavoidable.
     let response = server.call_tool(
@@ -2217,8 +2563,7 @@ fn a_running_command_is_interrupted_on_request_and_frees_its_session() {
     // ends the runaway at the 15s floor and the assertions below say so, instead of this test
     // sitting out five minutes of the default timeout.
     let mut server = Server::started_with(&[("WINDBG_MCP_CALL_TIMEOUT_SECS", "30")]);
-    let session =
-        session_id_of(&server.tool_text("open_dump", json!({ "path": dump }), TARGET_STEP));
+    let session = server.open_session("open_dump", json!({ "path": dump }), TARGET_STEP);
 
     // An idle session says so and does nothing. Deterministic: the open above has been answered
     // and nothing else is outstanding.
@@ -2377,8 +2722,7 @@ fn a_bounded_runaway_command_aborts_and_leaves_its_session_usable() {
     // 30s of call budget leaves the watchdog its 15s floor, which keeps the test short while
     // still exercising the real arithmetic rather than a special case.
     let mut server = Server::started_with(&[("WINDBG_MCP_CALL_TIMEOUT_SECS", "30")]);
-    let session =
-        session_id_of(&server.tool_text("open_dump", json!({ "path": dump }), TARGET_STEP));
+    let session = server.open_session("open_dump", json!({ "path": dump }), TARGET_STEP);
 
     let started = Instant::now();
     let response = server.call_tool(
@@ -2448,8 +2792,7 @@ fn a_bounded_command_queued_behind_another_job_still_beats_its_caller() {
     const QUEUE_WAIT: Duration = Duration::from_secs(30);
 
     let mut server = Server::started_with(&[("WINDBG_MCP_CALL_TIMEOUT_SECS", "60")]);
-    let session =
-        session_id_of(&server.tool_text("open_dump", json!({ "path": dump }), TARGET_STEP));
+    let session = server.open_session("open_dump", json!({ "path": dump }), TARGET_STEP);
 
     // Occupy the session for a known time, then queue the runaway behind it. `.sleep` blocks the
     // engine exactly the way a long command does, and unlike a calibrated spin its duration does
@@ -2526,8 +2869,7 @@ fn measure_what_the_bounded_path_costs_a_quick_command() {
     const ROUNDS: usize = 20;
 
     let mut server = Server::started();
-    let session =
-        session_id_of(&server.tool_text("open_dump", json!({ "path": dump }), TARGET_STEP));
+    let session = server.open_session("open_dump", json!({ "path": dump }), TARGET_STEP);
 
     /// min / median / max, because a mean hides the two modes entirely.
     fn spread(mut samples: Vec<Duration>) -> String {
@@ -2730,7 +3072,7 @@ fn a_live_kernel_session_attaches_coexists_and_detaches_cleanly() {
     // attach that claims its target and then fails the wait comes back as a tool error carrying a
     // valid `session_id`, and that session is live, halted, and needs detaching just as much as a
     // successful one. Nothing below panics until that has happened.
-    let Some(session) = maybe_session_id(&report) else {
+    let Some(session) = maybe_session_id(&attached["result"]) else {
         assert_no_error(&attached, "attach_kernel");
         panic!(
             "the attach did not land, and left no session behind. The target must be booted with \
@@ -2756,10 +3098,10 @@ fn a_live_kernel_session_attaches_coexists_and_detaches_cleanly() {
         );
 
         // The milestones made it across: not still "attaching", which is where a parked one sits.
-        let status = server.tool_text("session_status", json!({ "session_id": session }), STEP);
-        assert!(
-            status.contains("ready for work"),
-            "a landed attach must report as open, not mid-attach:\n{status}"
+        let status = server.tool_data("session_status", json!({ "session_id": session }), STEP);
+        assert_eq!(
+            status["sessions"][0]["state"]["state"], "open",
+            "a landed attach must report as open, not mid-attach: {status}"
         );
 
         // The transport lives in the worker — the process `end_session` can terminate.
@@ -2800,7 +3142,7 @@ fn a_live_kernel_session_attaches_coexists_and_detaches_cleanly() {
                 "opening a dump must not be blocked by a live kernel session:\n{}",
                 text_of(&opened["result"])
             );
-            let dump_session = session_id_of(&text_of(&opened["result"]));
+            let dump_session = session_id_of(&opened["result"]);
             let after = server.call_tool("modules", json!({ "session_id": session }), TARGET_STEP);
             assert!(
                 !is_tool_error(&after),
@@ -2873,13 +3215,13 @@ fn disconnecting_releases_a_live_kernel_session_rather_than_killing_it() {
     // something to bail on. From here the disconnect is the release, so nothing needs a detach —
     // but the assertion order still has to survive an attach that half-failed.
     assert_no_error(&attached, "attach_kernel");
-    let session = maybe_session_id(&report)
+    let session = maybe_session_id(&attached["result"])
         .unwrap_or_else(|| panic!("the attach left no session behind:\n{report}"));
     assert!(
         !is_tool_error(&attached),
         "the attach claimed its target and then failed; this test needs one that landed:\n{report}"
     );
-    let status = server.tool_text("session_status", json!({}), STEP);
+    let status = server.tool_data("session_status", json!({}), STEP);
     let worker = engine_pid_of(&status, &session);
     // `call_tool`, for the reason the block below spells out: at this point the target is broken
     // in and the release is still several steps away, so a panic here would leave it halted. The
@@ -2950,7 +3292,7 @@ fn disconnecting_releases_a_live_kernel_session_rather_than_killing_it() {
     // Keyed on the handle, not on `landed`: a re-attach that claimed the target and then failed
     // its wait comes back as a tool error *with* a session, and skipping the release for it would
     // leave the target halted — the one thing this test exists to catch.
-    let (after, ended, released) = match maybe_session_id(&report) {
+    let (after, ended, released) = match maybe_session_id(&reattached["result"]) {
         Some(session) => {
             // `call_tool`, not `tool_text`. This `.time` is *expected* to fail on the very path
             // the handle-keyed match above exists for — a re-attach that claimed the target and
@@ -3296,152 +3638,55 @@ enum HeaviestTag {
     NothingListed,
 }
 
-/// The heaviest tag in `pool_census` output.
-fn heaviest_census_tag(census: &str) -> HeaviestTag {
-    let mut lines = census
-        .lines()
-        .skip_while(|line| !(line.starts_with("tag ") && line.contains("allocs")));
-    if lines.next().is_none() {
-        return HeaviestTag::NothingListed;
-    }
-    let Some(row) = lines.find(|line| !line.trim().is_empty()) else {
+/// The heaviest tag in a `pool_census` result.
+///
+/// Reads the first entry of the census's own ordering rather than parsing a fixed-width column
+/// out of the table. The column-reading version had a trap worth remembering: `display_tag`
+/// keeps trailing spaces, so a real tag like `Ntf ` had to be taken as exactly four characters
+/// and never split on whitespace, or the cross-check below queried a tag nobody allocated and
+/// blamed the walk for not finding it. A field cannot be mis-sliced.
+fn heaviest_census_tag(census: &Value) -> HeaviestTag {
+    let Some(first) = census["tags"].as_array().and_then(|tags| tags.first()) else {
         return HeaviestTag::NothingListed;
     };
-    // A fixed-width column, read as one. Splitting on whitespace looks equivalent and is not:
-    // `display_tag` keeps spaces, so a real tag like `Ntf ` would come back as `Ntf`, which is a
-    // *different* four bytes — the cross-check below would then query a tag nobody allocated and
-    // blame the walk for not finding it. Every rendering is exactly four characters.
-    let tag: String = row.chars().take(4).collect();
+    let tag = first["tag"].as_str().unwrap_or_default().to_string();
     if tag.chars().count() != 4 || tag.contains('.') {
+        // Still a rendering, and still ambiguous: the *tag* is four raw bytes, and every
+        // unprintable one — like a literal `.` — comes back as `.`.
         return HeaviestTag::Ambiguous;
     }
     HeaviestTag::Queryable(tag)
 }
 
-/// Pinned in the default tier, because the failure it guards against is a *silent skip*: the
-/// cross-check it feeds only runs on `Queryable`, so a parser that stops matching takes the proof
-/// with it and the live run still passes. The three-way split matters just as much — collapsing
-/// `Ambiguous` into `NothingListed` turns an unremarkable target into a test failure.
-#[test]
-fn a_census_table_yields_its_heaviest_tag() {
-    const HEADER: &str = "tag      allocs        bytes  nonpaged   paged";
-    let table = |rows: &str| {
-        format!(
-            "3 distinct tag(s) allocated, heaviest first.\n\n{HEADER}\n{rows}\n\
-             \n--- pool walk ---\nchunks walked: 5 (4 allocated), coverage: complete\n"
-        )
-    };
-
-    assert!(matches!(
-        heaviest_census_tag(&table(
-            "MmSt        912       0x1f40       912       0\n\
-             Tgsm          4         0x1a0         4       0"
-        )),
-        HeaviestTag::Queryable(tag) if tag == "MmSt"
-    ));
-
-    // A three-byte tag is rendered padded with the space it actually contains, and `parse_tag`
-    // takes it straight back. Splitting on whitespace would hand `pool_find_tag` the three-byte
-    // `Ntf` instead — a different tag, which nothing allocated, blamed on the walk.
-    assert!(matches!(
-        heaviest_census_tag(&table("Ntf         912       0x1f40       912       0")),
-        HeaviestTag::Queryable(tag) if tag == "Ntf "
-    ));
-
-    // A walk that found nothing has no heaviest tag, and nothing may invent one.
-    assert!(matches!(
-        heaviest_census_tag("The pool snapshot contains no allocated chunks."),
-        HeaviestTag::NothingListed
-    ));
-
-    // Unprintable tag bytes render as `.`, and so does a literal `.` — the rendering cannot be
-    // turned back into bytes. That is a fact about rendering, not about the pool, so it must not
-    // read as "the walk found nothing".
-    assert!(matches!(
-        heaviest_census_tag(&table("Nt.f        912       0x1f40       912       0")),
-        HeaviestTag::Ambiguous
-    ));
-}
-
-/// The walk's stated diagnostic total, and the per-category counts printed beneath it.
-fn diagnostic_counts(report: &str) -> Option<(usize, Vec<usize>)> {
-    let total = report.lines().find_map(|line| {
-        let (count, _) = line.split_once(" diagnostic(s) in ")?;
-        count.trim().parse::<usize>().ok()
-    })?;
-    let categories = report
-        .lines()
-        .filter_map(|line| {
-            let trimmed = line.trim_start();
-            let digits: String = trimmed.chars().take_while(|c| c.is_ascii_digit()).collect();
-            // `x` and two spaces, or a `0x1f40` in some other table would read as a category.
-            (!digits.is_empty() && trimmed[digits.len()..].starts_with("x  "))
-                .then(|| digits.parse().ok())
-                .flatten()
-        })
-        .collect();
-    Some((total, categories))
-}
-
-/// A walk's diagnostic total has to account for the categories printed beneath it.
+/// A walk's diagnostic total has to account for the categories reported under it.
 ///
 /// The arithmetic is trivial — a sum is at least the part of it you can see — and it is exactly
 /// what broke. The total used to be the number of *lines that survived* the walk's collapsing, so
-/// a real run printed "71 diagnostic(s)" above a category reading "5621x" (#77): a statement about
-/// this code's own truncation, rendered as a measurement of the target. Fixtures cannot catch it
-/// because nothing collapses until a category floods, so this live tier is the only place the two
-/// numbers are ever far enough apart to disagree.
-fn assert_diagnostic_total_covers_its_categories(report: &str) {
-    if report.contains("the walk reported no diagnostics.") {
+/// a real run reported "71 diagnostic(s)" beside a category reading "5621x" (#77): a statement
+/// about this code's own truncation, presented as a measurement of the target. Fixtures cannot
+/// catch it because nothing collapses until a category floods, so this live tier is the only
+/// place the two numbers are ever far enough apart to disagree.
+fn assert_diagnostic_total_covers_its_categories(diagnostics: &Value) {
+    let emitted = diagnostics["walk"]["diagnostics_emitted"]
+        .as_u64()
+        .unwrap_or_else(|| panic!("the walk reports how much it complained: {diagnostics}"));
+    if emitted == 0 {
         return;
     }
-    let (total, categories) = diagnostic_counts(report)
-        .unwrap_or_else(|| panic!("no diagnostic summary to check in:\n{report}"));
+    let categories: Vec<u64> = diagnostics["categories"]
+        .as_array()
+        .into_iter()
+        .flatten()
+        .filter_map(|category| category["total"].as_u64())
+        .collect();
     assert!(
         !categories.is_empty(),
-        "a diagnostic total with no categories under it means this parser stopped matching, and \
-         a check that silently matches nothing is not a check:\n{report}"
+        "a diagnostic total with no categories under it means the walk grouped nothing, and a          check that silently matches nothing is not a check: {diagnostics}"
     );
-    let listed: usize = categories.iter().sum();
+    let listed: u64 = categories.iter().sum();
     assert!(
-        total >= listed,
-        "the walk reported {total} diagnostic(s) but the categories under it account for {listed} \
-         — so the total is counting something other than the messages the walk emitted, and a \
-         reader takes it for a property of the target (#77):\n{report}"
-    );
-}
-
-/// Pinned in the default tier for the same reason as the census parser above: the live check it
-/// feeds is the *only* one that can see this fault, so a parser that quietly stops matching would
-/// take the proof with it and leave the live run passing.
-#[test]
-fn a_walk_report_yields_its_diagnostic_counts() {
-    let report = "--- pool walk ---\nchunks walked: 413279 (234110 allocated), coverage: \
-                  INCOMPLETE - the walk did not reach everything it set out to\n\
-                  7731 diagnostic(s) in 24 categories:\n\
-                  \x205621x  rejecting implausible LFH metadata at #\n\
-                  \x201770x  cannot read LFH subsegment # sparse virtual range at #\n\
-                  \nlast 12 of the 71 kept verbatim (the rest are in the counts above):\n\
-                  \x20 rejecting implausible LFH metadata at 0xffff8c8f0de00260\n";
-
-    let (total, categories) = diagnostic_counts(report).expect("the summary is right there");
-    assert_eq!(total, 7731);
-    assert_eq!(categories, vec![5621, 1770]);
-    // The verbatim example carries an address, not a count, and must not be read as a category.
-    assert_diagnostic_total_covers_its_categories(report);
-
-    // The shape of the bug: a total that counted surviving lines instead of messages.
-    let understated = report.replace("7731 diagnostic(s)", "71 diagnostic(s)");
-    assert!(
-        std::panic::catch_unwind(|| assert_diagnostic_total_covers_its_categories(&understated))
-            .is_err(),
-        "the check has to reject the very output that motivated it"
-    );
-
-    // A quiet walk has nothing to reconcile, and must not be made to fail for it.
-    assert_diagnostic_total_covers_its_categories(
-        "--- pool walk ---\nchunks walked: 5 (4 allocated), coverage: complete\n\
-         the walk reported no diagnostics.\n",
+        emitted >= listed,
+        "the walk reported {emitted} diagnostic(s) but the categories under it account for          {listed} — so the total is counting something other than the messages the walk emitted,          and a reader takes it for a property of the target (#77): {diagnostics}"
     );
 }
 
@@ -3490,7 +3735,7 @@ fn a_live_kernel_pool_walk_is_bounded_and_leaves_its_session_usable() {
         TARGET_STEP,
     );
     let report = text_of(&attached["result"]);
-    let Some(session) = maybe_session_id(&report) else {
+    let Some(session) = maybe_session_id(&attached["result"]) else {
         assert_no_error(&attached, "attach_kernel");
         panic!(
             "the attach did not land, and left no session behind. The target must be booted with \
@@ -3568,11 +3813,11 @@ fn a_live_kernel_pool_walk_is_bounded_and_leaves_its_session_usable() {
         // caller's timeout fired, the walk carried on, and this call waited out the remainder.
         let follow_up = Instant::now();
         let registers =
-            server.tool_text("registers", json!({ "session_id": session }), TARGET_STEP);
+            server.tool_data("registers", json!({ "session_id": session }), TARGET_STEP);
         let waited = follow_up.elapsed();
         assert!(
-            registers.contains("rip="),
-            "the session should still be a broken-in kernel after a pool walk:\n{registers}"
+            registers["instruction_pointer"].is_string(),
+            "the session should still be a broken-in kernel after a pool walk: {registers}"
         );
         assert!(
             waited < NOT_QUEUED,
@@ -3581,13 +3826,18 @@ fn a_live_kernel_pool_walk_is_bounded_and_leaves_its_session_usable() {
         );
 
         // An empty answer has to say what the walk managed, or "no such chunk" and "the walk
-        // reached almost none of the pool" are the same sentence. Reachable only because the
-        // call succeeded — the first live run took this branch on an *error* text and announced
-        // that the tag existed, inventing a fact about the pool out of a failure to look at it.
-        if absent.contains("No allocated chunks carry tag") {
+        // reached almost none of the pool" are the same answer. As fields now: `matches: 0`
+        // beside the coverage the count came from, which is what makes a zero readable.
+        let empty = walk["result"]["structuredContent"].clone();
+        assert_eq!(empty["status"], "ok", "checked above: {absent}");
+        if empty["matches"] == 0 {
             assert!(
-                absent.contains("--- pool walk ---") && absent.contains("chunks walked:"),
-                "an empty result must carry the walk's own coverage:\n{absent}"
+                empty["walk"]["chunks_walked"].as_u64().unwrap_or_default() > 0,
+                "an empty result must carry the walk's own coverage: {empty}"
+            );
+            assert!(
+                empty["walk"]["coverage"].is_string(),
+                "coverage is one of complete/deadline_truncated/partial: {empty}"
             );
         } else {
             eprintln!(
@@ -3615,31 +3865,40 @@ fn a_live_kernel_pool_walk_is_bounded_and_leaves_its_session_usable() {
             !is_tool_error(&census_call),
             "pool_census failed:\n{census}"
         );
+        let totals = census_call["result"]["structuredContent"].clone();
         assert!(
-            census.contains("--- pool walk ---") && census.contains("chunks walked:"),
-            "the census must always report the walk behind it:\n{census}"
+            totals["walk"]["chunks_walked"].as_u64().unwrap_or_default() > 0,
+            "the census must always report the walk behind it: {totals}"
         );
-        let complete = census.contains("coverage: complete");
-        println!(
-            "the census reports this walk {}",
-            if complete { "complete" } else { "INCOMPLETE" }
-        );
+        let coverage = totals["walk"]["coverage"]
+            .as_str()
+            .unwrap_or_default()
+            .to_string();
+        let complete = coverage == "complete";
+        println!("the census reports this walk {coverage}");
         // An incomplete walk is an acceptable outcome, but "incomplete" on its own is not a
-        // finding — the categories are. The census already carries them, so printing that
-        // section costs nothing and turns a run of this tier into a measurement of the target
-        // rather than a pass. Measured 21.9s and INCOMPLETE against Server 26100, which is well
-        // inside the budget: on that target the coverage gap is *not* the deadline.
+        // finding — *why*, and the categories, are. `deadline_truncated` and `partial` want
+        // opposite responses, which is the whole reason coverage is three values and not a bool.
+        // Measured 21.9s and INCOMPLETE against Server 26100, which is well inside the budget:
+        // on that target the coverage gap is not the deadline, and now the result says so.
         if !complete {
-            let report: String = census
-                .lines()
-                .skip_while(|line| !line.starts_with("--- pool walk ---"))
-                .collect::<Vec<_>>()
-                .join("\n");
-            println!("why the walk fell short:\n{report}");
-            assert_diagnostic_total_covers_its_categories(&report);
+            assert!(
+                coverage == "deadline_truncated" || coverage == "partial",
+                "a walk that fell short says which way: {totals}"
+            );
+            let diagnostics = server.tool_data(
+                "pool_diagnostics",
+                json!({ "session_id": session, "limit": 40 }),
+                POOL_CALL_BUDGET,
+            );
+            println!(
+                "why the walk fell short: {}",
+                text_of(&census_call["result"])
+            );
+            assert_diagnostic_total_covers_its_categories(&diagnostics);
         }
 
-        match heaviest_census_tag(&census) {
+        match heaviest_census_tag(&totals) {
             // What one tool saw, the other has to find. Only meaningful when the walk completed:
             // an incomplete snapshot is deliberately not cached, so these would be two separate
             // walks of a moving target and could honestly disagree.
@@ -3659,21 +3918,31 @@ fn a_live_kernel_pool_walk_is_bounded_and_leaves_its_session_usable() {
                      census's walk, not the first one"
                 );
                 let cached = Instant::now();
-                let call = server.call_tool(
+                let found = server.tool_data(
                     "pool_find_tag",
                     json!({ "tag": tag, "session_id": session }),
                     POOL_CALL_BUDGET,
                 );
                 let reuse = cached.elapsed();
-                let found = text_of(&call["result"]);
+                assert_eq!(found["tag"], tag.as_str(), "{found}");
                 assert!(
-                    !is_tool_error(&call),
-                    "looking up the census's own heaviest tag `{tag}` failed:\n{found}"
-                );
-                assert!(
-                    found.contains(&format!("tag `{tag}`")) && found.contains("allocation(s)"),
+                    found["matches"].as_u64().unwrap_or_default() > 0,
                     "the census called `{tag}` the heaviest tag, so find_tag must find it in the \
-                     same snapshot:\n{found}"
+                     same snapshot: {found}"
+                );
+                // The two tools drew on one walk, so their counts for this tag have to agree.
+                // Comparing numbers rather than the phrase `allocation(s)` is the point: a count
+                // that disagreed used to render identically to one that did not.
+                let censused = totals["tags"]
+                    .as_array()
+                    .into_iter()
+                    .flatten()
+                    .find(|t| t["tag"] == tag.as_str())
+                    .cloned()
+                    .unwrap_or_else(|| panic!("the census listed `{tag}`: {totals}"));
+                assert_eq!(
+                    censused["allocations"], found["matches"],
+                    "one snapshot, two answers about `{tag}`: {censused} vs {found}"
                 );
                 assert!(
                     reuse < CACHED_QUERY_CEILING,
@@ -3912,7 +4181,7 @@ fn with_live_kernel_session<R>(
     // The handle decides whether there is anything to clean up, not `isError`: an attach that
     // claimed its target and then failed the wait comes back as a tool error carrying a live,
     // halted session.
-    let Some(session) = maybe_session_id(&report) else {
+    let Some(session) = maybe_session_id(&attached["result"]) else {
         assert_no_error(&attached, "attach_kernel");
         panic!(
             "the attach did not land, and left no session behind. The target must be booted with \
@@ -4166,7 +4435,7 @@ fn a_disconnect_lets_a_live_kernel_batch_restore_its_patch_first() {
     );
     let report = text_of(&attached["result"]);
     assert_no_error(&attached, "attach_kernel");
-    let session = maybe_session_id(&report)
+    let session = maybe_session_id(&attached["result"])
         .unwrap_or_else(|| panic!("the attach left no session behind:\n{report}"));
     assert!(
         !is_tool_error(&attached),
@@ -4180,7 +4449,7 @@ fn a_disconnect_lets_a_live_kernel_batch_restore_its_patch_first() {
         // Read now, because the re-attach below has to wait for this process to be gone: the KD
         // transport is single-owner, so a second attach that races the first worker's exit fails
         // on the port rather than on anything this test is about.
-        let status = server.tool_text("session_status", json!({}), STEP);
+        let status = server.tool_data("session_status", json!({}), STEP);
         let worker = engine_pid_of(&status, &session);
         let scratch = kernel_scratch(&mut server, &session)?;
 
@@ -4337,7 +4606,7 @@ fn ending_a_live_kernel_session_mid_batch_restores_its_patch() {
     );
     let report = text_of(&attached["result"]);
     assert_no_error(&attached, "attach_kernel");
-    let session = maybe_session_id(&report)
+    let session = maybe_session_id(&attached["result"])
         .unwrap_or_else(|| panic!("the attach left no session behind:\n{report}"));
     assert!(
         !is_tool_error(&attached),
@@ -4349,7 +4618,7 @@ fn ending_a_live_kernel_session_mid_batch_restores_its_patch() {
     let outcome = catch_unwind(AssertUnwindSafe(|| {
         // The second attach has to wait for this worker to exit before it can claim the KD
         // transport, which is single-owner.
-        let status = server.tool_text("session_status", json!({}), STEP);
+        let status = server.tool_data("session_status", json!({}), STEP);
         let worker = engine_pid_of(&status, &session);
         let scratch = kernel_scratch(&mut server, &session)?;
         let mut steps = patch_steps(&scratch);
@@ -4568,7 +4837,7 @@ fn a_messagemanager_ctf_fixture_is_visible_through_mcp() {
         TARGET_STEP,
     );
     let report = text_of(&attached["result"]);
-    let Some(session) = maybe_session_id(&report) else {
+    let Some(session) = maybe_session_id(&attached["result"]) else {
         assert_no_error(&attached, "attach_kernel for MessageManager CTF");
         panic!(
             "the CTF attach did not land and left no session to release. Confirm the guest is \
@@ -4593,11 +4862,27 @@ fn a_messagemanager_ctf_fixture_is_visible_through_mcp() {
 
         // A fresh kernel attach may initially expose only `nt`; the unqualified reload above
         // populates DbgEng's full module inventory as well as loading the pool types.
-        let modules = server.tool_text("modules", json!({ "session_id": session }), TARGET_STEP);
+        // Matched against module *names*, not against a substring of the whole `lm` listing:
+        // "messagemanager appears somewhere in that text" was true of a symbol path echoed into
+        // the same output, which is the kind of accidental pass a field cannot give.
+        let modules = server.tool_data("modules", json!({ "session_id": session }), TARGET_STEP);
+        let driver = modules["modules"]
+            .as_array()
+            .into_iter()
+            .flatten()
+            .find(|m| {
+                m["name"]
+                    .as_str()
+                    .is_some_and(|name| name.eq_ignore_ascii_case("MessageManager"))
+            })
+            .cloned();
         assert!(
-            modules.to_ascii_lowercase().contains("messagemanager"),
+            driver.is_some(),
             "the fixture reported ready, but KD does not list MessageManager.sys after the full \
-             module reload:\n{modules}\n\nsymbol setup said:{}",
+             module reload:\n{}\n\nsymbol setup said:{}",
+            text_of(
+                &server.call_tool("modules", json!({ "session_id": session }), TARGET_STEP)["result"]
+            ),
             symbols.transcript
         );
 
@@ -4620,22 +4905,37 @@ fn a_messagemanager_ctf_fixture_is_visible_through_mcp() {
             "the structured pool query failed:\n{found}\n\nsymbol setup said:{}",
             symbols.transcript
         );
+        let matches = call["result"]["structuredContent"].clone();
         assert!(
-            found.contains("tag `Tgsm`") && found.contains("allocation(s)"),
+            matches["matches"].as_u64().unwrap_or_default() > 0,
             "the target fixture retained `Tgsm` messages, but the MCP pool snapshot did not find \
-             them. Read the attached coverage report before treating an incomplete walk as an \
-             allocator result:\n{found}"
+             them. Read the walk's coverage before treating an incomplete walk as an allocator \
+             result: {matches}"
         );
+        // Every chunk it hands back really carries the tag that was asked for, at an address in
+        // this server's one representation — the two claims a caller acts on.
+        for chunk in matches["chunks"].as_array().into_iter().flatten() {
+            assert_eq!(chunk["tag"], "Tgsm", "{chunk}");
+            assert_eq!(
+                chunk["state"], "allocated",
+                "find_tag indexes only allocated chunks"
+            );
+            assert!(address_of(&chunk["address"]) != 0, "{chunk}");
+        }
         println!(
-            "MessageManager `Tgsm` allocations found through MCP in {:?}:\n{found}",
-            started.elapsed()
+            "MessageManager `Tgsm` allocations found through MCP in {:?}: {} chunk(s), {} bytes, \
+             walk {}",
+            started.elapsed(),
+            matches["matches"],
+            matches["total_bytes"],
+            matches["walk"]["coverage"],
         );
 
         let registers =
-            server.tool_text("registers", json!({ "session_id": session }), TARGET_STEP);
+            server.tool_data("registers", json!({ "session_id": session }), TARGET_STEP);
         assert!(
-            registers.contains("rip="),
-            "the kernel session did not remain usable after the CTF pool walk:\n{registers}"
+            registers["instruction_pointer"].is_string(),
+            "the kernel session did not remain usable after the CTF pool walk: {registers}"
         );
     }));
 


### PR DESCRIPTION
Closes #84.

Every tool answered in prose, so anything driving this server programmatically had to parse it — `VERDICT: HIT`, `allocation(s)`, module-name substrings, the `session_id:` line at the foot of an opener's report. A rewording here broke automation there with no debugger behaviour changing at all.

Twenty-two tools now return **the same text and a typed result beside it**, with an `outputSchema` in `tools/list`. The text is byte-for-byte what it was: this adds a channel rather than migrating one, and a tool with no typed shape yet is untouched.

## Against the acceptance criteria

| Criterion | Where |
|---|---|
| Existing clients still get the current text | `content` is unchanged on every tool; `structuredContent` is additive. The one text edit is `set_breakpoint`, which previously returned an empty string on success. |
| Schemas in `tools/list` | `output_schema` on all 22, recorded in `tests/golden/tools_list.json` (dialect, per-branch `status` const, payload `$ref`). |
| Smoke tests assert typed fields | The handle, session states, engine pids, module records, register values, pool counts and coverage. `tool_text` remains where the *rendering* is under test. |
| One lossless address representation | `0x`-prefixed, lowercase, 16-digit zero-padded **string**, documented in `src/structured.rs` and the README, asserted by `address_of` at every read. |
| Pool walks distinguish their outcomes | `walk.coverage` ∈ `complete` / `deadline_truncated` / `partial`; a failed or interrupted walk is the error branch with category `debugger` / `interrupted`. |
| Errors stay tool errors, with a category | `isError: true` and the same text, plus the `error` branch of the same schema carrying `ErrorCategory`. |

## Design notes

- **One schema, both outcomes.** Results are internally tagged on `status` (`"ok"`/`"error"`), so a failure conforms to the schema a success does. Structured content on success only would leave "did this work?" answerable in prose alone, and would have a validating client reject the message telling it what went wrong.
- **Values are built where the values are.** The #77 rule, pointed at results: the worker builds its half while it still holds win-kexp's types; the supervisor builds the session answers from its own registry. Nothing is re-derived from a rendering.
- **Two failures stop pretending to be debugger failures**: `interrupted` (somebody asked for it to stop) and `not_run` (a pool query refused for want of budget — nothing ran, so nothing changed, unlike `timeout`).

## Depends on win-kexp

Two commits, already on `main`, and the pin is bumped here:

- `feat(dbgeng): read registers, modules and breakpoints as values` — typed readers over `IDebugRegisters`/`IDebugSymbols3`/`IDebugControl`, verified against a launched process and the sample kernel dump with `examples/typed_context.rs`.
- `feat(pool): report why a walk fell short, not just that it did` — `WalkCoverage` replaces `complete: bool`, and an interrupted walk is no longer a failed one. Also fixes a pre-existing case of the same loss, where filtering a rendered pool map laundered a partial walk into a complete-looking one.

## Verification

- 234 unit tests; debugger tier against the sample kernel dump (31 tests, ~23s), including a new contract test that drives **every** schema-bearing tool down its failure path and checks both halves arrive — with its table diffed against `tools/list`, so a tool that grows a schema and is not covered fails rather than slipping through.
- `cargo clippy --all-targets` and `cargo fmt --check` clean; markdownlint clean.
- **Live-kernel tier: all 8 tests pass** against a real KDNET target (Server 2025, build 26100). Attach/coexist/detach, the bounded pool walk, the three kernel-byte patch-and-restore paths (`end_session` mid-batch, disconnect mid-batch, a step that fails), the batch that reports inside its caller's budget, and a disconnect releasing rather than killing the session. Guest left running, not halted; KD port released.
- **MessageManager CTF tier passes** — the fixture's `Tgsm` allocations are visible through the typed pool tools, every chunk carrying the tag, the `allocated` state and a well-formed address.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added structured results and output schemas for session management, execution control, registers, modules, breakpoints and pool inspection.
  - Added consistent status indicators, typed addresses, execution verdicts and diagnostic details.
  - Structured responses now accompany existing readable text output.

- **Bug Fixes**
  - Improved reporting for interruptions, timeouts, invalid requests, unavailable sessions and incomplete pool queries.
  - Added clearer session lifecycle and cleanup information.

- **Documentation**
  - Documented structured response formats, error categories, address formatting and coverage semantics.
  - Updated smoke-test guidance for validating schemas and typed fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
