### PR TITLE
Expose version-aware user heap walking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -883,7 +883,7 @@ dependencies = [
 [[package]]
 name = "win-kexp"
 version = "0.1.0"
-source = "git+https://github.com/glslang/win-kexp?branch=main#cbccef8b2171ee67980c577bf4f264521756c1b3"
+source = "git+https://github.com/glslang/win-kexp?rev=7988474148044652e3f1ea3ebb2287fa1754de84#7988474148044652e3f1ea3ebb2287fa1754de84"
 dependencies = [
  "byte-strings",
  "goblin",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -883,7 +883,7 @@ dependencies = [
 [[package]]
 name = "win-kexp"
 version = "0.1.0"
-source = "git+https://github.com/glslang/win-kexp?rev=7988474148044652e3f1ea3ebb2287fa1754de84#7988474148044652e3f1ea3ebb2287fa1754de84"
+source = "git+https://github.com/glslang/win-kexp?rev=294c041d9de1f1181d4a67afd249429a209b5cb3#294c041d9de1f1181d4a67afd249429a209b5cb3"
 dependencies = [
  "byte-strings",
  "goblin",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -883,7 +883,7 @@ dependencies = [
 [[package]]
 name = "win-kexp"
 version = "0.1.0"
-source = "git+https://github.com/glslang/win-kexp?rev=37dc18ef3a55f52a7c7495705fa686e593f934d5#37dc18ef3a55f52a7c7495705fa686e593f934d5"
+source = "git+https://github.com/glslang/win-kexp?rev=239b4e4b1f1afd92e96da6a7101ada8a79c80164#239b4e4b1f1afd92e96da6a7101ada8a79c80164"
 dependencies = [
  "byte-strings",
  "goblin",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -883,7 +883,7 @@ dependencies = [
 [[package]]
 name = "win-kexp"
 version = "0.1.0"
-source = "git+https://github.com/glslang/win-kexp?rev=719cad36dd878f0036981e116222792424189ef5#719cad36dd878f0036981e116222792424189ef5"
+source = "git+https://github.com/glslang/win-kexp?branch=main#549a949fb9413960a16eac4d5bab807815c1814d"
 dependencies = [
  "byte-strings",
  "goblin",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -883,7 +883,7 @@ dependencies = [
 [[package]]
 name = "win-kexp"
 version = "0.1.0"
-source = "git+https://github.com/glslang/win-kexp?rev=294c041d9de1f1181d4a67afd249429a209b5cb3#294c041d9de1f1181d4a67afd249429a209b5cb3"
+source = "git+https://github.com/glslang/win-kexp?rev=37dc18ef3a55f52a7c7495705fa686e593f934d5#37dc18ef3a55f52a7c7495705fa686e593f934d5"
 dependencies = [
  "byte-strings",
  "goblin",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -883,7 +883,7 @@ dependencies = [
 [[package]]
 name = "win-kexp"
 version = "0.1.0"
-source = "git+https://github.com/glslang/win-kexp?rev=239b4e4b1f1afd92e96da6a7101ada8a79c80164#239b4e4b1f1afd92e96da6a7101ada8a79c80164"
+source = "git+https://github.com/glslang/win-kexp?rev=719cad36dd878f0036981e116222792424189ef5#719cad36dd878f0036981e116222792424189ef5"
 dependencies = [
  "byte-strings",
  "goblin",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.8.1"
 edition = "2024"
 
 [dependencies]
-win-kexp = { git = "https://github.com/glslang/win-kexp", rev = "719cad36dd878f0036981e116222792424189ef5" }
+win-kexp = { git = "https://github.com/glslang/win-kexp", branch = "main" }
 # 3.1.1 is a floor, not a preference: every 3.x before it generates a `tools/list` that omits
 # SEP-2549's required `ttlMs`/`cacheScope`, which a spec-strict `2026-07-28` client rejects
 # outright — the server connects and appears to expose no tools at all (upstream issue #1114).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.8.1"
 edition = "2024"
 
 [dependencies]
-win-kexp = { git = "https://github.com/glslang/win-kexp", rev = "294c041d9de1f1181d4a67afd249429a209b5cb3" }
+win-kexp = { git = "https://github.com/glslang/win-kexp", rev = "37dc18ef3a55f52a7c7495705fa686e593f934d5" }
 # 3.1.1 is a floor, not a preference: every 3.x before it generates a `tools/list` that omits
 # SEP-2549's required `ttlMs`/`cacheScope`, which a spec-strict `2026-07-28` client rejects
 # outright — the server connects and appears to expose no tools at all (upstream issue #1114).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.8.1"
 edition = "2024"
 
 [dependencies]
-win-kexp = { git = "https://github.com/glslang/win-kexp", rev = "37dc18ef3a55f52a7c7495705fa686e593f934d5" }
+win-kexp = { git = "https://github.com/glslang/win-kexp", rev = "239b4e4b1f1afd92e96da6a7101ada8a79c80164" }
 # 3.1.1 is a floor, not a preference: every 3.x before it generates a `tools/list` that omits
 # SEP-2549's required `ttlMs`/`cacheScope`, which a spec-strict `2026-07-28` client rejects
 # outright — the server connects and appears to expose no tools at all (upstream issue #1114).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.8.1"
 edition = "2024"
 
 [dependencies]
-win-kexp = { git = "https://github.com/glslang/win-kexp", rev = "239b4e4b1f1afd92e96da6a7101ada8a79c80164" }
+win-kexp = { git = "https://github.com/glslang/win-kexp", rev = "719cad36dd878f0036981e116222792424189ef5" }
 # 3.1.1 is a floor, not a preference: every 3.x before it generates a `tools/list` that omits
 # SEP-2549's required `ttlMs`/`cacheScope`, which a spec-strict `2026-07-28` client rejects
 # outright — the server connects and appears to expose no tools at all (upstream issue #1114).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.8.1"
 edition = "2024"
 
 [dependencies]
-win-kexp = { git = "https://github.com/glslang/win-kexp", rev = "7988474148044652e3f1ea3ebb2287fa1754de84" }
+win-kexp = { git = "https://github.com/glslang/win-kexp", rev = "294c041d9de1f1181d4a67afd249429a209b5cb3" }
 # 3.1.1 is a floor, not a preference: every 3.x before it generates a `tools/list` that omits
 # SEP-2549's required `ttlMs`/`cacheScope`, which a spec-strict `2026-07-28` client rejects
 # outright — the server connects and appears to expose no tools at all (upstream issue #1114).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.8.1"
 edition = "2024"
 
 [dependencies]
-win-kexp = { git = "https://github.com/glslang/win-kexp", branch = "main" }
+win-kexp = { git = "https://github.com/glslang/win-kexp", rev = "7988474148044652e3f1ea3ebb2287fa1754de84" }
 # 3.1.1 is a floor, not a preference: every 3.x before it generates a `tools/list` that omits
 # SEP-2549's required `ttlMs`/`cacheScope`, which a spec-strict `2026-07-28` client rejects
 # outright — the server connects and appears to expose no tools at all (upstream issue #1114).

--- a/README.md
+++ b/README.md
@@ -328,6 +328,7 @@ gh attestation verify <zip> --repo glslang/windbg-mcp `
 | TTD analysis | `ttd_calls`, `ttd_memory`, `ttd_events`, `index_trace`, `record_trace` |
 | Driver IOCTL | `decode_ioctl`, `driver_object`, `device_object`, `irp_stack`, `ioctl_trace`, `reachable_from_dispatch` |
 | Kernel pool | `pool_find_tag`, `pool_chunk`, `pool_census`, `pool_diagnostics` |
+| User Segment Heap | `heap_list`, `heap_allocations`, `heap_chunk`, `heap_census`, `heap_diagnostics` |
 | Raw     | `execute` — run any debugger command, returns full text output |
 
 ### Sessions and session handles
@@ -623,6 +624,7 @@ matching `outputSchema` in `tools/list`, so a program can read a field instead o
 | `run_to_address` | `verdict` (`hit`/`stopped_elsewhere`/`timeout`), `target`, `stopped_at` |
 | `go`, `step_over`, `step_into`, `step_back`, `step_over_back`, `reverse_go` | `stopped_at` |
 | `pool_find_tag`, `pool_chunk`, `pool_census`, `pool_diagnostics` | the chunks/totals/diagnostics as values, each carrying the `walk` behind them |
+| `heap_list`, `heap_allocations`, `heap_chunk`, `heap_census`, `heap_diagnostics` | PEB heap roots and Segment Heap allocations/totals/diagnostics, each carrying exact `ntdll` layout provenance, skipped-heap scope, and walk coverage |
 | `walk_memory` | `nodes[]` with each field's `value` — `null` where the debugger could not read it — plus `walked`/`unreadable` counts and a `stopped` reason (`complete`, `cap`, `null_link`, `loop`, `unreadable_link`, `deadline`, `interrupted`), each carrying the address it is about |
 | `crash_triage` | `bug_check` (`code`, `name`, four `parameters`), `process_name`, `frames[]` as `{module, rva, symbol}`, the `faulting_frame` picked out of them — and `!analyze`'s own conclusions kept apart under `analysis` |
 
@@ -633,7 +635,7 @@ Two conventions hold across all of them:
   past 2^53 does not survive a JSON parser that reads numbers as doubles; zero-padded so lexical
   order matches numeric order. The debugger's backtick form (``fffff803`1ab10000``) appears only in
   the text.
-- **A pool answer says what the walk covered.** `walk.coverage` is `complete`, `deadline_truncated`
+- **An allocator answer says what the walk covered.** `walk.coverage` is `complete`, `deadline_truncated`
   (the call's budget ran out — more time reaches more of the pool) or `partial` (unreadable regions
   or a traversal cap — more time changes nothing). Counts from anything but `complete` are floors,
   not totals. A walk that failed outright, or was stopped by `interrupt`, is not a coverage state at
@@ -706,6 +708,17 @@ timeline). For anything else, `dx` evaluates arbitrary data-model/LINQ expressio
   `Unreadable` is the walk's own limit (a Verifier guard page reads that way) and says nothing
   about whether the allocator freed anything. `pool_chunk` also
   reports the **neighbouring** chunks, which is what tells you what a reclaim would land next to. `pool_diagnostics` returns the walk's own diagnostics filtered by substring: a real walk emits tens of thousands across a hundred-plus categories, so any per-call summary truncates and the one line explaining a specific heap is never in the truncated head — filter by a heap address or a phrase to reach it.
+- The **user Segment Heap** tools share that typed decoder but discover roots through the current
+  process's PDB-resolved `_PEB.NumberOfHeaps` and `ProcessHeaps`. They require a stopped x64 user
+  target (or a dump with sufficient memory) and the exact loaded `ntdll` PDB. `heap_list` reports
+  every root and explicitly separates Segment Heaps walked from classic NT, unknown, and unreadable
+  heaps skipped. V1 does not decode classic NT heaps, WOW64, or ARM64; use `!heap` for classic heaps.
+  Snapshots are cached per target/PEB/`ntdll` image and invalidated when execution resumes; pass
+  `refresh: true` for the final observation after target execution. Allocation `capacity` is always
+  allocator-backed, while `requested_size` is optional and appears only when the selected schema
+  validates exact unused-byte metadata. Read `layout`, `scope`, and `walk` before treating an absent
+  allocation as evidence. The agent workflow is in
+  [`skills/windbg-debugging/heap-walking.md`](skills/windbg-debugging/heap-walking.md).
 - **`crash_triage` reads a bug check two ways, and keeps them apart.** The code and its parameters
   (`ReadBugCheckData`), the stack, each frame's module, and the crashing process (out of the current
   `_EPROCESS`'s audit name — the full image name, not the 15-byte `ImageFileName` that turns

--- a/README.md
+++ b/README.md
@@ -636,7 +636,7 @@ Two conventions hold across all of them:
   order matches numeric order. The debugger's backtick form (``fffff803`1ab10000``) appears only in
   the text.
 - **An allocator answer says what the walk covered.** `walk.coverage` is `complete`, `deadline_truncated`
-  (the call's budget ran out — more time reaches more of the pool) or `partial` (unreadable regions
+  (the call's budget ran out — more time reaches more of the allocator) or `partial` (unreadable regions
   or a traversal cap — more time changes nothing). Counts from anything but `complete` are floors,
   not totals. A walk that failed outright, or was stopped by `interrupt`, is not a coverage state at
   all: it is the error branch below, with category `debugger` or `interrupted`.
@@ -716,8 +716,9 @@ timeline). For anything else, `dx` evaluates arbitrary data-model/LINQ expressio
   Snapshots are cached per target/PEB/`ntdll` image and invalidated when execution resumes; pass
   `refresh: true` for the final observation after target execution. Allocation `capacity` is always
   allocator-backed, while `requested_size` is optional and appears only when the selected schema
-  validates exact unused-byte metadata. Read `layout`, `scope`, and `walk` before treating an absent
-  allocation as evidence. The agent workflow is in
+  validates exact unused-byte metadata. `heap_allocations` defaults to `state: allocated`; when
+  investigating freed memory, pass `state: reusable_free` or `state: cached_free` explicitly. Read
+  `layout`, `scope`, and `walk` before treating an absent allocation as evidence. The agent workflow is in
   [`skills/windbg-debugging/heap-walking.md`](skills/windbg-debugging/heap-walking.md).
 - **`crash_triage` reads a bug check two ways, and keeps them apart.** The code and its parameters
   (`ReadBugCheckData`), the stack, each frame's module, and the crashing process (out of the current

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -529,7 +529,10 @@ before a release, or when a change touches the relevant path. Drivers live in
   backend, writes a temporary `/ma` full-memory dump, reopens it, and repeats the checks. Set
   `WIN_KEXP_USER_HEAP_SYMBOLS` (or `_NT_SYMBOL_PATH`) when the default Microsoft symbol-store path
   is not appropriate. Missing private types are a failed prerequisite; export symbols must not be
-  accepted as a layout. The helper removes its temporary dump after a successful run.
+  accepted as a layout. The dump is written to the operating system temporary directory as
+  `win-kexp-user-heap-<pid>.dmp`, outside either checkout. The helper removes it after a successful
+  run; after a failed run, delete that file from the temporary directory manually and never add it
+  to version control.
 - **Ctrl+C teardown** — `examples/ctrl_c_teardown.ps1`: a console Ctrl+C must leave a worker time
   to release its target, not kill it where it stands. Unattended, and it needs no target beyond the
   sample dump — but it is here rather than in `cargo test` because Ctrl+C cannot be aimed: the

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -523,6 +523,13 @@ before a release, or when a change touches the relevant path. Drivers live in
 
 - **Live user-mode** — `examples/test_usermode.ps1`: launch `cmd.exe` under the debugger, break in,
   read registers/modules, set a breakpoint.
+- **Typed user Segment Heap** — from a sibling `win-kexp` checkout, run
+  `cargo run --example user_heap_smoke`. The helper launches an x64 child that retains known
+  LFH/VS/backend/large allocations, reloads the exact `ntdll` PDB, verifies each pointer and
+  backend, writes a temporary `/ma` full-memory dump, reopens it, and repeats the checks. Set
+  `WIN_KEXP_USER_HEAP_SYMBOLS` (or `_NT_SYMBOL_PATH`) when the default Microsoft symbol-store path
+  is not appropriate. Missing private types are a failed prerequisite; export symbols must not be
+  accepted as a layout. The helper removes its temporary dump after a successful run.
 - **Ctrl+C teardown** — `examples/ctrl_c_teardown.ps1`: a console Ctrl+C must leave a worker time
   to release its target, not kill it where it stands. Unattended, and it needs no target beyond the
   sample dump — but it is here rather than in `cargo test` because Ctrl+C cannot be aimed: the

--- a/skills/windbg-debugging/SKILL.md
+++ b/skills/windbg-debugging/SKILL.md
@@ -20,6 +20,7 @@ session of a workflow you haven't run yet in this environment.
 | Build / engine bundling / symbols / elevation | [setup.md](setup.md) |
 | Triage a `.dmp` crash dump | [crash-dump.md](crash-dump.md) |
 | Launch/attach a process, or debug the kernel | [live-and-kernel.md](live-and-kernel.md) |
+| Walk kernel pools or user Segment Heaps | [heap-walking.md](heap-walking.md) |
 | Record / open / navigate / analyze a `.run` trace | [ttd.md](ttd.md) |
 | Enumerate a driver's IOCTLs & test user-mode reachability | [driver-ioctl.md](driver-ioctl.md) |
 
@@ -36,6 +37,8 @@ already does the job.
 | Transaction | `debug_batch` — an ordered sequence with assertions and a rollback the engine runs, not the client |
 | TTD nav | `step_back` (`t-`), `step_over_back` (`p-`), `reverse_go` (`g-`), `goto_position` (`!tt`) |
 | TTD analysis | `ttd_calls`, `ttd_memory`, `ttd_events`, `index_trace`, `record_trace` |
+| Kernel pool | `pool_find_tag`, `pool_chunk`, `pool_census`, `pool_diagnostics` |
+| User Segment Heap | `heap_list`, `heap_allocations`, `heap_chunk`, `heap_census`, `heap_diagnostics` |
 | Raw | `execute` — run any debugger command, returns full text output |
 
 The forward control tools (`go`/`step_over`/`step_into`) and the reverse ones
@@ -120,9 +123,10 @@ inside the debugger, so a batch built from long steps waits out the one it is in
   Verify with `lm m <mod>` (`(pdb symbols)` vs `(export symbols)`) — never with
   `x <mod>!<sym>`, which prints *nothing* when unresolved, so its silence proves nothing.
   Details in [setup.md](setup.md).
-- **The pool tools need *private* `nt` types, not exports** — they decode segment-heap
-  internals, so `missing kernel pool symbols (ExPoolState)` is a symbol problem on *this*
-  host (symbols never come over the KD wire), not a statement about the target's pool.
+- **Allocator tools need private PDB types, not exports** — `pool_*` resolves `nt` and `heap_*`
+  resolves `ntdll`. Reload only the matching module (`.reload /f nt` or `.reload /f ntdll.dll`) and
+  confirm `(pdb symbols)` with `lm m <mod>`. Missing types are a symbol problem on this host;
+  symbols never come over the KD wire. See [heap-walking.md](heap-walking.md).
 - **`!`-extension commands need the WinDbg `winext\` extensions bundled** next to the engine
   ([setup.md](setup.md)) **and** the module-qualified form: use `!ext.analyze -v`, not bare
   `!analyze` (which this engine resolves to *"No export analyze found"* even after `.load ext`).

--- a/skills/windbg-debugging/heap-walking.md
+++ b/skills/windbg-debugging/heap-walking.md
@@ -1,0 +1,63 @@
+# Kernel pool and user Segment Heap walking
+
+Use the typed allocator tools when the question is about allocator state, chunk ownership,
+neighbours, or aggregate usage. They resolve the exact loaded module's PDB layout and return
+structured provenance and coverage; raw `!heap`/`!pool` text is the fallback for an allocator the
+v1 decoder does not support.
+
+## Choose the target and symbols
+
+1. Stop the target. The walkers refuse a running target because allocator metadata is not a
+   consistent snapshot while it changes.
+2. For a broken-in x64 kernel target or suitable kernel dump, load private `nt` types with
+   `set_symbol_path`, then `execute { "command": ".reload /f nt" }`. Use `pool_*`.
+3. For a stopped x64 user process or sufficiently complete user dump, load private `ntdll` types
+   with `set_symbol_path`, then `execute { "command": ".reload /f ntdll.dll" }`. Use `heap_*`.
+4. Check `execute { "command": "lm m nt" }` or `lm m ntdll`. The module must report PDB symbols,
+   not exports or deferred symbols. If loading fails, follow [setup.md](setup.md)'s engine and
+   symbol-store checks before retrying the walk.
+
+Never choose offsets by Windows build number or substitute a nearby build's layout. Each answer's
+`layout` names the image and PDB, gives a stable fingerprint, and identifies the structurally
+validated VS family. An unfamiliar or ambiguous family is intentionally refused.
+
+## Kernel pool workflow
+
+- Use `pool_census` to establish the population, `pool_find_tag` to narrow allocated chunks,
+  `pool_chunk` for one address and its contiguous allocator neighbours, and `pool_diagnostics`
+  when expected memory is absent.
+- The first query walks the pool. Later queries reuse the same session snapshot. Pass
+  `refresh: true` after any execution that could change the target; control tools invalidate the
+  cache automatically, but explicit refresh makes the intent clear at the final observation.
+- Read both `layout` and `walk`. `deadline_truncated` and `partial` counts are floors, and an
+  uncovered address is not evidence that it was never pool.
+
+## User heap workflow
+
+Start with `heap_list`. It lists every PEB heap root and separates:
+
+- supported Segment Heaps that were walked;
+- classic NT heaps, which v1 lists but skips;
+- unknown roots; and
+- roots whose signatures could not be read.
+
+Then use:
+
+- `heap_allocations` for capped filters by heap, backend (`lfh`, `vs`, `segment`, `large`), state,
+  and capacity;
+- `heap_chunk` for the allocation containing an address, its offset, and same-heap neighbours;
+- `heap_census` for heaviest heap/backend/state/size-class groups; and
+- `heap_diagnostics` for categories and examples, optionally scoped to one heap.
+
+User results report allocation `capacity`. `requested_size` is present only when the selected PDB
+schema validates exact unused-byte metadata; absence means unknown, not equal to capacity. Reuse
+the cached snapshot while stopped, refresh after execution, and inspect all three result guards:
+`layout` (what decoded it), `scope` (which PEB heaps were included or skipped), and `walk` (whether
+coverage was complete).
+
+## V1 boundary
+
+V1 supports x64 Segment Heaps in stopped live targets and dumps with sufficient memory. It does
+not decode classic NT heaps, WOW64, or ARM64. Microsoft `!heap` supports both Segment and NT heaps,
+so direct a classic-heap case to `execute { "command": "!heap ..." }` and state that its output is
+outside typed Segment Heap coverage. See Microsoft's [`!heap` documentation](https://learn.microsoft.com/en-us/windows-hardware/drivers/debuggercmds/-heap).

--- a/skills/windbg-debugging/heap-walking.md
+++ b/skills/windbg-debugging/heap-walking.md
@@ -44,7 +44,8 @@ Start with `heap_list`. It lists every PEB heap root and separates:
 Then use:
 
 - `heap_allocations` for capped filters by heap, backend (`lfh`, `vs`, `segment`, `large`), state,
-  and capacity;
+  and capacity. It defaults to `state: allocated`; when investigating freed memory, pass
+  `state: reusable_free` or `state: cached_free` explicitly;
 - `heap_chunk` for the allocation containing an address, its offset, and same-heap neighbours;
 - `heap_census` for heaviest heap/backend/state/size-class groups; and
 - `heap_diagnostics` for categories and examples, optionally scoped to one heap.

--- a/skills/windbg-debugging/setup.md
+++ b/skills/windbg-debugging/setup.md
@@ -204,8 +204,8 @@ Symbols are never fetched from the target over the KD wire, so all of this is ab
 
 ### Allocator tools need private `nt` or `ntdll` types
 
-`pool_find_tag`, `pool_census`, `pool_chunk` and `pool_diagnostics` decode segment-heap
-internals (`_EX_POOL_HEAP_MANAGER_STATE`, the page-range descriptors, the VS and LFH
+`pool_find_tag`, `pool_census`, `pool_chunk` and `pool_diagnostics` decode the kernel pool's
+segment allocator internals (`_EX_POOL_HEAP_MANAGER_STATE`, the page-range descriptors, the VS and LFH
 headers). Exports are not enough. Without full type information every pool query fails up
 front with `missing allocator symbols (ExPoolState); run '.reload /f nt' and retry` — which
 is a symbol problem on this host, not a statement about the target's pool.

--- a/skills/windbg-debugging/setup.md
+++ b/skills/windbg-debugging/setup.md
@@ -202,16 +202,22 @@ Two more things that mislead here:
 Symbols are never fetched from the target over the KD wire, so all of this is about the
 **debugging host**, whatever the target is.
 
-### Kernel pool tools need *private* `nt` types
+### Allocator tools need private `nt` or `ntdll` types
 
 `pool_find_tag`, `pool_census`, `pool_chunk` and `pool_diagnostics` decode segment-heap
 internals (`_EX_POOL_HEAP_MANAGER_STATE`, the page-range descriptors, the VS and LFH
 headers). Exports are not enough. Without full type information every pool query fails up
-front with `missing kernel pool symbols (ExPoolState); run '.reload /f nt' and retry` — which
+front with `missing allocator symbols (ExPoolState); run '.reload /f nt' and retry` — which
 is a symbol problem on this host, not a statement about the target's pool.
 
 Offline / no symbols? Navigation, memory reads, disassembly, and the data model still work
 — query by address instead of by name.
+
+The user-mode `heap_list`, `heap_allocations`, `heap_chunk`, `heap_census` and
+`heap_diagnostics` tools have the same requirement for the exact loaded `ntdll` PDB. Use
+`.reload /f ntdll.dll` for them, and `.reload /f nt` for `pool_*`; the error guidance is deliberately
+module-specific. `heap_list` still lists classic NT heaps as unsupported once the PDB is loaded;
+use `!heap` for those rather than treating them as missing Segment Heap coverage.
 
 ## Kernel connection profiles — configure once, keep the key out of the transcript
 

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -159,6 +159,12 @@ pub enum EngineOp {
         query: PoolOp,
         patience_ms: u32,
     },
+    /// A user-mode Segment Heap query, with the same queue-aware deadline and interrupt
+    /// semantics as [`Self::Pool`].
+    Heap {
+        query: HeapOp,
+        patience_ms: u32,
+    },
     /// Everything a bug check is, in one job: the code and its four parameters, the crashing
     /// stack with each frame attributed to a module, the process — and, when `analyze` is set,
     /// `!analyze -v`'s own conclusions beside them ([`crate::triage`]).
@@ -248,6 +254,7 @@ impl EngineOp {
         match self {
             Self::BoundedCommand { patience_ms, .. }
             | Self::Pool { patience_ms, .. }
+            | Self::Heap { patience_ms, .. }
             | Self::CrashTriage { patience_ms, .. }
             | Self::Walk(WalkOp { patience_ms, .. })
             | Self::Batch(BatchOp { patience_ms, .. }) => Some(patience_ms),
@@ -400,6 +407,131 @@ impl PoolOp {
     }
 }
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub enum HeapBackendFilter {
+    Lfh,
+    Vs,
+    Segment,
+    Large,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub enum HeapStateFilter {
+    Allocated,
+    ReusableFree,
+    CachedFree,
+    Unreadable,
+}
+
+/// The five user Segment Heap tools after defaults and output caps are applied.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum HeapOp {
+    List {
+        refresh: bool,
+    },
+    Allocations {
+        heap: Option<String>,
+        backend: Option<HeapBackendFilter>,
+        state: HeapStateFilter,
+        min_capacity: Option<u64>,
+        max_capacity: Option<u64>,
+        refresh: bool,
+        limit: usize,
+    },
+    Chunk {
+        address: String,
+        refresh: bool,
+    },
+    Census {
+        heap: Option<String>,
+        refresh: bool,
+        limit: usize,
+    },
+    Diagnostics {
+        heap: Option<String>,
+        filter: Option<String>,
+        refresh: bool,
+        limit: usize,
+    },
+}
+
+impl HeapOp {
+    pub const MAX_ROWS: u32 = 2000;
+    const ALLOCATION_ROWS: u32 = 64;
+    const CENSUS_ROWS: u32 = 40;
+    const DIAGNOSTIC_ROWS: u32 = 60;
+
+    fn rows(limit: Option<u32>, default: u32) -> usize {
+        limit.unwrap_or(default).min(Self::MAX_ROWS) as usize
+    }
+
+    pub fn list(refresh: Option<bool>) -> Self {
+        Self::List {
+            refresh: refresh.unwrap_or(false),
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn allocations(
+        heap: Option<String>,
+        backend: Option<HeapBackendFilter>,
+        state: Option<HeapStateFilter>,
+        min_capacity: Option<u64>,
+        max_capacity: Option<u64>,
+        refresh: Option<bool>,
+        limit: Option<u32>,
+    ) -> Self {
+        Self::Allocations {
+            heap,
+            backend,
+            state: state.unwrap_or(HeapStateFilter::Allocated),
+            min_capacity,
+            max_capacity,
+            refresh: refresh.unwrap_or(false),
+            limit: Self::rows(limit, Self::ALLOCATION_ROWS),
+        }
+    }
+
+    pub fn chunk(address: String, refresh: Option<bool>) -> Self {
+        Self::Chunk {
+            address,
+            refresh: refresh.unwrap_or(false),
+        }
+    }
+
+    pub fn census(heap: Option<String>, refresh: Option<bool>, limit: Option<u32>) -> Self {
+        Self::Census {
+            heap,
+            refresh: refresh.unwrap_or(false),
+            limit: Self::rows(limit, Self::CENSUS_ROWS),
+        }
+    }
+
+    pub fn diagnostics(
+        heap: Option<String>,
+        filter: Option<String>,
+        refresh: Option<bool>,
+        limit: Option<u32>,
+    ) -> Self {
+        Self::Diagnostics {
+            heap,
+            filter,
+            refresh: refresh.unwrap_or(false),
+            limit: Self::rows(limit, Self::DIAGNOSTIC_ROWS),
+        }
+    }
+
+    pub fn refreshes(&self) -> bool {
+        match self {
+            Self::List { refresh }
+            | Self::Allocations { refresh, .. }
+            | Self::Chunk { refresh, .. }
+            | Self::Census { refresh, .. }
+            | Self::Diagnostics { refresh, .. } => *refresh,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -424,6 +556,10 @@ mod tests {
             EngineOp::Registers { all: false },
             EngineOp::Pool {
                 query: PoolOp::census(None, None),
+                patience_ms: 0,
+            },
+            EngineOp::Heap {
+                query: HeapOp::list(None),
                 patience_ms: 0,
             },
             EngineOp::CrashTriage {
@@ -470,6 +606,26 @@ mod tests {
             unreachable!("still a pool query")
         };
         assert_eq!(patience_ms, 42_000);
+    }
+
+    #[test]
+    fn heap_defaults_and_row_caps_are_applied_before_crossing_the_worker_pipe() {
+        let HeapOp::Allocations { state, limit, .. } =
+            HeapOp::allocations(None, None, None, None, None, None, Some(u32::MAX))
+        else {
+            unreachable!()
+        };
+        assert!(matches!(state, HeapStateFilter::Allocated));
+        assert_eq!(limit, HeapOp::MAX_ROWS as usize);
+
+        let HeapOp::Census { limit, .. } = HeapOp::census(None, None, None) else {
+            unreachable!()
+        };
+        assert_eq!(limit, 40);
+        let HeapOp::Diagnostics { limit, .. } = HeapOp::diagnostics(None, None, None, None) else {
+            unreachable!()
+        };
+        assert_eq!(limit, 60);
     }
 }
 

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -332,23 +332,23 @@ pub enum PoolOp {
     },
 }
 
-impl PoolOp {
-    /// Most rows or lines a pool answer will render in one response.
-    ///
-    /// The worker builds the whole reply as a single `String` before it crosses the pipe, so an
-    /// unbounded `limit` is a request to allocate a snapshot-sized buffer — hundreds of thousands
-    /// of chunks, or ~19k diagnostic lines on an idle machine. Clamping costs a caller nothing
-    /// they can act on; a worker killed mid-session costs them the session.
-    pub const MAX_ROWS: u32 = 2000;
+/// Most rows or lines an allocator answer will render in one response.
+///
+/// The worker builds the whole reply as a single `String` before it crosses the pipe, so an
+/// unbounded `limit` is a request to allocate a snapshot-sized buffer — hundreds of thousands
+/// of chunks, or ~19k diagnostic lines on an idle machine. Clamping costs a caller nothing
+/// they can act on; a worker killed mid-session costs them the session.
+pub const MAX_ROWS: u32 = 2000;
 
+fn clamp_rows(limit: Option<u32>, default: u32) -> usize {
+    limit.unwrap_or(default).min(MAX_ROWS) as usize
+}
+
+impl PoolOp {
     /// Rows each question prints when the caller names no `limit`.
     const FIND_TAG_ROWS: u32 = 64;
     const CENSUS_ROWS: u32 = 40;
     const DIAGNOSTIC_LINES: u32 = 60;
-
-    fn rows(limit: Option<u32>, default: u32) -> usize {
-        limit.unwrap_or(default).min(Self::MAX_ROWS) as usize
-    }
 
     /// Every allocated chunk carrying `tag`.
     pub fn find_tag(
@@ -361,7 +361,7 @@ impl PoolOp {
             tag,
             paged,
             refresh: refresh.unwrap_or(false),
-            limit: Self::rows(limit, Self::FIND_TAG_ROWS),
+            limit: clamp_rows(limit, Self::FIND_TAG_ROWS),
         }
     }
 
@@ -377,7 +377,7 @@ impl PoolOp {
     pub fn census(refresh: Option<bool>, limit: Option<u32>) -> Self {
         Self::Census {
             refresh: refresh.unwrap_or(false),
-            limit: Self::rows(limit, Self::CENSUS_ROWS),
+            limit: clamp_rows(limit, Self::CENSUS_ROWS),
         }
     }
 
@@ -386,7 +386,7 @@ impl PoolOp {
         Self::Diagnostics {
             filter,
             refresh: refresh.unwrap_or(false),
-            limit: Self::rows(limit, Self::DIAGNOSTIC_LINES),
+            limit: clamp_rows(limit, Self::DIAGNOSTIC_LINES),
         }
     }
 
@@ -456,14 +456,9 @@ pub enum HeapOp {
 }
 
 impl HeapOp {
-    pub const MAX_ROWS: u32 = 2000;
     const ALLOCATION_ROWS: u32 = 64;
     const CENSUS_ROWS: u32 = 40;
     const DIAGNOSTIC_ROWS: u32 = 60;
-
-    fn rows(limit: Option<u32>, default: u32) -> usize {
-        limit.unwrap_or(default).min(Self::MAX_ROWS) as usize
-    }
 
     pub fn list(refresh: Option<bool>) -> Self {
         Self::List {
@@ -488,7 +483,7 @@ impl HeapOp {
             min_capacity,
             max_capacity,
             refresh: refresh.unwrap_or(false),
-            limit: Self::rows(limit, Self::ALLOCATION_ROWS),
+            limit: clamp_rows(limit, Self::ALLOCATION_ROWS),
         }
     }
 
@@ -503,7 +498,7 @@ impl HeapOp {
         Self::Census {
             heap,
             refresh: refresh.unwrap_or(false),
-            limit: Self::rows(limit, Self::CENSUS_ROWS),
+            limit: clamp_rows(limit, Self::CENSUS_ROWS),
         }
     }
 
@@ -517,7 +512,7 @@ impl HeapOp {
             heap,
             filter,
             refresh: refresh.unwrap_or(false),
-            limit: Self::rows(limit, Self::DIAGNOSTIC_ROWS),
+            limit: clamp_rows(limit, Self::DIAGNOSTIC_ROWS),
         }
     }
 
@@ -616,7 +611,7 @@ mod tests {
             unreachable!()
         };
         assert!(matches!(state, HeapStateFilter::Allocated));
-        assert_eq!(limit, HeapOp::MAX_ROWS as usize);
+        assert_eq!(limit, MAX_ROWS as usize);
 
         let HeapOp::Census { limit, .. } = HeapOp::census(None, None, None) else {
             unreachable!()

--- a/src/server.rs
+++ b/src/server.rs
@@ -21,7 +21,9 @@ use crate::engine::{
     SessionState, Sessions,
 };
 use crate::kdconn;
-use crate::proto::{EngineOp, Output, PoolOp, ReachabilityOp};
+use crate::proto::{
+    EngineOp, HeapBackendFilter, HeapOp, HeapStateFilter, Output, PoolOp, ReachabilityOp,
+};
 use crate::structured::{self, ErrorCategory, Outcome, TargetCreated};
 use crate::ttd;
 use crate::walk;
@@ -227,6 +229,13 @@ fn engine_result_for(
 /// of nothing.
 fn pool_op(query: PoolOp) -> EngineOp {
     EngineOp::Pool {
+        query,
+        patience_ms: 0,
+    }
+}
+
+fn heap_op(query: HeapOp) -> EngineOp {
+    EngineOp::Heap {
         query,
         patience_ms: 0,
     }
@@ -1666,6 +1675,95 @@ pub struct PoolDiagnosticsArgs {
 }
 
 #[derive(Deserialize, JsonSchema)]
+pub struct HeapListArgs {
+    /// Force a fresh snapshot instead of reusing the one cached for this stopped target.
+    #[serde(default)]
+    pub refresh: Option<bool>,
+    #[serde(default)]
+    pub session_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum HeapBackendArg {
+    Lfh,
+    Vs,
+    Segment,
+    Large,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum HeapStateArg {
+    Allocated,
+    ReusableFree,
+    CachedFree,
+    Unreadable,
+}
+
+#[derive(Deserialize, JsonSchema)]
+pub struct HeapAllocationsArgs {
+    /// Optional Segment Heap root address.
+    #[serde(default)]
+    pub heap: Option<String>,
+    #[serde(default)]
+    pub backend: Option<HeapBackendArg>,
+    /// Defaults to `allocated`.
+    #[serde(default)]
+    pub state: Option<HeapStateArg>,
+    #[serde(default)]
+    pub min_capacity: Option<u64>,
+    #[serde(default)]
+    pub max_capacity: Option<u64>,
+    #[serde(default)]
+    pub refresh: Option<bool>,
+    /// Maximum rows to return (default 64, maximum 2000).
+    #[serde(default)]
+    pub limit: Option<u32>,
+    #[serde(default)]
+    pub session_id: Option<String>,
+}
+
+#[derive(Deserialize, JsonSchema)]
+pub struct HeapChunkArgs {
+    /// Address anywhere in the allocator header or user capacity.
+    pub address: String,
+    #[serde(default)]
+    pub refresh: Option<bool>,
+    #[serde(default)]
+    pub session_id: Option<String>,
+}
+
+#[derive(Deserialize, JsonSchema)]
+pub struct HeapCensusArgs {
+    #[serde(default)]
+    pub heap: Option<String>,
+    #[serde(default)]
+    pub refresh: Option<bool>,
+    /// Maximum groups to return (default 40, maximum 2000).
+    #[serde(default)]
+    pub limit: Option<u32>,
+    #[serde(default)]
+    pub session_id: Option<String>,
+}
+
+#[derive(Deserialize, JsonSchema)]
+pub struct HeapDiagnosticsArgs {
+    #[serde(default)]
+    pub heap: Option<String>,
+    /// Case-insensitive substring applied to diagnostic categories and kept examples.
+    #[serde(default)]
+    pub filter: Option<String>,
+    #[serde(default)]
+    pub refresh: Option<bool>,
+    /// Maximum rows to return (default 60, maximum 2000).
+    #[serde(default)]
+    pub limit: Option<u32>,
+    #[serde(default)]
+    pub session_id: Option<String>,
+}
+
+#[derive(Deserialize, JsonSchema)]
 pub struct CrashTriageArgs {
     /// How many stack frames to walk (default 16, maximum 128). The default reaches past the
     /// kernel's own bug-check path to the driver frame on every crash seen so far; raise it for a
@@ -2478,6 +2576,158 @@ impl WindbgServer {
             .run(
                 args.session_id.as_deref(),
                 pool_op(PoolOp::census(args.refresh, args.limit)),
+            )
+            .await;
+        engine_result_for(args.session_id.as_deref(), out)
+    }
+
+    /// List every heap root in the current process PEB. Segment Heaps are marked supported;
+    /// classic NT heaps are listed but deliberately excluded from v1 coverage and should be
+    /// inspected with `!heap`.
+    #[rmcp::tool(
+        annotations(
+            title = "List user-mode heaps",
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
+        output_schema = schema_for_output::<Outcome<structured::HeapListResult>>()
+    )]
+    async fn heap_list(
+        &self,
+        Parameters(args): Parameters<HeapListArgs>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let out = self
+            .run(
+                args.session_id.as_deref(),
+                heap_op(HeapOp::list(args.refresh)),
+            )
+            .await;
+        engine_result_for(args.session_id.as_deref(), out)
+    }
+
+    /// List user Segment Heap chunks, filtered by heap, backend, state, and capacity. Defaults
+    /// to allocated chunks. Requires a stopped x64 live target or sufficiently complete dump and
+    /// matching `ntdll` PDB type information.
+    #[rmcp::tool(
+        annotations(
+            title = "List Segment Heap allocations",
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
+        output_schema = schema_for_output::<Outcome<structured::HeapAllocationsResult>>()
+    )]
+    async fn heap_allocations(
+        &self,
+        Parameters(args): Parameters<HeapAllocationsArgs>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let backend = args.backend.map(|backend| match backend {
+            HeapBackendArg::Lfh => HeapBackendFilter::Lfh,
+            HeapBackendArg::Vs => HeapBackendFilter::Vs,
+            HeapBackendArg::Segment => HeapBackendFilter::Segment,
+            HeapBackendArg::Large => HeapBackendFilter::Large,
+        });
+        let state = args.state.map(|state| match state {
+            HeapStateArg::Allocated => HeapStateFilter::Allocated,
+            HeapStateArg::ReusableFree => HeapStateFilter::ReusableFree,
+            HeapStateArg::CachedFree => HeapStateFilter::CachedFree,
+            HeapStateArg::Unreadable => HeapStateFilter::Unreadable,
+        });
+        let out = self
+            .run(
+                args.session_id.as_deref(),
+                heap_op(HeapOp::allocations(
+                    args.heap,
+                    backend,
+                    state,
+                    args.min_capacity,
+                    args.max_capacity,
+                    args.refresh,
+                    args.limit,
+                )),
+            )
+            .await;
+        engine_result_for(args.session_id.as_deref(), out)
+    }
+
+    /// Locate the user allocation containing an address and return its contiguous neighbours
+    /// from the same heap, backend, and subsegment. An uncovered address is not reported as free;
+    /// inspect the returned coverage before treating absence as evidence.
+    #[rmcp::tool(
+        annotations(
+            title = "Locate a Segment Heap chunk",
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
+        output_schema = schema_for_output::<Outcome<structured::HeapChunkResult>>()
+    )]
+    async fn heap_chunk(
+        &self,
+        Parameters(args): Parameters<HeapChunkArgs>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let out = self
+            .run(
+                args.session_id.as_deref(),
+                heap_op(HeapOp::chunk(args.address, args.refresh)),
+            )
+            .await;
+        engine_result_for(args.session_id.as_deref(), out)
+    }
+
+    /// Group Segment Heap chunks by heap, backend, state, and size class, heaviest first.
+    #[rmcp::tool(
+        annotations(
+            title = "Census Segment Heap usage",
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
+        output_schema = schema_for_output::<Outcome<structured::HeapCensusResult>>()
+    )]
+    async fn heap_census(
+        &self,
+        Parameters(args): Parameters<HeapCensusArgs>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let out = self
+            .run(
+                args.session_id.as_deref(),
+                heap_op(HeapOp::census(args.heap, args.refresh, args.limit)),
+            )
+            .await;
+        engine_result_for(args.session_id.as_deref(), out)
+    }
+
+    /// Inspect Segment Heap walk diagnostic categories and kept examples, optionally scoped to
+    /// one heap root and narrowed by a case-insensitive substring.
+    #[rmcp::tool(
+        annotations(
+            title = "Filter Segment Heap diagnostics",
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        ),
+        output_schema = schema_for_output::<Outcome<structured::HeapDiagnosticsResult>>()
+    )]
+    async fn heap_diagnostics(
+        &self,
+        Parameters(args): Parameters<HeapDiagnosticsArgs>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let out = self
+            .run(
+                args.session_id.as_deref(),
+                heap_op(HeapOp::diagnostics(
+                    args.heap,
+                    args.filter,
+                    args.refresh,
+                    args.limit,
+                )),
             )
             .await;
         engine_result_for(args.session_id.as_deref(), out)

--- a/src/server.rs
+++ b/src/server.rs
@@ -1736,6 +1736,7 @@ pub struct HeapChunkArgs {
 
 #[derive(Deserialize, JsonSchema)]
 pub struct HeapCensusArgs {
+    /// Optional Segment Heap root address.
     #[serde(default)]
     pub heap: Option<String>,
     #[serde(default)]
@@ -1749,6 +1750,7 @@ pub struct HeapCensusArgs {
 
 #[derive(Deserialize, JsonSchema)]
 pub struct HeapDiagnosticsArgs {
+    /// Optional Segment Heap root address.
     #[serde(default)]
     pub heap: Option<String>,
     /// Case-insensitive substring applied to diagnostic categories and kept examples.
@@ -2583,7 +2585,8 @@ impl WindbgServer {
 
     /// List every heap root in the current process PEB. Segment Heaps are marked supported;
     /// classic NT heaps are listed but deliberately excluded from v1 coverage and should be
-    /// inspected with `!heap`.
+    /// inspected with `!heap`. Requires a stopped x64 live target or sufficiently complete dump
+    /// and matching `ntdll` PDB type information.
     #[rmcp::tool(
         annotations(
             title = "List user-mode heaps",
@@ -2624,6 +2627,17 @@ impl WindbgServer {
         &self,
         Parameters(args): Parameters<HeapAllocationsArgs>,
     ) -> Result<CallToolResult, ErrorData> {
+        if args
+            .min_capacity
+            .zip(args.max_capacity)
+            .is_some_and(|(minimum, maximum)| minimum > maximum)
+        {
+            return typed_error(
+                ErrorCategory::InvalidArgument,
+                "min_capacity cannot exceed max_capacity".into(),
+                args.session_id,
+            );
+        }
         let backend = args.backend.map(|backend| match backend {
             HeapBackendArg::Lfh => HeapBackendFilter::Lfh,
             HeapBackendArg::Vs => HeapBackendFilter::Vs,
@@ -2655,7 +2669,8 @@ impl WindbgServer {
 
     /// Locate the user allocation containing an address and return its contiguous neighbours
     /// from the same heap, backend, and subsegment. An uncovered address is not reported as free;
-    /// inspect the returned coverage before treating absence as evidence.
+    /// inspect the returned coverage before treating absence as evidence. Requires a stopped x64
+    /// live target or sufficiently complete dump and matching `ntdll` PDB type information.
     #[rmcp::tool(
         annotations(
             title = "Locate a Segment Heap chunk",
@@ -2679,7 +2694,9 @@ impl WindbgServer {
         engine_result_for(args.session_id.as_deref(), out)
     }
 
-    /// Group Segment Heap chunks by heap, backend, state, and size class, heaviest first.
+    /// Group Segment Heap chunks by heap, backend, state, and size class, heaviest first. Requires
+    /// a stopped x64 live target or sufficiently complete dump and matching `ntdll` PDB type
+    /// information.
     #[rmcp::tool(
         annotations(
             title = "Census Segment Heap usage",
@@ -2704,7 +2721,8 @@ impl WindbgServer {
     }
 
     /// Inspect Segment Heap walk diagnostic categories and kept examples, optionally scoped to
-    /// one heap root and narrowed by a case-insensitive substring.
+    /// one heap root and narrowed by a case-insensitive substring. Requires a stopped x64 live
+    /// target or sufficiently complete dump and matching `ntdll` PDB type information.
     #[rmcp::tool(
         annotations(
             title = "Filter Segment Heap diagnostics",

--- a/src/structured.rs
+++ b/src/structured.rs
@@ -732,6 +732,8 @@ pub struct AllocatorModuleInfo {
     pub size: u32,
     pub timestamp: u32,
     pub checksum: u32,
+    #[serde(flatten)]
+    pub symbols: SymbolState,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
@@ -753,6 +755,7 @@ impl From<&win_kexp::allocator::LayoutProvenance> for AllocatorLayoutInfo {
                 size: layout.module.size,
                 timestamp: layout.module.timestamp,
                 checksum: layout.module.checksum,
+                symbols: layout.module.symbols.into(),
             },
             pdb: layout.module.symbol_file.clone(),
             fingerprint: layout.fingerprint.clone(),
@@ -764,16 +767,17 @@ impl From<&win_kexp::allocator::LayoutProvenance> for AllocatorLayoutInfo {
     }
 }
 
-/// How much of the pool the walk behind an answer actually covered.
+/// How much of an allocator the walk behind an answer actually covered.
 ///
-/// Every pool answer carries this, because every one of them is drawn from a snapshot and a
+/// Every allocator answer carries this, because every one of them is drawn from a snapshot and a
 /// count taken from a partial snapshot is a floor rather than a total. The three ways of falling
 /// short are separate values because they need different responses; a fourth — the walk failing
 /// outright, or being interrupted — is not a coverage state at all but the `error` branch of
 /// [`Outcome`], with category [`ErrorCategory::Debugger`] or [`ErrorCategory::Interrupted`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
-pub enum PoolCoverage {
+#[schemars(rename = "PoolCoverage")]
+pub enum AllocatorCoverage {
     /// The walk covered everything it set out to. Counts here are totals.
     Complete,
     /// It stopped because its deadline — what was left of this call's budget — ran out. What it
@@ -786,7 +790,17 @@ pub enum PoolCoverage {
     Partial,
 }
 
-impl From<win_kexp::pool::query::WalkCoverage> for PoolCoverage {
+impl AllocatorCoverage {
+    pub(crate) const fn as_str(self) -> &'static str {
+        match self {
+            Self::Complete => "complete",
+            Self::DeadlineTruncated => "deadline_truncated",
+            Self::Partial => "partial",
+        }
+    }
+}
+
+impl From<win_kexp::pool::query::WalkCoverage> for AllocatorCoverage {
     fn from(coverage: win_kexp::pool::query::WalkCoverage) -> Self {
         use win_kexp::pool::query::WalkCoverage as Engine;
         match coverage {
@@ -800,7 +814,7 @@ impl From<win_kexp::pool::query::WalkCoverage> for PoolCoverage {
 /// The state of the walk an answer was drawn from.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct WalkInfo {
-    pub coverage: PoolCoverage,
+    pub coverage: AllocatorCoverage,
     /// Chunks the walk indexed, allocated and free.
     pub chunks_walked: usize,
     pub allocated_chunks: usize,
@@ -845,11 +859,19 @@ pub struct WalkGaps {
 impl WalkGaps {
     /// `None` when the walk met none of this, so the ordinary answer does not carry four zeroes.
     pub(crate) fn of(report: &win_kexp::pool::query::PoolSnapshotReport) -> Option<Self> {
+        Self::from_measurements(report.stalls, report.refused_chunks)
+    }
+
+    pub(crate) fn of_heap(report: &win_kexp::heap::HeapWalkReport) -> Option<Self> {
+        Self::from_measurements(report.stalls, report.refused_headers)
+    }
+
+    fn from_measurements(stalls: win_kexp::pool::WalkStalls, refused_chunks: u64) -> Option<Self> {
         let gaps = Self {
-            stalled_pages: report.stalls.pages,
-            skipped_bytes: report.stalls.skipped_bytes,
-            recovered_bytes: report.stalls.recovered_bytes,
-            refused_chunks: report.refused_chunks,
+            stalled_pages: stalls.pages,
+            skipped_bytes: stalls.skipped_bytes,
+            recovered_bytes: stalls.recovered_bytes,
+            refused_chunks,
         };
         (gaps != Self::default()).then_some(gaps)
     }
@@ -982,7 +1004,6 @@ pub struct PoolChunkAt {
     pub chunk: Option<PoolChunkInfo>,
     /// How far into that chunk the address sits.
     #[serde(skip_serializing_if = "Option::is_none")]
-    /// Signed displacement from `allocation.user_address`; header addresses are negative.
     pub offset: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub previous: Option<PoolChunkInfo>,
@@ -1173,15 +1194,14 @@ impl From<&win_kexp::heap::HeapScope> for HeapScopeInfo {
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct HeapWalkInfo {
-    pub coverage: PoolCoverage,
+    pub coverage: AllocatorCoverage,
     pub chunks_walked: usize,
     pub allocated_chunks: usize,
     pub diagnostics_emitted: usize,
     pub unreadable_gaps: usize,
-    pub refused_headers: u64,
-    pub stalled_pages: u64,
-    pub skipped_bytes: u64,
-    pub recovered_bytes: u64,
+    /// What the walk could not read or decode, when there was anything. Healthy results omit it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub gaps: Option<WalkGaps>,
 }
 
 impl From<&win_kexp::heap::HeapWalkReport> for HeapWalkInfo {
@@ -1192,10 +1212,7 @@ impl From<&win_kexp::heap::HeapWalkReport> for HeapWalkInfo {
             allocated_chunks: walk.allocated_chunks,
             diagnostics_emitted: walk.diagnostic_count,
             unreadable_gaps: walk.unreadable_gaps,
-            refused_headers: walk.refused_headers,
-            stalled_pages: walk.stalls.pages,
-            skipped_bytes: walk.stalls.skipped_bytes,
-            recovered_bytes: walk.stalls.recovered_bytes,
+            gaps: WalkGaps::of_heap(walk),
         }
     }
 }
@@ -1223,13 +1240,19 @@ pub struct HeapChunkResult {
     pub scope: HeapScopeInfo,
     pub walk: HeapWalkInfo,
     pub address: String,
+    /// Whether the Segment Heap snapshot covers this address at all. False is not "free": the
+    /// address may not be user heap, or may sit in a region this walk never reached. Read
+    /// `walk.coverage` before treating absence as evidence.
     pub covered: bool,
+    /// Signed displacement from `allocation.user_address`; a header address is negative.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub offset: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub allocation: Option<HeapAllocationInfo>,
+    /// The contiguous previous allocation in the same heap, backend, and subsegment.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub previous: Option<HeapAllocationInfo>,
+    /// The contiguous next allocation in the same heap, backend, and subsegment.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub next: Option<HeapAllocationInfo>,
 }
@@ -1719,15 +1742,16 @@ mod tests {
     fn pool_coverage_keeps_the_walks_own_reason() {
         use win_kexp::pool::query::WalkCoverage as Engine;
         for (engine, expected, wire) in [
-            (Engine::Complete, PoolCoverage::Complete, "complete"),
+            (Engine::Complete, AllocatorCoverage::Complete, "complete"),
             (
                 Engine::BudgetExpired,
-                PoolCoverage::DeadlineTruncated,
+                AllocatorCoverage::DeadlineTruncated,
                 "deadline_truncated",
             ),
-            (Engine::Partial, PoolCoverage::Partial, "partial"),
+            (Engine::Partial, AllocatorCoverage::Partial, "partial"),
         ] {
-            assert_eq!(PoolCoverage::from(engine), expected);
+            assert_eq!(AllocatorCoverage::from(engine), expected);
+            assert_eq!(expected.as_str(), wire);
             assert_eq!(serde_json::to_value(expected).unwrap(), wire);
         }
     }
@@ -1756,6 +1780,7 @@ mod tests {
         assert_eq!(wire["fingerprint"], "fnv1a64:0123456789abcdef");
         assert_eq!(wire["semantic_family"], "affinity_slot_vs");
         assert_eq!(wire["module"]["base"], "0x00007ffb12340000");
+        assert_eq!(wire["module"]["symbols"], "pdb");
     }
 
     #[test]
@@ -1825,7 +1850,7 @@ mod tests {
         // `None` says nothing about whether the field then serialises as `"gaps": null`, which
         // would be a shape change on every healthy pool answer — the ones that are fine.
         let walk = |gaps| WalkInfo {
-            coverage: PoolCoverage::Partial,
+            coverage: AllocatorCoverage::Partial,
             chunks_walked: 0,
             allocated_chunks: 0,
             diagnostics_emitted: 0,
@@ -1837,6 +1862,38 @@ mod tests {
         let wire = serde_json::to_value(walk(Some(gaps))).unwrap();
         assert_eq!(wire["gaps"]["recovered_bytes"], 0x40000);
         assert_eq!(wire["gaps"]["refused_chunks"], 884);
+    }
+
+    #[test]
+    fn heap_walk_gaps_use_the_shared_optional_shape() {
+        let report = |stalls, refused_headers| win_kexp::heap::HeapWalkReport {
+            coverage: win_kexp::pool::query::WalkCoverage::Complete,
+            total_chunks: 0,
+            allocated_chunks: 0,
+            diagnostic_count: 0,
+            unreadable_gaps: 0,
+            refused_headers,
+            stalls,
+        };
+
+        let quiet = serde_json::to_value(HeapWalkInfo::from(&report(
+            win_kexp::pool::WalkStalls::default(),
+            0,
+        )))
+        .unwrap();
+        assert!(quiet.get("gaps").is_none(), "{quiet}");
+
+        let wire = serde_json::to_value(HeapWalkInfo::from(&report(
+            win_kexp::pool::WalkStalls {
+                pages: 2,
+                skipped_bytes: 0x2000,
+                recovered_bytes: 0x8000,
+            },
+            17,
+        )))
+        .unwrap();
+        assert_eq!(wire["gaps"]["stalled_pages"], 2);
+        assert_eq!(wire["gaps"]["refused_chunks"], 17);
     }
 
     /// A field's JSON type must not depend on its value.

--- a/src/structured.rs
+++ b/src/structured.rs
@@ -714,6 +714,56 @@ impl From<&win_kexp::dbgeng::BreakpointInfo> for BreakpointInfo {
 
 // ---- pool -----------------------------------------------------------------
 
+/// The exact image and PDB-backed structural family used by an allocator walk.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct AllocatorLayoutInfo {
+    pub module: AllocatorModuleInfo,
+    pub pdb: String,
+    pub fingerprint: String,
+    pub semantic_family: AllocatorSemanticFamily,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct AllocatorModuleInfo {
+    pub name: String,
+    pub image_name: String,
+    pub loaded_image_name: String,
+    pub base: String,
+    pub size: u32,
+    pub timestamp: u32,
+    pub checksum: u32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum AllocatorSemanticFamily {
+    InlineVs,
+    AffinitySlotVs,
+}
+
+impl From<&win_kexp::allocator::LayoutProvenance> for AllocatorLayoutInfo {
+    fn from(layout: &win_kexp::allocator::LayoutProvenance) -> Self {
+        use win_kexp::allocator::VsSemanticFamily;
+        Self {
+            module: AllocatorModuleInfo {
+                name: layout.module.name.clone(),
+                image_name: layout.module.image_name.clone(),
+                loaded_image_name: layout.module.loaded_image_name.clone(),
+                base: addr(layout.module.base),
+                size: layout.module.size,
+                timestamp: layout.module.timestamp,
+                checksum: layout.module.checksum,
+            },
+            pdb: layout.module.symbol_file.clone(),
+            fingerprint: layout.fingerprint.clone(),
+            semantic_family: match layout.semantic_family {
+                VsSemanticFamily::Inline => AllocatorSemanticFamily::InlineVs,
+                VsSemanticFamily::AffinitySlots => AllocatorSemanticFamily::AffinitySlotVs,
+            },
+        }
+    }
+}
+
 /// How much of the pool the walk behind an answer actually covered.
 ///
 /// Every pool answer carries this, because every one of them is drawn from a snapshot and a
@@ -896,6 +946,7 @@ impl From<&win_kexp::pool::PoolSpan> for PoolChunkInfo {
 /// What `pool_find_tag` found.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct PoolTagMatches {
+    pub layout: AllocatorLayoutInfo,
     pub tag: String,
     pub scope: PoolScope,
     /// How many allocated chunks carry the tag. A floor rather than a total unless
@@ -919,6 +970,7 @@ pub enum PoolScope {
 /// What `pool_chunk` found at an address.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct PoolChunkAt {
+    pub layout: AllocatorLayoutInfo,
     /// The address asked about.
     pub address: String,
     /// Whether the snapshot covers this address at all. False is *not* "free": it means the
@@ -930,6 +982,7 @@ pub struct PoolChunkAt {
     pub chunk: Option<PoolChunkInfo>,
     /// How far into that chunk the address sits.
     #[serde(skip_serializing_if = "Option::is_none")]
+    /// Signed displacement from `allocation.user_address`; header addresses are negative.
     pub offset: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub previous: Option<PoolChunkInfo>,
@@ -941,6 +994,7 @@ pub struct PoolChunkAt {
 /// What `pool_census` totalled.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct PoolCensus {
+    pub layout: AllocatorLayoutInfo,
     /// How many distinct tags are allocated. The listing below is capped by `limit`.
     pub distinct_tags: usize,
     pub tags: Vec<PoolTagTotals>,
@@ -959,6 +1013,7 @@ pub struct PoolTagTotals {
 /// What `pool_diagnostics` selected.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct PoolDiagnosticsReport {
+    pub layout: AllocatorLayoutInfo,
     /// The substring the listing was narrowed to, when it was.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub filter: Option<String>,
@@ -981,6 +1036,236 @@ pub struct DiagnosticCategory {
     pub shape: String,
     /// Every message of this shape the walk emitted, not just the ones kept verbatim.
     pub total: usize,
+}
+
+// ---- user Segment Heap ----------------------------------------------------
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum HeapKindName {
+    Segment,
+    Nt,
+    Unknown,
+    Unreadable,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum HeapBackendName {
+    Lfh,
+    Vs,
+    Segment,
+    Large,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum HeapChunkState {
+    Allocated,
+    ReusableFree,
+    CachedFree,
+    Unreadable,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct HeapRootInfo {
+    pub index: usize,
+    pub address: String,
+    pub kind: HeapKindName,
+    pub supported: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+impl From<&win_kexp::heap::HeapRoot> for HeapRootInfo {
+    fn from(root: &win_kexp::heap::HeapRoot) -> Self {
+        use win_kexp::heap::HeapKind;
+        Self {
+            index: root.index,
+            address: addr(root.address),
+            kind: match root.kind {
+                HeapKind::Segment => HeapKindName::Segment,
+                HeapKind::Nt => HeapKindName::Nt,
+                HeapKind::Unknown => HeapKindName::Unknown,
+                HeapKind::Unreadable => HeapKindName::Unreadable,
+            },
+            supported: root.supported,
+            reason: root.reason.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct HeapAllocationInfo {
+    pub heap: String,
+    pub backend: HeapBackendName,
+    pub state: HeapChunkState,
+    pub header_address: String,
+    pub user_address: String,
+    pub capacity: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub requested_size: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub subsegment: Option<String>,
+    pub size_class: u32,
+}
+
+impl From<&win_kexp::heap::HeapAllocation> for HeapAllocationInfo {
+    fn from(allocation: &win_kexp::heap::HeapAllocation) -> Self {
+        use win_kexp::heap::{HeapBackend, HeapState};
+        Self {
+            heap: addr(allocation.heap),
+            backend: match allocation.backend {
+                HeapBackend::Lfh => HeapBackendName::Lfh,
+                HeapBackend::Vs => HeapBackendName::Vs,
+                HeapBackend::Segment => HeapBackendName::Segment,
+                HeapBackend::Large => HeapBackendName::Large,
+            },
+            state: match allocation.state {
+                HeapState::Allocated => HeapChunkState::Allocated,
+                HeapState::ReusableFree => HeapChunkState::ReusableFree,
+                HeapState::CachedFree => HeapChunkState::CachedFree,
+                HeapState::Unreadable => HeapChunkState::Unreadable,
+            },
+            header_address: addr(allocation.header_address),
+            user_address: addr(allocation.user_address),
+            capacity: allocation.capacity,
+            requested_size: allocation.requested_size,
+            subsegment: allocation.subsegment.map(addr),
+            size_class: allocation.size_class,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct HeapScopeInfo {
+    pub segment_heaps_walked: Vec<String>,
+    pub nt_heaps_skipped: Vec<String>,
+    pub unknown_heaps_skipped: Vec<String>,
+    pub unreadable_heaps_skipped: Vec<String>,
+}
+
+impl From<&win_kexp::heap::HeapScope> for HeapScopeInfo {
+    fn from(scope: &win_kexp::heap::HeapScope) -> Self {
+        Self {
+            segment_heaps_walked: scope
+                .segment_heaps_walked
+                .iter()
+                .copied()
+                .map(addr)
+                .collect(),
+            nt_heaps_skipped: scope.nt_heaps_skipped.iter().copied().map(addr).collect(),
+            unknown_heaps_skipped: scope
+                .unknown_heaps_skipped
+                .iter()
+                .copied()
+                .map(addr)
+                .collect(),
+            unreadable_heaps_skipped: scope
+                .unreadable_heaps_skipped
+                .iter()
+                .copied()
+                .map(addr)
+                .collect(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct HeapWalkInfo {
+    pub coverage: PoolCoverage,
+    pub chunks_walked: usize,
+    pub allocated_chunks: usize,
+    pub diagnostics_emitted: usize,
+    pub unreadable_gaps: usize,
+    pub refused_headers: u64,
+    pub stalled_pages: u64,
+    pub skipped_bytes: u64,
+    pub recovered_bytes: u64,
+}
+
+impl From<&win_kexp::heap::HeapWalkReport> for HeapWalkInfo {
+    fn from(walk: &win_kexp::heap::HeapWalkReport) -> Self {
+        Self {
+            coverage: walk.coverage.into(),
+            chunks_walked: walk.total_chunks,
+            allocated_chunks: walk.allocated_chunks,
+            diagnostics_emitted: walk.diagnostic_count,
+            unreadable_gaps: walk.unreadable_gaps,
+            refused_headers: walk.refused_headers,
+            stalled_pages: walk.stalls.pages,
+            skipped_bytes: walk.stalls.skipped_bytes,
+            recovered_bytes: walk.stalls.recovered_bytes,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct HeapListResult {
+    pub layout: AllocatorLayoutInfo,
+    pub scope: HeapScopeInfo,
+    pub walk: HeapWalkInfo,
+    pub heaps: Vec<HeapRootInfo>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct HeapAllocationsResult {
+    pub layout: AllocatorLayoutInfo,
+    pub scope: HeapScopeInfo,
+    pub walk: HeapWalkInfo,
+    pub matches: usize,
+    pub allocations: Vec<HeapAllocationInfo>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct HeapChunkResult {
+    pub layout: AllocatorLayoutInfo,
+    pub scope: HeapScopeInfo,
+    pub walk: HeapWalkInfo,
+    pub address: String,
+    pub covered: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub offset: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub allocation: Option<HeapAllocationInfo>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub previous: Option<HeapAllocationInfo>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub next: Option<HeapAllocationInfo>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct HeapCensusRowInfo {
+    pub heap: String,
+    pub backend: HeapBackendName,
+    pub state: HeapChunkState,
+    pub size_class: u32,
+    pub chunks: usize,
+    pub total_capacity: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct HeapCensusResult {
+    pub layout: AllocatorLayoutInfo,
+    pub scope: HeapScopeInfo,
+    pub walk: HeapWalkInfo,
+    pub groups: usize,
+    pub rows: Vec<HeapCensusRowInfo>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct HeapDiagnosticsResult {
+    pub layout: AllocatorLayoutInfo,
+    pub scope: HeapScopeInfo,
+    pub walk: HeapWalkInfo,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub heap: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub filter: Option<String>,
+    pub matched_categories: usize,
+    pub matched_examples: usize,
+    pub categories: Vec<DiagnosticCategory>,
+    pub examples: Vec<String>,
 }
 
 /// What `crash_triage` read off a bug check.
@@ -1447,6 +1732,52 @@ mod tests {
         }
     }
 
+    #[test]
+    fn allocator_layout_keeps_exact_image_pdb_and_structural_family() {
+        let engine = win_kexp::allocator::LayoutProvenance {
+            module: win_kexp::dbgeng::ModuleIdentity {
+                name: "ntdll".into(),
+                image_name: "ntdll.dll".into(),
+                loaded_image_name: r"C:\Windows\System32\ntdll.dll".into(),
+                symbol_file: r"C:\symbols\ntdll.pdb".into(),
+                symbols: win_kexp::dbgeng::SymbolKind::Pdb,
+                base: 0x7ffb_1234_0000,
+                size: 0x234000,
+                timestamp: 0x1234_5678,
+                checksum: 0xabcdef,
+            },
+            fingerprint: "fnv1a64:0123456789abcdef".into(),
+            semantic_family: win_kexp::allocator::VsSemanticFamily::AffinitySlots,
+        };
+
+        let wire = serde_json::to_value(AllocatorLayoutInfo::from(&engine)).unwrap();
+        assert_eq!(wire["module"]["name"], "ntdll");
+        assert_eq!(wire["pdb"], r"C:\symbols\ntdll.pdb");
+        assert_eq!(wire["fingerprint"], "fnv1a64:0123456789abcdef");
+        assert_eq!(wire["semantic_family"], "affinity_slot_vs");
+        assert_eq!(wire["module"]["base"], "0x00007ffb12340000");
+    }
+
+    #[test]
+    fn heap_requested_size_is_optional_rather_than_inferred_from_capacity() {
+        let allocation = |requested_size| win_kexp::heap::HeapAllocation {
+            heap: 0x10000,
+            backend: win_kexp::heap::HeapBackend::Large,
+            state: win_kexp::heap::HeapState::Allocated,
+            header_address: 0x20000,
+            user_address: 0x20000,
+            capacity: 0x20000,
+            requested_size,
+            subsegment: None,
+            size_class: 0x20000,
+        };
+        let unknown = serde_json::to_value(HeapAllocationInfo::from(&allocation(None))).unwrap();
+        assert!(unknown.get("requested_size").is_none(), "{unknown}");
+        let exact =
+            serde_json::to_value(HeapAllocationInfo::from(&allocation(Some(0x1f234)))).unwrap();
+        assert_eq!(exact["requested_size"], 0x1f234);
+    }
+
     /// The gap figures answer the question `coverage` raises and cannot settle: `partial` says
     /// a walk fell short, and these say by how much. They have to come from the walk as numbers
     /// — the diagnostics cannot supply them, because they collapse messages by shape and the
@@ -1454,6 +1785,7 @@ mod tests {
     #[test]
     fn walk_gaps_carry_what_the_diagnostics_cannot() {
         let report = |stalls, refused_chunks| win_kexp::pool::query::PoolSnapshotReport {
+            layout: Default::default(),
             total_chunks: 0,
             allocated_chunks: 0,
             coverage: win_kexp::pool::query::WalkCoverage::Partial,

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -1061,8 +1061,7 @@ fn execute(e: &DebugEngine, id: u64, op: EngineOp, queued: Duration) -> Result<O
         // Zero costs nothing to say. It spawns no watchdog at all — which is the whole reason these
         // ops are off the bounded path (DECISIONS.md, 2026-08-02: arming one rounds a command up to
         // a multiple of 200ms) — so this stays unbounded, as `index_trace` in particular must.
-        EngineOp::Command { command } => e
-            .execute_command_bounded(&command, 0)
+        EngineOp::Command { command } => raw_command(e, &command, 0)
             .map(|run| Output::text(told(run)))
             .map_err(failed),
         EngineOp::BoundedCommand {
@@ -1070,7 +1069,7 @@ fn execute(e: &DebugEngine, id: u64, op: EngineOp, queued: Duration) -> Result<O
             patience_ms,
         } => {
             let budget = watchdog_budget_ms(Duration::from_millis(u64::from(patience_ms)), queued);
-            e.execute_command_bounded(&command, budget)
+            raw_command(e, &command, budget)
                 .map(|run| Output::text(told(run)))
                 .map_err(failed)
         }
@@ -1279,6 +1278,17 @@ fn told(run: CommandRun) -> String {
         ));
     }
     out
+}
+
+/// Executes arbitrary debugger text and conservatively retires allocator snapshots afterward.
+///
+/// A raw command can resume the target or write allocator memory, and DbgEng does not expose a
+/// reliable classification of those effects. Invalidate even when execution reports an error:
+/// the command may have changed memory before its failing token was reached.
+fn raw_command(e: &DebugEngine, command: &str, budget_ms: u32) -> Result<CommandRun, String> {
+    let result = e.execute_command_bounded(command, budget_ms).map_err(es);
+    query::invalidate_allocator_snapshots();
+    result
 }
 
 /// Runs a command that moves the target, and reports where it ended up.
@@ -2199,10 +2209,7 @@ impl Debuggee for BatchEngine<'_> {
     fn command(&mut self, command: &str, budget_ms: u32) -> Result<Ran, String> {
         // Bounded, always. A batch is the one place a runaway command would also strand a
         // rollback, so the step self-aborts rather than eating the reserve.
-        self.e
-            .execute_command_bounded(command, budget_ms)
-            .map(|run| self.ran(run))
-            .map_err(es)
+        raw_command(self.e, command, budget_ms).map(|run| self.ran(run))
     }
 
     fn resume(&mut self, command: &str, timeout_ms: u32) -> Result<Ran, String> {

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -2377,6 +2377,19 @@ fn parse_pool_addr(text: &str) -> Result<u64, String> {
     parse_windbg_addr(text).map_or_else(|| parse_u64(text), Ok)
 }
 
+/// Parses a user-heap address using WinDbg's hexadecimal default radix.
+///
+/// User-mode pointers can be much shorter than kernel pointers, so every nonempty bare hex run
+/// is hexadecimal here. Prefixed and backtick-separated inputs keep the common parser's
+/// validation and error text.
+fn parse_heap_addr(text: &str) -> Result<u64, String> {
+    let text = text.trim();
+    if !text.is_empty() && text.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return u64::from_str_radix(text, 16).map_err(|_| format!("invalid address: {text:?}"));
+    }
+    parse_pool_addr(text)
+}
+
 /// The walk's own diagnostic categories, commonest first.
 ///
 /// The grouping is the walk's, not ours: it collapses floods as it goes and keeps a total per
@@ -2696,16 +2709,42 @@ fn heap_failure(error: heap_query::HeapQueryError) -> Failed {
 }
 
 fn heap_walk_text(walk: &heap_query::HeapWalkReport) -> String {
+    let coverage = structured::AllocatorCoverage::from(walk.coverage);
     format!(
-        "coverage={:?}; {} chunks ({} allocated); {} diagnostics; {} unreadable gaps; {} \
+        "coverage={}; {} chunks ({} allocated); {} diagnostics; {} unreadable gaps; {} \
          refused headers",
-        walk.coverage,
+        coverage.as_str(),
         walk.total_chunks,
         walk.allocated_chunks,
         walk.diagnostic_count,
         walk.unreadable_gaps,
         walk.refused_headers
     )
+}
+
+fn heap_root_matches(candidate: u64, selected: Option<u64>) -> bool {
+    selected.is_none_or(|selected| candidate == selected)
+}
+
+fn heap_allocation_matches(
+    allocation: &HeapAllocation,
+    heap: Option<u64>,
+    backend: Option<HeapBackend>,
+    state: HeapState,
+    min_capacity: Option<u64>,
+    max_capacity: Option<u64>,
+) -> bool {
+    heap_root_matches(allocation.heap, heap)
+        && backend.is_none_or(|backend| allocation.backend == backend)
+        && allocation.state == state
+        && min_capacity.is_none_or(|minimum| allocation.capacity >= minimum)
+        && max_capacity.is_none_or(|maximum| allocation.capacity <= maximum)
+}
+
+fn heap_diagnostic_selected(text: &str, heap: Option<u64>, filter: Option<&str>) -> bool {
+    let text = text.to_ascii_lowercase();
+    heap.is_none_or(|heap| text.contains(&format!("{heap:#x}")))
+        && filter.is_none_or(|filter| text.contains(&filter.to_ascii_lowercase()))
 }
 
 fn heap_row(allocation: &HeapAllocation) -> String {
@@ -2778,7 +2817,7 @@ fn heap(e: &DebugEngine, args: HeapOp, within: Duration) -> Result<Output, Faile
             }
             let heap = heap
                 .as_deref()
-                .map(parse_pool_addr)
+                .map(parse_heap_addr)
                 .transpose()
                 .map_err(|error| {
                     Failed::categorised(structured::ErrorCategory::InvalidArgument, error)
@@ -2799,14 +2838,15 @@ fn heap(e: &DebugEngine, args: HeapOp, within: Duration) -> Result<Output, Faile
             let matches: Vec<_> = answer
                 .found
                 .iter()
-                .filter(|allocation| heap.is_none_or(|heap| allocation.heap == heap))
-                .filter(|allocation| backend.is_none_or(|backend| allocation.backend == backend))
-                .filter(|allocation| allocation.state == state)
                 .filter(|allocation| {
-                    min_capacity.is_none_or(|minimum| allocation.capacity >= minimum)
-                })
-                .filter(|allocation| {
-                    max_capacity.is_none_or(|maximum| allocation.capacity <= maximum)
+                    heap_allocation_matches(
+                        allocation,
+                        heap,
+                        backend,
+                        state,
+                        min_capacity,
+                        max_capacity,
+                    )
                 })
                 .collect();
             let mut text = format!(
@@ -2834,7 +2874,7 @@ fn heap(e: &DebugEngine, args: HeapOp, within: Duration) -> Result<Output, Faile
             ))
         }
         HeapOp::Chunk { address, refresh } => {
-            let address = parse_pool_addr(&address).map_err(|error| {
+            let address = parse_heap_addr(&address).map_err(|error| {
                 Failed::categorised(structured::ErrorCategory::InvalidArgument, error)
             })?;
             let answer = heap_query::chunk_at(e, address, walk(refresh)).map_err(heap_failure)?;
@@ -2887,7 +2927,7 @@ fn heap(e: &DebugEngine, args: HeapOp, within: Duration) -> Result<Output, Faile
         } => {
             let heap = heap
                 .as_deref()
-                .map(parse_pool_addr)
+                .map(parse_heap_addr)
                 .transpose()
                 .map_err(|error| {
                     Failed::categorised(structured::ErrorCategory::InvalidArgument, error)
@@ -2896,7 +2936,7 @@ fn heap(e: &DebugEngine, args: HeapOp, within: Duration) -> Result<Output, Faile
             let rows: Vec<_> = answer
                 .found
                 .iter()
-                .filter(|row| heap.is_none_or(|heap| row.heap == heap))
+                .filter(|row| heap_root_matches(row.heap, heap))
                 .collect();
             let mut text = format!(
                 "{} census group(s), heaviest first; {}\n\n",
@@ -2944,34 +2984,25 @@ fn heap(e: &DebugEngine, args: HeapOp, within: Duration) -> Result<Output, Faile
         } => {
             let heap = heap
                 .as_deref()
-                .map(parse_pool_addr)
+                .map(parse_heap_addr)
                 .transpose()
                 .map_err(|error| {
                     Failed::categorised(structured::ErrorCategory::InvalidArgument, error)
                 })?;
             let answer = heap_query::diagnostics(e, walk(refresh)).map_err(heap_failure)?;
-            let heap_needle = heap.map(|heap| format!("{heap:#x}"));
-            let filter_needle = filter.as_ref().map(|filter| filter.to_ascii_lowercase());
-            let selected = |text: &str| {
-                let text = text.to_ascii_lowercase();
-                heap_needle
-                    .as_ref()
-                    .is_none_or(|needle| text.contains(needle))
-                    && filter_needle
-                        .as_ref()
-                        .is_none_or(|needle| text.contains(needle))
-            };
             let categories: Vec<_> = answer
                 .found
                 .categories
                 .iter()
-                .filter(|category| selected(&category.shape))
+                .filter(|category| {
+                    heap_diagnostic_selected(&category.shape, heap, filter.as_deref())
+                })
                 .collect();
             let examples: Vec<_> = answer
                 .found
                 .examples
                 .iter()
-                .filter(|example| selected(example))
+                .filter(|example| heap_diagnostic_selected(example, heap, filter.as_deref()))
                 .collect();
             let (example_rows, category_rows) =
                 split_row_budget(limit, examples.len(), categories.len());
@@ -3970,6 +4001,114 @@ mod tests {
     fn pool_addr_rejects_nonsense() {
         assert!(parse_pool_addr("not-an-address").is_err());
         assert!(parse_pool_addr("").is_err());
+    }
+
+    #[test]
+    fn heap_addr_reads_a_short_bare_run_as_hex() {
+        assert_eq!(parse_heap_addr("10000"), Ok(0x1_0000));
+        assert_eq!(parse_heap_addr("ffff"), Ok(0xffff));
+        assert_eq!(parse_heap_addr("0x10000"), Ok(0x1_0000));
+    }
+
+    fn heap_filter_fixture() -> HeapAllocation {
+        HeapAllocation {
+            heap: 0x10000,
+            backend: HeapBackend::Vs,
+            state: HeapState::Allocated,
+            header_address: 0x20000,
+            user_address: 0x20010,
+            capacity: 0x80,
+            requested_size: None,
+            subsegment: Some(0x30000),
+            size_class: 0x80,
+        }
+    }
+
+    #[test]
+    fn heap_filter_rejects_capacity_below_minimum() {
+        let allocation = heap_filter_fixture();
+        assert!(!heap_allocation_matches(
+            &allocation,
+            None,
+            None,
+            HeapState::Allocated,
+            Some(0x81),
+            None,
+        ));
+        assert!(heap_allocation_matches(
+            &allocation,
+            None,
+            None,
+            HeapState::Allocated,
+            Some(0x80),
+            None,
+        ));
+    }
+
+    #[test]
+    fn heap_filter_rejects_capacity_above_maximum() {
+        let allocation = heap_filter_fixture();
+        assert!(!heap_allocation_matches(
+            &allocation,
+            None,
+            None,
+            HeapState::Allocated,
+            None,
+            Some(0x7f),
+        ));
+        assert!(heap_allocation_matches(
+            &allocation,
+            None,
+            None,
+            HeapState::Allocated,
+            None,
+            Some(0x80),
+        ));
+    }
+
+    #[test]
+    fn heap_filter_requires_the_selected_allocator_identity() {
+        let allocation = heap_filter_fixture();
+        assert!(!heap_allocation_matches(
+            &allocation,
+            Some(0x20000),
+            Some(HeapBackend::Vs),
+            HeapState::Allocated,
+            None,
+            None,
+        ));
+        assert!(!heap_allocation_matches(
+            &allocation,
+            Some(0x10000),
+            Some(HeapBackend::Lfh),
+            HeapState::Allocated,
+            None,
+            None,
+        ));
+        assert!(heap_allocation_matches(
+            &allocation,
+            Some(0x10000),
+            Some(HeapBackend::Vs),
+            HeapState::Allocated,
+            None,
+            None,
+        ));
+    }
+
+    #[test]
+    fn heap_diagnostic_filter_uses_the_hex_heap_needle() {
+        let example = "cannot discover heap 0x10000: VS free tree unreadable";
+        assert!(heap_diagnostic_selected(
+            example,
+            Some(0x10000),
+            Some("free TREE")
+        ));
+        assert!(!heap_diagnostic_selected(example, Some(0x20000), None));
+        assert!(!heap_diagnostic_selected(
+            example,
+            Some(0x10000),
+            Some("LFH")
+        ));
     }
 
     // ---- the protocol channel this worker was handed -------------------------------

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -43,13 +43,15 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use win_kexp::dbgeng::{CommandRun, DebugEngine, InterruptHandle, Interruption, RunToOutcome};
+use win_kexp::heap::{self as heap_query, HeapAllocation, HeapBackend, HeapState, HeapWalk};
 use win_kexp::pool::query::{self, PoolPageFilter, PoolWalk};
 use win_kexp::pool::{DiagnosticShape, PoolDiagnostics, PoolSpan, PoolState};
 use windows_sys::Win32::Foundation::{HANDLE_FLAG_INHERIT, SetHandleInformation};
 
 use crate::batch::{self, BatchOp, Debuggee, Ran};
 use crate::proto::{
-    EngineOp, Failed, Output, PoolOp, ReachabilityOp, WorkerMessage, WorkerRequest,
+    EngineOp, Failed, HeapBackendFilter, HeapOp, HeapStateFilter, Output, PoolOp, ReachabilityOp,
+    WorkerMessage, WorkerRequest,
 };
 use crate::server::{
     fmt_addr, format_recipe, format_report, hexdump, matches_module_pattern, module_pattern,
@@ -1196,6 +1198,31 @@ fn execute(e: &DebugEngine, id: u64, op: EngineOp, queued: Duration) -> Result<O
                 None => pool(e, query, Duration::ZERO),
             }
         }
+        EngineOp::Heap { query, patience_ms } => {
+            let patience = Duration::from_millis(u64::from(patience_ms));
+            match walk_budget(patience, queued) {
+                Some(budget) => {
+                    tracing::debug!("worker: heap walk budget {budget:?} (queued {queued:?})");
+                    heap(e, query, budget)
+                }
+                None if query.refreshes() => Err(Failed::categorised(
+                    structured::ErrorCategory::NotRun,
+                    format!(
+                        "This heap query was not run: it reached the engine with {}s of its \
+                         caller's timeout left, which is not enough to walk the heap and report \
+                         back before that timeout expires. It requested `refresh`, so no cached \
+                         snapshot can answer it. Nothing was read and nothing changed. It waited \
+                         {}s behind other work on this session; issue it when the session is idle, \
+                         or raise WINDBG_MCP_CALL_TIMEOUT_SECS (an allocator walk reserves {}s of \
+                         reply headroom).",
+                        patience.saturating_sub(queued).as_secs(),
+                        queued.as_secs(),
+                        WATCHDOG_HEADROOM.as_secs()
+                    ),
+                )),
+                None => heap(e, query, Duration::ZERO),
+            }
+        }
         // `id` is passed because a batch is the one op that can stop *itself*: it checks between
         // steps whether an interrupt has been raised for the job it is running as.
         EngineOp::Batch(op) => run_batch(e, id, op, queued)
@@ -1209,10 +1236,14 @@ fn execute(e: &DebugEngine, id: u64, op: EngineOp, queued: Duration) -> Result<O
         )),
         // Reaching here means any batch has already been told to stop and has finished unwinding —
         // the reader saw this request go past and said so, and this thread runs one job at a time.
-        EngineOp::EndSession => e
-            .end_session()
-            .map(|_| Output::text("session ended"))
-            .map_err(failed),
+        EngineOp::EndSession => {
+            let ended = e
+                .end_session()
+                .map(|_| Output::text("session ended"))
+                .map_err(failed);
+            query::invalidate_allocator_caches();
+            ended
+        }
     }
 }
 
@@ -1261,6 +1292,7 @@ fn told(run: CommandRun) -> String {
 /// pointer to report and saying `0` would name the null page as the answer.
 fn resumed(e: &DebugEngine, command: &str, timeout_ms: u32) -> Result<Output, Failed> {
     let run = e.execute_and_wait(command, timeout_ms).map_err(failed)?;
+    query::invalidate_allocator_snapshots();
     let stopped_at = e.instruction_pointer().ok().map(structured::addr);
     // Matched on the variant rather than on "was it cut short at all", even though
     // `execute_and_wait` produces only `OnRequest` today: a go/step that hits its own deadline is
@@ -2176,6 +2208,7 @@ impl Debuggee for BatchEngine<'_> {
     fn resume(&mut self, command: &str, timeout_ms: u32) -> Result<Ran, String> {
         self.e
             .execute_and_wait(command, timeout_ms)
+            .inspect(|_| query::invalidate_allocator_snapshots())
             .map(|run| self.ran(run))
             .map_err(es)
     }
@@ -2496,6 +2529,7 @@ fn pool(e: &DebugEngine, args: PoolOp, within: Duration) -> Result<Output, Faile
             Ok(Output::typed(
                 out,
                 structured::PoolTagMatches {
+                    layout: (&answer.walk.layout).into(),
                     tag,
                     scope: match filter {
                         None => structured::PoolScope::Both,
@@ -2544,6 +2578,7 @@ fn pool(e: &DebugEngine, args: PoolOp, within: Duration) -> Result<Output, Faile
             Ok(Output::typed(
                 out,
                 structured::PoolChunkAt {
+                    layout: (&answer.walk.layout).into(),
                     address: structured::addr(address),
                     covered: found.is_some(),
                     offset: found
@@ -2578,6 +2613,7 @@ fn pool(e: &DebugEngine, args: PoolOp, within: Duration) -> Result<Output, Faile
             Ok(Output::typed(
                 out,
                 structured::PoolDiagnosticsReport {
+                    layout: (&report.layout).into(),
                     filter,
                     matched_categories: categories.len(),
                     matched_examples: examples.len(),
@@ -2609,6 +2645,7 @@ fn pool(e: &DebugEngine, args: PoolOp, within: Duration) -> Result<Output, Faile
             Ok(Output::typed(
                 out,
                 structured::PoolCensus {
+                    layout: (&answer.walk.layout).into(),
                     distinct_tags: census.len(),
                     tags: census
                         .iter()
@@ -2622,6 +2659,355 @@ fn pool(e: &DebugEngine, args: PoolOp, within: Duration) -> Result<Output, Faile
                         })
                         .collect(),
                     walk: walk_info(&answer.walk),
+                },
+            ))
+        }
+    }
+}
+
+fn heap_backend_name(backend: HeapBackend) -> structured::HeapBackendName {
+    match backend {
+        HeapBackend::Lfh => structured::HeapBackendName::Lfh,
+        HeapBackend::Vs => structured::HeapBackendName::Vs,
+        HeapBackend::Segment => structured::HeapBackendName::Segment,
+        HeapBackend::Large => structured::HeapBackendName::Large,
+    }
+}
+
+fn heap_state_name(state: HeapState) -> structured::HeapChunkState {
+    match state {
+        HeapState::Allocated => structured::HeapChunkState::Allocated,
+        HeapState::ReusableFree => structured::HeapChunkState::ReusableFree,
+        HeapState::CachedFree => structured::HeapChunkState::CachedFree,
+        HeapState::Unreadable => structured::HeapChunkState::Unreadable,
+    }
+}
+
+fn heap_failure(error: heap_query::HeapQueryError) -> Failed {
+    match error {
+        heap_query::HeapQueryError::Interrupted => {
+            Failed::categorised(structured::ErrorCategory::Interrupted, error.to_string())
+        }
+        heap_query::HeapQueryError::InvalidPeb(_) => {
+            Failed::categorised(structured::ErrorCategory::Debugger, error.to_string())
+        }
+        other => Failed::from(other.to_string()),
+    }
+}
+
+fn heap_walk_text(walk: &heap_query::HeapWalkReport) -> String {
+    format!(
+        "coverage={:?}; {} chunks ({} allocated); {} diagnostics; {} unreadable gaps; {} \
+         refused headers",
+        walk.coverage,
+        walk.total_chunks,
+        walk.allocated_chunks,
+        walk.diagnostic_count,
+        walk.unreadable_gaps,
+        walk.refused_headers
+    )
+}
+
+fn heap_row(allocation: &HeapAllocation) -> String {
+    format!(
+        "{}  {:>8}  {:<13}  {:<7}  heap {}  class {:#x}",
+        fmt_addr(allocation.user_address),
+        format!("{:#x}", allocation.capacity),
+        format!("{:?}", allocation.state),
+        format!("{:?}", allocation.backend),
+        fmt_addr(allocation.heap),
+        allocation.size_class,
+    )
+}
+
+/// Answers one user Segment Heap question under the caller-derived deadline.
+fn heap(e: &DebugEngine, args: HeapOp, within: Duration) -> Result<Output, Failed> {
+    let walk = |refresh: bool| HeapWalk::from(refresh).within(within);
+    match args {
+        HeapOp::List { refresh } => {
+            let answer = heap_query::list(e, walk(refresh)).map_err(heap_failure)?;
+            let mut text = format!(
+                "{} PEB heap(s); {}\n\nindex  address             kind        supported\n",
+                answer.found.len(),
+                heap_walk_text(&answer.walk)
+            );
+            for root in &answer.found {
+                text.push_str(&format!(
+                    "{:>5}  {}  {:<11} {}{}\n",
+                    root.index,
+                    fmt_addr(root.address),
+                    format!("{:?}", root.kind),
+                    root.supported,
+                    root.reason
+                        .as_deref()
+                        .map(|reason| format!(" — {reason}"))
+                        .unwrap_or_default()
+                ));
+            }
+            Ok(Output::typed(
+                text,
+                structured::HeapListResult {
+                    layout: (&answer.layout).into(),
+                    scope: (&answer.scope).into(),
+                    walk: (&answer.walk).into(),
+                    heaps: answer
+                        .found
+                        .iter()
+                        .map(structured::HeapRootInfo::from)
+                        .collect(),
+                },
+            ))
+        }
+        HeapOp::Allocations {
+            heap,
+            backend,
+            state,
+            min_capacity,
+            max_capacity,
+            refresh,
+            limit,
+        } => {
+            if min_capacity
+                .zip(max_capacity)
+                .is_some_and(|(min, max)| min > max)
+            {
+                return Err(Failed::categorised(
+                    structured::ErrorCategory::InvalidArgument,
+                    "min_capacity cannot exceed max_capacity",
+                ));
+            }
+            let heap = heap
+                .as_deref()
+                .map(parse_pool_addr)
+                .transpose()
+                .map_err(|error| {
+                    Failed::categorised(structured::ErrorCategory::InvalidArgument, error)
+                })?;
+            let backend = backend.map(|backend| match backend {
+                HeapBackendFilter::Lfh => HeapBackend::Lfh,
+                HeapBackendFilter::Vs => HeapBackend::Vs,
+                HeapBackendFilter::Segment => HeapBackend::Segment,
+                HeapBackendFilter::Large => HeapBackend::Large,
+            });
+            let state = match state {
+                HeapStateFilter::Allocated => HeapState::Allocated,
+                HeapStateFilter::ReusableFree => HeapState::ReusableFree,
+                HeapStateFilter::CachedFree => HeapState::CachedFree,
+                HeapStateFilter::Unreadable => HeapState::Unreadable,
+            };
+            let answer = heap_query::allocations(e, walk(refresh)).map_err(heap_failure)?;
+            let matches: Vec<_> = answer
+                .found
+                .iter()
+                .filter(|allocation| heap.is_none_or(|heap| allocation.heap == heap))
+                .filter(|allocation| backend.is_none_or(|backend| allocation.backend == backend))
+                .filter(|allocation| allocation.state == state)
+                .filter(|allocation| {
+                    min_capacity.is_none_or(|minimum| allocation.capacity >= minimum)
+                })
+                .filter(|allocation| {
+                    max_capacity.is_none_or(|maximum| allocation.capacity <= maximum)
+                })
+                .collect();
+            let mut text = format!(
+                "{} matching allocation(s); {}\n\naddress             capacity  state          backend  heap/class\n",
+                matches.len(),
+                heap_walk_text(&answer.walk)
+            );
+            for allocation in matches.iter().take(limit) {
+                text.push_str(&heap_row(allocation));
+                text.push('\n');
+            }
+            Ok(Output::typed(
+                text,
+                structured::HeapAllocationsResult {
+                    layout: (&answer.layout).into(),
+                    scope: (&answer.scope).into(),
+                    walk: (&answer.walk).into(),
+                    matches: matches.len(),
+                    allocations: matches
+                        .into_iter()
+                        .take(limit)
+                        .map(structured::HeapAllocationInfo::from)
+                        .collect(),
+                },
+            ))
+        }
+        HeapOp::Chunk { address, refresh } => {
+            let address = parse_pool_addr(&address).map_err(|error| {
+                Failed::categorised(structured::ErrorCategory::InvalidArgument, error)
+            })?;
+            let answer = heap_query::chunk_at(e, address, walk(refresh)).map_err(heap_failure)?;
+            let text = match &answer.found {
+                Some(found) => format!(
+                    "{} is {:#x} from user address {}\n{}\n{}",
+                    fmt_addr(address),
+                    found.offset,
+                    fmt_addr(found.allocation.user_address),
+                    heap_row(&found.allocation),
+                    heap_walk_text(&answer.walk)
+                ),
+                None => format!(
+                    "{} is not covered by the Segment Heap snapshot. This is not evidence that \
+                     it is free; inspect coverage and retry with refresh=true after execution.\n{}",
+                    fmt_addr(address),
+                    heap_walk_text(&answer.walk)
+                ),
+            };
+            Ok(Output::typed(
+                text,
+                structured::HeapChunkResult {
+                    layout: (&answer.layout).into(),
+                    scope: (&answer.scope).into(),
+                    walk: (&answer.walk).into(),
+                    address: structured::addr(address),
+                    covered: answer.found.is_some(),
+                    offset: answer.found.as_ref().map(|found| found.offset),
+                    allocation: answer
+                        .found
+                        .as_ref()
+                        .map(|found| (&found.allocation).into()),
+                    previous: answer
+                        .found
+                        .as_ref()
+                        .and_then(|found| found.previous.as_ref())
+                        .map(Into::into),
+                    next: answer
+                        .found
+                        .as_ref()
+                        .and_then(|found| found.next.as_ref())
+                        .map(Into::into),
+                },
+            ))
+        }
+        HeapOp::Census {
+            heap,
+            refresh,
+            limit,
+        } => {
+            let heap = heap
+                .as_deref()
+                .map(parse_pool_addr)
+                .transpose()
+                .map_err(|error| {
+                    Failed::categorised(structured::ErrorCategory::InvalidArgument, error)
+                })?;
+            let answer = heap_query::census(e, walk(refresh)).map_err(heap_failure)?;
+            let rows: Vec<_> = answer
+                .found
+                .iter()
+                .filter(|row| heap.is_none_or(|heap| row.heap == heap))
+                .collect();
+            let mut text = format!(
+                "{} census group(s), heaviest first; {}\n\n",
+                rows.len(),
+                heap_walk_text(&answer.walk)
+            );
+            for row in rows.iter().take(limit) {
+                text.push_str(&format!(
+                    "heap {} {:?}/{:?} class {:#x}: {} chunks, {:#x} bytes\n",
+                    fmt_addr(row.heap),
+                    row.backend,
+                    row.state,
+                    row.size_class,
+                    row.chunks,
+                    row.total_capacity
+                ));
+            }
+            Ok(Output::typed(
+                text,
+                structured::HeapCensusResult {
+                    layout: (&answer.layout).into(),
+                    scope: (&answer.scope).into(),
+                    walk: (&answer.walk).into(),
+                    groups: rows.len(),
+                    rows: rows
+                        .into_iter()
+                        .take(limit)
+                        .map(|row| structured::HeapCensusRowInfo {
+                            heap: structured::addr(row.heap),
+                            backend: heap_backend_name(row.backend),
+                            state: heap_state_name(row.state),
+                            size_class: row.size_class,
+                            chunks: row.chunks,
+                            total_capacity: row.total_capacity,
+                        })
+                        .collect(),
+                },
+            ))
+        }
+        HeapOp::Diagnostics {
+            heap,
+            filter,
+            refresh,
+            limit,
+        } => {
+            let heap = heap
+                .as_deref()
+                .map(parse_pool_addr)
+                .transpose()
+                .map_err(|error| {
+                    Failed::categorised(structured::ErrorCategory::InvalidArgument, error)
+                })?;
+            let answer = heap_query::diagnostics(e, walk(refresh)).map_err(heap_failure)?;
+            let heap_needle = heap.map(|heap| format!("{heap:#x}"));
+            let filter_needle = filter.as_ref().map(|filter| filter.to_ascii_lowercase());
+            let selected = |text: &str| {
+                let text = text.to_ascii_lowercase();
+                heap_needle
+                    .as_ref()
+                    .is_none_or(|needle| text.contains(needle))
+                    && filter_needle
+                        .as_ref()
+                        .is_none_or(|needle| text.contains(needle))
+            };
+            let categories: Vec<_> = answer
+                .found
+                .categories
+                .iter()
+                .filter(|category| selected(&category.shape))
+                .collect();
+            let examples: Vec<_> = answer
+                .found
+                .examples
+                .iter()
+                .filter(|example| selected(example))
+                .collect();
+            let (example_rows, category_rows) =
+                split_row_budget(limit, examples.len(), categories.len());
+            let mut text = format!(
+                "{} matching categories, {} kept examples; {}\n",
+                categories.len(),
+                examples.len(),
+                heap_walk_text(&answer.walk)
+            );
+            for category in categories.iter().take(category_rows) {
+                text.push_str(&format!("{} × {}\n", category.total, category.shape));
+            }
+            for example in examples.iter().take(example_rows) {
+                text.push_str("  ");
+                text.push_str(example);
+                text.push('\n');
+            }
+            Ok(Output::typed(
+                text,
+                structured::HeapDiagnosticsResult {
+                    layout: (&answer.layout).into(),
+                    scope: (&answer.scope).into(),
+                    walk: (&answer.walk).into(),
+                    heap: heap.map(structured::addr),
+                    filter,
+                    matched_categories: categories.len(),
+                    matched_examples: examples.len(),
+                    categories: categories
+                        .into_iter()
+                        .take(category_rows)
+                        .map(|category| structured::DiagnosticCategory {
+                            shape: category.shape.trim().to_string(),
+                            total: category.total,
+                        })
+                        .collect(),
+                    examples: examples.into_iter().take(example_rows).cloned().collect(),
                 },
             ))
         }
@@ -3087,6 +3473,7 @@ fn run_to_address(e: &DebugEngine, address: &str, wait: u32) -> Result<Output, F
     let target =
         resolve(e, address).ok_or_else(|| format!("could not resolve address `{address}`"))?;
     let res = e.run_to_address(target, wait).map_err(failed)?;
+    query::invalidate_allocator_snapshots();
     let mut msg = match res.outcome {
         RunToOutcome::Hit => format!("VERDICT: HIT — execution reached {}\n", fmt_addr(target)),
         RunToOutcome::StoppedElsewhere { stopped_at } => format!(
@@ -3203,6 +3590,7 @@ mod tests {
     /// the gap figures do with a walk that met either is `structured`'s question.
     fn quiet_walk() -> query::PoolSnapshotReport {
         query::PoolSnapshotReport {
+            layout: Default::default(),
             total_chunks: 0,
             allocated_chunks: 0,
             coverage: coverage(true),
@@ -4455,5 +4843,10 @@ mod tests {
         // The default, and the reason the distinction is worth making at all.
         assert!(!PoolOp::census(None, None).refreshes());
         assert!(!PoolOp::chunk("0x1000".into(), Some(false)).refreshes());
+
+        assert!(HeapOp::list(Some(true)).refreshes());
+        assert!(HeapOp::chunk("0x1000".into(), Some(true)).refreshes());
+        assert!(!HeapOp::census(None, None, None).refreshes());
+        assert!(!HeapOp::diagnostics(None, None, Some(false), None).refreshes());
     }
 }

--- a/tests/golden/tools_list.json
+++ b/tests/golden/tools_list.json
@@ -392,14 +392,14 @@
         "dialect": "https://json-schema.org/draft/2020-12/schema"
       },
       "params": [
-        "backend: any",
+        "backend: enum[\"lfh\"|\"vs\"|\"segment\"|\"large\"]|null",
         "heap: string|null",
         "limit: integer|null/uint32",
         "max_capacity: integer|null/uint64",
         "min_capacity: integer|null/uint64",
         "refresh: boolean|null",
         "session_id: string|null",
-        "state: any"
+        "state: enum[\"allocated\"|\"reusable_free\"|\"cached_free\"|\"unreadable\"]|null"
       ],
       "required": [],
       "title": "List Segment Heap allocations"

--- a/tests/golden/tools_list.json
+++ b/tests/golden/tools_list.json
@@ -3,7 +3,7 @@
     "(none)",
     "https://json-schema.org/draft/2020-12/schema"
   ],
-  "toolCount": 45,
+  "toolCount": 50,
   "tools": [
     {
       "hints": {
@@ -363,6 +363,190 @@
         "position"
       ],
       "title": "Go to TTD position"
+    },
+    {
+      "hints": {
+        "destructive": false,
+        "idempotent": true,
+        "openWorld": true,
+        "readOnly": true
+      },
+      "name": "heap_allocations",
+      "output": {
+        "branches": [
+          {
+            "payload": "#/$defs/HeapAllocationsResult",
+            "required": [
+              "status"
+            ],
+            "status": "ok"
+          },
+          {
+            "payload": "#/$defs/Failure",
+            "required": [
+              "status"
+            ],
+            "status": "error"
+          }
+        ],
+        "dialect": "https://json-schema.org/draft/2020-12/schema"
+      },
+      "params": [
+        "backend: any",
+        "heap: string|null",
+        "limit: integer|null/uint32",
+        "max_capacity: integer|null/uint64",
+        "min_capacity: integer|null/uint64",
+        "refresh: boolean|null",
+        "session_id: string|null",
+        "state: any"
+      ],
+      "required": [],
+      "title": "List Segment Heap allocations"
+    },
+    {
+      "hints": {
+        "destructive": false,
+        "idempotent": true,
+        "openWorld": true,
+        "readOnly": true
+      },
+      "name": "heap_census",
+      "output": {
+        "branches": [
+          {
+            "payload": "#/$defs/HeapCensusResult",
+            "required": [
+              "status"
+            ],
+            "status": "ok"
+          },
+          {
+            "payload": "#/$defs/Failure",
+            "required": [
+              "status"
+            ],
+            "status": "error"
+          }
+        ],
+        "dialect": "https://json-schema.org/draft/2020-12/schema"
+      },
+      "params": [
+        "heap: string|null",
+        "limit: integer|null/uint32",
+        "refresh: boolean|null",
+        "session_id: string|null"
+      ],
+      "required": [],
+      "title": "Census Segment Heap usage"
+    },
+    {
+      "hints": {
+        "destructive": false,
+        "idempotent": true,
+        "openWorld": true,
+        "readOnly": true
+      },
+      "name": "heap_chunk",
+      "output": {
+        "branches": [
+          {
+            "payload": "#/$defs/HeapChunkResult",
+            "required": [
+              "status"
+            ],
+            "status": "ok"
+          },
+          {
+            "payload": "#/$defs/Failure",
+            "required": [
+              "status"
+            ],
+            "status": "error"
+          }
+        ],
+        "dialect": "https://json-schema.org/draft/2020-12/schema"
+      },
+      "params": [
+        "address: string",
+        "refresh: boolean|null",
+        "session_id: string|null"
+      ],
+      "required": [
+        "address"
+      ],
+      "title": "Locate a Segment Heap chunk"
+    },
+    {
+      "hints": {
+        "destructive": false,
+        "idempotent": true,
+        "openWorld": true,
+        "readOnly": true
+      },
+      "name": "heap_diagnostics",
+      "output": {
+        "branches": [
+          {
+            "payload": "#/$defs/HeapDiagnosticsResult",
+            "required": [
+              "status"
+            ],
+            "status": "ok"
+          },
+          {
+            "payload": "#/$defs/Failure",
+            "required": [
+              "status"
+            ],
+            "status": "error"
+          }
+        ],
+        "dialect": "https://json-schema.org/draft/2020-12/schema"
+      },
+      "params": [
+        "filter: string|null",
+        "heap: string|null",
+        "limit: integer|null/uint32",
+        "refresh: boolean|null",
+        "session_id: string|null"
+      ],
+      "required": [],
+      "title": "Filter Segment Heap diagnostics"
+    },
+    {
+      "hints": {
+        "destructive": false,
+        "idempotent": true,
+        "openWorld": true,
+        "readOnly": true
+      },
+      "name": "heap_list",
+      "output": {
+        "branches": [
+          {
+            "payload": "#/$defs/HeapListResult",
+            "required": [
+              "status"
+            ],
+            "status": "ok"
+          },
+          {
+            "payload": "#/$defs/Failure",
+            "required": [
+              "status"
+            ],
+            "status": "error"
+          }
+        ],
+        "dialect": "https://json-schema.org/draft/2020-12/schema"
+      },
+      "params": [
+        "refresh: boolean|null",
+        "session_id: string|null"
+      ],
+      "required": [],
+      "title": "List user-mode heaps"
     },
     {
       "hints": {

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -708,9 +708,37 @@ fn capabilities_advertise_only_what_is_implemented() {
 /// Describes a schema node tightly enough that a dialect or codegen change shows up, without
 /// churning on prose edits.
 fn describe_type(node: &Value) -> String {
-    if let Some(variants) = node.get("enum").and_then(|e| e.as_array()) {
+    describe_type_with_defs(node, None)
+}
+
+fn enum_values<'a>(
+    node: &'a Value,
+    definitions: Option<&'a serde_json::Map<String, Value>>,
+) -> Option<&'a Vec<Value>> {
+    node.get("enum").and_then(Value::as_array).or_else(|| {
+        let name = node.get("$ref")?.as_str()?.strip_prefix("#/$defs/")?;
+        definitions?.get(name)?.get("enum")?.as_array()
+    })
+}
+
+fn describe_type_with_defs(
+    node: &Value,
+    definitions: Option<&serde_json::Map<String, Value>>,
+) -> String {
+    if let Some(variants) = enum_values(node, definitions) {
         let names: Vec<String> = variants.iter().map(|v| v.to_string()).collect();
         return format!("enum[{}]", names.join("|"));
+    }
+    if let Some(branches) = node.get("anyOf").and_then(Value::as_array)
+        && branches
+            .iter()
+            .any(|branch| enum_values(branch, definitions).is_some())
+    {
+        return branches
+            .iter()
+            .map(|branch| describe_type_with_defs(branch, definitions))
+            .collect::<Vec<_>>()
+            .join("|");
     }
     if let Some(reference) = node.get("$ref").and_then(|r| r.as_str()) {
         return format!("ref({reference})");
@@ -725,7 +753,9 @@ fn describe_type(node: &Value) -> String {
         _ => "any".to_string(),
     };
     let base = match node.get("items") {
-        Some(items) if base.starts_with("array") => format!("array<{}>", describe_type(items)),
+        Some(items) if base.starts_with("array") => {
+            format!("array<{}>", describe_type_with_defs(items, definitions))
+        }
         _ => base,
     };
     match node.get("format").and_then(|f| f.as_str()) {
@@ -734,15 +764,49 @@ fn describe_type(node: &Value) -> String {
     }
 }
 
+#[test]
+fn nullable_enum_keeps_its_allowed_values_in_the_golden_digest() {
+    let schema = json!({
+        "anyOf": [
+            { "type": "string", "enum": ["lfh", "vs", "segment", "large"] },
+            { "type": "null" }
+        ]
+    });
+    assert_eq!(
+        describe_type(&schema),
+        "enum[\"lfh\"|\"vs\"|\"segment\"|\"large\"]|null"
+    );
+
+    let definitions = json!({
+        "HeapBackendArg": {
+            "type": "string",
+            "enum": ["lfh", "vs", "segment", "large"]
+        }
+    });
+    let referenced = json!({
+        "anyOf": [
+            { "$ref": "#/$defs/HeapBackendArg" },
+            { "type": "null" }
+        ]
+    });
+    assert_eq!(
+        describe_type_with_defs(&referenced, definitions.as_object()),
+        "enum[\"lfh\"|\"vs\"|\"segment\"|\"large\"]|null"
+    );
+}
+
 /// The structural contract of one tool: everything a client binds against, minus the prose.
 fn digest_tool(tool: &Value) -> Value {
     let schema = &tool["inputSchema"];
+    let definitions = schema["$defs"].as_object();
     let mut params: Vec<String> = schema["properties"]
         .as_object()
         .map(|props| {
             props
                 .iter()
-                .map(|(name, node)| format!("{name}: {}", describe_type(node)))
+                .map(|(name, node)| {
+                    format!("{name}: {}", describe_type_with_defs(node, definitions))
+                })
                 .collect()
         })
         .unwrap_or_default();
@@ -1225,6 +1289,25 @@ fn a_malformed_walk_is_refused_before_a_session_is_needed() {
         text_of(&too_many["result"]).contains("at most"),
         "the refusal must name the cap, got:\n{}",
         text_of(&too_many["result"])
+    );
+}
+
+#[test]
+fn an_inverted_heap_capacity_range_is_refused_before_a_session_is_needed() {
+    let mut server = Server::started();
+    let response = server.call_tool(
+        "heap_allocations",
+        json!({ "min_capacity": 0x2000, "max_capacity": 0x1000 }),
+        STEP,
+    );
+    assert!(is_tool_error(&response), "{response}");
+    assert_eq!(
+        response["result"]["structuredContent"]["error"]["category"], "invalid_argument",
+        "the malformed range must be rejected before session routing: {response}"
+    );
+    assert!(
+        text_of(&response["result"]).contains("min_capacity cannot exceed max_capacity"),
+        "{response}"
     );
 }
 

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -1040,6 +1040,15 @@ fn every_tool_with_an_output_schema_answers_with_structured_content() {
         ),
         ("pool_census", json!({}), "error"),
         ("pool_diagnostics", json!({}), "error"),
+        ("heap_list", json!({}), "error"),
+        ("heap_allocations", json!({}), "error"),
+        (
+            "heap_chunk",
+            json!({ "address": "0x0000000000010000" }),
+            "error",
+        ),
+        ("heap_census", json!({}), "error"),
+        ("heap_diagnostics", json!({}), "error"),
         ("crash_triage", json!({}), "error"),
         // A well-formed request, so it takes the *session* refusal path like every row above it
         // rather than the argument one — which this tool also has, and which is checked in
@@ -4807,7 +4816,7 @@ fn a_live_kernel_pool_walk_is_bounded_and_leaves_its_session_usable() {
         assert!(
             !is_tool_error(&walk),
             "the pool walk failed outright, so nothing below would be measuring a walk. If this \
-             names missing kernel pool symbols after the probe above resolved, then the walker \
+             names missing allocator symbols after the probe above resolved, then the walker \
              wants type information the public store does not carry, which is a different \
              problem from an unset symbol path.\n{absent}\n\nsymbol setup said:{transcript}"
         );


### PR DESCRIPTION
## Summary

- add `heap_list`, `heap_allocations`, `heap_chunk`, `heap_census`, and `heap_diagnostics`
- route heap operations through the supervisor/worker protocol with pool-equivalent queue budgeting, deadlines, interruption, partial coverage, and cache lifecycle
- expose allocator layout provenance on both pool and heap structured results
- add schema/golden coverage, user-heap documentation, and the Segment Heap v1 agent playbook
- pin `win-kexp` to the exact implementation commit from glslang/win-kexp#105

## Why

User-mode Segment Heap inspection needs the same typed, target-version-aware safety guarantees as kernel pool inspection. This surfaces the shared decoder without parsing debugger text and makes incomplete coverage visible before absence is treated as evidence.

## Impact

The five new tools support stopped x64 live targets and sufficiently complete dumps. Classic NT heaps are listed but deliberately excluded from Segment Heap coverage and directed to `!heap`. Kernel `pool_*` inputs remain stable.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --all-targets`
- `cargo test -q` (344 passed, 12 ignored)

The test suite was rerun against the exact Git revision pinned in this PR. Opt-in user live/dump and KDNET smoke tiers remain environment-gated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added five read-only User Segment Heap inspection tools for listing heaps, viewing allocations, locating chunks, generating census reports, and running diagnostics.
  - Added filtering by heap backend and allocation state, with structured results, coverage details, allocation sizing, and diagnostic information.
  - Added allocator layout and symbol provenance to pool and heap results.
  - Added caching and refresh handling for efficient heap walks.

- **Documentation**
  - Expanded guidance for Segment Heap workflows, symbol setup, supported targets, troubleshooting, and smoke testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->