### PR TITLE
Bundle winxp\kdexts.dll in the README's engine setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Documentation
+
+- README's engine-bundling section now copies **`winxp\kdexts.dll`**, which it had never listed
+  even though `attach_kernel` auto-`.load`s it: without that file `driver_object` /
+  `device_object` / `irp_stack` fail with *"No export drvobj found"*. The skill's `setup.md` and
+  the driver-IOCTL docs already had it, so the README was the odd one out.
+
 ## [0.7.0] - 2026-08-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -87,6 +87,10 @@ and a client that validates against the spec schema then rejects the whole tool 
 - **For crash-dump `!analyze`** (and any other `!`-extension command), the engine needs the
   WinDbg `winext\` extensions bundled next to the binary — System32's engine ships none, so
   `!analyze` would return *"No export analyze found"*. See *Bundling the WinDbg engine* below.
+- **For the kernel driver tools** (`driver_object` / `device_object` / `irp_stack`), the engine
+  needs `winxp\kdexts.dll` bundled next to the binary — it exports `!drvobj`/`!devobj`/`!irp`, which
+  System32 doesn't ship, so without it those three return *"No export drvobj found"* even though the
+  kernel attach itself succeeded. See *Bundling the WinDbg engine* below.
 - **For Time Travel Debugging (`.run`) replay**, the System32 engine is *not* enough — it rejects
   `.run` traces (`0x80070057`). You need the **WinDbg engine** (which bundles the TTD replay
   components) loaded next to the binary — see *TTD engine* below.
@@ -117,9 +121,11 @@ stdio. Run it after a dependency bump or an MCP spec revision — see
 
 ### Bundling the WinDbg engine
 
-Needed for two things: TTD `.run` replay (System32's engine rejects traces with `0x80070057`) and
-crash-dump `!analyze` (which lives in the `winext\` extensions that System32 doesn't ship).
-`DebugCreate` binds to whichever `dbgeng.dll` the loader finds first, and the app directory is
+Needed for three things: TTD `.run` replay (System32's engine rejects traces with `0x80070057`),
+crash-dump `!analyze` (which lives in the `winext\` extensions that System32 doesn't ship), and the
+kernel driver tools `driver_object`/`device_object`/`irp_stack` (which need `winxp\kdexts.dll`).
+So a live-kernel-only user needs this section too, even though the attach itself works on the
+System32 engine. `DebugCreate` binds to whichever `dbgeng.dll` the loader finds first, and the app directory is
 searched before `System32`, so the copied **WinDbg** engine (which replays TTD traces and ships the
 extensions) wins. One-time, from the installed WinDbg store package:
 
@@ -142,8 +148,9 @@ Copy-Item "$wd\winxp\kdexts.dll" "$dst\winxp" -Force   # !drvobj/!devobj/!irp �
   `winext\`, `!analyze` returns *"No export analyze found"*.
 - `winxp\kdexts.dll` provides `!drvobj`/`!devobj`/`!irp`, behind the
   `driver_object`/`device_object`/`irp_stack` tools. `attach_kernel` / `attach_kernel_local`
-  `.load kdexts` for you, but without the file those tools return *"No export drvobj found"*. It
-  lives in `winxp\`, not `winext\` — the engine searches that subdir by name.
+  `.load kdexts` for you and nothing complains at attach time, so a missing file first surfaces as
+  *"No export drvobj found"* from those three tools. It lives in `winxp\`, not `winext\` — the
+  engine searches that subdir by name.
 - **`msdia140.dll` is required for PDB symbols.** Without it, `dbghelp` can't parse any PDB
   (`dia error 0x8007007e`) and silently falls back to *export* symbols — which makes `module!name`
   lookups (and so `ttd_calls("ucrtbase!__stdio_common_vfprintf")`) fail even with the right PDB in

--- a/README.md
+++ b/README.md
@@ -125,9 +125,9 @@ Needed for three things: TTD `.run` replay (System32's engine rejects traces wit
 crash-dump `!analyze` (which lives in the `winext\` extensions that System32 doesn't ship), and the
 kernel driver tools `driver_object`/`device_object`/`irp_stack` (which need `winxp\kdexts.dll`).
 So a live-kernel-only user needs this section too, even though the attach itself works on the
-System32 engine. `DebugCreate` binds to whichever `dbgeng.dll` the loader finds first, and the app directory is
-searched before `System32`, so the copied **WinDbg** engine (which replays TTD traces and ships the
-extensions) wins. One-time, from the installed WinDbg store package:
+System32 engine. `DebugCreate` binds to whichever `dbgeng.dll` the loader finds first, and the app
+directory is searched before `System32`, so the copied **WinDbg** engine (which replays TTD traces
+and ships the extensions) wins. One-time, from the installed WinDbg store package:
 
 ```pwsh
 $wd  = (Get-AppxPackage Microsoft.WinDbg).InstallLocation + "\amd64"

--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ Copy-Item "$wd\dbgeng.dll","$wd\dbghelp.dll","$wd\dbgcore.dll","$wd\dbgmodel.dll
           "$wd\symsrv.dll","$wd\msdia140.dll" $dst -Force
 Copy-Item "$wd\ttd"    "$dst\ttd"    -Recurse -Force   # TTDReplay*.dll, TtdExt.dll, TTDAnalyze.dll, ...
 Copy-Item "$wd\winext" "$dst\winext" -Recurse -Force   # ext.dll (!analyze), kext.dll, … — crash-dump triage
