### PR TITLE
Size what the pool walk missed, not only that it fell short

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,11 +133,21 @@ single-owner, so in parallel the second attach fails and can leave the target ha
 
 **Check the target is reachable before starting the tier, not by starting it.** A KDNET attach that
 finds nothing parks its worker in `WaitForEvent(INFINITE)` for the whole run and reports a timeout
-that measures the environment rather than the code. This debugger host is itself a Hyper-V guest —
-`Get-VM` does not exist here and there is no local VM to start — so the target is a *sibling* guest:
-find it in the neighbour table (`Get-NetNeighbor | ? LinkLayerAddress -like '00-15-5D*'`) and probe
-**TCP 5985**, since it answers WinRM and nothing else. ICMP and 445 are closed, so a failed ping
-proves nothing.
+that measures the environment rather than the code.
+
+What settles it is not "can I reach the guest" but **does the guest's `bcdedit /dbgsettings hostip`
+equal this debugger host's current IP**, on the port the profile names — that is what makes the
+target dial in, and the host IP moves between sessions. Read it on the guest and compare the key by
+*hash* rather than printing it. That check is the same everywhere; how you reach the guest to run it
+is not.
+
+*Finding* the guest is topology-specific, so what follows is one instance and not the procedure. On
+the machine this was written for, the debugger host is itself a Hyper-V guest — `Get-VM` does not
+exist and there is no local VM to start — so the target is a *sibling*: it appears in the neighbour
+table (`Get-NetNeighbor | ? LinkLayerAddress -like '00-15-5D*'`) and answers **TCP 5985** and
+nothing else, ICMP and 445 being closed, so a failed ping proves nothing there. Elsewhere it may be
+a local VM, another hypervisor, or one of several neighbours — and with several, the neighbour table
+alone will happily validate the wrong guest, which is what the `hostip` comparison above is for.
 
 ## Live kernel + driver IOCTL gotchas (learned driving HEVD over KDNET)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,8 +118,26 @@ $env:WINDBG_MCP_SMOKE_KERNEL = "net:port=50000,key=<w.x.y.z>"
 cargo test --test mcp_smoke -- --ignored --nocapture --test-threads=1 live_kernel
 ```
 
+**Do not ask for that string before checking whether a profile already holds it.** The same
+connection is usually configured for `attach_kernel { "profile": … }`, in
+`%USERPROFILE%\.windbg-mcp\profiles.json` or a `WINDBG_MCP_PROFILE_<NAME>` variable, and the tier
+takes the *raw* string only because it has to exercise the explicit path — not because it needs a
+second copy. Read the profile and set the variable from it in one step, so the key never lands in a
+command line, a tool argument or this transcript; print the profile *name* and the port when
+reporting what you are attaching to, never the value. `attach_kernel {}` lists the configured names
+without disclosing any of them. Only ask the user for a raw connection when no profile is
+configured at all.
+
 `--test-threads=1` is not optional: the filter matches **eight** tests, and the KD transport is
 single-owner, so in parallel the second attach fails and can leave the target halted.
+
+**Check the target is reachable before starting the tier, not by starting it.** A KDNET attach that
+finds nothing parks its worker in `WaitForEvent(INFINITE)` for the whole run and reports a timeout
+that measures the environment rather than the code. This debugger host is itself a Hyper-V guest —
+`Get-VM` does not exist here and there is no local VM to start — so the target is a *sibling* guest:
+find it in the neighbour table (`Get-NetNeighbor | ? LinkLayerAddress -like '00-15-5D*'`) and probe
+**TCP 5985**, since it answers WinRM and nothing else. ICMP and 445 are closed, so a failed ping
+proves nothing.
 
 ## Live kernel + driver IOCTL gotchas (learned driving HEVD over KDNET)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -883,7 +883,7 @@ dependencies = [
 [[package]]
 name = "win-kexp"
 version = "0.1.0"
-source = "git+https://github.com/glslang/win-kexp?branch=main#c829ff07f90028ca811fd843a44fd10c60b26cf8"
+source = "git+https://github.com/glslang/win-kexp?branch=main#cbccef8b2171ee67980c577bf4f264521756c1b3"
 dependencies = [
  "byte-strings",
  "goblin",

--- a/src/server.rs
+++ b/src/server.rs
@@ -2426,6 +2426,10 @@ impl WindbgServer {
     /// hundred-plus categories, so the summaries the other tools print are necessarily
     /// truncated — and the one line explaining a specific heap is reliably not in the
     /// truncated head. Filter by a heap address or a phrase to get at it.
+    /// For *how much* a walk missed rather than why, `walk.gaps` on any pool answer already says
+    /// it — pages stepped over, bytes skipped against bytes read past them, chunk headers
+    /// refused — and the diagnostics cannot, since a category's count counts occurrences of a
+    /// message shape rather than bytes or chunks.
     #[rmcp::tool(
         annotations(
             title = "Filter pool walk diagnostics",

--- a/src/server.rs
+++ b/src/server.rs
@@ -2426,10 +2426,12 @@ impl WindbgServer {
     /// hundred-plus categories, so the summaries the other tools print are necessarily
     /// truncated — and the one line explaining a specific heap is reliably not in the
     /// truncated head. Filter by a heap address or a phrase to get at it.
-    /// For *how much* a walk missed rather than why, `walk.gaps` on any pool answer already says
-    /// it — pages stepped over, bytes skipped against bytes read past them, chunk headers
-    /// refused — and the diagnostics cannot, since a category's count counts occurrences of a
-    /// message shape rather than bytes or chunks.
+    /// `walk.gaps` on any pool answer sizes the two things a walk *records* running into — pages
+    /// a region query stalled on, and chunk headers a decoder refused — in bytes and chunks,
+    /// which the diagnostics cannot, since a category's count counts occurrences of a message
+    /// shape. It is not a total of everything a walk missed: one cut short by its deadline or a
+    /// traversal cap carries no gaps at all. `walk.coverage` is still what says a walk fell
+    /// short, and this tool is still what says why.
     #[rmcp::tool(
         annotations(
             title = "Filter pool walk diagnostics",

--- a/src/structured.rs
+++ b/src/structured.rs
@@ -781,10 +781,14 @@ pub struct WalkGaps {
     /// walk that gave up at the first stall would have reported as nothing at all. Large next to
     /// `skipped_bytes` means the stalls were isolated pages in otherwise healthy regions.
     pub recovered_bytes: u64,
-    /// Chunk headers a backend decoder refused. A refusal costs more than its own chunk —
-    /// every header after it in that extent is then decoded at a guessed offset — so a large
-    /// number here means the chunks reported from those extents are worth less than their
-    /// count suggests.
+    /// Chunk headers a backend decoder refused.
+    ///
+    /// **Not a count of chunks lost.** A refusal resynchronises sixteen bytes along and tries
+    /// again, so one lost sync bills a refusal per sixteen bytes until it recovers: a live
+    /// 26100 walk reported 106,516 of these from 542 affected extents. Read it as the size of
+    /// the disruption — the chunks reported from those extents were decoded at guessed offsets
+    /// and are worth less than their count suggests — rather than as a population of bad
+    /// chunks, which it overstates by orders of magnitude.
     pub refused_chunks: u64,
 }
 

--- a/src/structured.rs
+++ b/src/structured.rs
@@ -758,6 +758,47 @@ pub struct WalkInfo {
     pub diagnostics_emitted: usize,
     /// How many distinct kinds of complaint those fell into.
     pub diagnostic_categories: usize,
+    /// What the walk could not read, in bytes and chunks, when there was anything. Absent on a
+    /// walk that met none of it, which is the ordinary case.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub gaps: Option<WalkGaps>,
+}
+
+/// What a walk could not read, and what it read anyway by stepping over rather than giving up.
+///
+/// Sizes what `coverage` only names. `partial` says a walk fell short; these say by how much,
+/// which is the difference between "a page was unreadable" and "a third of the pool was" — and
+/// the diagnostics cannot answer it, because they collapse messages by shape and the counts
+/// beside them count *occurrences of a shape*, not bytes or chunks.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct WalkGaps {
+    /// Pages the debugger's valid-region query could not advance over. The walk steps over one
+    /// and asks again rather than abandoning the rest of the region behind it.
+    pub stalled_pages: u64,
+    /// Bytes those steps filed as unreadable.
+    pub skipped_bytes: u64,
+    /// Bytes of committed memory read *after* a stall, in the regions that stalled — coverage a
+    /// walk that gave up at the first stall would have reported as nothing at all. Large next to
+    /// `skipped_bytes` means the stalls were isolated pages in otherwise healthy regions.
+    pub recovered_bytes: u64,
+    /// Chunk headers a backend decoder refused, resynchronising sixteen bytes at a time past
+    /// each. A refusal costs more than the chunk: every header after it in that extent is
+    /// decoded at a guessed offset, so a large number here means the chunks reported from those
+    /// extents are worth less than their count suggests.
+    pub refused_chunks: u64,
+}
+
+impl WalkGaps {
+    /// `None` when the walk met none of this, so the ordinary answer does not carry four zeroes.
+    pub(crate) fn of(report: &win_kexp::pool::query::PoolSnapshotReport) -> Option<Self> {
+        let gaps = Self {
+            stalled_pages: report.stalls.pages,
+            skipped_bytes: report.stalls.skipped_bytes,
+            recovered_bytes: report.stalls.recovered_bytes,
+            refused_chunks: report.refused_chunks,
+        };
+        (gaps != Self::default()).then_some(gaps)
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
@@ -1400,6 +1441,52 @@ mod tests {
             assert_eq!(PoolCoverage::from(engine), expected);
             assert_eq!(serde_json::to_value(expected).unwrap(), wire);
         }
+    }
+
+    /// The gap figures answer the question `coverage` raises and cannot settle: `partial` says
+    /// a walk fell short, and these say by how much. They have to come from the walk as numbers
+    /// — the diagnostics cannot supply them, because they collapse messages by shape and the
+    /// count beside a shape counts occurrences of *that shape*, not bytes or chunks.
+    #[test]
+    fn walk_gaps_carry_what_the_diagnostics_cannot() {
+        let report = |stalls, refused_chunks| win_kexp::pool::query::PoolSnapshotReport {
+            total_chunks: 0,
+            allocated_chunks: 0,
+            coverage: win_kexp::pool::query::WalkCoverage::Partial,
+            diagnostics: win_kexp::pool::PoolDiagnostics::default(),
+            stalls,
+            refused_chunks,
+        };
+
+        // The ordinary walk meets none of this, and says so by saying nothing: four zeroes on
+        // every pool answer would be noise on the answers that are fine.
+        assert_eq!(
+            WalkGaps::of(&report(win_kexp::pool::WalkStalls::default(), 0)),
+            None
+        );
+
+        let gaps = WalkGaps::of(&report(
+            win_kexp::pool::WalkStalls {
+                pages: 3,
+                skipped_bytes: 0x3000,
+                recovered_bytes: 0x40000,
+            },
+            884,
+        ))
+        .expect("a walk that stalled has gaps to report");
+        assert_eq!(gaps.stalled_pages, 3);
+        assert_eq!(gaps.skipped_bytes, 0x3000);
+        // The figure the whole measurement is for: committed memory read on the far side of a
+        // stall, which a walk that abandoned the region at the first one reports as nothing.
+        assert_eq!(gaps.recovered_bytes, 0x40000);
+        assert_eq!(gaps.refused_chunks, 884);
+
+        // Any one of them alone is still worth reporting — a walk can refuse chunks without
+        // ever stalling, and reporting nothing there would hide the refusals entirely.
+        assert!(WalkGaps::of(&report(win_kexp::pool::WalkStalls::default(), 1)).is_some());
+        let wire = serde_json::to_value(gaps).unwrap();
+        assert_eq!(wire["recovered_bytes"], 0x40000);
+        assert_eq!(wire["refused_chunks"], 884);
     }
 
     /// A field's JSON type must not depend on its value.

--- a/src/structured.rs
+++ b/src/structured.rs
@@ -772,8 +772,8 @@ pub struct WalkInfo {
 /// beside them count *occurrences of a shape*, not bytes or chunks.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub struct WalkGaps {
-    /// Pages the debugger's valid-region query could not advance over. The walk steps over one
-    /// and asks again rather than abandoning the rest of the region behind it.
+    /// Pages the debugger's valid-region query could not advance over, stepped over one at a
+    /// time rather than abandoning the rest of the region behind them.
     pub stalled_pages: u64,
     /// Bytes those steps filed as unreadable.
     pub skipped_bytes: u64,
@@ -781,10 +781,10 @@ pub struct WalkGaps {
     /// walk that gave up at the first stall would have reported as nothing at all. Large next to
     /// `skipped_bytes` means the stalls were isolated pages in otherwise healthy regions.
     pub recovered_bytes: u64,
-    /// Chunk headers a backend decoder refused, resynchronising sixteen bytes at a time past
-    /// each. A refusal costs more than the chunk: every header after it in that extent is
-    /// decoded at a guessed offset, so a large number here means the chunks reported from those
-    /// extents are worth less than their count suggests.
+    /// Chunk headers a backend decoder refused. A refusal costs more than its own chunk —
+    /// every header after it in that extent is then decoded at a guessed offset — so a large
+    /// number here means the chunks reported from those extents are worth less than their
+    /// count suggests.
     pub refused_chunks: u64,
 }
 
@@ -1484,9 +1484,23 @@ mod tests {
         // Any one of them alone is still worth reporting — a walk can refuse chunks without
         // ever stalling, and reporting nothing there would hide the refusals entirely.
         assert!(WalkGaps::of(&report(win_kexp::pool::WalkStalls::default(), 1)).is_some());
-        let wire = serde_json::to_value(gaps).unwrap();
-        assert_eq!(wire["recovered_bytes"], 0x40000);
-        assert_eq!(wire["refused_chunks"], 884);
+
+        // The omission has to be asserted where it happens, on `WalkInfo`. `of` returning
+        // `None` says nothing about whether the field then serialises as `"gaps": null`, which
+        // would be a shape change on every healthy pool answer — the ones that are fine.
+        let walk = |gaps| WalkInfo {
+            coverage: PoolCoverage::Partial,
+            chunks_walked: 0,
+            allocated_chunks: 0,
+            diagnostics_emitted: 0,
+            diagnostic_categories: 0,
+            gaps,
+        };
+        let quiet = serde_json::to_value(walk(None)).unwrap();
+        assert!(quiet.get("gaps").is_none(), "{quiet}");
+        let wire = serde_json::to_value(walk(Some(gaps))).unwrap();
+        assert_eq!(wire["gaps"]["recovered_bytes"], 0x40000);
+        assert_eq!(wire["gaps"]["refused_chunks"], 884);
     }
 
     /// A field's JSON type must not depend on its value.

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -2639,6 +2639,7 @@ fn walk_info(report: &query::PoolSnapshotReport) -> structured::WalkInfo {
         allocated_chunks: report.allocated_chunks,
         diagnostics_emitted: report.diagnostics.emitted(),
         diagnostic_categories: report.diagnostics.shapes().len(),
+        gaps: structured::WalkGaps::of(report),
     }
 }
 
@@ -3191,9 +3192,25 @@ fn reachable(e: &DebugEngine, args: ReachabilityOp) -> Result<String, String> {
 
 #[cfg(test)]
 mod tests {
+    use win_kexp::pool::WalkStalls;
+
     use super::*;
 
     // ---- pool walk diagnostics ------------------------------------------------------
+
+    /// A report from a walk that met no unreadable page and refused no chunk, for the fixtures
+    /// below to spread over their own fields. They exercise the diagnostic *rendering*; what
+    /// the gap figures do with a walk that met either is `structured`'s question.
+    fn quiet_walk() -> query::PoolSnapshotReport {
+        query::PoolSnapshotReport {
+            total_chunks: 0,
+            allocated_chunks: 0,
+            coverage: coverage(true),
+            diagnostics: PoolDiagnostics::default(),
+            stalls: WalkStalls::default(),
+            refused_chunks: 0,
+        }
+    }
 
     fn report_with(complete: bool, diagnostics: &[&str]) -> query::PoolSnapshotReport {
         query::PoolSnapshotReport {
@@ -3201,6 +3218,7 @@ mod tests {
             allocated_chunks: 3007,
             coverage: coverage(complete),
             diagnostics: diagnostics.iter().map(|line| line.to_string()).collect(),
+            ..quiet_walk()
         }
     }
 
@@ -3227,6 +3245,7 @@ mod tests {
             allocated_chunks: 3007,
             coverage: coverage(false),
             diagnostics: lines.into_iter().collect(),
+            ..quiet_walk()
         }
     }
 
@@ -3335,6 +3354,7 @@ mod tests {
             allocated_chunks: 3007,
             coverage: coverage(true),
             diagnostics: lines.into_iter().collect(),
+            ..quiet_walk()
         }
     }
 

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -3212,6 +3212,37 @@ mod tests {
         }
     }
 
+    /// The gap figures reach an answer through `walk_info`, which is a struct literal: a field
+    /// wired to `None`, or to the wrong half of the report, compiles and silently drops what the
+    /// walk measured. `structured` proves the mapping; this proves the assignment.
+    #[test]
+    fn walk_info_carries_what_the_walk_measured() {
+        let mut report = quiet_walk();
+        assert!(
+            walk_info(&report).gaps.is_none(),
+            "a walk that met none of it reports none"
+        );
+
+        report.stalls = WalkStalls {
+            pages: 2,
+            skipped_bytes: 0x2000,
+            recovered_bytes: 0x8000,
+        };
+        report.refused_chunks = 7;
+        let gaps = walk_info(&report)
+            .gaps
+            .expect("a walk that stalled has gaps to report");
+        assert_eq!(
+            (
+                gaps.stalled_pages,
+                gaps.skipped_bytes,
+                gaps.recovered_bytes,
+                gaps.refused_chunks
+            ),
+            (2, 0x2000, 0x8000, 7)
+        );
+    }
+
     fn report_with(complete: bool, diagnostics: &[&str]) -> query::PoolSnapshotReport {
         query::PoolSnapshotReport {
             total_chunks: 4211,


### PR DESCRIPTION
Depends on [glslang/win-kexp#102](https://github.com/glslang/win-kexp/pull/102), now merged; the pin moved to `cbccef8` in the second commit here.

## What this adds

`coverage: partial` says a walk did not cover the pool. It cannot say *by how much*, and neither can `pool_diagnostics`: it collapses messages by shape, so the count beside a category counts occurrences of that shape — not bytes, not chunks. A caller reading `partial` has no way to tell one unreadable page from a third of the pool.

win-kexp#102 makes the walker carry those figures as figures. This surfaces them as `walk.gaps` on every pool answer:

| field | what it says |
|---|---|
| `stalled_pages` | pages a valid-region query could not advance over |
| `skipped_bytes` | what those steps wrote off |
| `recovered_bytes` | committed memory read *past* them, in the same regions |
| `refused_chunks` | chunk headers a decoder refused and resynchronised past |

`recovered_bytes` is the one the walker's stall handling is judged by — it is coverage a walk that abandoned the region at the first stall reported as nothing at all — and it only means anything next to `skipped_bytes`, which is why they travel together rather than as a single "how bad was it" number.

Absent when a walk met none of it, which is the ordinary case: four zeroes on every healthy answer would be noise on the answers that are fine.

Also updates the three `PoolSnapshotReport` fixtures the new fields reach, onto a `quiet_walk()` base the diagnostic-rendering tests spread their own fields over — those tests are about rendering, and what the gap figures do is `structured`'s question, with its own test.

## Verified

Against merged win-kexp `main`, no `[patch]`:

- `cargo test` — 303 unit + 37 smoke, all passing;
- `WINDBG_MCP_SMOKE_DUMP=1 cargo test --test mcp_smoke` — the tier CLAUDE.md asks for after `cargo update -p win-kexp`, 37 passing;
- `cargo clippy --all-targets` clean;
- the recorded wire surface is unchanged, since the golden records output *branch* names rather than full schemas.

## What is **not** verified

**No pool answer carrying a populated `walk.gaps` has been observed.** The sample dump is a kernel *mini*dump whose pool metadata is not paged in, so the walk cannot run on it at all — `pool_census` and `pool_diagnostics` both fail there with `sparse virtual range at 0xfffff8038a06bd50`, and they do so identically on `main`, so it is not this change. The unit test covers the mapping and the omit-when-empty rule; a live KDNET target is what would show the fields populated end to end, and that is also where win-kexp#102's own numbers (3,285 stalls, 884 refusals) can be re-measured against the fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Pool walk results now report gap details, including stalled pages, skipped bytes, recovered bytes, and refused chunks.
  - Gap information is shown only when relevant, keeping normal results concise.
  - Pool diagnostics distinguish between the extent of missed data and the messages explaining its causes.

- **Documentation**
  - Clarified how pool-walk gaps and diagnostic message counts should be interpreted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->