### PR TITLE
Let the CTF orchestrator survive a vcvars warning

### DIFF
--- a/examples/messagemanager/ctf_regression.ps1
+++ b/examples/messagemanager/ctf_regression.ps1
@@ -65,7 +65,19 @@ $source = Join-Path $PSScriptRoot 'mm_exploit.c'
 $build = Join-Path $PSScriptRoot 'build.cmd'
 
 if (-not $SkipHarnessBuild) {
-    & $build $source $localFixture
+    # Windows PowerShell 5.1 wraps a native command's stderr as error records, and under `Stop`
+    # those are terminating — so a build that *succeeded* aborts this script if anything on the
+    # way printed to stderr. `vcvars64.bat` does: on a toolchain without `vswhere.exe` beside it
+    # it complains and carries on, `cl` runs, and the fixture is produced. The same wart is
+    # already handled for the cargo call below; the exit code is the only thing that says whether
+    # the compiler ran.
+    $previousPreference = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
+    try {
+        & $build $source $localFixture 2>&1 | ForEach-Object { Write-Host $_.ToString() }
+    } finally {
+        $ErrorActionPreference = $previousPreference
+    }
     if ($LASTEXITCODE -ne 0) { throw "MessageManager fixture build failed: $LASTEXITCODE" }
 }
 if (-not (Test-Path -LiteralPath $localFixture -PathType Leaf)) {


### PR DESCRIPTION
Found while running the live tiers for #106 (now merged), and split out because it is unrelated to that change.

`examples/messagemanager/ctf_regression.ps1` could not build its own harness on a fresh host. `vcvars64.bat` complains to stderr when there is no `vswhere.exe` beside the toolchain; Windows PowerShell 5.1 turns a native command's stderr into error records; and under `$ErrorActionPreference = 'Stop'` those are terminating. So the script aborted before deploying anything — on a build that had **succeeded**: `cl` ran, the fixture was produced, `%ERRORLEVEL%` was 0.

```
build.cmd : 'vswhere.exe' is not recognized as an internal or external command,
At C:\workspace\windbg-mcp\examples\messagemanager\ctf_regression.ps1:68 char:5
+     & $build $source $localFixture
```

The script already documents and handles this exact wart a hundred lines below, around its `cargo test` call, for the same reason. The build call was left unguarded, so the fix is the same one: run it with `Continue` and let the exit code decide, which is the only thing that says whether the compiler ran.

`-SkipHarnessBuild` is the workaround, and needing it to build the harness is the wrong shape.

## Verification

Ran the CTF tier end to end on this host with the fix in place, including the build it previously could not do:

```
'vswhere.exe' is not recognized as an internal or external command,
mm_exploit.c
fixture ready on <guest> (pid 4208, messages 256)
[fixture] ready: 256 Tgsm messages retained for up to 900 seconds; pid=4208
test a_messagemanager_ctf_fixture_is_visible_through_mcp ...
MessageManager `Tgsm` allocations found through MCP in 18.7997068s: 286 chunk(s), 32032 bytes, walk "partial"
MessageManager CTF session detached cleanly
test result: ok. 1 passed; 0 failed
PASS: MessageManager CTF regression completed.
```

The warning still prints — it is the toolchain's, and worth seeing — but it no longer ends the run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fixture build output handling in PowerShell.
  * Build failures continue to be detected reliably using the command exit code.
  * Restored the previous error-handling preference after the build completes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->