### PR TITLE
Verify the live-attach redaction claim, and stop assuming there is no target

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,22 +111,31 @@ that patches a byte of the running kernel** and has to put it back (through a fa
 clamped call budget, a disconnect and an `end_session`) — the one claim a crash dump cannot test,
 because a byte patched in a dump is patched in a file nobody reads again. It is gated on the
 connection string (which nobody can guess) *and* `#[ignore]`d, so a stale variable can never freeze
-a VM during an ordinary `cargo test`. Run it last, on its own:
+a VM during an ordinary `cargo test`. Run it last, on its own.
+
+**Before deciding a live-kernel claim cannot be checked, read the profiles.** This host normally has
+one configured, and a configured profile *is* a KDNET target — connection, port and key — so the
+tier can be run. The failure this is here to stop is not asking the user for a key; it is concluding
+"no KDNET target on this host" without looking, shipping the live claim as unverified, and saying so
+in a PR. Two lines settle it:
 
 ```pwsh
-$env:WINDBG_MCP_SMOKE_KERNEL = "net:port=50000,key=<w.x.y.z>"
+Get-Content "$env:USERPROFILE\.windbg-mcp\profiles.json" -Raw | ConvertFrom-Json | Get-Member -MemberType NoteProperty | Select-Object Name
+Get-ChildItem Env: | Where-Object Name -like 'WINDBG_MCP_PROFILE_*' | Select-Object Name
+```
+
+Then set the variable **from the profile, in one step**, so the key never lands in a command line, a
+tool argument or this transcript:
+
+```pwsh
+$env:WINDBG_MCP_SMOKE_KERNEL = (Get-Content "$env:USERPROFILE\.windbg-mcp\profiles.json" -Raw | ConvertFrom-Json).'ctf-vm'
 cargo test --test mcp_smoke -- --ignored --nocapture --test-threads=1 live_kernel
 ```
 
-**Do not ask for that string before checking whether a profile already holds it.** The same
-connection is usually configured for `attach_kernel { "profile": … }`, in
-`%USERPROFILE%\.windbg-mcp\profiles.json` or a `WINDBG_MCP_PROFILE_<NAME>` variable, and the tier
-takes the *raw* string only because it has to exercise the explicit path — not because it needs a
-second copy. Read the profile and set the variable from it in one step, so the key never lands in a
-command line, a tool argument or this transcript; print the profile *name* and the port when
-reporting what you are attaching to, never the value. `attach_kernel {}` lists the configured names
-without disclosing any of them. Only ask the user for a raw connection when no profile is
-configured at all.
+The tier takes the *raw* string only because it has to exercise the explicit path — not because it
+needs a second copy of the key. Print the profile **name** and the port when reporting what you are
+attaching to, never the value; `attach_kernel {}` lists the configured names without disclosing any
+of them. Only ask the user for a raw connection when no profile is configured at all.
 
 `--test-threads=1` is not optional: the filter matches **eight** tests, and the KD transport is
 single-owner, so in parallel the second attach fails and can leave the target halted.

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -488,6 +488,14 @@ about. This is the other half — an attach that lands:
   containing one cannot be turned back into the bytes it came from. That is a fact about rendering
   and says nothing about the walk, so it skips the comparison with a note rather than failing.
 
