### PR TITLE
Surface what a pool walk could not place, and print a live walk's own figures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -883,7 +883,7 @@ dependencies = [
 [[package]]
 name = "win-kexp"
 version = "0.1.0"
-source = "git+https://github.com/glslang/win-kexp?rev=5db04f3b83f240384dea184bce52ada0a97bc494#5db04f3b83f240384dea184bce52ada0a97bc494"
+source = "git+https://github.com/glslang/win-kexp?rev=7d694ca#7d694cacbd31f18677c70b042a693c6ab209895f"
 dependencies = [
  "byte-strings",
  "goblin",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -883,7 +883,7 @@ dependencies = [
 [[package]]
 name = "win-kexp"
 version = "0.1.0"
-source = "git+https://github.com/glslang/win-kexp?rev=7d694ca#7d694cacbd31f18677c70b042a693c6ab209895f"
+source = "git+https://github.com/glslang/win-kexp?rev=39f296dc7da0360cee4034dbc3470b9690d8e341#39f296dc7da0360cee4034dbc3470b9690d8e341"
 dependencies = [
  "byte-strings",
  "goblin",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -883,7 +883,7 @@ dependencies = [
 [[package]]
 name = "win-kexp"
 version = "0.1.0"
-source = "git+https://github.com/glslang/win-kexp?rev=39f296dc7da0360cee4034dbc3470b9690d8e341#39f296dc7da0360cee4034dbc3470b9690d8e341"
+source = "git+https://github.com/glslang/win-kexp?rev=40f79cd4c8f39413808a41a6aaacbbd78a34fad8#40f79cd4c8f39413808a41a6aaacbbd78a34fad8"
 dependencies = [
  "byte-strings",
  "goblin",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.8.1"
 edition = "2024"
 
 [dependencies]
-win-kexp = { git = "https://github.com/glslang/win-kexp", rev = "7d694ca" }
+win-kexp = { git = "https://github.com/glslang/win-kexp", rev = "39f296dc7da0360cee4034dbc3470b9690d8e341" }
 # 3.1.1 is a floor, not a preference: every 3.x before it generates a `tools/list` that omits
 # SEP-2549's required `ttlMs`/`cacheScope`, which a spec-strict `2026-07-28` client rejects
 # outright — the server connects and appears to expose no tools at all (upstream issue #1114).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.8.1"
 edition = "2024"
 
 [dependencies]
-win-kexp = { git = "https://github.com/glslang/win-kexp", rev = "5db04f3b83f240384dea184bce52ada0a97bc494" }
+win-kexp = { git = "https://github.com/glslang/win-kexp", rev = "7d694ca" }
 # 3.1.1 is a floor, not a preference: every 3.x before it generates a `tools/list` that omits
 # SEP-2549's required `ttlMs`/`cacheScope`, which a spec-strict `2026-07-28` client rejects
 # outright — the server connects and appears to expose no tools at all (upstream issue #1114).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.8.1"
 edition = "2024"
 
 [dependencies]
-win-kexp = { git = "https://github.com/glslang/win-kexp", rev = "39f296dc7da0360cee4034dbc3470b9690d8e341" }
+win-kexp = { git = "https://github.com/glslang/win-kexp", rev = "40f79cd4c8f39413808a41a6aaacbbd78a34fad8" }
 # 3.1.1 is a floor, not a preference: every 3.x before it generates a `tools/list` that omits
 # SEP-2549's required `ttlMs`/`cacheScope`, which a spec-strict `2026-07-28` client rejects
 # outright — the server connects and appears to expose no tools at all (upstream issue #1114).

--- a/src/server.rs
+++ b/src/server.rs
@@ -2456,12 +2456,13 @@ impl WindbgServer {
     /// hundred-plus categories, so the summaries the other tools print are necessarily
     /// truncated — and the one line explaining a specific heap is reliably not in the
     /// truncated head. Filter by a heap address or a phrase to get at it.
-    /// `walk.gaps` on any pool answer sizes the two things a walk *records* running into — pages
-    /// a region query stalled on, and chunk headers a decoder refused — in bytes and chunks,
-    /// which the diagnostics cannot, since a category's count counts occurrences of a message
-    /// shape. It is not a total of everything a walk missed: one cut short by its deadline or a
-    /// traversal cap carries no gaps at all. `walk.coverage` is still what says a walk fell
-    /// short, and this tool is still what says why.
+    /// `walk.gaps` on any pool answer sizes the three things a walk *records* running into —
+    /// pages a region query stalled on, chunk headers a decoder refused, and committed bytes it
+    /// declined to decode because it could not say where a chunk began in them — in bytes and
+    /// chunks, which the diagnostics cannot, since a category's count counts occurrences of a
+    /// message shape. It is not a total of everything a walk missed: one cut short by its
+    /// deadline or a traversal cap carries no gaps at all. `walk.coverage` is still what says a
+    /// walk fell short, and this tool is still what says why.
     #[rmcp::tool(
         annotations(
             title = "Filter pool walk diagnostics",

--- a/src/structured.rs
+++ b/src/structured.rs
@@ -896,24 +896,37 @@ pub struct WalkGaps {
     /// and are worth less than their count suggests — rather than as a population of bad
     /// chunks, which it overstates by orders of magnitude.
     pub refused_chunks: u64,
+    /// Committed bytes of a variable-size subsegment the walk declined to decode, because it
+    /// could not say where a chunk began in them.
+    ///
+    /// A chunk of that kind is only findable from the end of the one before it, and a walk that
+    /// has lost that thread does not guess: guessing is what filled a snapshot with chunks
+    /// decoded at arbitrary offsets. This is what declining costs — coverage, in bytes — so that
+    /// a clean `refused_chunks` cannot be mistaken for a walk that read everything.
+    pub unplaced_bytes: u64,
 }
 
 impl WalkGaps {
     /// `None` when the walk met none of this, so the ordinary answer does not carry four zeroes.
     pub(crate) fn of(report: &win_kexp::pool::query::PoolSnapshotReport) -> Option<Self> {
-        Self::from_measurements(report.stalls, report.refused_chunks)
+        Self::from_measurements(report.stalls, report.refused_chunks, report.unplaced_bytes)
     }
 
     pub(crate) fn of_heap(report: &win_kexp::heap::HeapWalkReport) -> Option<Self> {
-        Self::from_measurements(report.stalls, report.refused_headers)
+        Self::from_measurements(report.stalls, report.refused_headers, report.unplaced_bytes)
     }
 
-    fn from_measurements(stalls: win_kexp::pool::WalkStalls, refused_chunks: u64) -> Option<Self> {
+    fn from_measurements(
+        stalls: win_kexp::pool::WalkStalls,
+        refused_chunks: u64,
+        unplaced_bytes: u64,
+    ) -> Option<Self> {
         let gaps = Self {
             stalled_pages: stalls.pages,
             skipped_bytes: stalls.skipped_bytes,
             recovered_bytes: stalls.recovered_bytes,
             refused_chunks,
+            unplaced_bytes,
         };
         (gaps != Self::default()).then_some(gaps)
     }
@@ -1859,6 +1872,7 @@ mod tests {
             diagnostics: win_kexp::pool::PoolDiagnostics::default(),
             stalls,
             refused_chunks,
+            unplaced_bytes: 0,
         };
 
         // The ordinary walk meets none of this, and says so by saying nothing: four zeroes on
@@ -1916,6 +1930,7 @@ mod tests {
             unreadable_gaps: 0,
             refused_headers,
             stalls,
+            unplaced_bytes: 0,
         };
 
         let quiet = serde_json::to_value(HeapWalkInfo::from(&report(

--- a/src/structured.rs
+++ b/src/structured.rs
@@ -880,6 +880,12 @@ pub struct WalkInfo {
 pub struct WalkGaps {
     /// Pages the debugger's valid-region query could not advance over, stepped over one at a
     /// time rather than abandoning the rest of the region behind them.
+    ///
+    /// Narrower than it reads, and zero on a healthy walk. A query that reports finding *nothing*
+    /// in the span it was asked about has answered for every byte through to the end of it, so
+    /// that ends the region rather than being stepped over, and is not counted here. What remains
+    /// is the query that reports a region and cannot size it — which has said nothing about what
+    /// lies behind it, and is the case stepping exists for.
     pub stalled_pages: u64,
     /// Bytes those steps filed as unreadable.
     pub skipped_bytes: u64,
@@ -907,7 +913,7 @@ pub struct WalkGaps {
 }
 
 impl WalkGaps {
-    /// `None` when the walk met none of this, so the ordinary answer does not carry four zeroes.
+    /// `None` when the walk met none of this, so the ordinary answer does not carry five zeroes.
     pub(crate) fn of(report: &win_kexp::pool::query::PoolSnapshotReport) -> Option<Self> {
         Self::from_measurements(report.stalls, report.refused_chunks, report.unplaced_bytes)
     }
@@ -1875,7 +1881,7 @@ mod tests {
             unplaced_bytes: 0,
         };
 
-        // The ordinary walk meets none of this, and says so by saying nothing: four zeroes on
+        // The ordinary walk meets none of this, and says so by saying nothing: five zeroes on
         // every pool answer would be noise on the answers that are fine.
         assert_eq!(
             WalkGaps::of(&report(win_kexp::pool::WalkStalls::default(), 0)),

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -3788,6 +3788,7 @@ mod tests {
             diagnostics: PoolDiagnostics::default(),
             stalls: WalkStalls::default(),
             refused_chunks: 0,
+            unplaced_bytes: 0,
         }
     }
 

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -5068,6 +5068,11 @@ fn a_live_kernel_pool_walk_is_bounded_and_leaves_its_session_usable() {
             .to_string();
         let complete = coverage == "complete";
         println!("the census reports this walk {coverage}");
+        // The gap figures, printed rather than asserted on: they are the only place a live run
+        // reports what the walk could not decode, and the two issues they were built for
+        // (glslang/win-kexp#103, #104) are settled by comparing them across runs. A threshold
+        // here would fail on an idle machine or pass on a busy one; a number in the log will not.
+        println!("what the walk did and could not reach: {}", totals["walk"]);
         // An incomplete walk is an acceptable outcome, but "incomplete" on its own is not a
         // finding — *why*, and the categories, are. `deadline_truncated` and `partial` want
         // opposite responses, which is the whole reason coverage is three values and not a bool.
@@ -5090,6 +5095,11 @@ fn a_live_kernel_pool_walk_is_bounded_and_leaves_its_session_usable() {
                 "why the walk fell short ({} diagnostic(s)): {}",
                 diagnostics["walk"]["diagnostics_emitted"], diagnostics["categories"]
             );
+            // The categories fold every number into `#`, which is what makes them countable and
+            // also what makes them useless for reading a *value* back off a live target. The
+            // verbatim samples are the only place those survive, and this tier is the only place
+            // they are ever produced.
+            println!("verbatim samples: {}", diagnostics["examples"]);
             assert_diagnostic_total_covers_its_categories(&diagnostics);
         }
 

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -5100,6 +5100,22 @@ fn a_live_kernel_pool_walk_is_bounded_and_leaves_its_session_usable() {
             // verbatim samples are the only place those survive, and this tier is the only place
             // they are ever produced.
             println!("verbatim samples: {}", diagnostics["examples"]);
+            // Filtered, because the unfiltered sample is shared across every shape the walk met
+            // and the interesting one is crowded out. glslang/win-kexp#104 turns on which of two
+            // answers the engine gives when it cannot advance — a region reported *behind* the
+            // cursor, meaning the region is over and the page step is pointless, or a zero-length
+            // region reported ahead of it, meaning the step is right. The numbers separate them
+            // and exist nowhere but here.
+            let stalls = server.tool_data(
+                "pool_diagnostics",
+                json!({
+                    "session_id": session,
+                    "filter": "made no progress",
+                    "limit": 40,
+                }),
+                POOL_CALL_BUDGET,
+            );
+            println!("stall samples: {}", stalls["examples"]);
             assert_diagnostic_total_covers_its_categories(&diagnostics);
         }
 


### PR DESCRIPTION
Follows glslang/win-kexp#107 (merged). Pin moved to `39f296d` on `main`.

## `WalkGaps.unplaced_bytes`

Committed bytes of a variable-size subsegment a walk declined to decode because it
could not say where a chunk began in them. It is the counterpart to `refused_chunks`:
win-kexp's `walk_vs` now refuses to decode from a guessed offset, and a walk that
stops guessing has to report what that costs, or a clean refusal count reads as a walk
that saw everything. On the live 26100 target it settles at 290,816 bytes over 19
extents — holes whose far side the chunk chain could not reach.

## The live tier prints the walk's own figures

Neither the totals nor the verbatim diagnostic samples are asserted on. The categories
fold every number into `#`, so a live run is the only place those values exist, and a
threshold would fail on an idle machine and pass on a busy one.

This is what turned win-kexp#103 from an argument into a measurement. The verbatim line
read:

```
VS subsegment 0xffffce89caeec000 declares 0xffd0 of chunks where its page range
leaves room for 0x10fd0
```

One page — and that page was the whole issue. Without the sample there was only a
category count with the numbers folded out of it, which cannot say which side is short
or by how much.

## Measured across the fix, same target

| | before | after |
|---|---|---|
| `refused_chunks` | 106,516 | **0** |
| chunks walked | 408,013 | 446,516 |
| diagnostics / categories | 3,569 / 14 | **2,205 / 12** |

## Verification

`cargo test --bins` (319 pass), `cargo test --test mcp_smoke` dev tier (39 pass),
`cargo clippy --all-targets` clean. The live-kernel tier (8 tests) ran green against a
real KDNET 26100 target on the win-kexp branch whose tree is byte-identical to the
merged `main` commit pinned here, so those figures carry over without a re-run.

Unrelated environment note for anyone running that tier: it needs the six engine DLLs
beside `target\debug`, which the harness copies from `target\release`. If `release` is
missing even one, the copy aborts before `symsrv.dll`/`msdia140.dll` and the tier fails
with `nt` loaded without a PDB — a symbol failure that looks nothing like a missing
`dbgcore.dll`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved module listings with consistent filtering across loaded and unloaded modules.
  * Added literal `*` and `?` filter support, Unicode-aware matching, and safer output escaping.
  * Displayed clearer symbol states and additional pool/heap gap coverage information.

* **Bug Fixes**
  * Prevented unsafe filter content from affecting rendered results.
  * Corrected unloaded-module matching and symbol-state presentation.

* **Documentation**
  * Updated module filtering guidance, crash-dump walkthroughs, trace examples, and smoke-test instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->