### PR TITLE
Have Dependabot watch every ecosystem, not just Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,50 @@
-# Keeps the SHA-pinned actions in .github/workflows current: Dependabot
-# bumps each pin (and its trailing version comment) when upstream releases.
+# Dependabot watches every dependency this repo has, in each ecosystem it has one in.
+# Listing the ecosystem is what makes staleness visible: while only `github-actions` was
+# listed, nothing ever reported that a newer `rmcp` had shipped, and the requirement drifted
+# far enough behind that a spec-current MCP client saw no tools at all.
 version: 2
 updates:
+  # Rust crates: Cargo.toml plus the committed Cargo.lock. This also covers `win-kexp`, the
+  # git dependency pinned to `main` — Dependabot bumps its locked revision, so a pushed
+  # win-kexp commit arrives as a PR instead of waiting for someone to remember
+  # `cargo update -p win-kexp`.
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+    # `auto` (the default, stated here because it is a choice): this crate ships a binary with
+    # a lockfile, so an in-range release lands as a lockfile bump and the requirement in
+    # Cargo.toml is rewritten only when the new version falls outside it. `increase` would
+    # rewrite `rmcp = "3.1.1"` on every release and silently invalidate the comment above it
+    # explaining why 3.1.1 is a floor rather than a preference.
+    versioning-strategy: auto
+    open-pull-requests-limit: 10
+    groups:
+      # Routine churn arrives as one PR; majors stay individual, so a breaking bump is
+      # reviewed — and auto-merged — on its own CI evidence rather than riding along with
+      # a batch. Groups apply to version updates only, so a security advisory still gets
+      # its own PR.
+      cargo-minor-and-patch:
+        patterns: ["*"]
+        update-types: [minor, patch]
+
+  # Keeps the SHA-pinned actions in .github/workflows current: Dependabot bumps each pin
+  # (and its trailing version comment) when upstream releases.
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      actions-minor-and-patch:
+        patterns: ["*"]
+        update-types: [minor, patch]
+
+  # The Z3 solve script under examples/. No lockfile and nothing in CI installs it, so this
+  # is a low-traffic manifest bump on a slower cadence — listed because an example that has
+  # quietly stopped installing is still a broken example.
+  - package-ecosystem: npm
+    directory: /examples/flareauthenticator
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 3

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -42,7 +42,9 @@ updates:
 
   # The Z3 solve script under examples/. No lockfile and nothing in CI installs it, so this
   # is a low-traffic manifest bump on a slower cadence — listed because an example that has
-  # quietly stopped installing is still a broken example.
+  # quietly stopped installing is still a broken example. Because no required check exercises
+  # it, `dependabot-auto-merge.yml` deliberately leaves these PRs for a human: the value here
+  # is being told a release exists, not merging it unread.
   - package-ecosystem: npm
     directory: /examples/flareauthenticator
     schedule:

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -20,7 +20,20 @@ jobs:
   dependabot-auto-merge:
     name: Dependabot auto-merge
     runs-on: ubuntu-latest
-    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    # Auto-merge is only honest for an ecosystem the required checks actually exercise.
+    # Build & test covers cargo, and both it and Documentation lint run the workflows that
+    # github_actions updates touch — but nothing in CI installs the npm example under
+    # examples/, so a breaking `z3-solver` bump would merge on green checks that never
+    # looked at it. Those PRs still get opened (being told a release exists is the point);
+    # they just wait for a human.
+    #
+    # This is an allowlist rather than a "not npm" test on purpose: the branch prefix is
+    # Dependabot's naming, not ours, so if it ever changes the wrong way an unrecognised
+    # prefix leaves the PR for review instead of silently merging it unchecked.
+    if: >-
+      github.event.pull_request.user.login == 'dependabot[bot]'
+      && (startsWith(github.head_ref, 'dependabot/cargo/')
+      || startsWith(github.head_ref, 'dependabot/github_actions/'))
     # Write scope lives on the job, not the workflow, so nothing else inherits
     # it. Dependabot-triggered runs start read-only; this elevates just this job.
     permissions:

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -3,8 +3,16 @@ name: Dependabot auto-merge
 # Auto-approve Dependabot PRs and enable squash auto-merge. The approval here
 # satisfies the "Main Branch" ruleset's required review; GitHub still holds the
 # merge until that ruleset's required status checks (Build & test, Documentation
-# lint) pass, so a red CI run never merges. Requires the repo setting
-# "Allow GitHub Actions to create and approve pull requests".
+# lint, Smoke test (debugger tier)) pass, so a red CI run never merges. Requires
+# the repo setting "Allow GitHub Actions to create and approve pull requests".
+#
+# `--auto` waits on *required* checks only, so that list is load-bearing rather
+# than descriptive: a job CI runs but the ruleset does not require is one this
+# workflow will merge straight past, green or red. The debugger tier was in that
+# position until it was made required — which matters most for the case that put
+# it there, a `win-kexp` revision bump, whose regressions are exactly the ones
+# that compile cleanly and only show up once DbgEng opens a target. Anything
+# added to ci.yml as a real gate has to be added to the ruleset too.
 
 on:
   pull_request:
