### PR TITLE
Record the session: opt-in JSONL transcripts, and a cast renderer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,66 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Opt-in session transcripts, and an asciicast renderer for them**
+  ([#87](https://github.com/glslang/windbg-mcp/issues/87)). Point `WINDBG_MCP_TRANSCRIPT` at a path
+  and the supervisor records what it was asked and what it did, one JSON object per line: the tool
+  call and its result; a session opening, changing state and being released; a wait abandoned, an
+  `interrupt`, a worker process dying; and — derived from each result's *typed* half — where
+  execution stopped, what a `run_to_address` concluded, every breakpoint or memory mutation, each
+  assertion that did not hold, and how a `debug_batch` ended with whether its rollback completed.
+  Unset, which is the default, nothing is written.
+
+  What existed before had opposite problems. A client's own log is tens of megabytes of prompts
+  with the debugger operations buried inside shell-command source; the curated proof records under
+  `examples/` are readable and are written afterwards from memory — one of them says so on its
+  face, captioning its own timing as *"illustrative because live recording was not enabled for the
+  original run"*. The server is the only party that sees the whole of a session, and it was
+  recording none of it.
+
+  - **Written by the supervisor, from values.** One writer, so no locking and no interleaving
+    between processes — and a worker's facts still arrive as facts, because they cross the pipe as
+    the typed half of its reply and are read back through [`structured`](./src/structured.rs)
+    types. Nothing in a transcript is scraped out of a rendering, which is the rule
+    [#77](https://github.com/glslang/windbg-mcp/issues/77) was fixed by. A tool this server cannot
+    type — an arbitrary `execute` — contributes its call and its result and no derived event, which
+    is the honest answer rather than a guess about what the command did.
+  - **Redacted, and by the same rule as everywhere else.** `kdconn` grew a scan for arbitrary text
+    beside its connection parser, sharing the one list of secret parameter names, so a raw
+    `connection` passed to `attach_kernel` is recorded as `key=<redacted>`; an argument member
+    *named* like a secret is masked whole, before any tool has one. Profiles still keep the key out
+    of the request in the first place — this is the backstop for the caller who passed a raw string
+    anyway.
+  - **Bounded, and it says so.** Fields are capped (`WINDBG_MCP_TRANSCRIPT_MAX_FIELD`, 16 KiB by
+    default) and a record reports how much it dropped. A transcript that quietly truncated would
+    read as complete, which is worse than not having one.
+  - **Never the transport.** Standard output stays JSON-RPC: the transcript is a file this module
+    opens, and a test reads the source to keep it that way.
+  - **`windbg-mcp --render-cast <transcript.jsonl>`** renders one as an [asciicast v2] recording —
+    each call as a prompt line, its output beneath, and the derived facts marked between them. It
+    is derived offline from the same JSONL, so a cast can be made from a transcript recorded weeks
+    ago and its timings are the recorded ones, measured on a monotonic clock. `--idle-limit`,
+    `--max-lines`, `--title`, `--width`/`--height` shape it.
+
+  Retention is the operator's: nothing but secrets is masked, and debugger output is the contents of
+  somebody's memory. The README says what to do with one.
+
+  [asciicast v2]: https://docs.asciinema.org/manual/asciicast/v2/
+
+- **`debug_batch` answers with its report as values**, not only as prose — the last tool whose
+  whole answer was a rendering, and the one with the most at stake in being readable by a program.
+  `outcome`, the position it stopped `at`, `committed`, `rollback_complete`, what the session holds
+  `after`, and every step of both blocks with what it changed and whether an assertion was `unmet`.
+  It is built in the worker from the executor's own `BatchReport`, which is what lets a transcript
+  record a transaction's verdict as a fact.
+
+  **Visible change for existing clients**: `debug_batch` now declares an `outputSchema` and returns
+  `structuredContent`. The text is unchanged and so is `isError` — a batch that did not commit is
+  still a tool error carrying the whole report. Note the pairing this tool alone has: a batch that
+  *ran* answers `status: "ok"` (the report is the answer) on a result flagged `isError`, while
+  `status: "error"` means the batch never ran. Reading only `isError` cannot tell those apart.
+
 ## [0.9.0] - 2026-08-14
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -206,6 +206,25 @@ Issue `.sympath` alone, or use the **`set_symbol_path`** tool (goes through the 
 `AppendSymbolPath`/`SetSymbolPath` API, immune to the quirk; appends + reloads). When a driver's
 `module!Symbol` names don't resolve, **ask the user for the PDB folder** and apply it with that tool.
 
+## Recording a session while debugging this server
+
+`WINDBG_MCP_TRANSCRIPT=<path>` makes the supervisor write a JSONL record of every tool call, every
+session transition, every timeout and every worker death (`src/record.rs`; the README has the
+format). It is off unless the variable is set, and it is often the fastest way to answer "what
+actually happened in that session" — the `tracing` stream on stderr is prose about the *server* and
+interleaves both roles, while this is values about the *session*, keyed by session and request.
+
+Two things worth knowing when using it here:
+
+- **It records the supervisor's view.** A worker inherits the variable and ignores it (the role
+  check in `main` runs first), so there is exactly one writer and no interleaving. A fact that
+  exists only inside a worker reaches the transcript only if it crosses the pipe as a value — which
+  is the same rule as everything else in `src/structured.rs`, and the reason `debug_batch` grew a
+  typed report.
+- **`windbg-mcp --render-cast <transcript.jsonl>`** turns one into an asciicast. That is the
+  supported way to produce the recordings under `examples/` and `docs/` — the older ones are
+  hand-reconstructed and say so, and a new walkthrough should not add another.
+
 ## Plugin vs. dev build
 
 This project is also installed as a user-scope Claude Code plugin (`windbg-mcp@windbg-mcp`), which is

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,16 +151,23 @@ alone will happily validate the wrong guest, which is what the `hostip` comparis
 
 ## Live kernel + driver IOCTL gotchas (learned driving HEVD over KDNET)
 
-**Attach by `profile`, not by connection string.** `attach_kernel { "profile": "<name>" }` resolves
-the connection inside the server (`src/kdconn.rs`), so the target's debug key never lands in a tool
-argument — and therefore never in the session transcript, where one key previously ended up
-replicated across hundreds of records. `attach_kernel {}` lists the profiles this host has.
-Configure one with `WINDBG_MCP_PROFILE_<NAME>` or `%USERPROFILE%\.windbg-mcp\profiles.json`; raw
-`connection` still works for a target nothing is configured for. Note the live smoke tier below is
-one of those: `WINDBG_MCP_SMOKE_KERNEL` is a raw connection string, passed straight to
-`attach_kernel { "connection": … }`, and is deliberately *not* a profile — the tier has to exercise
-the explicit path, and it is a variable in a developer's own shell rather than something a client
-ever sees.
+**Attach by `profile`, not by connection string — always, for any live target.** `attach_kernel
+{ "profile": "<name>" }` resolves the connection inside the server (`src/kdconn.rs`), so the
+target's debug key never lands in a tool argument — and therefore never in the *client's*
+transcript, where one key previously ended up replicated across hundreds of records.
+`attach_kernel {}` lists the profiles this host has. Configure one with
+`WINDBG_MCP_PROFILE_<NAME>` or `%USERPROFILE%\.windbg-mcp\profiles.json`; raw `connection` still
+works for a target nothing is configured for, and is the last resort rather than the quick option.
+
+A raw `connection` now also reaches a second place: with recording on (below) it is written to the
+server's own transcript file, scrubbed to `key=<redacted>`. That backstop is not a reason to pass
+one. A profile keeps the key out of the request, so there is nothing for either transcript to
+redact, and redaction is a thing that has to keep working while a key never sent cannot leak.
+
+The live smoke tier below is the one sanctioned exception: `WINDBG_MCP_SMOKE_KERNEL` is a raw
+connection string, passed straight to `attach_kernel { "connection": … }`, and is deliberately
+*not* a profile — the tier has to exercise the explicit path, and it is a variable in a developer's
+own shell rather than something a client ever sees.
 
 A worker process does **not** inherit `WINDBG_MCP_PROFILE_*` (`engine::spawn_worker` strips them):
 it is told the one connection it is opening over its private pipe, and a `launch`ed debuggee would
@@ -224,6 +231,12 @@ Two things worth knowing when using it here:
 - **`windbg-mcp --render-cast <transcript.jsonl>`** turns one into an asciicast. That is the
   supported way to produce the recordings under `examples/` and `docs/` — the older ones are
   hand-reconstructed and say so, and a new walkthrough should not add another.
+
+Recording a **live kernel** session is where this needs care, because a transcript of one is as
+sensitive as the target: not the connection (attach by `profile` and there is no key in it), but
+everything the debugger printed — stack frames, strings, whatever the guest holds. Nothing but
+secrets is masked, so treat the file like a crash dump: keep it out of the repo, and delete it when
+the investigation is done. It is **appended** to, so a path reused across runs accumulates.
 
 ## Plugin vs. dev build
 

--- a/README.md
+++ b/README.md
@@ -698,6 +698,10 @@ half, never scraped from the text beside it — where execution stopped, what a 
 concluded, every breakpoint or memory mutation, each assertion that did not hold, and how a
 `debug_batch` ended with whether its rollback completed. See [`src/record.rs`](./src/record.rs).
 
+A record's `session` is the one the call was **routed** to, not the one it named: omitting
+`session_id` accepts the current session rather than none, so the field answers "which target was
+this?" even for the calls that did not say.
+
 **It is not the log.** `RUST_LOG` output is prose about the server, on stderr; this is values about
 the *session*, in a file of its own. Standard output stays JSON-RPC and nothing else.
 
@@ -712,6 +716,10 @@ The rendering is derived, so a cast can be made from a transcript recorded weeks
 timings are the recorded ones. `--idle-limit <s>` tells a player how long to sit in a pause (`0`
 plays at the speed it happened), `--max-lines <n>` caps how much of a long result is shown, and
 `--title`/`--width`/`--height` shape the recording.
+
+A file holding several runs renders as one recording with the runs laid end to end, separated by
+however long the server was actually down — each run's own clock starts at zero, so playing those
+offsets as they stand would step backwards at the join and no player would accept it.
 
 **Redaction.** Every string recorded is scrubbed for `key=`/`password=` values, and an argument
 member *named* like a secret is masked whole — so a raw `connection` passed to `attach_kernel` is

--- a/README.md
+++ b/README.md
@@ -686,9 +686,9 @@ $env:WINDBG_MCP_TRANSCRIPT = "$env:USERPROFILE\.windbg-mcp\session.jsonl"
 ```
 
 ```jsonc
-{"v":1,"seq":1,"at":"2026-08-16T07:13:01.508Z","mono_ms":1,"event":"tool_request","request":1,"tool":"open_dump","args":{"path":"C:\\dumps\\a.dmp"}}
-{"v":1,"seq":2,"at":"2026-08-16T07:13:01.643Z","mono_ms":135,"event":"session_open","session":"sess-…","kind":"crash dump","target":"C:\\dumps\\a.dmp","engine_pid":1656}
-{"v":1,"seq":11,"at":"2026-08-16T07:13:04.272Z","mono_ms":2765,"event":"batch","request":3,"session":"sess-…","outcome":"failed","at_step":2,"committed":false,"rollback_complete":true,"after":"stopped","elapsed_ms":603}
+{"v":1,"run":4158027124358305144,"seq":1,"at":"2026-08-16T12:05:20.549Z","mono_ms":1,"event":"tool_request","request":1,"tool":"open_dump","args":{"path":"C:\\dumps\\a.dmp"}}
+{"v":1,"run":4158027124358305144,"seq":2,"at":"2026-08-16T12:05:20.672Z","mono_ms":125,"event":"session_open","session":"sess-18cc47a3b2779cc8-1","kind":"crash dump","target":{"text":"C:\\dumps\\a.dmp"},"engine_pid":832}
+{"v":1,"run":4158027124358305144,"seq":11,"at":"2026-08-16T12:05:23.129Z","mono_ms":2582,"event":"batch","request":3,"session":"sess-18cc47a3b2779cc8-1","outcome":"failed","at_step":2,"committed":false,"rollback_complete":true,"after":"stopped","elapsed_ms":402}
 ```
 
 Every record carries the format version, the run that wrote it, a sequence number, a wall clock
@@ -724,10 +724,14 @@ offsets as they stand would step backwards at the join and no player would accep
 pointed at the same path interleave their lines; they are grouped back into their own runs by the
 `run` field every record carries, so neither session is read as part of the other.
 
-**Redaction.** Every string recorded is scrubbed for `key=`/`password=` values, and an argument
-member *named* like a secret is masked whole — so a raw `connection` passed to `attach_kernel` is
-recorded as `net:port=50000,key=<redacted>`. Prefer a [profile](#kernel-connection-profiles-keeping-the-kdnet-key-out-of-the-transcript)
-anyway: it keeps the key out of the request in the first place, and this is the backstop.
+**Redaction**, by two mechanisms that are not equally strong. Every secret this server has been
+handed — from a profile or from a raw `connection` — is masked **by value**, wherever it appears
+and in whatever syntax, so a key that reached this process cannot leave it in a transcript. Under
+that sits a scan for `key=`/`password=` in text, which also catches a secret the server has never
+seen (one a target printed itself); it has to guess a syntax and is best-effort by nature. An
+argument member *named* like a secret is masked whole. Prefer a
+[profile](#kernel-connection-profiles-keeping-the-kdnet-key-out-of-the-transcript) regardless: it
+keeps the key out of the request in the first place, and all of this is the backstop.
 
 **Retention.** Nothing else is masked, and that is the point to plan around: debugger output is the
 contents of somebody's memory — stack frames, strings, registry paths, whatever the target holds —
@@ -739,7 +743,9 @@ starts with a `start` record naming its pid, which is what separates them.
 
 **Size.** Fields are capped at 16 KiB, and a record says how much it dropped rather than being
 quietly short. `WINDBG_MCP_TRANSCRIPT_MAX_FIELD` moves the cap; `0` removes it, at the cost of a
-file that grows with every module listing and pool census.
+file that grows with every module listing and pool census. A whole record is bounded too, well
+above what a capped one reaches: a record past that ceiling is replaced by an `oversized` marker
+naming its kind and size, which is a bug in the recorder rather than something a session did.
 
 ## Limitations & notes
 

--- a/README.md
+++ b/README.md
@@ -586,6 +586,13 @@ rollback completed — reported *beside* the original failure, never instead of 
 session is left stopped, running, detached, or uncertain. A batch that did not commit comes back as a
 tool error carrying that whole report.
 
+It carries the same report as values (see [Structured results](#structured-results)), and the
+pairing is worth reading once: a batch that **ran** answers `status: "ok"` — the report is the
+answer — on a result flagged `isError` when the transaction did not commit or its rollback did not
+finish. `status: "error"` is the batch that never ran at all: refused for a malformed step, a stale
+handle, too little budget left to start. Reading only `isError` cannot tell those apart, and it is
+the difference between "resubmit" and "check what the target is left holding".
+
 Four honest limits, none of them hidden in the report:
 
 - A raw command that prints an error and returns success is a step that *succeeded* with that text
@@ -627,6 +634,7 @@ matching `outputSchema` in `tools/list`, so a program can read a field instead o
 | `heap_list`, `heap_allocations`, `heap_chunk`, `heap_census`, `heap_diagnostics` | PEB heap roots and Segment Heap allocations/totals/diagnostics, each carrying exact `ntdll` layout provenance, skipped-heap scope, and walk coverage |
 | `walk_memory` | `nodes[]` with each field's `value` — `null` where the debugger could not read it — plus `walked`/`unreadable` counts and a `stopped` reason (`complete`, `cap`, `null_link`, `loop`, `unreadable_link`, `deadline`, `interrupted`), each carrying the address it is about |
 | `crash_triage` | `bug_check` (`code`, `name`, four `parameters`), `process_name`, `frames[]` as `{module, rva, symbol}`, the `faulting_frame` picked out of them — and `!analyze`'s own conclusions kept apart under `analysis` |
+| `debug_batch` | `outcome` (`committed`/`failed`/`timed_out`/`abandoned`/`interrupted`), the position it stopped `at`, `committed`, `rollback_complete`, what the session holds `after`, and every step of both blocks with what it `changed` and whether an assertion was `unmet` |
 
 Two conventions hold across all of them:
 
@@ -667,6 +675,60 @@ and `ttd_memory` query `@$cursession.TTD.{Calls,Memory}` (every call to a functi
 an address range), and `ttd_events` queries `@$curprocess.TTD.Events` (the module/thread/exception
 timeline). For anything else, `dx` evaluates arbitrary data-model/LINQ expressions, e.g.
 `@$cursession.TTD.Calls("ntdll!NtCreateFile").Where(c => c.ReturnValue != 0)`.
+
+### Session transcripts (`WINDBG_MCP_TRANSCRIPT`)
+
+Point `WINDBG_MCP_TRANSCRIPT` at a path and the server records what it was asked and what it did,
+one JSON object per line. Unset — the default — nothing is written and nothing is spent.
+
+```pwsh
+$env:WINDBG_MCP_TRANSCRIPT = "$env:USERPROFILE\.windbg-mcp\session.jsonl"
+```
+
+```jsonc
+{"v":1,"seq":1,"at":"2026-08-16T07:13:01.508Z","mono_ms":1,"event":"tool_request","request":1,"tool":"open_dump","args":{"path":"C:\\dumps\\a.dmp"}}
+{"v":1,"seq":2,"at":"2026-08-16T07:13:01.643Z","mono_ms":135,"event":"session_open","session":"sess-…","kind":"crash dump","target":"C:\\dumps\\a.dmp","engine_pid":1656}
+{"v":1,"seq":11,"at":"2026-08-16T07:13:04.272Z","mono_ms":2765,"event":"batch","request":3,"session":"sess-…","outcome":"failed","at_step":2,"committed":false,"rollback_complete":true,"after":"stopped","elapsed_ms":603}
+```
+
+Every record carries the format version, a sequence number, a wall clock and a monotonic offset.
+The events are the tool call and its result; a session opening, changing state and being released;
+a wait abandoned, an `interrupt`, a worker process dying; and — derived from each result's *typed*
+half, never scraped from the text beside it — where execution stopped, what a `run_to_address`
+concluded, every breakpoint or memory mutation, each assertion that did not hold, and how a
+`debug_batch` ended with whether its rollback completed. See [`src/record.rs`](./src/record.rs).
+
+**It is not the log.** `RUST_LOG` output is prose about the server, on stderr; this is values about
+the *session*, in a file of its own. Standard output stays JSON-RPC and nothing else.
+
+Render one as a terminal recording with the same executable:
+
+```pwsh
+windbg-mcp --render-cast session.jsonl -o session.cast   # asciicast v2
+asciinema play session.cast
+```
+
+The rendering is derived, so a cast can be made from a transcript recorded weeks ago and the
+timings are the recorded ones. `--idle-limit <s>` tells a player how long to sit in a pause (`0`
+plays at the speed it happened), `--max-lines <n>` caps how much of a long result is shown, and
+`--title`/`--width`/`--height` shape the recording.
+
+**Redaction.** Every string recorded is scrubbed for `key=`/`password=` values, and an argument
+member *named* like a secret is masked whole — so a raw `connection` passed to `attach_kernel` is
+recorded as `net:port=50000,key=<redacted>`. Prefer a [profile](#kernel-connection-profiles-keeping-the-kdnet-key-out-of-the-transcript)
+anyway: it keeps the key out of the request in the first place, and this is the backstop.
+
+**Retention.** Nothing else is masked, and that is the point to plan around: debugger output is the
+contents of somebody's memory — stack frames, strings, registry paths, whatever the target holds —
+so a transcript of a live session is as sensitive as the machine it was taken from. Treat one like
+a crash dump. Keep it out of version control unless you have read it, put it somewhere with the
+same access as the target, and delete it when the investigation is done. The file is **appended**
+to, never truncated, so a path reused across runs accumulates until something removes it; each run
+starts with a `start` record naming its pid, which is what separates them.
+
+**Size.** Fields are capped at 16 KiB, and a record says how much it dropped rather than being
+quietly short. `WINDBG_MCP_TRANSCRIPT_MAX_FIELD` moves the cap; `0` removes it, at the cost of a
+file that grows with every module listing and pool census.
 
 ## Limitations & notes
 

--- a/README.md
+++ b/README.md
@@ -691,7 +691,8 @@ $env:WINDBG_MCP_TRANSCRIPT = "$env:USERPROFILE\.windbg-mcp\session.jsonl"
 {"v":1,"seq":11,"at":"2026-08-16T07:13:04.272Z","mono_ms":2765,"event":"batch","request":3,"session":"sess-…","outcome":"failed","at_step":2,"committed":false,"rollback_complete":true,"after":"stopped","elapsed_ms":603}
 ```
 
-Every record carries the format version, a sequence number, a wall clock and a monotonic offset.
+Every record carries the format version, the run that wrote it, a sequence number, a wall clock
+and a monotonic offset.
 The events are the tool call and its result; a session opening, changing state and being released;
 a wait abandoned, an `interrupt`, a worker process dying; and — derived from each result's *typed*
 half, never scraped from the text beside it — where execution stopped, what a `run_to_address`
@@ -719,7 +720,9 @@ plays at the speed it happened), `--max-lines <n>` caps how much of a long resul
 
 A file holding several runs renders as one recording with the runs laid end to end, separated by
 however long the server was actually down — each run's own clock starts at zero, so playing those
-offsets as they stand would step backwards at the join and no player would accept it.
+offsets as they stand would step backwards at the join and no player would accept it. Two servers
+pointed at the same path interleave their lines; they are grouped back into their own runs by the
+`run` field every record carries, so neither session is read as part of the other.
 
 **Redaction.** Every string recorded is scrubbed for `key=`/`password=` values, and an argument
 member *named* like a secret is masked whole — so a raw `connection` passed to `attach_kernel` is

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -93,6 +93,30 @@ appears on neither the JSON-RPC transport nor the log, checked against every lin
 wrote rather than against one result. `WINDBG_MCP_PROFILES` is pointed at a path that does not
 exist, so a developer's real profiles can never be read into a failure message.
 
+**Session transcripts.** A server is started with `WINDBG_MCP_TRANSCRIPT` pointed at a temporary
+file, driven through a few calls, and shut down; the file is then read back as JSONL and asserted
+on — every line a complete object, the calls in the order they were made, a `start` first and a
+`shutdown` last, and sequence numbers that only increase. One of those calls passes a raw KDNET
+connection (refused for its shape, so nothing dials and no test waits on a network), and the key
+must appear nowhere in the file's **bytes** — checked against the whole file rather than a parsed
+field, because a key that leaked into a corner nobody thought to look at is still a leak. Every
+line the server wrote to stdout is then re-parsed as JSON-RPC, which is the claim that a transcript
+being written cannot corrupt a client's connection.
+
+A second test covers the other selector: a server recording, three `attach_kernel` calls that route
+through a configured **profile** (an unknown name, the empty listing, and the connection string
+typed into `profile`), and the profile's key absent from the file — while its *name* is still
+readable, because a transcript has to say which target a session was pointed at. It also counts the
+calls it recorded, so the absence assertion cannot pass on an empty file.
+
+The same executable is then run as `--render-cast` over that transcript, and the result is
+validated as asciicast v2: a version-2 header with a shape, then events that are `[time, "o", data]`
+triples whose times never go backwards. In the **protocol** tier deliberately — every property here
+is about the shipped binary reading an environment variable, opening a file beside a live transport,
+and reaching its own renderer, and none of that is provable in-process. `src/record.rs` and
+`src/cast.rs` cover the shapes. A companion test asserts the opposite case: a server nobody asked to
+record writes no file at all.
+
 **Debugger tier.** Opens the checked-in kernel crash dump, confirms it mints a `session_id` that
 `session_status` reports, reads it through `modules` / `registers` / `backtrace`, then checks the
 session-handle contract on the wire (a stale handle is refused; the handle stops working once
@@ -183,7 +207,12 @@ processes, so they need real ones:
   engine seam, the report coming back — by running one batch to `COMMITTED` (with a capture bound
   from one step and interpolated into the next) and one to `FAILED at step 2 of 3`, with the same
   `always` block on both. The claim only a real engine can settle is the second one: the rollback
-  ran **inside the worker process**, on the failing path, before the tool call returned.
+  ran **inside the worker process**, on the failing path, before the tool call returned. Both
+  outcomes are read from the **typed** half as well as the prose — `outcome`, `at`, `committed`,
+  `rollback_complete`, each step's `result`, the interpolated `action` — because that half is what
+  a transcript records and what a client branches on, and the two agreeing is what keeps the report
+  honest. It also pins the pairing only this tool has: a batch that ran answers `status: "ok"` on a
+  result flagged `isError`.
 - *A walk marks what it cannot read and keeps going.* The claim
   [#103](https://github.com/glslang/windbg-mcp/issues/103) is about, and the one that needs a real
   engine: `src/walk.rs` proves the traversal against a fake address space, and this proves the
@@ -236,6 +265,11 @@ processes, so they need real ones:
   break provoked, so the interrupted step comes back `Ok` with its assertions intact and the executor
   saw a step that simply ran. `src/batch.rs` pins the executor's half against a scripted debuggee,
   which answers `Ok` to the interrupted step for exactly this reason.
+  It records a transcript too, because this is the only place the *interrupted*-transaction half of
+  the [#87](https://github.com/glslang/windbg-mcp/issues/87) contract is real: an `interrupt` that
+  genuinely reached a running batch, recorded as its own cause, followed by a verdict whose
+  `outcome` is `interrupted` and whose `rollback_complete` is true — as fields, which is what an
+  unattended run has to be able to act on rather than a paragraph it would have to match on.
 - *Interrupting a batch during its **rollback** is refused.* The severe half of the same problem,
   and it needs no earlier interrupt to set up: cleanup is reached on every path, so a *first* break
   landing there hits a restore command — recorded as a step that worked, reported as `rollback:

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -228,6 +228,11 @@ processes, so they need real ones:
 - *A call that names no session records the one it reached.* Two sessions open and a `modules` call
   with no `session_id`, which routes to the newest. With one session open this proves nothing —
   any answer would be right — which is why there are two.
+- *A session reclaimed at the limit records what became of it.* The third way a target is let go,
+  after `end_session` and a disconnect: opening past `MAX_SESSIONS` reclaims the oldest idle
+  session in a background task, with no caller to answer and nothing in the tool result to say it
+  happened. The test opens one past the limit and waits for the record rather than assuming it has
+  landed, so a reclamation that never reports is this assertion failing and not a puzzle later.
 - *A walk marks what it cannot read and keeps going.* The claim
   [#103](https://github.com/glslang/windbg-mcp/issues/103) is about, and the one that needs a real
   engine: `src/walk.rs` proves the traversal against a fake address space, and this proves the

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -109,6 +109,12 @@ typed into `profile`), and the profile's key absent from the file — while its 
 readable, because a transcript has to say which target a session was pointed at. It also counts the
 calls it recorded, so the absence assertion cannot pass on an empty file.
 
+A third pins that recording is opt-in, and it uses **the same path twice** — which is the only way
+that claim can be tested. A path the server was never told about could not be written whatever the
+default was, so asserting it stays absent asserts nothing; here the first run proves the server
+does write that exact file when asked, and the second, with the variable unset, proves it does not
+when it is not.
+
 The same executable is then run as `--render-cast` over that transcript, and the result is
 validated as asciicast v2: a version-2 header with a shape, then events that are `[time, "o", data]`
 triples whose times never go backwards. In the **protocol** tier deliberately — every property here
@@ -213,6 +219,15 @@ processes, so they need real ones:
   a transcript records and what a client branches on, and the two agreeing is what keeps the report
   honest. It also pins the pairing only this tool has: a batch that ran answers `status: "ok"` on a
   result flagged `isError`.
+- *A transcript records both teardowns and invents neither.* Two sessions, one ended by hand and
+  one left to the disconnect, and the file has to account for both — a disconnect has no caller to
+  answer, so the transcript is the only record of whether each target was released or a worker was
+  killed still holding one. The other half is the absence: an `end_session` terminates its worker
+  on purpose, so the pipe reaching EOF is the teardown finishing, and a "lost its engine" record
+  after it would report a failure that did not happen.
+- *A call that names no session records the one it reached.* Two sessions open and a `modules` call
+  with no `session_id`, which routes to the newest. With one session open this proves nothing —
+  any answer would be right — which is why there are two.
 - *A walk marks what it cannot read and keeps going.* The claim
   [#103](https://github.com/glslang/windbg-mcp/issues/103) is about, and the one that needs a real
   engine: `src/walk.rs` proves the traversal against a fake address space, and this proves the

--- a/src/cast.rs
+++ b/src/cast.rs
@@ -403,14 +403,20 @@ fn frame(record: &Record, max_lines: usize) -> Option<String> {
         Event::Start { version, .. } => {
             line(
                 &mut out,
-                &format!("{DIM}windbg-mcp {version} — session transcript{RESET}"),
+                &format!(
+                    "{DIM}windbg-mcp {} — session transcript{RESET}",
+                    visible(version)
+                ),
             );
         }
         Event::ToolRequest { tool, args, .. } => {
             let args = args.as_ref().map_or_else(String::new, render_args);
             line(
                 &mut out,
-                &format!("{PROMPT}${RESET} {TOOL}{tool}{RESET} {args}"),
+                &format!(
+                    "{PROMPT}${RESET} {TOOL}{}{RESET} {DIM}{args}{RESET}",
+                    visible(tool)
+                ),
             );
         }
         Event::ToolResult {
@@ -565,6 +571,13 @@ fn frame(record: &Record, max_lines: usize) -> Option<String> {
             DIM,
             &format!("server shutting down, releasing {sessions} session(s)"),
         ),
+        // Shown rather than skipped: a viewer has to know a record was here and what it was, or
+        // the recording quietly misses a step of the session it claims to be.
+        Event::Oversized { of, bytes } => note(
+            &mut out,
+            FAIL,
+            &format!("a `{of}` record was {bytes} bytes and was not stored"),
+        ),
     }
     (!out.is_empty()).then_some(out)
 }
@@ -574,10 +587,12 @@ fn frame(record: &Record, max_lines: usize) -> Option<String> {
 fn render_args(args: &Value) -> String {
     let rendered = serde_json::to_string(args).unwrap_or_default();
     let clipped: String = rendered.chars().take(160).collect();
-    match clipped.chars().count() < rendered.chars().count() {
-        true => format!("{DIM}{clipped}…{RESET}"),
-        false => format!("{DIM}{clipped}{RESET}"),
-    }
+    let ellipsis = if clipped.chars().count() < rendered.chars().count() {
+        "…"
+    } else {
+        ""
+    };
+    format!("{}{ellipsis}", visible(&clipped))
 }
 
 /// A result's text, clipped to what is watchable and saying how much was left out.
@@ -591,7 +606,7 @@ fn body(out: &mut String, text: &Capped, max_lines: usize) {
         n => lines.len().min(n),
     };
     for l in &lines[..shown] {
-        line(out, l);
+        line(out, &visible(l));
     }
     // Two different elisions, and they are not the same fact: this one is the *rendering* holding
     // back, and `dropped` is the *transcript* having done so. A viewer who cannot tell them apart
@@ -611,8 +626,11 @@ fn body(out: &mut String, text: &Capped, max_lines: usize) {
     }
 }
 
+/// A marked line between the frames. `text` is built from transcript values, so it is made
+/// visible here — one of the two doors everything from the transcript comes through, the other
+/// being [`body`].
 fn note(out: &mut String, colour: &str, text: &str) {
-    line(out, &format!("{colour}  · {text}{RESET}"));
+    line(out, &format!("{colour}  · {}{RESET}", visible(text)));
 }
 
 fn suffix(detail: &Option<Capped>) -> String {
@@ -626,6 +644,56 @@ fn suffix(detail: &Option<Capped>) -> String {
 fn line(out: &mut String, text: &str) {
     out.push_str(text);
     out.push_str("\r\n");
+}
+
+/// Text from the transcript, made safe to put in a frame a terminal will interpret.
+///
+/// **This is a security boundary, not tidying.** A cast frame is a stream of bytes a player writes
+/// straight to a terminal, and the text in a transcript is whatever the *target* produced —
+/// symbol names, strings out of a dump, a driver's own `DbgPrint`. A target chosen for analysis is
+/// frequently the least trustworthy program anyone has, and it can put an escape sequence in a
+/// string: OSC 52 writes the viewer's clipboard, others retitle the window, redraw what is already
+/// on screen, or query the terminal and have it type the answer back. None of that is content;
+/// all of it executes when someone plays the recording, on the machine of whoever was sent it.
+///
+/// So every control character from the transcript is rendered as a *visible* escape and never
+/// passed through. The renderer's own styling is added outside this, from constants in this file,
+/// which is the whole reason the two can be told apart at all: what this server writes is
+/// interpreted, what the target wrote is shown.
+fn visible(text: &str) -> String {
+    if !text
+        .chars()
+        .any(|c| c.is_control() || matches!(c, '\u{2028}' | '\u{2029}'))
+    {
+        return text.to_string();
+    }
+    let mut out = String::with_capacity(text.len());
+    for c in text.chars() {
+        match c {
+            // Kept, because the renderer builds lines out of them: a result is many lines and is
+            // meant to be read as many lines. `\r` is not — a lone carriage return moves the
+            // cursor back over what was already drawn.
+            '\n' => out.push('\n'),
+            '\t' => out.push('\t'),
+            // `^[`, the caret notation a terminal cannot act on. `U+2028`/`U+2029` are not
+            // control characters by `is_control` but do break a line in a renderer that knows
+            // Unicode, so they are named too.
+            c if c.is_control() => out.push_str(&format!("^{}", caret(c))),
+            '\u{2028}' => out.push_str("<U+2028>"),
+            '\u{2029}' => out.push_str("<U+2029>"),
+            c => out.push(c),
+        }
+    }
+    out
+}
+
+/// A control character in caret notation: `ESC` is `^[`, `NUL` is `^@`.
+fn caret(c: char) -> char {
+    match u32::from(c) {
+        code @ 0..=0x1f => char::from_u32(code + 0x40).unwrap_or('?'),
+        0x7f => '?',
+        _ => '?',
+    }
 }
 
 // SGR sequences, spelled out rather than pulled from a crate: there are six of them and they are
@@ -968,6 +1036,75 @@ mod tests {
         );
         assert!(summary.frames > 0, "everything before it is still there");
         read_cast(&options.output);
+    }
+
+    /// A cast frame is bytes a player writes straight to a terminal, and the text in a transcript
+    /// is whatever the **target** produced. So a target can put an escape sequence in a string and
+    /// have it *execute* on the machine of whoever plays the recording.
+    ///
+    /// That is not hypothetical for this server: the targets are dumps and drivers chosen for
+    /// analysis, frequently the least trustworthy program anyone has, and a recording is made
+    /// precisely to be sent to somebody else. OSC 52 writes the viewer's clipboard; other
+    /// sequences retitle the window, redraw the screen above, or query the terminal and have it
+    /// type the answer back as input.
+    ///
+    /// Everything from the transcript is rendered visible; the renderer's own styling, added from
+    /// constants outside that, still works. Both halves are asserted here, because a fix that
+    /// escaped the styling too would leave a cast of unreadable noise.
+    #[test]
+    fn a_target_cannot_smuggle_terminal_control_sequences_into_a_cast() {
+        let input = scratch("hostile-output");
+        let _ = std::fs::remove_file(&input);
+        let rec = Recorder::to_file(&input, 0).expect("a transcript");
+        let call = rec.tool_request("execute", None);
+        // OSC 52 (clipboard write), a window retitle, and a bare carriage return that would
+        // overdraw the line above it.
+        rec.tool_result(
+            call,
+            false,
+            "\u{1b}]52;c;aGVsbG8=\u{7}pwned\u{1b}]0;gotcha\u{7}\roverdrawn",
+            None,
+        );
+        let options = Options {
+            output: input.with_extension("cast"),
+            input,
+            width: DEFAULT_WIDTH,
+            height: DEFAULT_HEIGHT,
+            title: None,
+            idle_limit: 0.0,
+            max_lines: 0,
+        };
+        render(&options).expect("the render succeeds");
+
+        let (_, events) = read_cast(&options.output);
+        let screen: String = events.iter().map(|(_, _, d)| d.clone()).collect();
+        // The renderer's own styling is intact...
+        assert!(
+            screen.contains(RESET),
+            "the styling should survive: {screen:?}"
+        );
+        // ...and every escape the target wrote is shown rather than performed.
+        assert!(
+            !screen.contains("\u{1b}]"),
+            "an OSC sequence from the target reached the frame: {screen:?}"
+        );
+        assert!(
+            !screen.contains('\u{7}'),
+            "a BEL from the target reached the frame: {screen:?}"
+        );
+        assert!(screen.contains("^["), "shown in caret notation: {screen:?}");
+        // The text itself is still readable, which is the point of showing rather than dropping.
+        assert!(
+            screen.contains("pwned") && screen.contains("overdrawn"),
+            "{screen:?}"
+        );
+        // A lone carriage return is not passed through — only the line endings this renderer
+        // writes, which always follow a newline.
+        assert_eq!(
+            screen.matches('\r').count(),
+            screen.matches("\r\n").count(),
+            "a bare carriage return would overdraw the line above: {screen:?}"
+        );
     }
 
     /// The rendering must never be written over the transcript it came from.

--- a/src/cast.rs
+++ b/src/cast.rs
@@ -153,10 +153,12 @@ pub fn render(options: &Options) -> Result<Summary, String> {
             options.input.display()
         ));
     }
+    let runs = runs(&records).len();
+    let timeline = timeline(&records);
     let mut out = String::new();
     writeln!(out, "{}", header(options, &records)).map_err(|e| e.to_string())?;
     let mut frames = 0;
-    for record in &records {
+    for (record, at) in records.iter().zip(&timeline) {
         let Some(text) = frame(record, options.max_lines) else {
             continue;
         };
@@ -165,7 +167,7 @@ pub fn render(options: &Options) -> Result<Summary, String> {
         // characters, quotes and half-finished escape sequences, and a hand-built line would be
         // the one thing that could make a cast unplayable.
         let event = Value::Array(vec![
-            Value::from(record.mono_ms as f64 / 1000.0),
+            Value::from(*at as f64 / 1000.0),
             Value::from("o"),
             Value::from(text),
         ]);
@@ -190,7 +192,8 @@ pub fn render(options: &Options) -> Result<Summary, String> {
         records: records.len(),
         frames,
         unreadable,
-        duration_ms: records.last().map_or(0, |r| r.mono_ms),
+        runs,
+        duration_ms: timeline.last().copied().unwrap_or(0),
     })
 }
 
@@ -202,7 +205,93 @@ pub struct Summary {
     pub records: usize,
     pub frames: usize,
     pub unreadable: usize,
+    /// How many server runs the transcript holds. More than one is ordinary — the file is
+    /// appended to — and worth reporting, because it is why a cast can be longer than any single
+    /// session was.
+    pub runs: usize,
     pub duration_ms: u64,
+}
+
+/// One playback time per record, in milliseconds, never decreasing.
+///
+/// `mono_ms` is measured from the start of **its own run**, and a transcript is appended to — so a
+/// file holding two runs has a second one that starts again at zero. Written into a cast as they
+/// stand, those offsets step backwards at the join, and a player refuses the recording. The fix is
+/// not to discard the earlier run (it is the part somebody kept the file for) but to lay the runs
+/// end to end: each `start` after the first continues from where the previous one stopped.
+///
+/// The gap between runs is the **wall clock's**, when the two stamps allow it — that is how long
+/// the server was actually down, and it is the honest thing to show. When they do not (a clock
+/// that stepped, an unparseable stamp), the runs are simply butted together with [`RUN_GAP`],
+/// which is visibly a join rather than a wait.
+///
+/// Within a run the order is `seq`, not file order. They agree for anything this build writes —
+/// `Recorder::write` numbers under the same lock it writes under — but a file from a build before
+/// that fix can have them disagree, and a cast rendered from one must still play.
+fn timeline(records: &[Record]) -> Vec<u64> {
+    let mut times = vec![0u64; records.len()];
+    let mut base = 0u64;
+    for run in runs(records) {
+        let first = &records[run.start];
+        // Where this run begins on the playback clock: after everything before it, plus however
+        // long the server was down.
+        let start = match run.start {
+            0 => 0,
+            _ => base + gap(records.get(run.start.wrapping_sub(1)), Some(first)),
+        };
+        let mut order: Vec<usize> = run.clone().collect();
+        order.sort_by_key(|i| records[*i].seq);
+        let mut last = start;
+        for (position, index) in order.into_iter().enumerate() {
+            // Sorted by `seq`, so the *n*th record of the run takes the *n*th slot of the run's
+            // span whatever order its line was written in.
+            let at = start + records[index].mono_ms;
+            last = last.max(at);
+            times[run.start + position] = last;
+        }
+        base = last;
+    }
+    times
+}
+
+/// How long the server was down between two runs, in milliseconds, from their wall clocks.
+///
+/// [`RUN_GAP`] when the stamps cannot answer — either is unreadable, or the later one is not later,
+/// which a clock that stepped backwards produces. Never zero, so a join is always visible.
+fn gap(before: Option<&Record>, after: Option<&Record>) -> u64 {
+    let (Some(before), Some(after)) = (before, after) else {
+        return RUN_GAP;
+    };
+    let measured = crate::record::unix_seconds(&after.at)
+        .zip(crate::record::unix_seconds(&before.at))
+        .and_then(|(after, before)| after.checked_sub(before))
+        .map(|secs| secs.saturating_mul(1000));
+    measured.filter(|gap| *gap > 0).unwrap_or(RUN_GAP)
+}
+
+/// The stand-in gap between two runs whose wall clocks cannot be compared. Long enough to read as
+/// a break, short enough not to be a wait.
+const RUN_GAP: u64 = 1_000;
+
+/// The records of each run, as ranges. A run begins at a `start` record — the first thing every
+/// run writes — and the leading records of a file that has none are treated as one run, so a
+/// transcript whose head was lost still renders.
+fn runs(records: &[Record]) -> Vec<std::ops::Range<usize>> {
+    let mut bounds: Vec<usize> = records
+        .iter()
+        .enumerate()
+        .filter(|(_, r)| matches!(r.event, Event::Start { .. }))
+        .map(|(i, _)| i)
+        .collect();
+    if bounds.first() != Some(&0) {
+        bounds.insert(0, 0);
+    }
+    bounds
+        .iter()
+        .enumerate()
+        .map(|(n, start)| *start..bounds.get(n + 1).copied().unwrap_or(records.len()))
+        .filter(|run| !run.is_empty())
+        .collect()
 }
 
 /// Reads a transcript, skipping what it cannot parse.
@@ -385,15 +474,15 @@ fn frame(record: &Record, max_lines: usize) -> Option<String> {
             &format!(
                 "changed: {}{}",
                 detail.text,
-                step.as_deref()
-                    .map(|s| format!(" [{s}]"))
+                step.as_ref()
+                    .map(|s| format!(" [{}]", s.text))
                     .unwrap_or_default()
             ),
         ),
         Event::Assertion { step, detail, .. } => note(
             &mut out,
             FAIL,
-            &format!("assertion did not hold at {step}: {}", detail.text),
+            &format!("assertion did not hold at {}: {}", step.text, detail.text),
         ),
         Event::Batch {
             outcome,
@@ -644,6 +733,95 @@ mod tests {
         assert!(
             !screen.contains('\n')
                 || screen.matches('\n').count() == screen.matches("\r\n").count()
+        );
+    }
+
+    /// A transcript is **appended** to, so one file can hold several runs — and each run's
+    /// `mono_ms` starts again at zero.
+    ///
+    /// Written into a cast as they stand, those offsets step backwards at the join and a player
+    /// refuses the whole recording. The runs are laid end to end instead, which keeps the earlier
+    /// one — it is the part somebody kept the file for.
+    #[test]
+    fn several_runs_in_one_file_render_as_one_rising_timeline() {
+        let input = scratch("two-runs");
+        let _ = std::fs::remove_file(&input);
+        for run in 0..2 {
+            let rec = Recorder::to_file(&input, 0).expect("a transcript");
+            let call = rec.tool_request("modules", None);
+            // Long enough that the second run's own offsets are unambiguously small numbers,
+            // which is what would step backwards without the fix.
+            std::thread::sleep(std::time::Duration::from_millis(30));
+            rec.tool_result(call, false, &format!("run {run}"), None);
+            rec.write(Event::Shutdown { sessions: 0 });
+        }
+        let options = Options {
+            output: input.with_extension("cast"),
+            input,
+            width: DEFAULT_WIDTH,
+            height: DEFAULT_HEIGHT,
+            title: None,
+            idle_limit: DEFAULT_IDLE_LIMIT,
+            max_lines: 0,
+        };
+        let summary = render(&options).expect("the render succeeds");
+        assert_eq!(summary.runs, 2, "the file holds two runs");
+
+        let (_, events) = read_cast(&options.output);
+        assert!(
+            events.windows(2).all(|w| w[0].0 <= w[1].0),
+            "the join went backwards: {:?}",
+            events.iter().map(|(t, _, _)| *t).collect::<Vec<_>>()
+        );
+        // Both runs are in it, in the order they happened.
+        let screen: Vec<String> = events.iter().map(|(_, _, d)| d.clone()).collect();
+        let of = |needle: &str| screen.iter().position(|d| d.contains(needle));
+        assert!(of("run 0") < of("run 1"), "{screen:#?}");
+        // And the second run really is offset past the first, rather than restarting.
+        let second = events[of("run 1").expect("the second run is rendered")].0;
+        let first = events[of("run 0").expect("the first run is rendered")].0;
+        assert!(second > first, "{first} -> {second}");
+    }
+
+    /// Within a run, order comes from `seq` rather than from the order the lines happen to sit in.
+    ///
+    /// `Recorder::write` numbers under the same lock it writes under, so the two agree for
+    /// anything this build produces. A file from a build *before* that fix can have them disagree,
+    /// and a cast rendered from one still has to play.
+    #[test]
+    fn a_file_whose_lines_are_out_of_order_still_renders_forwards() {
+        let input = scratch("out-of-order");
+        let _ = std::fs::remove_file(&input);
+        let rec = Recorder::to_file(&input, 0).expect("a transcript");
+        let call = rec.tool_request("modules", None);
+        rec.tool_result(call, false, "first", None);
+        rec.write(Event::Shutdown { sessions: 0 });
+        drop(rec);
+
+        // Swap two lines, as a race between two writers would have left them.
+        let mut lines: Vec<String> = std::fs::read_to_string(&input)
+            .expect("the transcript")
+            .lines()
+            .map(str::to_string)
+            .collect();
+        lines.swap(1, 2);
+        std::fs::write(&input, lines.join("\n")).expect("rewrite");
+
+        let options = Options {
+            output: input.with_extension("cast"),
+            input,
+            width: DEFAULT_WIDTH,
+            height: DEFAULT_HEIGHT,
+            title: None,
+            idle_limit: 0.0,
+            max_lines: 0,
+        };
+        render(&options).expect("the render succeeds");
+        let (_, events) = read_cast(&options.output);
+        assert!(
+            events.windows(2).all(|w| w[0].0 <= w[1].0),
+            "times went backwards: {:?}",
+            events.iter().map(|(t, _, _)| *t).collect::<Vec<_>>()
         );
     }
 

--- a/src/cast.rs
+++ b/src/cast.rs
@@ -1,0 +1,798 @@
+//! Rendering a transcript as a terminal recording — [asciicast v2].
+//!
+//! The second half of [#87](https://github.com/glslang/windbg-mcp/issues/87), and the half with
+//! the evidence behind it: the recordings checked in under `examples/` are captioned
+//! *"Reconstructed terminal session"*, and one of them says outright that *"timing is illustrative
+//! because live recording was not enabled for the original run"*. A cast reconstructed afterwards
+//! is a drawing of a session, not a recording of one.
+//!
+//! # Derived, not written twice
+//!
+//! This renders from the JSONL that [`crate::record`] already wrote, offline, rather than emitting
+//! a `.cast` alongside it as the session runs. One source of truth, and three things fall out of
+//! it: a cast can be made from a transcript recorded weeks ago, the rendering can be changed
+//! without re-running anything, and the timings are the recorded ones — `mono_ms`, measured on a
+//! monotonic clock, so they cannot go backwards and cannot be reordered by a clock that steps.
+//!
+//! # What a viewer sees
+//!
+//! A terminal session: each tool call as a prompt line, its result printed under it, and the facts
+//! the transcript derived — a stop position, a mutation, a batch verdict, a session opening or
+//! being let go — as marked lines between them. It is the debugger's side of the conversation,
+//! which is the part worth watching; the model's prompts are not in the transcript and are not
+//! this server's to record.
+//!
+//! [asciicast v2]: https://docs.asciinema.org/manual/asciicast/v2/
+
+use std::fmt::Write as _;
+use std::io::Write as _;
+use std::path::PathBuf;
+
+use serde_json::Value;
+
+use crate::record::{Capped, Event, Record};
+
+/// The flag that selects this role. See [`crate::main`].
+pub const RENDER_FLAG: &str = "--render-cast";
+
+/// How wide the recorded terminal is said to be.
+///
+/// Wide enough for the tables this server prints — a pool census row, a module listing — which
+/// wrap into illegibility at 80. A player scales the recording to fit, so this is a shape rather
+/// than a requirement on the viewer.
+const DEFAULT_WIDTH: u32 = 120;
+const DEFAULT_HEIGHT: u32 = 32;
+
+/// What a player is told to shorten a pause to, in seconds.
+///
+/// Not a change to the timings — every event keeps the instant it happened at, and this is a
+/// header field a player applies while playing. It is here because a real session has real gaps
+/// in it: a minute while somebody reads a stack trace is a minute of nothing, and a recording
+/// nobody watches to the end proves nothing. `--idle-limit 0` turns it off and plays the session
+/// at the speed it happened.
+const DEFAULT_IDLE_LIMIT: f64 = 2.0;
+
+/// How much of a result is shown before the rendering says how much more there was.
+///
+/// The transcript's own cap is about what is *kept*; this one is about what is *watchable*. A
+/// 400-line module listing scrolling past is not a demonstration of anything, and the transcript
+/// still holds every byte of it that was recorded.
+const DEFAULT_MAX_LINES: usize = 24;
+
+/// What to render, and how.
+#[derive(Debug)]
+pub struct Options {
+    pub input: PathBuf,
+    pub output: PathBuf,
+    pub width: u32,
+    pub height: u32,
+    pub title: Option<String>,
+    pub idle_limit: f64,
+    pub max_lines: usize,
+}
+
+impl Options {
+    /// Reads the role's command line. `Err` carries the usage message, which the caller prints.
+    ///
+    /// Hand-rolled because this is the whole of it: the server takes no other options, and a
+    /// dependency for one flag list is a dependency in every build of the MCP server too.
+    pub fn parse(args: &[String]) -> Result<Self, String> {
+        let mut input = None;
+        let mut output = None;
+        let mut width = DEFAULT_WIDTH;
+        let mut height = DEFAULT_HEIGHT;
+        let mut title = None;
+        let mut idle_limit = DEFAULT_IDLE_LIMIT;
+        let mut max_lines = DEFAULT_MAX_LINES;
+        let mut rest = args.iter();
+        while let Some(arg) = rest.next() {
+            let mut value = |what: &str| {
+                rest.next()
+                    .cloned()
+                    .ok_or_else(|| format!("`{what}` needs a value"))
+            };
+            match arg.as_str() {
+                "--out" | "-o" => output = Some(PathBuf::from(value("--out")?)),
+                "--width" => width = number(&value("--width")?, "--width")?,
+                "--height" => height = number(&value("--height")?, "--height")?,
+                "--title" => title = Some(value("--title")?),
+                "--idle-limit" => {
+                    idle_limit = value("--idle-limit")?
+                        .parse()
+                        .map_err(|_| "`--idle-limit` takes a number of seconds".to_string())?;
+                }
+                "--max-lines" => {
+                    max_lines = number(&value("--max-lines")?, "--max-lines")? as usize
+                }
+                other if other.starts_with('-') => return Err(format!("unknown option `{other}`")),
+                path if input.is_none() => input = Some(PathBuf::from(path)),
+                extra => return Err(format!("unexpected argument `{extra}`")),
+            }
+        }
+        let input = input.ok_or_else(|| "no transcript named".to_string())?;
+        Ok(Self {
+            output: output.unwrap_or_else(|| input.with_extension("cast")),
+            input,
+            width,
+            height,
+            title,
+            idle_limit,
+            max_lines,
+        })
+    }
+}
+
+fn number(value: &str, what: &str) -> Result<u32, String> {
+    value
+        .parse()
+        .map_err(|_| format!("`{what}` takes a whole number"))
+}
+
+pub const USAGE: &str = "\
+usage: windbg-mcp --render-cast <transcript.jsonl> [options]
+
+Renders a session transcript (WINDBG_MCP_TRANSCRIPT) as an asciicast v2 recording.
+
+  -o, --out <file>       where to write it (default: the transcript's name, with .cast)
+      --title <text>     the recording's title
+      --width <cols>     terminal width  (default: 120)
+      --height <rows>    terminal height (default: 32)
+      --idle-limit <s>   what a player shortens a pause to; 0 plays it at real speed (default: 2)
+      --max-lines <n>    how much of a long result to show; 0 shows all of it (default: 24)
+";
+
+/// Renders `options.input` into `options.output`, and reports what it wrote.
+pub fn render(options: &Options) -> Result<Summary, String> {
+    let transcript = std::fs::read_to_string(&options.input)
+        .map_err(|e| format!("could not read `{}`: {e}", options.input.display()))?;
+    let (records, unreadable) = parse(&transcript);
+    if records.is_empty() {
+        return Err(format!(
+            "`{}` holds no transcript records. A file this server wrote has one JSON object per \
+             line, the first of them a `start`.",
+            options.input.display()
+        ));
+    }
+    let mut out = String::new();
+    writeln!(out, "{}", header(options, &records)).map_err(|e| e.to_string())?;
+    let mut frames = 0;
+    for record in &records {
+        let Some(text) = frame(record, options.max_lines) else {
+            continue;
+        };
+        // `[time, "o", data]`, where the time is the recorded one in seconds. Serialized as an
+        // array so the escaping is serde's problem — a debugger's output carries control
+        // characters, quotes and half-finished escape sequences, and a hand-built line would be
+        // the one thing that could make a cast unplayable.
+        let event = Value::Array(vec![
+            Value::from(record.mono_ms as f64 / 1000.0),
+            Value::from("o"),
+            Value::from(text),
+        ]);
+        writeln!(out, "{event}").map_err(|e| e.to_string())?;
+        frames += 1;
+    }
+    if let Some(parent) = options
+        .output
+        .parent()
+        .filter(|p| !p.as_os_str().is_empty())
+    {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| format!("could not create `{}`: {e}", parent.display()))?;
+    }
+    // Truncating, unlike the transcript: a rendering is derived, so rewriting it is how it is
+    // updated, and appending would produce a file with two headers and no valid reading.
+    let mut file = std::fs::File::create(&options.output)
+        .map_err(|e| format!("could not write `{}`: {e}", options.output.display()))?;
+    file.write_all(out.as_bytes())
+        .map_err(|e| format!("could not write `{}`: {e}", options.output.display()))?;
+    Ok(Summary {
+        records: records.len(),
+        frames,
+        unreadable,
+        duration_ms: records.last().map_or(0, |r| r.mono_ms),
+    })
+}
+
+/// What a render produced. `unreadable` is reported rather than swallowed: a transcript whose tail
+/// was cut off by a crash is exactly the case the format is designed to survive, and a renderer
+/// that said nothing about it would hide how much of the session it had.
+#[derive(Debug)]
+pub struct Summary {
+    pub records: usize,
+    pub frames: usize,
+    pub unreadable: usize,
+    pub duration_ms: u64,
+}
+
+/// Reads a transcript, skipping what it cannot parse.
+///
+/// One record per line, so a line that will not read costs that record and nothing after it. The
+/// case this is for is the last line of a file whose server died mid-write — the property the
+/// single-`write_all` rule in [`crate::record`] exists to give.
+fn parse(transcript: &str) -> (Vec<Record>, usize) {
+    let mut records = Vec::new();
+    let mut unreadable = 0;
+    for line in transcript.lines().filter(|l| !l.trim().is_empty()) {
+        match serde_json::from_str::<Record>(line) {
+            Ok(record) => records.push(record),
+            Err(_) => unreadable += 1,
+        }
+    }
+    (records, unreadable)
+}
+
+/// The asciicast header: version, shape, when it was recorded, and what to call it.
+fn header(options: &Options, records: &[Record]) -> Value {
+    let mut header = serde_json::json!({
+        "version": 2,
+        "width": options.width,
+        "height": options.height,
+        "env": { "TERM": "xterm-256color" },
+    });
+    // The wall clock of the first record — the moment the session actually started, which is the
+    // one thing the monotonic times cannot say.
+    if let Some(at) = records
+        .first()
+        .and_then(|r| crate::record::unix_seconds(&r.at))
+    {
+        header["timestamp"] = Value::from(at);
+    }
+    if options.idle_limit > 0.0 {
+        header["idle_time_limit"] = Value::from(options.idle_limit);
+    }
+    let title = options.title.clone().or_else(|| {
+        records.iter().find_map(|r| match &r.event {
+            Event::SessionOpen { kind, target, .. } => {
+                Some(format!("windbg-mcp — {kind} {target}"))
+            }
+            _ => None,
+        })
+    });
+    if let Some(title) = title {
+        header["title"] = Value::from(title);
+    }
+    header
+}
+
+// ---- rendering one record --------------------------------------------------
+
+/// A terminal line's worth of output for one record, or `None` for one that shows nothing.
+///
+/// Line endings are `\r\n`: this is a terminal recording, and a bare newline leaves the cursor in
+/// the column it was in.
+fn frame(record: &Record, max_lines: usize) -> Option<String> {
+    let mut out = String::new();
+    match &record.event {
+        Event::Start { version, .. } => {
+            line(
+                &mut out,
+                &format!("{DIM}windbg-mcp {version} — session transcript{RESET}"),
+            );
+        }
+        Event::ToolRequest { tool, args, .. } => {
+            let args = args.as_ref().map_or_else(String::new, render_args);
+            line(
+                &mut out,
+                &format!("{PROMPT}${RESET} {TOOL}{tool}{RESET} {args}"),
+            );
+        }
+        Event::ToolResult {
+            verdict,
+            text,
+            elapsed_ms,
+            ..
+        } => {
+            body(&mut out, text, max_lines);
+            let failed = *verdict == crate::record::Verdict::Error;
+            let mark = if failed {
+                format!("{FAIL}error{RESET}")
+            } else {
+                format!("{OK}ok{RESET}")
+            };
+            line(
+                &mut out,
+                &format!("{DIM}[{mark}{DIM} in {elapsed_ms} ms]{RESET}"),
+            );
+            out.push_str("\r\n");
+        }
+        Event::SessionOpen {
+            session,
+            kind,
+            target,
+            engine_pid,
+        } => note(
+            &mut out,
+            NOTE,
+            &format!("session {session} — {kind} `{target}` (engine pid {engine_pid})"),
+        ),
+        Event::SessionState {
+            session,
+            state,
+            detail,
+        } => note(
+            &mut out,
+            NOTE,
+            &format!("session {session} → {state}{}", suffix(detail)),
+        ),
+        Event::SessionEnd {
+            session, released, ..
+        } => note(
+            &mut out,
+            if *released { NOTE } else { FAIL },
+            &match released {
+                true => format!("session {session} released its target"),
+                false => format!("session {session} ENDED WITHOUT RELEASING its target"),
+            },
+        ),
+        Event::WorkerLost { session, detail } => note(
+            &mut out,
+            FAIL,
+            &format!("session {session} lost its engine: {}", detail.text),
+        ),
+        Event::CallTimeout { session, budget_ms } => note(
+            &mut out,
+            FAIL,
+            &format!(
+                "session {session}: a wait was abandoned after {budget_ms} ms (the job may still be running)"
+            ),
+        ),
+        Event::Interrupt {
+            session, delivered, ..
+        } => note(
+            &mut out,
+            NOTE,
+            &match delivered {
+                true => format!("session {session} interrupted"),
+                false => format!("session {session}: an interrupt was not acknowledged"),
+            },
+        ),
+        Event::Stop {
+            command,
+            stopped_at,
+            interrupted,
+            ..
+        } => note(
+            &mut out,
+            STOP,
+            &format!(
+                "`{command}` stopped at {}{}",
+                stopped_at.as_deref().unwrap_or("an unknown position"),
+                if *interrupted { " (on request)" } else { "" }
+            ),
+        ),
+        Event::RunTo {
+            verdict,
+            target,
+            stopped_at,
+            ..
+        } => note(
+            &mut out,
+            STOP,
+            &format!(
+                "run to {target}: {}{}",
+                verdict.to_uppercase(),
+                stopped_at
+                    .as_deref()
+                    .map(|at| format!(" at {at}"))
+                    .unwrap_or_default()
+            ),
+        ),
+        // The one a person scrubbing through a recording is looking for.
+        Event::Mutation { detail, step, .. } => note(
+            &mut out,
+            MUTATION,
+            &format!(
+                "changed: {}{}",
+                detail.text,
+                step.as_deref()
+                    .map(|s| format!(" [{s}]"))
+                    .unwrap_or_default()
+            ),
+        ),
+        Event::Assertion { step, detail, .. } => note(
+            &mut out,
+            FAIL,
+            &format!("assertion did not hold at {step}: {}", detail.text),
+        ),
+        Event::Batch {
+            outcome,
+            at_step,
+            rollback_complete,
+            after,
+            ..
+        } => note(
+            &mut out,
+            if *rollback_complete && outcome == "committed" {
+                OK
+            } else {
+                FAIL
+            },
+            &format!(
+                "batch {}{} — rollback {}, session {after}",
+                outcome.to_uppercase(),
+                at_step
+                    .map(|at| format!(" at step {at}"))
+                    .unwrap_or_default(),
+                if *rollback_complete {
+                    "complete"
+                } else {
+                    "INCOMPLETE"
+                }
+            ),
+        ),
+        Event::Shutdown { sessions } => note(
+            &mut out,
+            DIM,
+            &format!("server shutting down, releasing {sessions} session(s)"),
+        ),
+    }
+    (!out.is_empty()).then_some(out)
+}
+
+/// A tool's arguments as one line. Kept short: the prompt is a reminder of what was asked, and the
+/// transcript is where the whole of it lives.
+fn render_args(args: &Value) -> String {
+    let rendered = serde_json::to_string(args).unwrap_or_default();
+    let clipped: String = rendered.chars().take(160).collect();
+    match clipped.chars().count() < rendered.chars().count() {
+        true => format!("{DIM}{clipped}…{RESET}"),
+        false => format!("{DIM}{clipped}{RESET}"),
+    }
+}
+
+/// A result's text, clipped to what is watchable and saying how much was left out.
+fn body(out: &mut String, text: &Capped, max_lines: usize) {
+    if text.text.is_empty() {
+        return;
+    }
+    let lines: Vec<&str> = text.text.lines().collect();
+    let shown = match max_lines {
+        0 => lines.len(),
+        n => lines.len().min(n),
+    };
+    for l in &lines[..shown] {
+        line(out, l);
+    }
+    // Two different elisions, and they are not the same fact: this one is the *rendering* holding
+    // back, and `dropped` is the *transcript* having done so. A viewer who cannot tell them apart
+    // does not know whether the rest exists.
+    let hidden = lines.len() - shown;
+    if hidden > 0 {
+        line(
+            out,
+            &format!("{DIM}… {hidden} more line(s) in the transcript{RESET}"),
+        );
+    }
+    if let Some(dropped) = text.dropped {
+        line(
+            out,
+            &format!("{DIM}… {dropped} more byte(s) were not recorded (field cap){RESET}"),
+        );
+    }
+}
+
+fn note(out: &mut String, colour: &str, text: &str) {
+    line(out, &format!("{colour}  · {text}{RESET}"));
+}
+
+fn suffix(detail: &Option<Capped>) -> String {
+    detail
+        .as_ref()
+        .map(|d| format!(" — {}", d.text))
+        .unwrap_or_default()
+}
+
+/// One terminal line. `\r\n`, because a player is driving a terminal and not writing a file.
+fn line(out: &mut String, text: &str) {
+    out.push_str(text);
+    out.push_str("\r\n");
+}
+
+// SGR sequences, spelled out rather than pulled from a crate: there are six of them and they are
+// the whole of this renderer's styling.
+const RESET: &str = "\u{1b}[0m";
+const DIM: &str = "\u{1b}[2m";
+const PROMPT: &str = "\u{1b}[1;32m";
+const TOOL: &str = "\u{1b}[1;36m";
+const OK: &str = "\u{1b}[32m";
+const FAIL: &str = "\u{1b}[1;31m";
+const NOTE: &str = "\u{1b}[34m";
+const STOP: &str = "\u{1b}[33m";
+const MUTATION: &str = "\u{1b}[1;35m";
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use super::*;
+    use crate::record::Recorder;
+
+    fn scratch(name: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join("windbg-mcp-cast-tests");
+        std::fs::create_dir_all(&dir).expect("a scratch directory");
+        dir.join(format!("{name}-{}.jsonl", std::process::id()))
+    }
+
+    /// A transcript with one of everything a rendering has to cope with.
+    fn transcript(name: &str) -> Options {
+        let input = scratch(name);
+        let _ = std::fs::remove_file(&input);
+        let rec = Recorder::to_file(&input, 0).expect("a transcript");
+        rec.write(Event::SessionOpen {
+            session: "sess-1".to_string(),
+            kind: "crash dump".to_string(),
+            target: r"C:\dumps\a.dmp".to_string(),
+            engine_pid: 42,
+        });
+        let call = rec.tool_request("go", Some(&serde_json::json!({ "session_id": "sess-1" })));
+        rec.tool_result(
+            call,
+            false,
+            "Breakpoint 0 hit\nnt!KeBugCheckEx:",
+            Some(&serde_json::json!({
+                "status": "ok",
+                "command": "g",
+                "stopped_at": "0xfffff8031ab10000",
+                "interrupted": false,
+                "output": "Breakpoint 0 hit",
+            })),
+        );
+        rec.write(Event::Shutdown { sessions: 1 });
+        Options {
+            output: input.with_extension("cast"),
+            input,
+            width: DEFAULT_WIDTH,
+            height: DEFAULT_HEIGHT,
+            title: None,
+            idle_limit: DEFAULT_IDLE_LIMIT,
+            max_lines: DEFAULT_MAX_LINES,
+        }
+    }
+
+    /// Reads a cast back the way a player does: a header object, then one event array per line.
+    fn read_cast(path: &Path) -> (Value, Vec<(f64, String, String)>) {
+        let text = std::fs::read_to_string(path).expect("the cast exists");
+        let mut lines = text.lines();
+        let header: Value =
+            serde_json::from_str(lines.next().expect("a header line")).expect("the header is JSON");
+        let events = lines
+            .filter(|l| !l.trim().is_empty())
+            .map(|l| {
+                let event: Vec<Value> = serde_json::from_str(l)
+                    .unwrap_or_else(|e| panic!("an event line is not an array ({e}): {l}"));
+                assert_eq!(event.len(), 3, "an asciicast event is a 3-tuple: {l}");
+                (
+                    event[0].as_f64().expect("the time is a number"),
+                    event[1].as_str().expect("the code is a string").to_string(),
+                    event[2].as_str().expect("the data is a string").to_string(),
+                )
+            })
+            .collect();
+        (header, events)
+    }
+
+    /// The acceptance criterion: what comes out validates as asciicast v2.
+    #[test]
+    fn a_rendering_is_a_valid_asciicast_v2() {
+        let options = transcript("valid");
+        let summary = render(&options).expect("the render succeeds");
+        assert_eq!(summary.unreadable, 0);
+        assert!(summary.frames > 0);
+
+        let (header, events) = read_cast(&options.output);
+        assert_eq!(header["version"], 2);
+        assert_eq!(header["width"], DEFAULT_WIDTH);
+        assert_eq!(header["height"], DEFAULT_HEIGHT);
+        assert!(
+            header["timestamp"].as_u64().unwrap_or(0) > 1_700_000_000,
+            "the header carries when this was recorded: {header}"
+        );
+        assert!(!events.is_empty());
+        assert!(events.iter().all(|(_, code, _)| code == "o"));
+        // Times are non-decreasing, which is the one thing a player cannot cope with.
+        assert!(
+            events.windows(2).all(|w| w[0].0 <= w[1].0),
+            "an asciicast's times must not go backwards"
+        );
+        assert!(events.iter().all(|(t, _, _)| *t >= 0.0));
+    }
+
+    /// The timings are the recorded ones. This is the whole reason the feature exists: a cast
+    /// reconstructed afterwards has to caption its own timing as illustrative.
+    #[test]
+    fn the_times_are_the_transcripts_own() {
+        let options = transcript("timing");
+        render(&options).expect("the render succeeds");
+        let recorded: Vec<u64> = std::fs::read_to_string(&options.input)
+            .expect("the transcript")
+            .lines()
+            .filter_map(|l| serde_json::from_str::<Record>(l).ok())
+            .map(|r| r.mono_ms)
+            .collect();
+        let (_, events) = read_cast(&options.output);
+        // Every frame's time is one of the recorded instants, to the millisecond.
+        for (at, _, _) in &events {
+            let ms = (at * 1000.0).round() as u64;
+            assert!(
+                recorded.contains(&ms),
+                "{at}s is not an instant this transcript recorded: {recorded:?}"
+            );
+        }
+    }
+
+    /// What a viewer is actually shown: the call, its output, and the derived facts.
+    #[test]
+    fn the_rendering_shows_the_call_its_output_and_what_it_did() {
+        let options = transcript("content");
+        render(&options).expect("the render succeeds");
+        let (_, events) = read_cast(&options.output);
+        let screen: String = events.iter().map(|(_, _, data)| data.clone()).collect();
+        for expected in [
+            "go",                 // the tool
+            "Breakpoint 0 hit",   // its output
+            "0xfffff8031ab10000", // the stop the typed half derived
+            "crash dump",         // the session it ran against
+            "shutting down",      // the end of the transcript
+        ] {
+            assert!(
+                screen.contains(expected),
+                "`{expected}` is missing:\n{screen}"
+            );
+        }
+        // A terminal recording, so every line ends with a carriage return.
+        assert!(
+            !screen.contains('\n')
+                || screen.matches('\n').count() == screen.matches("\r\n").count()
+        );
+    }
+
+    /// A transcript whose tail was cut off mid-write still renders — that is what one record per
+    /// `write_all` buys, and a renderer that refused the file would throw it away.
+    #[test]
+    fn a_truncated_transcript_still_renders_what_it_has() {
+        let options = transcript("truncated");
+        let mut text = std::fs::read_to_string(&options.input).expect("the transcript");
+        text.push_str("{\"v\":1,\"seq\":99,\"at\":\"2026-08-16T06:00:00.0");
+        std::fs::write(&options.input, &text).expect("write the truncated transcript");
+
+        let summary = render(&options).expect("a truncated transcript still renders");
+        assert_eq!(
+            summary.unreadable, 1,
+            "the torn line is reported, not hidden"
+        );
+        assert!(summary.frames > 0, "everything before it is still there");
+        read_cast(&options.output);
+    }
+
+    /// An empty or non-transcript file is refused with an explanation rather than producing a cast
+    /// of nothing, which would look like a session in which nothing happened.
+    #[test]
+    fn a_file_that_is_not_a_transcript_is_refused() {
+        let path = scratch("not-a-transcript");
+        std::fs::write(&path, "hello\nthis is not JSON\n").expect("write");
+        let options = Options::parse(&[path.display().to_string()]).expect("parse");
+        let error = render(&options).expect_err("this is not a transcript");
+        assert!(error.contains("no transcript records"), "{error}");
+    }
+
+    /// A long result is clipped to what is watchable, and says so — a viewer has to be able to
+    /// tell "there was more" from "that was all of it".
+    #[test]
+    fn a_long_result_is_clipped_and_says_so() {
+        let input = scratch("clipped");
+        let _ = std::fs::remove_file(&input);
+        let rec = Recorder::to_file(&input, 0).expect("a transcript");
+        let call = rec.tool_request("modules", None);
+        rec.tool_result(
+            call,
+            false,
+            &(1..=100).map(|i| format!("line {i}\n")).collect::<String>(),
+            None,
+        );
+        let options = Options {
+            output: input.with_extension("cast"),
+            input,
+            width: DEFAULT_WIDTH,
+            height: DEFAULT_HEIGHT,
+            title: None,
+            idle_limit: 0.0,
+            max_lines: 10,
+        };
+        render(&options).expect("the render succeeds");
+        let (header, events) = read_cast(&options.output);
+        assert!(
+            header.get("idle_time_limit").is_none(),
+            "`--idle-limit 0` plays it at the speed it happened: {header}"
+        );
+        let screen: String = events.iter().map(|(_, _, d)| d.clone()).collect();
+        assert!(screen.contains("line 10"), "{screen}");
+        assert!(!screen.contains("line 11"), "{screen}");
+        assert!(screen.contains("90 more line(s)"), "{screen}");
+    }
+
+    /// The two elisions are different facts and must read differently: one is this renderer
+    /// holding back, the other is the transcript never having had the bytes.
+    #[test]
+    fn a_field_the_transcript_capped_is_reported_separately() {
+        let input = scratch("capped");
+        let _ = std::fs::remove_file(&input);
+        // A tiny field cap, so the transcript itself drops most of the result.
+        let rec = Recorder::to_file(&input, 32).expect("a transcript");
+        let call = rec.tool_request("modules", None);
+        rec.tool_result(call, false, &"m".repeat(500), None);
+        let options = Options {
+            output: input.with_extension("cast"),
+            input,
+            width: DEFAULT_WIDTH,
+            height: DEFAULT_HEIGHT,
+            title: None,
+            idle_limit: DEFAULT_IDLE_LIMIT,
+            max_lines: 0,
+        };
+        render(&options).expect("the render succeeds");
+        let (_, events) = read_cast(&options.output);
+        let screen: String = events.iter().map(|(_, _, d)| d.clone()).collect();
+        assert!(
+            screen.contains("were not recorded (field cap)"),
+            "the viewer has to know the bytes were never kept:\n{screen}"
+        );
+    }
+
+    /// The options, including the default output path — the one a caller gets by naming nothing.
+    #[test]
+    fn options_default_the_output_beside_the_transcript() {
+        let options = Options::parse(&["run.jsonl".to_string()]).expect("parse");
+        assert_eq!(options.output, PathBuf::from("run.cast"));
+        assert_eq!(options.width, DEFAULT_WIDTH);
+        assert_eq!(options.idle_limit, DEFAULT_IDLE_LIMIT);
+
+        let options = Options::parse(&[
+            "run.jsonl".to_string(),
+            "--out".to_string(),
+            "proof.cast".to_string(),
+            "--width".to_string(),
+            "80".to_string(),
+            "--idle-limit".to_string(),
+            "0".to_string(),
+            "--title".to_string(),
+            "MessageManager".to_string(),
+        ])
+        .expect("parse");
+        assert_eq!(options.output, PathBuf::from("proof.cast"));
+        assert_eq!(options.width, 80);
+        assert_eq!(options.idle_limit, 0.0);
+        assert_eq!(options.title.as_deref(), Some("MessageManager"));
+    }
+
+    /// A mistyped flag is an error with a name in it, not a silently ignored argument.
+    #[test]
+    fn a_bad_option_is_refused() {
+        for (args, expected) in [
+            (vec![], "no transcript named"),
+            (vec!["--nope".to_string()], "unknown option"),
+            (
+                vec!["a.jsonl".to_string(), "--width".to_string()],
+                "needs a value",
+            ),
+            (
+                vec![
+                    "a.jsonl".to_string(),
+                    "--width".to_string(),
+                    "wide".to_string(),
+                ],
+                "whole number",
+            ),
+            (
+                vec!["a.jsonl".to_string(), "b.jsonl".to_string()],
+                "unexpected argument",
+            ),
+        ] {
+            let error = Options::parse(&args).expect_err("this should not parse");
+            assert!(
+                error.contains(expected),
+                "`{error}` should mention `{expected}`"
+            );
+        }
+    }
+}

--- a/src/cast.rs
+++ b/src/cast.rs
@@ -143,6 +143,20 @@ Renders a session transcript (WINDBG_MCP_TRANSCRIPT) as an asciicast v2 recordin
 
 /// Renders `options.input` into `options.output`, and reports what it wrote.
 pub fn render(options: &Options) -> Result<Summary, String> {
+    // Before anything is read, because what follows would destroy the evidence. Writing the cast
+    // truncates its output, and two ways of asking lead here: `--out` naming the input, and a
+    // transcript that already ends in `.cast`, whose default output is itself. The render would
+    // then *succeed* — the records are in memory by then — and replace the only JSONL copy of the
+    // session with a rendering of it. That is the one failure this whole feature exists to
+    // prevent, arriving through the tool meant to make the session shareable.
+    if same_file(&options.input, &options.output) {
+        return Err(format!(
+            "the rendering would be written over the transcript it is made from (`{}`). Name a \
+             different `--out`: the transcript is the record, and a cast is a rendering of it that \
+             can be made again.",
+            options.input.display()
+        ));
+    }
     let transcript = std::fs::read_to_string(&options.input)
         .map_err(|e| format!("could not read `{}`: {e}", options.input.display()))?;
     let (records, unreadable) = parse(&transcript);
@@ -210,6 +224,20 @@ pub struct Summary {
     /// session was.
     pub runs: usize,
     pub duration_ms: u64,
+}
+
+/// Whether two paths name the same file.
+///
+/// By identity where the filesystem can say so — `canonicalize` resolves `.`, `..`, a symlink and
+/// (on Windows) the case of a path that exists, which a string comparison of
+/// `run.jsonl` against `./RUN.jsonl` would not. It only answers for paths that exist, and the
+/// output usually does not yet, so the comparison falls back to the paths as given: enough for
+/// the two ways this is actually reached, both of which produce literally equal paths.
+fn same_file(a: &std::path::Path, b: &std::path::Path) -> bool {
+    match (a.canonicalize(), b.canonicalize()) {
+        (Ok(a), Ok(b)) => a == b,
+        _ => a == b,
+    }
 }
 
 /// The records in playback order, each with the time it plays at — never decreasing.
@@ -940,6 +968,47 @@ mod tests {
         );
         assert!(summary.frames > 0, "everything before it is still there");
         read_cast(&options.output);
+    }
+
+    /// The rendering must never be written over the transcript it came from.
+    ///
+    /// The render would *succeed* — the records are in memory by the time the output is truncated
+    /// — and the only JSONL copy of the session would be replaced by a rendering of it. Two ways
+    /// in: `--out` naming the input, and a transcript already called `.cast`, whose default output
+    /// is itself. Both are checked, and both before a single byte is read.
+    #[test]
+    fn a_rendering_never_overwrites_the_transcript_it_came_from() {
+        let input = scratch("self-overwrite");
+        let _ = std::fs::remove_file(&input);
+        let rec = Recorder::to_file(&input, 0).expect("a transcript");
+        rec.write(Event::Shutdown { sessions: 0 });
+        drop(rec);
+        let before = std::fs::read_to_string(&input).expect("the transcript");
+
+        // Explicitly, with `--out`.
+        let options = Options::parse(&[
+            input.display().to_string(),
+            "--out".to_string(),
+            input.display().to_string(),
+        ])
+        .expect("parse");
+        let error = render(&options).expect_err("this would destroy the transcript");
+        assert!(error.contains("written over the transcript"), "{error}");
+
+        // And by default, for a transcript that happens to be named `.cast`.
+        let named_cast = input.with_extension("cast");
+        std::fs::copy(&input, &named_cast).expect("copy");
+        let options = Options::parse(&[named_cast.display().to_string()]).expect("parse");
+        assert_eq!(options.output, options.input, "the default collides here");
+        let error = render(&options).expect_err("this would destroy the transcript");
+        assert!(error.contains("written over the transcript"), "{error}");
+
+        assert_eq!(
+            std::fs::read_to_string(&input).expect("the transcript"),
+            before,
+            "the transcript was modified by a render that should have refused"
+        );
+        let _ = std::fs::remove_file(&named_cast);
     }
 
     /// An empty or non-transcript file is refused with an explanation rather than producing a cast

--- a/src/cast.rs
+++ b/src/cast.rs
@@ -158,8 +158,8 @@ pub fn render(options: &Options) -> Result<Summary, String> {
     let mut out = String::new();
     writeln!(out, "{}", header(options, &records)).map_err(|e| e.to_string())?;
     let mut frames = 0;
-    for (record, at) in records.iter().zip(&timeline) {
-        let Some(text) = frame(record, options.max_lines) else {
+    for (index, at) in &timeline {
+        let Some(text) = frame(&records[*index], options.max_lines) else {
             continue;
         };
         // `[time, "o", data]`, where the time is the recorded one in seconds. Serialized as an
@@ -193,7 +193,7 @@ pub fn render(options: &Options) -> Result<Summary, String> {
         frames,
         unreadable,
         runs,
-        duration_ms: timeline.last().copied().unwrap_or(0),
+        duration_ms: timeline.last().map_or(0, |(_, at)| *at),
     })
 }
 
@@ -212,86 +212,105 @@ pub struct Summary {
     pub duration_ms: u64,
 }
 
-/// One playback time per record, in milliseconds, never decreasing.
+/// The records in playback order, each with the time it plays at — never decreasing.
 ///
-/// `mono_ms` is measured from the start of **its own run**, and a transcript is appended to — so a
-/// file holding two runs has a second one that starts again at zero. Written into a cast as they
-/// stand, those offsets step backwards at the join, and a player refuses the recording. The fix is
-/// not to discard the earlier run (it is the part somebody kept the file for) but to lay the runs
-/// end to end: each `start` after the first continues from where the previous one stopped.
+/// Three things have to be reconciled, and they are all consequences of a transcript being a file
+/// that is *appended* to.
 ///
-/// The gap between runs is the **wall clock's**, when the two stamps allow it — that is how long
-/// the server was actually down, and it is the honest thing to show. When they do not (a clock
-/// that stepped, an unparseable stamp), the runs are simply butted together with [`RUN_GAP`],
-/// which is visibly a join rather than a wait.
+/// **Runs.** `mono_ms` is measured from the start of its own run, so a file holding two of them
+/// has a second that begins again at zero. Written out as they stand those offsets step backwards
+/// at the join and a player refuses the recording. The runs are laid end to end instead — keeping
+/// the earlier one, which is the part somebody kept the file for — separated by the **wall
+/// clock's** gap, since that is how long the server was actually down. When the stamps cannot
+/// answer (a clock that stepped, an unreadable one) the runs are butted together with [`RUN_GAP`],
+/// which reads as a join rather than a wait.
 ///
-/// Within a run the order is `seq`, not file order. They agree for anything this build writes —
-/// `Recorder::write` numbers under the same lock it writes under — but a file from a build before
-/// that fix can have them disagree, and a cast rendered from one must still play.
-fn timeline(records: &[Record]) -> Vec<u64> {
-    let mut times = vec![0u64; records.len()];
+/// **Interleaving.** Two supervisors can share a path, so the runs are grouped by `run` id rather
+/// than by position: their lines alternate in the file, and taking the file in order would tell
+/// one story out of two.
+///
+/// **Order within a run** is `seq`, not file order — and the records are *reordered*, not merely
+/// restamped. Rising timestamps on lines still emitted in file order would show a result before
+/// the request that produced it, which is a recording of something that did not happen. The two
+/// agree for anything this build writes, since `Recorder::write` numbers under the same lock it
+/// writes under; a file from before that fix still has to play, and to play correctly.
+fn timeline(records: &[Record]) -> Vec<(usize, u64)> {
+    let mut playback = Vec::with_capacity(records.len());
     let mut base = 0u64;
+    let mut previous: Option<usize> = None;
     for run in runs(records) {
-        let first = &records[run.start];
+        let Some(&first) = run.first() else { continue };
         // Where this run begins on the playback clock: after everything before it, plus however
-        // long the server was down.
-        let start = match run.start {
-            0 => 0,
-            _ => base + gap(records.get(run.start.wrapping_sub(1)), Some(first)),
+        // long the server was down in between.
+        let start = match previous {
+            None => 0,
+            Some(previous) => base + gap(&records[previous], &records[first]),
         };
-        let mut order: Vec<usize> = run.clone().collect();
-        order.sort_by_key(|i| records[*i].seq);
         let mut last = start;
-        for (position, index) in order.into_iter().enumerate() {
-            // Sorted by `seq`, so the *n*th record of the run takes the *n*th slot of the run's
-            // span whatever order its line was written in.
-            let at = start + records[index].mono_ms;
-            last = last.max(at);
-            times[run.start + position] = last;
+        for index in run {
+            last = last.max(start + records[index].mono_ms);
+            playback.push((index, last));
+            previous = Some(index);
         }
         base = last;
     }
-    times
+    playback
 }
 
 /// How long the server was down between two runs, in milliseconds, from their wall clocks.
 ///
 /// [`RUN_GAP`] when the stamps cannot answer — either is unreadable, or the later one is not later,
 /// which a clock that stepped backwards produces. Never zero, so a join is always visible.
-fn gap(before: Option<&Record>, after: Option<&Record>) -> u64 {
-    let (Some(before), Some(after)) = (before, after) else {
-        return RUN_GAP;
-    };
-    let measured = crate::record::unix_seconds(&after.at)
+fn gap(before: &Record, after: &Record) -> u64 {
+    crate::record::unix_seconds(&after.at)
         .zip(crate::record::unix_seconds(&before.at))
         .and_then(|(after, before)| after.checked_sub(before))
-        .map(|secs| secs.saturating_mul(1000));
-    measured.filter(|gap| *gap > 0).unwrap_or(RUN_GAP)
+        .map(|secs| secs.saturating_mul(1000))
+        .filter(|gap| *gap > 0)
+        .unwrap_or(RUN_GAP)
 }
 
 /// The stand-in gap between two runs whose wall clocks cannot be compared. Long enough to read as
 /// a break, short enough not to be a wait.
 const RUN_GAP: u64 = 1_000;
 
-/// The records of each run, as ranges. A run begins at a `start` record — the first thing every
-/// run writes — and the leading records of a file that has none are treated as one run, so a
-/// transcript whose head was lost still renders.
-fn runs(records: &[Record]) -> Vec<std::ops::Range<usize>> {
-    let mut bounds: Vec<usize> = records
-        .iter()
-        .enumerate()
-        .filter(|(_, r)| matches!(r.event, Event::Start { .. }))
-        .map(|(i, _)| i)
-        .collect();
-    if bounds.first() != Some(&0) {
-        bounds.insert(0, 0);
+/// The record indices of each run, in the order the runs happened, each sorted by `seq`.
+///
+/// Grouped by the `run` field first, which is what separates two servers appending to one file.
+/// Then split again at every `start` record, because a run id is missing from a transcript written
+/// before the field existed (they all read as run `0`) and because a `start` is where a run begins
+/// whatever else is true. Records before the first `start` are a run of their own, so a file whose
+/// head was lost still renders.
+fn runs(records: &[Record]) -> Vec<Vec<usize>> {
+    let mut order: Vec<u64> = Vec::new();
+    let mut grouped: std::collections::HashMap<u64, Vec<Vec<usize>>> =
+        std::collections::HashMap::new();
+    for (index, record) in records.iter().enumerate() {
+        let segments = grouped.entry(record.run).or_insert_with(|| {
+            order.push(record.run);
+            Vec::new()
+        });
+        // A `start` opens a segment; so does the first record of a group that did not begin with
+        // one.
+        if segments.is_empty() || matches!(record.event, Event::Start { .. }) {
+            segments.push(Vec::new());
+        }
+        segments
+            .last_mut()
+            .expect("a segment was just opened")
+            .push(index);
     }
-    bounds
-        .iter()
-        .enumerate()
-        .map(|(n, start)| *start..bounds.get(n + 1).copied().unwrap_or(records.len()))
-        .filter(|run| !run.is_empty())
-        .collect()
+    let mut runs: Vec<Vec<usize>> = order
+        .into_iter()
+        .flat_map(|run| grouped.remove(&run).unwrap_or_default())
+        .collect();
+    // By where each run first appears, so interleaved groups still come out in the order they
+    // started, and by `seq` within one.
+    runs.sort_by_key(|run| run.first().copied().unwrap_or(usize::MAX));
+    for run in &mut runs {
+        run.sort_by_key(|index| records[*index].seq);
+    }
+    runs
 }
 
 /// Reads a transcript, skipping what it cannot parse.
@@ -333,7 +352,7 @@ fn header(options: &Options, records: &[Record]) -> Value {
     let title = options.title.clone().or_else(|| {
         records.iter().find_map(|r| match &r.event {
             Event::SessionOpen { kind, target, .. } => {
-                Some(format!("windbg-mcp — {kind} {target}"))
+                Some(format!("windbg-mcp — {kind} {}", target.text))
             }
             _ => None,
         })
@@ -393,7 +412,10 @@ fn frame(record: &Record, max_lines: usize) -> Option<String> {
         } => note(
             &mut out,
             NOTE,
-            &format!("session {session} — {kind} `{target}` (engine pid {engine_pid})"),
+            &format!(
+                "session {session} — {kind} `{}` (engine pid {engine_pid})",
+                target.text
+            ),
         ),
         Event::SessionState {
             session,
@@ -611,7 +633,7 @@ mod tests {
         rec.write(Event::SessionOpen {
             session: "sess-1".to_string(),
             kind: "crash dump".to_string(),
-            target: r"C:\dumps\a.dmp".to_string(),
+            target: Capped::of(r"C:\dumps\a.dmp", 0),
             engine_pid: 42,
         });
         let call = rec.tool_request("go", Some(&serde_json::json!({ "session_id": "sess-1" })));
@@ -783,22 +805,29 @@ mod tests {
         assert!(second > first, "{first} -> {second}");
     }
 
-    /// Within a run, order comes from `seq` rather than from the order the lines happen to sit in.
+    /// Within a run, order comes from `seq` rather than from the order the lines happen to sit in
+    /// — and the records are **reordered**, not merely restamped.
+    ///
+    /// The distinction is the whole test. Rising timestamps on lines still emitted in file order
+    /// would satisfy a player and show a result *before* the request that produced it: a recording
+    /// of something that did not happen, which is worse than one that will not play. So this
+    /// asserts the content order and treats the times as the secondary claim.
     ///
     /// `Recorder::write` numbers under the same lock it writes under, so the two agree for
-    /// anything this build produces. A file from a build *before* that fix can have them disagree,
-    /// and a cast rendered from one still has to play.
+    /// anything this build produces. A file from a build *before* that fix has to render, and
+    /// render correctly.
     #[test]
-    fn a_file_whose_lines_are_out_of_order_still_renders_forwards() {
+    fn a_file_whose_lines_are_out_of_order_is_reordered_not_just_restamped() {
         let input = scratch("out-of-order");
         let _ = std::fs::remove_file(&input);
         let rec = Recorder::to_file(&input, 0).expect("a transcript");
         let call = rec.tool_request("modules", None);
-        rec.tool_result(call, false, "first", None);
+        rec.tool_result(call, false, "the answer", None);
         rec.write(Event::Shutdown { sessions: 0 });
         drop(rec);
 
-        // Swap two lines, as a race between two writers would have left them.
+        // The request and its result, swapped — as a race between two writers would have left
+        // them before the numbering moved inside the file lock.
         let mut lines: Vec<String> = std::fs::read_to_string(&input)
             .expect("the transcript")
             .lines()
@@ -818,6 +847,76 @@ mod tests {
         };
         render(&options).expect("the render succeeds");
         let (_, events) = read_cast(&options.output);
+        let screen: Vec<String> = events.iter().map(|(_, _, d)| d.clone()).collect();
+        let asked = screen
+            .iter()
+            .position(|d| d.contains("modules"))
+            .unwrap_or_else(|| panic!("the call is not rendered: {screen:#?}"));
+        let answered = screen
+            .iter()
+            .position(|d| d.contains("the answer"))
+            .unwrap_or_else(|| panic!("the result is not rendered: {screen:#?}"));
+        assert!(
+            asked < answered,
+            "the result was played before the call that produced it: {screen:#?}"
+        );
+        assert!(
+            events.windows(2).all(|w| w[0].0 <= w[1].0),
+            "times went backwards: {:?}",
+            events.iter().map(|(t, _, _)| *t).collect::<Vec<_>>()
+        );
+    }
+
+    /// Two servers pointed at one path, which [`Recorder::to_file`] allows: their records
+    /// interleave in the file, and a reader taking it in order tells one story out of two.
+    ///
+    /// Grouped by the run each record names, so each server's session comes out whole. Without the
+    /// `run` field the second `start` would look like the beginning of a single later run, and
+    /// everything after it — two sets of sequence numbers, request ids and sessions, each numbered
+    /// from scratch — would be attributed to it.
+    #[test]
+    fn two_servers_sharing_a_file_render_as_two_runs() {
+        let input = scratch("interleaved");
+        let _ = std::fs::remove_file(&input);
+        // Two recorders on one path, writing alternately — which is what concurrent supervisors
+        // produce, and what append mode is for.
+        let first = Recorder::to_file(&input, 0).expect("a transcript");
+        let second = Recorder::to_file(&input, 0).expect("the same transcript");
+        let a = first.tool_request("registers", None);
+        let b = second.tool_request("modules", None);
+        first.tool_result(a, false, "from the first server", None);
+        second.tool_result(b, false, "from the second server", None);
+        first.write(Event::Shutdown { sessions: 0 });
+        second.write(Event::Shutdown { sessions: 0 });
+
+        let options = Options {
+            output: input.with_extension("cast"),
+            input,
+            width: DEFAULT_WIDTH,
+            height: DEFAULT_HEIGHT,
+            title: None,
+            idle_limit: 0.0,
+            max_lines: 0,
+        };
+        let summary = render(&options).expect("the render succeeds");
+        assert_eq!(summary.runs, 2, "two servers wrote this file");
+
+        let (_, events) = read_cast(&options.output);
+        let screen: Vec<String> = events.iter().map(|(_, _, d)| d.clone()).collect();
+        let at = |needle: &str| {
+            screen
+                .iter()
+                .position(|d| d.contains(needle))
+                .unwrap_or_else(|| panic!("`{needle}` is not rendered: {screen:#?}"))
+        };
+        // Each server's call and its answer are adjacent, rather than one server's result landing
+        // between the other's call and its own.
+        assert!(at("registers") < at("from the first server"), "{screen:#?}");
+        assert!(at("modules") < at("from the second server"), "{screen:#?}");
+        assert!(
+            at("from the first server") < at("modules"),
+            "the two runs are interleaved rather than laid end to end: {screen:#?}"
+        );
         assert!(
             events.windows(2).all(|w| w[0].0 <= w[1].0),
             "times went backwards: {:?}",

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -362,6 +362,26 @@ impl SessionState {
     pub fn is_live(&self) -> bool {
         !matches!(self, Self::Failed(_) | Self::Closed(_))
     }
+
+    /// The state's name on its own, for a transcript that records a transition as a value.
+    pub fn name(&self) -> &'static str {
+        match self {
+            Self::Opening => "opening",
+            Self::Attaching => "attaching",
+            Self::Open => "open",
+            Self::Failed(_) => "failed",
+            Self::Retired(_) => "retired",
+            Self::Closed(_) => "closed",
+        }
+    }
+
+    /// Why it is in this state, for the three that carry a reason.
+    pub fn detail(&self) -> Option<&str> {
+        match self {
+            Self::Opening | Self::Attaching | Self::Open => None,
+            Self::Failed(why) | Self::Retired(why) | Self::Closed(why) => Some(why),
+        }
+    }
 }
 
 /// One session: a worker process, its queue, and the outstanding calls against it.
@@ -411,6 +431,11 @@ pub struct Session {
     /// had already been spent. A worker that finishes early retracts it by naming zero.
     unwinding: Arc<Mutex<Option<Instant>>>,
     child: Mutex<Option<Child>>,
+    /// Where this session's life is recorded, when anything is. Held here rather than reached for
+    /// through [`Sessions`] because the transitions worth recording happen in [`Self::update_state`],
+    /// which the registry does not call and cannot see — a worker dying moves a session from a
+    /// task that holds nothing but the session itself.
+    rec: crate::record::Recorder,
 }
 
 type Waiters = Arc<Mutex<HashMap<u64, oneshot::Sender<Result<Output, EngineError>>>>>;
@@ -444,14 +469,39 @@ impl Session {
         &self,
         next: impl FnOnce(&SessionState) -> Option<SessionState>,
     ) -> SessionState {
-        let mut slot = self.state.lock().unwrap_or_else(|e| e.into_inner());
-        if !slot.0.is_live() {
-            return slot.0.clone();
+        // Whether this *changed* anything, which is a different question from whether a transition
+        // was taken: a transition to the state the session is already in restamps it — that is
+        // what `in_state_for` measures and nothing here may quietly stop doing — while there is
+        // nothing about it worth a line in a transcript. Every conditional transition comes
+        // through here and most of them decline, so recording each call would fill a file with a
+        // session repeatedly not moving.
+        let (settled, moved) = {
+            let mut slot = self.state.lock().unwrap_or_else(|e| e.into_inner());
+            if !slot.0.is_live() {
+                return slot.0.clone();
+            }
+            let moved = match next(&slot.0) {
+                Some(next) => {
+                    let moved = next != slot.0;
+                    *slot = (next, Instant::now());
+                    moved
+                }
+                None => false,
+            };
+            (slot.0.clone(), moved)
+        };
+        if moved {
+            // Outside the lock: writing a record touches a disk, and nothing that does belongs
+            // inside the mutex every state read in this process contends on.
+            self.rec.write(crate::record::Event::SessionState {
+                session: self.id.clone(),
+                state: settled.name().to_string(),
+                detail: settled
+                    .detail()
+                    .map(|d| crate::record::Capped::of(&crate::kdconn::scrub(d), 0)),
+            });
         }
-        if let Some(next) = next(&slot.0) {
-            *slot = (next, Instant::now());
-        }
-        slot.0.clone()
+        settled
     }
 
     /// How far the opener got. See [`OpenPhase`] for why this is not read off the state.
@@ -816,16 +866,33 @@ impl Registry {
 pub struct Sessions {
     inner: Arc<Mutex<Registry>>,
     call_timeout: Duration,
+    rec: crate::record::Recorder,
 }
 
 impl Sessions {
     /// Creates an empty registry. No process is started until something is opened, so a server
     /// that is only ever asked for `tools/list` never loads DbgEng at all.
+    ///
+    /// Recording is off unless [`Self::recording`] turns it on, which is what every test here
+    /// relies on: a registry is built in a dozen of them and none of them is about transcripts.
     pub fn new(call_timeout: Duration) -> Self {
         Self {
             inner: Arc::new(Mutex::new(Registry::default())),
             call_timeout,
+            rec: crate::record::Recorder::disabled(),
         }
+    }
+
+    /// Records this registry's sessions into `rec`. Called once, by `main`, with whatever the
+    /// environment asked for.
+    pub fn recording(mut self, rec: crate::record::Recorder) -> Self {
+        self.rec = rec;
+        self
+    }
+
+    /// The transcript this server is writing, so the tool surface can record against the same one.
+    pub fn recorder(&self) -> crate::record::Recorder {
+        self.rec.clone()
     }
 
     fn registry(&self) -> std::sync::MutexGuard<'_, Registry> {
@@ -979,6 +1046,14 @@ impl Sessions {
         }
         // A timeout is an operational outcome, not broken plumbing: the target may simply still be
         // running. Note the job itself is *not* cancelled — only this wait for it.
+        //
+        // Its own record, and not merely a failed `tool_result`: the two say different things. The
+        // result says this caller gave up; this says the *job* is still out there, which is the
+        // fact that makes a later reply, or a session that will not go idle, make sense.
+        self.rec.write(crate::record::Event::CallTimeout {
+            session: session.id.clone(),
+            budget_ms: budget.as_millis().min(u128::from(u64::MAX)) as u64,
+        });
         Err(EngineError::Timeout(format!(
             "engine call timed out (the target may still be running). The session `{}` is still \
              holding this call; `session_status` reports it, and `end_session` ends it outright — \
@@ -1123,7 +1198,19 @@ impl Sessions {
         named: bool,
     ) -> Result<Output, EngineError> {
         let call = Call::new(EngineOp::Interrupt).named(named);
-        self.call_within(session, call, INTERRUPT_TIMEOUT).await
+        let outcome = self.call_within(session, call, INTERRUPT_TIMEOUT).await;
+        // Recorded from this side because an interrupt is a *cause*: whatever the interrupted call
+        // reports next — a short result, a batch that says `INTERRUPTED`, a walk that stopped —
+        // reads as an unexplained truncation without the record that somebody asked for it.
+        self.rec.write(crate::record::Event::Interrupt {
+            session: session.id.clone(),
+            delivered: outcome.is_ok(),
+            detail: match &outcome {
+                Ok(out) => Some(crate::record::Capped::of(&out.text, 0)),
+                Err(e) => Some(crate::record::Capped::of(&e.to_string(), 0)),
+            },
+        });
+        outcome
     }
 
     /// Ends a session: asks the worker to release its target, then terminates it.
@@ -1150,6 +1237,20 @@ impl Sessions {
                 _ => None,
             },
         };
+        // From the same value the caller is answered with, not from the paragraph below it. The
+        // one fact an unattended run is read for is `released`: false means the worker was killed
+        // still holding its target, and for a live kernel that is a machine left halted.
+        //
+        // Not for a stale handle, which tore nothing down: recording an end for a session that was
+        // never ended would put a teardown in the transcript that did not happen.
+        if !matches!(outcome, Release::Stale(_)) {
+            self.rec.write(crate::record::Event::SessionEnd {
+                session: ended.session_id.clone(),
+                released: ended.released,
+                worker_terminated: ended.worker_terminated,
+                waited_ms: ended.waited_ms,
+            });
+        }
         let (reason, message) = match outcome {
             // A refused handle is the mechanism working, not a session to tear down.
             Release::Stale(why) => return Err(EngineError::Stale(why)),
@@ -1281,6 +1382,12 @@ impl Sessions {
             registry.closing = true;
             registry.owning_workers()
         };
+        // Recorded before the releases rather than after them, and even when there are none: this
+        // is the record that says the transcript ends here on purpose. Without it a file that
+        // stops mid-session is indistinguishable from one whose server was killed.
+        self.rec.write(crate::record::Event::Shutdown {
+            sessions: owners.len(),
+        });
         if owners.is_empty() {
             return;
         }
@@ -1584,6 +1691,19 @@ impl Sessions {
             released: AtomicBool::new(false),
             unwinding,
             child: Mutex::new(Some(child)),
+            rec: self.rec.clone(),
+        });
+        // Recorded here, where the worker exists and the session has its identity, rather than
+        // where `open` returns: an open that then fails still started a process against a target,
+        // and a transcript that only knew about the ones that worked would be missing exactly the
+        // sessions somebody is reading it to understand.
+        self.rec.write(crate::record::Event::SessionOpen {
+            session: session.id.clone(),
+            kind: kind.label().to_string(),
+            // Already masked where it is a connection: an attach resolves its label in
+            // `kdconn::select` before a worker is ever spawned.
+            target: crate::kdconn::scrub(&session.what),
+            engine_pid: pid,
         });
 
         // Both halves hold a `Weak`, so a session dropped from the registry takes its worker's
@@ -2239,6 +2359,13 @@ async fn reader(
             "the engine worker process exited".to_string(),
         ));
     }
+    // Beside the state transition rather than instead of it: the transition says the session is
+    // closed, and this says the calls it owed replies to are being answered with a failure nobody
+    // asked for. A reader looking at a result that never arrived needs the second one.
+    session.rec.write(crate::record::Event::WorkerLost {
+        session: session.id.clone(),
+        detail: crate::record::Capped::of(&worker_gone(&session.id), 0),
+    });
     session.fail_outstanding(&worker_gone(&session.id));
 }
 
@@ -2544,6 +2671,15 @@ mod tests {
     /// A `Session` with no worker behind it, for the routing tests. Its queue has no consumer,
     /// which is all these need: they never submit a call.
     fn dormant(id: &str, state: SessionState) -> Arc<Session> {
+        dormant_recording(id, state, crate::record::Recorder::disabled())
+    }
+
+    /// [`dormant`] with a transcript, for the one test that is about what gets recorded.
+    fn dormant_recording(
+        id: &str,
+        state: SessionState,
+        rec: crate::record::Recorder,
+    ) -> Arc<Session> {
         let (tx, _rx) = mpsc::unbounded_channel();
         // The phase a session in this state would really have reached. They are separate fields
         // for good reason, but a double whose phase contradicts its state would prove nothing.
@@ -2568,7 +2704,61 @@ mod tests {
             released: AtomicBool::new(false),
             unwinding: Arc::new(Mutex::new(None)),
             child: Mutex::new(None),
+            rec,
         })
+    }
+
+    /// A transition that changes nothing still restamps the session — that is what `session_status`
+    /// measures — but it must not put a line in the transcript.
+    ///
+    /// Both halves matter and they pull in opposite directions. Skipping the restamp would quietly
+    /// change what `in_state_for` means, and with it the "this attach is overdue" advice built on
+    /// it; recording every call would fill a file with a session repeatedly not moving, because
+    /// most conditional transitions decline. `update_state` is the single funnel for all of them,
+    /// so this is the one place either could go wrong.
+    #[test]
+    fn a_transition_that_changes_nothing_restamps_without_recording_it() {
+        let path = std::env::temp_dir().join(format!(
+            "windbg-mcp-engine-transitions-{}.jsonl",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_file(&path);
+        let rec = crate::record::Recorder::to_file(&path, 0).expect("open a transcript");
+        let session = dormant_recording("sess-1", SessionState::Opening, rec);
+
+        session.set_state(SessionState::Attaching);
+        // Let it age first. A reset is invisible from a stamp taken an instant ago — the two
+        // readings would differ by the time the assertion itself took, and the test would pass
+        // whether or not anything restamped.
+        std::thread::sleep(Duration::from_millis(20));
+        let aged = session.in_state_for();
+        assert!(
+            aged >= Duration::from_millis(20),
+            "the baseline has to be a session that has visibly been sitting in this state"
+        );
+        // The same state again, which is what a milestone arriving twice would do.
+        session.set_state(SessionState::Attaching);
+        assert!(
+            session.in_state_for() < aged,
+            "a repeated transition has to restamp: `in_state_for` should have gone back down"
+        );
+        // And a transition that declines outright.
+        session.update_state(|_| None);
+        session.set_state(SessionState::Open);
+
+        let states: Vec<String> = std::fs::read_to_string(&path)
+            .expect("the transcript")
+            .lines()
+            .filter_map(|l| serde_json::from_str::<serde_json::Value>(l).ok())
+            .filter(|r| r["event"] == "session_state")
+            .filter_map(|r| r["state"].as_str().map(str::to_string))
+            .collect();
+        assert_eq!(
+            states,
+            ["attaching", "open"],
+            "only the transitions that moved the session belong in the transcript"
+        );
+        let _ = std::fs::remove_file(&path);
     }
 
     /// A long-lived child to stand in for a worker, where what is under test is which sessions own

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1098,9 +1098,31 @@ impl Sessions {
             // Refused *before* the opener was written, so this worker is `Ready` and holds
             // nothing at all — no dump, no trace, no attach. There is no target to release and so
             // nothing for its channel closing to accomplish; killing it is the whole teardown.
+            //
+            // And nothing is recorded, because nothing happened to a target: no session was
+            // registered, so there is none to end either. The caller is told why in the result.
+            // Recording an open here — as this did, from inside `spawn` — would put a session in
+            // the transcript that never existed, with no end to match it, and a disconnect racing
+            // a handshake is enough to produce one *after* the shutdown record.
             session.kill();
             return Err(OpenError::NoRoom(why));
         }
+        // Admitted, so this session exists and is routable. Recorded now rather than when the
+        // *opener* returns: a target that then fails to open still had a process started against
+        // it, and a transcript that only knew about the ones that worked would be missing exactly
+        // the sessions somebody is reading it to understand.
+        self.rec.write(crate::record::Event::SessionOpen {
+            session: session.id.clone(),
+            kind: kind.label().to_string(),
+            // Already masked where it is a connection: an attach resolves its label in
+            // `kdconn::select` before a worker is ever spawned. Scrubbed anyway, and capped,
+            // because a `launch` target is a command line somebody wrote.
+            target: crate::record::Capped::of(
+                &crate::kdconn::scrub(&session.what),
+                self.rec.field_limit(),
+            ),
+            engine_pid: session.pid,
+        });
         // Released only now: from here the session is counted in `all` instead, and holding both
         // would count this open twice.
         drop(slot);
@@ -1723,23 +1745,6 @@ impl Sessions {
             child: Mutex::new(Some(child)),
             rec: self.rec.clone(),
         });
-        // Recorded here, where the worker exists and the session has its identity, rather than
-        // where `open` returns: an open that then fails still started a process against a target,
-        // and a transcript that only knew about the ones that worked would be missing exactly the
-        // sessions somebody is reading it to understand.
-        self.rec.write(crate::record::Event::SessionOpen {
-            session: session.id.clone(),
-            kind: kind.label().to_string(),
-            // Already masked where it is a connection: an attach resolves its label in
-            // `kdconn::select` before a worker is ever spawned. Scrubbed anyway, and capped,
-            // because a `launch` target is a command line somebody wrote.
-            target: crate::record::Capped::of(
-                &crate::kdconn::scrub(&session.what),
-                self.rec.field_limit(),
-            ),
-            engine_pid: pid,
-        });
-
         // Both halves hold a `Weak`, so a session dropped from the registry takes its worker's
         // plumbing with it rather than keeping the Arc alive forever.
         let pumping = std::thread::Builder::new()

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1729,8 +1729,12 @@ impl Sessions {
             session: session.id.clone(),
             kind: kind.label().to_string(),
             // Already masked where it is a connection: an attach resolves its label in
-            // `kdconn::select` before a worker is ever spawned.
-            target: crate::kdconn::scrub(&session.what),
+            // `kdconn::select` before a worker is ever spawned. Scrubbed anyway, and capped,
+            // because a `launch` target is a command line somebody wrote.
+            target: crate::record::Capped::of(
+                &crate::kdconn::scrub(&session.what),
+                self.rec.field_limit(),
+            ),
             engine_pid: pid,
         });
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -493,12 +493,13 @@ impl Session {
         if moved {
             // Outside the lock: writing a record touches a disk, and nothing that does belongs
             // inside the mutex every state read in this process contends on.
+            let limit = self.rec.field_limit();
             self.rec.write(crate::record::Event::SessionState {
                 session: self.id.clone(),
                 state: settled.name().to_string(),
                 detail: settled
                     .detail()
-                    .map(|d| crate::record::Capped::of(&crate::kdconn::scrub(d), 0)),
+                    .map(|d| crate::record::Capped::of(&crate::kdconn::scrub(d), limit)),
             });
         }
         settled
@@ -1205,10 +1206,16 @@ impl Sessions {
         self.rec.write(crate::record::Event::Interrupt {
             session: session.id.clone(),
             delivered: outcome.is_ok(),
-            detail: match &outcome {
-                Ok(out) => Some(crate::record::Capped::of(&out.text, 0)),
-                Err(e) => Some(crate::record::Capped::of(&e.to_string(), 0)),
-            },
+            // Scrubbed and capped like every other debugger-supplied string that reaches the
+            // transcript — this one is the engine's own words about what it stopped, and it is
+            // the one path that was not going through the rule the module documents.
+            detail: Some(crate::record::Capped::of(
+                &crate::kdconn::scrub(&match &outcome {
+                    Ok(out) => out.text.clone(),
+                    Err(e) => e.to_string(),
+                }),
+                self.rec.field_limit(),
+            )),
         });
         outcome
     }
@@ -1409,10 +1416,31 @@ impl Sessions {
                         SHUTDOWN_RELEASE_TIMEOUT,
                     )
                     .await;
+                let note = shutdown_note(&outcome, session.released.load(Ordering::SeqCst));
+                // The same record `end_session` writes, and this is the path that needs it more:
+                // a disconnect has no caller to answer, so without it the transcript of an
+                // unattended run ends with "shutting down" and never says what became of each
+                // target. `released` is read from the note rather than from this attempt's own
+                // outcome, because two teardowns can race for one session and the loser's failure
+                // is not news about the target — see [`ShutdownNote`].
+                session.rec.write(crate::record::Event::SessionEnd {
+                    session: session.id.clone(),
+                    released: matches!(
+                        note,
+                        ShutdownNote::Released | ShutdownNote::ReleasedElsewhere
+                    ),
+                    worker_terminated: !matches!(outcome, Release::AlreadyGone | Release::Stale(_)),
+                    waited_ms: match &outcome {
+                        Release::Parked { waited } => {
+                            Some(waited.as_millis().min(u128::from(u64::MAX)) as u64)
+                        }
+                        _ => None,
+                    },
+                });
                 // `end_session` renders this for its caller. Shutdown has no caller — the client
                 // has already gone — so the log is the only place it can land, and it is exactly
                 // where an operator looks after finding a guest that did not come back.
-                match shutdown_note(&outcome, session.released.load(Ordering::SeqCst)) {
+                match note {
                     ShutdownNote::Released => {
                         tracing::info!("shutting down: session {} released its target", session.id)
                     }
@@ -2354,18 +2382,23 @@ async fn reader(
     let Some(session) = session.upgrade() else {
         return;
     };
-    if session.state().is_live() {
+    // Whether this death is *news*. A session already settled is one somebody ended — `release`
+    // terminates the worker on purpose, so its pipe reaching EOF here is the last step of an
+    // orderly teardown, not a loss. Recording it either way would put a red "lost its engine"
+    // line after every successful `end_session`, describing a failure that did not happen.
+    let unexpected = session.state().is_live();
+    if unexpected {
         session.set_state(SessionState::Closed(
             "the engine worker process exited".to_string(),
         ));
+        // Beside the state transition rather than instead of it: the transition says the session
+        // is closed, and this says the calls it owed replies to are being answered with a failure
+        // nobody asked for. A reader looking at a result that never arrived needs the second one.
+        session.rec.write(crate::record::Event::WorkerLost {
+            session: session.id.clone(),
+            detail: crate::record::Capped::of(&worker_gone(&session.id), session.rec.field_limit()),
+        });
     }
-    // Beside the state transition rather than instead of it: the transition says the session is
-    // closed, and this says the calls it owed replies to are being answered with a failure nobody
-    // asked for. A reader looking at a result that never arrived needs the second one.
-    session.rec.write(crate::record::Event::WorkerLost {
-        session: session.id.clone(),
-        detail: crate::record::Capped::of(&worker_gone(&session.id), 0),
-    });
     session.fail_outstanding(&worker_gone(&session.id));
 }
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -905,19 +905,31 @@ impl Sessions {
     /// This is where a stale handle is refused. It is *not* the whole check — the session can
     /// still be retired between here and the worker — which is why [`Gate`] repeats it at the
     /// front of the queue.
+    ///
+    /// It is also where the transcript learns **which** session a call reached
+    /// ([`crate::record::routed_to`]), and it is here rather than at the call sites because the
+    /// caller's argument is not the answer: a call naming no session still acts on the current
+    /// one. Two tools resolve by hand instead of going through `run_call` — `interrupt` and
+    /// `end_session` — and recording at the funnel is what stops them, and the next one like
+    /// them, from being missed.
     pub fn resolve(&self, supplied: Option<&str>) -> Result<Arc<Session>, EngineError> {
         let registry = self.registry();
         let Some(want) = supplied else {
-            return registry.current().ok_or_else(|| {
+            let current = registry.current().ok_or_else(|| {
                 EngineError::Stale(
                     "no debug session is open. Start one with open_dump / open_trace / \
                      attach_process / attach_kernel / attach_kernel_local / launch."
                         .to_string(),
                 )
-            });
+            })?;
+            crate::record::routed_to(&current.id);
+            return Ok(current);
         };
         match registry.find(want) {
-            Some(session) if session.state().accepts_handle() => Ok(session),
+            Some(session) if session.state().accepts_handle() => {
+                crate::record::routed_to(&session.id);
+                Ok(session)
+            }
             Some(session) => Err(EngineError::Stale(stale_handle(want, &session.state()))),
             None => Err(EngineError::Stale(format!(
                 "unknown session handle `{want}`: this server is not holding it. Either it was \
@@ -1244,20 +1256,6 @@ impl Sessions {
                 _ => None,
             },
         };
-        // From the same value the caller is answered with, not from the paragraph below it. The
-        // one fact an unattended run is read for is `released`: false means the worker was killed
-        // still holding its target, and for a live kernel that is a machine left halted.
-        //
-        // Not for a stale handle, which tore nothing down: recording an end for a session that was
-        // never ended would put a teardown in the transcript that did not happen.
-        if !matches!(outcome, Release::Stale(_)) {
-            self.rec.write(crate::record::Event::SessionEnd {
-                session: ended.session_id.clone(),
-                released: ended.released,
-                worker_terminated: ended.worker_terminated,
-                waited_ms: ended.waited_ms,
-            });
-        }
         let (reason, message) = match outcome {
             // A refused handle is the mechanism working, not a session to tear down.
             Release::Stale(why) => return Err(EngineError::Stale(why)),
@@ -1352,7 +1350,7 @@ impl Sessions {
         }
         session.fail_outstanding(&format!("session `{}` was ended", session.id));
         session.kill();
-        match out {
+        let outcome = match out {
             Ok(out) => Release::Released(out.text),
             // Carries what it actually waited, because that is no longer one constant: a session
             // unwinding a transaction is given the extra time it asked for, and a report naming
@@ -1360,7 +1358,31 @@ impl Sessions {
             Err(EngineError::Timeout(_)) => Release::Parked { waited },
             Err(EngineError::Lost(_)) => Release::AlreadyGone,
             Err(e) => Release::Refused(e.to_string()),
-        }
+        };
+        // Recorded **here**, at the one place every teardown passes, rather than by each caller.
+        // There are three — `end_session`, the shutdown sweep, and the reclamation that pays for
+        // a new session at the limit — and the first two rounds of review each found one that had
+        // been forgotten. A caller cannot forget this one.
+        //
+        // `released` is the session's flag, not this attempt's outcome, and the difference shows
+        // when two teardowns race for one session: only the winner is told it worked, and the
+        // loser's failure is not news about the *target*. The question a transcript is read for is
+        // "was it let go?", which the flag answers and this attempt's result does not.
+        //
+        // A stale handle never reaches here — it returns above — so no teardown that tore nothing
+        // down is recorded as one.
+        session.rec.write(crate::record::Event::SessionEnd {
+            session: session.id.clone(),
+            released: session.released.load(Ordering::SeqCst),
+            worker_terminated: !matches!(outcome, Release::AlreadyGone),
+            waited_ms: match &outcome {
+                Release::Parked { waited } => {
+                    Some(waited.as_millis().min(u128::from(u64::MAX)) as u64)
+                }
+                _ => None,
+            },
+        });
+        outcome
     }
 
     /// Ends every session, then terminates any worker that did not let go. Called when the client
@@ -1417,26 +1439,6 @@ impl Sessions {
                     )
                     .await;
                 let note = shutdown_note(&outcome, session.released.load(Ordering::SeqCst));
-                // The same record `end_session` writes, and this is the path that needs it more:
-                // a disconnect has no caller to answer, so without it the transcript of an
-                // unattended run ends with "shutting down" and never says what became of each
-                // target. `released` is read from the note rather than from this attempt's own
-                // outcome, because two teardowns can race for one session and the loser's failure
-                // is not news about the target — see [`ShutdownNote`].
-                session.rec.write(crate::record::Event::SessionEnd {
-                    session: session.id.clone(),
-                    released: matches!(
-                        note,
-                        ShutdownNote::Released | ShutdownNote::ReleasedElsewhere
-                    ),
-                    worker_terminated: !matches!(outcome, Release::AlreadyGone | Release::Stale(_)),
-                    waited_ms: match &outcome {
-                        Release::Parked { waited } => {
-                            Some(waited.as_millis().min(u128::from(u64::MAX)) as u64)
-                        }
-                        _ => None,
-                    },
-                });
                 // `end_session` renders this for its caller. Shutdown has no caller — the client
                 // has already gone — so the log is the only place it can land, and it is exactly
                 // where an operator looks after finding a guest that did not come back.

--- a/src/kdconn.rs
+++ b/src/kdconn.rs
@@ -47,7 +47,19 @@ const SECRET_PARAMS: &[&str] = &["key", "password"];
 
 /// What a redacted secret is replaced with. Deliberately not the same length as any real value —
 /// a mask that preserved length would leak the key's shape.
-const MASK: &str = "<redacted>";
+pub(crate) const MASK: &str = "<redacted>";
+
+/// Whether `name` names a value that must never be rendered.
+///
+/// The one test, shared by everything that hides a secret: the connection parser
+/// ([`Param::is_secret`]), the text scan ([`secret_at`]), and the transcript's walk over a tool's
+/// argument object ([`crate::record`]). A fourth place with its own list is a fourth place to
+/// forget an entry.
+pub(crate) fn is_secret_name(name: &str) -> bool {
+    SECRET_PARAMS
+        .iter()
+        .any(|p| p.eq_ignore_ascii_case(name.trim()))
+}
 
 /// What a connection whose structure cannot be trusted is reported as, in full. See [`redact`].
 const OPAQUE: &str = "<connection redacted>";
@@ -173,9 +185,7 @@ impl<'a> Param<'a> {
     }
 
     fn is_secret(&self) -> bool {
-        SECRET_PARAMS
-            .iter()
-            .any(|p| p.eq_ignore_ascii_case(self.name.trim()))
+        is_secret_name(self.name)
     }
 
     fn render(&self, secrets: Secrets, out: &mut String) {
@@ -257,6 +267,101 @@ fn redact(connection: &str) -> String {
         return OPAQUE.to_string();
     }
     Parsed::of(connection).render(Secrets::Mask)
+}
+
+/// Masks every secret parameter value in **arbitrary text**, wherever one appears in it.
+///
+/// [`redact`] is for a string that *is* a connection: it parses one, and hands back [`OPAQUE`] for
+/// anything whose structure it cannot trust — which is the right answer there and the wrong one
+/// here, where the input is a blob of JSON or a page of debugger output that happens to contain a
+/// connection somewhere inside it. Passing that through `redact` would mask the entire blob.
+///
+/// So this scans instead, and the two share the one thing that must not drift: [`SECRET_PARAMS`]
+/// and [`MASK`]. A secret is a *whole* parameter name (`pubkey=` is not `key=`, matched the same
+/// way [`Param::is_secret`] matches), followed by `=` or a JSON `:`, and its value is masked
+/// whether it is bare (`key=1.2.3.4`, as a connection string writes it) or quoted
+/// (`"key": "1.2.3.4"`, as a tool call does).
+///
+/// Written for [`crate::record`], where the argument object of an `attach_kernel` that supplied a
+/// raw `connection` is the one place a KDNET key can still reach a file this server writes. It
+/// scans rather than reaches into the JSON because the text half of a result is not JSON at all,
+/// and a transcript that protected only the structured half would leak through the other one.
+pub(crate) fn scrub(text: &str) -> String {
+    let bytes = text.as_bytes();
+    let mut out = String::with_capacity(text.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        match secret_at(text, i) {
+            Some((value, end)) => {
+                out.push_str(&text[i..value]);
+                out.push_str(MASK);
+                i = end;
+            }
+            None => {
+                // Advance one *character*, not one byte: the index has to stay on a boundary for
+                // the slicing above, and this text is arbitrary — a debugger's output carries
+                // whatever the target is named.
+                let step = text[i..].chars().next().map_or(1, char::len_utf8);
+                out.push_str(&text[i..i + step]);
+                i += step;
+            }
+        }
+    }
+    out
+}
+
+/// A secret parameter starting at `i`, as `(where its value starts, where it ends)`.
+///
+/// Two syntaxes and no others: `key=…`, how a connection string writes it, and `"key":…`, how JSON
+/// does. Requiring the quote before a `:` is what keeps this off ordinary prose — a debugger
+/// printing `Key: \REGISTRY\MACHINE\…` is not a parameter, and a transcript that masked it would
+/// lose a fact to a rule about a different syntax. The bare `key:` form is not a connection string
+/// either, so nothing that can carry a real key is given up for that.
+///
+/// `None` also when the value is empty, which neither this nor [`Parsed::render`] masks: there is
+/// nothing there to hide, and a `key=<redacted>` grown out of `key=` would report a secret that
+/// was never supplied.
+fn secret_at(text: &str, i: usize) -> Option<(usize, usize)> {
+    let rest = &text[i..];
+    // `get`, not a slice: `i` is a character boundary but `i + name.len()` need not be, and this
+    // text is whatever a target chose to call itself.
+    let name = SECRET_PARAMS.iter().find(|p| {
+        rest.get(..p.len())
+            .is_some_and(|s| s.eq_ignore_ascii_case(p))
+    })?;
+    // Whole-name matching at the front: `pubkey=` is not `key=`. The back is settled by what may
+    // follow — a quote or the separator — so `keyring=` cannot match either.
+    if text[..i].chars().next_back().is_some_and(name_char) {
+        return None;
+    }
+    let mut at = i + name.len();
+    let quoted_name = text[at..].starts_with('"');
+    at += usize::from(quoted_name);
+    match (quoted_name, text[at..].chars().next()?) {
+        (false, '=') | (true, ':') => at += 1,
+        _ => return None,
+    }
+    // Filler after the separator is ordinary in JSON and refused in a connection string
+    // ([`is_ambiguous`]), and skipping it here can only ever mask a value already committed to
+    // being a secret's.
+    at = text.len() - text[at..].trim_start().len();
+    let quoted = text[at..].starts_with('"');
+    let start = at + usize::from(quoted);
+    let body = &text[start..];
+    let len = match quoted {
+        // Up to the closing quote. None of these values contains an escaped one, and stopping
+        // early would mask a shorter run than the value — never a longer one.
+        true => body.find('"').unwrap_or(body.len()),
+        false => body
+            .find(|c: char| c.is_whitespace() || matches!(c, ',' | ';' | '"' | '}' | ']'))
+            .unwrap_or(body.len()),
+    };
+    (len > 0).then_some((start, start + len))
+}
+
+/// Whether a character can be part of a parameter name, for the whole-name test in [`secret_at`].
+fn name_char(c: char) -> bool {
+    c.is_alphanumeric() || c == '_' || c == '-'
 }
 
 /// A character with no unambiguous place *between* the parameters of a connection string.
@@ -954,6 +1059,106 @@ mod tests {
         }
         // Nothing to mask is not the same as something to hide.
         assert_eq!(redact("net:port=1,key="), "net:port=1,key=");
+    }
+
+    // ---- scrubbing arbitrary text --------------------------------------
+    //
+    // The transcript's half of redaction. `redact` answers "render this connection safely";
+    // `scrub` answers "there may be one somewhere in this blob", which is a different question
+    // with a different failure mode — masking the blob.
+
+    /// The case the whole function exists for: a tool call carrying a raw connection, exactly as
+    /// it crosses the wire, recorded into a file.
+    #[test]
+    fn scrubbing_masks_a_key_inside_a_tool_call() {
+        let call = format!(r#"{{"connection":"{FAKE}","session_id":null}}"#);
+        let out = scrub(&call);
+        assert!(!out.contains(FAKE_KEY), "the key survived scrubbing: {out}");
+        assert_eq!(
+            out,
+            r#"{"connection":"net:port=50000,key=<redacted>","session_id":null}"#
+        );
+    }
+
+    /// The other shape a secret arrives in: a JSON member of its own, quoted both sides.
+    #[test]
+    fn scrubbing_masks_a_quoted_json_member() {
+        assert_eq!(
+            scrub(r#"{"key":"1.2.3.4","port":50000}"#),
+            r#"{"key":"<redacted>","port":50000}"#
+        );
+        // Pretty-printed, where a space follows the colon.
+        assert_eq!(
+            scrub("{\n  \"password\": \"hunter2\"\n}"),
+            "{\n  \"password\": \"<redacted>\"\n}"
+        );
+    }
+
+    /// A blob is not a connection string, so nothing but the parameter may be touched. This is
+    /// what `redact` cannot do: given any of these it answers `OPAQUE` for the whole thing.
+    #[test]
+    fn scrubbing_leaves_the_text_around_a_secret_alone() {
+        let text = "attaching to net:port=50000,key=1.2.3.4 (profile CTF)\nlink up in 25s";
+        assert_eq!(
+            scrub(text),
+            "attaching to net:port=50000,key=<redacted> (profile CTF)\nlink up in 25s"
+        );
+        assert_eq!(scrub(""), "");
+        for clean in ["no secret here", "net:port=50000", "{\"tag\":\"Tgsm\"}"] {
+            assert_eq!(scrub(clean), clean);
+        }
+    }
+
+    /// Whole names only, at both ends, and the same rule the parser uses.
+    #[test]
+    fn scrubbing_matches_whole_parameter_names_only() {
+        for untouched in ["pubkey=abc", "keyring=abc", "monkey=abc", "my-key=abc"] {
+            assert_eq!(scrub(untouched), untouched);
+        }
+        // Case-insensitive, like `is_secret`.
+        assert_eq!(scrub("KEY=1.2.3.4"), "KEY=<redacted>");
+        assert_eq!(scrub("Password=hunter2"), "Password=<redacted>");
+    }
+
+    /// The reason a bare `key:` is not a separator. A debugger printing a registry path is prose,
+    /// and a transcript that masked it would lose a fact to a rule about connection strings —
+    /// while giving up nothing, because no connection string is written that way.
+    #[test]
+    fn scrubbing_does_not_mask_prose_that_merely_says_key() {
+        for prose in [
+            r"Key: \REGISTRY\MACHINE\SYSTEM",
+            "the key is in the profile",
+            "password rotation is monthly",
+        ] {
+            assert_eq!(scrub(prose), prose);
+        }
+    }
+
+    /// An empty value is not a secret. `redact` takes the same view, and the two must agree:
+    /// reporting `<redacted>` where nothing was supplied describes a target that does not exist.
+    #[test]
+    fn scrubbing_leaves_an_empty_value_alone() {
+        for empty in ["net:port=1,key=", r#"{"key":""}"#, "key= "] {
+            assert_eq!(scrub(empty), empty);
+        }
+    }
+
+    /// Several in one blob, which is what a batch of tool calls looks like.
+    #[test]
+    fn scrubbing_masks_every_secret_in_the_text() {
+        let out = scrub("key=1.2.3.4 then password=hunter2 then key=5.6.7.8");
+        assert_eq!(
+            out,
+            "key=<redacted> then password=<redacted> then key=<redacted>"
+        );
+    }
+
+    /// Arbitrary text really is arbitrary: a target names its own modules, and a scan that
+    /// advanced by bytes would panic on the first one that is not ASCII.
+    #[test]
+    fn scrubbing_survives_text_that_is_not_ascii() {
+        let text = "модуль ключ ✓ key=1.2.3.4 ✓";
+        assert_eq!(scrub(text), "модуль ключ ✓ key=<redacted> ✓");
     }
 
     #[test]

--- a/src/kdconn.rs
+++ b/src/kdconn.rs
@@ -351,9 +351,11 @@ fn secret_at(text: &str, i: usize) -> Option<(usize, usize)> {
     let start = at + usize::from(quoted);
     let body = &text[start..];
     let len = match quoted {
-        // Up to the closing quote. None of these values contains an escaped one, and stopping
-        // early would mask a shorter run than the value — never a longer one.
-        true => body.find('"').unwrap_or(body.len()),
+        // Up to the closing quote — the first *unescaped* one. Stopping at an escaped quote would
+        // mask the head of the value and leave its tail in the file, which is the one way this
+        // scan can fail that produces a plausible-looking redacted line with the secret still in
+        // it. A `.server` password may contain anything a shell will pass.
+        true => closing_quote(body),
         false => body
             .find(|c: char| c.is_whitespace() || matches!(c, ',' | ';' | '"' | '}' | ']'))
             .unwrap_or(body.len()),
@@ -364,6 +366,25 @@ fn secret_at(text: &str, i: usize) -> Option<(usize, usize)> {
 /// Whether a character can be part of a parameter name, for the whole-name test in [`secret_at`].
 fn name_char(c: char) -> bool {
     c.is_alphanumeric() || c == '_' || c == '-'
+}
+
+/// How far a quoted value runs: to the first quote not preceded by an odd number of backslashes,
+/// or to the end of the text if it is unterminated.
+///
+/// JSON's own escaping rule, and it has to be honoured rather than approximated: `"hunter\"x"` is
+/// one value of `hunter"x`, and a scan that stopped at the inner quote would mask `hunter\` and
+/// leave `x` behind — a line that *looks* redacted while still carrying part of the secret.
+fn closing_quote(body: &str) -> usize {
+    let mut escaped = false;
+    for (at, c) in body.char_indices() {
+        match c {
+            _ if escaped => escaped = false,
+            '\\' => escaped = true,
+            '"' => return at,
+            _ => {}
+        }
+    }
+    body.len()
 }
 
 /// How many bytes of filler start at `at`: spaces and tabs, and **never a line break**.
@@ -1176,6 +1197,26 @@ mod tests {
             scrub(r#"{"password" : "hunter2"}"#),
             r#"{"password" : "<redacted>"}"#
         );
+    }
+
+    /// A quoted value ends at the first *unescaped* quote.
+    ///
+    /// The failure this prevents is the worst shape a redaction bug takes: a line that reads as
+    /// redacted while still carrying the tail of the secret. Stopping at the escaped quote would
+    /// mask `hunter\` and leave `suffix` in the transcript.
+    #[test]
+    fn scrubbing_masks_a_quoted_value_that_contains_a_quote() {
+        assert_eq!(
+            scrub(r#"{"password":"hunter\"suffix"}"#),
+            r#"{"password":"<redacted>"}"#
+        );
+        // A trailing backslash is escaped itself, so the quote after it really does close.
+        assert_eq!(
+            scrub(r#"{"password":"hunter\\"}"#),
+            r#"{"password":"<redacted>"}"#
+        );
+        // Unterminated: everything to the end is the value, which errs toward masking.
+        assert_eq!(scrub(r#"{"key":"1.2.3.4"#), r#"{"key":"<redacted>"#);
     }
 
     /// Filler stops at the end of the line, which is the difference between "no value" and "the

--- a/src/kdconn.rs
+++ b/src/kdconn.rs
@@ -22,9 +22,10 @@
 //! whose key is not configured anywhere has to be reachable, and an operator driving this server
 //! by hand should not have to write a config file first.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 use std::path::{Path, PathBuf};
+use std::sync::Mutex;
 
 use serde::{Deserialize, Serialize};
 
@@ -80,8 +81,17 @@ const NAME_LIMIT: usize = 64;
 pub struct Connection(String);
 
 impl Connection {
+    /// Wraps a raw connection string, and **remembers its secrets** so they can be masked by value
+    /// wherever they later turn up — see [`KNOWN_SECRETS`].
+    ///
+    /// Here because this is the one door: a profile resolved on this host and a raw `connection`
+    /// argument both become a `Connection`, and nothing dials without one. Registering at the
+    /// parse rather than at each caller is the same reasoning as `is_secret_name` having one
+    /// definition — a second place to remember is a place to forget.
     pub fn new(raw: impl Into<String>) -> Self {
-        Self(raw.into())
+        let raw = raw.into();
+        remember_secrets(&raw);
+        Self(raw)
     }
 
     /// The raw string, key and all — for handing to DbgEng and nothing else.
@@ -188,6 +198,13 @@ impl<'a> Param<'a> {
         is_secret_name(self.name)
     }
 
+    /// This parameter's value if it is a secret one, for [`remember_secrets`]. Blank values are
+    /// not secrets — the same rule [`Self::render`] applies when it decides whether to mask.
+    fn secret_value(&self) -> Option<&'a str> {
+        self.value
+            .filter(|v| self.is_secret() && !v.trim().is_empty())
+    }
+
     fn render(&self, secrets: Secrets, out: &mut String) {
         out.push_str(self.name);
         if let Some(value) = self.value {
@@ -269,24 +286,60 @@ fn redact(connection: &str) -> String {
     Parsed::of(connection).render(Secrets::Mask)
 }
 
-/// Masks every secret parameter value in **arbitrary text**, wherever one appears in it.
+/// Every secret this server has been handed, so it can be masked by **value** wherever it turns up.
+///
+/// This is the half of [`scrub`] that is a guarantee rather than a net, and it exists because the
+/// other half kept losing. A scan for `key=…` has to anticipate a syntax; review found it missing
+/// whitespace around the separator, then a line break after it, then an escaped quote inside the
+/// value, then a backslash-escaped member name — four shapes of one string, and no reason to think
+/// the list was finished. Knowing the actual value ends that: a key masked because it *is* the key
+/// does not care how it was written, escaped, quoted or split across a sentence.
+///
+/// Populated by [`Connection::new`], which every connection this server dials goes through, from a
+/// profile or from a raw argument alike. Bounded by the number of distinct targets a host talks to,
+/// which is a handful; nothing is ever removed, because a key stays a secret after its session ends.
+static KNOWN_SECRETS: Mutex<BTreeSet<String>> = Mutex::new(BTreeSet::new());
+
+/// Shorter than this and a value is not masked by [`KNOWN_SECRETS`].
+///
+/// A secret short enough to occur by accident would mask the text around it rather than itself: a
+/// key of `1` would blank every digit in a transcript. Real ones are far longer — a KDNET key is
+/// four dotted numbers — so the floor costs nothing and stops the mechanism from being worse than
+/// the leak it prevents.
+const MASKABLE_SECRET: usize = 6;
+
+/// Remembers the secret parameter values of `connection`, so [`scrub`] can mask them by value.
+fn remember_secrets(connection: &str) {
+    let mut known = KNOWN_SECRETS.lock().unwrap_or_else(|e| e.into_inner());
+    for param in &Parsed::of(connection).params {
+        if let Some(value) = param.secret_value().filter(|v| v.len() >= MASKABLE_SECRET) {
+            known.insert(value.to_string());
+        }
+    }
+}
+
+/// Masks every secret in **arbitrary text**, wherever one appears in it.
 ///
 /// [`redact`] is for a string that *is* a connection: it parses one, and hands back [`OPAQUE`] for
 /// anything whose structure it cannot trust — which is the right answer there and the wrong one
 /// here, where the input is a blob of JSON or a page of debugger output that happens to contain a
 /// connection somewhere inside it. Passing that through `redact` would mask the entire blob.
 ///
-/// So this scans instead, and the two share the one thing that must not drift: [`SECRET_PARAMS`]
-/// and [`MASK`]. A secret is a *whole* parameter name (`pubkey=` is not `key=`, matched the same
-/// way [`Param::is_secret`] matches), followed by `=` or a JSON `:`, and its value is masked
-/// whether it is bare (`key=1.2.3.4`, as a connection string writes it) or quoted
-/// (`"key": "1.2.3.4"`, as a tool call does).
+/// Two mechanisms, and the order matters because they are not equally strong:
 ///
-/// Written for [`crate::record`], where the argument object of an `attach_kernel` that supplied a
-/// raw `connection` is the one place a KDNET key can still reach a file this server writes. It
-/// scans rather than reaches into the JSON because the text half of a result is not JSON at all,
-/// and a transcript that protected only the structured half would leak through the other one.
+/// 1. **By value.** Every secret this server has been given is masked wherever it occurs, in any
+///    syntax at all — see [`KNOWN_SECRETS`]. This is the guarantee: a key that reached this process
+///    cannot leave it in a transcript, however the text around it is written.
+/// 2. **By pattern**, as a net under it: a *whole* parameter name (`pubkey=` is not `key=`, matched
+///    the way [`Param::is_secret`] matches), a separator, and a value — bare (`key=1.2.3.4`, as a
+///    connection string writes it) or quoted (`"key": "1.2.3.4"`, as a tool call does, escaped or
+///    not). This catches a secret this server has never seen, such as one a target printed itself.
+///    It is **best-effort**, and deliberately described as such: it has to guess a syntax, and the
+///    guesses that have been wrong so far were all found by someone looking, not by it failing
+///    loudly. Anything relying on redaction relies on (1).
 pub(crate) fn scrub(text: &str) -> String {
+    let masked = mask_known_values(text);
+    let text: &str = &masked;
     let bytes = text.as_bytes();
     let mut out = String::with_capacity(text.len());
     let mut i = 0;
@@ -308,6 +361,27 @@ pub(crate) fn scrub(text: &str) -> String {
         }
     }
     out
+}
+
+/// Replaces every known secret value with [`MASK`], wherever it occurs.
+///
+/// Borrowed back unchanged in the ordinary case, which is every call on a host that has never
+/// dialled a target with a key.
+fn mask_known_values(text: &str) -> std::borrow::Cow<'_, str> {
+    let known = KNOWN_SECRETS.lock().unwrap_or_else(|e| e.into_inner());
+    let present: Vec<&String> = known.iter().filter(|s| text.contains(s.as_str())).collect();
+    if present.is_empty() {
+        return std::borrow::Cow::Borrowed(text);
+    }
+    // Longest first, so a secret that contains another is masked whole rather than being cut into
+    // a mask and a remainder.
+    let mut present = present;
+    present.sort_by_key(|s| std::cmp::Reverse(s.len()));
+    let mut out = text.to_string();
+    for secret in present {
+        out = out.replace(secret.as_str(), MASK);
+    }
+    std::borrow::Cow::Owned(out)
 }
 
 /// A secret parameter starting at `i`, as `(where its value starts, where it ends)`.
@@ -335,8 +409,11 @@ fn secret_at(text: &str, i: usize) -> Option<(usize, usize)> {
         return None;
     }
     let mut at = i + name.len();
-    let quoted_name = text[at..].starts_with('"');
-    at += usize::from(quoted_name);
+    // A quote, optionally backslash-escaped: debugger output and log lines quote JSON inside
+    // strings, so the member name's own delimiter arrives as `\"` rather than `"`.
+    let escaped_name = text[at..].starts_with("\\\"");
+    let quoted_name = escaped_name || text[at..].starts_with('"');
+    at += usize::from(quoted_name) + usize::from(escaped_name);
     // Filler on **both** sides of the separator, because a secret arrives in text somebody typed.
     // `net:port=1, key = 1.2.3.4` is refused by [`is_dialable`] — but only after it has already
     // been recorded as an argument, so a scan that required `key=` exactly would mask the key in
@@ -347,15 +424,16 @@ fn secret_at(text: &str, i: usize) -> Option<(usize, usize)> {
         _ => return None,
     }
     at += inline_gap(text, at);
-    let quoted = text[at..].starts_with('"');
-    let start = at + usize::from(quoted);
+    let escaped_value = text[at..].starts_with("\\\"");
+    let quoted = escaped_value || text[at..].starts_with('"');
+    let start = at + usize::from(quoted) + usize::from(escaped_value);
     let body = &text[start..];
     let len = match quoted {
-        // Up to the closing quote — the first *unescaped* one. Stopping at an escaped quote would
-        // mask the head of the value and leave its tail in the file, which is the one way this
-        // scan can fail that produces a plausible-looking redacted line with the secret still in
-        // it. A `.server` password may contain anything a shell will pass.
-        true => closing_quote(body),
+        // Up to the closing quote, which is `\"` when the opening one was escaped and a plain
+        // unescaped `"` otherwise. Stopping in the wrong place would mask the head of the value
+        // and leave its tail in the file — the one way this scan fails that produces a
+        // plausible-looking redacted line with the secret still in it.
+        true => closing_quote(body, escaped_value),
         false => body
             .find(|c: char| c.is_whitespace() || matches!(c, ',' | ';' | '"' | '}' | ']'))
             .unwrap_or(body.len()),
@@ -368,18 +446,25 @@ fn name_char(c: char) -> bool {
     c.is_alphanumeric() || c == '_' || c == '-'
 }
 
-/// How far a quoted value runs: to the first quote not preceded by an odd number of backslashes,
-/// or to the end of the text if it is unterminated.
+/// How far a quoted value runs, to its closing delimiter or to the end of an unterminated one.
 ///
-/// JSON's own escaping rule, and it has to be honoured rather than approximated: `"hunter\"x"` is
-/// one value of `hunter"x`, and a scan that stopped at the inner quote would mask `hunter\` and
-/// leave `x` behind — a line that *looks* redacted while still carrying part of the secret.
-fn closing_quote(body: &str) -> usize {
-    let mut escaped = false;
+/// Which delimiter depends on how it was opened, and both spellings occur in text this server
+/// records. In JSON, `"hunter\"x"` is one value of `hunter"x`, so the close is the first quote
+/// *not* escaped — a scan stopping at the inner one would mask `hunter\` and leave `x` behind. In
+/// JSON that has itself been quoted into a string, which is how a log line carries a request it is
+/// quoting, every delimiter is written `\"` and the close is that pair.
+///
+/// Getting this wrong is the failure worth naming: a line that *looks* redacted while still
+/// carrying part of the secret is worse than one that plainly does not.
+fn closing_quote(body: &str, escaped: bool) -> usize {
+    if escaped {
+        return body.find("\\\"").unwrap_or(body.len());
+    }
+    let mut after_backslash = false;
     for (at, c) in body.char_indices() {
         match c {
-            _ if escaped => escaped = false,
-            '\\' => escaped = true,
+            _ if after_backslash => after_backslash = false,
+            '\\' => after_backslash = true,
             '"' => return at,
             _ => {}
         }
@@ -1199,6 +1284,52 @@ mod tests {
         );
     }
 
+    /// Masking **by value** is the half of `scrub` that is a guarantee, and this is what it buys:
+    /// the same key written four ways that the pattern scan handles differently, and one it does
+    /// not handle at all, all masked because they *are* the key.
+    ///
+    /// Three rounds of review found three separate syntaxes the scan missed. Chasing a fourth was
+    /// the wrong move; knowing the value ends the category.
+    #[test]
+    fn a_known_secret_is_masked_however_it_is_written() {
+        // Registered the way every real one is: by being dialled.
+        let _ = Connection::new("net:port=50011,key=203.0.113.77");
+        for written in [
+            // The shapes the scan also catches, for the avoidance of doubt.
+            "net:port=50011,key=203.0.113.77",
+            r#"{"connection":"net:port=50011,key=203.0.113.77"}"#,
+            // And the ones it does not: no parameter name in sight.
+            "the key for that box is 203.0.113.77, do not share it",
+            "KDNET_KEY=203.0.113.77",
+            r#"{"note":"reconnect with 203.0.113.77"}"#,
+            "203.0.113.77",
+        ] {
+            let out = scrub(written);
+            assert!(
+                !out.contains("203.0.113.77"),
+                "a key this server was handed survived as `{out}`"
+            );
+            assert!(
+                out.contains(MASK),
+                "and it should say something was masked: {out}"
+            );
+        }
+    }
+
+    /// A value too short to be a real secret is not masked, because masking it would do more
+    /// damage than the leak: a key of `1` would blank every digit in a transcript.
+    #[test]
+    fn a_secret_too_short_to_be_one_is_not_masked_by_value() {
+        let _ = Connection::new("net:port=1,key=1.2");
+        assert_eq!(
+            scrub("the value 1.2 appears often"),
+            "the value 1.2 appears often"
+        );
+        // The pattern scan still covers it where it is written as a parameter, which is the only
+        // place a two-character key means anything.
+        assert_eq!(scrub("key=1.2"), "key=<redacted>");
+    }
+
     /// A quoted value ends at the first *unescaped* quote.
     ///
     /// The failure this prevents is the worst shape a redaction bug takes: a line that reads as
@@ -1219,6 +1350,20 @@ mod tests {
         assert_eq!(scrub(r#"{"key":"1.2.3.4"#), r#"{"key":"<redacted>"#);
     }
 
+    /// JSON quoted inside a string arrives with its own delimiters escaped, which is how a
+    /// debugger's output and a log line carry a request they are quoting.
+    #[test]
+    fn scrubbing_masks_a_secret_whose_json_is_itself_escaped() {
+        assert_eq!(
+            scrub(r#"request was {\"password\":\"hunter2\"}"#),
+            r#"request was {\"password\":\"<redacted>\"}"#
+        );
+        assert_eq!(
+            scrub(r#"{\"key\": \"1.2.3.4\"}"#),
+            r#"{\"key\": \"<redacted>\"}"#
+        );
+    }
+
     /// Filler stops at the end of the line, which is the difference between "no value" and "the
     /// next line".
     ///
@@ -1227,10 +1372,12 @@ mod tests {
     /// there was an empty value and losing a fact from the transcript.
     #[test]
     fn scrubbing_does_not_run_past_the_end_of_a_line() {
+        // Values no other test registers: `KNOWN_SECRETS` is process-wide on purpose, so a test
+        // asserting something is *not* masked cannot reuse a key another test has dialled.
         for across in [
             "key=\nnt!KeBugCheckEx",
-            "net:port=1,key=\n1.2.3.4",
-            "password=\r\nhunter2",
+            "net:port=1,key=\n198.51.100.4",
+            "password=\r\nnotasecrethere",
         ] {
             assert_eq!(scrub(across), across);
         }

--- a/src/kdconn.rs
+++ b/src/kdconn.rs
@@ -337,14 +337,16 @@ fn secret_at(text: &str, i: usize) -> Option<(usize, usize)> {
     let mut at = i + name.len();
     let quoted_name = text[at..].starts_with('"');
     at += usize::from(quoted_name);
+    // Filler on **both** sides of the separator, because a secret arrives in text somebody typed.
+    // `net:port=1, key = 1.2.3.4` is refused by [`is_dialable`] — but only after it has already
+    // been recorded as an argument, so a scan that required `key=` exactly would mask the key in
+    // the connections this server accepts and miss it in the one it turns away.
+    at += inline_gap(text, at);
     match (quoted_name, text[at..].chars().next()?) {
         (false, '=') | (true, ':') => at += 1,
         _ => return None,
     }
-    // Filler after the separator is ordinary in JSON and refused in a connection string
-    // ([`is_ambiguous`]), and skipping it here can only ever mask a value already committed to
-    // being a secret's.
-    at = text.len() - text[at..].trim_start().len();
+    at += inline_gap(text, at);
     let quoted = text[at..].starts_with('"');
     let start = at + usize::from(quoted);
     let body = &text[start..];
@@ -362,6 +364,19 @@ fn secret_at(text: &str, i: usize) -> Option<(usize, usize)> {
 /// Whether a character can be part of a parameter name, for the whole-name test in [`secret_at`].
 fn name_char(c: char) -> bool {
     c.is_alphanumeric() || c == '_' || c == '-'
+}
+
+/// How many bytes of filler start at `at`: spaces and tabs, and **never a line break**.
+///
+/// The distinction is what keeps [`secret_at`] from running off the end of a line. `key=` with
+/// nothing after it is an empty value — which is not a secret and is left alone — while a scan
+/// that treated the newline as filler would decide the first token of the *next* line was the
+/// key's value and mask that instead. Debugger output is full of lines that end in `=`.
+fn inline_gap(text: &str, at: usize) -> usize {
+    text[at..]
+        .bytes()
+        .take_while(|b| *b == b' ' || *b == b'\t')
+        .count()
 }
 
 /// A character with no unambiguous place *between* the parameters of a connection string.
@@ -1140,6 +1155,43 @@ mod tests {
     fn scrubbing_leaves_an_empty_value_alone() {
         for empty in ["net:port=1,key=", r#"{"key":""}"#, "key= "] {
             assert_eq!(scrub(empty), empty);
+        }
+    }
+
+    /// Filler around the separator, which is how a *person* writes a connection string.
+    ///
+    /// This is the shape [`is_dialable`] refuses — and it is refused only after the argument has
+    /// already been recorded, so a scan that insisted on `key=` exactly would mask the key in the
+    /// connections this server accepts and miss it in the one it turns away.
+    #[test]
+    fn scrubbing_masks_a_secret_with_filler_around_the_separator() {
+        assert_eq!(
+            scrub("net:port=50000, key = 1.2.3.4"),
+            "net:port=50000, key = <redacted>"
+        );
+        assert_eq!(scrub("key\t=\t1.2.3.4"), "key\t=\t<redacted>");
+        // The JSON spelling of the same thing. `serde_json` does not emit it, but `scrub` also
+        // runs over result text, which is whatever the target printed.
+        assert_eq!(
+            scrub(r#"{"password" : "hunter2"}"#),
+            r#"{"password" : "<redacted>"}"#
+        );
+    }
+
+    /// Filler stops at the end of the line, which is the difference between "no value" and "the
+    /// next line".
+    ///
+    /// A trim that skipped every whitespace character masked the first token *after* the line
+    /// break — so `key=` at the end of a line ate the symbol below it, reporting a secret where
+    /// there was an empty value and losing a fact from the transcript.
+    #[test]
+    fn scrubbing_does_not_run_past_the_end_of_a_line() {
+        for across in [
+            "key=\nnt!KeBugCheckEx",
+            "net:port=1,key=\n1.2.3.4",
+            "password=\r\nhunter2",
+        ] {
+            assert_eq!(scrub(across), across);
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -91,11 +91,17 @@ fn render_cast(args: &[String]) -> Result<()> {
     };
     let summary = cast::render(&options).map_err(|e| anyhow::anyhow!("{e}"))?;
     println!(
-        "wrote {} — {} frame(s) from {} record(s), {:.1}s of session",
+        "wrote {} — {} frame(s) from {} record(s), {:.1}s of session{}",
         options.output.display(),
         summary.frames,
         summary.records,
-        summary.duration_ms as f64 / 1000.0
+        summary.duration_ms as f64 / 1000.0,
+        // Worth saying, because it explains a recording longer than any one session was: a
+        // transcript is appended to, and the runs are laid end to end.
+        match summary.runs {
+            0 | 1 => String::new(),
+            runs => format!(" across {runs} server runs"),
+        }
     );
     // Loud, because it means part of the session is missing from the recording, and a renderer
     // that mentioned it only in a return value nobody reads would be hiding that.

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,11 +6,18 @@
 //! [`worker::WORKER_FLAG`] it is an **engine worker**, owning exactly one debug session — which
 //! is what dbgeng.dll's one-session-per-process rule makes the natural unit, and what lets a
 //! session that cannot be unwound be killed without taking the server with it.
+//!
+//! There is also a third, which is not a server at all: [`cast::RENDER_FLAG`] turns a recorded
+//! transcript into a terminal recording and exits. It touches neither DbgEng nor MCP, and it is
+//! here rather than in a second binary because it reads a format this crate defines — a renderer
+//! that could drift out of step with the writer is a renderer that will.
 
 mod batch;
+mod cast;
 mod engine;
 mod kdconn;
 mod proto;
+mod record;
 mod server;
 mod structured;
 mod triage;
@@ -61,11 +68,46 @@ fn main() -> Result<()> {
         // inherited pipe handles, which is why a worker started by hand cannot get anywhere.
         worker::run(&args);
     }
+    if let Some(at) = args.iter().position(|arg| arg == cast::RENDER_FLAG) {
+        // Before the runtime: this reads a file and writes a file, and neither wants one.
+        return render_cast(&args[at + 1..]);
+    }
 
     tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()?
         .block_on(serve())
+}
+
+/// The renderer role: a transcript in, an asciicast out.
+///
+/// The one place in this binary that prints to standard output, and it is safe to: this role
+/// never speaks MCP, so there is no JSON-RPC transport to corrupt. It exits before `serve` is ever
+/// reached.
+fn render_cast(args: &[String]) -> Result<()> {
+    let options = match cast::Options::parse(args) {
+        Ok(options) => options,
+        Err(why) => anyhow::bail!("{why}\n\n{}", cast::USAGE),
+    };
+    let summary = cast::render(&options).map_err(|e| anyhow::anyhow!("{e}"))?;
+    println!(
+        "wrote {} — {} frame(s) from {} record(s), {:.1}s of session",
+        options.output.display(),
+        summary.frames,
+        summary.records,
+        summary.duration_ms as f64 / 1000.0
+    );
+    // Loud, because it means part of the session is missing from the recording, and a renderer
+    // that mentioned it only in a return value nobody reads would be hiding that.
+    if summary.unreadable > 0 {
+        println!(
+            "note: {} line(s) of `{}` could not be read and were skipped — the usual cause is a \
+             transcript whose last record was cut short by the server exiting mid-write",
+            summary.unreadable,
+            options.input.display()
+        );
+    }
+    Ok(())
 }
 
 /// stdout is the JSON-RPC transport, so all logging must go to stderr. A worker's stderr is
@@ -86,7 +128,9 @@ fn init_logging() {
 }
 
 async fn serve() -> Result<()> {
-    let sessions = Sessions::new(call_timeout());
+    // Opened before anything is served, so the transcript's first record is this run starting
+    // rather than whatever the first tool call happened to be.
+    let sessions = Sessions::new(call_timeout()).recording(record::Recorder::from_env());
     let server = WindbgServer::new(sessions.clone());
 
     tracing::info!("windbg-mcp starting on stdio");

--- a/src/record.rs
+++ b/src/record.rs
@@ -55,6 +55,7 @@
 //!   no buffering in this process, so an abrupt exit leaves whole records behind it.
 
 use std::fs::OpenOptions;
+use std::future::Future;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -400,6 +401,41 @@ impl InFlight {
             self.session = Some(session);
         }
     }
+}
+
+// ---- which session a call reached ------------------------------------------
+
+tokio::task_local! {
+    /// Where the tool call running on this task was routed.
+    ///
+    /// A task-local rather than a return value because the answer is discovered deep inside the
+    /// call — [`crate::engine::Sessions::resolve`] picks the current session for anyone who named
+    /// none — and is wanted by the recorder, forty-odd tool bodies further out. Threading it back
+    /// would mean changing the signature of every one of them to carry a fact none of them uses.
+    static ROUTED: Mutex<Option<String>>;
+}
+
+/// Runs `work` with somewhere to note the session it reaches, and hands back both.
+pub async fn tracking_route<F: Future>(work: F) -> (F::Output, Option<String>) {
+    ROUTED
+        .scope(Mutex::new(None), async move {
+            let outcome = work.await;
+            let routed = ROUTED.with(|r| r.lock().unwrap_or_else(|e| e.into_inner()).clone());
+            (outcome, routed)
+        })
+        .await
+}
+
+/// Notes that the work on this task reached `session`.
+///
+/// Called from **resolution** rather than from each tool, which is what makes it hard to forget:
+/// a tool that resolves a session by any route is recorded, including the two that do it by hand
+/// instead of going through `run_call`. Silent outside a scope, because the in-process tests call
+/// tool bodies directly and a missing transcript is not a reason to fail a debug call.
+pub fn routed_to(session: &str) {
+    let _ = ROUTED.try_with(|routed| {
+        *routed.lock().unwrap_or_else(|e| e.into_inner()) = Some(session.to_string());
+    });
 }
 
 // ---- the records ----------------------------------------------------------

--- a/src/record.rs
+++ b/src/record.rs
@@ -43,14 +43,16 @@
 //! * **Never the MCP transport.** The process's standard output is JSON-RPC. This writes to its
 //!   own file, opened here, and to nothing else — a test in this module holds that line by
 //!   reading the source.
-//! * **Redacted.** Every string that goes in is scrubbed for KDNET keys and remote passwords
-//!   ([`kdconn::scrub`]), and an argument member *named* like a secret is masked whole. Profiles
-//!   keep a key out of the request in the first place; this is what covers a caller who passed a
-//!   raw `connection` anyway.
+//! * **Redacted.** Every string that goes in passes [`kdconn::scrub`], which masks a secret this
+//!   server has been handed **by value** — in any syntax, that being the guarantee — and scans for
+//!   `key=`/`password=` as a best-effort net under it. An argument member *named* like a secret is
+//!   masked whole. Profiles keep a key out of the request in the first place; this covers a caller
+//!   who passed a raw `connection` anyway.
 //! * **Bounded, and says so.** A rendering can be megabytes. Fields are capped at
 //!   [`FIELD_LIMIT_ENV`] bytes and the record says how much was dropped, rather than being
 //!   silently short — a transcript that quietly truncates is worse than one that does not exist,
-//!   because it reads as complete.
+//!   because it reads as complete. A whole record is bounded too
+//!   ([`Recorder::over_ceiling`]), which is what holds the promise for a field somebody forgot.
 //! * **Parseable after a crash.** One record is one `write_all` to a file opened for append, with
 //!   no buffering in this process, so an abrupt exit leaves whole records behind it.
 
@@ -87,6 +89,10 @@ const DEFAULT_FIELD_LIMIT: usize = 16 * 1024;
 
 /// The record format's version, carried on every line so a reader never has to guess.
 pub const SCHEMA: u32 = 1;
+
+/// Headroom over the field cap for a whole record: its envelope, and the several capped fields
+/// one can carry. See [`Recorder::over_ceiling`].
+const RECORD_OVERHEAD: usize = 4096;
 
 // ---- the sink -------------------------------------------------------------
 
@@ -215,10 +221,13 @@ impl Recorder {
     pub fn write(&self, event: Event) {
         let Some(sink) = &self.0 else { return };
         let mut file = sink.file.lock().unwrap_or_else(|e| e.into_inner());
+        let record_seq = sink.seq.fetch_add(1, Ordering::Relaxed);
+        // Read before the event moves into the record, for the marker below.
+        let kind = name_of(&event);
         let record = Record {
             v: SCHEMA,
             run: sink.run,
-            seq: sink.seq.fetch_add(1, Ordering::Relaxed),
+            seq: record_seq,
             at: rfc3339(SystemTime::now()),
             mono_ms: ms(sink.started.elapsed()),
             event,
@@ -233,11 +242,55 @@ impl Recorder {
                 return;
             }
         };
+        // The backstop under the per-field caps. Those are applied field by field, by hand, and
+        // three rounds of review each found a field that had been missed — the derived batch
+        // details, a session's target, a caller's handle. Every one of them was a *new* place to
+        // remember, which is a losing shape. This bounds the record itself, so a field nobody
+        // capped — including one added later — cannot put an unbounded line in the file. It
+        // reports what it dropped rather than dropping it silently, and it is deliberately far
+        // above what a well-capped record reaches, so it fires only when something slipped past.
+        if let Some(bytes) = self.over_ceiling(&line) {
+            tracing::warn!(
+                "a transcript record of kind `{kind}` was {bytes} bytes, past the whole-record \
+                 ceiling, and was replaced by a marker: a field of it is not being capped"
+            );
+            let marker = Record {
+                v: SCHEMA,
+                run: sink.run,
+                seq: record_seq,
+                at: record.at,
+                mono_ms: record.mono_ms,
+                event: Event::Oversized { of: kind, bytes },
+            };
+            match serde_json::to_string(&marker) {
+                Ok(replacement) => line = replacement,
+                Err(e) => {
+                    tracing::error!("an oversized-record marker did not serialize: {e}");
+                    return;
+                }
+            }
+        }
         line.push('\n');
         // One `write_all` per record, on a file opened for append and with no buffer in front of
         // it: that is what leaves a parseable prefix behind an abrupt exit.
         if let Err(e) = file.write_all(line.as_bytes()) {
             tracing::error!("could not write a transcript record: {e}");
+        }
+    }
+
+    /// How big a serialized record is, if that is past the whole-record ceiling.
+    ///
+    /// The ceiling is the field cap with room for the several capped fields a record can hold and
+    /// its envelope — generous on purpose. It is not the bound the documentation promises, which
+    /// is per field; it is the thing that makes that promise hold even where a field was missed.
+    /// `None` when the cap is off, which is an operator asking for everything.
+    fn over_ceiling(&self, line: &str) -> Option<usize> {
+        match self.limit() {
+            0 => None,
+            limit => {
+                let ceiling = limit.saturating_mul(8).saturating_add(RECORD_OVERHEAD);
+                (line.len() > ceiling).then_some(line.len())
+            }
         }
     }
 
@@ -264,7 +317,7 @@ impl Recorder {
         let session = args
             .and_then(|a| a.get("session_id"))
             .and_then(Value::as_str)
-            .map(kdconn::scrub);
+            .map(|id| Capped::of(&kdconn::scrub(id), self.limit()).text);
         self.write(Event::ToolRequest {
             request,
             tool: tool.to_string(),
@@ -663,6 +716,12 @@ pub enum Event {
     },
     /// The server is going down and every session is being let go.
     Shutdown { sessions: usize },
+    /// A record that would have been past the whole-record ceiling, replaced by its size.
+    ///
+    /// Present so that a field which is not being capped shows up as a **fact in the transcript**
+    /// rather than as an enormous line. Seeing one means this module has a bug, not that the
+    /// session did something unusual — `of` names the event kind to look at.
+    Oversized { of: String, bytes: usize },
 }
 
 // ---- deriving the typed events --------------------------------------------
@@ -1336,6 +1395,46 @@ mod tests {
                 assert!(field.dropped.is_some(), "and it has to say so: {field:?}");
             }
         }
+    }
+
+    /// The whole-record ceiling: the backstop under the per-field caps.
+    ///
+    /// Three rounds of review each found a *different* field that had been missed — derived batch
+    /// details, a session's target, a caller's handle — because capping was something each new
+    /// field had to remember to do. This bounds the record itself, so the next missed field is a
+    /// marker in the transcript instead of an unbounded line, and says which kind to go and look
+    /// at. `tool` is the field used here because it is genuinely uncapped and genuinely the
+    /// caller's: an MCP client chooses the name it asks for.
+    #[test]
+    fn a_record_no_field_cap_bounded_is_replaced_by_a_marker() {
+        let path = std::env::temp_dir()
+            .join("windbg-mcp-transcript-tests")
+            .join(format!("ceiling-{}.jsonl", std::process::id()));
+        let _ = std::fs::remove_file(&path);
+        let rec = Recorder::to_file(&path, 64).expect("open the transcript");
+        let enormous = "t".repeat(64 * 8 + RECORD_OVERHEAD + 1);
+        let call = rec.tool_request(&enormous, None);
+        rec.tool_result(call, false, "", None);
+
+        let records = records(&path);
+        let Event::Oversized { of, bytes } = &records[1].event else {
+            panic!(
+                "expected the request to be replaced: {:?}",
+                records[1].event
+            )
+        };
+        assert_eq!(of, "tool_request");
+        assert!(*bytes > 64 * 8, "the marker says how big it was: {bytes}");
+        // The marker is a record like any other — numbered in sequence, so nothing is lost from
+        // the ordering, and small.
+        assert_eq!(records[1].seq, 1);
+        let longest = std::fs::read_to_string(&path)
+            .expect("the transcript")
+            .lines()
+            .map(str::len)
+            .max()
+            .unwrap_or(0);
+        assert!(longest <= 64 * 8 + RECORD_OVERHEAD, "{longest} bytes");
     }
 
     /// A tool this module knows nothing about contributes its result and no derived events. The

--- a/src/record.rs
+++ b/src/record.rs
@@ -1,0 +1,1269 @@
+//! The session transcript: an opt-in, server-side JSONL record of what this server was asked and
+//! what it did.
+//!
+//! A debugger server is the only party that sees the whole of a session — the tool call, the
+//! session it was routed to, the target's answer, the state the session moved to, the worker that
+//! died — and until now it recorded none of it. What existed instead were artifacts with opposite
+//! problems ([#87](https://github.com/glslang/windbg-mcp/issues/87)): a client's own log, which is
+//! tens of megabytes of prompts with the debugger operations buried inside shell-command source,
+//! and a hand-curated proof record, which is readable and is written afterwards from memory. The
+//! recordings in `examples/` say as much on their face — *"timing is illustrative because live
+//! recording was not enabled for the original run"*.
+//!
+//! # What it is not
+//!
+//! It is **not the log**. `tracing` reports on the server; this reports on the *session*, and the
+//! two answer to different readers. A log line is prose for whoever is debugging this server; a
+//! record here is a value, keyed by session and request, for a program that has to reconstruct
+//! what happened — or for [`crate::cast`], which renders the same stream as a terminal recording.
+//!
+//! # Where the records come from
+//!
+//! Every one is written by the **supervisor**, which is what makes this a single-writer file with
+//! no locking and no interleaving between processes. That is not a limitation: a worker's facts
+//! reach here as the typed half of its reply ([`crate::proto::Output::data`]), built on the side
+//! of the pipe where the engine's own types are in hand. So a stop position, a batch's verdict and
+//! its rollback state are recorded from [`crate::structured`] values — never re-read out of the
+//! rendering, which would measure the rendering ([#77](https://github.com/glslang/windbg-mcp/issues/77)).
+//!
+//! A worker inherits [`TRANSCRIPT_ENV`] like any other variable and never acts on it: the role
+//! check in [`crate::main`] runs before the server is built, so [`Recorder::from_env`] is only ever
+//! reached by the supervisor. Two processes appending to one file is a thing this design does not
+//! have to cope with because it cannot happen.
+//!
+//! # Safety properties, and why each one is here
+//!
+//! * **Opt-in.** Nothing is written unless [`TRANSCRIPT_ENV`] names a path. A debugger's output is
+//!   the contents of somebody's memory, and it is not this server's to spill into a file by
+//!   default.
+//! * **Never the MCP transport.** The process's standard output is JSON-RPC. This writes to its
+//!   own file, opened here, and to nothing else — a test in this module holds that line by
+//!   reading the source.
+//! * **Redacted.** Every string that goes in is scrubbed for KDNET keys and remote passwords
+//!   ([`kdconn::scrub`]), and an argument member *named* like a secret is masked whole. Profiles
+//!   keep a key out of the request in the first place; this is what covers a caller who passed a
+//!   raw `connection` anyway.
+//! * **Bounded, and says so.** A rendering can be megabytes. Fields are capped at
+//!   [`FIELD_LIMIT_ENV`] bytes and the record says how much was dropped, rather than being
+//!   silently short — a transcript that quietly truncates is worse than one that does not exist,
+//!   because it reads as complete.
+//! * **Parseable after a crash.** One record is one `write_all` to a file opened for append, with
+//!   no buffering in this process, so an abrupt exit leaves whole records behind it.
+
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::kdconn;
+use crate::structured::{
+    BatchReportInfo, BreakpointSet, ErrorCategory, Outcome, RunToReport, StopReport,
+};
+
+/// Names the file to record into. Absent — the ordinary case — and nothing is recorded at all.
+pub const TRANSCRIPT_ENV: &str = "WINDBG_MCP_TRANSCRIPT";
+
+/// Overrides [`DEFAULT_FIELD_LIMIT`], in bytes. `0` means no cap.
+pub const FIELD_LIMIT_ENV: &str = "WINDBG_MCP_TRANSCRIPT_MAX_FIELD";
+
+/// How much of one field is kept before it is truncated.
+///
+/// Chosen against what the fields actually hold. A typed answer is facts and is far under it; a
+/// rendering is what runs long — a module table, a pool census, a batch of a thousand steps — and
+/// 16 KiB is several screens of one. The whole point of the cap is that a transcript stays a
+/// record of the session rather than becoming a second copy of every byte the debugger printed,
+/// which is the failure the client's own log already demonstrates.
+const DEFAULT_FIELD_LIMIT: usize = 16 * 1024;
+
+/// The record format's version, carried on every line so a reader never has to guess.
+pub const SCHEMA: u32 = 1;
+
+// ---- the sink -------------------------------------------------------------
+
+/// A transcript sink. Cheap to clone and to call when disabled, which is the common case.
+#[derive(Clone)]
+pub struct Recorder(Option<Arc<Sink>>);
+
+/// Renders as where it is writing, and nothing else. A `Debug` that dumped the open file handle
+/// and the counters would be noise in every `{:?}` of a [`crate::engine::Session`], which is the
+/// only place this is ever printed.
+impl std::fmt::Debug for Recorder {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.path() {
+            Some(path) => write!(f, "Recorder({})", path.display()),
+            None => f.write_str("Recorder(off)"),
+        }
+    }
+}
+
+struct Sink {
+    /// The open file. A `Mutex` rather than a channel because a record must be *on disk* before
+    /// the call that produced it returns — a queue would lose the tail of a session precisely
+    /// when the server is going down, which is when a transcript earns its keep.
+    file: Mutex<std::fs::File>,
+    path: PathBuf,
+    /// Where `mono_ms` is measured from: this server's start, not the wall clock, so a record's
+    /// ordering survives a clock that steps.
+    started: Instant,
+    limit: usize,
+    seq: AtomicU64,
+    request: AtomicU64,
+}
+
+impl Recorder {
+    /// A recorder that writes nothing — for every run that did not ask for one, and for tests
+    /// that are not about recording.
+    pub fn disabled() -> Self {
+        Self(None)
+    }
+
+    /// Reads [`TRANSCRIPT_ENV`] and opens the file it names.
+    ///
+    /// A path that cannot be opened is **loud but not fatal**: an operator who asked for a
+    /// transcript and silently got none is badly served, and a debug session refused because a log
+    /// file would not open is served worse. So it reports the failure and runs without one.
+    pub fn from_env() -> Self {
+        let Some(path) = std::env::var_os(TRANSCRIPT_ENV).filter(|p| !p.is_empty()) else {
+            return Self::disabled();
+        };
+        let limit = field_limit();
+        match Self::to_file(Path::new(&path), limit) {
+            Ok(recorder) => {
+                tracing::info!(
+                    "recording a session transcript to {} (fields capped at {})",
+                    Path::new(&path).display(),
+                    match limit {
+                        0 => "no limit".to_string(),
+                        n => format!("{n} bytes"),
+                    }
+                );
+                recorder
+            }
+            Err(e) => {
+                tracing::error!(
+                    "{TRANSCRIPT_ENV} names `{}`, which could not be opened for recording ({e}); \
+                     this session is NOT being recorded",
+                    Path::new(&path).display()
+                );
+                Self::disabled()
+            }
+        }
+    }
+
+    /// Opens `path` for append and writes the header record.
+    ///
+    /// Append rather than truncate: two servers pointed at one path, or a second run of the same
+    /// one, must not silently erase what is already there. Each run's records are told apart by
+    /// the `start` record and its pid.
+    pub fn to_file(path: &Path, limit: usize) -> std::io::Result<Self> {
+        if let Some(parent) = path.parent().filter(|p| !p.as_os_str().is_empty()) {
+            std::fs::create_dir_all(parent)?;
+        }
+        let file = OpenOptions::new().create(true).append(true).open(path)?;
+        let recorder = Self(Some(Arc::new(Sink {
+            file: Mutex::new(file),
+            path: path.to_path_buf(),
+            started: Instant::now(),
+            limit,
+            seq: AtomicU64::new(0),
+            request: AtomicU64::new(0),
+        })));
+        recorder.write(Event::Start {
+            version: env!("CARGO_PKG_VERSION").to_string(),
+            pid: std::process::id(),
+            field_limit: limit,
+            schema: SCHEMA,
+        });
+        Ok(recorder)
+    }
+
+    pub fn enabled(&self) -> bool {
+        self.0.is_some()
+    }
+
+    /// Where records are going, for a caller that has to report it.
+    pub fn path(&self) -> Option<&Path> {
+        self.0.as_ref().map(|s| s.path.as_path())
+    }
+
+    /// Records `event`, stamped and numbered. Does nothing when disabled.
+    pub fn write(&self, event: Event) {
+        let Some(sink) = &self.0 else { return };
+        let record = Record {
+            v: SCHEMA,
+            seq: sink.seq.fetch_add(1, Ordering::Relaxed),
+            at: rfc3339(SystemTime::now()),
+            mono_ms: ms(sink.started.elapsed()),
+            event,
+        };
+        // A record that will not serialize is a bug in an event type, not a debugger failure, and
+        // it must not cost the caller anything. It is still worth saying loudly: a transcript
+        // missing a line it should have is exactly the sort of thing this file is trusted about.
+        let mut line = match serde_json::to_string(&record) {
+            Ok(line) => line,
+            Err(e) => {
+                tracing::error!("a transcript record did not serialize: {e}");
+                return;
+            }
+        };
+        line.push('\n');
+        let mut file = sink.file.lock().unwrap_or_else(|e| e.into_inner());
+        // One `write_all` per record, on a file opened for append and with no buffer in front of
+        // it: that is what leaves a parseable prefix behind an abrupt exit.
+        if let Err(e) = file.write_all(line.as_bytes()) {
+            tracing::error!("could not write a transcript record: {e}");
+        }
+    }
+
+    // ---- tool calls -------------------------------------------------------
+
+    /// Records a tool request and returns the handle its result is recorded against.
+    ///
+    /// The handle carries the start instant, so the elapsed time on the result is measured across
+    /// the call rather than recomputed from two wall-clock stamps that a clock step could reorder.
+    pub fn tool_request(&self, tool: &str, args: Option<&Value>) -> InFlight {
+        let Some(sink) = &self.0 else {
+            return InFlight::untracked();
+        };
+        let request = sink.request.fetch_add(1, Ordering::Relaxed) + 1;
+        // The session a call names is worth having on the *request*, not only on the result: a
+        // call that never comes back is one this is the only record of.
+        let session = args
+            .and_then(|a| a.get("session_id"))
+            .and_then(Value::as_str)
+            .map(str::to_string);
+        self.write(Event::ToolRequest {
+            request,
+            tool: tool.to_string(),
+            session: session.clone(),
+            args: args.map(|a| self.payload(scrubbed(a))),
+        });
+        InFlight {
+            request,
+            tool: tool.to_string(),
+            session,
+            at: Instant::now(),
+        }
+    }
+
+    /// Records a tool result, and whatever the typed half of it says happened.
+    ///
+    /// `data` is the same structured content the client receives. Reading the derived events out
+    /// of it is a *typed* read — [`derived`] deserializes the payload each tool declares — not a
+    /// scrape of the text beside it.
+    pub fn tool_result(&self, call: InFlight, is_error: bool, text: &str, data: Option<&Value>) {
+        if self.0.is_none() {
+            return;
+        }
+        let scrubbed_data = data.map(scrubbed);
+        self.write(Event::ToolResult {
+            request: call.request,
+            tool: call.tool.clone(),
+            session: call.session.clone(),
+            elapsed_ms: ms(call.at.elapsed()),
+            verdict: if is_error {
+                Verdict::Error
+            } else {
+                Verdict::Ok
+            },
+            category: scrubbed_data.as_ref().and_then(category_of),
+            // Scrubbed *then* capped, and the order is load-bearing: cutting first can leave the
+            // front of a secret behind, because the cut lands wherever the byte count says and a
+            // `key=1.2` is a key partly disclosed. Scrubbing first costs a scan of a rendering
+            // that may be megabytes, which is the right side to pay on.
+            text: Capped::of(&kdconn::scrub(text), self.limit()),
+            // Cloned only when the value is small enough to keep; the marker branch does not
+            // clone at all. `derived` reads the same value below without taking a copy either.
+            data: scrubbed_data.as_ref().map(|d| self.payload_of(d)),
+        });
+        if let Some(data) = &scrubbed_data {
+            for event in derived(&call, data) {
+                self.write(event);
+            }
+        }
+    }
+
+    // ---- fields -----------------------------------------------------------
+
+    fn limit(&self) -> usize {
+        self.0.as_ref().map_or(DEFAULT_FIELD_LIMIT, |s| s.limit)
+    }
+
+    /// A JSON value as a capped field: itself, or a marker naming what was dropped.
+    ///
+    /// A value is kept whole or not at all, unlike text: half a JSON object is not a smaller JSON
+    /// object, and a reader that had to cope with both would be parsing a shape this cannot
+    /// promise. The marker is an object so it can never be mistaken for the payload.
+    fn payload(&self, value: Value) -> Value {
+        match self.dropped_bytes(&value) {
+            Some(size) => serde_json::json!({ "transcript_dropped_bytes": size }),
+            None => value,
+        }
+    }
+
+    /// [`Self::payload`] for a value the caller still needs.
+    fn payload_of(&self, value: &Value) -> Value {
+        match self.dropped_bytes(value) {
+            Some(size) => serde_json::json!({ "transcript_dropped_bytes": size }),
+            None => value.clone(),
+        }
+    }
+
+    /// How big `value` is, if that is over the cap. `None` means it fits.
+    fn dropped_bytes(&self, value: &Value) -> Option<usize> {
+        let limit = self.limit();
+        if limit == 0 {
+            return None;
+        }
+        let size = serde_json::to_string(value).map_or(0, |s| s.len());
+        (size > limit).then_some(size)
+    }
+}
+
+/// A tool call in flight: what its result will be recorded against.
+pub struct InFlight {
+    request: u64,
+    tool: String,
+    session: Option<String>,
+    at: Instant,
+}
+
+impl InFlight {
+    /// The handle a disabled recorder hands back. Its request number is zero, which no recorded
+    /// request ever is.
+    fn untracked() -> Self {
+        Self {
+            request: 0,
+            tool: String::new(),
+            session: None,
+            at: Instant::now(),
+        }
+    }
+}
+
+// ---- the records ----------------------------------------------------------
+
+/// One line of the transcript: the envelope every event shares.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Record {
+    /// The format version, on every line rather than only in the header — a reader that starts
+    /// mid-file, or in the middle of a second run appended to the first, still knows what it has.
+    pub v: u32,
+    /// Position in this run, from zero. What orders records that share a millisecond.
+    pub seq: u64,
+    /// Wall clock, RFC 3339 in UTC. For a person, and for lining a transcript up against other
+    /// evidence.
+    pub at: String,
+    /// Milliseconds since this run started. Monotonic, so this is what a renderer measures
+    /// intervals with — a wall clock can step, and an asciicast whose times went backwards would
+    /// not play.
+    pub mono_ms: u64,
+    #[serde(flatten)]
+    pub event: Event,
+}
+
+/// Whether a tool call reported success.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Verdict {
+    Ok,
+    Error,
+}
+
+/// A text field, and what was left out of it.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Capped {
+    pub text: String,
+    /// Bytes dropped from the end. Absent when nothing was — which is the ordinary case, and
+    /// keeping the key out of it is what makes a truncated field visible at a glance.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dropped: Option<usize>,
+}
+
+impl Capped {
+    /// `text` if it fits, else as much of it as does — cut at a character boundary, because a
+    /// record has to be valid JSON and half a character is not a character.
+    pub fn of(text: &str, limit: usize) -> Self {
+        if limit == 0 || text.len() <= limit {
+            return Self {
+                text: text.to_string(),
+                dropped: None,
+            };
+        }
+        let mut end = limit;
+        while end > 0 && !text.is_char_boundary(end) {
+            end -= 1;
+        }
+        Self {
+            text: text[..end].to_string(),
+            dropped: Some(text.len() - end),
+        }
+    }
+}
+
+/// What happened. One variant per thing worth recording, tagged on `event`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "event", rename_all = "snake_case")]
+pub enum Event {
+    /// The first record of a run. Its pid is what tells two runs apart in one appended-to file.
+    Start {
+        version: String,
+        pid: u32,
+        field_limit: usize,
+        schema: u32,
+    },
+    /// A tool call arrived.
+    ToolRequest {
+        request: u64,
+        tool: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        session: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        args: Option<Value>,
+    },
+    /// It answered.
+    ToolResult {
+        request: u64,
+        tool: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        session: Option<String>,
+        elapsed_ms: u64,
+        verdict: Verdict,
+        /// The failure's kind, where the typed half named one. What a reader counts failures by
+        /// without matching on wording.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        category: Option<ErrorCategory>,
+        text: Capped,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        data: Option<Value>,
+    },
+    /// A session was opened, and a worker process is holding it.
+    SessionOpen {
+        session: String,
+        kind: String,
+        /// What was opened, already redacted where it is a connection — this is the session's own
+        /// label, which is built masked (see [`kdconn::select`]).
+        target: String,
+        engine_pid: u32,
+    },
+    /// A session moved. Every transition goes through one place in the supervisor, so this covers
+    /// an open landing, a handle being retired, a failed open and a worker's death alike.
+    SessionState {
+        session: String,
+        state: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        detail: Option<Capped>,
+    },
+    /// A session was released. `released` is the fact that matters: false means the worker was
+    /// killed still holding its target, which for a live kernel means a machine left halted.
+    SessionEnd {
+        session: String,
+        released: bool,
+        worker_terminated: bool,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        waited_ms: Option<u64>,
+    },
+    /// The engine process holding a session is gone, and the calls it owed replies to are being
+    /// failed out.
+    WorkerLost { session: String, detail: Capped },
+    /// A wait was abandoned. The job itself was not cancelled — it may still be running — which is
+    /// why this is its own event and not a failed result.
+    CallTimeout { session: String, budget_ms: u64 },
+    /// Someone Ctrl+Broke a session's engine.
+    Interrupt {
+        session: String,
+        /// Whether the worker acknowledged it.
+        delivered: bool,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        detail: Option<Capped>,
+    },
+    /// A target was resumed and stopped again. Derived from the tool's own typed answer.
+    ///
+    /// The resume itself has no event of its own: the `tool_request` immediately before this *is*
+    /// the resume, stamped at the instant the target was let go, and a second record saying the
+    /// same thing at the same time would be a fact counted twice. What this adds is the half the
+    /// request cannot know — where it ended up, and whether it got there on its own.
+    Stop {
+        request: u64,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        session: Option<String>,
+        /// The debugger command that moved it.
+        command: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        stopped_at: Option<String>,
+        /// Whether it was broken into on request rather than stopping on its own.
+        interrupted: bool,
+    },
+    /// A `run_to_address` verdict.
+    RunTo {
+        request: u64,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        session: Option<String>,
+        verdict: String,
+        target: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        stopped_at: Option<String>,
+    },
+    /// Something about the target changed. The event an operator reading a transcript after the
+    /// fact is looking for: what did this session leave behind?
+    Mutation {
+        request: u64,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        session: Option<String>,
+        /// What kind of change — `breakpoint`, or a batch step's own description.
+        kind: String,
+        detail: Capped,
+        /// For a batch step: which block it was in and where.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        step: Option<String>,
+    },
+    /// An assertion inside a transactional batch did not hold. Its own record because it is the
+    /// fact that decided the transaction, and a reader should not have to walk the step list to
+    /// find it.
+    Assertion {
+        request: u64,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        session: Option<String>,
+        step: String,
+        detail: Capped,
+    },
+    /// How a transactional batch ended, and whether it put everything back.
+    Batch {
+        request: u64,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        session: Option<String>,
+        outcome: String,
+        /// The 1-based position it stopped at, absent when it committed. `at_step` rather than
+        /// the payload's own `at`, because these events are flattened into a record whose `at` is
+        /// the wall clock — two fields of that name would be one field, and JSON would not say
+        /// which.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        at_step: Option<u32>,
+        committed: bool,
+        /// Whether the `always` block completed. The one an unattended run is read for.
+        rollback_complete: bool,
+        /// What the session holds now: `stopped`, `running`, `detached`, `uncertain`.
+        after: String,
+        elapsed_ms: u64,
+    },
+    /// The server is going down and every session is being let go.
+    Shutdown { sessions: usize },
+}
+
+// ---- deriving the typed events --------------------------------------------
+
+/// The events a tool's typed answer implies, read as values.
+///
+/// Keyed on the tool name because the name is what says which type the payload is — the same
+/// mapping `output_schema` declares in [`crate::server`]. A tool that is not here contributes its
+/// `tool_result` and nothing more, which is the honest answer: this server cannot know what an
+/// arbitrary `execute` command did to the target, and inventing a `mutation` event by matching on
+/// command text would be a guess wearing a value's clothes.
+fn derived(call: &InFlight, data: &Value) -> Vec<Event> {
+    let request = call.request;
+    let session = call.session.clone();
+    match call.tool.as_str() {
+        "go" | "step_over" | "step_into" | "step_back" | "step_over_back" | "reverse_go" => {
+            let Some(stop) = typed::<StopReport>(data) else {
+                return Vec::new();
+            };
+            vec![Event::Stop {
+                request,
+                session,
+                command: stop.command,
+                stopped_at: stop.stopped_at,
+                interrupted: stop.interrupted,
+            }]
+        }
+        "run_to_address" => {
+            let Some(run) = typed::<RunToReport>(data) else {
+                return Vec::new();
+            };
+            vec![Event::RunTo {
+                request,
+                session,
+                verdict: name_of(&run.verdict),
+                target: run.target,
+                stopped_at: run.stopped_at,
+            }]
+        }
+        "set_breakpoint" => {
+            let Some(set) = typed::<BreakpointSet>(data) else {
+                return Vec::new();
+            };
+            // Only what this call added. The rest of the list is state, not a change, and a
+            // transcript that recorded the whole list as a mutation would report the same
+            // breakpoint again every time another one was set.
+            set.added
+                .iter()
+                .map(|id| Event::Mutation {
+                    request,
+                    session: session.clone(),
+                    kind: "breakpoint".to_string(),
+                    detail: Capped::of(&breakpoint_detail(&set, *id), 0),
+                    step: None,
+                })
+                .collect()
+        }
+        "debug_batch" => batch_events(request, session, data),
+        _ => Vec::new(),
+    }
+}
+
+/// A batch's verdict, the assertion that decided it, and everything it changed.
+fn batch_events(request: u64, session: Option<String>, data: &Value) -> Vec<Event> {
+    let Some(report) = typed::<BatchReportInfo>(data) else {
+        return Vec::new();
+    };
+    let mut events = Vec::new();
+    for (block, steps) in [("steps", &report.steps), ("always", &report.always)] {
+        for step in steps {
+            let at = format!("{block}[{}] {}", step.position, step.label);
+            // Recorded whether or not the step then succeeded: a command that errors may already
+            // have written, which is exactly when a record of it matters.
+            if let Some(changes) = &step.changes {
+                events.push(Event::Mutation {
+                    request,
+                    session: session.clone(),
+                    kind: "batch_step".to_string(),
+                    detail: Capped::of(changes, 0),
+                    step: Some(at.clone()),
+                });
+            }
+            if step.result == crate::structured::StepResultName::Unmet {
+                events.push(Event::Assertion {
+                    request,
+                    session: session.clone(),
+                    step: at,
+                    detail: Capped::of(step.detail.as_deref().unwrap_or_default(), 0),
+                });
+            }
+        }
+    }
+    events.push(Event::Batch {
+        request,
+        session,
+        outcome: name_of(&report.outcome),
+        at_step: report.at,
+        committed: report.committed,
+        rollback_complete: report.rollback_complete,
+        after: name_of(&report.after),
+        elapsed_ms: report.elapsed_ms,
+    });
+    events
+}
+
+/// The payload of a successful outcome, or `None` for a failure or a shape that is not this one.
+///
+/// Both are ordinary. A tool that failed carries the error branch, and a client of a *future*
+/// version may see a payload this build cannot read — neither is worth losing the `tool_result`
+/// record over, so this returns nothing rather than reporting an error nobody can act on.
+/// Deserialized from a borrow, not from a clone: a payload can be the whole of a pool census, and
+/// the recorder already holds it.
+fn typed<'a, T: Deserialize<'a>>(data: &'a Value) -> Option<T> {
+    match Outcome::<T>::deserialize(data) {
+        Ok(Outcome::Ok(payload)) => Some(payload),
+        _ => None,
+    }
+}
+
+/// The failure category a result's typed half names, when it names one.
+fn category_of(data: &Value) -> Option<ErrorCategory> {
+    match Outcome::<serde::de::IgnoredAny>::deserialize(data).ok()? {
+        Outcome::Error(failure) => Some(failure.error.category),
+        Outcome::Ok(_) => None,
+    }
+}
+
+/// The serde name of an enum variant — `"stopped_elsewhere"`, `"committed"` — taken from its own
+/// serialization rather than written out a second time here, so a renamed variant cannot leave a
+/// stale spelling behind in the transcript.
+fn name_of<T: Serialize>(value: &T) -> String {
+    match serde_json::to_value(value) {
+        Ok(Value::String(name)) => name,
+        // A tagged object: the discriminator is the name. The tags this crate uses, in the one
+        // place that has to know all of them.
+        Ok(Value::Object(map)) => ["event", "state", "kind", "status", "reason"]
+            .iter()
+            .find_map(|tag| map.get(*tag).and_then(Value::as_str))
+            .unwrap_or("unknown")
+            .to_string(),
+        _ => "unknown".to_string(),
+    }
+}
+
+/// How one added breakpoint reads in a transcript: where it will fire, and what it is.
+fn breakpoint_detail(set: &BreakpointSet, id: u32) -> String {
+    let Some(bp) = set.breakpoints.iter().find(|b| b.id == id) else {
+        // The listing failed, so the id is all this call knows. It still happened.
+        return format!("breakpoint {id} set (the session's list could not be read back)");
+    };
+    let at = bp
+        .address
+        .as_deref()
+        .or(bp.expression.as_deref())
+        .unwrap_or("an unresolved location");
+    let deferred = if bp.deferred { ", deferred" } else { "" };
+    format!("breakpoint {id} at {at}{deferred}")
+}
+
+// ---- redaction ------------------------------------------------------------
+
+/// Every string in a value, scrubbed — and any member *named* like a secret masked whole.
+///
+/// Two rules because there are two ways a secret arrives. A connection string is a string leaf
+/// that happens to contain `key=…`, which [`kdconn::scrub`] finds. A member named `key` is a
+/// secret by its name, whatever its value looks like — and no tool in this server has one today,
+/// which is exactly why the rule belongs here rather than being left for the first one that does.
+fn scrubbed(value: &Value) -> Value {
+    match value {
+        Value::String(s) => Value::String(kdconn::scrub(s)),
+        Value::Array(items) => Value::Array(items.iter().map(scrubbed).collect()),
+        Value::Object(map) => Value::Object(
+            map.iter()
+                .map(|(name, value)| {
+                    let value = match kdconn::is_secret_name(name) {
+                        true => Value::String(kdconn::MASK.to_string()),
+                        false => scrubbed(value),
+                    };
+                    (name.clone(), value)
+                })
+                .collect(),
+        ),
+        other => other.clone(),
+    }
+}
+
+// ---- odds and ends --------------------------------------------------------
+
+fn field_limit() -> usize {
+    std::env::var(FIELD_LIMIT_ENV)
+        .ok()
+        .and_then(|v| v.trim().parse().ok())
+        .unwrap_or(DEFAULT_FIELD_LIMIT)
+}
+
+fn ms(d: Duration) -> u64 {
+    d.as_millis().min(u128::from(u64::MAX)) as u64
+}
+
+/// A wall-clock instant as RFC 3339 in UTC, to the millisecond.
+///
+/// Written out rather than pulled in: the crate has no date dependency, this is the only place
+/// that needs one, and the arithmetic below is the whole of it. Days are converted with the
+/// civil-from-days algorithm, which is exact for every date a file's timestamp can hold.
+fn rfc3339(at: SystemTime) -> String {
+    let since = at.duration_since(UNIX_EPOCH).unwrap_or(Duration::ZERO);
+    let secs = since.as_secs();
+    let (days, rem) = ((secs / 86_400) as i64, secs % 86_400);
+    let (y, m, d) = civil_from_days(days);
+    format!(
+        "{y:04}-{m:02}-{d:02}T{:02}:{:02}:{:02}.{:03}Z",
+        rem / 3600,
+        (rem % 3600) / 60,
+        rem % 60,
+        since.subsec_millis()
+    )
+}
+
+/// A stamp this module wrote, read back as seconds since the epoch.
+///
+/// The inverse of [`rfc3339`], and it parses only the shape that function emits — this is for
+/// reading *this* server's own transcripts ([`crate::cast`] needs a header timestamp), not for
+/// accepting RFC 3339 in general, which has offsets and fractional widths nothing here produces.
+/// `None` for anything else, so a hand-edited or truncated stamp is skipped rather than guessed at.
+pub fn unix_seconds(at: &str) -> Option<u64> {
+    let (date, rest) = at.split_once('T')?;
+    let time = rest.strip_suffix('Z')?;
+    let mut date = date.splitn(3, '-');
+    let (y, m, d): (i64, u32, u32) = (
+        date.next()?.parse().ok()?,
+        date.next()?.parse().ok()?,
+        date.next()?.parse().ok()?,
+    );
+    let mut clock = time.split(':');
+    let (hh, mm): (u64, u64) = (clock.next()?.parse().ok()?, clock.next()?.parse().ok()?);
+    let ss: u64 = clock.next()?.split('.').next()?.parse().ok()?;
+    if !(1..=12).contains(&m) || !(1..=31).contains(&d) || hh > 23 || mm > 59 || ss > 60 {
+        return None;
+    }
+    let days = days_from_civil(y, m, d);
+    u64::try_from(days.checked_mul(86_400)?)
+        .ok()?
+        .checked_add(hh * 3600 + mm * 60 + ss)
+}
+
+/// A civil date as days since 1970-01-01 — [`civil_from_days`] the other way round, and the same
+/// era shift.
+fn days_from_civil(y: i64, m: u32, d: u32) -> i64 {
+    let y = y - i64::from(m <= 2);
+    let era = y.div_euclid(400);
+    let yoe = y - era * 400;
+    let mp = i64::from(if m > 2 { m - 3 } else { m + 9 });
+    let doy = (153 * mp + 2) / 5 + i64::from(d) - 1;
+    let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
+    era * 146_097 + doe - 719_468
+}
+
+/// Days since 1970-01-01 as a civil date. Howard Hinnant's algorithm, shifted to an era starting
+/// in March so a leap day is the last day of the year and needs no special case.
+fn civil_from_days(z: i64) -> (i64, u32, u32) {
+    let z = z + 719_468;
+    let era = z.div_euclid(146_097);
+    let doe = z.rem_euclid(146_097);
+    let yoe = (doe - doe / 1460 + doe / 36_524 - doe / 146_096) / 365;
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = (doy - (153 * mp + 2) / 5 + 1) as u32;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 } as u32;
+    (y + i64::from(m <= 2), m, d)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Reads a transcript back the way a consumer has to: one JSON object per line.
+    fn records(path: &Path) -> Vec<Record> {
+        std::fs::read_to_string(path)
+            .expect("the transcript exists")
+            .lines()
+            .filter(|l| !l.trim().is_empty())
+            .map(|line| {
+                serde_json::from_str(line)
+                    .unwrap_or_else(|e| panic!("a transcript line is not a record ({e}): {line}"))
+            })
+            .collect()
+    }
+
+    /// A recorder writing into a fresh file under the test's own temporary directory.
+    fn recorder(name: &str) -> (Recorder, PathBuf) {
+        let path = std::env::temp_dir()
+            .join("windbg-mcp-transcript-tests")
+            .join(format!("{name}-{}.jsonl", std::process::id()));
+        let _ = std::fs::remove_file(&path);
+        let recorder = Recorder::to_file(&path, DEFAULT_FIELD_LIMIT).expect("open the transcript");
+        (recorder, path)
+    }
+
+    fn event_names(records: &[Record]) -> Vec<String> {
+        records.iter().map(|r| name_of(&r.event)).collect()
+    }
+
+    /// The acceptance criterion in one test: a short session's records read back as JSONL, in the
+    /// order the calls were made, carrying what each one answered.
+    #[test]
+    fn a_session_reads_back_as_ordered_records() {
+        let (rec, path) = recorder("ordered");
+        let call = rec.tool_request("open_dump", Some(&serde_json::json!({ "path": "a.dmp" })));
+        rec.tool_result(call, false, "loaded", None);
+        let call = rec.tool_request("go", Some(&serde_json::json!({ "session_id": "sess-1" })));
+        rec.tool_result(
+            call,
+            false,
+            "Breakpoint 0 hit",
+            Some(&serde_json::json!({
+                "status": "ok",
+                "command": "g",
+                "stopped_at": "0xfffff8031ab10000",
+                "interrupted": false,
+                "output": "Breakpoint 0 hit",
+            })),
+        );
+
+        let records = records(&path);
+        assert_eq!(
+            event_names(&records),
+            [
+                "start",
+                "tool_request",
+                "tool_result",
+                "tool_request",
+                "tool_result",
+                "stop"
+            ],
+            "the request order, and the stop the second call produced"
+        );
+        // Sequence numbers order records that share a millisecond, which on a fast call is all of
+        // them.
+        let seqs: Vec<u64> = records.iter().map(|r| r.seq).collect();
+        assert_eq!(seqs, (0..records.len() as u64).collect::<Vec<_>>());
+        assert!(records.iter().all(|r| r.v == SCHEMA));
+        // Monotonic time never goes backwards, which is what a renderer relies on.
+        assert!(records.windows(2).all(|w| w[0].mono_ms <= w[1].mono_ms));
+
+        let Event::ToolResult {
+            request,
+            tool,
+            session,
+            verdict,
+            ..
+        } = &records[4].event
+        else {
+            panic!("expected a tool result: {:?}", records[4].event)
+        };
+        assert_eq!((tool.as_str(), *verdict), ("go", Verdict::Ok));
+        assert_eq!(session.as_deref(), Some("sess-1"));
+        // The derived stop is keyed to the same request, which is what lets a reader join them.
+        let Event::Stop {
+            request: stop_request,
+            stopped_at,
+            interrupted,
+            command,
+            ..
+        } = &records[5].event
+        else {
+            panic!("expected a stop: {:?}", records[5].event)
+        };
+        assert_eq!(stop_request, request);
+        assert_eq!(command, "g");
+        assert_eq!(stopped_at.as_deref(), Some("0xfffff8031ab10000"));
+        assert!(!interrupted);
+    }
+
+    /// The security criterion: a raw `connection` reaches this server as a tool argument, and the
+    /// key must not reach the file.
+    #[test]
+    fn a_live_attach_transcript_contains_no_key() {
+        let (rec, path) = recorder("no-key");
+        let call = rec.tool_request(
+            "attach_kernel",
+            Some(&serde_json::json!({ "connection": "net:port=50000,key=1.2.3.4" })),
+        );
+        // The engine's own answer names the target too, in prose this time.
+        rec.tool_result(
+            call,
+            true,
+            "could not attach over net:port=50000,key=1.2.3.4",
+            None,
+        );
+        rec.write(Event::SessionOpen {
+            session: "sess-1".to_string(),
+            kind: "kernel target".to_string(),
+            target: "net:port=50000,key=<redacted>".to_string(),
+            engine_pid: 4,
+        });
+
+        let raw = std::fs::read_to_string(&path).expect("the transcript exists");
+        assert!(
+            !raw.contains("1.2.3.4"),
+            "the key reached the transcript:\n{raw}"
+        );
+        assert!(
+            raw.contains("net:port=50000"),
+            "the transport and port are not secrets and should still identify the target:\n{raw}"
+        );
+        // And it reads back as records, rather than the scrub having broken the JSON.
+        assert_eq!(records(&path).len(), 4);
+    }
+
+    /// A member *named* like a secret is masked whole, whatever it holds. No tool has one today,
+    /// which is the point: the rule is here before the tool that needs it.
+    #[test]
+    fn an_argument_named_like_a_secret_is_masked_whole() {
+        let (rec, path) = recorder("secret-name");
+        let call = rec.tool_request(
+            "execute",
+            Some(&serde_json::json!({ "key": "0123456789", "command": "version" })),
+        );
+        rec.tool_result(call, false, "ok", None);
+        let raw = std::fs::read_to_string(&path).expect("the transcript exists");
+        assert!(!raw.contains("0123456789"), "{raw}");
+        assert!(raw.contains("<redacted>"), "{raw}");
+        assert!(raw.contains("version"), "the rest is untouched: {raw}");
+    }
+
+    /// A truncated field says so. A transcript that quietly shortened a rendering would read as
+    /// complete, which is worse than not having one.
+    #[test]
+    fn an_oversized_field_is_cut_and_says_how_much_was_dropped() {
+        let path = std::env::temp_dir()
+            .join("windbg-mcp-transcript-tests")
+            .join(format!("capped-{}.jsonl", std::process::id()));
+        let _ = std::fs::remove_file(&path);
+        let rec = Recorder::to_file(&path, 64).expect("open the transcript");
+        let call = rec.tool_request("modules", None);
+        rec.tool_result(call, false, &"m".repeat(500), None);
+
+        let records = records(&path);
+        let Event::ToolResult { text, .. } = &records[2].event else {
+            panic!("expected a tool result")
+        };
+        assert_eq!(text.text.len(), 64);
+        assert_eq!(text.dropped, Some(500 - 64));
+    }
+
+    /// Cutting a capped field must not cut a character in half — the record has to stay valid
+    /// JSON, and a lone surrogate of a UTF-8 sequence is not a string.
+    #[test]
+    fn a_field_is_cut_at_a_character_boundary() {
+        // Three bytes each, so a 4-byte limit lands inside the second one.
+        let capped = Capped::of("✓✓✓", 4);
+        assert_eq!(capped.text, "✓");
+        assert_eq!(capped.dropped, Some(6));
+        assert_eq!(Capped::of("abc", 0).dropped, None, "0 means no limit");
+        assert_eq!(Capped::of("abc", 3).dropped, None, "exactly at the limit");
+    }
+
+    /// An oversized *payload* is dropped whole rather than cut: half an object is not a smaller
+    /// object, and the marker says how much there was.
+    #[test]
+    fn an_oversized_payload_is_replaced_by_a_marker() {
+        let path = std::env::temp_dir()
+            .join("windbg-mcp-transcript-tests")
+            .join(format!("payload-{}.jsonl", std::process::id()));
+        let _ = std::fs::remove_file(&path);
+        let rec = Recorder::to_file(&path, 64).expect("open the transcript");
+        let call = rec.tool_request("pool_census", None);
+        let big = serde_json::json!({ "status": "ok", "rows": vec!["x".repeat(200)] });
+        rec.tool_result(call, false, "census", Some(&big));
+
+        let records = records(&path);
+        let Event::ToolResult { data, .. } = &records[2].event else {
+            panic!("expected a tool result")
+        };
+        let data = data.as_ref().expect("a payload marker is still a payload");
+        assert!(
+            data["transcript_dropped_bytes"].as_u64().unwrap_or(0) > 64,
+            "the marker says how much there was: {data}"
+        );
+    }
+
+    /// The batch criterion: a transaction that failed records the assertion that decided it, what
+    /// it had already changed, and whether the rollback finished — as fields, not as prose.
+    #[test]
+    fn a_failed_batch_records_its_assertion_and_its_rollback() {
+        let (rec, path) = recorder("batch");
+        let call = rec.tool_request("debug_batch", None);
+        rec.tool_result(
+            call,
+            true,
+            "BATCH: FAILED at step 2 of 3",
+            Some(&serde_json::json!({
+                "status": "ok",
+                "outcome": "failed",
+                "at": 2,
+                "committed": false,
+                "rollback_complete": true,
+                "after": { "state": "stopped", "ip": "0xfffff8031ab10000" },
+                "budget_ms": 60000,
+                "elapsed_ms": 120,
+                "steps": [
+                    { "position": 1, "label": "patch", "action": "eb fffff803 90",
+                      "result": "ok", "changes": "wrote 1 byte at fffff803", "cut_short": false },
+                    { "position": 2, "label": "check", "action": "db fffff803 L1",
+                      "result": "unmet", "detail": "expected `91`", "cut_short": false },
+                    { "position": 3, "label": "never", "action": "version",
+                      "result": "skipped", "detail": "a step before it failed", "cut_short": false }
+                ],
+                "always": [
+                    { "position": 1, "label": "restore", "action": "eb fffff803 cc",
+                      "result": "ok", "changes": "wrote 1 byte at fffff803", "cut_short": false }
+                ]
+            })),
+        );
+
+        let records = records(&path);
+        assert_eq!(
+            event_names(&records),
+            [
+                "start",
+                "tool_request",
+                "tool_result",
+                // The step that changed something, then the assertion that stopped the batch,
+                // then the rollback's own change, then the verdict.
+                "mutation",
+                "assertion",
+                "mutation",
+                "batch",
+            ]
+        );
+        let Event::Assertion { step, detail, .. } = &records[4].event else {
+            panic!("expected an assertion: {:?}", records[4].event)
+        };
+        assert_eq!(step, "steps[2] check");
+        assert_eq!(detail.text, "expected `91`");
+        let Event::Mutation { step, detail, .. } = &records[5].event else {
+            panic!("expected the rollback's mutation")
+        };
+        assert_eq!(step.as_deref(), Some("always[1] restore"));
+        assert_eq!(detail.text, "wrote 1 byte at fffff803");
+        let Event::Batch {
+            outcome,
+            at_step,
+            committed,
+            rollback_complete,
+            after,
+            ..
+        } = &records[6].event
+        else {
+            panic!("expected the batch verdict")
+        };
+        assert_eq!((outcome.as_str(), *at_step), ("failed", Some(2)));
+        assert!(!committed);
+        assert!(rollback_complete, "the `always` block ran");
+        assert_eq!(after, "stopped");
+    }
+
+    /// A tool this module knows nothing about contributes its result and no derived events. The
+    /// alternative — guessing at what an `execute` command did — would put a fact in the record
+    /// that nothing measured.
+    #[test]
+    fn an_unrecognised_tool_derives_nothing() {
+        let (rec, path) = recorder("underived");
+        let call = rec.tool_request(
+            "execute",
+            Some(&serde_json::json!({ "command": "eb 0 90" })),
+        );
+        rec.tool_result(
+            call,
+            false,
+            "",
+            Some(&serde_json::json!({ "status": "ok" })),
+        );
+        assert_eq!(
+            event_names(&records(&path)),
+            ["start", "tool_request", "tool_result"]
+        );
+    }
+
+    /// A failure carries its category, so a reader counts failures by kind rather than by wording.
+    #[test]
+    fn a_failure_records_the_category_it_was_given() {
+        let (rec, path) = recorder("category");
+        let call = rec.tool_request("registers", None);
+        rec.tool_result(
+            call,
+            true,
+            "no debug session is open",
+            Some(&serde_json::json!({
+                "status": "error",
+                "error": { "category": "stale_session", "message": "no debug session is open" }
+            })),
+        );
+        let records = records(&path);
+        let Event::ToolResult {
+            verdict, category, ..
+        } = &records[2].event
+        else {
+            panic!("expected a tool result")
+        };
+        assert_eq!(*verdict, Verdict::Error);
+        assert_eq!(*category, Some(ErrorCategory::StaleSession));
+    }
+
+    /// A disabled recorder is the ordinary case, and it must touch nothing at all.
+    #[test]
+    fn a_disabled_recorder_records_nothing() {
+        let rec = Recorder::disabled();
+        assert!(!rec.enabled());
+        assert!(rec.path().is_none());
+        let call = rec.tool_request("go", None);
+        rec.tool_result(call, false, "text", None);
+        rec.write(Event::Shutdown { sessions: 1 });
+    }
+
+    /// Appending rather than truncating: a second run must not erase the first. The `start`
+    /// records are what separate them.
+    #[test]
+    fn a_second_run_appends_to_the_same_file() {
+        let (first, path) = recorder("append");
+        first.write(Event::Shutdown { sessions: 0 });
+        drop(first);
+        let second = Recorder::to_file(&path, DEFAULT_FIELD_LIMIT).expect("reopen");
+        second.write(Event::Shutdown { sessions: 0 });
+
+        let records = records(&path);
+        assert_eq!(
+            event_names(&records),
+            ["start", "shutdown", "start", "shutdown"]
+        );
+        // Each run numbers its own records, which is why the pid on `start` is what tells them
+        // apart rather than the sequence.
+        assert_eq!(records[2].seq, 0);
+    }
+
+    /// stdout is the JSON-RPC transport. This module must never reach it — a single stray
+    /// `println!` would corrupt the protocol for every client, and it would do it only on the
+    /// runs where recording is on, which is the worst way to find out.
+    ///
+    /// Checked by reading the source, the way `engine`'s spawn-lock rule is: the property is about
+    /// what is *written*, and no runtime test can prove the absence of a call nobody made today.
+    #[test]
+    fn this_module_never_writes_to_stdout() {
+        // Only the half that ships. The tests below it do not run in a server, and one of them is
+        // *named* after the thing being searched for.
+        let source = include_str!("record.rs");
+        let code = source
+            .split_once("\n#[cfg(test)]")
+            .expect("this module has a test half")
+            .0;
+        for forbidden in ["println!", "print!", "stdout"] {
+            let uses = code
+                .lines()
+                .filter(|l| !l.trim_start().starts_with("//"))
+                .filter(|l| l.contains(forbidden))
+                .count();
+            assert_eq!(
+                uses, 0,
+                "`{forbidden}` in the transcript writer would corrupt the MCP transport"
+            );
+        }
+    }
+
+    /// The wall clock is written out by hand, so it is worth checking against dates whose
+    /// arithmetic differs: an epoch, a leap day, and a century that is not a leap year.
+    #[test]
+    fn wall_clock_stamps_are_rfc3339_in_utc() {
+        let at = |secs: u64, millis: u32| {
+            rfc3339(
+                UNIX_EPOCH + Duration::from_secs(secs) + Duration::from_millis(u64::from(millis)),
+            )
+        };
+        assert_eq!(at(0, 0), "1970-01-01T00:00:00.000Z");
+        assert_eq!(at(1, 500), "1970-01-01T00:00:01.500Z");
+        // 2000-02-29, the leap day of a century that *is* a leap year.
+        assert_eq!(at(951_782_400, 0), "2000-02-29T00:00:00.000Z");
+        // 2100-03-01: 2100 is not a leap year, so the day before it is the 28th.
+        assert_eq!(at(4_107_542_400, 0), "2100-03-01T00:00:00.000Z");
+        assert_eq!(at(1_755_324_000, 123), "2025-08-16T06:00:00.123Z");
+    }
+
+    /// A stamp has to survive being read back, because that is what gives an asciicast rendered
+    /// from a transcript the time it was actually recorded at.
+    #[test]
+    fn a_stamp_reads_back_as_the_second_it_was_written_from() {
+        for secs in [0, 1, 951_782_400, 1_755_324_000, 4_107_542_400] {
+            let stamp = rfc3339(UNIX_EPOCH + Duration::from_secs(secs));
+            assert_eq!(unix_seconds(&stamp), Some(secs), "round-tripping {stamp}");
+        }
+        // The milliseconds are dropped, deliberately — the header of an asciicast is whole
+        // seconds — but nothing else about the stamp is.
+        assert_eq!(
+            unix_seconds(&rfc3339(UNIX_EPOCH + Duration::from_millis(1_500))),
+            Some(1)
+        );
+    }
+
+    /// Anything this module did not write is refused rather than guessed at.
+    #[test]
+    fn a_stamp_that_is_not_one_of_ours_is_refused() {
+        for bad in [
+            "",
+            "2026-08-16",
+            "2026-08-16T06:00:00",       // no zone
+            "2026-08-16T06:00:00+01:00", // an offset, which `rfc3339` never emits
+            "2026-13-16T06:00:00.000Z",  // month 13
+            "2026-08-16T25:00:00.000Z",  // hour 25
+            "not-a-date",
+        ] {
+            assert_eq!(unix_seconds(bad), None, "`{bad}` is not a stamp");
+        }
+    }
+}

--- a/src/record.rs
+++ b/src/record.rs
@@ -19,17 +19,21 @@
 //!
 //! # Where the records come from
 //!
-//! Every one is written by the **supervisor**, which is what makes this a single-writer file with
-//! no locking and no interleaving between processes. That is not a limitation: a worker's facts
-//! reach here as the typed half of its reply ([`crate::proto::Output::data`]), built on the side
-//! of the pipe where the engine's own types are in hand. So a stop position, a batch's verdict and
-//! its rollback state are recorded from [`crate::structured`] values — never re-read out of the
+//! Every one is written by the **supervisor**. That is not a limitation: a worker's facts reach
+//! here as the typed half of its reply ([`crate::proto::Output::data`]), built on the side of the
+//! pipe where the engine's own types are in hand. So a stop position, a batch's verdict and its
+//! rollback state are recorded from [`crate::structured`] values — never re-read out of the
 //! rendering, which would measure the rendering ([#77](https://github.com/glslang/windbg-mcp/issues/77)).
 //!
 //! A worker inherits [`TRANSCRIPT_ENV`] like any other variable and never acts on it: the role
 //! check in [`crate::main`] runs before the server is built, so [`Recorder::from_env`] is only ever
-//! reached by the supervisor. Two processes appending to one file is a thing this design does not
-//! have to cope with because it cannot happen.
+//! reached by the supervisor. One server is therefore one writer, and within it the file lock in
+//! [`Recorder::write`] is what makes the record order and the line order the same order.
+//!
+//! **Two servers can still share a path**, because the file is opened for append and nothing
+//! stops an operator pointing both at it. Their lines then interleave, which is why every record
+//! carries a [`Record::run`] and not just the `start` line: grouping by it is what keeps two
+//! independently numbered sessions from being read as one.
 //!
 //! # Safety properties, and why each one is here
 //!
@@ -107,6 +111,8 @@ struct Sink {
     /// when the server is going down, which is when a transcript earns its keep.
     file: Mutex<std::fs::File>,
     path: PathBuf,
+    /// Which run this is, on every record it writes. See [`Record::run`].
+    run: u64,
     /// Where `mono_ms` is measured from: this server's start, not the wall clock, so a record's
     /// ordering survives a clock that steps.
     started: Instant,
@@ -158,8 +164,10 @@ impl Recorder {
     /// Opens `path` for append and writes the header record.
     ///
     /// Append rather than truncate: two servers pointed at one path, or a second run of the same
-    /// one, must not silently erase what is already there. Each run's records are told apart by
-    /// the `start` record and its pid.
+    /// one, must not silently erase what is already there. Which run wrote which line is then
+    /// [`Record::run`]'s job — on every record, because two servers appending at once interleave
+    /// theirs and a marker at the top of each run would only be able to describe a file whose
+    /// runs do not overlap.
     pub fn to_file(path: &Path, limit: usize) -> std::io::Result<Self> {
         if let Some(parent) = path.parent().filter(|p| !p.as_os_str().is_empty()) {
             std::fs::create_dir_all(parent)?;
@@ -168,6 +176,7 @@ impl Recorder {
         let recorder = Self(Some(Arc::new(Sink {
             file: Mutex::new(file),
             path: path.to_path_buf(),
+            run: mint_run_id(),
             started: Instant::now(),
             limit,
             seq: AtomicU64::new(0),
@@ -207,6 +216,7 @@ impl Recorder {
         let mut file = sink.file.lock().unwrap_or_else(|e| e.into_inner());
         let record = Record {
             v: SCHEMA,
+            run: sink.run,
             seq: sink.seq.fetch_add(1, Ordering::Relaxed),
             at: rfc3339(SystemTime::now()),
             mono_ms: ms(sink.started.elapsed()),
@@ -243,10 +253,17 @@ impl Recorder {
         let request = sink.request.fetch_add(1, Ordering::Relaxed) + 1;
         // The session a call names is worth having on the *request*, not only on the result: a
         // call that never comes back is one this is the only record of.
+        //
+        // Scrubbed, like the argument object it is lifted out of. A handle this server issued is
+        // `sess-…` and holds nothing — but this is whatever the *caller* sent, and the case the
+        // backstop exists for is precisely a caller who put a connection string somewhere it does
+        // not belong. `kdconn` already refuses that mistake in `profile` *without echoing it*; a
+        // copy taken before the scrub would write it to a file instead. It survives to the result
+        // too, because a handle that does not resolve is never replaced by a routed one.
         let session = args
             .and_then(|a| a.get("session_id"))
             .and_then(Value::as_str)
-            .map(str::to_string);
+            .map(kdconn::scrub);
         self.write(Event::ToolRequest {
             request,
             tool: tool.to_string(),
@@ -393,6 +410,20 @@ pub struct Record {
     /// The format version, on every line rather than only in the header — a reader that starts
     /// mid-file, or in the middle of a second run appended to the first, still knows what it has.
     pub v: u32,
+    /// Which run of this server wrote the line, unique among the runs that could be sharing the
+    /// file.
+    ///
+    /// On **every** record, not only on `start`, because two supervisors can be pointed at one
+    /// path and this file is opened for append — which is a thing [`Recorder::to_file`] allows on
+    /// purpose. Their records then interleave, and with the run named only once a reader would
+    /// take everything after the later `start` as one run, mixing two sets of `seq`, `request` and
+    /// session identifiers that were each numbered from scratch. Grouping by this field is what
+    /// makes such a file readable rather than merely present.
+    ///
+    /// Defaulted for a transcript written before this field existed; all of its records then share
+    /// run `0` and are segmented by their `start` records instead.
+    #[serde(default)]
+    pub run: u64,
     /// Position in this run, from zero. What orders records that share a millisecond.
     pub seq: u64,
     /// Wall clock, RFC 3339 in UTC. For a person, and for lining a transcript up against other
@@ -487,7 +518,10 @@ pub enum Event {
         kind: String,
         /// What was opened, already redacted where it is a connection — this is the session's own
         /// label, which is built masked (see [`kdconn::select`]).
-        target: String,
+        ///
+        /// Capped like everything else: a `launch` target is a whole command line, and it is the
+        /// caller's.
+        target: Capped,
         engine_pid: u32,
     },
     /// A session moved. Every transition goes through one place in the supervisor, so this covers
@@ -798,6 +832,19 @@ fn ms(d: Duration) -> u64 {
     d.as_millis().min(u128::from(u64::MAX)) as u64
 }
 
+/// An identifier for this run: distinct from any other run that could be appending to the same
+/// file at the same time, and from the run before it in a file that reuses a pid.
+///
+/// The wall clock in nanoseconds, mixed with the pid. Neither alone is enough — two processes can
+/// start in the same nanosecond about as easily as a pid is reused, which is to say rarely, and a
+/// transcript is not the place to rely on rarely.
+fn mint_run_id() -> u64 {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |d| d.as_nanos() as u64);
+    nanos ^ ((std::process::id() as u64) << 48)
+}
+
 /// A wall-clock instant as RFC 3339 in UTC, to the millisecond.
 ///
 /// Written out rather than pulled in: the crate has no date dependency, this is the only place
@@ -992,7 +1039,7 @@ mod tests {
         rec.write(Event::SessionOpen {
             session: "sess-1".to_string(),
             kind: "kernel target".to_string(),
-            target: "net:port=50000,key=<redacted>".to_string(),
+            target: Capped::of("net:port=50000,key=<redacted>", 0),
             engine_pid: 4,
         });
 
@@ -1007,6 +1054,42 @@ mod tests {
         );
         // And it reads back as records, rather than the scrub having broken the JSON.
         assert_eq!(records(&path).len(), 4);
+    }
+
+    /// The `session_id` a record carries is the caller's string until it resolves, so it is
+    /// scrubbed like the argument object it was lifted out of.
+    ///
+    /// A handle this server issued is `sess-…` and holds nothing. But the backstop exists for the
+    /// caller who puts a connection string where it does not belong — `kdconn` already refuses
+    /// exactly that mistake in `profile`, and refuses it *without echoing the value back*. A copy
+    /// taken before the scrub would write to a file what that refusal was careful not to say. It
+    /// reaches the result too: a handle that does not resolve is never replaced by a routed one.
+    #[test]
+    fn a_session_handle_carrying_a_secret_is_scrubbed_like_any_other_argument() {
+        let (rec, path) = recorder("session-handle");
+        let call = rec.tool_request(
+            "registers",
+            Some(&serde_json::json!({ "session_id": "net:port=50000,key=1.2.3.4" })),
+        );
+        // Unresolvable, so nothing overwrites what the caller sent — which is the case that
+        // carries the value all the way through to the result.
+        rec.tool_result(call, true, "unknown session handle", None);
+
+        let raw = std::fs::read_to_string(&path).expect("the transcript exists");
+        assert!(!raw.contains("1.2.3.4"), "the key reached the file:\n{raw}");
+        let sessions: Vec<String> = records(&path)
+            .iter()
+            .filter_map(|r| match &r.event {
+                Event::ToolRequest { session, .. } | Event::ToolResult { session, .. } => {
+                    session.clone()
+                }
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            sessions, ["net:port=50000,key=<redacted>"; 2],
+            "both the request and the result carry the masked form"
+        );
     }
 
     /// A member *named* like a secret is masked whole, whatever it holds. No tool has one today,

--- a/src/record.rs
+++ b/src/record.rs
@@ -131,7 +131,7 @@ impl Recorder {
         let Some(path) = std::env::var_os(TRANSCRIPT_ENV).filter(|p| !p.is_empty()) else {
             return Self::disabled();
         };
-        let limit = field_limit();
+        let limit = configured_field_limit();
         match Self::to_file(Path::new(&path), limit) {
             Ok(recorder) => {
                 tracing::info!(
@@ -192,8 +192,19 @@ impl Recorder {
     }
 
     /// Records `event`, stamped and numbered. Does nothing when disabled.
+    ///
+    /// **The lock is taken before the record is built, not after.** Numbering and stamping outside
+    /// it would make `seq` and `mono_ms` an order of their own, different from the order the lines
+    /// land in: two threads recording at once can be numbered one way and preempted into writing
+    /// the other. A reader then has a file whose lines disagree with their own sequence numbers,
+    /// and a cast rendered from it has times that go backwards — which a player refuses. Inside
+    /// the lock, the two orders are the same order by construction.
+    ///
+    /// It costs serializing a small record while holding the lock. That is the right side to pay
+    /// on: this contends only with other records, never with a debugger operation.
     pub fn write(&self, event: Event) {
         let Some(sink) = &self.0 else { return };
+        let mut file = sink.file.lock().unwrap_or_else(|e| e.into_inner());
         let record = Record {
             v: SCHEMA,
             seq: sink.seq.fetch_add(1, Ordering::Relaxed),
@@ -212,7 +223,6 @@ impl Recorder {
             }
         };
         line.push('\n');
-        let mut file = sink.file.lock().unwrap_or_else(|e| e.into_inner());
         // One `write_all` per record, on a file opened for append and with no buffer in front of
         // it: that is what leaves a parseable prefix behind an abrupt exit.
         if let Err(e) = file.write_all(line.as_bytes()) {
@@ -282,7 +292,7 @@ impl Recorder {
             data: scrubbed_data.as_ref().map(|d| self.payload_of(d)),
         });
         if let Some(data) = &scrubbed_data {
-            for event in derived(&call, data) {
+            for event in derived(&call, data, self.limit()) {
                 self.write(event);
             }
         }
@@ -290,8 +300,18 @@ impl Recorder {
 
     // ---- fields -----------------------------------------------------------
 
-    fn limit(&self) -> usize {
+    /// How many bytes of one field this transcript keeps. `0` is no cap.
+    ///
+    /// Public because the supervisor writes events of its own ([`crate::engine`]) and has to cap
+    /// them to the same figure. A caller that picked its own would be a second answer to "how big
+    /// may a record be", which is the sort of thing that stays right until someone reads the
+    /// documentation and believes it.
+    pub fn field_limit(&self) -> usize {
         self.0.as_ref().map_or(DEFAULT_FIELD_LIMIT, |s| s.limit)
+    }
+
+    fn limit(&self) -> usize {
+        self.field_limit()
     }
 
     /// A JSON value as a capped field: itself, or a marker naming what was dropped.
@@ -316,12 +336,16 @@ impl Recorder {
 
     /// How big `value` is, if that is over the cap. `None` means it fits.
     fn dropped_bytes(&self, value: &Value) -> Option<usize> {
-        let limit = self.limit();
-        if limit == 0 {
-            return None;
+        // A value that will not serialize is dropped rather than kept. Kept, it takes the whole
+        // record down with it in [`Self::write`] — the same serialization fails there — and a
+        // missing line is worse than a marker saying a payload could not be measured.
+        let Ok(rendered) = serde_json::to_string(value) else {
+            return Some(0);
+        };
+        match self.limit() {
+            0 => None,
+            limit => (rendered.len() > limit).then_some(rendered.len()),
         }
-        let size = serde_json::to_string(value).map_or(0, |s| s.len());
-        (size > limit).then_some(size)
     }
 }
 
@@ -342,6 +366,21 @@ impl InFlight {
             tool: String::new(),
             session: None,
             at: Instant::now(),
+        }
+    }
+
+    /// Names the session this call was actually **routed** to, which is not always the one it
+    /// named.
+    ///
+    /// A caller that omits `session_id` is not saying "no session" — it is accepting whatever the
+    /// current one is ([`crate::engine::Sessions::resolve`]), which is the ordinary way this
+    /// server is driven. Recording the argument alone would put `null` on every such call and on
+    /// every event derived from it, so with more than one target open a transcript could not say
+    /// which one was read or changed. The request record is already written by then, deliberately:
+    /// it is stamped when the call *arrived*, and routing had not happened yet.
+    pub fn routed_to(&mut self, session: Option<String>) {
+        if let Some(session) = session {
+            self.session = Some(session);
         }
     }
 }
@@ -518,9 +557,10 @@ pub enum Event {
         /// What kind of change — `breakpoint`, or a batch step's own description.
         kind: String,
         detail: Capped,
-        /// For a batch step: which block it was in and where.
+        /// For a batch step: which block it was in and where. Capped like the rest, because the
+        /// label inside it is the caller's own string.
         #[serde(default, skip_serializing_if = "Option::is_none")]
-        step: Option<String>,
+        step: Option<Capped>,
     },
     /// An assertion inside a transactional batch did not hold. Its own record because it is the
     /// fact that decided the transaction, and a reader should not have to walk the step list to
@@ -529,7 +569,7 @@ pub enum Event {
         request: u64,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         session: Option<String>,
-        step: String,
+        step: Capped,
         detail: Capped,
     },
     /// How a transactional batch ended, and whether it put everything back.
@@ -564,7 +604,7 @@ pub enum Event {
 /// `tool_result` and nothing more, which is the honest answer: this server cannot know what an
 /// arbitrary `execute` command did to the target, and inventing a `mutation` event by matching on
 /// command text would be a guess wearing a value's clothes.
-fn derived(call: &InFlight, data: &Value) -> Vec<Event> {
+fn derived(call: &InFlight, data: &Value, limit: usize) -> Vec<Event> {
     let request = call.request;
     let session = call.session.clone();
     match call.tool.as_str() {
@@ -605,25 +645,30 @@ fn derived(call: &InFlight, data: &Value) -> Vec<Event> {
                     request,
                     session: session.clone(),
                     kind: "breakpoint".to_string(),
-                    detail: Capped::of(&breakpoint_detail(&set, *id), 0),
+                    detail: Capped::of(&breakpoint_detail(&set, *id), limit),
                     step: None,
                 })
                 .collect()
         }
-        "debug_batch" => batch_events(request, session, data),
+        "debug_batch" => batch_events(request, session, data, limit),
         _ => Vec::new(),
     }
 }
 
 /// A batch's verdict, the assertion that decided it, and everything it changed.
-fn batch_events(request: u64, session: Option<String>, data: &Value) -> Vec<Event> {
+///
+/// Every field here is capped like any other, and the step label is the reason it has to be: it is
+/// the *caller's* string, of whatever length they sent, and a batch of a thousand labelled steps
+/// would otherwise produce a thousand unbounded lines beside a payload the cap had already
+/// replaced with a marker.
+fn batch_events(request: u64, session: Option<String>, data: &Value, limit: usize) -> Vec<Event> {
     let Some(report) = typed::<BatchReportInfo>(data) else {
         return Vec::new();
     };
     let mut events = Vec::new();
     for (block, steps) in [("steps", &report.steps), ("always", &report.always)] {
         for step in steps {
-            let at = format!("{block}[{}] {}", step.position, step.label);
+            let at = Capped::of(&format!("{block}[{}] {}", step.position, step.label), limit);
             // Recorded whether or not the step then succeeded: a command that errors may already
             // have written, which is exactly when a record of it matters.
             if let Some(changes) = &step.changes {
@@ -631,7 +676,7 @@ fn batch_events(request: u64, session: Option<String>, data: &Value) -> Vec<Even
                     request,
                     session: session.clone(),
                     kind: "batch_step".to_string(),
-                    detail: Capped::of(changes, 0),
+                    detail: Capped::of(changes, limit),
                     step: Some(at.clone()),
                 });
             }
@@ -640,7 +685,7 @@ fn batch_events(request: u64, session: Option<String>, data: &Value) -> Vec<Even
                     request,
                     session: session.clone(),
                     step: at,
-                    detail: Capped::of(step.detail.as_deref().unwrap_or_default(), 0),
+                    detail: Capped::of(step.detail.as_deref().unwrap_or_default(), limit),
                 });
             }
         }
@@ -741,7 +786,8 @@ fn scrubbed(value: &Value) -> Value {
 
 // ---- odds and ends --------------------------------------------------------
 
-fn field_limit() -> usize {
+/// The cap this host's environment asks for, or [`DEFAULT_FIELD_LIMIT`].
+fn configured_field_limit() -> usize {
     std::env::var(FIELD_LIMIT_ENV)
         .ok()
         .and_then(|v| v.trim().parse().ok())
@@ -1087,12 +1133,15 @@ mod tests {
         let Event::Assertion { step, detail, .. } = &records[4].event else {
             panic!("expected an assertion: {:?}", records[4].event)
         };
-        assert_eq!(step, "steps[2] check");
+        assert_eq!(step.text, "steps[2] check");
         assert_eq!(detail.text, "expected `91`");
         let Event::Mutation { step, detail, .. } = &records[5].event else {
             panic!("expected the rollback's mutation")
         };
-        assert_eq!(step.as_deref(), Some("always[1] restore"));
+        assert_eq!(
+            step.as_ref().map(|s| s.text.as_str()),
+            Some("always[1] restore")
+        );
         assert_eq!(detail.text, "wrote 1 byte at fffff803");
         let Event::Batch {
             outcome,
@@ -1109,6 +1158,65 @@ mod tests {
         assert!(!committed);
         assert!(rollback_complete, "the `always` block ran");
         assert_eq!(after, "stopped");
+    }
+
+    /// The cap covers the **derived** records too, and the step label is why it has to: that
+    /// string is the caller's, of whatever length they sent, so a batch of long labels could
+    /// otherwise produce unbounded lines beside a payload the cap had already replaced.
+    #[test]
+    fn a_derived_records_fields_are_capped_like_any_other() {
+        let path = std::env::temp_dir()
+            .join("windbg-mcp-transcript-tests")
+            .join(format!("derived-cap-{}.jsonl", std::process::id()));
+        let _ = std::fs::remove_file(&path);
+        let rec = Recorder::to_file(&path, 32).expect("open the transcript");
+        let call = rec.tool_request("debug_batch", None);
+        rec.tool_result(
+            call,
+            true,
+            "BATCH: FAILED",
+            Some(&serde_json::json!({
+                "status": "ok",
+                "outcome": "failed",
+                "at": 1,
+                "committed": false,
+                "rollback_complete": true,
+                "after": { "state": "stopped", "ip": "0x0" },
+                "budget_ms": 1,
+                "elapsed_ms": 1,
+                "steps": [{
+                    "position": 1,
+                    "label": "L".repeat(400),
+                    "action": "eb 0 90",
+                    "result": "unmet",
+                    "detail": "D".repeat(400),
+                    "changes": "C".repeat(400),
+                    "cut_short": false,
+                }],
+                "always": []
+            })),
+        );
+
+        let records = records(&path);
+        let capped: Vec<(&Capped, &Capped)> = records
+            .iter()
+            .filter_map(|r| match &r.event {
+                Event::Mutation { detail, step, .. } => Some((step.as_ref()?, detail)),
+                Event::Assertion { step, detail, .. } => Some((step, detail)),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            capped.len(),
+            2,
+            "a mutation and the assertion: {records:#?}"
+        );
+        for (step, detail) in capped {
+            for field in [step, detail] {
+                assert!(field.text.len() <= 32, "over the cap: {field:?}");
+                assert!(field.dropped.is_some(), "and it has to say so: {field:?}");
+            }
+        }
     }
 
     /// A tool this module knows nothing about contributes its result and no derived events. The

--- a/src/server.rs
+++ b/src/server.rs
@@ -2162,6 +2162,26 @@ pub(crate) fn changes_debug_target(command: &str) -> bool {
     })
 }
 
+tokio::task_local! {
+    /// Where the tool call running on this task was routed, for the transcript.
+    ///
+    /// A task-local rather than a return value because the answer is discovered deep inside the
+    /// call — `resolve` picks the current session for anyone who named none — and is wanted by
+    /// [`WindbgServer::call_tool`], forty-odd tool bodies further out. Threading it back would
+    /// mean changing the signature of every one of them to carry a fact none of them uses.
+    ///
+    /// Scoped per call, so nothing leaks between them, and read after the tool returns.
+    static ROUTED: std::sync::Mutex<Option<String>>;
+}
+
+/// Records which session the call on this task reached. Silent outside a scope — the tool tests
+/// call these functions directly, and a missing transcript is not a reason to fail a debug call.
+fn note_routed(session: &str) {
+    let _ = ROUTED.try_with(|routed| {
+        *routed.lock().unwrap_or_else(|e| e.into_inner()) = Some(session.to_string());
+    });
+}
+
 impl WindbgServer {
     /// Routes a call to the session the caller named — or to the current one — and runs it.
     ///
@@ -2172,6 +2192,7 @@ impl WindbgServer {
     /// of it, and that is `engine::Gate`'s job.
     async fn run_call(&self, session_id: Option<&str>, call: Call) -> Result<Output, EngineError> {
         let session = self.sessions.resolve(session_id)?;
+        note_routed(&session.id);
         self.sessions
             .call(&session, call.named(session_id.is_some()))
             .await
@@ -2202,20 +2223,26 @@ impl WindbgServer {
                 id,
                 report,
                 summary,
-            }) => outcome_result(
-                format!(
-                    "{report}\n\nsession_id: {id}\nPass this as `session_id` on later calls to \
-                     route them to this session and to fail loudly rather than act on a different \
-                     target."
-                ),
-                structured::OpenOutcome::Ok(structured::OpenedSession {
-                    session_id: id,
-                    kind: kind.into(),
-                    target,
-                    report,
-                    summary,
-                }),
-            ),
+            }) => {
+                // An opener does not route to a session, it *mints* one — and the transcript
+                // wants the same field filled in either way, so the call that created a target
+                // is joinable to the events about it.
+                note_routed(&id);
+                outcome_result(
+                    format!(
+                        "{report}\n\nsession_id: {id}\nPass this as `session_id` on later calls \
+                         to route them to this session and to fail loudly rather than act on a \
+                         different target."
+                    ),
+                    structured::OpenOutcome::Ok(structured::OpenedSession {
+                        session_id: id,
+                        kind: kind.into(),
+                        target,
+                        report,
+                        summary,
+                    }),
+                )
+            }
             // No worker, so no session — and no argument the model can change fixes that.
             Err(OpenError::Unavailable(m)) => Err(ErrorData::internal_error(m, None)),
             Err(OpenError::NoRoom(m)) => {
@@ -3105,12 +3132,19 @@ impl WindbgServer {
         // The alternative is a batch that applies three mutations and then trips over a typo in
         // the fourth — survivable, because that is what `always` is for, but not something a
         // caller should have to survive.
+        //
+        // Typed, like every other refusal from a tool that declares an output schema: these are
+        // precisely the documented "the batch never ran" cases, so they are the `status: "error"`
+        // branch. Answering them with text alone would break the contract the schema states, and
+        // break it on the two failures a caller is most likely to hit.
+        let refused =
+            |why: String| typed_error(ErrorCategory::InvalidArgument, why, args.session_id.clone());
         if let Err(why) = batch::validate(&args.steps, &args.always) {
-            return tool_error(why);
+            return refused(why);
         }
         let budget_ms = match batch::budget_ms(args.timeout_ms) {
             Ok(budget_ms) => budget_ms,
-            Err(why) => return tool_error(why),
+            Err(why) => return refused(why),
         };
         // Read before the steps move into the op, and before any of them runs: a `.detach` that
         // reports an error may still have detached, so the handle has to be retired ahead of the
@@ -4086,18 +4120,26 @@ impl rmcp::ServerHandler for WindbgServer {
         request: rmcp::model::CallToolRequestParams,
         context: rmcp::service::RequestContext<rmcp::RoleServer>,
     ) -> Result<rmcp::model::CallToolResponse, ErrorData> {
-        let args = request
-            .arguments
-            .clone()
-            .map(serde_json::Value::Object)
-            .filter(|_| self.rec.enabled());
-        let call = self.rec.tool_request(&request.name, args.as_ref());
         let tcc = rmcp::handler::server::tool::ToolCallContext::new(self, request, context);
-        let outcome = Self::tool_router().call(tcc).await;
-        // A protocol error is recorded too, as a failure with its message. It is the rarest
-        // outcome here — this server answers almost everything as a tool result on purpose — and
-        // so the one a transcript most needs to name rather than leave as a request with nothing
-        // after it.
+        // Nothing at all when there is no transcript, which is the default: not the argument
+        // clone, not the routing scope, and — the one that would actually cost something — not
+        // `text_of`, which joins and copies every content block a tool produced. A module listing
+        // or a pool census is megabytes, and paying for it on every call of a server that is not
+        // recording is the kind of overhead nobody would ever see and everybody would pay.
+        if !self.rec.enabled() {
+            return Self::tool_router().call(tcc).await;
+        }
+        let args = tcc.arguments.clone().map(serde_json::Value::Object);
+        let mut call = self.rec.tool_request(tcc.name(), args.as_ref());
+        let routed = ROUTED.scope(std::sync::Mutex::new(None), async move {
+            let outcome = Self::tool_router().call(tcc).await;
+            let routed = ROUTED.with(|r| r.lock().unwrap_or_else(|e| e.into_inner()).clone());
+            (outcome, routed)
+        });
+        let (outcome, routed) = routed.await;
+        // Where it actually went, which for a call that named no session is the only record of
+        // which target it read or changed.
+        call.routed_to(routed);
         match &outcome {
             Ok(rmcp::model::CallToolResponse::Complete(result)) => self.rec.tool_result(
                 call,
@@ -4105,10 +4147,15 @@ impl rmcp::ServerHandler for WindbgServer {
                 &text_of(result),
                 result.structured_content.as_ref(),
             ),
-            // The MRTR shapes: the call has not produced a result yet, so there is nothing to
-            // record about one. Named rather than folded into the error arm, which would report a
-            // failure that did not happen.
-            Ok(_) => self.rec.tool_result(call, false, "", None),
+            // An MRTR round trip: the server is asking the *client* for something, and this call
+            // has not produced a result. Deliberately recorded as nothing rather than as an empty
+            // success — a `tool_result` says the call finished, and it has not. The request record
+            // stands on its own, which is exactly what happened. (This server elicits nothing
+            // today, so the arm is here to be correct rather than because it is reached.)
+            Ok(_) => {}
+            // A protocol error is a result: the rarest outcome here, since almost everything is
+            // answered as a tool result on purpose, and so the one most worth naming rather than
+            // leaving as a request with nothing after it.
             Err(e) => self.rec.tool_result(call, true, &e.message, None),
         }
         outcome
@@ -4865,6 +4912,22 @@ mod tests {
         assert!(
             !text.contains("session"),
             "validation must not have reached a session: {text}"
+        );
+        // Typed, because this tool declares an output schema and a refusal is a result like any
+        // other. It is also the documented "the batch never ran" case, which is the *only* thing
+        // `status: "error"` means here — a batch that ran answers `ok` and reports its verdict in
+        // the payload — so a caller that cannot see this branch cannot tell "resubmit after fixing
+        // the argument" from "go and look at what the target is holding".
+        let data = result
+            .structured_content
+            .as_ref()
+            .expect("a schema-bearing tool must answer with structured content");
+        assert_eq!(data["status"], "error", "{data}");
+        assert_eq!(data["error"]["category"], "invalid_argument", "{data}");
+        assert_eq!(
+            data["error"]["message"].as_str().unwrap_or_default(),
+            text,
+            "the typed message and the text are one failure, not two accounts of it"
         );
     }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -43,6 +43,10 @@ const OPEN_TAKING_TOO_LONG: Duration = Duration::from_secs(120);
 #[derive(Clone)]
 pub struct WindbgServer {
     sessions: Sessions,
+    /// The session transcript, if this run was asked for one. Taken from the registry rather than
+    /// passed in separately, so the tool surface and the supervisor can never end up recording
+    /// into two different files.
+    rec: crate::record::Recorder,
 }
 
 fn text_result(s: String) -> Result<CallToolResult, ErrorData> {
@@ -217,6 +221,65 @@ fn engine_result_for(
             e.to_string(),
             session_id.map(str::to_string),
         ),
+    }
+}
+
+/// Renders a `debug_batch` outcome, where "did the tool fail?" and "did the engine call fail?" are
+/// not the same question.
+///
+/// Every other tool answers one question, so [`engine_result`] can key `isError` on the engine's
+/// `Ok`/`Err`. A batch answers two: the call succeeds whenever the transaction *ran*, and whether
+/// that transaction committed — and whether its rollback finished — is the verdict inside the
+/// report. The worker sends the report on both paths for exactly that reason (see
+/// `worker::run_batch`), so the verdict is read back from the typed half here instead of being
+/// encoded in the engine result and lost.
+///
+/// **Fails closed.** A report whose verdict cannot be read is rendered as an error. It cannot
+/// happen — the payload is a plain data type, and [`Output::typed`] logs it if it ever does — but
+/// the two ways of being wrong are not symmetric: a caller wrongly told "error" re-reads a report
+/// that is right there in the text, while one wrongly told "success" walks away from a target that
+/// may still be patched.
+fn batch_result(
+    session_id: Option<&str>,
+    r: Result<Output, EngineError>,
+) -> Result<CallToolResult, ErrorData> {
+    let out = match r {
+        Ok(out) => out,
+        // The batch never ran: refused before it started, a stale handle, a worker that died. The
+        // ordinary failure rendering, with its own category.
+        Err(e) => {
+            return typed_error(
+                ErrorCategory::of(&e),
+                e.to_string(),
+                session_id.map(str::to_string),
+            );
+        }
+    };
+    let settled = out.data.as_ref().is_some_and(batch_settled);
+    let content = vec![ContentBlock::text(out.text)];
+    Ok(with_structured(
+        if settled {
+            CallToolResult::success(content)
+        } else {
+            CallToolResult::error(content)
+        },
+        out.data,
+    ))
+}
+
+/// Whether a batch report says the transaction committed **and** its rollback finished — the two
+/// facts that together mean nothing is owed. `false` for a payload that will not read back as a
+/// report; see [`batch_result`] on failing closed.
+fn batch_settled(data: &serde_json::Value) -> bool {
+    match serde::Deserialize::deserialize(data) {
+        Ok(Outcome::<structured::BatchReportInfo>::Ok(report)) => {
+            report.committed && report.rollback_complete
+        }
+        Ok(Outcome::Error(_)) => false,
+        Err(error) => {
+            tracing::error!("a batch report did not read back as one: {error}");
+            false
+        }
     }
 }
 
@@ -2222,7 +2285,10 @@ impl WindbgServer {
 #[rmcp::tool_router]
 impl WindbgServer {
     pub fn new(sessions: Sessions) -> Self {
-        Self { sessions }
+        Self {
+            rec: sessions.recorder(),
+            sessions,
+        }
     }
 
     /// Open a crash dump (.dmp) or a Time Travel Debugging trace (.run) and wait for it to load.
@@ -3016,13 +3082,21 @@ impl WindbgServer {
     /// the current one ends. One edge remains: a step that overruns far enough to consume the
     /// reserved cleanup budget too leaves the rollback unrun, and the result says
     /// `rollback: INCOMPLETE`.
-    #[rmcp::tool(annotations(
-        title = "Run a transactional debugger batch",
-        read_only_hint = false,
-        destructive_hint = true,
-        idempotent_hint = false,
-        open_world_hint = true
-    ))]
+    /// The structured half carries all of that as values — `outcome`, the position it stopped at,
+    /// `committed`, `rollback_complete`, what each step changed, and what the session holds now.
+    /// Note the pairing: a batch that *ran* and did not commit answers with `status: "ok"` (the
+    /// report is the answer) on a result flagged `isError`, because the transaction is what
+    /// failed, not the call. `status: "error"` means the batch never ran at all.
+    #[rmcp::tool(
+        annotations(
+            title = "Run a transactional debugger batch",
+            read_only_hint = false,
+            destructive_hint = true,
+            idempotent_hint = false,
+            open_world_hint = true
+        ),
+        output_schema = schema_for_output::<Outcome<structured::BatchReportInfo>>()
+    )]
     async fn debug_batch(
         &self,
         Parameters(args): Parameters<DebugBatchArgs>,
@@ -3053,7 +3127,8 @@ impl WindbgServer {
         if retires {
             call = call.retiring("a `debug_batch` step replaced or released the target");
         }
-        engine_result(self.run_call(args.session_id.as_deref(), call).await)
+        let session_id = args.session_id.as_deref();
+        batch_result(session_id, self.run_call(session_id, call).await)
     }
 
     /// Show the current register set, as `r` prints it and as typed values beside it.
@@ -3994,7 +4069,66 @@ that times out or a client that disconnects, and the result names the exact fail
 changed, whether the rollback completed, and whether the target is left stopped, running or gone. \
 Use `execute` for any raw command not covered by a dedicated tool."
 )]
-impl rmcp::ServerHandler for WindbgServer {}
+impl rmcp::ServerHandler for WindbgServer {
+    /// Every tool call, recorded on its way through.
+    ///
+    /// Written out rather than left to `#[rmcp::tool_handler]` — which supplies it only when the
+    /// impl does not — because this is the one place *every* tool passes, whatever it is and
+    /// whatever it answers. The alternative was a line in each of forty-odd tool bodies, which is
+    /// forty-odd places to forget one, and the ones that would be forgotten are the ones added
+    /// next. The rest of the handler is still the macro's.
+    ///
+    /// It records the call and its result, and nothing else: the events that say what the *target*
+    /// did are derived from the typed half of the result by [`crate::record`], and the ones about
+    /// sessions come from the supervisor, which is where sessions live.
+    async fn call_tool(
+        &self,
+        request: rmcp::model::CallToolRequestParams,
+        context: rmcp::service::RequestContext<rmcp::RoleServer>,
+    ) -> Result<rmcp::model::CallToolResponse, ErrorData> {
+        let args = request
+            .arguments
+            .clone()
+            .map(serde_json::Value::Object)
+            .filter(|_| self.rec.enabled());
+        let call = self.rec.tool_request(&request.name, args.as_ref());
+        let tcc = rmcp::handler::server::tool::ToolCallContext::new(self, request, context);
+        let outcome = Self::tool_router().call(tcc).await;
+        // A protocol error is recorded too, as a failure with its message. It is the rarest
+        // outcome here — this server answers almost everything as a tool result on purpose — and
+        // so the one a transcript most needs to name rather than leave as a request with nothing
+        // after it.
+        match &outcome {
+            Ok(rmcp::model::CallToolResponse::Complete(result)) => self.rec.tool_result(
+                call,
+                result.is_error.unwrap_or(false),
+                &text_of(result),
+                result.structured_content.as_ref(),
+            ),
+            // The MRTR shapes: the call has not produced a result yet, so there is nothing to
+            // record about one. Named rather than folded into the error arm, which would report a
+            // failure that did not happen.
+            Ok(_) => self.rec.tool_result(call, false, "", None),
+            Err(e) => self.rec.tool_result(call, true, &e.message, None),
+        }
+        outcome
+    }
+}
+
+/// The text a result carries, as one string — what a transcript records and what a renderer
+/// prints. Non-text blocks (an image, a resource link) are named rather than dropped: a record
+/// that silently omitted one would misreport what the caller was told.
+fn text_of(result: &CallToolResult) -> String {
+    result
+        .content
+        .iter()
+        .map(|block| match block.as_text() {
+            Some(text) => text.text.clone(),
+            None => "<non-text content block>".to_string(),
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/server.rs
+++ b/src/server.rs
@@ -164,6 +164,19 @@ fn ms(d: Duration) -> u64 {
     d.as_millis().min(u128::from(u64::MAX)) as u64
 }
 
+/// The session an open ended up with, for the outcomes that have one.
+///
+/// A `match` rather than a chain of `if let`s, so a new [`OpenError`] variant is a compile error
+/// here rather than an outcome that quietly stops being recorded against its session.
+fn opened_session(outcome: &Result<OpenReport, OpenError>) -> Option<&str> {
+    match outcome {
+        Ok(report) => Some(&report.id),
+        Err(OpenError::PostCommit { id, .. }) | Err(OpenError::Timeout { id, .. }) => Some(id),
+        // Nothing was created, so there is no session to name.
+        Err(OpenError::Unavailable(_) | OpenError::NoRoom(_) | OpenError::Clean(_)) => None,
+    }
+}
+
 /// A failed open, with the two things a caller has to act on as fields.
 ///
 /// `session_id` because an open that failed *after* creating its target hands back the only
@@ -2162,26 +2175,6 @@ pub(crate) fn changes_debug_target(command: &str) -> bool {
     })
 }
 
-tokio::task_local! {
-    /// Where the tool call running on this task was routed, for the transcript.
-    ///
-    /// A task-local rather than a return value because the answer is discovered deep inside the
-    /// call — `resolve` picks the current session for anyone who named none — and is wanted by
-    /// [`WindbgServer::call_tool`], forty-odd tool bodies further out. Threading it back would
-    /// mean changing the signature of every one of them to carry a fact none of them uses.
-    ///
-    /// Scoped per call, so nothing leaks between them, and read after the tool returns.
-    static ROUTED: std::sync::Mutex<Option<String>>;
-}
-
-/// Records which session the call on this task reached. Silent outside a scope — the tool tests
-/// call these functions directly, and a missing transcript is not a reason to fail a debug call.
-fn note_routed(session: &str) {
-    let _ = ROUTED.try_with(|routed| {
-        *routed.lock().unwrap_or_else(|e| e.into_inner()) = Some(session.to_string());
-    });
-}
-
 impl WindbgServer {
     /// Routes a call to the session the caller named — or to the current one — and runs it.
     ///
@@ -2192,7 +2185,6 @@ impl WindbgServer {
     /// of it, and that is `engine::Gate`'s job.
     async fn run_call(&self, session_id: Option<&str>, call: Call) -> Result<Output, EngineError> {
         let session = self.sessions.resolve(session_id)?;
-        note_routed(&session.id);
         self.sessions
             .call(&session, call.named(session_id.is_some()))
             .await
@@ -2218,31 +2210,38 @@ impl WindbgServer {
         // Kept for the typed answer, which describes what was asked for rather than re-deriving
         // it from the report the debugger printed.
         let target = what.clone();
-        match self.sessions.open(kind, what, op).await {
+        let outcome = self.sessions.open(kind, what, op).await;
+        // An opener does not route to a session, it *mints* one — and the transcript wants the
+        // same field filled in either way, so the call that created a target can be joined to the
+        // events about it.
+        //
+        // From **every** outcome that carries an id, not only the successful one. The two that
+        // fail with a handle are the ones a reader most needs joined up: `PostCommit` left a
+        // target open, and `Timeout` left an open that may still land — both are recovery cases
+        // where the next question is "what happened to that session?", and the answer is in the
+        // events this field is what links to.
+        if let Some(id) = opened_session(&outcome) {
+            crate::record::routed_to(id);
+        }
+        match outcome {
             Ok(OpenReport {
                 id,
                 report,
                 summary,
-            }) => {
-                // An opener does not route to a session, it *mints* one — and the transcript
-                // wants the same field filled in either way, so the call that created a target
-                // is joinable to the events about it.
-                note_routed(&id);
-                outcome_result(
-                    format!(
-                        "{report}\n\nsession_id: {id}\nPass this as `session_id` on later calls \
+            }) => outcome_result(
+                format!(
+                    "{report}\n\nsession_id: {id}\nPass this as `session_id` on later calls \
                          to route them to this session and to fail loudly rather than act on a \
                          different target."
-                    ),
-                    structured::OpenOutcome::Ok(structured::OpenedSession {
-                        session_id: id,
-                        kind: kind.into(),
-                        target,
-                        report,
-                        summary,
-                    }),
-                )
-            }
+                ),
+                structured::OpenOutcome::Ok(structured::OpenedSession {
+                    session_id: id,
+                    kind: kind.into(),
+                    target,
+                    report,
+                    summary,
+                }),
+            ),
             // No worker, so no session — and no argument the model can change fixes that.
             Err(OpenError::Unavailable(m)) => Err(ErrorData::internal_error(m, None)),
             Err(OpenError::NoRoom(m)) => {
@@ -4131,12 +4130,7 @@ impl rmcp::ServerHandler for WindbgServer {
         }
         let args = tcc.arguments.clone().map(serde_json::Value::Object);
         let mut call = self.rec.tool_request(tcc.name(), args.as_ref());
-        let routed = ROUTED.scope(std::sync::Mutex::new(None), async move {
-            let outcome = Self::tool_router().call(tcc).await;
-            let routed = ROUTED.with(|r| r.lock().unwrap_or_else(|e| e.into_inner()).clone());
-            (outcome, routed)
-        });
-        let (outcome, routed) = routed.await;
+        let (outcome, routed) = crate::record::tracking_route(Self::tool_router().call(tcc)).await;
         // Where it actually went, which for a call that named no session is the only record of
         // which target it read or changed.
         call.routed_to(routed);

--- a/src/structured.rs
+++ b/src/structured.rs
@@ -1637,6 +1637,185 @@ pub enum WalkStop {
     Interrupted,
 }
 
+// ---- transactional batches ------------------------------------------------
+
+/// What a `debug_batch` did, as values.
+///
+/// The last tool whose whole answer was a rendering. It is also the one with the most at stake in
+/// being readable by a program: a batch is run precisely when something *mutates* the target, and
+/// the two questions a caller has to act on afterwards — did this commit, and did the rollback put
+/// everything back — were answerable only by matching on `BATCH: FAILED` and `rollback: INCOMPLETE`
+/// in prose. A transcript recording that prose records the wording, not the verdict
+/// ([#87](https://github.com/glslang/windbg-mcp/issues/87)).
+///
+/// One thing is deliberately **not** here: each step's debugger output. It is in the text half,
+/// which is where a rendering belongs, and carrying a copy of every step's captured output would
+/// make the typed answer the larger of the two channels while adding no fact this does not already
+/// name. What each step *changed* is a fact, and that is [`BatchStepInfo::changes`].
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct BatchReportInfo {
+    /// How the batch as a whole ended.
+    pub outcome: BatchOutcomeName,
+    /// The 1-based position the outcome is about: the step that failed, or the first one not
+    /// attempted. Absent only for [`BatchOutcomeName::Committed`], where every step ran.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub at: Option<u32>,
+    /// Every step ran and every assertion held. The same fact as `outcome == committed`, named
+    /// because it is the one a caller branches on.
+    pub committed: bool,
+    /// Whether every `always` step completed. **Read this even when `committed` is true**: a
+    /// rollback that did not finish is a target left patched, and it is independent of how the
+    /// steps themselves went.
+    pub rollback_complete: bool,
+    /// What the session holds now — the question the step list cannot answer.
+    pub after: SessionAfterInfo,
+    /// The budget the batch was given.
+    pub budget_ms: u64,
+    /// What it actually took.
+    pub elapsed_ms: u64,
+    /// The `steps` block, in order.
+    pub steps: Vec<BatchStepInfo>,
+    /// The `always` block, in order. Present whatever the outcome: it runs on every path, which
+    /// is what a batch is for.
+    pub always: Vec<BatchStepInfo>,
+}
+
+/// How a batch ended. Mirrors [`crate::batch::BatchOutcome`] without its position, which is
+/// [`BatchReportInfo::at`] — one field for one fact, rather than a payload on four of five
+/// variants.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum BatchOutcomeName {
+    /// Every step ran and every assertion held.
+    Committed,
+    /// A step failed, or an assertion did not hold.
+    Failed,
+    /// The deadline expired.
+    TimedOut,
+    /// The session was torn down under it — a disconnect, or `end_session`. Nothing was wrong
+    /// with the steps, so resubmitting the whole batch is the right next move.
+    Abandoned,
+    /// `interrupt` was called on this batch's session. The session still holds its target, so
+    /// this batch can be resubmitted as it stands.
+    Interrupted,
+}
+
+/// One step, as the report tells it.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct BatchStepInfo {
+    /// 1-based position within its own block.
+    pub position: u32,
+    /// The step's label, or the action if it was not given one.
+    pub label: String,
+    /// What actually ran, after interpolation — not what was written.
+    pub action: String,
+    pub result: StepResultName,
+    /// Why, for every result but [`StepResultName::Ok`]: the debugger's refusal, the assertion
+    /// that did not hold, or why the step was never attempted.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
+    /// What this step changed, where the executor recognised a mutation. Recorded whether or not
+    /// the step then succeeded — a command that errors may already have written.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub changes: Option<String>,
+    /// A break landed while this step was running, so its output is what it had reached rather
+    /// than what it would have produced.
+    pub cut_short: bool,
+}
+
+/// How one step ended. [`crate::batch::StepResult`] without its message, which is
+/// [`BatchStepInfo::detail`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum StepResultName {
+    Ok,
+    /// The debugger refused the operation.
+    Failed,
+    /// The action succeeded and an assertion on it did not hold.
+    Unmet,
+    /// Never attempted.
+    Skipped,
+}
+
+/// What the session holds once the batch is done.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "state", rename_all = "snake_case")]
+pub enum SessionAfterInfo {
+    /// The engine answered with a current instruction pointer.
+    Stopped { ip: String },
+    /// The target was told to run and never reported a stop.
+    Running { why: String },
+    /// A step released or replaced the target.
+    Detached { by: String },
+    /// The probe failed and nothing in the batch explains it. Reported as not knowing, never
+    /// guessed at.
+    Uncertain { why: String },
+}
+
+impl From<&crate::batch::BatchReport> for BatchReportInfo {
+    fn from(report: &crate::batch::BatchReport) -> Self {
+        use crate::batch::BatchOutcome;
+        let (outcome, at) = match report.outcome {
+            BatchOutcome::Committed => (BatchOutcomeName::Committed, None),
+            BatchOutcome::Failed { at } => (BatchOutcomeName::Failed, Some(at as u32)),
+            BatchOutcome::TimedOut { at } => (BatchOutcomeName::TimedOut, Some(at as u32)),
+            BatchOutcome::Abandoned { at } => (BatchOutcomeName::Abandoned, Some(at as u32)),
+            BatchOutcome::Interrupted { at } => (BatchOutcomeName::Interrupted, Some(at as u32)),
+        };
+        Self {
+            outcome,
+            at,
+            // From the report's own predicates, not from `outcome` re-tested here: they are what
+            // the text is rendered from, so this cannot disagree with what a reader is told.
+            committed: report.committed(),
+            rollback_complete: report.rollback_complete(),
+            after: (&report.after).into(),
+            budget_ms: ms(report.budget),
+            elapsed_ms: ms(report.elapsed),
+            steps: report.steps.iter().map(BatchStepInfo::from).collect(),
+            always: report.always.iter().map(BatchStepInfo::from).collect(),
+        }
+    }
+}
+
+impl From<&crate::batch::StepOutcome> for BatchStepInfo {
+    fn from(step: &crate::batch::StepOutcome) -> Self {
+        use crate::batch::StepResult;
+        let (result, detail) = match &step.result {
+            StepResult::Ok => (StepResultName::Ok, None),
+            StepResult::Failed(why) => (StepResultName::Failed, Some(why.clone())),
+            StepResult::Unmet(why) => (StepResultName::Unmet, Some(why.clone())),
+            StepResult::Skipped(why) => (StepResultName::Skipped, Some(why.clone())),
+        };
+        Self {
+            position: step.position as u32,
+            label: step.label.clone(),
+            action: step.rendered.clone(),
+            result,
+            detail,
+            changes: step.changes.clone(),
+            cut_short: step.cut_short,
+        }
+    }
+}
+
+impl From<&crate::batch::SessionAfter> for SessionAfterInfo {
+    fn from(after: &crate::batch::SessionAfter) -> Self {
+        use crate::batch::SessionAfter;
+        match after {
+            SessionAfter::Stopped { ip } => Self::Stopped { ip: ip.clone() },
+            SessionAfter::Running { why } => Self::Running { why: why.clone() },
+            SessionAfter::Detached { by } => Self::Detached { by: by.clone() },
+            SessionAfter::Uncertain { why } => Self::Uncertain { why: why.clone() },
+        }
+    }
+}
+
+/// A duration in whole milliseconds, saturating rather than wrapping.
+fn ms(d: std::time::Duration) -> u64 {
+    d.as_millis().min(u128::from(u64::MAX)) as u64
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -1224,9 +1224,7 @@ fn execute(e: &DebugEngine, id: u64, op: EngineOp, queued: Duration) -> Result<O
         }
         // `id` is passed because a batch is the one op that can stop *itself*: it checks between
         // steps whether an interrupt has been raised for the job it is running as.
-        EngineOp::Batch(op) => run_batch(e, id, op, queued)
-            .map(Output::text)
-            .map_err(Failed::from),
+        EngineOp::Batch(op) => run_batch(e, id, op, queued).map_err(Failed::from),
         // Answered by the request reader, which is the only way it could reach a busy engine at
         // all, so it is never queued and never arrives here. See [`EngineOp::Interrupt`].
         EngineOp::Interrupt => Err(Failed::from(
@@ -2425,12 +2423,20 @@ impl Debuggee for BatchEngine<'_> {
     }
 }
 
-/// Runs a batch and renders its report.
+/// Runs a batch and reports what happened, as the rendered report and as values.
 ///
 /// The report is the result either way — a failed transaction that did not say which step failed
-/// and whether the rollback ran would be worse than no report at all. `Err` only chooses how
-/// [`crate::server`] renders it: a tool-execution error the model can read and act on.
-fn run_batch(e: &DebugEngine, job: u64, op: BatchOp, queued: Duration) -> Result<String, String> {
+/// and whether the rollback ran would be worse than no report at all. So a batch that **ran**
+/// answers `Ok` whatever it concluded, and its verdict is a field inside
+/// [`crate::structured::BatchReportInfo`] rather than the choice of `Ok`/`Err`;
+/// [`crate::server::batch_result`] is what turns that verdict into a tool-execution error, and the
+/// two `Err`s here are the batch that never started at all.
+///
+/// It is built here rather than parsed from the rendering on the other side of the pipe for the
+/// reason [#77](https://github.com/glslang/windbg-mcp/issues/77) gives, and it exists at all so a
+/// transcript can record a transaction's outcome and rollback state as facts
+/// ([#87](https://github.com/glslang/windbg-mcp/issues/87)).
+fn run_batch(e: &DebugEngine, job: u64, op: BatchOp, queued: Duration) -> Result<Output, String> {
     let Some(budget) = batch_budget(
         op.budget_ms,
         Duration::from_millis(u64::from(op.patience_ms)),
@@ -2497,11 +2503,10 @@ fn run_batch(e: &DebugEngine, job: u64, op: BatchOp, queued: Duration) -> Result
             }
         );
     }
-    if report.committed() && report.rollback_complete() {
-        Ok(rendered)
-    } else {
-        Err(rendered)
-    }
+    Ok(Output::typed(
+        rendered,
+        crate::structured::BatchReportInfo::from(&report),
+    ))
 }
 
 /// Column header for the chunk tables below. Kept next to [`pool_row`] so the two cannot

--- a/tests/golden/tools_list.json
+++ b/tests/golden/tools_list.json
@@ -163,7 +163,25 @@
         "readOnly": false
       },
       "name": "debug_batch",
-      "output": null,
+      "output": {
+        "branches": [
+          {
+            "payload": "#/$defs/BatchReportInfo",
+            "required": [
+              "status"
+            ],
+            "status": "ok"
+          },
+          {
+            "payload": "#/$defs/Failure",
+            "required": [
+              "status"
+            ],
+            "status": "error"
+          }
+        ],
+        "dialect": "https://json-schema.org/draft/2020-12/schema"
+      },
       "params": [
         "always: array<ref(#/$defs/BatchStep)>",
         "session_id: string|null",

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -3961,6 +3961,67 @@ fn a_transcript_records_both_teardowns_and_invents_neither() {
     let _ = std::fs::remove_file(&transcript);
 }
 
+/// A session reclaimed to pay for a new one is a teardown nobody asked for, and the transcript is
+/// the only place it is reported.
+///
+/// The third way a target is let go, after `end_session` and a disconnect: opening at the session
+/// limit reclaims the oldest idle one, in a background task, with no caller to answer and nothing
+/// in the tool result to say it happened. Whether that target was released cleanly or its worker
+/// was killed still holding it is exactly the question a transcript exists for — and for a live
+/// kernel it is the difference between a machine that came back and one that is sitting halted.
+#[test]
+fn a_session_reclaimed_at_the_limit_records_what_became_of_it() {
+    let Some(dump) = target_tier() else { return };
+    let transcript = marker_path("reclaimed");
+    let _ = std::fs::remove_file(&transcript);
+    let mut server = Server::started_with(&[(
+        "WINDBG_MCP_TRANSCRIPT",
+        transcript.to_str().expect("a UTF-8 temp path"),
+    )]);
+
+    // One past the limit the server documents, so the oldest idle session pays for the last open.
+    const MAX_SESSIONS: usize = 4;
+    let opened: Vec<String> = (0..=MAX_SESSIONS)
+        .map(|_| server.open_session("open_dump", json!({ "path": dump }), TARGET_STEP))
+        .collect();
+    let reclaimed = &opened[0];
+
+    // The reclamation releases in a task of its own, so its record can land after the open that
+    // provoked it returned. Waited for rather than assumed — and the failure if it never comes is
+    // this assertion, not a confusing one later.
+    let deadline = Instant::now() + Duration::from_secs(30);
+    let ended = loop {
+        let found = std::fs::read_to_string(&transcript)
+            .unwrap_or_default()
+            .lines()
+            .filter_map(|l| serde_json::from_str::<Value>(l).ok())
+            .find(|r| r["event"] == "session_end" && r["session"] == *reclaimed);
+        match found {
+            Some(record) => break record,
+            None if Instant::now() >= deadline => panic!(
+                "session {reclaimed} was reclaimed to make room and the transcript never said \
+                 what became of it:\n{}",
+                std::fs::read_to_string(&transcript).unwrap_or_default()
+            ),
+            None => std::thread::sleep(Duration::from_millis(100)),
+        }
+    };
+    assert_eq!(
+        ended["released"], true,
+        "a dump session lets go cleanly even when it is reclaimed rather than ended: {ended}"
+    );
+    // And the handle now says it is gone, which is the caller-visible half of the same fact.
+    let status = server.tool_data(
+        "session_status",
+        json!({ "session_id": reclaimed }),
+        TARGET_STEP,
+    );
+    assert_eq!(status["sessions"][0]["live"], false, "{status}");
+
+    assert_eq!(server.shutdown(), Some(0));
+    let _ = std::fs::remove_file(&transcript);
+}
+
 /// A worker whose supervisor died without saying goodbye still lets go and exits.
 ///
 /// This is the mechanism the whole teardown story now rests on. The supervisor does not terminate

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -1122,6 +1122,15 @@ fn every_tool_with_an_output_schema_answers_with_structured_content() {
             json!({ "addresses": ["0xffff800000000000"] }),
             "error",
         ),
+        // Well-formed for the same reason: a batch that fails `validate` never reaches a session,
+        // and it is the session refusal this row is here for. `status: "error"` is the batch that
+        // did not run — a batch that *runs* and fails answers `status: "ok"` on an `isError`
+        // result, which the dump tier checks because it needs a target to run against.
+        (
+            "debug_batch",
+            json!({ "steps": [{ "op": "command", "command": "version" }] }),
+            "error",
+        ),
     ];
 
     let mut server = Server::started();
@@ -1218,6 +1227,167 @@ fn a_tool_call_round_trips_over_the_wire() {
             "decoded output should mention `{expected}`, got:\n{text}"
         );
     }
+}
+
+/// The session transcript, end to end through the shipped binary: recorded by a real server
+/// process over a real stdio connection, read back as JSONL, and rendered as an asciicast.
+///
+/// In the base tier deliberately. Every acceptance criterion in
+/// [#87](https://github.com/glslang/windbg-mcp/issues/87) except the ones needing a target is
+/// about *this* — the environment variable being read, the file being written beside a live
+/// JSON-RPC transport rather than into it, and the renderer being reachable from the same
+/// executable — and none of that is provable in-process. `src/record.rs` covers the shapes.
+#[test]
+fn a_recorded_session_reads_back_as_jsonl_and_renders_as_a_cast() {
+    let transcript = marker_path("transcript");
+    let _ = std::fs::remove_file(&transcript);
+    let mut server = Server::started_with(&[(
+        "WINDBG_MCP_TRANSCRIPT",
+        transcript.to_str().expect("a UTF-8 temp path"),
+    )]);
+
+    server.tool_text("decode_ioctl", json!({ "code": "0x70000" }), STEP);
+    // A raw connection carrying a key. Refused here for its shape — so nothing dials and this
+    // test never waits on a network — but the key still crossed the wire as a tool argument,
+    // which is the only thing this row is about.
+    let key = "9.8.7.6";
+    server.call_tool(
+        "attach_kernel",
+        json!({ "connection": format!("net:port=50000, key={key}") }),
+        STEP,
+    );
+    // A failure with a category, so the transcript has one of each verdict.
+    server.call_tool("registers", json!({}), STEP);
+    // Read before the shutdown consumes the server; asserted after the file is, so a failure
+    // reports the transcript's problem rather than this.
+    let stdout = server.stdout_lines();
+    assert_eq!(server.shutdown(), Some(0), "the server exits cleanly");
+
+    let raw = std::fs::read_to_string(&transcript)
+        .unwrap_or_else(|e| panic!("no transcript at {}: {e}", transcript.display()));
+    // JSONL: every line is one complete object. Parsed as `Value` rather than as this crate's
+    // own type, because a consumer of the file has neither.
+    let records: Vec<Value> = raw
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .map(|l| serde_json::from_str(l).unwrap_or_else(|e| panic!("not JSONL ({e}): {l}")))
+        .collect();
+    let kinds: Vec<&str> = records.iter().filter_map(|r| r["event"].as_str()).collect();
+    assert_eq!(kinds.first(), Some(&"start"), "a run starts with a header");
+    assert_eq!(
+        kinds.last(),
+        Some(&"shutdown"),
+        "and ends where the server did, so a truncated file is visibly truncated"
+    );
+    // Request order, which is the criterion: the calls, in the order they were made, each with
+    // its result.
+    let calls: Vec<(&str, &str)> = records
+        .iter()
+        .filter(|r| matches!(r["event"].as_str(), Some("tool_request" | "tool_result")))
+        .map(|r| {
+            (
+                r["event"].as_str().unwrap_or_default(),
+                r["tool"].as_str().unwrap_or_default(),
+            )
+        })
+        .collect();
+    assert_eq!(
+        calls,
+        [
+            ("tool_request", "decode_ioctl"),
+            ("tool_result", "decode_ioctl"),
+            ("tool_request", "attach_kernel"),
+            ("tool_result", "attach_kernel"),
+            ("tool_request", "registers"),
+            ("tool_result", "registers"),
+        ]
+    );
+    assert!(
+        records
+            .windows(2)
+            .all(|w| w[0]["seq"].as_u64() < w[1]["seq"].as_u64()),
+        "records are numbered in the order they were written"
+    );
+
+    // The security criterion, checked against the bytes of the file rather than a parsed field:
+    // a key that leaked into some corner of a record nobody thought to look at is still a leak.
+    assert!(
+        !raw.contains(key),
+        "the supplied KD key reached the transcript:\n{raw}"
+    );
+    assert!(
+        raw.contains("<redacted>"),
+        "and it should be visible that something was masked:\n{raw}"
+    );
+
+    // The transport criterion: stdout carried JSON-RPC and nothing else, so a transcript being
+    // written cannot corrupt a client's connection.
+    for line in stdout {
+        let message: Value = serde_json::from_str(&line)
+            .unwrap_or_else(|e| panic!("a non-JSON-RPC line reached stdout ({e}): {line}"));
+        assert_eq!(message["jsonrpc"], "2.0", "not a JSON-RPC message: {line}");
+    }
+
+    // And the same executable renders it. Anything else would be a second tool to keep in step
+    // with a format this one defines.
+    let cast = transcript.with_extension("cast");
+    let rendered = Command::new(EXE)
+        .arg("--render-cast")
+        .arg(&transcript)
+        .arg("--out")
+        .arg(&cast)
+        .output()
+        .expect("run the renderer");
+    assert!(
+        rendered.status.success(),
+        "the renderer failed: {}",
+        String::from_utf8_lossy(&rendered.stderr)
+    );
+
+    let cast_text = std::fs::read_to_string(&cast).expect("the cast exists");
+    let mut lines = cast_text.lines();
+    let header: Value =
+        serde_json::from_str(lines.next().expect("a header line")).expect("the header is JSON");
+    assert_eq!(header["version"], 2, "asciicast v2: {header}");
+    assert!(header["width"].as_u64().unwrap_or(0) > 0, "{header}");
+    assert!(header["height"].as_u64().unwrap_or(0) > 0, "{header}");
+    let mut previous = -1.0;
+    let mut frames = 0;
+    for line in lines.filter(|l| !l.trim().is_empty()) {
+        let event: Vec<Value> = serde_json::from_str(line)
+            .unwrap_or_else(|e| panic!("an event line is not an array ({e}): {line}"));
+        assert_eq!(event.len(), 3, "an asciicast event is `[time, code, data]`");
+        let at = event[0].as_f64().expect("the time is a number");
+        assert_eq!(event[1], "o", "this renderer only writes output events");
+        assert!(event[2].is_string(), "the data is a string");
+        assert!(at >= previous, "an asciicast's times must not go backwards");
+        previous = at;
+        frames += 1;
+    }
+    assert!(frames > 0, "the recording has frames");
+    assert!(
+        !cast_text.contains(key),
+        "the key must not survive into the rendering either"
+    );
+
+    let _ = std::fs::remove_file(&transcript);
+    let _ = std::fs::remove_file(&cast);
+}
+
+/// Recording is opt-in, and its absence has to cost nothing at all: no file, no directory, and
+/// no change to what a client sees.
+#[test]
+fn nothing_is_recorded_unless_a_transcript_is_asked_for() {
+    let would_be = marker_path("unrecorded");
+    let _ = std::fs::remove_file(&would_be);
+    let mut server = Server::started();
+    server.tool_text("decode_ioctl", json!({ "code": "0x70000" }), STEP);
+    assert_eq!(server.shutdown(), Some(0));
+    assert!(
+        !would_be.exists(),
+        "a server nobody asked to record wrote {}",
+        would_be.display()
+    );
 }
 
 /// Bad calls have to fail as *protocol* errors, and — the part that matters — the connection
@@ -1442,6 +1612,51 @@ fn an_unknown_profile_is_refused_with_the_names_that_exist_but_no_values() {
         "a key reached the JSON-RPC transport"
     );
     assert!(!server.stderr().contains(key), "a key reached the log");
+}
+
+/// The same claim about the **third** place this server writes: a session transcript.
+///
+/// Its own test rather than an extra assertion on the one above, because it needs a server started
+/// with recording on, and because it is the other half of a pair — the transcript tier covers a raw
+/// `connection`, and this covers `profile`, which is the selector that is *supposed* to make the
+/// question moot. "Supposed to" is what a test is for: a profile's key lives in this server's own
+/// memory for the life of the process, and a recorder is a new thing that writes memory to a file.
+#[test]
+fn a_profiles_key_never_reaches_a_session_transcript() {
+    let (connection, key) = FAKE_PROFILE;
+    let transcript = marker_path("profile-transcript");
+    let _ = std::fs::remove_file(&transcript);
+    let mut env = profile_env().to_vec();
+    env.push((
+        "WINDBG_MCP_TRANSCRIPT",
+        transcript.to_str().expect("a UTF-8 temp path"),
+    ));
+    let mut server = Server::started_with(&env);
+
+    // Every route by which a profile's key could plausibly be written: naming a profile that does
+    // not exist (the reply lists the ones that do), asking for the list, and the mistake of typing
+    // the connection string into `profile`. None of these dials, so none of them waits.
+    server.call_tool("attach_kernel", json!({ "profile": "no-such-vm" }), STEP);
+    server.call_tool("attach_kernel", json!({}), STEP);
+    server.call_tool("attach_kernel", json!({ "profile": connection }), STEP);
+    assert_eq!(server.shutdown(), Some(0));
+
+    let raw = std::fs::read_to_string(&transcript)
+        .unwrap_or_else(|e| panic!("no transcript at {}: {e}", transcript.display()));
+    assert!(!raw.contains(key), "a profile's key reached the transcript");
+    // And the recording really did happen — otherwise the assertion above passes on an empty file,
+    // which is the way a test like this stops testing anything.
+    assert!(
+        raw.matches("\"tool\":\"attach_kernel\"").count() >= 3,
+        "the three calls should all be recorded:\n{raw}"
+    );
+    // The profile *name* is not a secret and is the whole point of the feature: a transcript has
+    // to say which target a session was pointed at.
+    assert!(
+        raw.contains("smoke_kdnet"),
+        "the profile's name should still be readable:\n{raw}"
+    );
+    let _ = std::fs::remove_file(&transcript);
 }
 
 /// The harness's own guard, pinned because losing it is silent and expensive.
@@ -2628,7 +2843,7 @@ fn a_batch_commits_or_fails_and_its_rollback_runs_either_way() {
 
     // A batch that should commit: a capture bound from one step and interpolated into the next,
     // which is the whole of the "named values" contract in three steps.
-    let committed = server.tool_text(
+    let committed_response = server.call_tool(
         "debug_batch",
         json!({
             "session_id": session_id,
@@ -2642,6 +2857,8 @@ fn a_batch_commits_or_fails_and_its_rollback_runs_either_way() {
         }),
         TARGET_STEP,
     );
+    assert_no_error(&committed_response, "debug_batch");
+    let committed = text_of(&committed_response["result"]);
     assert!(
         committed.contains("BATCH: COMMITTED"),
         "the batch should have committed:
@@ -2663,6 +2880,40 @@ fn a_batch_commits_or_fails_and_its_rollback_runs_either_way() {
         !committed.contains("u {{ip}}"),
         "the capture was not interpolated:
 {committed}"
+    );
+    // The same verdict as values. Read from the typed half rather than from the sentences above,
+    // because that half is what a transcript records and what a client branches on — and the two
+    // agreeing is the property that keeps the report honest.
+    let data = &committed_response["result"]["structuredContent"];
+    assert_eq!(
+        data["status"], "ok",
+        "a batch that ran answers `ok`: {data}"
+    );
+    assert_eq!(data["outcome"], "committed", "{data}");
+    assert_eq!(data["committed"], true, "{data}");
+    assert_eq!(data["rollback_complete"], true, "{data}");
+    assert_eq!(
+        data["after"]["state"], "stopped",
+        "a dump is stopped: {data}"
+    );
+    assert!(
+        data["at"].is_null(),
+        "a committed batch stopped at no step: {data}"
+    );
+    assert_eq!(
+        data["steps"].as_array().map(Vec::len),
+        Some(3),
+        "every step belongs in the typed report: {data}"
+    );
+    assert_eq!(data["always"].as_array().map(Vec::len), Some(1), "{data}");
+    // The interpolation again, from the values: `action` is what ran, not what was written.
+    let disassembly = data["steps"][2]["action"]
+        .as_str()
+        .unwrap_or_default()
+        .to_string();
+    assert!(
+        disassembly.starts_with("u 0x") && !disassembly.contains("{{ip}}"),
+        "the typed step should carry the substituted action, not the template: {disassembly}"
     );
 
     // The same shape with an assertion that cannot hold. The batch must stop at that step, name
@@ -2701,6 +2952,31 @@ fn a_batch_commits_or_fails_and_its_rollback_runs_either_way() {
         text.contains("rollback: COMPLETE"),
         "the `always` block must run on the failing path — that is the whole point:
 {text}"
+    );
+    // The pairing this tool is the only one with: the *call* produced its answer (`status: "ok"`,
+    // the report), and the *transaction* did not commit (`isError`, asserted above). A caller that
+    // read only `status` would think this worked; one that read only `isError` could not tell a
+    // batch that failed from one that never ran.
+    let failed = &failing["result"]["structuredContent"];
+    assert_eq!(failed["status"], "ok", "the batch ran: {failed}");
+    assert_eq!(failed["outcome"], "failed", "{failed}");
+    assert_eq!(failed["committed"], false, "{failed}");
+    assert_eq!(
+        failed["at"], 2,
+        "the typed report must name the failing position: {failed}"
+    );
+    assert_eq!(
+        failed["steps"][1]["result"], "unmet",
+        "an assertion that did not hold is `unmet`, not `failed`: {failed}"
+    );
+    assert!(
+        failed["steps"][1]["detail"].is_string(),
+        "the assertion that did not hold must say so: {failed}"
+    );
+    assert_eq!(failed["steps"][2]["result"], "skipped", "{failed}");
+    assert_eq!(
+        failed["rollback_complete"], true,
+        "the `always` block ran, and the values must say so too: {failed}"
     );
 
     server.tool_text(
@@ -2808,7 +3084,15 @@ fn interrupting_a_running_batch_stops_it_and_rolls_it_back() {
     let _ = std::fs::remove_file(&running);
     let _ = std::fs::remove_file(&reached_later);
 
-    let mut server = Server::started();
+    // Recorded, because this is the only place the interrupted-transaction half of the transcript
+    // contract ([#87](https://github.com/glslang/windbg-mcp/issues/87)) is real: an `interrupt`
+    // that actually reached a running batch, and a report that came back saying so.
+    let transcript = marker_path("interrupt-batch-transcript");
+    let _ = std::fs::remove_file(&transcript);
+    let mut server = Server::started_with(&[(
+        "WINDBG_MCP_TRANSCRIPT",
+        transcript.to_str().expect("a UTF-8 temp path"),
+    )]);
     let response = server.call_tool("open_dump", json!({ "path": dump }), TARGET_STEP);
     assert_no_error(&response, "open_dump");
     let session_id = session_id_of(&response["result"]);
@@ -2896,9 +3180,47 @@ fn interrupting_a_running_batch_stops_it_and_rolls_it_back() {
         json!({ "session_id": session_id }),
         TARGET_STEP,
     );
+    assert_eq!(server.shutdown(), Some(0));
+
+    // The transcript's account of the same thing, and the reason it is worth asserting: the report
+    // above is a paragraph, and this is what a reader after the fact — or an unattended run — has
+    // to be able to act on. The `interrupt` is recorded as its own cause, and the transaction's
+    // verdict says it was interrupted and that the rollback finished, as fields.
+    let events: Vec<Value> = std::fs::read_to_string(&transcript)
+        .unwrap_or_else(|e| panic!("no transcript at {}: {e}", transcript.display()))
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .map(|l| serde_json::from_str(l).unwrap_or_else(|e| panic!("not JSONL ({e}): {l}")))
+        .collect();
+    let interrupt = events
+        .iter()
+        .find(|r| r["event"] == "interrupt")
+        .unwrap_or_else(|| panic!("the interrupt is not in the transcript: {events:#?}"));
+    assert_eq!(
+        interrupt["delivered"], true,
+        "the interrupt reached the worker, and the record has to say so: {interrupt}"
+    );
+    let batch = events
+        .iter()
+        .find(|r| r["event"] == "batch")
+        .unwrap_or_else(|| panic!("the batch verdict is not in the transcript: {events:#?}"));
+    assert_eq!(batch["outcome"], "interrupted", "{batch}");
+    assert_eq!(batch["committed"], false, "{batch}");
+    assert_eq!(
+        batch["rollback_complete"], true,
+        "the rollback ran, and a transcript that did not say so would be the one fact an \
+         unattended run is read for: {batch}"
+    );
+    // Ordered as cause and effect, which is what makes the pair readable.
+    let position = |event: &str| events.iter().position(|r| r["event"] == event);
+    assert!(
+        position("interrupt") < position("batch"),
+        "the interrupt is recorded before the verdict it produced"
+    );
 
     let _ = std::fs::remove_file(&running);
     let _ = std::fs::remove_file(&reached_later);
+    let _ = std::fs::remove_file(&transcript);
 }
 
 /// An `interrupt` that arrives while a batch is running its **rollback** is refused, and the

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -1374,19 +1374,36 @@ fn a_recorded_session_reads_back_as_jsonl_and_renders_as_a_cast() {
     let _ = std::fs::remove_file(&cast);
 }
 
-/// Recording is opt-in, and its absence has to cost nothing at all: no file, no directory, and
-/// no change to what a client sees.
+/// Recording is opt-in, and its absence has to cost nothing at all.
+///
+/// **The same path, twice**, which is the only way this can mean anything: a path the server was
+/// never told about could not be written whatever the default was, so asserting it stays absent
+/// asserts nothing. Here the first run proves the server *does* write that exact file when asked,
+/// and the second — same path, no variable — proves it does not when it is not.
 #[test]
 fn nothing_is_recorded_unless_a_transcript_is_asked_for() {
-    let would_be = marker_path("unrecorded");
-    let _ = std::fs::remove_file(&would_be);
-    let mut server = Server::started();
-    server.tool_text("decode_ioctl", json!({ "code": "0x70000" }), STEP);
-    assert_eq!(server.shutdown(), Some(0));
+    let path = marker_path("opt-in");
+    let _ = std::fs::remove_file(&path);
+    let named = path.to_str().expect("a UTF-8 temp path");
+
+    let mut asked = Server::started_with(&[("WINDBG_MCP_TRANSCRIPT", named)]);
+    asked.tool_text("decode_ioctl", json!({ "code": "0x70000" }), STEP);
+    assert_eq!(asked.shutdown(), Some(0));
     assert!(
-        !would_be.exists(),
+        path.exists(),
+        "the control half of this test is broken: a server that was asked to record wrote nothing \
+         to {}, so the assertion below cannot mean anything",
+        path.display()
+    );
+
+    std::fs::remove_file(&path).expect("clear the transcript between the two halves");
+    let mut unasked = Server::started();
+    unasked.tool_text("decode_ioctl", json!({ "code": "0x70000" }), STEP);
+    assert_eq!(unasked.shutdown(), Some(0));
+    assert!(
+        !path.exists(),
         "a server nobody asked to record wrote {}",
-        would_be.display()
+        path.display()
     );
 }
 
@@ -3821,6 +3838,127 @@ fn engine_workers_do_not_outlive_the_connection() {
         !process_alive(worker),
         "engine worker pid {worker} outlived the connection — every disconnect would leak one"
     );
+}
+
+/// A call that names no session is still routed to one, and the transcript has to say which.
+///
+/// Omitting `session_id` is not "no session" — it accepts whatever the current one is — and it is
+/// the ordinary way this server is driven. Recording only the argument would put `null` on every
+/// such call *and on every event derived from it*, so with two targets open a transcript could not
+/// answer the question it exists for: which one was read, and which one was changed.
+///
+/// Two sessions, deliberately, because with one open the bug is invisible — any answer at all
+/// would be the right one.
+#[test]
+fn a_call_that_names_no_session_records_the_one_it_reached() {
+    let Some(dump) = target_tier() else { return };
+    let transcript = marker_path("routing");
+    let _ = std::fs::remove_file(&transcript);
+    let mut server = Server::started_with(&[(
+        "WINDBG_MCP_TRANSCRIPT",
+        transcript.to_str().expect("a UTF-8 temp path"),
+    )]);
+
+    let first = server.open_session("open_dump", json!({ "path": dump }), TARGET_STEP);
+    let second = server.open_session("open_dump", json!({ "path": dump }), TARGET_STEP);
+    assert_ne!(first, second, "two sessions, or this proves nothing");
+    // No `session_id`: this goes to the newest usable session, which is the second one.
+    server.tool_text("modules", json!({ "filter": "nt" }), TARGET_STEP);
+    assert_eq!(server.shutdown(), Some(0));
+
+    let events: Vec<Value> = std::fs::read_to_string(&transcript)
+        .unwrap_or_else(|e| panic!("no transcript at {}: {e}", transcript.display()))
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .map(|l| serde_json::from_str(l).unwrap_or_else(|e| panic!("not JSONL ({e}): {l}")))
+        .collect();
+    let result = events
+        .iter()
+        .find(|r| r["event"] == "tool_result" && r["tool"] == "modules")
+        .unwrap_or_else(|| panic!("the unnamed call is not in the transcript: {events:#?}"));
+    assert_eq!(
+        result["session"], second,
+        "the result must name the session the call was routed to, not `null` because the caller \
+         named none: {result}"
+    );
+    // The openers too: an opener mints a session rather than routing to one, and the record has
+    // to carry it either way or the call that created a target cannot be joined to it.
+    let opened: Vec<&Value> = events
+        .iter()
+        .filter(|r| r["event"] == "tool_result" && r["tool"] == "open_dump")
+        .collect();
+    assert_eq!(opened.len(), 2, "{events:#?}");
+    assert_eq!(opened[0]["session"], first, "{}", opened[0]);
+    assert_eq!(opened[1]["session"], second, "{}", opened[1]);
+    let _ = std::fs::remove_file(&transcript);
+}
+
+/// What a transcript says about the two teardowns, which is the pair that matters most in a file
+/// nobody was watching being written.
+///
+/// A **disconnect** has no caller to answer, so the transcript is the only account of what became
+/// of each target — `released` false means a worker was killed still holding one, which for a live
+/// kernel is a machine left halted. That record has to be there, per session, and not only the
+/// `shutdown` line saying a teardown began.
+///
+/// An **`end_session`** must not then be followed by a "lost its engine" record. Its worker is
+/// terminated on purpose, so the pipe reaching EOF is the last step of an orderly teardown rather
+/// than a loss, and a red line after every successful release would describe a failure that did
+/// not happen. Both halves in one test because they are the same claim from opposite ends: the
+/// transcript reports the teardown that happened and no teardown that did not.
+#[test]
+fn a_transcript_records_both_teardowns_and_invents_neither() {
+    let Some(dump) = target_tier() else { return };
+
+    // Ended by hand, then disconnected. Two sessions so the disconnect has one of its own.
+    let transcript = marker_path("teardowns");
+    let _ = std::fs::remove_file(&transcript);
+    let mut server = Server::started_with(&[(
+        "WINDBG_MCP_TRANSCRIPT",
+        transcript.to_str().expect("a UTF-8 temp path"),
+    )]);
+    let ended = server.open_session("open_dump", json!({ "path": dump }), TARGET_STEP);
+    let abandoned = server.open_session("open_dump", json!({ "path": dump }), TARGET_STEP);
+    server.tool_text("end_session", json!({ "session_id": ended }), TARGET_STEP);
+    assert_eq!(server.shutdown(), Some(0));
+
+    let events: Vec<Value> = std::fs::read_to_string(&transcript)
+        .unwrap_or_else(|e| panic!("no transcript at {}: {e}", transcript.display()))
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .map(|l| serde_json::from_str(l).unwrap_or_else(|e| panic!("not JSONL ({e}): {l}")))
+        .collect();
+    let for_session = |session: &str, event: &str| -> Vec<Value> {
+        events
+            .iter()
+            .filter(|r| r["event"] == event && r["session"] == session)
+            .cloned()
+            .collect()
+    };
+
+    // The session the client ended, and the one it walked away from, both accounted for.
+    for (session, how) in [(&ended, "end_session"), (&abandoned, "the disconnect")] {
+        let ends = for_session(session, "session_end");
+        assert_eq!(
+            ends.len(),
+            1,
+            "{how} should have recorded exactly one end for {session}: {events:#?}"
+        );
+        assert_eq!(
+            ends[0]["released"], true,
+            "a dump session lets go cleanly, and the record is what says so: {}",
+            ends[0]
+        );
+    }
+
+    // And no invented loss. The worker of an ended session is terminated deliberately, so its
+    // pipe closing is the teardown finishing rather than an engine that died.
+    let lost = for_session(&ended, "worker_lost");
+    assert!(
+        lost.is_empty(),
+        "an orderly end_session reported a lost engine: {lost:#?}"
+    );
+    let _ = std::fs::remove_file(&transcript);
 }
 
 /// A worker whose supervisor died without saying goodbye still lets go and exits.


### PR DESCRIPTION
Closes #87.

## The problem

This server is the only party that sees the whole of a session — the tool call, the session it was routed to, the target's answer, the state the session moved to, the worker that died — and it recorded none of it. What existed instead were artifacts with opposite problems: a client's own log, tens of megabytes of prompts with the debugger operations buried inside shell-command source, and the curated proof records under `examples/`, which are readable and are written afterwards.

One of them says so on its face — *"its timing is illustrative because live recording was not enabled for the original run"* — and a second reconstructed cast was added six days after the issue was filed.

## What this adds

`WINDBG_MCP_TRANSCRIPT=<path>` records one JSON object per line. Unset, which is the default, nothing is written and nothing is spent.

```jsonc
{"v":1,"seq":2,"at":"2026-08-16T07:13:01.643Z","mono_ms":135,"event":"session_open","session":"sess-…","kind":"crash dump","target":"C:\dumps\a.dmp","engine_pid":1656}
{"v":1,"seq":10,"at":"2026-08-16T07:13:04.272Z","mono_ms":2765,"event":"assertion","request":3,"session":"sess-…","step":"steps[2] lm m nt","detail":{"text":"the output does not contain \"nope\""}}
{"v":1,"seq":11,"at":"2026-08-16T07:13:04.272Z","mono_ms":2765,"event":"batch","request":3,"session":"sess-…","outcome":"failed","at_step":2,"committed":false,"rollback_complete":true,"after":"stopped","elapsed_ms":603}
```

The events are the tool call and its result; a session opening, changing state, being released; a wait abandoned, an `interrupt`, a worker process dying; and — derived from each result's **typed** half — where execution stopped, what a `run_to_address` concluded, every breakpoint or memory mutation, each assertion that did not hold, and how a `debug_batch` ended with whether its rollback completed.

`windbg-mcp --render-cast <transcript.jsonl>` renders one as asciicast v2 — each call as a prompt line, its output beneath, the derived facts marked between them. Derived offline from the same JSONL, so a cast can be made from a transcript recorded weeks ago and its timings are the recorded ones, measured on a monotonic clock.

## Four properties it is built around

- **Written by the supervisor, from values.** One writer, so no locking and no interleaving between processes — and a worker's facts still arrive as facts, because they cross the pipe as the typed half of its reply and are read back through `structured` types. Nothing here is scraped out of a rendering, which is the rule #77 was fixed by. A tool this server cannot type — an arbitrary `execute` — contributes its call and its result and no derived event, because guessing what the command did would put a fact in the record that nothing measured.
- **Redacted by the same rule as everywhere else.** `kdconn` grew a scan for arbitrary text beside its connection parser, sharing the one list of secret parameter names and the one mask, so a raw `connection` is recorded as `key=<redacted>` and an argument member *named* like a secret is masked whole, before any tool has one. Scrubbing happens **before** the field cap, not after: cutting first can leave the front of a key behind. Profiles (#81) still keep the key out of the request in the first place; this is the backstop.
- **Bounded, and it says so.** Fields are capped (`WINDBG_MCP_TRANSCRIPT_MAX_FIELD`, 16 KiB default) and a record reports how much it dropped. A transcript that quietly truncated would read as complete, which is worse than not having one.
- **Never the transport.** Standard output stays JSON-RPC; the transcript is a file this module opens, and a test reads the source to keep it that way.

## Enabling change: `debug_batch` answers with values

It was the last tool whose whole answer was a rendering, and the one with the most at stake in being readable by a program — a batch runs precisely when something *mutates* the target, and "did this commit" and "did the rollback put everything back" were answerable only by matching on `BATCH: FAILED` and `rollback: INCOMPLETE` in prose. A transcript recording that prose records the wording, not the verdict.

The worker now builds `structured::BatchReportInfo` from the executor's own `BatchReport` and returns it on both paths; `server::batch_result` reads the verdict back to decide `isError`, and **fails closed** — a caller wrongly told "error" re-reads a report that is right there in the text, while one wrongly told "success" walks away from a target that may still be patched.

> [!IMPORTANT]
> **Visible change for existing clients.** `debug_batch` now declares an `outputSchema` and returns `structuredContent`. The text and `isError` are unchanged. Note the pairing only this tool has: a batch that **ran** answers `status: "ok"` (the report is the answer) on a result flagged `isError`, while `status: "error"` means it never ran. Reading only `isError` cannot tell those apart, and it is the difference between "resubmit" and "check what the target is left holding".

The golden `tools_list.json` is re-recorded; the diff is exactly that one schema.

## Testing

`cargo test` (355 unit + 42 smoke), `cargo clippy --all-targets`, `cargo fmt --check`, and the debugger tier (`WINDBG_MCP_SMOKE_DUMP=1`) all pass. Also driven by hand against the checked-in kernel dump, end to end through the shipped binary.

- **Unit** — the record shapes, the redaction, the caps and their truncation markers, the derived events, the RFC 3339 round trip, and the cast's validity, clipping and tolerance of a torn tail. One test reads this module's own source to keep it off standard output; one pins that a transition to the state a session is already in still restamps `in_state_for` but does *not* record a line (verified against a deliberately broken version, which it catches).
- **Protocol tier** — drives the shipped binary with recording on, reads the JSONL back, checks the calls are in order with a `start` first and a `shutdown` last, that the supplied key is absent from the file's **bytes**, that every stdout line still re-parses as JSON-RPC, and that `--render-cast` produces a valid asciicast v2. A second test pins the `profile` path; a third that a server nobody asked to record writes no file at all.
- **Debugger tier** — the batch verdict is now read from the typed half as well as the prose, and the interrupted-batch test checks the transcript records the `interrupt` as its own cause followed by a verdict whose `outcome` is `interrupted` and whose `rollback_complete` is true.

## What is not covered

No KDNET target on this host, so the "a live attach transcript contains no supplied KD key" criterion is checked against attaches that are **refused** (for their shape, so nothing dials), plus the profile path. A landing attach is safe by construction — the raw string travels in `EngineOp::AttachKernel`, which the recorder never sees, and the session label is masked in `kdconn::select` before a worker is spawned — but that is an argument, not a measurement. Worth one pass on the live-kernel tier before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added opt-in JSONL recording of debugging sessions, with secret redaction, field-size limits and shutdown tracking.
  * Added offline conversion of session transcripts into asciicast recordings.
  * Added structured `debug_batch` results covering outcomes, rollback status, session state and step details.
* **Documentation**
  * Documented transcript recording, rendering, retention, redaction and batch-result semantics.
* **Tests**
  * Expanded coverage for transcript integrity, sensitive-data handling, rendering and structured batch outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->