### PR TITLE
crash_triage puts the scope back, and is read-only again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,9 +24,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and a user-mode access violation). The implicit *thread* it does move — visibly, on the `0x9F`,
   where the thread it blames is not the one the dump opens on — and does put back.
 
-  So the stack `crash_triage` reports with `analyze: true` is the target's default context (the
-  crash, on a crash dump) rather than "the thread the analysis blamed", and it is that regardless
-  of where the caller had navigated, which is what makes two triages of one session agree. The
+  So the stack `crash_triage` reports is the target's default context (the crash, on a crash dump)
+  rather than "the thread the analysis blamed", regardless of where the caller had navigated —
+  which is what makes two triages of one session agree. That normalisation is the analysis's own
+  side effect, so it holds exactly when the analysis ran: with `analyze: false`, or when it is
+  skipped for want of time or an `ext.dll`, the walk describes the selected context instead, and
+  `analysis.ran` is what tells them apart. The
   smoke tier checks the promise from a scope the analysis would otherwise discard — frame 3, since
   a check starting at the default would pass whether the scope was restored or merely reset.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,9 +27,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   So the stack `crash_triage` reports is the target's default context (the crash, on a crash dump)
   rather than "the thread the analysis blamed", regardless of where the caller had navigated —
   which is what makes two triages of one session agree. That normalisation is the analysis's own
-  side effect, so it holds exactly when the analysis ran: with `analyze: false`, or when it is
-  skipped for want of time or an `ext.dll`, the walk describes the selected context instead, and
-  `analysis.ran` is what tells them apart. The
+  side effect, so it holds exactly when the analysis *completed*: with `analyze: false`, when it is
+  skipped for want of time or an `ext.dll`, or when the deadline cut it short before the reset it
+  does partway through its output, the walk describes the selected context instead — `analysis.ran`
+  and `analysis.truncated` are what tell those apart. The
   smoke tier checks the promise from a scope the analysis would otherwise discard — frame 3, since
   a check starting at the default would pass whether the scope was restored or merely reset.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`crash_triage` is read-only again, and now earns it**
