### PR TITLE
Add walk_memory: a structure walk that reports its holes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`walk_memory`: a structure traversal where an unreadable node is a row, not an end**
+  ([#103](https://github.com/glslang/windbg-mcp/issues/103)). Walking a kernel list through
+  `execute` was all-or-nothing — one unmapped dereference inside a MASM `.for` loop ended the
+  whole script with `An unexpected exception was raised (0x80040205)`, leaving no rows, no
+  iteration number, and no way to tell which node faulted. Driving the MessageManager
+  use-after-free that meant bisecting a 512-entry handle table by hand to find the one bad
+  pointer, which was of course the pointer the walk existed to find.
+
+  The new tool names its nodes three ways — an explicit `addresses` list (the bulk read),
+  `start` + `stride` (an array), or `start` + `next_offset` (a pointer chain) — and reads named
+  `fields` out of each. Offsets may be negative, so a pool header 16 bytes before the address
+  the allocator returned is one argument rather than arithmetic per node. A value the debugger
+  cannot read comes back as `null` in its own field, a node where nothing read is counted, and
+  the walk carries on.
+
+  A **chain** is the one traversal a hole really does stop, because the address of everything
+  after it lived in the bytes that would not read — so it stops and says *which node*. It also
+  stops on a null link, on a loop (reporting where the list closed: back at the head that is a
+  healthy circular `_LIST_ENTRY`, anywhere else it is corruption), and at `count`, where it hands
+  back the address to resume from.
+
+  Fields of one structure are fetched in a single read, falling back to per-field reads only
+  where there is a hole — one round trip per node in the ordinary case, which is what lets a
+  512-node walk finish over KDNET. The walk checks its deadline and the session's interrupt
+  between nodes: there is no *command* behind it, so win-kexp's watchdog has nothing to bound,
+  and a walk cut short answers with what it really read rather than failing.
+
 ## [0.8.1] - 2026-08-13
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   where there is a hole — one round trip per node in the ordinary case, which is what lets a
   512-node walk finish over KDNET. The walk checks its deadline and the session's interrupt
   between nodes: there is no *command* behind it, so win-kexp's watchdog has nothing to bound,
-  and a walk cut short answers with what it really read rather than failing.
+  and a walk cut short answers with what it really read rather than failing. The one part that
+  *is* a command — the `?` resolving a symbolic `start`, which can block on a symbol server —
+  takes the watchdog with what is left of the walk's budget.
 
 ## [0.8.1] - 2026-08-13
 

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -5,6 +5,48 @@ status. Keep entries short; link to code with `file:line` where it helps a futur
 
 ---
 
+## A walk reports its holes; only a chain is stopped by one (2026-08-13, issue #103)
+
+**Context.** Inspecting a kernel list meant a MASM `.for` loop through `execute`, which is
+all-or-nothing: one unmapped `poi` ends the script with `0x80040205` and returns no rows, no
+iteration number, and no way to tell which node faulted. For a server whose subject is pool and
+use-after-free analysis that is exactly backwards — "some of these nodes are freed" is the normal
+case, and the pointer that will not read is the one the walk was for.
+
+**Decision.** `walk_memory` issues one `ReadVirtual` per value and reports what failed instead of
+propagating it: an unreadable value is `null` in its own field, an unreadable *node* is counted,
+and the walk continues. The traversal, the loop detection and the rendering live in `src/walk.rs`
+behind a reader closure, engine-free, so the holes that matter are testable against a fake address
+space rather than only against a target that happens to have one.
+
+**A chain is the exception, and it is a real one.** An array's next address is arithmetic and a
+list's was supplied, so a hole costs those walks one node. A chain's next address lived in the
+bytes that would not read, so a hole costs it everything after — it stops, and `stopped` names the
+node rather than reporting an end of list that was never observed. The same enum distinguishes a
+null link, a loop (with where the list closed), the count cap (with where to resume), the deadline
+and an interrupt: seven reasons rather than a `complete` flag, because they call for opposite
+responses.
+
+**The cap is refused, not clamped.** `count` past 1024 is an error. Clamping would answer a
+different question and then label it `complete` — and "every node asked for was visited" is the one
+sentence a caller reads to decide whether to look further.
+
+**Nothing read at all is the one ambiguous answer**, so the worker attaches the engine's own words
+for the first failed read (`MemoryWalk.note`). A list of freed objects reads identically to a target
+that is not broken in, or a `start` that is not where the caller thinks.
+
+**Bounded between nodes, because nothing else bounds it.** A walk is a long run of reads with no
+`Execute` behind it, so win-kexp's watchdog has nothing to interrupt. The deadline and the session's
+interrupt are polled once per node, *before* its reads — after them, a break landing during node 3
+would still buy node 4's round trips. A walk that reaches the engine with less than the reply's own
+headroom left is refused outright, as a pool query that must walk already is.
+
+**Status.** Done. Covered by `src/walk.rs` unit tests over an address space with holes in it, and
+by `mcp_smoke::a_walk_marks_what_it_cannot_read_and_keeps_going`, which asserts the *contrast*:
+the same dereference through `execute` fails, and the walk returns it as a row.
+
+---
+
 ## A typed result is a second channel, not a replacement (2026-08-12, issue #84)
 
 **Context.** Every tool answered in prose, so the only way to drive this server programmatically was

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -41,6 +41,23 @@ interrupt are polled once per node, *before* its reads — after them, a break l
 would still buy node 4's round trips. A walk that reaches the engine with less than the reply's own
 headroom left is refused outright, as a pool query that must walk already is.
 
+**The one exception is a command, so it takes the watchdog.** Resolving a symbolic `start` runs a
+`?`, which can send the engine to a symbol server; the between-node deadline cannot bound it,
+because it is not polled until the resolve returns. So the resolve is handed what is left of the
+walk's budget, floored at 1ms — zero *disarms* win-kexp's watchdog, which would leave the one
+blocking part of the call as the only unbounded thing in it. A resolve cut short is reported as
+`NotRun`, never as a bad expression: being stopped says nothing about whether the symbol exists.
+
+**Two fields are `null`, not absent**, against this module's own habit of eliding `None`. A walk's
+unreadable value and unread chain link are the findings, and an omitted key makes "the debugger
+could not read this" and "this object came back malformed" the same observation for every client.
+`start` and `note` keep the elision, because those absences really are absences.
+
+**Field names are capped at 64 characters** — the only argument that is *amplified*. Every other
+input is spent once; a name is copied into each field of each node, up to 16,384 times, so a single
+large one can take the worker out of memory and cost the caller the session that the node and field
+caps exist to protect.
+
 **Status.** Done. Covered by `src/walk.rs` unit tests over an address space with holes in it, and
 by `mcp_smoke::a_walk_marks_what_it_cannot_read_and_keeps_going`, which asserts the *contrast*:
 the same dereference through `execute` fails, and the walk returns it as a row.

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -1,12 +1,13 @@
 # Follow-ups
 
-Deferred work, in five clusters: items 1–6 come from the reachability-confirmation effort (path
+Deferred work, in six clusters: items 1–6 come from the reachability-confirmation effort (path
 recipe + `run_to_address`, merged 2026-07-04), items 7–11 from surveying this server against the
 MCP `2026-07-28` extensions (tasks, apps), item 12 from the opener split
 (glslang/win-kexp#71, 2026-08-01), items 13–14 from the bounded-command coverage review
-(#46, 2026-08-02), item 15 from the private worker channel (#65 / #72, 2026-08-04), and items 16–18
+(#46, 2026-08-02), item 15 from the private worker channel (#65 / #72, 2026-08-04), items 16–18
 from transactional batches (#82, 2026-08-09/10 — item 17 is what validating the tool against the CTF
-session's own transcript turned up, and item 18 what reviewing it did). Each item notes its repo,
+session's own transcript turned up, and item 18 what reviewing it did), and item 19 from
+`walk_memory` (#103, 2026-08-13). Each item notes its repo,
 why it was deferred, and where it picks up. See [`DECISIONS.md`](./DECISIONS.md) for the design rationale (D1–D5) items 1–6 extend,
 and the 2026-08-02 entries that items 13–14 and item 10 extend.
 
@@ -488,3 +489,24 @@ killed outright still gets the rollback rather than a truncated transaction.
   running" unreachable and the remaining-budget figure the grace is sized from, and the dump tier
   drives both teardowns end to end — the disconnect one asserting against a file the rollback wrote,
   because by then there is no client, supervisor or worker left to ask.
+
+## 19. [windbg-mcp] Let a `debug_batch` step walk a structure
+
+`walk_memory` (#103) is a supervisor-validated op like the pool queries, and item 17 already built
+the machinery a batch needs to call one: a `StepAction` variant, a `Debuggee` method, and a
+rendering the step's `expect` checks can match on. It was left out because the two tools answer
+different questions — a batch exists so that a *mutation* is undone on every path, and a walk
+mutates nothing.
+
+Where it would earn its place is the assertion half. A batch that patches a driver's dispatch table
+and has to prove it put every entry back currently asserts on `execute` text, which is exactly the
+all-or-nothing read this issue removed everywhere else: one unreadable entry and the assertion fails
+for a reason that has nothing to do with the restore. A `walk` step whose `expect` matched on the
+rendered table would state the postcondition as what it is — "these sixteen pointers are these
+sixteen values" — instead of on a command that may not survive being asked.
+
+Picks up at `batch::StepAction` (the variant and its `owns` keys), `batch::Debuggee::walk`
+alongside `pool`, and `worker::walk_memory`, which already returns the text a check would run
+against. The one design question is the budget: a walk step is up to 1024 reads inside a
+transaction whose whole point is that its rollback still fits, so the step's share has to come out
+of the batch's deadline the way `pool`'s does rather than out of the call's.

--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ gh attestation verify <zip> --repo glslang/windbg-mcp `
 | Group | Tools |
 |-------|-------|
 | Session | `open_dump`, `open_trace`, `attach_kernel_local`, `attach_kernel`, `attach_process`, `launch`, `interrupt`, `end_session`, `session_status` |
-| State   | `registers`, `read_memory`, `backtrace`, `modules`, `threads`, `disassemble`, `dx` |
+| State   | `registers`, `read_memory`, `walk_memory`, `backtrace`, `modules`, `threads`, `disassemble`, `dx` |
 | Crash   | `crash_triage` — a bug check as fields: code and parameters, crashing process, the stack as `module+RVA`, and the faulting driver frame |
 | Control | `go`, `step_over`, `step_into`, `set_breakpoint`, `run_to_address` |
 | Transaction | `debug_batch` — an ordered sequence with assertions and a rollback the engine process runs on every path |
@@ -481,6 +481,51 @@ that could retire the session handle.
 Nothing legitimate is lost: these parameters were always single operands. Use `execute` to run a
 command list — it is annotated destructive and retires the handle when a command changes the target.
 
+### Walking a structure (`walk_memory`)
+
+Walking a kernel list through `execute` is all-or-nothing. A single unmapped dereference inside a
+MASM `.for` loop ends the whole script with `An unexpected exception was raised (0x80040205)` — no
+rows, no iteration number, no indication of how many nodes were classified before it. In pool and
+use-after-free work that is precisely backwards: "some of these nodes are freed" is the normal case,
+and the pointer that will not read is usually the one worth looking at
+([#103](https://github.com/glslang/windbg-mcp/issues/103)).
+
+`walk_memory` reads each value on its own, so a hole is a row rather than an end. Three ways to name
+the nodes, one of them required:
+
+| | |
+|---|---|
+| `addresses` | walk these exactly — the bulk read |
+| `start` + `stride` | an array: element *i* is `start + i * stride` |
+| `start` + `next_offset` | a chain: the next node is the pointer at `node + next_offset` |
+
+`fields` says what to read out of each node (`{name, offset, size}`, size 1/2/4/8, **offsets may be
+negative** — a pool header sits 16 bytes before the address the allocator returned). `start` is any
+expression `?` evaluates, so a symbol or `poi(<head>)` works; the addresses in a list are numbers, in
+any form the debugger prints. Fields of one structure are fetched in a single read and fall back to
+per-field reads only where there is a hole, so a node costs one round trip in the ordinary case —
+which is what lets a 512-node walk finish over KDNET.
+
+```jsonc
+// Every message pointer in a 512-slot handle table, freed ones included.
+{ "start": "MessageManager!g_Handles", "stride": 16, "count": 512,
+  "fields": [{ "name": "msg", "offset": 8 }] }
+
+// Then the refcount out of each of those pointers — one call, holes and all.
+{ "addresses": ["0xffffc00f6ec02f90", "0xffffc00f6ec03000", …],
+  "fields": [{ "name": "refs", "offset": 16, "size": 4 },
+             { "name": "flink", "offset": 0 }] }
+```
+
+An unreadable value comes back as `null` in its own field (`0x????????????????` in the text), a node
+where *nothing* read is counted, and the walk carries on — for a list or an array. A **chain** is the
+exception, because the address of everything after an unreadable node lived in the bytes that would
+not read: it stops and says which node. It also stops on a null link, on a **loop** (reporting where
+the list closed — back at the head that is a healthy circular `_LIST_ENTRY`, anywhere else it is
+corruption), and at `count`, where it hands back the address to resume from. `count` past the cap of
+1024 is refused rather than clamped, so "every node asked for was visited" is never about a number
+this server lowered.
+
 ### Transactional batches (`debug_batch`)
 
 A sequence that *mutates* a target — patch a byte, arm a breakpoint, resume a thread — has to put
@@ -578,6 +623,7 @@ matching `outputSchema` in `tools/list`, so a program can read a field instead o
 | `run_to_address` | `verdict` (`hit`/`stopped_elsewhere`/`timeout`), `target`, `stopped_at` |
 | `go`, `step_over`, `step_into`, `step_back`, `step_over_back`, `reverse_go` | `stopped_at` |
 | `pool_find_tag`, `pool_chunk`, `pool_census`, `pool_diagnostics` | the chunks/totals/diagnostics as values, each carrying the `walk` behind them |
+| `walk_memory` | `nodes[]` with each field's `value` — `null` where the debugger could not read it — plus `walked`/`unreadable` counts and a `stopped` reason (`complete`, `cap`, `null_link`, `loop`, `unreadable_link`, `deadline`, `interrupted`), each carrying the address it is about |
 | `crash_triage` | `bug_check` (`code`, `name`, four `parameters`), `process_name`, `frames[]` as `{module, rva, symbol}`, the `faulting_frame` picked out of them — and `!analyze`'s own conclusions kept apart under `analysis` |
 
 Two conventions hold across all of them:
@@ -701,6 +747,10 @@ timeline). For anything else, `dx` evaluates arbitrary data-model/LINQ expressio
   clean "memory read error"; query the specific field you need (e.g.
   `dt nt!_DRIVER_OBJECT <addr> DriverName`) instead of dumping whole structures. See the
   [crash-dump walkthrough](docs/crash-dump-walkthrough.md).
+- **That failure is all-or-nothing inside a `.for` loop**, which is what `walk_memory` is for: one
+  unmapped dereference takes the whole script down with no rows at all, and the node it happened on
+  is usually the interesting one. Walk a list, an array or a chain with `walk_memory` and each hole
+  is a marked value instead.
 - Single-stepping is only valid once the target is stopped with a real thread context (after a
   `go`/step or a breakpoint hit). Stepping straight after a bare `goto_position` to the very start of
   a trace (before any thread is live) returns `0x80040205` — `go` to a breakpoint first.

--- a/docs/crash-dump-walkthrough.md
+++ b/docs/crash-dump-walkthrough.md
@@ -199,6 +199,16 @@ a missing page, will hit this. **Query the exact field you need** (e.g.
 `dt _DRIVER_OBJECT <addr> DriverName`) rather than dumping whole structures, and prefer the
 addresses `!analyze` hands you (PDO, IRP, DRIVER_OBJECT) — those are in the triage data.
 
+Reading one field across *many* objects is where this bites hardest: inside a `.for` loop the
+first uncaptured page ends the whole script, so a table with one missing page in it comes back
+empty rather than nearly complete. Use **`walk_memory`** for that — it reads each value on its
+own, marks the ones it could not read, and walks the rest:
+
+```jsonc
+{ "addresses": ["0xffffb00a1c2d3000", "0xffffb00a1c2d4000", …],
+  "fields": [{ "name": "DriverName", "offset": 56 }] }
+```
+
 ## 6. Why `!ext.analyze` and not `!analyze`?
 
 The bundled WinDbg engine has no debugger extensions next to it unless you copy the

--- a/docs/messagemanager-walkthrough.md
+++ b/docs/messagemanager-walkthrough.md
@@ -589,8 +589,11 @@ so the loop is deliberately KD-free and reads the crash afterwards:
   enlarging its `memcpy` to widen the mutex hold silently no-ops the call. The missing-inc window is a
   few instructions; millions of cross-move attempts win it, one-per-message does not (§8).
 - **A single unmapped `poi` aborts a whole `execute` script with `0x80040205`** — walking a list where
-  some nodes point at freed/unmapped chunks fails opaquely with no partial result. Read defensively
-  (bisect the range, or print pointers without dereferencing first) rather than trusting one big walk.
+  some nodes point at freed/unmapped chunks fails opaquely with no partial result. That is what cost
+  this session an afternoon of hand-bisecting the 512-entry handle table, and it is now
+  [fixed](https://github.com/glslang/windbg-mcp/issues/103): use **`walk_memory`**, which reads each
+  value on its own and marks the holes instead of aborting. The table above is two calls — the slots
+  as an array for their `msg*`, then those pointers as `addresses` for their refcount and links.
 - **A full pool walk is expensive on a *live* KDNET target** — `pool_find_tag`/`pool_census`
   traverse every free tree node-by-node over the wire, and a live target mutates the lists under
   the walk (stale pointers get chased, diagnostics balloon), so the call can exceed the engine

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -164,6 +164,15 @@ processes, so they need real ones:
   from one step and interpolated into the next) and one to `FAILED at step 2 of 3`, with the same
   `always` block on both. The claim only a real engine can settle is the second one: the rollback
   ran **inside the worker process**, on the failing path, before the tool call returned.
+- *A walk marks what it cannot read and keeps going.* The claim
+  [#103](https://github.com/glslang/windbg-mcp/issues/103) is about, and the one that needs a real
+  engine: `src/walk.rs` proves the traversal against a fake address space, and this proves the
+  holes behave the same when they are DbgEng's. It asserts the **contrast** rather than describing
+  it — `execute { "? poi(0x1000)" }` fails outright (the low 64 KB is reserved on every Windows
+  target, so it needs no knowledge of this dump), while `walk_memory` returns the same address as a
+  row between two module bases whose `MZ` it really read. Then array mode over the `nt` DOS header
+  at its own field widths, and a chain from that unmapped address, which must stop with
+  `unreadable_link` **naming the node** and carry the engine's reason for reading nothing at all.
 - *A pool walk takes this server's deadline, not the walker's default.* Asserted against the
   worker's log (`RUST_LOG=windbg_mcp=debug`) rather than against the answer, because on a dump the
   number has no visible consequence — the pool is local memory, so every budget from 15s to 120s

--- a/skills/windbg-debugging/SKILL.md
+++ b/skills/windbg-debugging/SKILL.md
@@ -31,7 +31,7 @@ already does the job.
 | Group | Tools |
 |-------|-------|
 | Session | `open_dump`, `open_trace`, `attach_kernel_local`, `attach_kernel`, `attach_process`, `launch`, `end_session`, `session_status` |
-| State | `registers`, `read_memory`, `backtrace`, `modules`, `threads`, `disassemble`, `dx` |
+| State | `registers`, `read_memory`, `walk_memory`, `backtrace`, `modules`, `threads`, `disassemble`, `dx` |
 | Control | `go`, `step_over`, `step_into`, `set_breakpoint`, `run_to_address` |
 | Transaction | `debug_batch` — an ordered sequence with assertions and a rollback the engine runs, not the client |
 | TTD nav | `step_back` (`t-`), `step_over_back` (`p-`), `reverse_go` (`g-`), `goto_position` (`!tt`) |
@@ -129,6 +129,14 @@ inside the debugger, so a batch built from long steps waits out the one it is in
   `open_dump` runs `.load ext` for you.
 - **`read_memory` takes a numeric/`0x`-hex address only.** For a register/symbol
   expression use `execute` with `db`/`dd` (e.g. `db @rip`).
+- **Never walk a list with a MASM `.for` loop — use `walk_memory`.** One unmapped `poi` aborts
+  the *whole* script with `0x80040205` and returns nothing, so a table with one freed entry in it
+  tells you only that something failed. `walk_memory` marks the hole and keeps going. Name the
+  nodes with `addresses` (an explicit list), `start` + `stride` (an array), or `start` +
+  `next_offset` (a chain), and `fields` to read out of each; offsets may be negative, so a pool
+  header at `-16` is an argument. A chain is the one walk a hole stops — it says which node —
+  and it also reports null links, loops (with where the list closed), and the resume address
+  when it hits `count`.
 - **Single-stepping needs a live thread context** — valid only once the target is stopped
   after a `go`/step or a breakpoint hit. Stepping straight after `goto_position 0` (before
   any thread is live) returns `0x80040205`; `go` to a breakpoint first.

--- a/skills/windbg-debugging/crash-dump.md
+++ b/skills/windbg-debugging/crash-dump.md
@@ -100,6 +100,8 @@ offending frame. No elevation needed; works on System32's engine.
   page raises `An unexpected exception was raised (0x80040205)` (not a clean read error), and a
   full-struct `dt` can hit it just by following a pointer into a missing page — read the one
   field you need (`dt nt!_DRIVER_OBJECT <addr> DriverName`) and prefer the addresses
-  `!ext.analyze` already resolved (PDO, IRP, DRIVER_OBJECT live in the triage data).
+  `!ext.analyze` already resolved (PDO, IRP, DRIVER_OBJECT live in the triage data). To read the
+  same field across many objects, use `walk_memory` rather than a `.for` loop: one uncaptured page
+  aborts the whole loop, while the walk marks that node and reads the rest.
 - For a kernel dump, `!ext.analyze -v` reports the **bugcheck code and arguments** — start
   there rather than from the raw stack.

--- a/skills/windbg-debugging/live-and-kernel.md
+++ b/skills/windbg-debugging/live-and-kernel.md
@@ -69,6 +69,10 @@ four at a time).
   launcher). Attach to a classic Win32 process instead.
 - **`read_memory` is numeric/hex only.** Use `execute` → `db @rip` for register/symbol
   expressions.
+- **Walk driver lists and handle tables with `walk_memory`, not a `.for` loop.** A freed node
+  whose page has gone takes a MASM loop down with `0x80040205` and no partial output; the walk
+  marks it and continues, and a chain reports the node whose link would not read. Fields of one
+  structure cost a single read per node, which matters over KDNET.
 - **`go` is bounded by the per-call timeout** (~60s). A long-running live target may not
   reach a breakpoint within one call; on a live kernel it is force-broken at the cap.
 - **Unreachable kernel target waits forever.** `attach_kernel` to a target that never

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ mod server;
 mod structured;
 mod triage;
 mod ttd;
+mod walk;
 mod worker;
 
 use std::time::Duration;

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -28,6 +28,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::batch::BatchOp;
 use crate::kdconn::Connection;
+use crate::walk::WalkOp;
 
 /// One unit of debugger work, as it crosses the process boundary.
 ///
@@ -112,6 +113,20 @@ pub enum EngineOp {
         address: String,
         size: u32,
     },
+    /// A structure traversal: a list of addresses, an array, or a pointer chain, with named
+    /// fields read out of every node ([`crate::walk`]).
+    ///
+    /// One indivisible job for the usual reason and one of its own. The usual one: it is up to a
+    /// thousand reads, and letting another call for the same session interleave would let the
+    /// table describe a target that moved between its rows. Its own: the walk is a **long run of
+    /// reads with no command behind it**, so win-kexp's watchdog — which bounds an `Execute` —
+    /// has nothing to bound. The only thing that keeps it inside its caller's wait is the
+    /// deadline it checks between nodes, and that arithmetic needs the queue wait only the worker
+    /// can see.
+    ///
+    /// `patience_ms` lives inside [`WalkOp`], filled in and derived exactly as
+    /// [`Self::BoundedCommand`]'s is.
+    Walk(WalkOp),
     SymbolPath {
         path: String,
         append: bool,
@@ -227,6 +242,7 @@ impl EngineOp {
             Self::BoundedCommand { patience_ms, .. }
             | Self::Pool { patience_ms, .. }
             | Self::CrashTriage { patience_ms, .. }
+            | Self::Walk(WalkOp { patience_ms, .. })
             | Self::Batch(BatchOp { patience_ms, .. }) => Some(patience_ms),
             _ => None,
         }
@@ -408,6 +424,10 @@ mod tests {
                 analyze: true,
                 patience_ms: 0,
             },
+            EngineOp::Walk(
+                WalkOp::new(Some(vec!["0x1000".into()]), None, None, None, None, None)
+                    .expect("a one-address walk"),
+            ),
             EngineOp::Batch(BatchOp {
                 budget_ms: 1_000,
                 patience_ms: 0,

--- a/src/server.rs
+++ b/src/server.rs
@@ -24,6 +24,7 @@ use crate::kdconn;
 use crate::proto::{EngineOp, Output, PoolOp, ReachabilityOp};
 use crate::structured::{self, ErrorCategory, Outcome, TargetCreated};
 use crate::ttd;
+use crate::walk;
 
 /// How long to wait for an execution-control command (go/step/reverse) to reach its
 /// next stop (ms).
@@ -1255,6 +1256,39 @@ pub struct ReadMemoryArgs {
     pub address: String,
     /// Number of bytes to read.
     pub size: u32,
+    /// Session handle from open_dump/open_trace/attach_*/launch. Optional; pass it to
+    /// refuse the call if this server's debug target has been replaced since you opened it.
+    #[serde(default)]
+    pub session_id: Option<String>,
+}
+
+#[derive(Deserialize, JsonSchema)]
+pub struct WalkMemoryArgs {
+    /// Walk these addresses exactly, in this order. The bulk read: pass the pointers you already
+    /// have and get a value for each, with the unreadable ones marked instead of ending the walk.
+    /// Each is decimal, "0x"-hex, or the debugger's backtick form ("ffffc00f`6ec02f90"); a bare
+    /// run of 8+ hex digits is read as hex. Mutually exclusive with `start`.
+    #[serde(default)]
+    pub addresses: Option<Vec<String>>,
+    /// Where an array or a chain starts. An address, or any expression `?` evaluates — a symbol
+    /// ("MessageManager!g_Table"), an offset from one, or "poi(<head>)" when the list head is a
+    /// link rather than a node. Needs `stride` or `next_offset` beside it.
+    #[serde(default)]
+    pub start: Option<String>,
+    /// Array mode: bytes from one element to the next. Negative walks downwards.
+    #[serde(default)]
+    pub stride: Option<i64>,
+    /// Chain mode: byte offset within a node of the pointer to the next node (0 for a
+    /// `_LIST_ENTRY.Flink` at the top of the structure).
+    #[serde(default)]
+    pub next_offset: Option<i64>,
+    /// Most nodes to walk (default 64, max 1024). Not for `addresses`, which is its own count.
+    #[serde(default)]
+    pub count: Option<u32>,
+    /// Values to read out of each node. Omit for one pointer at offset 0 — or, for a chain,
+    /// nothing beyond the links it already reports.
+    #[serde(default)]
+    pub fields: Option<Vec<walk::FieldArg>>,
     /// Session handle from open_dump/open_trace/attach_*/launch. Optional; pass it to
     /// refuse the call if this server's debug target has been replaced since you opened it.
     #[serde(default)]
@@ -2690,6 +2724,65 @@ impl WindbgServer {
         engine_result(out)
     }
 
+    /// Walk a structure and read named fields out of every node — **without one unreadable
+    /// address ending the walk**.
+    /// This is the tool for a list, a handle table or a pointer array where some entries are
+    /// freed: a MASM `.for` loop through `execute` aborts on the first unmapped dereference with
+    /// `0x80040205` and no partial output, which loses exactly the node worth looking at. Here an
+    /// unreadable value is `null` in its own field, an unreadable node is counted, and the walk
+    /// carries on.
+    /// Three ways to name the nodes, one of them required: `addresses` (an explicit list — the
+    /// bulk read), `start` + `stride` (an array), or `start` + `next_offset` (a pointer chain).
+    /// `fields` says what to read from each node; offsets may be negative, so a pool header at
+    /// -16 is one argument.
+    /// A chain is the exception to "a hole does not stop it": a node whose next pointer will not
+    /// read has no address after it, so the walk stops and says which node. It also stops on a
+    /// null link, on a loop (reporting where the list closed — at the head that is a healthy
+    /// circular `_LIST_ENTRY`, anywhere else it is corruption), and at `count`, where it hands
+    /// back the address to resume from.
+    /// Two calls answer the usual question: walk the table for the object pointers, then walk
+    /// those pointers as `addresses` for their fields.
+    #[rmcp::tool(
+        annotations(
+            title = "Walk a structure in memory",
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
+        output_schema = schema_for_output::<Outcome<structured::MemoryWalk>>()
+    )]
+    async fn walk_memory(
+        &self,
+        Parameters(args): Parameters<WalkMemoryArgs>,
+    ) -> Result<CallToolResult, ErrorData> {
+        // `start` is interpolated into a `?`, so it is an operand like every other one this
+        // server builds a command around.
+        if let Some(start) = &args.start
+            && let Err(e) = reject_command_breakers("start", start, Quotes::Rejected)
+        {
+            return typed_error(ErrorCategory::InvalidArgument, e, args.session_id);
+        }
+        let op = match walk::WalkOp::new(
+            args.addresses,
+            args.start,
+            args.stride,
+            args.next_offset,
+            args.count,
+            args.fields,
+        ) {
+            Ok(op) => op,
+            // Refused here, before a session is chosen. Every one of these is a fact about the
+            // request rather than about a target, so a caller learns about it now instead of
+            // after queueing behind whatever that session is busy with.
+            Err(why) => return typed_error(ErrorCategory::InvalidArgument, why, args.session_id),
+        };
+        let out = self
+            .run(args.session_id.as_deref(), EngineOp::Walk(op))
+            .await;
+        engine_result_for(args.session_id.as_deref(), out)
+    }
+
     /// Show the call stack of the current thread (`k`).
     #[rmcp::tool(annotations(
         title = "Show call stack",
@@ -3550,7 +3643,13 @@ mod tests {
             assert_eq!(ann(name).destructive_hint, Some(true), "`{name}`");
         }
 
-        for name in ["read_memory", "backtrace", "modules", "decode_ioctl"] {
+        for name in [
+            "read_memory",
+            "walk_memory",
+            "backtrace",
+            "modules",
+            "decode_ioctl",
+        ] {
             assert_eq!(
                 ann(name).read_only_hint,
                 Some(true),

--- a/src/structured.rs
+++ b/src/structured.rs
@@ -1084,8 +1084,13 @@ pub struct WalkNode {
     pub index: u32,
     pub address: String,
     /// The link this node held, for a chain — the address the walk went to next. `null` when the
-    /// link could not be read, which for a chain is also where the walk ends.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    /// link could not be read, which for a chain is also where the walk ends, and always for a
+    /// list or an array, which follow no link.
+    ///
+    /// **Always present, `null` included.** The two nullable fields on a walk are the ones a
+    /// caller reads to find the holes, so an omitted key would make "this node's link is
+    /// unreadable" and "this object came back malformed" the same observation — see
+    /// [`WalkFieldValue::value`].
     pub next: Option<String>,
     pub fields: Vec<WalkFieldValue>,
     /// Whether *anything* at this node could be read. `false` is the interesting case in a
@@ -1105,7 +1110,13 @@ pub struct WalkFieldValue {
     /// The value, zero-extended to 64 bits and rendered in this module's one address form
     /// whatever [`Self::size`] is — so a client never has to know a field's width to compare it.
     /// `null` means the debugger could not read those bytes.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    ///
+    /// **Always present, `null` included** — the one place in this module where an absent key
+    /// would be wrong rather than tidy. Everywhere else `null` is the boring case and omitting it
+    /// saves noise; here it *is* the finding, and a client that has to tell a missing key from a
+    /// null one is doing extra work to read the answer the tool exists to give. `MemoryWalk`'s own
+    /// optional fields ([`MemoryWalk::start`], [`MemoryWalk::note`]) keep the usual treatment,
+    /// because "there is no start" and "nothing needed explaining" really are absences.
     pub value: Option<String>,
 }
 
@@ -1369,6 +1380,56 @@ mod tests {
         let inline = breakpoint(BreakpointKind::Other { kind_code: 3 });
         assert_eq!(inline["kind"], "other");
         assert_eq!(inline["kind_code"], 3);
+    }
+
+    /// A walk's two nullable fields are **present and null**, never absent.
+    ///
+    /// They are the ones a caller reads to find the holes, which is the whole point of the tool,
+    /// so an omitted key would make "the debugger could not read this" and "this object came back
+    /// malformed" the same observation — and leave every client writing missing-key handling to
+    /// read the ordinary answer. The rest of the module keeps `skip_serializing_if`, where an
+    /// absence really is one.
+    #[test]
+    fn an_unreadable_value_is_a_null_not_a_missing_key() {
+        let node = WalkNode {
+            index: 0,
+            address: addr(0x1000),
+            next: None,
+            fields: vec![WalkFieldValue {
+                name: "value".into(),
+                address: addr(0x1000),
+                size: 8,
+                value: None,
+            }],
+            readable: false,
+        };
+        let wire = serde_json::to_value(&node).unwrap();
+        assert!(
+            wire.get("next").is_some_and(serde_json::Value::is_null),
+            "{wire}"
+        );
+        assert!(
+            wire["fields"][0]
+                .get("value")
+                .is_some_and(serde_json::Value::is_null),
+            "{wire}"
+        );
+
+        // The walk's own optionals keep the usual treatment: "there is no start" and "nothing
+        // needed explaining" are absences, not findings.
+        let walk = MemoryWalk {
+            mode: WalkMode::List,
+            start: None,
+            requested: 1,
+            walked: 1,
+            unreadable: 1,
+            nodes: vec![node],
+            stopped: WalkStop::Complete,
+            note: None,
+        };
+        let wire = serde_json::to_value(&walk).unwrap();
+        assert!(wire.get("start").is_none(), "{wire}");
+        assert!(wire.get("note").is_none(), "{wire}");
     }
 
     /// A chunk's state is four named values, and the fourth is not a kind of free.

--- a/src/structured.rs
+++ b/src/structured.rs
@@ -1026,6 +1026,118 @@ pub struct AnalysisInfo {
     pub note: Option<String>,
 }
 
+// ---- memory walks ---------------------------------------------------------
+
+/// What `walk_memory` visited, what it read at each node, and why it stopped.
+///
+/// The shape exists because a walk's *holes* are its most valuable output. A MASM `.for` loop
+/// through `execute` answers all-or-nothing — one unmapped dereference and the whole script is
+/// `0x80040205` with no rows at all — and in pool work "some of these nodes are freed" is the
+/// normal case ([#103](https://github.com/glslang/windbg-mcp/issues/103)). So a value that could
+/// not be read is a `null` in its own field, a node where nothing could be read is counted, and
+/// the walk carries on.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct MemoryWalk {
+    pub mode: WalkMode,
+    /// The resolved address the walk started from. Absent for a list of addresses, which has no
+    /// start — every entry is one address among many rather than the place a traversal began.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub start: Option<String>,
+    /// How many nodes the walk was asked for: `count`, or the length of the address list.
+    pub requested: u32,
+    /// How many it actually produced. Short of `requested` means it stopped early, and
+    /// [`Self::stopped`] says why — which is never "an address would not read", for an array or
+    /// a list.
+    pub walked: u32,
+    /// How many of those nodes yielded **no** readable value at all. A node with one unreadable
+    /// field among several is not one of these; per-field `value: null` marks those.
+    pub unreadable: u32,
+    pub nodes: Vec<WalkNode>,
+    pub stopped: WalkStop,
+    /// Why *nothing* could be read, when nothing could: the debugger's own words for the first
+    /// failed read.
+    ///
+    /// Present only when every node came back unreadable, which is the one case where this tool's
+    /// answer is ambiguous. A list of freed objects legitimately reads that way — and so does a
+    /// target that is not broken in, a session whose engine has let go, or a `start` pointing at
+    /// nothing. Without the engine's message those are the same table.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub note: Option<String>,
+}
+
+/// How a walk found its nodes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum WalkMode {
+    /// Addresses supplied outright.
+    List,
+    /// `start + i * stride`.
+    Array,
+    /// The pointer at `node + next_offset`, followed.
+    Chain,
+}
+
+/// One node: where it was, what it held, and whether anything there could be read.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct WalkNode {
+    /// Position in the walk, from 0.
+    pub index: u32,
+    pub address: String,
+    /// The link this node held, for a chain — the address the walk went to next. `null` when the
+    /// link could not be read, which for a chain is also where the walk ends.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub next: Option<String>,
+    pub fields: Vec<WalkFieldValue>,
+    /// Whether *anything* at this node could be read. `false` is the interesting case in a
+    /// use-after-free walk: the node's page is gone.
+    pub readable: bool,
+}
+
+/// One field of one node.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct WalkFieldValue {
+    /// The column name, as the request gave it or defaulted to the offset (`+0x18`).
+    pub name: String,
+    /// Where this value was read from: the node's address plus the field's offset.
+    pub address: String,
+    /// Bytes read: 1, 2, 4 or 8.
+    pub size: u32,
+    /// The value, zero-extended to 64 bits and rendered in this module's one address form
+    /// whatever [`Self::size`] is — so a client never has to know a field's width to compare it.
+    /// `null` means the debugger could not read those bytes.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub value: Option<String>,
+}
+
+/// Why a walk ended.
+///
+/// Seven reasons rather than a `complete` flag, because they call for opposite responses: a chain
+/// that hit a null link is *finished*, one that hit the cap has more to walk and says where from,
+/// one that hit an unreadable link has more that cannot be reached from here, and one the clock
+/// stopped may have all of it still there.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "reason", rename_all = "snake_case")]
+pub enum WalkStop {
+    /// Every node asked for was visited. Holes in an array or a list are reported per node and do
+    /// not stop the walk, so this is the ordinary outcome for both.
+    Complete,
+    /// A chain reached the requested `count` with the list still going. `next` is the address to
+    /// walk from to continue.
+    Cap { next: String },
+    /// A chain's next pointer is null: the list ends here.
+    NullLink,
+    /// A chain arrived at a node it had already visited. At the head that is the ordinary end of
+    /// a circular `_LIST_ENTRY`; anywhere else it is a corrupted list, which is a finding.
+    Loop { at: String },
+    /// A chain's next pointer could not be read, so there is no address to continue from. Only a
+    /// chain ends this way — an array's next address is arithmetic and a list's was supplied.
+    UnreadableLink { at: String },
+    /// The call's remaining time ran out. What is missing is unknown rather than absent.
+    Deadline,
+    /// `interrupt` was called on this session.
+    Interrupted,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -419,6 +419,14 @@ pub enum Halt {
 /// node 3 and still pay for node 4's round trips. What it stops is reported as the walk's outcome
 /// rather than as a failure, and the nodes already read come back — a walk cut short is this tool
 /// working, not this tool breaking.
+///
+/// **There is deliberately no poll after the last node**, which looks like a gap and is not. The
+/// loop leaves four ways: the count was reached, the address list ran out, a chain ended on its own
+/// terms, or `halt` fired — so the only path on which an interrupt *truncates* a walk is the one
+/// that already observes it. A break landing during the final read changed nothing, and recording
+/// it in [`structured::WalkStop`] would report a truncation that did not happen, telling a caller
+/// the rest is unknown when there is no rest. The interrupt is a fact about the **call**, and
+/// `worker::cut_short` says so in the prose, for every tool alike.
 pub fn run(
     source: &Resolved,
     fields: &[Field],

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -68,6 +68,19 @@ pub const MAX_NODES: u32 = 1024;
 /// Most fields one node may be asked for.
 pub const MAX_FIELDS: usize = 16;
 
+/// Longest a field's name may be.
+///
+/// The one argument here that is **amplified**, which is why it needs a bound of its own on top of
+/// [`MAX_NODES`] and [`MAX_FIELDS`]. Every other input is spent once — an address is parsed to a
+/// `u64` and dropped — but a name is cloned into each field of each node, rendered into the table,
+/// and serialized again, so a single large one becomes up to 16,384 copies and can take the worker
+/// out of memory. That costs the caller their session, which is exactly what the node and field
+/// caps exist to prevent, arriving through the argument they do not cover.
+///
+/// 64 characters, because this is a **column header**. The generated default is `+0x18`; a name
+/// wider than the value beneath it has already stopped helping anyone read the table.
+pub const MAX_FIELD_NAME: usize = 64;
+
 /// Nodes a walk visits when the caller names no `count`.
 const DEFAULT_NODES: u32 = 64;
 
@@ -127,7 +140,7 @@ pub struct Field {
 /// place that cannot see the rest of the request to make it consistently.
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
 pub struct FieldArg {
-    /// Column name for this value. Defaults to the offset, e.g. `+0x18`.
+    /// Column name for this value, at most 64 characters. Defaults to the offset, e.g. `+0x18`.
     #[serde(default)]
     pub name: Option<String>,
     /// Byte offset within the node. Negative reads *behind* it — a pool header is at -16.
@@ -287,6 +300,18 @@ impl WalkOp {
                 if !FIELD_SIZES.contains(&size) {
                     return Err(format!(
                         "field size {size} is not a width the debugger reads: pass 1, 2, 4 or 8."
+                    ));
+                }
+                // Counted in `char`s rather than bytes, so the limit a caller is told is the one
+                // they can see: a name of accented or CJK characters must not be refused at a
+                // third of its apparent length.
+                if let Some(name) = &field.name
+                    && name.chars().count() > MAX_FIELD_NAME
+                {
+                    return Err(format!(
+                        "a field name is {} characters; this tool allows {MAX_FIELD_NAME}. It is \
+                         a column header, and it is copied into every node the walk returns.",
+                        name.chars().count()
                     ));
                 }
                 Ok(Field {
@@ -1222,6 +1247,44 @@ mod tests {
 
         let chain = WalkOp::new(None, Some("0x1000".into()), None, Some(0), None, None).unwrap();
         assert!(chain.fields.is_empty());
+    }
+
+    /// The one argument that is *amplified* — a name is copied into every field of every node —
+    /// so the node and field caps do not bound it and it needs its own.
+    #[test]
+    fn a_field_name_is_bounded_because_it_is_copied_per_node() {
+        let err = WalkOp::new(
+            None,
+            Some("0x1000".into()),
+            Some(8),
+            None,
+            None,
+            Some(vec![FieldArg {
+                name: Some("n".repeat(MAX_FIELD_NAME + 1)),
+                offset: 0,
+                size: None,
+            }]),
+        )
+        .unwrap_err();
+        assert!(err.contains("column header"), "{err}");
+
+        // And the bound is on characters a reader sees, not on the bytes they encode to: a name
+        // of CJK characters must not be refused at a third of its apparent length.
+        assert!(
+            WalkOp::new(
+                None,
+                Some("0x1000".into()),
+                Some(8),
+                None,
+                None,
+                Some(vec![FieldArg {
+                    name: Some("識".repeat(MAX_FIELD_NAME)),
+                    offset: 0,
+                    size: None,
+                }]),
+            )
+            .is_ok()
+        );
     }
 
     #[test]

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -1,0 +1,1320 @@
+//! Walking memory node by node, where **an unreadable node is a row rather than an end**.
+//!
+//! The natural way to inspect a kernel list through this server used to be a MASM loop through
+//! `execute`:
+//!
+//! ```text
+//! r @$t0 = poi(<head>); .for (...) { r @$t9 = poi(@$t7+8); r @$ta = poi(@$t9) ... }
+//! ```
+//!
+//! One node pointing at a freed chunk whose page has come back unmapped ends the whole script
+//! with `An unexpected exception was raised (0x80040205)`: no rows, no iteration number, no
+//! indication of how many nodes were classified before it. Driving the MessageManager
+//! use-after-free that meant bisecting a 512-entry handle table by hand to find the one bad
+//! pointer — which was, inevitably, the pointer the walk existed to find
+//! ([#103](https://github.com/glslang/windbg-mcp/issues/103)).
+//!
+//! That is backwards for this server in particular. Its subject is pool and UAF analysis, where
+//! "some of these nodes are freed" is the normal case and not an error, so a walk has to report
+//! the holes rather than die on the first one. Every read here is its own `ReadVirtual`, and one
+//! that fails marks a value unreadable and leaves the walk running.
+//!
+//! # Three ways to name the nodes, one way to read them
+//!
+//! * `addresses` — an explicit list. The bulk read: N pointers, N answers, no arithmetic.
+//! * `start` + `stride` — an array. Element `i` is `start + i * stride`.
+//! * `start` + `next_offset` — a chain. The next node is the pointer at `node + next_offset`.
+//!
+//! `fields` then says what to pull out of each node, and applies to all three. A caller with 512
+//! handle-table slots reads the message pointer out of each in one call, and reads the refcount
+//! out of those 512 pointers in a second — one round trip per *question* rather than per node,
+//! and neither call has an iteration that can abort the rest.
+//!
+//! # Why a chain stops and an array does not
+//!
+//! An unreadable node in an array or a list costs that node's values and nothing else: the next
+//! address is arithmetic, or was supplied. An unreadable node in a *chain* costs the walk, because
+//! the address of everything after it lived in the bytes that would not read. So the two behave
+//! differently on purpose, and the report says which happened
+//! ([`structured::WalkStop::UnreadableLink`]).
+//!
+//! A chain also stops on a **loop**, which is not an error either: a list that points back into
+//! itself is a finding, and every address visited is kept so the walk reports where it closed
+//! instead of running to its cap.
+//!
+//! # Engine-free
+//!
+//! [`run`] takes a reader closure rather than a `DebugEngine`, exactly as
+//! [`crate::server::reachability`] takes a disassembler: the traversal, the span coalescing, the
+//! loop detection and the rendering are all testable against a fake address space, and the worker
+//! supplies the one closure that touches DbgEng.
+
+use std::collections::HashSet;
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::structured::{self, addr};
+
+/// Most nodes one walk will visit.
+///
+/// A guard against the worker, not a judgement about what is useful. The reply is built as a
+/// single `String` before it crosses the pipe, and each node is a row plus a cell per field — so
+/// an unbounded `count` is a request to allocate a table nobody asked for, in a process whose
+/// death costs the caller their session. It is also the read budget: over KDNET every node is at
+/// least one round trip on the wire.
+pub const MAX_NODES: u32 = 1024;
+
+/// Most fields one node may be asked for.
+pub const MAX_FIELDS: usize = 16;
+
+/// Nodes a walk visits when the caller names no `count`.
+const DEFAULT_NODES: u32 = 64;
+
+/// Sizes a field may have: the four widths the debugger's own `db`/`dw`/`dd`/`dq` read.
+const FIELD_SIZES: [u32; 4] = [1, 2, 4, 8];
+
+/// The widest run of bytes this will fetch in one read to satisfy several fields at once.
+///
+/// Fields of one structure sit close together, so a single read of the span they cover is one
+/// round trip instead of one per field — over a KD link that is the difference between a walk that
+/// answers and a walk that times out. Past this the span has stopped being "one structure" and
+/// become a request to haul back memory nobody asked about, so the walk reads each field on its
+/// own instead.
+const MAX_SPAN: i64 = 4096;
+
+/// Where a walk's nodes come from, as the tool's arguments name them.
+///
+/// The three are exclusive rather than combinable: each answers "what is the next address?", and a
+/// request naming two would have to pick one silently.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum Source {
+    /// Addresses supplied outright, already parsed. Nothing is derived, so every entry is visited
+    /// whether or not the one before it could be read.
+    List { addresses: Vec<u64> },
+    /// `start + i * stride`, `count` times. `stride` is signed so an array that runs downwards is
+    /// an argument rather than a different tool.
+    Array {
+        start: String,
+        stride: i64,
+        count: u32,
+    },
+    /// `start`, then the pointer at `node + next_offset`, up to `count` nodes.
+    Chain {
+        start: String,
+        next_offset: i64,
+        count: u32,
+    },
+}
+
+/// One value to read out of every node.
+///
+/// `offset` is signed because the interesting field is often *behind* the pointer a caller holds:
+/// a pool chunk's header sits 0x10 bytes before the address the allocator returned, and asking for
+/// it should not mean doing the subtraction per node and losing the table's alignment with the
+/// pointers the target actually stores.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Field {
+    pub name: String,
+    pub offset: i64,
+    pub size: u32,
+}
+
+/// A field as the tool takes it, before defaults.
+///
+/// Separate from [`Field`] so the wire form has no optional halves: a `size` still `None` on the
+/// far side of the pipe is a decision the worker would have to make, and the worker is the one
+/// place that cannot see the rest of the request to make it consistently.
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+pub struct FieldArg {
+    /// Column name for this value. Defaults to the offset, e.g. `+0x18`.
+    #[serde(default)]
+    pub name: Option<String>,
+    /// Byte offset within the node. Negative reads *behind* it — a pool header is at -16.
+    pub offset: i64,
+    /// Bytes to read: 1, 2, 4 or 8. Defaults to 8 (a pointer).
+    #[serde(default)]
+    pub size: Option<u32>,
+}
+
+/// A memory walk, as it crosses the pipe.
+///
+/// `patience_ms` is filled in by the supervisor's pump like every other deadline-carrying op — the
+/// value a caller constructs is ignored. A walk is a long run of reads with no *command* behind
+/// it, so win-kexp's watchdog cannot cut it short; the deadline it checks between nodes is the
+/// only thing keeping it from outliving the caller who asked for it.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WalkOp {
+    pub source: Source,
+    pub fields: Vec<Field>,
+    pub patience_ms: u32,
+}
+
+impl WalkOp {
+    /// Validates a request and fills in its defaults, or says what is wrong with it.
+    ///
+    /// **On the supervisor's side, before a worker is involved.** Everything checked here is a
+    /// fact about the request rather than about the target — the wrong number of traversal
+    /// arguments, a field width the debugger has no read for, a count past the cap — so answering
+    /// it costs nobody a round trip, and a session busy with something else does not have to
+    /// become idle before a caller learns they made a typo.
+    pub fn new(
+        addresses: Option<Vec<String>>,
+        start: Option<String>,
+        stride: Option<i64>,
+        next_offset: Option<i64>,
+        count: Option<u32>,
+        fields: Option<Vec<FieldArg>>,
+    ) -> Result<Self, String> {
+        let source = Self::source(addresses, start, stride, next_offset, count)?;
+        Ok(Self {
+            fields: Self::fields(fields, &source)?,
+            source,
+            patience_ms: 0,
+        })
+    }
+
+    fn source(
+        addresses: Option<Vec<String>>,
+        start: Option<String>,
+        stride: Option<i64>,
+        next_offset: Option<i64>,
+        count: Option<u32>,
+    ) -> Result<Source, String> {
+        match count {
+            // Refused rather than clamped. A clamp answers a different question than the one asked
+            // and then labels the result complete — and "every node asked for was visited" is the
+            // one sentence a caller reads to decide whether to look further, so it must never be
+            // about a count this server quietly lowered. A chain that stops at its cap hands back
+            // where to resume, which is the shape a caller with more to walk actually needs.
+            Some(count) if count > MAX_NODES => {
+                return Err(format!(
+                    "`count` is {count}; this tool walks at most {MAX_NODES} nodes in one call. \
+                     Walk in pieces — a chain that stops at its cap reports the address to resume \
+                     from, and an array is arithmetic."
+                ));
+            }
+            Some(0) => return Err("`count` is 0, so there is nothing to walk.".to_string()),
+            _ => {}
+        }
+        let nodes = count.unwrap_or(DEFAULT_NODES);
+        match (addresses, start, stride, next_offset) {
+            (Some(addresses), None, None, None) => {
+                if count.is_some() {
+                    return Err(
+                        "`addresses` and `count` say the same thing twice: the list is \
+                                the count. Pass the addresses you want walked."
+                            .to_string(),
+                    );
+                }
+                if addresses.is_empty() {
+                    return Err("`addresses` is empty, so there is nothing to walk.".to_string());
+                }
+                if addresses.len() > MAX_NODES as usize {
+                    return Err(format!(
+                        "`addresses` holds {} entries; this tool walks at most {MAX_NODES} nodes \
+                         in one call.",
+                        addresses.len()
+                    ));
+                }
+                Ok(Source::List {
+                    addresses: addresses
+                        .iter()
+                        .map(|a| parse_addr(a))
+                        .collect::<Result<_, _>>()?,
+                })
+            }
+            (Some(_), _, _, _) => Err("`addresses` supplies the nodes outright, so it cannot be \
+                                       combined with `start`, `stride` or `next_offset`."
+                .to_string()),
+            (None, Some(start), Some(stride), None) => Ok(Source::Array {
+                start,
+                stride,
+                count: nodes,
+            }),
+            (None, Some(start), None, Some(next_offset)) => Ok(Source::Chain {
+                start,
+                next_offset,
+                count: nodes,
+            }),
+            (None, Some(_), Some(_), Some(_)) => Err(
+                "`stride` and `next_offset` are two different walks: `stride` steps through an \
+                 array, `next_offset` follows a pointer chain. Pass one."
+                    .to_string(),
+            ),
+            (None, Some(_), None, None) => Err(
+                "`start` needs a traversal beside it: `stride` to step through an array, or \
+                 `next_offset` to follow a pointer chain."
+                    .to_string(),
+            ),
+            (None, None, _, _) => Err(
+                "no nodes to walk. Pass `addresses` (an explicit list), or `start` with `stride` \
+                 (an array) or `next_offset` (a pointer chain)."
+                    .to_string(),
+            ),
+        }
+    }
+
+    /// The fields to read from every node, defaulted by what the walk already reports.
+    ///
+    /// A list or an array with no fields named is the bulk-read case — "what is the pointer at
+    /// each of these addresses?" — so it defaults to one qword at offset 0. A **chain** already
+    /// reports the link it followed out of every node, so the same default there would print one
+    /// column twice; it defaults to nothing instead, and a chain walked with no fields is a list
+    /// of nodes and their links, which is exactly what a caller checking a list's shape asked for.
+    fn fields(fields: Option<Vec<FieldArg>>, source: &Source) -> Result<Vec<Field>, String> {
+        let fields = fields.unwrap_or_default();
+        if fields.is_empty() {
+            return Ok(match source {
+                Source::Chain { .. } => Vec::new(),
+                _ => vec![Field {
+                    name: "value".to_string(),
+                    offset: 0,
+                    size: 8,
+                }],
+            });
+        }
+        if fields.len() > MAX_FIELDS {
+            return Err(format!(
+                "`fields` names {} values; this tool reads at most {MAX_FIELDS} per node.",
+                fields.len()
+            ));
+        }
+        fields
+            .into_iter()
+            .map(|field| {
+                let size = field.size.unwrap_or(8);
+                if !FIELD_SIZES.contains(&size) {
+                    return Err(format!(
+                        "field size {size} is not a width the debugger reads: pass 1, 2, 4 or 8."
+                    ));
+                }
+                Ok(Field {
+                    name: field.name.unwrap_or_else(|| offset_name(field.offset)),
+                    offset: field.offset,
+                    size,
+                })
+            })
+            .collect()
+    }
+}
+
+/// The default column name for an unnamed field: its offset, as a caller would write it.
+fn offset_name(offset: i64) -> String {
+    if offset < 0 {
+        format!("-0x{:x}", offset.unsigned_abs())
+    } else {
+        format!("+0x{offset:x}")
+    }
+}
+
+/// Parses an address in any form a caller is likely to paste — the same rule `pool_chunk` uses, so
+/// a chunk address copied out of one tool goes into this one.
+fn parse_addr(text: &str) -> Result<u64, String> {
+    crate::server::parse_windbg_addr(text).map_or_else(|| crate::server::parse_u64(text), Ok)
+}
+
+/// A [`Source`] with its `start` expression resolved to a number.
+///
+/// Separate from [`Source`] because resolving a symbolic start is an engine call and everything
+/// after it is not: the walk below is handed numbers, which is what lets it be tested without one.
+#[derive(Debug, Clone)]
+pub enum Resolved {
+    List(Vec<u64>),
+    Array {
+        start: u64,
+        stride: i64,
+        count: u32,
+    },
+    Chain {
+        start: u64,
+        next_offset: i64,
+        count: u32,
+    },
+}
+
+impl Resolved {
+    /// The first node's address and how many nodes at most, or `None` when there are none to walk.
+    fn head(&self) -> Option<(u64, u32)> {
+        match self {
+            Self::List(addresses) => addresses
+                .first()
+                .map(|first| (*first, addresses.len() as u32)),
+            Self::Array { start, count, .. } | Self::Chain { start, count, .. } => {
+                Some((*start, *count))
+            }
+        }
+    }
+
+    /// The address the caller named as the start, for the report — `None` for a list, whose first
+    /// entry is one address among many rather than a place the walk began from.
+    fn start(&self) -> Option<u64> {
+        match self {
+            Self::List(_) => None,
+            Self::Array { start, .. } | Self::Chain { start, .. } => Some(*start),
+        }
+    }
+
+    /// The link this walk follows out of each node, when it follows one.
+    fn link(&self) -> Option<i64> {
+        match self {
+            Self::Chain { next_offset, .. } => Some(*next_offset),
+            _ => None,
+        }
+    }
+
+    fn mode(&self) -> structured::WalkMode {
+        match self {
+            Self::List(_) => structured::WalkMode::List,
+            Self::Array { .. } => structured::WalkMode::Array,
+            Self::Chain { .. } => structured::WalkMode::Chain,
+        }
+    }
+}
+
+/// Why a walk gave up before it ran out of nodes — the two reasons that are about the *call*
+/// rather than about the target.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Halt {
+    /// The caller's remaining patience ran out.
+    Deadline,
+    /// Someone called `interrupt` on this session.
+    Interrupted,
+}
+
+/// Walks `source`, reading `fields` out of every node it reaches.
+///
+/// `read` fetches bytes and returns `None` for memory the debugger could not read — the whole
+/// point of this module, and a plain `Option` because which of the several ways `ReadVirtual` says
+/// no is not a distinction a caller can act on, while threading a thousand copies of one message
+/// back would bury the table in it.
+///
+/// `halt` is polled **once per node, before its reads**, which is where a bound has to sit when
+/// the loop's body is the expensive part: checking afterwards would let an interrupt arrive during
+/// node 3 and still pay for node 4's round trips. What it stops is reported as the walk's outcome
+/// rather than as a failure, and the nodes already read come back — a walk cut short is this tool
+/// working, not this tool breaking.
+pub fn run(
+    source: &Resolved,
+    fields: &[Field],
+    mut read: impl FnMut(u64, usize) -> Option<Vec<u8>>,
+    mut halt: impl FnMut() -> Option<Halt>,
+) -> structured::MemoryWalk {
+    let (head, count) = source.head().unzip();
+    let count = count.unwrap_or(0);
+    let link = source.link();
+    let mut nodes: Vec<structured::WalkNode> = Vec::new();
+    // Every node visited, so a chain pointing back into itself is reported where it closes rather
+    // than walked to its cap. The head is in here from the first iteration: a circular
+    // `_LIST_ENTRY` returning to it is the ordinary end of a healthy list, not a special case.
+    let mut visited: HashSet<u64> = HashSet::new();
+    let mut unreadable = 0u32;
+    let mut stopped = structured::WalkStop::Complete;
+    let mut index = 0u32;
+    let mut next_node = head;
+
+    while index < count {
+        let Some(at) = next_node else { break };
+        if let Some(halted) = halt() {
+            stopped = match halted {
+                Halt::Deadline => structured::WalkStop::Deadline,
+                Halt::Interrupted => structured::WalkStop::Interrupted,
+            };
+            break;
+        }
+
+        let node = read_node(at, index, fields, link, &mut read);
+        if !node.readable {
+            unreadable += 1;
+        }
+        let followed = node.next.clone();
+        visited.insert(at);
+        nodes.push(node);
+        index += 1;
+
+        next_node = match source {
+            Resolved::List(addresses) => addresses.get(index as usize).copied(),
+            Resolved::Array { stride, .. } => Some(at.wrapping_add_signed(*stride)),
+            Resolved::Chain { .. } => {
+                // `followed` is the link this node held, and the three ways a chain ends are all
+                // statements about it. Each is a finding rather than a failure.
+                let Some(next) = followed.as_deref().and_then(parse_addr_back) else {
+                    stopped = structured::WalkStop::UnreadableLink { at: addr(at) };
+                    break;
+                };
+                if next == 0 {
+                    stopped = structured::WalkStop::NullLink;
+                    break;
+                }
+                if visited.contains(&next) {
+                    stopped = structured::WalkStop::Loop { at: addr(next) };
+                    break;
+                }
+                Some(next)
+            }
+        };
+    }
+
+    // A chain that reached its cap has one more thing to say than "done": where it was up to. The
+    // three ways it could have *ended* are ruled out above — the loop only leaves a link in hand
+    // when it is readable, non-null and unvisited — so this is unambiguously "there is more", and
+    // the address is what a caller walks from next.
+    if matches!(stopped, structured::WalkStop::Complete)
+        && matches!(source, Resolved::Chain { .. })
+        && let Some(next) = next_node
+    {
+        stopped = structured::WalkStop::Cap { next: addr(next) };
+    }
+
+    structured::MemoryWalk {
+        mode: source.mode(),
+        start: source.start().map(addr),
+        requested: count,
+        walked: nodes.len() as u32,
+        unreadable,
+        nodes,
+        stopped,
+        // Filled in by the caller that owns the reader, which is the only side that has the
+        // engine's words for a read that failed. See [`structured::MemoryWalk::note`].
+        note: None,
+    }
+}
+
+/// Whether a walk read nothing at all — the one outcome that needs the reader to explain itself.
+///
+/// A walk of freed objects legitimately comes back this way, and so does one against a target
+/// that is not broken in. They are the same table, so the caller of [`run`] attaches the
+/// debugger's own message when this holds.
+pub fn read_nothing(walk: &structured::MemoryWalk) -> bool {
+    walk.walked > 0 && walk.unreadable == walk.walked
+}
+
+/// Reads one node's fields, and the link out of it when there is one.
+///
+/// The fields are fetched in **one read of the span they cover**, where that span is narrow enough
+/// to be a structure rather than a haul ([`MAX_SPAN`]) — one round trip per node instead of one
+/// per field, which is what lets a 512-node walk finish over a KD link.
+///
+/// When that read fails the fields are read individually, and that is not merely a fallback: a
+/// node straddling a page boundary with only its second page unmapped answers *most* of the
+/// question, and a span read is all-or-nothing about it. Paying for per-field reads only where
+/// there is actually a hole keeps the precise answer and the cheap one at once.
+fn read_node(
+    at: u64,
+    index: u32,
+    fields: &[Field],
+    link: Option<i64>,
+    read: &mut impl FnMut(u64, usize) -> Option<Vec<u8>>,
+) -> structured::WalkNode {
+    // The link is read with the fields rather than after them: it lives in the same structure and
+    // usually in the same span, so folding it in is the difference between one read and two.
+    let reads = fields
+        .iter()
+        .map(|f| (f.offset, f.size))
+        .chain(link.map(|offset| (offset, 8)));
+    let lo = reads.clone().map(|(offset, _)| offset).min();
+    let hi = reads
+        .clone()
+        .map(|(offset, size)| offset.saturating_add(i64::from(size)))
+        .max();
+    // Only worth coalescing when there is more than one read to coalesce. With a single value the
+    // span read *is* that value's read, so a failed one would be retried below against the same
+    // bytes — and the single-value bulk read over a table full of holes is this tool's commonest
+    // shape, which would then cost two round trips per hole instead of one.
+    let coalesce = reads.count() > 1;
+    let buffer = lo
+        .zip(hi)
+        .filter(|(lo, hi)| coalesce && hi.saturating_sub(*lo) <= MAX_SPAN)
+        .and_then(|(lo, hi)| {
+            read(at.wrapping_add_signed(lo), (hi - lo) as usize).map(|bytes| (lo, bytes))
+        });
+
+    // One closure for both routes, so which one served a field cannot change the value it gets.
+    let mut value = |offset: i64, size: u32| -> Option<u64> {
+        match &buffer {
+            Some((lo, bytes)) => {
+                let from = offset.abs_diff(*lo) as usize;
+                bytes.get(from..from.checked_add(size as usize)?).map(le)
+            }
+            None => read(at.wrapping_add_signed(offset), size as usize)
+                .as_deref()
+                .map(le),
+        }
+    };
+
+    let values: Vec<structured::WalkFieldValue> = fields
+        .iter()
+        .map(|field| structured::WalkFieldValue {
+            name: field.name.clone(),
+            address: addr(at.wrapping_add_signed(field.offset)),
+            size: field.size,
+            value: value(field.offset, field.size).map(addr),
+        })
+        .collect();
+    let next = link.and_then(|offset| value(offset, 8)).map(addr);
+
+    structured::WalkNode {
+        index,
+        address: addr(at),
+        // "Nothing here could be read" is the claim worth making about a node, and it is not the
+        // same as any one field failing: a structure whose last qword is unreadable because it
+        // straddles a guard page still answers for the fields before it, and calling that node
+        // unreadable would overstate the hole by the width of the structure.
+        readable: values.iter().any(|v| v.value.is_some()) || next.is_some(),
+        next,
+        fields: values,
+    }
+}
+
+/// Little-endian, whatever the width: `db`/`dw`/`dd`/`dq` read the same bytes the same way.
+fn le(bytes: &[u8]) -> u64 {
+    bytes.iter().enumerate().fold(0u64, |value, (i, byte)| {
+        value | (u64::from(*byte) << (8 * i))
+    })
+}
+
+/// Reads back an address this module wrote with [`addr`].
+///
+/// A chain's link crosses from [`read_node`] to the traversal as the same string the caller sees,
+/// rather than as a second `u64` beside it, so the address a report prints and the address the
+/// walk followed cannot disagree.
+fn parse_addr_back(text: &str) -> Option<u64> {
+    u64::from_str_radix(text.strip_prefix("0x")?, 16).ok()
+}
+
+// ---- rendering ------------------------------------------------------------
+
+/// The walk as a table, for the reader who is not a program.
+pub fn render(walk: &structured::MemoryWalk) -> String {
+    let mut out = heading(walk);
+    out.push_str("\n\n");
+
+    // Column widths are the *value* widths, so an unreadable cell — `0x????????????????`, exactly
+    // as wide as the value it stands in for — keeps the table a table precisely where the
+    // interesting rows are.
+    let index_width = walk.walked.max(1).to_string().len().max(3);
+    let columns: Vec<(&str, usize)> = walk
+        .nodes
+        .first()
+        .map(|node| {
+            node.fields
+                .iter()
+                .map(|f| (f.name.as_str(), f.name.len().max(2 + 2 * f.size as usize)))
+                .collect()
+        })
+        .unwrap_or_default();
+    let chain = matches!(walk.mode, structured::WalkMode::Chain);
+
+    let mut header = format!("  {:>index_width$}  {:<18}", "idx", "node");
+    if chain {
+        header.push_str(&format!("  {:<18}", "next"));
+    }
+    for (name, width) in &columns {
+        header.push_str(&format!("  {name:<width$}"));
+    }
+    out.push_str(header.trim_end());
+    out.push('\n');
+
+    for node in &walk.nodes {
+        let mut row = format!("  {:>index_width$}  {}", node.index, node.address);
+        if chain {
+            row.push_str(&format!("  {}", cell(node.next.as_deref(), 8)));
+        }
+        for (field, (_, width)) in node.fields.iter().zip(&columns) {
+            row.push_str(&format!(
+                "  {:<width$}",
+                cell(field.value.as_deref(), field.size)
+            ));
+        }
+        out.push_str(row.trim_end());
+        out.push('\n');
+    }
+
+    out.push('\n');
+    out.push_str(&summary(walk));
+    out
+}
+
+/// The first line: what was walked, and how.
+fn heading(walk: &structured::MemoryWalk) -> String {
+    let start = walk.start.as_deref().unwrap_or("?");
+    match walk.mode {
+        structured::WalkMode::List => format!(
+            "Memory walk: {} address{} supplied.",
+            walk.requested,
+            if walk.requested == 1 { "" } else { "es" }
+        ),
+        structured::WalkMode::Array => {
+            format!("Memory walk: up to {} nodes from {start}.", walk.requested)
+        }
+        structured::WalkMode::Chain => format!(
+            "Memory walk: up to {} nodes chained from {start}.",
+            walk.requested
+        ),
+    }
+}
+
+/// One value in the table, or the debugger's own mark for memory it could not read.
+///
+/// `????` rather than a word, and exactly as wide as the value would have been: it is what `dd`
+/// prints for an unmapped page, so it reads as "the debugger could not read this" to anyone who
+/// has used the debugger, and it keeps the column aligned.
+fn cell(value: Option<&str>, size: u32) -> String {
+    let digits = 2 * size as usize;
+    match value {
+        // Trimmed to the field's own width: a byte read renders as `0x41`, not as a qword with
+        // fourteen leading zeroes it never read. The structured half keeps one width for every
+        // value; this half is for a person comparing a column.
+        Some(value) => {
+            let hex = value.trim_start_matches("0x");
+            format!("0x{}", &hex[hex.len().saturating_sub(digits)..])
+        }
+        None => format!("0x{}", "?".repeat(digits)),
+    }
+}
+
+/// The footer: how much was read, what could not be, and why it ended.
+fn summary(walk: &structured::MemoryWalk) -> String {
+    let mut out = format!(
+        "{} node{} walked",
+        walk.walked,
+        if walk.walked == 1 { "" } else { "s" }
+    );
+    if walk.unreadable > 0 {
+        out.push_str(&format!(
+            ", {} of which the debugger could not read at all",
+            walk.unreadable
+        ));
+    }
+    out.push_str(".\n");
+    out.push_str(&format!("Stopped: {}\n", stop_sentence(&walk.stopped)));
+    if let Some(note) = &walk.note {
+        out.push_str(&format!(
+            "\nNothing here could be read at all. The debugger's reason for the first read: \
+             {note}\nA list of freed objects really does look like this — but so does a target \
+             that is not broken in, or a `start` that is not where you think it is. \
+             `session_status` says which.\n"
+        ));
+    }
+    // Keyed on the *cells* rather than on `unreadable`, because one hole in a node that otherwise
+    // read fine puts a `????` in the table without making that node unreadable — and a legend for
+    // a mark the reader can see is the whole job of a legend.
+    let unread_cell = |node: &structured::WalkNode| {
+        node.fields.iter().any(|field| field.value.is_none())
+            || (matches!(walk.mode, structured::WalkMode::Chain) && node.next.is_none())
+    };
+    if walk.nodes.iter().any(unread_cell) {
+        out.push_str(
+            "\n`0x????` marks memory the debugger could not read — unmapped, paged out, or not \
+             captured in this dump. Those nodes are reported rather than dropped: in a \
+             use-after-free walk the pointer that will not read is usually the one worth looking \
+             at. `pool_chunk` says whether such an address was pool, and whether it is still \
+             allocated.\n",
+        );
+    }
+    out
+}
+
+fn stop_sentence(stopped: &structured::WalkStop) -> String {
+    match stopped {
+        structured::WalkStop::Complete => {
+            "every node asked for was visited; there is nothing left to walk.".to_string()
+        }
+        structured::WalkStop::Cap { next } => format!(
+            "the requested count was reached and the chain continues at {next}. Walk again from \
+             there for more."
+        ),
+        structured::WalkStop::NullLink => {
+            "the next pointer is null — the chain ends here.".to_string()
+        }
+        structured::WalkStop::Loop { at } => format!(
+            "the chain returned to {at}, a node it had already visited. Back at the head that is \
+             the ordinary end of a circular _LIST_ENTRY; anywhere else it is a loop."
+        ),
+        structured::WalkStop::UnreadableLink { at } => format!(
+            "the next pointer in the node at {at} could not be read, so there is no address to \
+             continue from. The nodes above are what the chain reached; `pool_chunk` on that node \
+             says whether it has been freed."
+        ),
+        structured::WalkStop::Deadline => "this call ran out of time. The nodes above were really \
+                                           read; the rest are unknown rather than absent. Walk a \
+                                           smaller `count`, issue it on an idle session, or raise \
+                                           the server's call timeout \
+                                           (WINDBG_MCP_CALL_TIMEOUT_SECS)."
+            .to_string(),
+        structured::WalkStop::Interrupted => {
+            "interrupted. The nodes above were read before the break landed.".to_string()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A fake address space. A walk's whole contract is what it does with the holes in one, and
+    /// nothing here needs a debugger to have holes.
+    struct Memory {
+        mapped: Vec<(u64, Vec<u8>)>,
+        reads: usize,
+    }
+
+    impl Memory {
+        fn new() -> Self {
+            Self {
+                mapped: Vec::new(),
+                reads: 0,
+            }
+        }
+
+        fn at(mut self, address: u64, bytes: &[u8]) -> Self {
+            self.mapped.push((address, bytes.to_vec()));
+            self
+        }
+
+        /// A node holding `next` at +0 and `value` at +8.
+        fn node(self, address: u64, next: u64, value: u64) -> Self {
+            let mut bytes = next.to_le_bytes().to_vec();
+            bytes.extend_from_slice(&value.to_le_bytes());
+            self.at(address, &bytes)
+        }
+
+        /// Every requested byte has to fall inside one mapping, which is what makes a read
+        /// straddling a hole fail outright — as `ReadVirtual` does — rather than come back short.
+        fn read(&mut self, address: u64, size: usize) -> Option<Vec<u8>> {
+            self.reads += 1;
+            let (base, bytes) = self.mapped.iter().find(|(base, bytes)| {
+                address >= *base && address + size as u64 <= base + bytes.len() as u64
+            })?;
+            let from = (address - base) as usize;
+            Some(bytes[from..from + size].to_vec())
+        }
+    }
+
+    fn field(name: &str, offset: i64, size: u32) -> Field {
+        Field {
+            name: name.to_string(),
+            offset,
+            size,
+        }
+    }
+
+    fn never_halts() -> Option<Halt> {
+        None
+    }
+
+    /// The failure this module exists for: one unreadable node in the middle of a list is a row,
+    /// and every node after it is still walked.
+    #[test]
+    fn an_unreadable_node_does_not_end_a_list_walk() {
+        let mut memory = Memory::new()
+            .at(0x1000, &0xaaaau64.to_le_bytes())
+            .at(0x3000, &0xccccu64.to_le_bytes());
+        let walk = run(
+            &Resolved::List(vec![0x1000, 0x2000, 0x3000]),
+            &[field("value", 0, 8)],
+            |a, s| memory.read(a, s),
+            never_halts,
+        );
+
+        assert_eq!(walk.walked, 3, "the hole must not shorten the walk");
+        assert_eq!(walk.unreadable, 1);
+        assert_eq!(walk.nodes[0].fields[0].value, Some(addr(0xaaaa)));
+        assert_eq!(walk.nodes[1].fields[0].value, None);
+        assert!(!walk.nodes[1].readable);
+        assert_eq!(walk.nodes[2].fields[0].value, Some(addr(0xcccc)));
+        assert_eq!(walk.stopped, structured::WalkStop::Complete);
+    }
+
+    /// The same for an array, whose next address is arithmetic and so cannot be lost to a hole.
+    #[test]
+    fn an_unreadable_element_does_not_end_an_array_walk() {
+        let mut memory = Memory::new()
+            .at(0x1000, &1u64.to_le_bytes())
+            .at(0x1010, &3u64.to_le_bytes());
+        let walk = run(
+            &Resolved::Array {
+                start: 0x1000,
+                stride: 8,
+                count: 3,
+            },
+            &[field("value", 0, 8)],
+            |a, s| memory.read(a, s),
+            never_halts,
+        );
+
+        assert_eq!(walk.walked, 3);
+        assert_eq!(walk.unreadable, 1);
+        assert_eq!(walk.nodes[1].address, addr(0x1008));
+        assert_eq!(walk.nodes[2].fields[0].value, Some(addr(3)));
+    }
+
+    /// A chain *is* ended by an unreadable node, because the address of everything after it lived
+    /// in the bytes that would not read — and the report says so rather than calling it the end of
+    /// the list.
+    #[test]
+    fn an_unreadable_link_ends_a_chain_and_says_which_node() {
+        let mut memory = Memory::new().node(0x1000, 0x2000, 0xaa);
+        let walk = run(
+            &Resolved::Chain {
+                start: 0x1000,
+                next_offset: 0,
+                count: 8,
+            },
+            &[field("value", 8, 8)],
+            |a, s| memory.read(a, s),
+            never_halts,
+        );
+
+        assert_eq!(walk.walked, 2, "the unreadable node is still a row");
+        assert_eq!(
+            walk.stopped,
+            structured::WalkStop::UnreadableLink { at: addr(0x2000) }
+        );
+    }
+
+    #[test]
+    fn a_chain_ends_on_a_null_link() {
+        let mut memory = Memory::new().node(0x1000, 0x2000, 1).node(0x2000, 0, 2);
+        let walk = run(
+            &Resolved::Chain {
+                start: 0x1000,
+                next_offset: 0,
+                count: 8,
+            },
+            &[],
+            |a, s| memory.read(a, s),
+            never_halts,
+        );
+
+        assert_eq!(walk.walked, 2);
+        assert_eq!(walk.stopped, structured::WalkStop::NullLink);
+    }
+
+    /// A corrupted list pointing back into itself is a finding, not a hang: the walk reports where
+    /// it closed instead of running to its cap.
+    #[test]
+    fn a_chain_that_loops_is_reported_where_it_closes() {
+        let mut memory = Memory::new()
+            .node(0x1000, 0x2000, 1)
+            .node(0x2000, 0x3000, 2)
+            .node(0x3000, 0x2000, 3);
+        let walk = run(
+            &Resolved::Chain {
+                start: 0x1000,
+                next_offset: 0,
+                count: 64,
+            },
+            &[],
+            |a, s| memory.read(a, s),
+            never_halts,
+        );
+
+        assert_eq!(walk.walked, 3);
+        assert_eq!(
+            walk.stopped,
+            structured::WalkStop::Loop { at: addr(0x2000) }
+        );
+    }
+
+    /// A circular `_LIST_ENTRY` closing on its head is the same mechanism, and must not run to the
+    /// cap either.
+    #[test]
+    fn a_circular_list_closes_on_its_head() {
+        let mut memory = Memory::new()
+            .node(0x1000, 0x2000, 1)
+            .node(0x2000, 0x1000, 2);
+        let walk = run(
+            &Resolved::Chain {
+                start: 0x1000,
+                next_offset: 0,
+                count: 64,
+            },
+            &[],
+            |a, s| memory.read(a, s),
+            never_halts,
+        );
+
+        assert_eq!(walk.walked, 2);
+        assert_eq!(
+            walk.stopped,
+            structured::WalkStop::Loop { at: addr(0x1000) }
+        );
+    }
+
+    /// Reaching the cap on a chain is not "done": it hands back where to resume, which is the
+    /// difference between a walk a caller can continue and one they have to reconstruct.
+    #[test]
+    fn a_chain_at_its_cap_reports_where_to_resume() {
+        let mut memory = Memory::new()
+            .node(0x1000, 0x2000, 1)
+            .node(0x2000, 0x3000, 2)
+            .node(0x3000, 0x4000, 3);
+        let walk = run(
+            &Resolved::Chain {
+                start: 0x1000,
+                next_offset: 0,
+                count: 2,
+            },
+            &[],
+            |a, s| memory.read(a, s),
+            never_halts,
+        );
+
+        assert_eq!(walk.walked, 2);
+        assert_eq!(
+            walk.stopped,
+            structured::WalkStop::Cap { next: addr(0x3000) }
+        );
+    }
+
+    /// A chain whose cap lands exactly on the last node reports the *end*, not the cap: the link
+    /// is read as part of the node, so "there is more" is a fact rather than an assumption.
+    #[test]
+    fn a_chain_that_ends_at_its_cap_says_it_ended() {
+        let mut memory = Memory::new().node(0x1000, 0x2000, 1).node(0x2000, 0, 2);
+        let walk = run(
+            &Resolved::Chain {
+                start: 0x1000,
+                next_offset: 0,
+                count: 2,
+            },
+            &[],
+            |a, s| memory.read(a, s),
+            never_halts,
+        );
+
+        assert_eq!(walk.stopped, structured::WalkStop::NullLink);
+    }
+
+    /// Fields of one structure cost one read, not one read each — over a KD link that is the
+    /// difference between a walk that answers and a walk that times out.
+    #[test]
+    fn fields_in_one_structure_are_fetched_in_one_read() {
+        let mut bytes = vec![0u8; 0x40];
+        bytes[0x10] = 0x41;
+        bytes[0x20] = 0x42;
+        let mut memory = Memory::new().at(0x1000, &bytes);
+        let walk = run(
+            &Resolved::List(vec![0x1000]),
+            &[field("a", 0x10, 1), field("b", 0x20, 1)],
+            |a, s| memory.read(a, s),
+            never_halts,
+        );
+
+        assert_eq!(memory.reads, 1, "two fields, one round trip");
+        assert_eq!(walk.nodes[0].fields[0].value, Some(addr(0x41)));
+        assert_eq!(walk.nodes[0].fields[1].value, Some(addr(0x42)));
+    }
+
+    /// A hole in the commonest shape of all — one value per node — costs one read, not two.
+    ///
+    /// The per-field fallback exists because a coalesced read is all-or-nothing; with a single
+    /// value there is nothing to coalesce, so retrying would re-read the bytes that just failed.
+    /// Over a 512-entry table where a third of the objects are freed that is 170 wasted round
+    /// trips on a KD link.
+    #[test]
+    fn a_single_value_costs_one_read_whether_or_not_it_is_there() {
+        let mut memory = Memory::new().at(0x1000, &7u64.to_le_bytes());
+        let walk = run(
+            &Resolved::List(vec![0x1000, 0x2000]),
+            &[field("value", 0, 8)],
+            |a, s| memory.read(a, s),
+            never_halts,
+        );
+
+        assert_eq!(walk.walked, 2);
+        assert_eq!(memory.reads, 2, "one read for the hit and one for the hole");
+    }
+
+    /// And when that one read fails, the fields are read individually — so a structure with only
+    /// its tail unmapped still answers for its head, instead of being written off whole.
+    #[test]
+    fn a_partly_mapped_node_answers_for_the_fields_that_are_mapped() {
+        // +0 is mapped, +0x100 is not, so the span covering both fails and only the per-field
+        // route can tell them apart.
+        let mut memory = Memory::new().at(0x1000, &0x1234u64.to_le_bytes());
+        let walk = run(
+            &Resolved::List(vec![0x1000]),
+            &[field("head", 0, 8), field("tail", 0x100, 8)],
+            |a, s| memory.read(a, s),
+            never_halts,
+        );
+
+        assert_eq!(walk.nodes[0].fields[0].value, Some(addr(0x1234)));
+        assert_eq!(walk.nodes[0].fields[1].value, None);
+        assert!(
+            walk.nodes[0].readable,
+            "a node with one readable field is not an unreadable node"
+        );
+        assert_eq!(walk.unreadable, 0);
+    }
+
+    /// A field behind the pointer a caller holds — a pool header at -0x10 — is one argument, not
+    /// arithmetic the caller does per node and the table then cannot line up.
+    #[test]
+    fn a_negative_offset_reads_behind_the_node() {
+        let mut memory = Memory::new().at(0x1000, &0xfeedu64.to_le_bytes());
+        let walk = run(
+            &Resolved::List(vec![0x1010]),
+            &[field("header", -0x10, 8)],
+            |a, s| memory.read(a, s),
+            never_halts,
+        );
+
+        assert_eq!(walk.nodes[0].fields[0].address, addr(0x1000));
+        assert_eq!(walk.nodes[0].fields[0].value, Some(addr(0xfeed)));
+    }
+
+    /// Widths narrower than a pointer read the bytes the debugger would, little-endian.
+    #[test]
+    fn narrow_fields_read_their_own_width() {
+        let mut memory = Memory::new().at(0x1000, &[0x78, 0x56, 0x34, 0x12, 0, 0, 0, 0]);
+        let walk = run(
+            &Resolved::List(vec![0x1000]),
+            &[field("b", 0, 1), field("w", 0, 2), field("d", 0, 4)],
+            |a, s| memory.read(a, s),
+            never_halts,
+        );
+
+        let value = |i: usize| walk.nodes[0].fields[i].value.clone().unwrap();
+        assert_eq!(value(0), addr(0x78));
+        assert_eq!(value(1), addr(0x5678));
+        assert_eq!(value(2), addr(0x1234_5678));
+    }
+
+    /// A halt is polled before a node's reads, not after: an interrupt landing during node 1 must
+    /// not buy node 2's round trips.
+    #[test]
+    fn a_halt_stops_before_the_next_nodes_reads() {
+        let mut memory = Memory::new()
+            .at(0x1000, &1u64.to_le_bytes())
+            .at(0x1008, &2u64.to_le_bytes())
+            .at(0x1010, &3u64.to_le_bytes());
+        let mut polls = 0;
+        let walk = run(
+            &Resolved::Array {
+                start: 0x1000,
+                stride: 8,
+                count: 3,
+            },
+            &[field("value", 0, 8)],
+            |a, s| memory.read(a, s),
+            || {
+                polls += 1;
+                (polls > 2).then_some(Halt::Interrupted)
+            },
+        );
+
+        assert_eq!(walk.walked, 2, "the third node's reads were never paid for");
+        assert_eq!(memory.reads, 2);
+        assert_eq!(walk.stopped, structured::WalkStop::Interrupted);
+    }
+
+    /// A walk that ran out of the caller's clock says so and hands back what it really read — the
+    /// same distinction the pool walk draws between "not there" and "not reached".
+    #[test]
+    fn a_deadline_returns_what_was_read() {
+        let mut memory = Memory::new().at(0x1000, &1u64.to_le_bytes());
+        let mut polls = 0;
+        let walk = run(
+            &Resolved::Array {
+                start: 0x1000,
+                stride: 8,
+                count: 64,
+            },
+            &[field("value", 0, 8)],
+            |a, s| memory.read(a, s),
+            || {
+                polls += 1;
+                (polls > 1).then_some(Halt::Deadline)
+            },
+        );
+
+        assert_eq!(walk.walked, 1);
+        assert_eq!(walk.stopped, structured::WalkStop::Deadline);
+    }
+
+    // ---- argument validation ------------------------------------------------
+
+    #[test]
+    fn a_list_and_a_traversal_are_not_combinable() {
+        let err = WalkOp::new(
+            Some(vec!["0x1000".into()]),
+            Some("0x2000".into()),
+            Some(8),
+            None,
+            None,
+            None,
+        )
+        .unwrap_err();
+        assert!(err.contains("cannot be combined"), "{err}");
+    }
+
+    #[test]
+    fn a_list_carries_its_own_count() {
+        let err =
+            WalkOp::new(Some(vec!["0x1000".into()]), None, None, None, Some(4), None).unwrap_err();
+        assert!(err.contains("the same thing twice"), "{err}");
+    }
+
+    #[test]
+    fn a_stride_and_a_next_offset_are_two_different_walks() {
+        let err =
+            WalkOp::new(None, Some("0x1000".into()), Some(8), Some(0), None, None).unwrap_err();
+        assert!(err.contains("Pass one"), "{err}");
+    }
+
+    #[test]
+    fn a_start_with_no_traversal_is_refused() {
+        let err = WalkOp::new(None, Some("0x1000".into()), None, None, None, None).unwrap_err();
+        assert!(err.contains("needs a traversal"), "{err}");
+    }
+
+    #[test]
+    fn nothing_at_all_is_refused() {
+        let err = WalkOp::new(None, None, None, None, None, None).unwrap_err();
+        assert!(err.contains("no nodes to walk"), "{err}");
+    }
+
+    /// Refused rather than clamped: a clamp would report "every node asked for was visited" about
+    /// a count this server lowered behind the caller's back.
+    #[test]
+    fn a_count_past_the_cap_is_refused_not_clamped() {
+        let err = WalkOp::new(
+            None,
+            Some("0x1000".into()),
+            Some(8),
+            None,
+            Some(MAX_NODES + 1),
+            None,
+        )
+        .unwrap_err();
+        assert!(err.contains("at most"), "{err}");
+    }
+
+    #[test]
+    fn a_field_size_the_debugger_cannot_read_is_refused() {
+        let err = WalkOp::new(
+            None,
+            Some("0x1000".into()),
+            Some(8),
+            None,
+            None,
+            Some(vec![FieldArg {
+                name: None,
+                offset: 0,
+                size: Some(3),
+            }]),
+        )
+        .unwrap_err();
+        assert!(err.contains("1, 2, 4 or 8"), "{err}");
+    }
+
+    /// A list or an array with no fields is the bulk-pointer read; a chain already prints its
+    /// link, so defaulting it the same way would print one column twice.
+    #[test]
+    fn the_default_field_depends_on_what_the_walk_already_reports() {
+        let array = WalkOp::new(None, Some("0x1000".into()), Some(8), None, None, None).unwrap();
+        assert_eq!(array.fields.len(), 1);
+        assert_eq!(array.fields[0].offset, 0);
+        assert_eq!(array.fields[0].size, 8);
+
+        let chain = WalkOp::new(None, Some("0x1000".into()), None, Some(0), None, None).unwrap();
+        assert!(chain.fields.is_empty());
+    }
+
+    #[test]
+    fn an_unnamed_field_is_named_for_its_offset() {
+        let op = WalkOp::new(
+            None,
+            Some("0x1000".into()),
+            Some(8),
+            None,
+            None,
+            Some(vec![
+                FieldArg {
+                    name: None,
+                    offset: 0x18,
+                    size: Some(4),
+                },
+                FieldArg {
+                    name: None,
+                    offset: -0x10,
+                    size: None,
+                },
+            ]),
+        )
+        .unwrap();
+        assert_eq!(op.fields[0].name, "+0x18");
+        assert_eq!(op.fields[1].name, "-0x10");
+    }
+
+    /// Addresses come in the forms the debugger prints, so a chunk address copied out of
+    /// `pool_chunk` goes straight into this tool.
+    #[test]
+    fn addresses_accept_the_forms_the_debugger_prints() {
+        let op = WalkOp::new(
+            Some(vec![
+                "ffffc00f`6ec02f90".into(),
+                "0x1000".into(),
+                "4096".into(),
+            ]),
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+        let Source::List { addresses } = op.source else {
+            panic!("a list")
+        };
+        assert_eq!(addresses, [0xffffc00f_6ec02f90, 0x1000, 4096]);
+    }
+
+    // ---- rendering ----------------------------------------------------------
+
+    /// An unreadable cell is as wide as the value it stands in for, so the column a caller is
+    /// scanning stays a column exactly where the interesting rows are.
+    #[test]
+    fn an_unreadable_cell_keeps_the_column_aligned() {
+        let mut memory = Memory::new().at(0x1000, &0xaaaau64.to_le_bytes());
+        let walk = run(
+            &Resolved::List(vec![0x1000, 0x2000]),
+            &[field("value", 0, 8)],
+            |a, s| memory.read(a, s),
+            never_halts,
+        );
+        let text = render(&walk);
+
+        let rows: Vec<&str> = text
+            .lines()
+            .filter(|l| l.contains(&addr(0x1000)) || l.contains(&addr(0x2000)))
+            .collect();
+        assert_eq!(rows.len(), 2, "{text}");
+        assert_eq!(rows[0].len(), rows[1].len(), "{text}");
+        assert!(rows[1].contains("0x????????????????"), "{text}");
+    }
+
+    /// The footer has to say what stopped the walk, or "2 nodes" reads the same whether the list
+    /// ended, the cap was hit, or the call ran out of time.
+    #[test]
+    fn the_summary_names_what_stopped_the_walk() {
+        let mut memory = Memory::new().node(0x1000, 0x2000, 1).node(0x2000, 0, 2);
+        let walk = run(
+            &Resolved::Chain {
+                start: 0x1000,
+                next_offset: 0,
+                count: 8,
+            },
+            &[],
+            |a, s| memory.read(a, s),
+            never_halts,
+        );
+        let text = render(&walk);
+
+        assert!(text.contains("2 nodes walked"), "{text}");
+        assert!(text.contains("the chain ends here"), "{text}");
+    }
+}

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -1825,32 +1825,85 @@ fn read_memory(e: &DebugEngine, address: &str, size: u32) -> Result<String, Stri
     Ok(hexdump(addr, &bytes))
 }
 
-/// Resolves the address a walk starts from.
+/// Resolves the address a walk starts from, **inside the walk's own deadline**.
 ///
-/// A number in any form the debugger prints costs nothing to recognise, so it is tried first. What
-/// is left is MASM — a symbol (`MessageManager!g_MessageTable`), an offset from one, a `poi()` of
-/// a list head that is not itself a node — and `?` is the only thing that reads those. One
-/// command for the whole walk, rather than one per node, which is the point of resolving here
-/// rather than making every address an expression.
-fn resolve_start(e: &DebugEngine, start: &str) -> Result<u64, Failed> {
+/// A number in any form the debugger prints costs nothing to recognise, so it is tried first, and
+/// the commonest shapes — an address list, a table base pasted out of another tool — never reach
+/// the engine at all. What is left is MASM — a symbol (`MessageManager!g_MessageTable`), an offset
+/// from one, a `poi()` of a list head that is not itself a node — and `?` is the only thing that
+/// reads those. One command for the whole walk, rather than one per node, which is the point of
+/// resolving here rather than making every address an expression.
+///
+/// **Bounded, because this one command is the one part of a walk a watchdog can reach.** Resolving
+/// a symbol can send the engine to a symbol server, and an unbounded `Execute` there outlives the
+/// caller's whole timeout with the session held — the walk's between-node deadline cannot help,
+/// since it is not polled until this returns. So the remaining budget is handed to win-kexp's
+/// watchdog, and what it costs (up to one 200ms watchdog join) is paid only by a caller who passed
+/// an expression rather than a number.
+/// The watchdog budget for [`resolve_start`]'s one command: what the walk has left, in ms.
+///
+/// **Floored at 1 and never 0**, which is the whole reason this is a named function rather than a
+/// cast at the call site. `execute_command_bounded(cmd, 0)` arms no watchdog at all, so a walk
+/// whose budget rounds down to nothing would run its `?` — the one part of the call that can block
+/// on a symbol server for minutes — as the single *unbounded* thing in it. That is the wedge the
+/// bound exists to prevent, reachable by sub-millisecond arithmetic alone.
+///
+/// The same reasoning as [`watchdog_budget_ms`]'s floor and deliberately not the same number: that
+/// one keeps a headroom because its command is already running and the job left is to free the
+/// worker. Here there is nothing to be generous to — 1ms means the resolve is cut short at once,
+/// which is the correct answer for a caller with no time, and it is reported as `NotRun` rather
+/// than as a bad expression.
+fn resolve_budget_ms(within: Duration) -> u32 {
+    u32::try_from(within.as_millis()).unwrap_or(u32::MAX).max(1)
+}
+
+fn resolve_start(e: &DebugEngine, start: &str, within: Duration) -> Result<u64, Failed> {
     if let Ok(address) = parse_pool_addr(start) {
         return Ok(address);
     }
-    let text = e.execute_command(&format!("? {start}")).map_err(|why| {
-        Failed::categorised(
-            structured::ErrorCategory::InvalidArgument,
-            format!("`start` = `{start}` could not be evaluated: {why}"),
-        )
-    })?;
+    let budget = resolve_budget_ms(within);
+    let run = e
+        .execute_command_bounded(&format!("? {start}"), budget)
+        .map_err(|why| {
+            Failed::categorised(
+                structured::ErrorCategory::InvalidArgument,
+                format!("`start` = `{start}` could not be evaluated: {why}"),
+            )
+        })?;
+    // A resolve that was cut short is not a bad expression, and must not be reported as one: it
+    // says nothing about whether the symbol exists. Both origins mean the same thing for the walk
+    // — nothing was read — but they call for opposite responses, so they are categorised apart.
+    if let Some(interruption) = run.cut_short {
+        return Err(match interruption {
+            Interruption::Deadline { after_ms } => Failed::categorised(
+                structured::ErrorCategory::NotRun,
+                format!(
+                    "Resolving `start` = `{start}` was still running after {after_ms}ms, which \
+                     was all the time this call had, so it was stopped and no node was walked. \
+                     Resolving a symbol can send the debugger to a symbol server; pass the \
+                     numeric address instead (`execute {{\"command\": \"? {start}\"}}` once, then \
+                     walk from what it prints), or raise the server's call timeout \
+                     (WINDBG_MCP_CALL_TIMEOUT_SECS)."
+                ),
+            ),
+            Interruption::OnRequest => Failed::categorised(
+                structured::ErrorCategory::Interrupted,
+                format!(
+                    "Resolving `start` = `{start}` was interrupted before the walk began, so \
+                     nothing was read."
+                ),
+            ),
+        });
+    }
     // A `?` that *runs* but produces nothing an address can be read out of is the caller's
     // mistake, not the target's — a misspelt symbol is the usual one — so it is categorised as
     // such, and the debugger's own words go with it rather than a paraphrase.
-    parse_eval(&text).ok_or_else(|| {
+    parse_eval(&run.output).ok_or_else(|| {
         Failed::categorised(
             structured::ErrorCategory::InvalidArgument,
             format!(
                 "`start` = `{start}` did not evaluate to an address. The debugger said: {}",
-                text.trim()
+                run.output.trim()
             ),
         )
     })
@@ -1863,11 +1916,15 @@ fn resolve_start(e: &DebugEngine, start: &str) -> Result<u64, Failed> {
 /// its per-field fallback, the loop detection, the table — is [`crate::walk`], which has no engine
 /// and so can be tested against an address space with holes in exactly the places that matter.
 ///
-/// **The deadline starts before the start expression is resolved**, because `?` on a symbol can
-/// block on a symbol server, and a budget that began after it would be a budget measured from an
-/// unknown point in the caller's wait.
+/// **The deadline starts before the start expression is resolved**, and the resolve is bounded by
+/// what is left of it ([`resolve_start`]) — `?` on a symbol can block on a symbol server, and a
+/// budget that began after it would be a budget measured from an unknown point in the caller's
+/// wait.
 fn walk_memory(e: &DebugEngine, op: walk::WalkOp, within: Duration) -> Result<Output, Failed> {
     let deadline = Instant::now() + within;
+    // What is left *now*, so the resolve cannot spend time the walk has already used and the walk
+    // cannot be handed time the resolve already spent. One deadline, read twice.
+    let left = || deadline.saturating_duration_since(Instant::now());
     let source = match op.source {
         walk::Source::List { addresses } => walk::Resolved::List(addresses),
         walk::Source::Array {
@@ -1875,7 +1932,7 @@ fn walk_memory(e: &DebugEngine, op: walk::WalkOp, within: Duration) -> Result<Ou
             stride,
             count,
         } => walk::Resolved::Array {
-            start: resolve_start(e, &start)?,
+            start: resolve_start(e, &start, left())?,
             stride,
             count,
         },
@@ -1884,7 +1941,7 @@ fn walk_memory(e: &DebugEngine, op: walk::WalkOp, within: Duration) -> Result<Ou
             next_offset,
             count,
         } => walk::Resolved::Chain {
-            start: resolve_start(e, &start)?,
+            start: resolve_start(e, &start, left())?,
             next_offset,
             count,
         },
@@ -3366,6 +3423,27 @@ mod tests {
     #[test]
     fn no_patience_left_still_arms_the_watchdog() {
         assert_eq!(watchdog_budget_ms(Duration::ZERO, Duration::ZERO), 15_000);
+    }
+
+    /// And a walk's start resolution is armed too, whatever is left of the clock.
+    ///
+    /// A walk is a run of reads that no watchdog can bound — the between-node deadline is the only
+    /// thing holding it — with exactly one exception: the `?` that resolves a symbolic `start`,
+    /// which is a command, can block on a symbol server, and *can* be bounded. Zero would leave
+    /// that one command unbounded inside a call whose every other part is bounded, so the floor is
+    /// what makes the exception hold at every budget rather than at most of them.
+    #[test]
+    fn resolving_a_symbolic_start_is_bounded_at_every_budget() {
+        assert_eq!(resolve_budget_ms(Duration::from_secs(30)), 30_000);
+        // Sub-millisecond, which truncates to zero — and zero disarms the watchdog entirely.
+        assert_ne!(resolve_budget_ms(Duration::from_micros(1)), 0);
+        assert_ne!(resolve_budget_ms(Duration::ZERO), 0);
+        // And a budget past what the API can carry saturates rather than wrapping to something
+        // small, which would cut a healthy resolve short.
+        assert_eq!(
+            resolve_budget_ms(Duration::from_secs(u32::MAX as u64)),
+            u32::MAX
+        );
     }
 
     /// An `!analyze` is only started when its watchdog fits inside what is left **and still leaves

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -57,6 +57,7 @@ use crate::server::{
 };
 use crate::structured;
 use crate::triage::{self, Analysis, AttributedFrame, Attribution};
+use crate::walk;
 
 /// The argument that turns this executable into a worker. Not a documented CLI: the supervisor
 /// re-executes itself with it, and nothing else should.
@@ -1071,6 +1072,34 @@ fn execute(e: &DebugEngine, id: u64, op: EngineOp, queued: Duration) -> Result<O
         EngineOp::ReadMemory { address, size } => read_memory(e, &address, size)
             .map(Output::text)
             .map_err(Failed::from),
+        // The caller's own deadline, on the same arithmetic as a pool walk's and for the same
+        // reason — with one difference that makes it matter more here. A pool walk is bounded by
+        // win-kexp *as well*; this one has no command behind it, so between-node checking is the
+        // only bound there is.
+        EngineOp::Walk(op) => {
+            let patience = Duration::from_millis(u64::from(op.patience_ms));
+            match walk_budget(patience, queued) {
+                Some(budget) => walk_memory(e, op, budget),
+                // Refused rather than attempted, as a pool query that must walk is. A walk with no
+                // time reads nothing and reports an empty table with `stopped: deadline`, which
+                // looks exactly like a target whose every node is missing — the one reading a
+                // caller must not take away from a call that never started.
+                None => Err(Failed::categorised(
+                    structured::ErrorCategory::NotRun,
+                    format!(
+                        "This walk was not run: it reached the engine with {}s of its caller's \
+                         timeout left, which is not enough to read a node and report back before \
+                         that timeout expires. Nothing was read and nothing changed. It waited \
+                         {}s behind other work on this session; issue it when the session is \
+                         idle, or raise the server's call timeout (WINDBG_MCP_CALL_TIMEOUT_SECS \
+                         — the reply itself reserves {}s of headroom).",
+                        patience.saturating_sub(queued).as_secs(),
+                        queued.as_secs(),
+                        WATCHDOG_HEADROOM.as_secs(),
+                    ),
+                )),
+            }
+        }
         EngineOp::SymbolPath {
             path,
             append,
@@ -1794,6 +1823,105 @@ fn read_memory(e: &DebugEngine, address: &str, size: u32) -> Result<String, Stri
     }
     let bytes = e.read_memory(addr, size as usize).map_err(es)?;
     Ok(hexdump(addr, &bytes))
+}
+
+/// Resolves the address a walk starts from.
+///
+/// A number in any form the debugger prints costs nothing to recognise, so it is tried first. What
+/// is left is MASM — a symbol (`MessageManager!g_MessageTable`), an offset from one, a `poi()` of
+/// a list head that is not itself a node — and `?` is the only thing that reads those. One
+/// command for the whole walk, rather than one per node, which is the point of resolving here
+/// rather than making every address an expression.
+fn resolve_start(e: &DebugEngine, start: &str) -> Result<u64, Failed> {
+    if let Ok(address) = parse_pool_addr(start) {
+        return Ok(address);
+    }
+    let text = e.execute_command(&format!("? {start}")).map_err(|why| {
+        Failed::categorised(
+            structured::ErrorCategory::InvalidArgument,
+            format!("`start` = `{start}` could not be evaluated: {why}"),
+        )
+    })?;
+    // A `?` that *runs* but produces nothing an address can be read out of is the caller's
+    // mistake, not the target's — a misspelt symbol is the usual one — so it is categorised as
+    // such, and the debugger's own words go with it rather than a paraphrase.
+    parse_eval(&text).ok_or_else(|| {
+        Failed::categorised(
+            structured::ErrorCategory::InvalidArgument,
+            format!(
+                "`start` = `{start}` did not evaluate to an address. The debugger said: {}",
+                text.trim()
+            ),
+        )
+    })
+}
+
+/// Walks a list, an array or a pointer chain, reading named fields out of every node.
+///
+/// The engine appears here twice and nowhere else in the walk: once to resolve the start, and once
+/// as the closure that reads bytes. Everything about the traversal — the coalesced span read and
+/// its per-field fallback, the loop detection, the table — is [`crate::walk`], which has no engine
+/// and so can be tested against an address space with holes in exactly the places that matter.
+///
+/// **The deadline starts before the start expression is resolved**, because `?` on a symbol can
+/// block on a symbol server, and a budget that began after it would be a budget measured from an
+/// unknown point in the caller's wait.
+fn walk_memory(e: &DebugEngine, op: walk::WalkOp, within: Duration) -> Result<Output, Failed> {
+    let deadline = Instant::now() + within;
+    let source = match op.source {
+        walk::Source::List { addresses } => walk::Resolved::List(addresses),
+        walk::Source::Array {
+            start,
+            stride,
+            count,
+        } => walk::Resolved::Array {
+            start: resolve_start(e, &start)?,
+            stride,
+            count,
+        },
+        walk::Source::Chain {
+            start,
+            next_offset,
+            count,
+        } => walk::Resolved::Chain {
+            start: resolve_start(e, &start)?,
+            next_offset,
+            count,
+        },
+    };
+
+    // Kept for the one case the table cannot explain by itself: a walk where *nothing* read. Only
+    // the first is kept — a thousand copies of "memory read failed" is the table with the answer
+    // buried in it, which is the shape this tool exists to replace.
+    let mut first_failure: Option<String> = None;
+    let mut report = walk::run(
+        &source,
+        &op.fields,
+        |address, size| match e.read_memory(address, size) {
+            Ok(bytes) => Some(bytes),
+            Err(why) => {
+                first_failure.get_or_insert_with(|| why.to_string());
+                None
+            }
+        },
+        || {
+            // The interrupt is asked about first. Both can be true at once — a caller who gives up
+            // and a clock that ran out land in the same poll — and being told a call was cut short
+            // by a deadline it *also* passed sends them to the timeout setting instead of to the
+            // break they just asked for.
+            if matches!(e.interrupted(), Ok(true)) {
+                Some(walk::Halt::Interrupted)
+            } else if Instant::now() >= deadline {
+                Some(walk::Halt::Deadline)
+            } else {
+                None
+            }
+        },
+    );
+    if walk::read_nothing(&report) {
+        report.note = first_failure;
+    }
+    Ok(Output::typed(walk::render(&report), report))
 }
 
 /// How long a batch may run, given what it asked for and what its caller has left.

--- a/tests/golden/tools_list.json
+++ b/tests/golden/tools_list.json
@@ -3,7 +3,7 @@
     "(none)",
     "https://json-schema.org/draft/2020-12/schema"
   ],
-  "toolCount": 44,
+  "toolCount": 45,
   "tools": [
     {
       "hints": {
@@ -1171,6 +1171,45 @@
         "size"
       ],
       "title": "TTD: find accesses to a memory range"
+    },
+    {
+      "hints": {
+        "destructive": false,
+        "idempotent": true,
+        "openWorld": true,
+        "readOnly": true
+      },
+      "name": "walk_memory",
+      "output": {
+        "branches": [
+          {
+            "payload": "#/$defs/MemoryWalk",
+            "required": [
+              "status"
+            ],
+            "status": "ok"
+          },
+          {
+            "payload": "#/$defs/Failure",
+            "required": [
+              "status"
+            ],
+            "status": "error"
+          }
+        ],
+        "dialect": "https://json-schema.org/draft/2020-12/schema"
+      },
+      "params": [
+        "addresses: array<string>",
+        "count: integer|null/uint32",
+        "fields: array<ref(#/$defs/FieldArg)>",
+        "next_offset: integer|null/int64",
+        "session_id: string|null",
+        "start: string|null",
+        "stride: integer|null/int64"
+      ],
+      "required": [],
+      "title": "Walk a structure in memory"
     }
   ],
   "usesDefs": true

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -1041,6 +1041,14 @@ fn every_tool_with_an_output_schema_answers_with_structured_content() {
         ("pool_census", json!({}), "error"),
         ("pool_diagnostics", json!({}), "error"),
         ("crash_triage", json!({}), "error"),
+        // A well-formed request, so it takes the *session* refusal path like every row above it
+        // rather than the argument one — which this tool also has, and which is checked in
+        // `a_malformed_walk_is_refused_before_a_session_is_needed`.
+        (
+            "walk_memory",
+            json!({ "addresses": ["0xffff800000000000"] }),
+            "error",
+        ),
     ];
 
     let mut server = Server::started();
@@ -1162,6 +1170,52 @@ fn bad_calls_are_rejected_without_killing_the_session() {
     assert!(
         text.contains("METHOD_BUFFERED"),
         "the session must still work after bad calls, got:\n{text}"
+    );
+}
+
+/// `walk_memory`'s traversal arguments are exclusive, and — the part worth a wire test — the
+/// refusal happens **before a session is chosen**.
+///
+/// It is a fact about the request, not about a target, so a caller finds out now rather than after
+/// queueing behind whatever that session is busy with. Driven with nothing open at all: a check
+/// that reached the session registry would come back "no session" instead, and the two messages
+/// send a caller to opposite places.
+#[test]
+fn a_malformed_walk_is_refused_before_a_session_is_needed() {
+    let mut server = Server::started();
+
+    let both = server.call_tool(
+        "walk_memory",
+        json!({ "start": "0x1000", "stride": 8, "next_offset": 0 }),
+        STEP,
+    );
+    assert!(is_tool_error(&both), "two traversals must be refused");
+    let text = text_of(&both["result"]);
+    assert!(
+        text.contains("Pass one"),
+        "the refusal must name the conflict, got:\n{text}"
+    );
+    assert!(
+        !text.contains("session"),
+        "this is refused before any session is needed, got:\n{text}"
+    );
+    assert_eq!(
+        both["result"]["structuredContent"]["error"]["category"], "invalid_argument",
+        "a caller branches on the category, not the wording: {both}"
+    );
+
+    // And the cap is a refusal rather than a silent clamp, so "every node asked for was visited"
+    // is never about a count this server lowered.
+    let too_many = server.call_tool(
+        "walk_memory",
+        json!({ "start": "0x1000", "stride": 8, "count": 100_000 }),
+        STEP,
+    );
+    assert!(is_tool_error(&too_many), "a count past the cap is refused");
+    assert!(
+        text_of(&too_many["result"]).contains("at most"),
+        "the refusal must name the cap, got:\n{}",
+        text_of(&too_many["result"])
     );
 }
 
@@ -1506,6 +1560,159 @@ fn a_dump_session_opens_reads_and_closes() {
     assert!(
         is_tool_error(&after) || !after["error"].is_null(),
         "a handle from an ended session must be refused, got {after}"
+    );
+}
+
+/// An address that is unmapped on **any** Windows target, so a hole needs no knowledge of this
+/// particular dump.
+///
+/// The low 64 KB of every process is permanently reserved — that is what makes a null-pointer
+/// dereference an access violation rather than a read — so nothing is ever mapped here, in user
+/// mode or in the user half of a kernel target's address space.
+const UNMAPPED: &str = "0x1000";
+
+/// The claim [#103](https://github.com/glslang/windbg-mcp/issues/103) is about, made against a
+/// real engine: a walk with a hole in it comes back with the hole *marked* and everything after it
+/// still walked.
+///
+/// The contrast is the point, so it is asserted rather than described. The same dereference
+/// through `execute` — which is how this was done before — fails outright, and a `.for` loop
+/// around it takes the whole script down with it, leaving no rows and no iteration number. That
+/// failure is what cost a MessageManager session an afternoon of hand-bisecting a 512-entry table.
+///
+/// Everything here is read-only against the checked-in dump, and the one address it assumes
+/// anything about is [`UNMAPPED`], which is unmapped on every Windows target there is.
+#[test]
+fn a_walk_marks_what_it_cannot_read_and_keeps_going() {
+    let Some(dump) = target_tier() else { return };
+    let mut server = Server::started();
+    let session_id = server.open_session("open_dump", json!({ "path": dump }), TARGET_STEP);
+
+    // The two anchors of a kernel dump's module list, used as addresses that certainly *are*
+    // readable — the alternative is a literal, and a literal would make this test a fact about
+    // one file.
+    let modules = server.tool_data("modules", json!({ "session_id": session_id }), TARGET_STEP);
+    let base = |want: &str| -> String {
+        modules["modules"]
+            .as_array()
+            .into_iter()
+            .flatten()
+            .find(|m| m["name"] == want)
+            .and_then(|m| m["start"].as_str())
+            .unwrap_or_else(|| panic!("the module list should include `{want}`: {modules}"))
+            .to_string()
+    };
+    let (nt, hal) = (base("nt"), base("hal"));
+
+    // The old way, first, so the improvement is measured rather than claimed: one unreadable
+    // dereference is a failed call with nothing in it.
+    let old = server.call_tool(
+        "execute",
+        json!({ "session_id": session_id, "command": format!("? poi({UNMAPPED})") }),
+        TARGET_STEP,
+    );
+    assert!(
+        is_tool_error(&old),
+        "the premise of #103 is that this fails; if it no longer does, this test is measuring \
+         nothing:\n{}",
+        text_of(&old["result"])
+    );
+
+    // The new way: the same address, in the middle of a list, is one row.
+    let walk = server.tool_data(
+        "walk_memory",
+        json!({
+            "session_id": session_id,
+            "addresses": [nt, UNMAPPED, hal],
+        }),
+        TARGET_STEP,
+    );
+    assert_eq!(walk["mode"], "list", "{walk}");
+    assert_eq!(
+        walk["walked"], 3,
+        "the hole must not shorten the walk: {walk}"
+    );
+    assert_eq!(walk["unreadable"], 1, "{walk}");
+    assert_eq!(walk["stopped"]["reason"], "complete", "{walk}");
+    let node = |i: usize| walk["nodes"][i].clone();
+    assert_eq!(node(1)["readable"], false, "{walk}");
+    assert!(
+        node(1)["fields"][0]["value"].is_null(),
+        "an unreadable value is absent, not zero: {walk}"
+    );
+    for i in [0, 2] {
+        assert_eq!(node(i)["readable"], true, "{walk}");
+        // Both anchors are PE images, so the qword at their base carries `MZ` — which is what
+        // makes this a real read of the target rather than an address echoed back.
+        let value = address_of(&node(i)["fields"][0]["value"]);
+        assert_eq!(
+            value & 0xffff,
+            0x5a4d,
+            "node {i} should read the `MZ` at a module base: {walk}"
+        );
+    }
+
+    // Array mode over the same header, with narrow fields: `e_magic` is two bytes and `e_lfanew`
+    // four, and reading them at their own widths is what a caller does to a real structure.
+    let header = server.tool_data(
+        "walk_memory",
+        json!({
+            "session_id": session_id,
+            "start": nt,
+            "stride": 0,
+            "count": 1,
+            "fields": [
+                { "name": "e_magic", "offset": 0, "size": 2 },
+                { "name": "e_lfanew", "offset": 0x3c, "size": 4 },
+            ],
+        }),
+        TARGET_STEP,
+    );
+    assert_eq!(header["mode"], "array", "{header}");
+    assert_eq!(
+        address_of(&header["nodes"][0]["fields"][0]["value"]),
+        0x5a4d,
+        "{header}"
+    );
+    let lfanew = address_of(&header["nodes"][0]["fields"][1]["value"]);
+    assert!(
+        (0x40..0x400).contains(&lfanew),
+        "`e_lfanew` should point at the PE header just past the DOS stub, got {lfanew:#x}: \
+         {header}"
+    );
+
+    // A chain is the one traversal a hole really does stop — the address after it lived in the
+    // bytes that would not read — and it has to say which node rather than come back empty.
+    let chain = server.tool_data(
+        "walk_memory",
+        json!({
+            "session_id": session_id,
+            "start": UNMAPPED,
+            "next_offset": 0,
+        }),
+        TARGET_STEP,
+    );
+    assert_eq!(chain["mode"], "chain", "{chain}");
+    assert_eq!(
+        chain["walked"], 1,
+        "the node it could not read is still a row: {chain}"
+    );
+    assert_eq!(chain["stopped"]["reason"], "unreadable_link", "{chain}");
+    assert_eq!(
+        chain["stopped"]["at"], "0x0000000000001000",
+        "the stop names the node, so a caller knows where to look: {chain}"
+    );
+    // Nothing read at all is the one answer this tool cannot make on its own, so the engine's
+    // reason rides along with it.
+    assert!(
+        chain["note"].as_str().is_some_and(|n| !n.is_empty()),
+        "a walk that read nothing has to explain itself: {chain}"
+    );
+
+    server.tool_data(
+        "end_session",
+        json!({ "session_id": session_id }),
+        TARGET_STEP,
     );
 }
 

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -1636,9 +1636,15 @@ fn a_walk_marks_what_it_cannot_read_and_keeps_going() {
     assert_eq!(walk["stopped"]["reason"], "complete", "{walk}");
     let node = |i: usize| walk["nodes"][i].clone();
     assert_eq!(node(1)["readable"], false, "{walk}");
+    // `get`, not indexing: indexing a missing key also yields `Null`, so the weaker assertion
+    // would pass against a payload that had dropped the field entirely — and an omitted key makes
+    // "the debugger could not read this" and "this object is malformed" the same observation for
+    // every client. The value is a null, and it is *there*.
     assert!(
-        node(1)["fields"][0]["value"].is_null(),
-        "an unreadable value is absent, not zero: {walk}"
+        node(1)["fields"][0]
+            .get("value")
+            .is_some_and(Value::is_null),
+        "an unreadable value is an explicit null, not a missing key and not zero: {walk}"
     );
     for i in [0, 2] {
         assert_eq!(node(i)["readable"], true, "{walk}");


### PR DESCRIPTION
Closes #103.

Walking a kernel list through `execute` is all-or-nothing. One unmapped dereference inside a MASM `.for` loop ends the whole script with `An unexpected exception was raised (0x80040205)` — no rows, no iteration number, no way to tell which node faulted. Driving the MessageManager use-after-free that meant bisecting a 512-entry handle table by hand to find the one bad pointer, which was of course the pointer the walk existed to find.

For a server whose subject is pool and UAF analysis that is backwards: "some of these nodes are freed" is the normal case, not an error.

## The tool

`walk_memory` names its nodes three ways — the issue's two proposed shapes, plus the array in between — and reads named `fields` out of each:

| | |
|---|---|
| `addresses` | walk these exactly — the bulk read |
| `start` + `stride` | an array: element *i* is `start + i * stride` |
| `start` + `next_offset` | a chain: the next node is the pointer at `node + next_offset` |

Field offsets may be **negative**, so a pool header 16 bytes before the address the allocator returned is an argument rather than arithmetic per node. `start` is any expression `?` evaluates (a symbol, `poi(<head>)` when the head is a link rather than a node); addresses in a list are numbers in any form the debugger prints.

A value the debugger cannot read is `null` in its own field, a node where nothing read is counted, and the walk carries on:

```
  idx  node                value
    0  0xfffff80389200000  0x0000000300905a4d
    1  0x0000000000001000  0x????????????????
    2  0xfffff8038aa00000  0x0000000300905a4d
```

The usual question is two calls: walk the table for the object pointers, then walk those pointers as `addresses` for their fields.

## Design notes

- **A chain is the one traversal a hole really stops**, because the address of everything after it lived in the bytes that would not read — so it stops and says *which node*. It also stops on a null link, on a loop (reporting where the list closed: back at the head that is a healthy circular `_LIST_ENTRY`, anywhere else it is corruption), and at `count`, where it hands back the address to resume from. Seven `stopped` reasons rather than a `complete` flag, because they call for opposite responses.
- **The cap is refused, not clamped.** `count` past 1024 is an error. Clamping would answer a different question and then label it `complete` — the one sentence a caller reads to decide whether to look further.
- **One read per node.** Fields of one structure are fetched in a single read of the span they cover, falling back to per-field reads only where there is a hole — and not coalescing at all for a single value, where a retry would re-read the bytes that just failed. Over a 512-entry table a third freed, that is 170 round trips on a KD link.
- **Bounded between nodes, because nothing else bounds it.** A walk is a long run of reads with no `Execute` behind it, so win-kexp's watchdog has nothing to interrupt. The deadline and the session's interrupt are polled once per node, *before* its reads; a break landing during node 3 must not buy node 4's round trips. A walk cut short answers with what it really read.
- **Nothing read at all is the one ambiguous answer**, so the reply carries the engine's own words for the first failed read. A list of freed objects reads identically to a target that is not broken in, or a `start` that is not where the caller thinks.
- **`src/walk.rs` is engine-free** — `run` takes a reader closure, as `reachability` takes a disassembler — so the traversal, the loop detection and the rendering are tested against an address space with holes in exactly the places that matter.
- Argument validation happens on the **supervisor's side**, before a session is chosen: every one of these is a fact about the request, not about a target.

## Testing

- `cargo test`: 287 unit tests (27 new in `walk.rs` — holes in every mode, loops, null links, the cap's resume address, the coalesced read and its fallback, negative offsets, narrow widths, halt placement, and the argument refusals), `cargo clippy --all-targets`, `cargo fmt --all --check`, markdownlint — all clean.
- `WINDBG_MCP_SMOKE_DUMP=1 cargo test`: 35 smoke tests. The new `a_walk_marks_what_it_cannot_read_and_keeps_going` asserts the **contrast** rather than describing it: `execute { "? poi(0x1000)" }` fails outright (the low 64 KB is reserved on every Windows target, so the hole needs no knowledge of this dump), while `walk_memory` returns that same address as a row between two module bases whose `MZ` it really read. Then array mode over the `nt` DOS header at its own field widths, and a chain from the unmapped address, which must stop with `unreadable_link` naming the node and carry the engine's reason for reading nothing.
- `a_malformed_walk_is_refused_before_a_session_is_needed` pins that the refusals happen with nothing open, and carry `invalid_argument` rather than a wording.
- Golden `tools/list` re-recorded (44 → 45 tools).

## Docs

README (tool table, a `walk_memory` section, the structured-results row, the `0x80040205` limitation), CHANGELOG, a DECISIONS entry, FOLLOWUPS item 19 (a `debug_batch` walk step, deferred with the budget question it raises), `docs/smoke-test.md`, the two walkthroughs that recorded this failure as a lesson, and three skill playbooks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