+New-Item   "$dst\winxp" -ItemType Directory -Force | Out-Null
+Copy-Item "$wd\winxp\kdexts.dll" "$dst\winxp" -Force   # !drvobj/!devobj/!irp — the kernel driver tools
 ```
 
 - The `ttd\` subdir provides the `@$cursession.TTD` / `@$curprocess.TTD` data model and the `!tt`
@@ -138,6 +140,10 @@ Copy-Item "$wd\winext" "$dst\winext" -Recurse -Force   # ext.dll (!analyze), kex
   `open_dump` runs `.load ext` for you, but note the **unqualified `!analyze` does not resolve** on
   this minimal engine — use the module-qualified **`!ext.analyze -v`** for crash-dump triage. Without
   `winext\`, `!analyze` returns *"No export analyze found"*.
+- `winxp\kdexts.dll` provides `!drvobj`/`!devobj`/`!irp`, behind the
+  `driver_object`/`device_object`/`irp_stack` tools. `attach_kernel` / `attach_kernel_local`
+  `.load kdexts` for you, but without the file those tools return *"No export drvobj found"*. It
+  lives in `winxp\`, not `winext\` — the engine searches that subdir by name.
 - **`msdia140.dll` is required for PDB symbols.** Without it, `dbghelp` can't parse any PDB
   (`dia error 0x8007007e`) and silently falls back to *export* symbols — which makes `module!name`
   lookups (and so `ttd_calls("ucrtbase!__stdio_common_vfprintf")`) fail even with the right PDB in

--- a/README.md
+++ b/README.md
@@ -187,8 +187,8 @@ knows how to drive it (setup, crash-dump, live/kernel, and TTD playbooks).
 ```
 
 The plugin ships source, not a binary, so after installing you still put the server binary in
-place — download a prebuilt release or build from source — and (for `.run` replay and
-crash-dump `!analyze`) bundle the WinDbg engine — the skill's `setup.md`
+place — download a prebuilt release or build from source — and (for `.run` replay, crash-dump
+`!analyze`, and the kernel driver tools) bundle the WinDbg engine — the skill's `setup.md`
 walks through it, and it mirrors the [*Build or download*](#build-or-download) and
 [*Bundling the WinDbg engine*](#bundling-the-windbg-engine) sections above. Then `/reload-plugins`
 to connect the server. The plugin points at `${CLAUDE_PLUGIN_ROOT}/target/release/windbg-mcp.exe`.
@@ -202,9 +202,11 @@ downloads that release's `.mcpb` bundle, verifies its SHA-256, and wires up the 
 inside it as an stdio server, with no Rust build or manual binary placement.
 
 The bundle is **Windows x64 only** and ships just the server binary, so the one-time engine setup
-still applies — for TTD `.run` replay and crash-dump `!analyze`, drop the WinDbg engine DLLs next
-to the client-extracted `windbg-mcp.exe` (the skill's `setup.md` covers it). Basic live and
-crash-dump work runs on the in-box `System32` engine without them.
+still applies — for TTD `.run` replay, crash-dump `!analyze`, and the
+`driver_object`/`device_object`/`irp_stack` tools, drop the WinDbg engine DLLs next to the
+client-extracted `windbg-mcp.exe` (the skill's `setup.md` covers it). Basic live and crash-dump
+work runs on the in-box `System32` engine without them — a kernel attach included, but not those
+three tools, which need `winxp\kdexts.dll`.
 
 ### Releasing
 

--- a/skills/windbg-debugging/setup.md
+++ b/skills/windbg-debugging/setup.md
@@ -75,16 +75,19 @@ dependency — no sibling checkout needed.
 
 Either way, run `/reload-plugins` afterwards so Claude Code connects the `windbg` MCP server.
 
-## WinDbg engine + extensions — for `.run` replay and crash-dump `!analyze`
+## WinDbg engine + extensions — for `.run` replay, crash-dump `!analyze`, and the kernel driver tools
 
 Drop the **WinDbg** store-package binaries next to `windbg-mcp.exe` (the `$dst` below — for a
 registry/MCPB install that's the client's extraction directory, **not** `target\release`) for
-two reasons:
+three reasons:
 
 - **TTD `.run` replay** — System32's `dbgeng.dll` **rejects** traces with `0x80070057`.
 - **Crash-dump `!analyze`** — it lives in the `winext\` extensions, which System32 doesn't ship
   (so a `.dmp`-only user still needs the `winext\` copy below, even though dump *loading* itself
   works on System32's engine).
+- **`driver_object`/`device_object`/`irp_stack`** — they run `!drvobj`/`!devobj`/`!irp` from
+  `winxp\kdexts.dll`, which System32 doesn't ship either (so a live-kernel-only user needs the
+  `winxp\` copy below, even though the attach itself works on the System32 engine).
 
 `DebugCreate` binds to whichever `dbgeng.dll` the loader finds first, and the app directory is
 searched before `System32`, so the copied engine wins. One-time, from the installed WinDbg store


### PR DESCRIPTION
The README's engine-bundling recipe copied the engine DLLs, `ttd\` and `winext\`, but never
`kdexts.dll`. Anyone who set the server up from the README alone therefore got a live kernel
session whose `driver_object` / `device_object` / `irp_stack` tools answer *"No export drvobj
found"*.

The failure is silent until the first tool call, because `attach_kernel` / `attach_kernel_local`
`.load kdexts` automatically (`src/worker.rs:2278`) — nothing complains at attach time.

This was a README-only gap: the skill's `setup.md`, `skills/windbg-debugging/driver-ioctl.md` and
`docs/driver-ioctl-walkthrough.md` all already bundle it. Note the file lives in `winxp\`, not
`winext\` — the engine searches that subdir by name.

Found while reviewing the install story for #109.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated WinDbg engine bundling instructions to include the `winxp\kdexts.dll` debugger extension.
  * Documented supported tools, automatic loading behaviour, and the error shown when the extension is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->