+  ([win-kexp#98](https://github.com/glslang/win-kexp/issues/98)). It ran `!analyze -v` for the
+  fields no API returns — the pool tag, the failure bucket, the per-parameter notes — and paid for
+  them with the session's selected scope, which is why the tool was annotated
+  `read_only_hint = false` despite never writing to the debuggee. It now saves the scope and
+  restores it (win-kexp's new `ScopeGuard`), on every path out including the interrupt one, so a
+  `.frame` or `.cxr` a caller had chosen survives a triage.
+
+  The measurement that made this possible also **corrected the reason**, which had been wrong in
+  this repo's comments, its README and its `crash-dump` skill. `!analyze -v` does not select a
+  faulting context and leave it selected: it ends with the scope at the target's **default**,
+  discarding whatever the caller had chosen — measured on four targets (`0x13A`, `0xD1`, `0x9F`
+  and a user-mode access violation). The implicit *thread* it does move — visibly, on the `0x9F`,
+  where the thread it blames is not the one the dump opens on — and does put back.
+
+  So the stack `crash_triage` reports with `analyze: true` is the target's default context (the
+  crash, on a crash dump) rather than "the thread the analysis blamed", and it is that regardless
+  of where the caller had navigated, which is what makes two triages of one session agree. The
+  smoke tier checks the promise from a scope the analysis would otherwise discard — frame 3, since
+  a check starting at the default would pass whether the scope was restored or merely reset.
+
 ### Documentation
 
 - README documents installing with [Scoop](https://scoop.sh) from the community

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -883,7 +883,7 @@ dependencies = [
 [[package]]
 name = "win-kexp"
 version = "0.1.0"
-source = "git+https://github.com/glslang/win-kexp?branch=main#74a759500850c1505916d96fd045318cac091fd8"
+source = "git+https://github.com/glslang/win-kexp?branch=main#84ee234c4eaefb1447f4bf800139a2d66c9e3b9f"
 dependencies = [
  "byte-strings",
  "goblin",

--- a/README.md
+++ b/README.md
@@ -686,8 +686,9 @@ timeline). For anything else, `dx` evaluates arbitrary data-model/LINQ expressio
   default, so a `.frame`/`.cxr` a caller had chosen would be silently discarded — `crash_triage`
   saves that scope and restores it (`ScopeGuard`, [win-kexp#98](https://github.com/glslang/win-kexp/issues/98)),
   which is why the tool reports itself read-only. The stack it walks is the **default** context
-  (the crash, on a crash dump) with `analyze: true`, and whatever the session has selected with
-  `analyze: false`. Needs a kernel target
+  (the crash, on a crash dump) whenever the analysis actually ran — running it is what resets the
+  scope there — and whatever the session has selected when it did not (`analyze: false`, no time
+  left, or an engine with no `ext.dll`); `analysis.ran` distinguishes them. Needs a kernel target
   *stopped at a bug check* — a live kernel that has not crashed yet, and a dump that is not a crash
   dump, are both **refused** with a message saying which of the two they are.
 - **`crash_triage` tries `!analyze -v` and then `!ext.analyze -v`**, and reports which one worked

--- a/README.md
+++ b/README.md
@@ -686,9 +686,11 @@ timeline). For anything else, `dx` evaluates arbitrary data-model/LINQ expressio
   default, so a `.frame`/`.cxr` a caller had chosen would be silently discarded — `crash_triage`
   saves that scope and restores it (`ScopeGuard`, [win-kexp#98](https://github.com/glslang/win-kexp/issues/98)),
   which is why the tool reports itself read-only. The stack it walks is the **default** context
-  (the crash, on a crash dump) whenever the analysis actually ran — running it is what resets the
-  scope there — and whatever the session has selected when it did not (`analyze: false`, no time
-  left, or an engine with no `ext.dll`); `analysis.ran` distinguishes them. Needs a kernel target
+  (the crash, on a crash dump) whenever the analysis ran to completion — running it is what resets
+  the scope there — and whatever the session has selected when it did not: `analyze: false`, no
+  time left, no `ext.dll`, or a run the deadline cut short before the reset it does partway
+  through its output. `analysis.ran` and `analysis.truncated` distinguish them. Needs a kernel
+  target
   *stopped at a bug check* — a live kernel that has not crashed yet, and a dump that is not a crash
   dump, are both **refused** with a message saying which of the two they are.
 - **`crash_triage` tries `!analyze -v` and then `!ext.analyze -v`**, and reports which one worked

--- a/README.md
+++ b/README.md
@@ -681,8 +681,13 @@ timeline). For anything else, `dx` evaluates arbitrary data-model/LINQ expressio
   whether that is the crash itself (a `0x9F` watchdog fires on an idle CPU — the culprit is not on
   that stack, and the bug check *arguments* are where to go next) or merely the 16-frame default
   cap, which `frames` raises to 128. `analyze: false` skips `!analyze` for a fast answer of
-  everything else; with it on, note that `!analyze -v` may leave the session's context on the
-  faulting thread it selected, exactly as running it through `execute` would. Needs a kernel target
+  everything else. **The call leaves the session exactly as it found it**, which running the same
+  `!analyze -v` through `execute` does not: the analysis resets the selected scope to the target's
+  default, so a `.frame`/`.cxr` a caller had chosen would be silently discarded — `crash_triage`
+  saves that scope and restores it (`ScopeGuard`, [win-kexp#98](https://github.com/glslang/win-kexp/issues/98)),
+  which is why the tool reports itself read-only. The stack it walks is the **default** context
+  (the crash, on a crash dump) with `analyze: true`, and whatever the session has selected with
+  `analyze: false`. Needs a kernel target
   *stopped at a bug check* — a live kernel that has not crashed yet, and a dump that is not a crash
   dump, are both **refused** with a message saying which of the two they are.
 - **`crash_triage` tries `!analyze -v` and then `!ext.analyze -v`**, and reports which one worked

--- a/skills/windbg-debugging/crash-dump.md
+++ b/skills/windbg-debugging/crash-dump.md
@@ -34,8 +34,9 @@ offending frame. No elevation needed; works on System32's engine.
    fast, and it still names the bug check. It walks **whichever context the session has selected**,
    which on a freshly opened dump is the crash: only run it on a session where you have moved the
    context yourself (`.thread`, `~Ns`, `.cxr`) if that is the stack you meant. The default
-   `analyze: true` re-selects the faulting context on the bug checks that carry one — and, for the
-   same reason, leaves it selected afterwards, so a later `registers` / `backtrace` can differ.
+   `analyze: true` walks the **target's default** context instead, because the `!analyze -v` it
+   runs first resets the scope there — and your scope is put back before the call returns, so a
+   triage costs you nothing either way and a later `registers` / `backtrace` reads as before.
    — **`faulting_frame` is not always there, and `faulting_frame_note` says why.** It is *absent*
    (the key is omitted, as every optional field in this server's structured results is) for four
    different reasons, and only two of them are findings about the crash. **Read the note before

--- a/skills/windbg-debugging/crash-dump.md
+++ b/skills/windbg-debugging/crash-dump.md
@@ -37,7 +37,8 @@ offending frame. No elevation needed; works on System32's engine.
    `analyze: true` walks the **target's default** context instead — the `!analyze -v` it runs
    first resets the scope there — and your scope is put back before the call returns, so a triage
    costs you nothing either way and a later `registers` / `backtrace` reads as before. If the
-   analysis did not actually run (`analysis.ran: false` — no time left, or no `ext.dll`), nothing
+   analysis did not run to completion (`ran: false` — no time left, no `ext.dll` — or
+   `truncated: true`, cut short before the reset it does partway through its output), nothing
    reset anything and you get the selected context after all.
    — **`faulting_frame` is not always there, and `faulting_frame_note` says why.** It is *absent*
    (the key is omitted, as every optional field in this server's structured results is) for four

--- a/skills/windbg-debugging/crash-dump.md
+++ b/skills/windbg-debugging/crash-dump.md
@@ -34,9 +34,11 @@ offending frame. No elevation needed; works on System32's engine.
    fast, and it still names the bug check. It walks **whichever context the session has selected**,
    which on a freshly opened dump is the crash: only run it on a session where you have moved the
    context yourself (`.thread`, `~Ns`, `.cxr`) if that is the stack you meant. The default
-   `analyze: true` walks the **target's default** context instead, because the `!analyze -v` it
-   runs first resets the scope there — and your scope is put back before the call returns, so a
-   triage costs you nothing either way and a later `registers` / `backtrace` reads as before.
+   `analyze: true` walks the **target's default** context instead — the `!analyze -v` it runs
+   first resets the scope there — and your scope is put back before the call returns, so a triage
+   costs you nothing either way and a later `registers` / `backtrace` reads as before. If the
+   analysis did not actually run (`analysis.ran: false` — no time left, or no `ext.dll`), nothing
+   reset anything and you get the selected context after all.
    — **`faulting_frame` is not always there, and `faulting_frame_note` says why.** It is *absent*
    (the key is omitted, as every optional field in this server's structured results is) for four
    different reasons, and only two of them are findings about the crash. **Read the note before

--- a/src/server.rs
+++ b/src/server.rs
@@ -2262,10 +2262,12 @@ impl WindbgServer {
     /// `!analyze -v` it runs by default would otherwise reset the selected scope, so the scope is
     /// saved and restored around the call.
     /// The stack it reports is the target's default context — the crash, on a crash dump —
-    /// whenever the `!analyze` actually ran, since running it is what resets the scope there.
-    /// With `analyze: false`, and in the cases where the analysis is skipped (no time left in the
-    /// call, no `ext.dll` on the engine), it is instead whatever the session has selected, the
-    /// same stack `backtrace` would show. `analysis.ran` says which of the two you got.
+    /// whenever the `!analyze` ran to completion, since running it is what resets the scope
+    /// there. Otherwise it is whatever the session has selected, the same stack `backtrace`
+    /// would show: with `analyze: false`, when the analysis could not run (no time left in the
+    /// call, no `ext.dll` on the engine), and when it was cut short, since the reset happens
+    /// partway through the analysis and a truncated one may not have reached it.
+    /// `analysis.ran` and `analysis.truncated` are what tell those apart.
     #[rmcp::tool(
         annotations(
             title = "Triage a bug check",

--- a/src/server.rs
+++ b/src/server.rs
@@ -2261,9 +2261,11 @@ impl WindbgServer {
     /// Reads the target and never writes to it, and leaves the session where it found it: the
     /// `!analyze -v` it runs by default would otherwise reset the selected scope, so the scope is
     /// saved and restored around the call.
-    /// The stack it reports is the target's default context — the crash, on a crash dump — not
-    /// wherever a caller had navigated to; with `analyze: false` it is whatever the session
-    /// currently has selected, the same one `backtrace` would show.
+    /// The stack it reports is the target's default context — the crash, on a crash dump —
+    /// whenever the `!analyze` actually ran, since running it is what resets the scope there.
+    /// With `analyze: false`, and in the cases where the analysis is skipped (no time left in the
+    /// call, no `ext.dll` on the engine), it is instead whatever the session has selected, the
+    /// same stack `backtrace` would show. `analysis.ran` says which of the two you got.
     #[rmcp::tool(
         annotations(
             title = "Triage a bug check",

--- a/src/server.rs
+++ b/src/server.rs
@@ -2258,30 +2258,31 @@ impl WindbgServer {
     /// and does not depend on `!analyze`'s attribution, which for such a driver is often wrong.
     /// `!analyze`'s own conclusions (pool tag, failure bucket, blamed module) travel beside them
     /// under `analysis`, so the two can be compared; pass `analyze: false` to skip it.
-    /// Reads the target and never writes to it, but with the default `analyze: true` it runs
-    /// `!analyze -v`, which on a bug check carrying an exception context selects that context and
-    /// leaves it selected — so a later `registers` or `backtrace` on the same session can see a
-    /// different thread than before. `analyze: false` touches nothing.
+    /// Reads the target and never writes to it, and leaves the session where it found it: the
+    /// `!analyze -v` it runs by default would otherwise reset the selected scope, so the scope is
+    /// saved and restored around the call.
+    /// The stack it reports is the target's default context — the crash, on a crash dump — not
+    /// wherever a caller had navigated to; with `analyze: false` it is whatever the session
+    /// currently has selected, the same one `backtrace` would show.
     #[rmcp::tool(
         annotations(
             title = "Triage a bug check",
-            // **Not read-only, and the distinction is the session rather than the target.**
-            // Nothing here writes to the debuggee. But `!analyze -v` selects the faulting context
-            // on the bug checks that carry one and leaves it selected, so two identical
-            // `backtrace` calls either side of a triage can differ — which is a change to the
-            // environment the other tools read, and is what this hint is about. `ioctl_trace` is
-            // annotated the same way for the same kind of reason: session state moves, nothing is
-            // harmed.
+            // **Read-only, and earned rather than assumed.** Nothing here writes to the debuggee,
+            // but until glslang/win-kexp#98 this said `false` anyway, because `!analyze -v` moves
+            // the session's selected scope and two identical `backtrace` calls either side of a
+            // triage could therefore differ — a change to what every other tool reads.
             //
-            // Per-tool rather than per-argument, so it describes the worst case: `analyze: false`
-            // really is a pure read, and cannot say so here.
+            // The measurement that settled it also corrected the reason. `!analyze` does not
+            // *select* a faulting context and leave it, as this comment used to claim: it ends
+            // with the scope at the target's **default**, discarding whatever the caller had
+            // chosen. (Four targets: `0x13A`, `0xD1`, `0x9F`, and a user-mode AV.) The implicit
+            // thread it really does move — visibly, on the `0x9F` — and really does put back.
             //
-            // It can be earned back by saving the scope around the `!analyze` and restoring it
-            // (`IDebugSymbols3::GetScope`/`SetScope`), which is a win-kexp primitive this does not
-            // have yet: glslang/win-kexp#98. Until then the honest annotation is this one — the
-            // alternative is a promise that cannot be verified on the bug checks where it matters,
-            // and no dump to hand carries an exception context to verify it against.
-            read_only_hint = false,
+            // So the scope is what needed a guard, and `crash_triage` now takes one for the whole
+            // call (`worker::crash_triage`): the analysis runs, the reads run at the default
+            // context, and the caller's scope is restored on the way out, including on the
+            // interrupt path. `ioctl_trace` keeps `false` for its own reasons — it is not this.
+            read_only_hint = true,
             destructive_hint = false,
             idempotent_hint = true,
             open_world_hint = true

--- a/src/structured.rs
+++ b/src/structured.rs
@@ -908,11 +908,13 @@ pub struct CrashTriage {
     /// The stack of **the context the session has selected**, innermost first, capped by the
     /// call's `frames` argument.
     ///
-    /// On a freshly opened crash dump that context is the crash, and with `analyze: true` it is
-    /// re-selected by `!analyze` for the bug checks that carry an exception context. But it is a
-    /// *selection*, and a caller who has moved it (`.thread`, `~Ns`, `.cxr` through `execute`)
-    /// gets the stack they moved it to — this is the same stack `backtrace` would print, not a
-    /// separately-discovered crash stack.
+    /// On a freshly opened crash dump that context is the crash. With `analyze: true` it is the
+    /// crash even on a session a caller had navigated away from, because the `!analyze -v` that
+    /// runs first leaves the scope at the target's default — and the scope the caller chose is
+    /// restored after the walk, so the normalisation costs them nothing. With `analyze: false`
+    /// nothing normalises it: a caller who has moved it (`.thread`, `~Ns`, `.cxr` through
+    /// `execute`) gets the stack they moved it to. Either way this is the same stack `backtrace`
+    /// would print from that context, not a separately-discovered crash stack.
     pub frames: Vec<FrameInfo>,
     /// Whether the stack went on past the cap.
     ///

--- a/src/structured.rs
+++ b/src/structured.rs
@@ -909,13 +909,15 @@ pub struct CrashTriage {
     /// call's `frames` argument.
     ///
     /// On a freshly opened crash dump that context is the crash. It is the crash even on a session
-    /// a caller had navigated away from **when the `!analyze -v` ran** ([`AnalysisInfo::ran`]),
-    /// because running it leaves the scope at the target's default — and the scope the caller
-    /// chose is restored after the walk, so that normalisation costs them nothing. When it did not
-    /// run — `analyze: false`, no time left, or an engine with no extensions — nothing normalises
-    /// anything: a caller who has moved the context (`.thread`, `~Ns`, `.cxr` through `execute`)
-    /// gets the stack they moved it to. Either way this is the same stack `backtrace` would print
-    /// from that context, not a separately-discovered crash stack.
+    /// a caller had navigated away from **when the `!analyze -v` ran to completion**
+    /// ([`AnalysisInfo::ran`] and not [`AnalysisInfo::truncated`]), because running it leaves the
+    /// scope at the target's default — and the scope the caller chose is restored after the walk,
+    /// so that normalisation costs them nothing. When it did not — `analyze: false`, no time left,
+    /// an engine with no extensions, or a run the deadline cut short before it reached the reset
+    /// it does partway through its own output — nothing normalises anything: a caller who has
+    /// moved the context (`.thread`, `~Ns`, `.cxr` through `execute`) gets the stack they moved it
+    /// to. Either way this is the same stack `backtrace` would print from that context, not a
+    /// separately-discovered crash stack.
     pub frames: Vec<FrameInfo>,
     /// Whether the stack went on past the cap.
     ///

--- a/src/structured.rs
+++ b/src/structured.rs
@@ -908,13 +908,14 @@ pub struct CrashTriage {
     /// The stack of **the context the session has selected**, innermost first, capped by the
     /// call's `frames` argument.
     ///
-    /// On a freshly opened crash dump that context is the crash. With `analyze: true` it is the
-    /// crash even on a session a caller had navigated away from, because the `!analyze -v` that
-    /// runs first leaves the scope at the target's default — and the scope the caller chose is
-    /// restored after the walk, so the normalisation costs them nothing. With `analyze: false`
-    /// nothing normalises it: a caller who has moved it (`.thread`, `~Ns`, `.cxr` through
-    /// `execute`) gets the stack they moved it to. Either way this is the same stack `backtrace`
-    /// would print from that context, not a separately-discovered crash stack.
+    /// On a freshly opened crash dump that context is the crash. It is the crash even on a session
+    /// a caller had navigated away from **when the `!analyze -v` ran** ([`AnalysisInfo::ran`]),
+    /// because running it leaves the scope at the target's default — and the scope the caller
+    /// chose is restored after the walk, so that normalisation costs them nothing. When it did not
+    /// run — `analyze: false`, no time left, or an engine with no extensions — nothing normalises
+    /// anything: a caller who has moved the context (`.thread`, `~Ns`, `.cxr` through `execute`)
+    /// gets the stack they moved it to. Either way this is the same stack `backtrace` would print
+    /// from that context, not a separately-discovered crash stack.
     pub frames: Vec<FrameInfo>,
     /// Whether the stack went on past the cap.
     ///

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -1350,15 +1350,32 @@ fn crash_triage(
         }
     };
 
-    // **`!analyze` runs before the reads, not after**, and the ordering is load-bearing twice
-    // over. `!analyze -v` selects the faulting context — on an exception bug check (`0x8E`,
-    // `0x7E`, `0x3B`: the common driver crash) it `.cxr`s to the context record, which is a
-    // different stack from the one the dump opens on. Reading afterwards means the frames describe
-    // the thread the analysis blamed, which is the stack worth having. It also makes the tool
-    // idempotent: run twice, and the second call re-selects the same context before reading rather
-    // than reading whatever the first one left selected.
+    // **The scope is saved here and restored when this returns.** `!analyze -v` leaves the
+    // session's scope at the target's *default*, discarding whatever the caller had selected —
+    // measured on a `0x13A`, a `0xD1`, a `0x9F` and a user-mode AV (glslang/win-kexp#98). Nothing
+    // is written to the debuggee, but a `.frame 3` or `.ecxr` a caller set before calling this is
+    // gone afterwards, and that is a change to what every other tool on the session reads. The
+    // guard is what lets this tool be annotated read-only; it restores on every path out,
+    // including the interrupt return below.
     //
-    // With `analyze: false` nothing selects a context at all, and the reads describe whichever one
+    // Best-effort by design: the bug check above already read through this engine, so a scope that
+    // cannot be read here is not a state this can reach — and failing a triage over the bookkeeping
+    // around it would trade the whole answer for tidiness.
+    let _scope = e.scope_guard().inspect_err(|why| {
+        tracing::debug!("worker: crash triage could not save the debugger scope: {why}");
+    });
+
+    // **`!analyze` runs before the reads, not after**, and the ordering is load-bearing — though
+    // not for the reason it looks like. The analysis *does* go and look at the thread it blames:
+    // on the `0x9F` sample its output says `Implicit thread is now …` partway through, naming a
+    // thread that is not the one the dump opens on. But it puts that back before it returns, and
+    // leaves the scope at the default. So the reads below describe the **default context** — for
+    // a crash dump, the crash — whether or not the analysis ran, and running the analysis first
+    // is what guarantees that: it normalises a session a caller had navigated (`.frame`, `.cxr`)
+    // back to the default before the stack is walked, which is what makes two triages of one
+    // session agree.
+    //
+    // With `analyze: false` nothing normalises anything, and the reads describe whichever scope
     // the session currently has — the same one `backtrace` would show. On a freshly opened crash
     // dump that *is* the crash context; on a session where a caller has moved it (`.thread`,
     // `~Ns`, `.cxr`) it is wherever they moved it, and this mode has no way to tell. Said plainly

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -1374,11 +1374,19 @@ fn crash_triage(
     // makes two triages of one session agree.
     //
     // **That normalisation is a side effect of the analysis, so it holds exactly when the analysis
-    // ran.** `run_analyze` declines to start when the patience is already spent, and both spellings
-    // can fail to resolve on an engine with no `ext.dll` — in either case nothing has moved the
-    // scope and the reads describe whatever the caller had selected, the same as `analyze: false`.
-    // `analysis.ran` is how a caller tells the two apart, and it is documented on the tool rather
-    // than papered over here.
+    // *completed*.** Two ways it does not. `run_analyze` declines to start when the patience is
+    // already spent, and both spellings can fail to resolve on an engine with no `ext.dll` —
+    // nothing has moved the scope, and the reads describe whatever the caller had selected, the
+    // same as `analyze: false`. And a run the **deadline** cut short is not a cancellation
+    // ([`Analysis::interrupted`] is false for it, deliberately), so the reads below still happen —
+    // but the reset is something `!analyze` does partway through its own output, not at the end,
+    // so a truncated run may or may not have reached it and this cannot tell which.
+    //
+    // Hence the qualification a caller is given is `ran` **and not** `truncated`, not `ran` alone.
+    // Not fixed by resetting the scope here instead: that would make the tool normalise a session
+    // it was not asked to normalise, and the claim would then be one no host with a working
+    // `ext.dll` can test — the whole point of this comment is that the reset is the analysis's,
+    // and where it does not happen there is nothing to demonstrate.
     //
     // With `analyze: false` nothing normalises anything, and the reads describe whichever scope
     // the session currently has — the same one `backtrace` would show. On a freshly opened crash

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -1369,11 +1369,16 @@ fn crash_triage(
     // not for the reason it looks like. The analysis *does* go and look at the thread it blames:
     // on the `0x9F` sample its output says `Implicit thread is now …` partway through, naming a
     // thread that is not the one the dump opens on. But it puts that back before it returns, and
-    // leaves the scope at the default. So the reads below describe the **default context** — for
-    // a crash dump, the crash — whether or not the analysis ran, and running the analysis first
-    // is what guarantees that: it normalises a session a caller had navigated (`.frame`, `.cxr`)
-    // back to the default before the stack is walked, which is what makes two triages of one
-    // session agree.
+    // leaves the scope at the default. So running it first *normalises* a session a caller had
+    // navigated (`.frame`, `.cxr`) back to the default before the stack is walked, which is what
+    // makes two triages of one session agree.
+    //
+    // **That normalisation is a side effect of the analysis, so it holds exactly when the analysis
+    // ran.** `run_analyze` declines to start when the patience is already spent, and both spellings
+    // can fail to resolve on an engine with no `ext.dll` — in either case nothing has moved the
+    // scope and the reads describe whatever the caller had selected, the same as `analyze: false`.
+    // `analysis.ran` is how a caller tells the two apart, and it is documented on the tool rather
+    // than papered over here.
     //
     // With `analyze: false` nothing normalises anything, and the reads describe whichever scope
     // the session currently has — the same one `backtrace` would show. On a freshly opened crash

--- a/tests/golden/tools_list.json
+++ b/tests/golden/tools_list.json
@@ -125,7 +125,7 @@
         "destructive": false,
         "idempotent": true,
         "openWorld": true,
-        "readOnly": false
+        "readOnly": true
       },
       "name": "crash_triage",
       "output": {

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -1703,6 +1703,44 @@ fn a_bug_check_is_triaged_into_its_fields() {
     );
     assert!(text.contains("STACK ("), "{text}");
 
+    // **The session is where it was left, which is what `read_only_hint = true` claims.** The
+    // `!analyze -v` a triage runs resets the debugger's selected scope to the target's default —
+    // measured on four targets (glslang/win-kexp#98) — so a caller who had chosen a frame would
+    // silently lose it. `crash_triage` saves and restores it; this is that promise, checked the
+    // only way it can be: from a scope the analysis would otherwise discard.
+    //
+    // Frame 3, not frame 0: frame 0 *is* the default, and a check that started there would pass
+    // whether the scope was restored or merely reset.
+    let moved = server.tool_text(
+        "execute",
+        json!({ "session_id": session_id, "command": ".frame 3" }),
+        TARGET_STEP,
+    );
+    // The whole rendered frame line — index, offsets and symbol if there is one — so the check
+    // does not depend on symbols being available on the host running this.
+    let selected = moved
+        .lines()
+        .map(str::trim)
+        .find(|line| line.starts_with("03 "))
+        .unwrap_or_else(|| panic!("`.frame 3` selected no frame 3 on this dump: {moved}"))
+        .to_string();
+
+    // With the analysis on, since that is the half that moves the scope.
+    server.tool_data(
+        "crash_triage",
+        json!({ "session_id": session_id }),
+        TARGET_STEP,
+    );
+    let after = server.tool_text(
+        "execute",
+        json!({ "session_id": session_id, "command": ".frame" }),
+        TARGET_STEP,
+    );
+    assert!(
+        after.lines().map(str::trim).any(|line| line == selected),
+        "crash_triage moved the session's scope: it was `{selected}`, and `.frame` now says:\n{after}"
+    );
+
     server.tool_data(
         "end_session",
         json!({ "session_id": session_id }),


### PR DESCRIPTION
Downstream half of [win-kexp#98](https://github.com/glslang/win-kexp/issues/98), whose `ScopeGuard` merged in [win-kexp#99](https://github.com/glslang/win-kexp/pull/99). `Cargo.lock` moves the pin to it.

## What changes

`crash_triage` takes a scope guard for the whole call, so the `!analyze -v` it runs by default no longer costs the caller their selected scope, and `read_only_hint` goes back to `true`. Nothing about the target reads differently.

## The reason in the old comments was wrong, and it was wrong here in three places

This repo said — in `worker::crash_triage`, in the tool description, in `structured::CrashTriage::frames`, in the README and in the `crash-dump` skill — that `!analyze -v` selects the faulting context on the bug checks that carry one and leaves it selected. Measured on four targets, it does not:

| target | scope before | scope after `!analyze -v` |
|---|---|---|
| `0x13A` kernel heap corruption (checked-in sample) | `.frame 3` | frame 0 — **reset** |
| `0xD1` driver fault (produced for this) | `.frame 3` (`myfault+0x1e35`) | frame 0 — **reset** |
| `0x9F` power-state watchdog (checked-in sample) | `.frame 3` | frame 0 — **reset** |
| user-mode access violation | `.ecxr` context | default — **reset** |

From a *default* scope it appears to move nothing, which is why this went unnoticed: the default is the analysis's own fixed point.

What it does move is the implicit **thread**, and it puts that back. The `0x9F` is where that is visible, because the thread it blames is not the one the dump opens on:

```
BEFORE      Implicit thread is now ffffe284`fe4e7040   nt!KeBugCheckEx …
!analyze    Implicit thread is now ffffe284`fe4dd040   <- FAULTING_THREAD, mid-analysis
AFTER       Implicit thread is now ffffe284`fe4e7040   nt!KeBugCheckEx …   (identical stack)
```

So the ordering (`!analyze` first, reads after) is still load-bearing, for a different reason than the comment gave: the analysis *normalises* a session the caller had navigated back to the default before the stack is walked, which is what makes two triages of one session agree. The reported stack is the default context — the crash, on a crash dump — never "the thread the analysis blamed". All five places now say that.

## Test

The smoke tier checks the promise, not the annotation: `.frame 3` → `crash_triage` → the same frame line afterwards, compared as text so it does not depend on symbols. **Frame 3 deliberately**: a check that started at frame 0 would pass whether the scope was restored or merely reset — which is exactly the trap that hid this behaviour for four months.

Mutation-checked: dropping the guard fails it, with `.frame` back at `nt!KeBugCheckEx`.

`UPDATE_GOLDEN=1` re-recorded `tests/golden/tools_list.json`; the diff is one line, `crash_triage`'s `readOnly` flipping to `true`.

Full `WINDBG_MCP_SMOKE_DUMP=1 cargo test --test mcp_smoke`: 33 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Crash triage now preserves the selected debugger context after analysis, including when interrupted.
  - Subsequent register and backtrace views remain consistent with the caller’s original selection.
  - Analysis uses the default crash context without unexpectedly changing the active session state.

- **Documentation**
  - Clarified context handling, read-only behaviour, and frame selection in the crash triage documentation.

- **Tests**
  - Added coverage confirming selected frame restoration after crash analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->