### PR TITLE
Fix heap-scoped diagnostic categories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -883,7 +883,7 @@ dependencies = [
 [[package]]
 name = "win-kexp"
 version = "0.1.0"
-source = "git+https://github.com/glslang/win-kexp?branch=main#549a949fb9413960a16eac4d5bab807815c1814d"
+source = "git+https://github.com/glslang/win-kexp?rev=a5a044ee41fc521c1cb2fa5cf1b07e5282eca2ec#a5a044ee41fc521c1cb2fa5cf1b07e5282eca2ec"
 dependencies = [
  "byte-strings",
  "goblin",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -883,7 +883,7 @@ dependencies = [
 [[package]]
 name = "win-kexp"
 version = "0.1.0"
-source = "git+https://github.com/glslang/win-kexp?rev=a5a044ee41fc521c1cb2fa5cf1b07e5282eca2ec#a5a044ee41fc521c1cb2fa5cf1b07e5282eca2ec"
+source = "git+https://github.com/glslang/win-kexp?rev=5db04f3b83f240384dea184bce52ada0a97bc494#5db04f3b83f240384dea184bce52ada0a97bc494"
 dependencies = [
  "byte-strings",
  "goblin",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.8.1"
 edition = "2024"
 
 [dependencies]
-win-kexp = { git = "https://github.com/glslang/win-kexp", branch = "main" }
+win-kexp = { git = "https://github.com/glslang/win-kexp", rev = "a5a044ee41fc521c1cb2fa5cf1b07e5282eca2ec" }
 # 3.1.1 is a floor, not a preference: every 3.x before it generates a `tools/list` that omits
 # SEP-2549's required `ttlMs`/`cacheScope`, which a spec-strict `2026-07-28` client rejects
 # outright — the server connects and appears to expose no tools at all (upstream issue #1114).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.8.1"
 edition = "2024"
 
 [dependencies]
-win-kexp = { git = "https://github.com/glslang/win-kexp", rev = "a5a044ee41fc521c1cb2fa5cf1b07e5282eca2ec" }
+win-kexp = { git = "https://github.com/glslang/win-kexp", rev = "5db04f3b83f240384dea184bce52ada0a97bc494" }
 # 3.1.1 is a floor, not a preference: every 3.x before it generates a `tools/list` that omits
 # SEP-2549's required `ttlMs`/`cacheScope`, which a spec-strict `2026-07-28` client rejects
 # outright — the server connects and appears to expose no tools at all (upstream issue #1114).

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -2748,9 +2748,39 @@ fn heap_allocation_matches(
         && max_capacity.is_none_or(|maximum| allocation.capacity <= maximum)
 }
 
-fn heap_diagnostic_matches_filter(text: &str, filter: Option<&str>) -> bool {
-    let text = text.to_ascii_lowercase();
-    filter.is_none_or(|filter| text.contains(&filter.to_ascii_lowercase()))
+fn query_heap_diagnostics<T, E>(
+    heap: Option<u64>,
+    all: impl FnOnce() -> Result<T, E>,
+    scoped: impl FnOnce(u64) -> Result<T, E>,
+) -> Result<T, E> {
+    match heap {
+        Some(heap) => scoped(heap),
+        None => all(),
+    }
+}
+
+struct HeapDiagnosticSelection<'a> {
+    categories: Vec<&'a DiagnosticShape>,
+    examples: Vec<&'a String>,
+}
+
+fn select_heap_diagnostics<'a>(
+    report: &'a heap_query::HeapDiagnosticReport,
+    filter: Option<&str>,
+) -> HeapDiagnosticSelection<'a> {
+    let needle = filter.map(str::to_ascii_lowercase);
+    HeapDiagnosticSelection {
+        categories: report
+            .categories
+            .iter()
+            .filter(|category| matches_filter(&category.shape, needle.as_deref()))
+            .collect(),
+        examples: report
+            .examples
+            .iter()
+            .filter(|example| matches_filter(example, needle.as_deref()))
+            .collect(),
+    }
 }
 
 fn heap_row(allocation: &HeapAllocation) -> String {
@@ -2998,25 +3028,15 @@ fn heap(e: &DebugEngine, args: HeapOp, within: Duration) -> Result<Output, Faile
             // Scope before win-kexp aggregates diagnostic shapes: those shapes deliberately
             // generalise addresses, so filtering them for the heap address afterwards loses the
             // category totals and leaves only incidental examples.
-            let answer = match heap {
-                Some(heap) => heap_query::diagnostics_for_heap(e, heap, walk(refresh)),
-                None => heap_query::diagnostics(e, walk(refresh)),
-            }
+            let answer = query_heap_diagnostics(
+                heap,
+                || heap_query::diagnostics(e, walk(refresh)),
+                |heap| heap_query::diagnostics_for_heap(e, heap, walk(refresh)),
+            )
             .map_err(heap_failure)?;
-            let categories: Vec<_> = answer
-                .found
-                .categories
-                .iter()
-                .filter(|category| {
-                    heap_diagnostic_matches_filter(&category.shape, filter.as_deref())
-                })
-                .collect();
-            let examples: Vec<_> = answer
-                .found
-                .examples
-                .iter()
-                .filter(|example| heap_diagnostic_matches_filter(example, filter.as_deref()))
-                .collect();
+            let selected = select_heap_diagnostics(&answer.found, filter.as_deref());
+            let categories = selected.categories;
+            let examples = selected.examples;
             let (example_rows, category_rows) =
                 split_row_budget(limit, examples.len(), categories.len());
             let mut text = format!(
@@ -4109,11 +4129,53 @@ mod tests {
     }
 
     #[test]
-    fn heap_diagnostic_filter_matches_generalised_categories_case_insensitively() {
-        let category = "unreadable VS free tree node <address>: sparse memory";
-        assert!(heap_diagnostic_matches_filter(category, None));
-        assert!(heap_diagnostic_matches_filter(category, Some("free TREE")));
-        assert!(!heap_diagnostic_matches_filter(category, Some("LFH")));
+    fn heap_diagnostic_scope_and_filter_preserve_scoped_totals_and_examples() {
+        let (routed_heap, report) = query_heap_diagnostics(
+            Some(0x20000),
+            || {
+                Ok::<_, ()>((
+                    None,
+                    heap_query::HeapDiagnosticReport {
+                        categories: Vec::new(),
+                        examples: Vec::new(),
+                    },
+                ))
+            },
+            |heap| {
+                Ok::<_, ()>((
+                    Some(heap),
+                    heap_query::HeapDiagnosticReport {
+                        categories: vec![
+                            DiagnosticShape {
+                                shape: "unreadable VS free tree node <address>: sparse memory"
+                                    .into(),
+                                total: 17,
+                            },
+                            DiagnosticShape {
+                                shape: "invalid LFH bitmap at <address>".into(),
+                                total: 3,
+                            },
+                        ],
+                        examples: vec![
+                            "unreadable VS free tree node 0x20100: sparse memory".into(),
+                            "invalid LFH bitmap at 0x20200".into(),
+                        ],
+                    },
+                ))
+            },
+        )
+        .unwrap();
+
+        assert_eq!(routed_heap, Some(0x20000));
+        let selected = select_heap_diagnostics(&report, Some("free TREE"));
+        assert_eq!(selected.categories.len(), 1);
+        assert_eq!(selected.categories[0].total, 17);
+        assert_eq!(selected.examples.len(), 1);
+        assert!(selected.examples[0].contains("0x20100"));
+
+        let unfiltered = select_heap_diagnostics(&report, None);
+        assert_eq!(unfiltered.categories.len(), 2);
+        assert_eq!(unfiltered.examples.len(), 2);
     }
 
     // ---- the protocol channel this worker was handed -------------------------------

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -2748,10 +2748,9 @@ fn heap_allocation_matches(
         && max_capacity.is_none_or(|maximum| allocation.capacity <= maximum)
 }
 
-fn heap_diagnostic_selected(text: &str, heap: Option<u64>, filter: Option<&str>) -> bool {
+fn heap_diagnostic_matches_filter(text: &str, filter: Option<&str>) -> bool {
     let text = text.to_ascii_lowercase();
-    heap.is_none_or(|heap| text.contains(&format!("{heap:#x}")))
-        && filter.is_none_or(|filter| text.contains(&filter.to_ascii_lowercase()))
+    filter.is_none_or(|filter| text.contains(&filter.to_ascii_lowercase()))
 }
 
 fn heap_row(allocation: &HeapAllocation) -> String {
@@ -2996,20 +2995,27 @@ fn heap(e: &DebugEngine, args: HeapOp, within: Duration) -> Result<Output, Faile
                 .map_err(|error| {
                     Failed::categorised(structured::ErrorCategory::InvalidArgument, error)
                 })?;
-            let answer = heap_query::diagnostics(e, walk(refresh)).map_err(heap_failure)?;
+            // Scope before win-kexp aggregates diagnostic shapes: those shapes deliberately
+            // generalise addresses, so filtering them for the heap address afterwards loses the
+            // category totals and leaves only incidental examples.
+            let answer = match heap {
+                Some(heap) => heap_query::diagnostics_for_heap(e, heap, walk(refresh)),
+                None => heap_query::diagnostics(e, walk(refresh)),
+            }
+            .map_err(heap_failure)?;
             let categories: Vec<_> = answer
                 .found
                 .categories
                 .iter()
                 .filter(|category| {
-                    heap_diagnostic_selected(&category.shape, heap, filter.as_deref())
+                    heap_diagnostic_matches_filter(&category.shape, filter.as_deref())
                 })
                 .collect();
             let examples: Vec<_> = answer
                 .found
                 .examples
                 .iter()
-                .filter(|example| heap_diagnostic_selected(example, heap, filter.as_deref()))
+                .filter(|example| heap_diagnostic_matches_filter(example, filter.as_deref()))
                 .collect();
             let (example_rows, category_rows) =
                 split_row_budget(limit, examples.len(), categories.len());
@@ -4103,19 +4109,11 @@ mod tests {
     }
 
     #[test]
-    fn heap_diagnostic_filter_uses_the_hex_heap_needle() {
-        let example = "cannot discover heap 0x10000: VS free tree unreadable";
-        assert!(heap_diagnostic_selected(
-            example,
-            Some(0x10000),
-            Some("free TREE")
-        ));
-        assert!(!heap_diagnostic_selected(example, Some(0x20000), None));
-        assert!(!heap_diagnostic_selected(
-            example,
-            Some(0x10000),
-            Some("LFH")
-        ));
+    fn heap_diagnostic_filter_matches_generalised_categories_case_insensitively() {
+        let category = "unreadable VS free tree node <address>: sparse memory";
+        assert!(heap_diagnostic_matches_filter(category, None));
+        assert!(heap_diagnostic_matches_filter(category, Some("free TREE")));
+        assert!(!heap_diagnostic_matches_filter(category, Some("LFH")));
     }
 
     // ---- the protocol channel this worker was handed -------------------------------


### PR DESCRIPTION
## Summary

- route heap-scoped diagnostic requests through win-kexp before category aggregation
- stop filtering generalized category shapes for a literal heap address
- retain the case-insensitive text filter for both scoped categories and examples
- pin the dependency to the exact upstream implementation commit

## Root cause

`PoolDiagnostics` generalizes addresses while creating category shapes. The previous windbg-mcp implementation applied the heap filter afterward, so every generalized category was discarded and only sampled examples that happened to include the root survived.

## Dependency

Depends on glslang/win-kexp#106 (`a5a044ee41fc521c1cb2fa5cf1b07e5282eca2ec`).

This is the replacement follow-up for the remaining review feedback on merged #122.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test` (352 passed, 12 opt-in tests ignored)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved heap diagnostic filtering so results are correctly limited to the selected heap before totals are calculated.
  - Text searches now independently match diagnostic categories and examples, with case-insensitive matching for more reliable results.
  - Removed confusing interactions between heap selection and text filtering, making diagnostic results clearer and more consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->