+The attach test also records a **transcript** and checks the supplied KD key is nowhere in it. The
+protocol tier passes a raw connection too, but its attach is refused for its shape before anything
+dials — so it proves the *argument* is scrubbed and nothing about a session that then exists, takes
+a label, opens a target and reports on it. Only here is that an attach that landed. Three guards
+keep it from passing on nothing: the connection must actually contain a `key=`, the transcript must
+contain a mask, and it must contain the kernel `session_open`. The failure message names the file
+rather than printing it, since printing it would put the key in the test output.
+
 The first run of this tier found a real bug — shutdown killed workers outright, so a disconnect
 froze the target — which no dump-based tier could have found, because killing a worker that holds
 a *dump* costs nothing. Both tests therefore collect their evidence and assert only after the

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -4747,7 +4747,17 @@ fn a_live_kernel_session_attaches_coexists_and_detaches_cleanly() {
     let Some(connection) = kernel_tier() else {
         return;
     };
-    let mut server = Server::started();
+    // Recorded, because this is the only place the transcript's redaction claim can be made
+    // against an attach that **landed**. The protocol tier passes a raw connection too, but its
+    // attach is refused for its shape before anything dials — so it proves the argument is
+    // scrubbed and nothing about a session that then exists, gets a label, opens a target and
+    // reports on it. Checked at the end of this test, after the detach.
+    let transcript = marker_path("live-attach");
+    let _ = std::fs::remove_file(&transcript);
+    let mut server = Server::started_with(&[(
+        "WINDBG_MCP_TRANSCRIPT",
+        transcript.to_str().expect("a UTF-8 temp path"),
+    )]);
 
     let attached = server.call_tool(
         "attach_kernel",
@@ -4892,6 +4902,40 @@ fn a_live_kernel_session_attaches_coexists_and_detaches_cleanly() {
         ended_text.contains("closed"),
         "end_session should report the session closed:\n{ended_text}"
     );
+
+    // The redaction claim, against a real attach. Last, so a failure here can never be the reason
+    // a machine is left halted — the detach above has already run.
+    let key = connection
+        .split("key=")
+        .nth(1)
+        .and_then(|rest| rest.split(',').next())
+        .unwrap_or_default();
+    assert!(
+        key.len() >= 4,
+        "this connection has no `key=` to look for, so the assertion below would pass on nothing"
+    );
+    let raw = std::fs::read_to_string(&transcript)
+        .unwrap_or_else(|e| panic!("no transcript at {}: {e}", transcript.display()));
+    // Deliberately *not* printing the file on failure: it would put the key in the test output,
+    // which is the thing being checked. The path is enough to go and look.
+    assert!(
+        !raw.contains(key),
+        "the supplied KD key reached the transcript of a landed attach ({})",
+        transcript.display()
+    );
+    assert!(
+        raw.contains("<redacted>"),
+        "nothing in the transcript was masked, so the check above proves nothing ({})",
+        transcript.display()
+    );
+    // And the session really is in there — otherwise a transcript that recorded nothing would
+    // satisfy both assertions above.
+    assert!(
+        raw.contains("\"event\":\"session_open\"") && raw.contains("\"kind\":\"kernel target\""),
+        "the transcript has no record of the kernel session it was recording ({})",
+        transcript.display()
+    );
+    let _ = std::fs::remove_file(&transcript);
     println!("live kernel session detached cleanly:\n{ended_text}");
 }
 


### PR DESCRIPTION
Closes the one item I left open on #129.

## What was wrong

I twice reported the live-kernel half of #87 as unverifiable — *"no KDNET target on this host"* — and said so in the PR. That was not true. `%USERPROFILE%\.windbg-mcp\profiles.json` holds `ctf-vm`: net, port 50000, with a key. Two lines would have told me.

`CLAUDE.md` already said not to **ask** the user for a connection string before checking a profile. That is a different mistake from the one I made — concluding no target existed without looking at all — so the rule now covers it: *before deciding a live-kernel claim cannot be checked, read the profiles; a configured profile **is** a target.* The recipe sets `WINDBG_MCP_SMOKE_KERNEL` from the profile in one step, so the key never lands in a command line or a transcript.

## What the run settles

Pre-flight, as the runbook requires — the guest's `bcdedit /dbgsettings hostip` is this host's IP on the profile's port, and the keys hash equal (compared as hashes, never printed). Then the tier:

```
test result: ok. 8 passed; 0 failed; finished in 211.67s
```

Including the graceful detach, and the disconnect check — target uptime advanced 6.003s across a 4s disconnect, so the session was released rather than the worker killed with the kernel halted.

**The open item:** with a transcript recording, a raw `connection` on an attach that **landed** leaves no key in the file. The protocol tier can only refuse an attach for its shape, which proves the *argument* is scrubbed and nothing about a session that then exists, takes a label, opens a target and reports on it.

| | |
|---|---|
| records / server runs | 260 / 10 |
| kernel sessions opened | 11 |
| sessions released | 11 — `"released":false` appears **zero** times |
| contains the KD key | **no** |
| target rendered as | `net:port=50000,key=<redacted>` |

The same file renders as a valid cast — 260 frames, monotonic across all 10 runs, and no escape sequence from the target reaching a frame. That is the multi-run timeline and the control-sequence escaping from #129 exercised on real data rather than synthetic.

## Made durable

The attach test now records its own transcript and asserts the key is absent, so this is checked whenever the tier runs rather than being something I once did. Three guards stop it passing on nothing: the connection must contain a `key=`, the file must contain a mask, and it must contain the kernel `session_open`. Its failure message names the path instead of printing the file — printing it would put the key in the test output.

Verified by inverting the assertion: it fails, so the file is genuinely read and the key genuinely is not in it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