@@ -21,11 +29,11 @@ jobs:
     name: Dependabot auto-merge
     runs-on: ubuntu-latest
     # Auto-merge is only honest for an ecosystem the required checks actually exercise.
-    # Build & test covers cargo, and both it and Documentation lint run the workflows that
-    # github_actions updates touch — but nothing in CI installs the npm example under
-    # examples/, so a breaking `z3-solver` bump would merge on green checks that never
-    # looked at it. Those PRs still get opened (being told a release exists is the point);
-    # they just wait for a human.
+    # Build & test and the debugger tier cover cargo, and every required job runs the
+    # workflows a github_actions update touches — but nothing in CI installs the npm
+    # example under examples/, so a breaking `z3-solver` bump would merge on green checks
+    # that never looked at it. Those PRs still get opened (being told a release exists is
+    # the point); they just wait for a human.
     #
     # This is an allowlist rather than a "not npm" test on purpose: the branch prefix is
     # Dependabot's naming, not ours, so if it ever changes the wrong way an unrecognised

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -194,8 +194,9 @@ target fails on the open. Run it after touching `engine::spawn_worker` or `worke
 
 ### A dependency moved
 
-`rmcp`, `schemars`, `tokio`, or a `win-kexp` pin bump (`cargo update -p win-kexp`). Note Dependabot
-only watches GitHub Actions here, so cargo bumps arrive by hand.
+`rmcp`, `schemars`, `tokio`, or a `win-kexp` pin bump (`cargo update -p win-kexp`). Dependabot
+watches the cargo ecosystem too, so most of these arrive as a PR — including the `win-kexp` locked
+revision — and the run below is what you do on that PR, not only on a bump you made yourself.
 
 1. `cargo test` — the protocol tier plus the existing unit tests.
 2. For a `win-kexp` bump, add the debugger tier locally too — CI runs it on the PR, but a local


### PR DESCRIPTION
While `github-actions` was the only listed ecosystem, nothing ever reported that a newer `rmcp` had shipped. The requirement drifted far enough behind that a spec-current MCP client saw a server exposing no tools at all — a failure a routine update PR would have surfaced years earlier.

This adds the two ecosystems the repo actually has and never watched:

| Ecosystem | Directory | Cadence | Covers |
|---|---|---|---|
| `cargo` | `/` | weekly | Cargo.toml + Cargo.lock, **including the `win-kexp` git pin** |
| `github-actions` | `/` | weekly | the SHA-pinned actions (unchanged, now grouped) |
| `npm` | `/examples/flareauthenticator` | monthly | `z3-solver` in the Z3 solve script |

Minor and patch updates are grouped into one PR per ecosystem so the weekly cadence stays readable; majors stay individual, so a breaking bump is reviewed — and auto-merged — on its own CI evidence rather than riding along with a batch. Groups apply to version updates only, so a security advisory still arrives as its own PR.

### Two judgment calls worth a look

**`versioning-strategy` stays at the default `auto`**, stated explicitly in the file because it is a choice. With a committed lockfile, an in-range release (3.1.1 → 3.2.0) lands as a lockfile bump and Cargo.toml is rewritten only when the new version falls outside the requirement. `increase` would catch this PR's motivating case more loudly, but it also rewrites `rmcp = "3.1.1"` on every release and silently invalidates the comment above it explaining why 3.1.1 is a *floor*, not a preference. Either way a PR gets opened.

**`win-kexp` is now in scope, and it will auto-merge.** Dependabot bumps the locked revision of a branch-pinned git dependency, so every push to win-kexp `main` opens a PR here, and `dependabot-auto-merge.yml` approves and squash-merges it once Build & test and Documentation lint pass. That replaces the manual `cargo update -p win-kexp` step in CLAUDE.md with an automatic one. Defensible — CI including the debugger smoke tier gates it — but if win-kexp bumps should stay deliberate, so they land together with the windbg-mcp change that needs them, an `ignore` entry for it is a one-line follow-up.

`docs/smoke-test.md` said Dependabot only watches GitHub Actions and cargo bumps arrive by hand; that line is corrected.

### Testing

- YAML parses; all three `updates` entries well-formed.
- `markdownlint-cli2 docs/smoke-test.md` — 0 issues.
- The config itself only takes effect once merged to `main`, and the first cargo run will likely open a backlog batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated dependency update guidance to include Cargo packages and locked revisions.
  * Clarified that dependency updates should be validated using the documented smoke tests.

* **Chores**
  * Expanded automated dependency monitoring to cover Cargo and npm packages.
  * Grouped minor and patch updates and added limits for automated update requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->