### PR TITLE
Document installing with Scoop from the community bucket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation
 
+- README documents installing with [Scoop](https://scoop.sh) from the community
+  [`gitfool/scoop-dungeon`](https://github.com/gitfool/scoop-dungeon) bucket
+  ([#109](https://github.com/glslang/windbg-mcp/issues/109)), whose `post_install` also does the
+  engine bundling — copying from the machine's own `Microsoft.WinDbg` store package, when one is
+  installed — so `scoop install` covers most of the manual setup this README otherwise walks
+  through. Nothing about that path redistributes Microsoft's engine. Includes the client config to
+  use (the version-independent `current` junction), the disconnect-before-`scoop update` caveat
+  (a connected client holds the binary open), and the one file `post_install` leaves out.
+  Documented with the trust boundary stated: the bucket is community-maintained and unaudited by
+  this project, and a manifest is code — `post_install` is arbitrary PowerShell over a URL and hash
+  that autoupdate rewrites — so the skill's `setup.md` tells an agent never to run `scoop install`
+  on the user's behalf, and points at the release zip's checksum and build attestation as the paths
+  this project can actually vouch for.
 - README's engine-bundling section now copies **`winxp\kdexts.dll`**, which it had never listed
   even though `attach_kernel` auto-`.load`s it: without that file `driver_object` /
   `device_object` / `irp_stack` fail with *"No export drvobj found"*. The skill's `setup.md` and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   [`gitfool/scoop-dungeon`](https://github.com/gitfool/scoop-dungeon) bucket
   ([#109](https://github.com/glslang/windbg-mcp/issues/109)), whose `post_install` also does the
   engine bundling — copying from the machine's own `Microsoft.WinDbg` store package, when one is
-  installed — so `scoop install` covers most of the manual setup this README otherwise walks
-  through. Nothing about that path redistributes Microsoft's engine. Includes the client config to
-  use (the version-independent `current` junction), the disconnect-before-`scoop update` caveat
-  (a connected client holds the binary open), and the one file `post_install` leaves out.
+  installed — so `scoop install` covers the manual setup this README otherwise walks through.
+  Nothing about that path redistributes Microsoft's engine. Includes the client config to use (the
+  version-independent `current` junction), the disconnect-before-`scoop update` caveat (a connected
+  client holds the binary open), and how to bundle after the fact if WinDbg arrives later.
   Documented with the trust boundary stated: the bucket is community-maintained and unaudited by
   this project, and a manifest is code — `post_install` is arbitrary PowerShell over a URL and hash
   that autoupdate rewrites — so the skill's `setup.md` tells an agent never to run `scoop install`

--- a/README.md
+++ b/README.md
@@ -119,6 +119,56 @@ cargo build --release
 stdio. Run it after a dependency bump or an MCP spec revision — see
 [`docs/smoke-test.md`](docs/smoke-test.md).
 
+### Install with Scoop
+
+A community-maintained [Scoop](https://scoop.sh) manifest lives in
+[`gitfool/scoop-dungeon`](https://github.com/gitfool/scoop-dungeon)
+([#109](https://github.com/glslang/windbg-mcp/issues/109)), which turns the download — and every
+later update — into one command:
+
+```pwsh
+scoop bucket add dungeon https://github.com/gitfool/scoop-dungeon
+scoop install windbg-mcp
+scoop update windbg-mcp    # later; the manifest's checkver/autoupdate tracks releases here
+```
+
+It unpacks the release zip and — when the `Microsoft.WinDbg` store package is installed on your
+machine — its `post_install` copies that package's engine DLLs (plus its `ttd\` and `winext\`
+subdirectories) next to the binary: most of the
+[*Bundling the WinDbg engine*](#bundling-the-windbg-engine) step below, done for you on install and
+on every update. That copy is local, from a WinDbg you already installed; neither the release zip
+nor the bucket redistributes Microsoft's engine. Without that package you get the in-box `System32`
+engine: live and crash-dump debugging work, TTD `.run` replay and `!analyze` don't.
+
+The one thing `post_install` doesn't copy is **`winxp\kdexts.dll`**, so if you use the kernel driver
+tools (`driver_object` / `device_object` / `irp_stack`) run that last pair of lines below by hand,
+with `$dst` set to `…\scoop\apps\windbg-mcp\current`.
+
+Point your MCP client at the `current` junction, so an update needs no config change:
+
+```jsonc
+{
+  "mcpServers": {
+    "windbg": { "command": "C:\\Users\\<you>\\scoop\\apps\\windbg-mcp\\current\\windbg-mcp.exe" }
+  }
+}
+```
+
+A connected client holds that binary open (and each engine worker re-executes the same image), so
+disconnect the `windbg` server — `/mcp` in Claude Code — before `scoop update`, then reconnect to
+actually run the new build.
+
+**The bucket is community-maintained — not by this repo, and not audited by it.** A Scoop manifest
+is code, not just a URL: `post_install` is arbitrary PowerShell, run against whatever download URL
+and hash the manifest carries at the time, and autoupdate rewrites both on each new release. So
+installing from it is a trust decision about that bucket, taken on your own judgement.
+
+Scoop is not required either way. It installs the same
+[release asset](https://github.com/glslang/windbg-mcp/releases) described above, which you can
+download directly, check against the published `SHA256SUMS.txt`, and verify with
+`gh attestation verify` — see [*Releasing*](#releasing) — none of which a third-party manifest can
+promise on this project's behalf.
+
 ### Bundling the WinDbg engine
 
 Needed for three things: TTD `.run` replay (System32's engine rejects traces with `0x80070057`),

--- a/README.md
+++ b/README.md
@@ -133,16 +133,15 @@ scoop update windbg-mcp    # later; the manifest's checkver/autoupdate tracks re
 ```
 
 It unpacks the release zip and — when the `Microsoft.WinDbg` store package is installed on your
-machine — its `post_install` copies that package's engine DLLs (plus its `ttd\` and `winext\`
-subdirectories) next to the binary: most of the
+machine — its `post_install` copies that package's engine DLLs and its `ttd\`, `winext\` and
+`winxp\` subdirectories next to the binary: the whole
 [*Bundling the WinDbg engine*](#bundling-the-windbg-engine) step below, done for you on install and
 on every update. That copy is local, from a WinDbg you already installed; neither the release zip
 nor the bucket redistributes Microsoft's engine. Without that package you get the in-box `System32`
-engine: live and crash-dump debugging work, TTD `.run` replay and `!analyze` don't.
-
-The one thing `post_install` doesn't copy is **`winxp\kdexts.dll`**, so if you use the kernel driver
-tools (`driver_object` / `device_object` / `irp_stack`) run that last pair of lines below by hand,
-with `$dst` set to `…\scoop\apps\windbg-mcp\current`.
+engine: live and crash-dump debugging work, TTD `.run` replay, `!analyze` and the kernel driver
+tools don't. The copy happens at install time, so if you add WinDbg afterwards, re-run
+`post_install` with `scoop update --force windbg-mcp` (`scoop reset` won't — it only re-links) or
+copy the files by hand as below, with `$dst` set to `…\scoop\apps\windbg-mcp\current`.
 
 Point your MCP client at the `current` junction, so an update needs no config change:
 

--- a/skills/windbg-debugging/setup.md
+++ b/skills/windbg-debugging/setup.md
@@ -29,10 +29,10 @@ A package-manager install lands outside the plugin layout in the same way:
 > [`gitfool/scoop-dungeon`](https://github.com/gitfool/scoop-dungeon) bucket? That also skips
 > Options A/B — point the client at
 > `%USERPROFILE%\scoop\apps\windbg-mcp\current\windbg-mcp.exe` rather than the plugin path. Its
-> `post_install` does most of the **engine bundling below** — the DLLs plus `ttd\` and `winext\`,
-> copied from the `Microsoft.WinDbg` store package on the machine, when one is installed. It does
-> **not** copy `winxp\kdexts.dll`, so run that last pair of lines by hand if the kernel driver
-> tools are in play; check the directory for `dbgeng.dll` before repeating the rest.
+> `post_install` does the **engine bundling below** — the DLLs plus `ttd\`, `winext\` and `winxp\`,
+> copied from the `Microsoft.WinDbg` store package on the machine, when one is installed. Check the
+> directory for `dbgeng.dll` before repeating any of it; if it is missing, WinDbg wasn't installed
+> when Scoop was, and the copy below (or `scoop update --force windbg-mcp`) is still needed.
 >
 > **Never run `scoop install` on the user's behalf.** That bucket is community-maintained, outside
 > this project's control, and a Scoop manifest is code: `post_install` is arbitrary PowerShell, run

--- a/skills/windbg-debugging/setup.md
+++ b/skills/windbg-debugging/setup.md
@@ -23,6 +23,25 @@ option below lands it there.
 > still do the one-time **engine bundling below**, dropping those DLLs next to the
 > *client-extracted* `windbg-mcp.exe` (its `${__dirname}`).
 
+A package-manager install lands outside the plugin layout in the same way:
+
+> **Already installed with [Scoop](https://scoop.sh)** from the community
+> [`gitfool/scoop-dungeon`](https://github.com/gitfool/scoop-dungeon) bucket? That also skips
+> Options A/B — point the client at
+> `%USERPROFILE%\scoop\apps\windbg-mcp\current\windbg-mcp.exe` rather than the plugin path. Its
+> `post_install` does most of the **engine bundling below** — the DLLs plus `ttd\` and `winext\`,
+> copied from the `Microsoft.WinDbg` store package on the machine, when one is installed. It does
+> **not** copy `winxp\kdexts.dll`, so run that last pair of lines by hand if the kernel driver
+> tools are in play; check the directory for `dbgeng.dll` before repeating the rest.
+>
+> **Never run `scoop install` on the user's behalf.** That bucket is community-maintained, outside
+> this project's control, and a Scoop manifest is code: `post_install` is arbitrary PowerShell, run
+> against whatever download URL and hash the manifest carries at that moment — and excavator
+> rewrites both automatically on each new release, so what a reader once checked is not what a
+> later install fetches. Options A/B are the paths this project can vouch for: a SHA-256 published
+> with the release, and `gh attestation verify` tying the zip to the workflow that built it. If the
+> user wants Scoop, they ask for it and they run it.
+
 ### Option A — download a prebuilt release (no Rust required)
 
 Each `vX.Y.Z` tag publishes a Windows x64 build on the


### PR DESCRIPTION
Documents the community Scoop manifest [gitfool/scoop-dungeon](https://github.com/gitfool/scoop-dungeon) published in #109, which makes install and update one command each and — where the machine has the `Microsoft.WinDbg` store package — copies that package's engine DLLs and its `ttd\`, `winext\` and `winxp\` subdirectories next to the binary, i.e. the manual bundling step the README otherwise walks through. That copy is local, from a WinDbg the user already installed; nothing here redistributes Microsoft's engine, and the release zip stays `windbg-mcp.exe` + `LICENSE`.

Documents the bucket rather than hosting a competing manifest: theirs already has checkver/autoupdate plus excavator CI, and a second manifest for the same app would only drift.

Three things a Scoop user needs that the manifest cannot tell them:

- point the client at the version-independent `current` junction so an update needs no config change;
- disconnect the server before `scoop update`, since a connected client holds the exe open (the server re-executes its own image per session);
- the bundling copy happens at install time, so adding WinDbg afterwards needs `post_install` re-run — `scoop update --force windbg-mcp`, not `scoop reset`, which only re-links shims and persist data.

**Trust boundary stated rather than implied.** A Scoop manifest is code — `post_install` is arbitrary PowerShell, run against a URL and hash that autoupdate rewrites on each release — in a repo this project neither controls nor audits. `setup.md` is read by an agent, where "you can install it with Scoop" is effectively an instruction to run it, so it says never to install on the user's behalf: the user asks for it and the user runs it. Both files point at what this project can vouch for instead — the release zip's published SHA-256 and its build attestation.

The first draft of this PR also told Scoop users to copy `winxp\kdexts.dll` by hand. [@gitfool fixed that](https://github.com/gitfool/scoop-dungeon/commit/edb8de1f80f620f35be7844fa043f2cb600b257e) after the issue thread — the manifest's `$subdirs` is now `@('ttd','winext','winxp')` and its DLL list already matched the README's six — so the second commit drops that paragraph.

Docs only: `README.md`, `skills/windbg-debugging/setup.md`, `CHANGELOG.md`. Rebased on current `main`, so it sits on top of the merged kdexts bundling change (#113) instead of carrying it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
