### PR TITLE
A profiles.json with a UTF-8 BOM is a valid one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- A `profiles.json` with a **UTF-8 BOM** is read rather than refused. Windows PowerShell
+  5.1's `Set-Content -Encoding utf8` — the obvious way to write the one config file this
+  server asks a Windows user to write by hand — puts a BOM in front, and `serde_json`
+  rejected the whole file with `expected value at line 1 column 1`: a message that reads as
+  "your JSON is malformed" about a file whose JSON is perfect. Found by configuring a real
+  KDNET profile and having the first attempt refused.
+
 ## [0.8.0] - 2026-08-13
 
 ### Changed

--- a/src/kdconn.rs
+++ b/src/kdconn.rs
@@ -566,12 +566,6 @@ fn read_profile_file(path: &Path) -> Result<BTreeMap<String, String>, String> {
     // "expected value at line 1 column 1", which reads as "your JSON is malformed" about a file
     // whose JSON is perfect. Skipping it costs nothing and the alternative is a config that
     // cannot be written with the platform's default text writer.
-    // **A leading UTF-8 BOM is not a broken file.** This is the one config file a Windows user
-    // writes by hand, and Windows PowerShell 5.1's own `Set-Content -Encoding utf8` — the obvious
-    // way to write it — puts a BOM in front. `serde_json` then rejects the whole file with
-    // "expected value at line 1 column 1", which reads as "your JSON is malformed" about a file
-    // whose JSON is perfect. Skipping it costs nothing and the alternative is a config that
-    // cannot be written with the platform's default text writer.
     let text = text.strip_prefix('\u{feff}').unwrap_or(text.as_str());
     let parsed: serde_json::Value = serde_json::from_str(text)
         .map_err(|e| format!("{} is not valid JSON ({e})", path.display()))?;

--- a/src/kdconn.rs
+++ b/src/kdconn.rs
@@ -560,7 +560,20 @@ fn read_profile_file(path: &Path) -> Result<BTreeMap<String, String>, String> {
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(BTreeMap::new()),
         Err(e) => return Err(format!("{} could not be read ({e})", path.display())),
     };
-    let parsed: serde_json::Value = serde_json::from_str(&text)
+    // **A leading UTF-8 BOM is not a broken file.** This is the one config file a Windows user
+    // writes by hand, and Windows PowerShell 5.1's own `Set-Content -Encoding utf8` — the obvious
+    // way to write it — puts a BOM in front. `serde_json` then rejects the whole file with
+    // "expected value at line 1 column 1", which reads as "your JSON is malformed" about a file
+    // whose JSON is perfect. Skipping it costs nothing and the alternative is a config that
+    // cannot be written with the platform's default text writer.
+    // **A leading UTF-8 BOM is not a broken file.** This is the one config file a Windows user
+    // writes by hand, and Windows PowerShell 5.1's own `Set-Content -Encoding utf8` — the obvious
+    // way to write it — puts a BOM in front. `serde_json` then rejects the whole file with
+    // "expected value at line 1 column 1", which reads as "your JSON is malformed" about a file
+    // whose JSON is perfect. Skipping it costs nothing and the alternative is a config that
+    // cannot be written with the platform's default text writer.
+    let text = text.strip_prefix('\u{feff}').unwrap_or(text.as_str());
+    let parsed: serde_json::Value = serde_json::from_str(text)
         .map_err(|e| format!("{} is not valid JSON ({e})", path.display()))?;
     let object = parsed.as_object().ok_or_else(|| {
         format!(
@@ -1310,6 +1323,19 @@ mod tests {
         assert!(
             !parsed.contains_key("blank"),
             "an empty value is not a profile"
+        );
+
+        // Written the way Windows PowerShell 5.1 writes UTF-8: with a BOM in front. Not a
+        // hypothetical — it is what `Set-Content -Encoding utf8` produces, and before this was
+        // handled the file it wrote was rejected as malformed JSON.
+        let bom = dir.join("bom.json");
+        std::fs::write(&bom, format!("\u{feff}{{ \"ctf-vm\": \"{FAKE}\" }}")).unwrap();
+        assert_eq!(
+            read_profile_file(&bom)
+                .expect("a UTF-8 BOM is not a broken profile file")
+                .get("ctf-vm")
+                .map(String::as_str),
+            Some(FAKE)
         );
 
         let bad = dir.join("bad.json");


### PR DESCRIPTION
Found while configuring a real KDNET profile on this host, following the advice `attach_kernel` itself prints.

`%USERPROFILE%\.windbg-mcp\profiles.json` is the one config file this server asks a Windows user to write by hand. Windows PowerShell 5.1's `Set-Content -Encoding utf8` — the obvious way to write it — emits a **UTF-8 BOM**, and `serde_json` rejected the file whole:

```
The configuration was read with problems, which may be why the profile you want is missing:
- C:\Users\Admin\.windbg-mcp\profiles.json is not valid JSON (expected value at line 1 column 1)
```

The JSON was perfect. The message reads as "you wrote it wrong" to someone who had just done exactly what the tool told them to, and the fix on their side is to know that `Set-Content -Encoding utf8` is not UTF-8 in the sense anyone means.

So the BOM is skipped before parsing. Three bytes, and the config becomes writable with the platform's default text writer.

The test writes the file the way PowerShell writes it, rather than asserting on a hand-built string, and is mutation-checked: with the skip removed it fails with the same message the user saw.

Verified end to end afterwards — `attach_kernel {}` lists `ctf-vm`, and `attach_kernel { "profile": "ctf-vm" }` attaches to the live KDNET target with the key never entering the request (the session reports `profile "ctf-vm" (net:port=50000,key=<redacted>)`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Profile JSON files with a leading UTF-8 byte order mark (BOM) are now accepted instead of being rejected as malformed.
* **Documentation**
  * Added a changelog entry documenting support for BOM-prefixed profile files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->