### PR TITLE
Say why a trace will not open, and document the engine bundle's real gaps

### DIFF
--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -7,7 +7,8 @@ MCP `2026-07-28` extensions (tasks, apps), item 12 from the opener split
 (#46, 2026-08-02), item 15 from the private worker channel (#65 / #72, 2026-08-04), items 16–18
 from transactional batches (#82, 2026-08-09/10 — item 17 is what validating the tool against the CTF
 session's own transcript turned up, and item 18 what reviewing it did), and item 19 from
-`walk_memory` (#103, 2026-08-13). Each item notes its repo,
+`walk_memory` (#103, 2026-08-13), and item 20 from standing the server up on an ARM64 guest
+(#131, 2026-08-16). Each item notes its repo,
 why it was deferred, and where it picks up. See [`DECISIONS.md`](./DECISIONS.md) for the design rationale (D1–D5) items 1–6 extend,
 and the 2026-08-02 entries that items 13–14 and item 10 extend.
 
@@ -537,3 +538,27 @@ alongside `pool`, and `worker::walk_memory`, which already returns the text a ch
 against. The one design question is the budget: a walk step is up to 1024 reads inside a
 transaction whose whole point is that its rollback still fits, so the step's share has to come out
 of the batch's deadline the way `pool`'s does rather than out of the call's.
+
+## 20. [windbg-mcp] Pick the TTD recorder by architecture, not by a fixed list
+
+`find_ttd` probes x64 before arm64 in both layouts it knows — `["x64", "arm64"]` for the classic
+SDK, and a list headed by `amd64\TTD\TTD.exe` for the MSIX package. On an ARM64 host that is always
+the wrong answer, because the ARM64 WinDbg package ships **all three** recorders (`amd64`, `arm64`,
+`x86`) and the first probe therefore always hits. `record_trace` picks the x64 recorder on exactly
+the hosts where the choice is not free, and a native ARM64 target cannot be recorded with it.
+
+Deferred rather than fixed on the spot because the honest selector is not the one the bug suggests.
+Host architecture is the obvious improvement, but x64-on-ARM64 emulation is a real workflow — an
+emulated x64 debuggee genuinely needs the `amd64` recorder — so the choice properly belongs to the
+*target*, which `record_trace` knows only after it has decided what to launch. Host-first is a
+strict improvement and a fine first cut; target-first is the design question worth thinking about
+before writing either.
+
+Found while setting up a Parallels ARM64 guest for [`docs/remote-phase0.md`](./docs/remote-phase0.md),
+and tracked as [#131](https://github.com/glslang/windbg-mcp/issues/131). Note the workaround is
+already load-bearing on that host: `search_path` runs before both layout probes, so a recorder on
+`PATH` masks the ordering entirely — which also means a host configured that way will not reproduce
+the bug.
+
+Picks up at `ttd::find_ttd` and `ttd::find_in_windowsapps`, both of which are pure path probes with
+no engine dependency, so the fix is testable without a debugger.

--- a/README.md
+++ b/README.md
@@ -170,56 +170,29 @@ promise on this project's behalf.
 
 ### Bundling the WinDbg engine
 
-Needed for three things: TTD `.run` replay (System32's engine rejects traces with `0x80070057`),
-crash-dump `!analyze` (which lives in the `winext\` extensions that System32 doesn't ship), and the
-kernel driver tools `driver_object`/`device_object`/`irp_stack` (which need `winxp\kdexts.dll`).
-So a live-kernel-only user needs this section too, even though the attach itself works on the
-System32 engine. `DebugCreate` binds to whichever `dbgeng.dll` the loader finds first, and the app
-directory is searched before `System32`, so the copied **WinDbg** engine (which replays TTD traces
-and ships the extensions) wins. One-time, from the installed WinDbg store package:
+Basic live and crash-dump debugging works on the `dbgeng.dll` already in `System32`. These do not,
+and each needs files that engine does not ship:
 
-```pwsh
-$wd  = (Get-AppxPackage Microsoft.WinDbg).InstallLocation + "\amd64"
-$dst = "C:\workspace\windbg-mcp\target\release"
-Copy-Item "$wd\dbgeng.dll","$wd\dbghelp.dll","$wd\dbgcore.dll","$wd\dbgmodel.dll",`
-          "$wd\symsrv.dll","$wd\msdia140.dll" $dst -Force
-Copy-Item "$wd\ttd"    "$dst\ttd"    -Recurse -Force   # TTDReplay*.dll, TtdExt.dll, TTDAnalyze.dll, ...
-Copy-Item "$wd\winext" "$dst\winext" -Recurse -Force   # ext.dll (!analyze), kext.dll, … — crash-dump triage
-Copy-Item "$wd\triage" "$dst\triage" -Recurse -Force   # triage.ini, pooltag.txt — !analyze's module attribution
-New-Item   "$dst\winxp" -ItemType Directory -Force | Out-Null
-Copy-Item "$wd\winxp\kdexts.dll" "$dst\winxp" -Force   # !drvobj/!devobj/!irp — the kernel driver tools
-```
+| Wanted | Needs |
+| --- | --- |
+| TTD `.run` replay | `ttd\` — System32's engine rejects traces with `0x80070057` |
+| Crash-dump `!analyze` | `winext\` for the extension, `triage\` for its module attribution |
+| `driver_object` / `device_object` / `irp_stack` | `winxp\kdexts.dll` |
+| `module!name` symbols anywhere | `msdia140.dll` + `symsrv.dll`, plus a symbol path |
 
-- The `ttd\` subdir provides the `@$cursession.TTD` / `@$curprocess.TTD` data model and the `!tt`
-  time-travel commands.
-- The `winext\` subdir provides `ext.dll` (which exports `!analyze`) and the other `!`-extensions.
-  `open_dump` runs `.load ext` for you, but note the **unqualified `!analyze` does not resolve** on
-  this minimal engine — use the module-qualified **`!ext.analyze -v`** for crash-dump triage. Without
-  `winext\`, `!analyze` returns *"No export analyze found"*.
-- `winxp\kdexts.dll` provides `!drvobj`/`!devobj`/`!irp`, behind the
-  `driver_object`/`device_object`/`irp_stack` tools. `attach_kernel` / `attach_kernel_local`
-  `.load kdexts` for you and nothing complains at attach time, so a missing file first surfaces as
-  *"No export drvobj found"* from those three tools. It lives in `winxp\`, not `winext\` — the
-  engine searches that subdir by name.
-- The `triage\` subdir provides `triage.ini` and `pooltag.txt`, which `!analyze` reads to attribute
-  a crash to a module and to name pool tags. **Its absence raises no error**, which is what makes it
-  worth copying deliberately: `!analyze` runs and reports `ANALYSIS_INCONCLUSIVE` / `Unknown_Module`
-  instead, so a missing file reads as an inconclusive crash.
-- **`msdia140.dll` is required for PDB symbols.** Without it, `dbghelp` can't parse any PDB
-  (`dia error 0x8007007e`) and silently falls back to *export* symbols — which makes `module!name`
-  lookups (and so `ttd_calls("ucrtbase!__stdio_common_vfprintf")`) fail even with the right PDB in
-  the cache. `symsrv.dll` is needed to read a symbol-store cache.
+The fix is a one-time file copy: `DebugCreate` binds to whichever `dbgeng.dll` the loader finds
+first and the app directory is searched before `System32`, so a WinDbg engine copied next to
+`windbg-mcp.exe` wins. Note the kernel row — a live-kernel-only user needs this too, even though
+the attach itself works on the System32 engine.
 
-(`cargo clean` wipes `target\`, so re-copy after one.) Live and dump debugging work with or without
-the TTD engine; PDB symbol *names* need `msdia140.dll` + a symbol path
-(`execute` → `.sympath srv*C:\ProgramData\Dbg\sym*https://msdl.microsoft.com/download/symbols`).
+**The copy list, what each file buys, and what to do when the store package will not install are in
+the skill's [`setup.md`](./skills/windbg-debugging/setup.md).**
+It is one document rather than two so the list cannot drift; it is also where symbols, elevation,
+kernel connection profiles and the differences an ARM64 host brings are written down.
 
-The script above starts from `Get-AppxPackage Microsoft.WinDbg`, which does not always resolve —
-and not always because the package merely needs installing. The skill's
-[`setup.md`](./skills/windbg-debugging/setup.md#when-the-store-package-will-not-install) covers that
-case: why MSIX can stage a payload it then refuses to run, and which two sources supply these files
-between them when it does. It is also the place to look for anything else environment-shaped —
-symbols, elevation, kernel connection profiles, and the differences an ARM64 host brings.
+Most of these fail *quietly* rather than loudly — a missing `triage\` turns `!analyze` into
+`ANALYSIS_INCONCLUSIVE`, a missing `msdia140.dll` silently downgrades symbols to exports — so it is
+worth doing deliberately rather than discovering later.
 
 ## Use with an MCP client
 

--- a/README.md
+++ b/README.md
@@ -214,35 +214,12 @@ Copy-Item "$wd\winxp\kdexts.dll" "$dst\winxp" -Force   # !drvobj/!devobj/!irp �
 the TTD engine; PDB symbol *names* need `msdia140.dll` + a symbol path
 (`execute` → `.sympath srv*C:\ProgramData\Dbg\sym*https://msdl.microsoft.com/download/symbols`).
 
-#### When the store package will not install
-
-`Get-AppxPackage Microsoft.WinDbg` returning nothing is not always a matter of installing it: MSIX
-registration fails from a **non-interactive** session — `Add-AppxPackage` returns `0x80070005` even
-when elevated — and leaves the payload staged but unrunnable, because `WindowsApps` denies execute
-to an unregistered package. Installing from the machine's own console session is the fix, and the
-one to reach for first.
-
-Where that is not available, the two sources below cover the same files between them. The
-**Windows SDK Debugging Tools** (`winsdksetup.exe /features OptionId.WindowsDesktopDebuggers`) give
-a plain directory — `C:\Program Files (x86)\Windows Kits\10\Debuggers\<arch>` — holding every file
-above **except `msdia140.dll` and `ttd\`**, so `!analyze`, the driver tools and symbols all work and
-TTD replay does not. For `ttd\` itself, the WinDbg `.msixbundle` is an ordinary zip and can be
-unpacked without being installed:
-
-```pwsh
-$w = "$env:TEMP\wdbg"; New-Item $w -ItemType Directory -Force | Out-Null
-$uri = ([xml](Invoke-WebRequest 'https://aka.ms/windbg/download' -UseBasicParsing).Content).AppInstaller.MainBundle.Uri
-Invoke-WebRequest $uri -OutFile "$w\b.zip" -UseBasicParsing      # ~1.1 GB
-Expand-Archive "$w\b.zip" "$w\b" -Force
-Copy-Item "$w\b\windbg_win-x64.msix" "$w\p.zip" -Force           # or windbg_win-arm64.msix
-Expand-Archive "$w\p.zip" "$w\p" -Force
-Copy-Item "$w\p\amd64\ttd" "$dst\ttd" -Recurse -Force            # or arm64\ttd, matching the .msix
-```
-
-Pick the architecture deliberately: the bundle carries `amd64\`, `arm64\` and `x86\` payloads, and
-an ARM64 package ships all three ([#131](https://github.com/glslang/windbg-mcp/issues/131)). See
-[#132](https://github.com/glslang/windbg-mcp/issues/132) for why this is written down rather than
-assumed away.
+The script above starts from `Get-AppxPackage Microsoft.WinDbg`, which does not always resolve —
+and not always because the package merely needs installing. The skill's
+[`setup.md`](./skills/windbg-debugging/setup.md#when-the-store-package-will-not-install) covers that
+case: why MSIX can stage a payload it then refuses to run, and which two sources supply these files
+between them when it does. It is also the place to look for anything else environment-shaped —
+symbols, elevation, kernel connection profiles, and the differences an ARM64 host brings.
 
 ## Use with an MCP client
 

--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ Copy-Item "$wd\dbgeng.dll","$wd\dbghelp.dll","$wd\dbgcore.dll","$wd\dbgmodel.dll
           "$wd\symsrv.dll","$wd\msdia140.dll" $dst -Force
 Copy-Item "$wd\ttd"    "$dst\ttd"    -Recurse -Force   # TTDReplay*.dll, TtdExt.dll, TTDAnalyze.dll, ...
 Copy-Item "$wd\winext" "$dst\winext" -Recurse -Force   # ext.dll (!analyze), kext.dll, … — crash-dump triage
+Copy-Item "$wd\triage" "$dst\triage" -Recurse -Force   # triage.ini, pooltag.txt — !analyze's module attribution
 New-Item   "$dst\winxp" -ItemType Directory -Force | Out-Null
 Copy-Item "$wd\winxp\kdexts.dll" "$dst\winxp" -Force   # !drvobj/!devobj/!irp — the kernel driver tools
 ```
@@ -200,6 +201,10 @@ Copy-Item "$wd\winxp\kdexts.dll" "$dst\winxp" -Force   # !drvobj/!devobj/!irp �
   `.load kdexts` for you and nothing complains at attach time, so a missing file first surfaces as
   *"No export drvobj found"* from those three tools. It lives in `winxp\`, not `winext\` — the
   engine searches that subdir by name.
+- The `triage\` subdir provides `triage.ini` and `pooltag.txt`, which `!analyze` reads to attribute
+  a crash to a module and to name pool tags. **Its absence raises no error**, which is what makes it
+  worth copying deliberately: `!analyze` runs and reports `ANALYSIS_INCONCLUSIVE` / `Unknown_Module`
+  instead, so a missing file reads as an inconclusive crash.
 - **`msdia140.dll` is required for PDB symbols.** Without it, `dbghelp` can't parse any PDB
   (`dia error 0x8007007e`) and silently falls back to *export* symbols — which makes `module!name`
   lookups (and so `ttd_calls("ucrtbase!__stdio_common_vfprintf")`) fail even with the right PDB in
@@ -208,6 +213,36 @@ Copy-Item "$wd\winxp\kdexts.dll" "$dst\winxp" -Force   # !drvobj/!devobj/!irp �
 (`cargo clean` wipes `target\`, so re-copy after one.) Live and dump debugging work with or without
 the TTD engine; PDB symbol *names* need `msdia140.dll` + a symbol path
 (`execute` → `.sympath srv*C:\ProgramData\Dbg\sym*https://msdl.microsoft.com/download/symbols`).
+
+#### When the store package will not install
+
+`Get-AppxPackage Microsoft.WinDbg` returning nothing is not always a matter of installing it: MSIX
+registration fails from a **non-interactive** session — `Add-AppxPackage` returns `0x80070005` even
+when elevated — and leaves the payload staged but unrunnable, because `WindowsApps` denies execute
+to an unregistered package. Installing from the machine's own console session is the fix, and the
+one to reach for first.
+
+Where that is not available, the two sources below cover the same files between them. The
+**Windows SDK Debugging Tools** (`winsdksetup.exe /features OptionId.WindowsDesktopDebuggers`) give
+a plain directory — `C:\Program Files (x86)\Windows Kits\10\Debuggers\<arch>` — holding every file
+above **except `msdia140.dll` and `ttd\`**, so `!analyze`, the driver tools and symbols all work and
+TTD replay does not. For `ttd\` itself, the WinDbg `.msixbundle` is an ordinary zip and can be
+unpacked without being installed:
+
+```pwsh
+$w = "$env:TEMP\wdbg"; New-Item $w -ItemType Directory -Force | Out-Null
+$uri = ([xml](Invoke-WebRequest 'https://aka.ms/windbg/download' -UseBasicParsing).Content).AppInstaller.MainBundle.Uri
+Invoke-WebRequest $uri -OutFile "$w\b.zip" -UseBasicParsing      # ~1.1 GB
+Expand-Archive "$w\b.zip" "$w\b" -Force
+Copy-Item "$w\b\windbg_win-x64.msix" "$w\p.zip" -Force           # or windbg_win-arm64.msix
+Expand-Archive "$w\p.zip" "$w\p" -Force
+Copy-Item "$w\p\amd64\ttd" "$dst\ttd" -Recurse -Force            # or arm64\ttd, matching the .msix
+```
+
+Pick the architecture deliberately: the bundle carries `amd64\`, `arm64\` and `x86\` payloads, and
+an ARM64 package ships all three ([#131](https://github.com/glslang/windbg-mcp/issues/131)). See
+[#132](https://github.com/glslang/windbg-mcp/issues/132) for why this is written down rather than
+assumed away.
 
 ## Use with an MCP client
 

--- a/docs/remote-phase0.md
+++ b/docs/remote-phase0.md
@@ -121,17 +121,25 @@ DHCP, which is not routable off the host machine. That address moves — but Par
 the guest as `<vm-name>.shared`, so prefer that as the `HostName` and the drift stops mattering.
 
 When a connection fails, the useful first question is whether the guest is reachable at layer 2 at
-all, which separates a stale address from a filtered one:
+all, which separates a stale address from a filtered one. **Force a fresh resolution before reading
+the neighbour table**, because the table on its own answers neither question: an entry can outlive
+the guest that owned the address, and no entry may mean only that nothing has tried recently.
 
 ```console
-arp -a | grep <guest-subnet>
+nc -z -G 2 <guest-address> 22 ; arp -a | grep <guest-address>
 ```
 
-An entry resolving to the guest's MAC means the address is current and the guest answered — so
-anything above that is being dropped, and the firewall is where to look. No entry means the address
-itself is wrong. `prlctl list -f` reports what the hypervisor believes, and
-`prlctl exec <vm> <command>` runs inside the guest through the Tools channel rather than the
-network, which is how you ask a machine why it is not answering.
+The probe supplies the traffic; the lookup reports what came back. A **complete** entry — a real MAC
+address — means something is answering at that address right now, so anything failing above layer 2
+is being filtered, and the firewall is where to look. An **incomplete** entry means nothing
+answered, which points at the address rather than at a rule. The probe does not need to succeed: a
+refused or filtered port still resolves the address, which is what makes it usable when every port
+is closed.
+
+Two hypervisor tools sit outside all of this: `prlctl list -f` reports what the hypervisor believes
+the address is — worth comparing against what you are dialling — and `prlctl exec <vm> <command>`
+runs inside the guest over the Tools channel rather than the network, which is how you ask a machine
+why it is not answering.
 
 ### 5. Configure kernel profiles in the file, not the environment
 

--- a/docs/remote-phase0.md
+++ b/docs/remote-phase0.md
@@ -1,0 +1,244 @@
+# Remote phase 0 — the server on the VM, the client somewhere else
+
+DbgEng is Windows-only, so `windbg-mcp` runs where Windows is. The harness and the model have no
+such requirement. This is the **zero-code** way to separate them: register the MCP server as an
+`ssh` command, so the stdio transport tunnels to the VM and nothing in this repo changes.
+
+It is deliberately **throwaway**. It exists to answer four questions (see
+[What to measure](#what-to-measure)) before any transport code is written, and its rough edges are
+artifacts of launching an exe through a login session rather than anything structural. Do not fix
+them here; running the server as a Windows service removes them at once.
+
+## What it gives you, and what it doesn't
+
+| | |
+| --- | --- |
+| **Works** | Dumps, TTD replay, live user-mode, `attach_kernel` by profile, `debug_batch`, the pool and heap walks |
+| **Works, unchanged** | Client disconnect still releases live targets — closing the ssh channel closes the remote stdin, the supervisor exits, and workers follow via EOF |
+| **Works, but verify** | The elevation-only tools, `record_trace` and `attach_kernel_local`. Windows OpenSSH grants a member of the Administrators group a **full, unfiltered token**, so these do work — but that is a property of the host's logon policy, not a guarantee. Check rather than assume (below) |
+| **Not addressed** | Sessions do not survive a client restart; there is no lease, no adopt, no progress notification, and worker logs reach you only as ssh stderr |
+
+Confirm the elevation question on your own host before relying on either answer — it is one
+command, and getting it wrong in the optimistic direction costs a confusing failure much later:
+
+```console
+ssh windbg-vm powershell -NoProfile -Command "([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole('Administrators')"
+```
+
+The KD link is unaffected by any of this. `attach_kernel` is the debugger host dialing its target
+over KDNET — how *you* reached the debugger host does not enter into it — which makes it the most
+interesting thing to test here.
+
+## Steps
+
+### 1. Install and start OpenSSH Server on the VM
+
+```pwsh
+Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0
+Set-Service sshd -StartupType Automatic
+Start-Service sshd
+```
+
+The capability install adds a firewall rule — but **it is scoped to the `Private` and `Domain`
+profiles, and a hypervisor's guest network usually comes up `Public`**. That combination is the
+most confusing failure here, because sshd is running and listening and everything looks correct
+from inside the guest, while the host's SYNs are silently dropped. A drop presents as `ssh`
+**hanging** after `Connecting to <address> port 22`, where nothing listening at all would have
+given you `Connection refused` immediately.
+
+Check both halves, not just the service:
+
+```pwsh
+Get-Service sshd | Format-Table Name,Status,StartType -AutoSize
+Get-NetConnectionProfile | Format-Table Name,NetworkCategory -AutoSize
+Get-NetFirewallRule -Name *OpenSSH* | Format-Table Name,Enabled,Direction,Profile,Action -AutoSize
+```
+
+If the profile is `Public` and the rule says `Private`, open the one port to the one host that
+needs it rather than reclassifying the network:
+
+```pwsh
+New-NetFirewallRule -Name sshd-from-hypervisor-host `
+  -DisplayName "OpenSSH Server (hypervisor host only)" `
+  -Direction Inbound -Protocol TCP -LocalPort 22 -Action Allow `
+  -Profile Any -RemoteAddress <host-address-on-the-guest-network> -Enabled True
+```
+
+`Set-NetConnectionProfile -NetworkCategory Private` also works and is one line shorter, but it
+activates every other `Private`-scoped inbound rule as a side effect — file and printer sharing,
+network discovery. On a debugger VM that shares a subnet with the target it is kernel-debugging,
+that is a lot of surface bought for one port.
+
+### 2. Keep `cmd.exe` as the default shell
+
+```pwsh
+Get-ItemProperty HKLM:\SOFTWARE\OpenSSH -Name DefaultShell -ErrorAction SilentlyContinue
+```
+
+If that returns PowerShell, remove the key or point it back at `C:\Windows\System32\cmd.exe`.
+
+**Why it matters:** OpenSSH runs an exec request through the default shell. `cmd /c` hands the
+child process the inherited pipe handles and stays out of the way; PowerShell captures a native
+command's output through its own pipeline and applies its output encoding, which can rewrite the
+line endings underneath line-delimited JSON-RPC. Step 6 is what actually catches this — the point
+here is to not be surprised by it.
+
+### 3. Install the key — and mind the administrators file
+
+If the VM user is in the Administrators group, which it will be if you are kernel debugging, sshd
+**ignores `~/.ssh/authorized_keys`** and reads `C:\ProgramData\ssh\administrators_authorized_keys`
+instead. On the VM, elevated:
+
+```pwsh
+Add-Content C:\ProgramData\ssh\administrators_authorized_keys '<contents of your id_ed25519.pub>'
+icacls C:\ProgramData\ssh\administrators_authorized_keys /inheritance:r /grant "Administrators:F" /grant "SYSTEM:F"
+```
+
+The `icacls` line is not optional: sshd refuses the file outright if any other principal can write
+it, and the refusal is not logged anywhere you would think to look. This is the single most common
+way this step fails silently.
+
+### 4. Give the host a stable name on the client
+
+```ssh-config
+Host windbg-vm
+    HostName <vm-address>
+    User <vm-user>
+    IdentityFile ~/.ssh/id_ed25519
+    RequestTTY no
+    BatchMode yes
+    ServerAliveInterval 30
+    ServerAliveCountMax 6
+```
+
+`RequestTTY no` is load-bearing — a PTY would apply echo and line discipline to the transport.
+`BatchMode yes` makes a missing key fail immediately instead of hanging on a prompt no one will
+ever see, because an MCP client's stdin belongs to the protocol.
+
+*Finding* the VM is topology-specific and this is one instance, not the procedure: under Parallels
+with a `shared` network adapter, the guest gets a `10.211.55.x` address from the hypervisor's own
+DHCP, which is not routable off the host machine. That address moves — but Parallels also registers
+the guest as `<vm-name>.shared`, so prefer that as the `HostName` and the drift stops mattering.
+
+When a connection fails, the useful first question is whether the guest is reachable at layer 2 at
+all, which separates a stale address from a filtered one:
+
+```console
+arp -a | grep <guest-subnet>
+```
+
+An entry resolving to the guest's MAC means the address is current and the guest answered — so
+anything above that is being dropped, and the firewall is where to look. No entry means the address
+itself is wrong. `prlctl list -f` reports what the hypervisor believes, and
+`prlctl exec <vm> <command>` runs inside the guest through the Tools channel rather than the
+network, which is how you ask a machine why it is not answering.
+
+### 5. Configure kernel profiles in the file, not the environment
+
+An ssh session inherits machine and user environment variables from the registry, but **nothing**
+from a PowerShell `$PROFILE` or an interactive shell. A `WINDBG_MCP_PROFILE_<NAME>` variable set
+the way most people set one will simply be absent, and `attach_kernel {}` will report no profiles
+at all.
+
+Use `%USERPROFILE%\.windbg-mcp\profiles.json` instead — it is read from disk by the process itself,
+so it is immune to how that process was started. Check both it and the binary over ssh rather than
+interactively, since that is the environment that will actually run:
+
+```console
+ssh windbg-vm "where windbg-mcp.exe & dir %USERPROFILE%\.windbg-mcp"
+```
+
+`&` chains work because the remote shell is `cmd` — which is also a trap for anything more
+elaborate. `ssh` joins its remaining arguments into **one string** and hands it to that shell, so
+`cmd` parses `|` and `;` before PowerShell ever sees them, and a remote one-liner with a pipe in it
+fails with something misleading like `'Select-Object' is not recognized`. Encode it instead:
+
+```console
+ENC=$(iconv -f UTF-8 -t UTF-16LE < script.ps1 | base64 | tr -d '\n')
+ssh windbg-vm "powershell -NoProfile -EncodedCommand $ENC"
+```
+
+Bear in mind too that a non-interactive PowerShell serializes its progress and error streams as
+**CLIXML on stderr** (`#< CLIXML`, then a wall of XML). Harmless here, but it is a concrete preview
+of why step 2 matters: routed through the MCP server's stdout, that is a corrupted transport.
+
+### 6. Probe the handshake before registering anything
+
+```console
+printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"probe","version":"0"}}}' \
+    | ssh -T windbg-vm '<path>\windbg-mcp.exe' | cat -vet | head -3
+```
+
+What you want is a single line of JSON on **stdout** carrying `serverInfo`, and
+`windbg-mcp starting on stdio` on **stderr** — that second line is also your proof the log path
+survives the hop.
+
+`cat -vet` renders a carriage return as `^M` (that is BSD's spelling; GNU `cat -A` is the same
+thing). If you see one, or a shell banner, or a blank first line, the shell is interfering: go back
+to step 2. Nothing past this point works if this does not, and the failure mode downstream is an
+unreadable parse error rather than anything that names the cause.
+
+A clean run answers `{"jsonrpc":"2.0","id":1,"result":{...,"serverInfo":{"name":"windbg-mcp",...}}}`
+on stdout with no `^M`, and the startup line on stderr. Note what this does **not** prove: the
+supervisor never loads DbgEng — only its workers do — so a successful handshake says nothing about
+whether the debugger works. `open_dump` is the first call that finds out.
+
+### 7. Register it with the client
+
+```console
+claude mcp add windbg-vm --scope local -- ssh -T windbg-vm '<path>\windbg-mcp.exe'
+```
+
+**`--scope local`, not `--scope project`.** The `project` scope writes `.mcp.json` into the
+repository, and this wiring is machine-specific in exactly the way [`CLAUDE.md`](../CLAUDE.md) says
+to keep out of version control — an address, a user name and an absolute path that are true for one
+host.
+
+Note also that the plugin build (`windbg-mcp@windbg-mcp`) and any local `target\release` server
+registration are unaffected and unaware of this one. If you are running both, they are separate
+servers with separate session registries; name them so you can tell which is which.
+
+## What to measure
+
+Phase 0 exists to answer these four questions. Answer them deliberately, then decide whether the
+rest of the plan is worth building.
+
+| Question | How |
+| --- | --- |
+| **Does the latency matter?** | Time a `modules` call over ssh against the same call made on the VM. A hop that disappears into the noise of a debugger operation settles the transport question. |
+| **Do long calls survive?** | Run `crash_triage` with `analyze: true`, or a `pool_census`. Both produce no output for a long stretch; this confirms the keepalive probes do not disturb a call inside its 300 s budget. |
+| **Does teardown still work?** | Quit the client, then `ssh windbg-vm "tasklist \| findstr windbg-mcp"`. Empty is the answer. This is the real check that the channel closing reaches the supervisor's stdin, and that its workers follow. |
+| **Can the model cope?** | Point the harness at whichever model you intend to use and watch it choose among 53 tools. This is the finding that sizes everything about tool-surface curation. |
+
+The teardown check is the one worth being fussy about. It is the property `src/main.rs` gives up
+its runtime to guarantee, and a live kernel target that is killed rather than released is left
+*frozen* — so "no orphaned process" and "the guest came back" are the same assertion.
+
+## Where this stops being enough
+
+Four things push you off phase 0, roughly in the order you will hit them:
+
+1. **Session lifetime.** Every client restart costs you every open session, which for a KDNET
+   attach means a reboot cycle on the target.
+2. **Logs.** Worker stderr arrives interleaved on the ssh channel and vanishes with it. There is no
+   log file and no way to ask for one.
+3. **Long-call visibility.** Nothing reports progress, so a parked `attach_kernel` and a healthy
+   90-second walk look identical from the client.
+4. **Start-up.** The server exists only while a client is connected to it, from whatever directory
+   and environment that login session happened to have.
+
+All four are the same fix — an HTTP listener running as a service, with leases and progress
+notifications — which is where this stops being a configuration exercise and starts being code.
+
+Note that **elevation is not on this list**, though an earlier draft of this document had it at the
+top. A Windows service is elevated by construction, which is a real advantage over *some* ways of
+starting a process — but not over ssh, which already hands an Administrators member a full token.
+The service earns its place on the four points above; claiming elevation as well would be talking
+up a problem that measurement does not support.
+
+## See also
+
+- [`CLAUDE.md`](../CLAUDE.md) — the supervisor/worker split, and why a worker's stdout is not the
+  protocol
+- [`smoke-test.md`](./smoke-test.md) — the tiers, including the live-kernel one this setup does not
+  change

--- a/skills/windbg-debugging/setup.md
+++ b/skills/windbg-debugging/setup.md
@@ -159,10 +159,12 @@ Copy-Item "$wd\winxp\kdexts.dll" "$dst\winxp" -Force   # !drvobj/!devobj/!irp �
 - The `ttd\` subdir provides the `@$cursession.TTD` / `@$curprocess.TTD` data model and the
   `!tt` time-travel commands.
 - The `winext\` subdir provides `ext.dll` (which exports `!analyze`) and the other `!`-extensions.
-  Required for crash-dump triage — without it `!analyze` returns *"No export analyze found"*. On a
-  minimal engine the **unqualified `!analyze` may not resolve** even with `winext\` present; the
-  module-qualified **`!ext.analyze -v`** does. `crash_triage` tries both and reports which one
-  answered, so its `analysis.command` tells you which case this host is in.
+  Required for crash-dump triage — without it `!analyze` returns *"No export analyze found"*.
+  Whether the **unqualified `!analyze` then resolves is engine- and Windows-version-dependent**, so
+  do not read either outcome as the rule: it did *not* on the x64 host this note was first written
+  against, and it *did* on an ARM64 host running the SDK engine. Where it does not, the
+  module-qualified **`!ext.analyze -v`** works. `crash_triage` tries both and reports which one
+  answered, so `analysis.command` settles it for the host in front of you.
 - The `triage\` subdir provides `triage.ini` and `pooltag.txt`, which `!analyze` reads to attribute
   a crash to a module and to name pool tags. **Its absence does not produce an error**, which is
   what makes it worth listing: `!analyze` runs, and reports `ANALYSIS_INCONCLUSIVE` /

--- a/skills/windbg-debugging/setup.md
+++ b/skills/windbg-debugging/setup.md
@@ -34,6 +34,12 @@ staged but unrunnable, since `WindowsApps` denies execute to an unregistered pac
 WinDbg from the machine's own console session rather than over SSH or a remote shell; that is also
 what makes `Get-AppxPackage Microsoft.WinDbg` resolve, which the copy below depends on.
 
+For `ttd\` specifically there is a way out that needs no install at all: the WinDbg `.msixbundle`
+is an ordinary zip and can be unpacked. The README's
+[*When the store package will not install*](../../README.md#when-the-store-package-will-not-install)
+carries the recipe, and the architecture warning that goes with it — the bundle holds `amd64\`,
+`arm64\` and `x86\` payloads, so which one you copy is a choice rather than a default.
+
 ## Get the server binary
 
 The plugin ships the source, not a binary. Put `windbg-mcp.exe` in place so the path in

--- a/skills/windbg-debugging/setup.md
+++ b/skills/windbg-debugging/setup.md
@@ -5,10 +5,34 @@ section for the workflow you're about to run before blaming the target.
 
 ## Platform
 
-- **Windows x64 only.** Host bitness must match the target.
+- **Windows x64 is the supported and tested configuration.** Host bitness must match the target
+  for *live* debugging.
 - `dbgeng.dll` / `dbghelp.dll` ship in `System32` on modern Windows 11 (verified on
   `10.0.26100`). That is enough for live user-mode/kernel debugging and crash-dump
   analysis — **but not for TTD `.run` replay** (see below).
+
+### ARM64 hosts
+
+Crash-dump analysis works on Windows on ARM, and the dump does **not** have to be ARM64: an ARM64
+engine read an x64 kernel minidump here in full — `!analyze -v`, symbols, failure bucket and pool
+tag. Live user-mode and live kernel are untested on ARM64, and the bitness rule above still applies
+to those.
+
+Two things change when you bundle the engine:
+
+- The store package's payload directory is **`\arm64`**, not `\amd64`.
+- If the store package will not install, the **Windows SDK Debugging Tools** are an alternative
+  source — `winsdksetup.exe /features OptionId.WindowsDesktopDebuggers /quiet /norestart`, landing
+  in `C:\Program Files (x86)\Windows Kits\10\Debuggers\arm64`. It supplies every file in the copy
+  below **except `msdia140.dll` and `ttd\`**, so `!analyze`, the driver tools and symbol resolution
+  all work and **TTD replay does not**
+  ([#132](https://github.com/glslang/windbg-mcp/issues/132)).
+
+That fallback matters because MSIX registration fails from a **non-interactive** session —
+`Add-AppxPackage` returns `0x80070005` even when the session is elevated, leaving the payload
+staged but unrunnable, since `WindowsApps` denies execute to an unregistered package. Install
+WinDbg from the machine's own console session rather than over SSH or a remote shell; that is also
+what makes `Get-AppxPackage Microsoft.WinDbg` resolve, which the copy below depends on.
 
 ## Get the server binary
 
@@ -124,6 +148,7 @@ Copy-Item "$wd\dbgeng.dll","$wd\dbghelp.dll","$wd\dbgcore.dll","$wd\dbgmodel.dll
           "$wd\symsrv.dll","$wd\msdia140.dll" $dst -Force
 Copy-Item "$wd\ttd"    "$dst\ttd"    -Recurse -Force   # TTDReplay*.dll, TtdExt.dll, TTDAnalyze.dll, ...
 Copy-Item "$wd\winext" "$dst\winext" -Recurse -Force   # ext.dll (!analyze), kext.dll, … — for crash dumps
+Copy-Item "$wd\triage" "$dst\triage" -Recurse -Force   # triage.ini, pooltag.txt — !analyze's module attribution
 New-Item   "$dst\winxp" -ItemType Directory -Force | Out-Null
 Copy-Item "$wd\winxp\kdexts.dll" "$dst\winxp" -Force   # !drvobj/!devobj/!irp — for the driver-IOCTL tools (kernel)
 ```
@@ -132,6 +157,13 @@ Copy-Item "$wd\winxp\kdexts.dll" "$dst\winxp" -Force   # !drvobj/!devobj/!irp �
   `!tt` time-travel commands.
 - The `winext\` subdir provides `ext.dll` (which exports `!analyze`) and the other `!`-extensions.
   Required for crash-dump triage — without it `!analyze` returns *"No export analyze found"*.
+- The `triage\` subdir provides `triage.ini` and `pooltag.txt`, which `!analyze` reads to attribute
+  a crash to a module and to name pool tags. **Its absence does not produce an error**, which is
+  what makes it worth listing: `!analyze` runs, and reports `ANALYSIS_INCONCLUSIVE` /
+  `Unknown_Module` / `Unknown_Image` with the bucket id built from those. Measured on the same dump
+  with and without it, the failure bucket goes from `0x13a_8_TNf__MessageManager!unknown_function`
+  to `0x13a_8_TNf__ANALYSIS_INCONCLUSIVE!unknown_function` — a missing file that reads as an
+  inconclusive crash.
 - `winxp\kdexts.dll` provides the kernel-object extensions `!drvobj`/`!devobj`/`!irp` used by the
   `driver_object`/`device_object`/`irp_stack` tools. `attach_kernel` / `attach_kernel_local`
   `.load kdexts` automatically; without the file those tools return *"No export drvobj found"*.

--- a/skills/windbg-debugging/setup.md
+++ b/skills/windbg-debugging/setup.md
@@ -159,7 +159,12 @@ searched before `System32`, so the copied engine wins. One-time, from the instal
 package:
 
 ```pwsh
-$wd  = (Get-AppxPackage Microsoft.WinDbg).InstallLocation + "\amd64"
+# Match $arch to windbg-mcp.exe, not to the machine: a process loads DLLs of its
+# own architecture, and the published release zip is x64 even on an ARM64 host.
+# See the table under "ARM64 hosts" — "amd64" is right for every x64 binary,
+# including one running under emulation.
+$arch = "amd64"
+$wd  = (Get-AppxPackage Microsoft.WinDbg).InstallLocation + "\$arch"
 # Set $dst to the folder that actually holds windbg-mcp.exe — pick the one for
 # your install (do not leave it as the placeholder):
 #   plugin / build-from-source layout      -> <plugin dir>\target\release
@@ -220,9 +225,12 @@ $w = "$env:TEMP\wdbg"; New-Item $w -ItemType Directory -Force | Out-Null
 $uri = ([xml](Invoke-WebRequest 'https://aka.ms/windbg/download' -UseBasicParsing).Content).AppInstaller.MainBundle.Uri
 Invoke-WebRequest $uri -OutFile "$w\b.zip" -UseBasicParsing      # ~1.1 GB
 Expand-Archive "$w\b.zip" "$w\b" -Force
-Copy-Item "$w\b\windbg_win-x64.msix" "$w\p.zip" -Force           # or windbg_win-arm64.msix
+# Same $arch as the copy block above. Note the two spellings: the .msix is named
+# x64/arm64, while the payload directory inside it is amd64/arm64.
+$msix = if ($arch -eq "arm64") { "windbg_win-arm64.msix" } else { "windbg_win-x64.msix" }
+Copy-Item "$w\b\$msix" "$w\p.zip" -Force
 Expand-Archive "$w\p.zip" "$w\p" -Force
-Copy-Item "$w\p\amd64\ttd" "$dst\ttd" -Recurse -Force            # amd64 or arm64 — see below
+Copy-Item "$w\p\$arch\ttd" "$dst\ttd" -Recurse -Force
 ```
 
 **Pick the architecture by `windbg-mcp.exe`, exactly as above** — not by the host, and not by which

--- a/skills/windbg-debugging/setup.md
+++ b/skills/windbg-debugging/setup.md
@@ -18,15 +18,34 @@ engine read an x64 kernel minidump here in full — `!analyze -v`, symbols, fail
 tag. Live user-mode and live kernel are untested on ARM64, and the bitness rule above still applies
 to those.
 
-Two things change when you bundle the engine:
+Two things change when you bundle the engine.
 
-- The store package's payload directory is **`\arm64`**, not `\amd64`.
-- If the store package will not install, the **Windows SDK Debugging Tools** are an alternative
-  source — `winsdksetup.exe /features OptionId.WindowsDesktopDebuggers /quiet /norestart`, landing
-  in `C:\Program Files (x86)\Windows Kits\10\Debuggers\arm64`. It supplies every file in the copy
-  below **except `msdia140.dll` and `ttd\`**, so `!analyze`, the driver tools and symbol resolution
-  all work and **TTD replay does not**
-  ([#132](https://github.com/glslang/windbg-mcp/issues/132)).
+**Match the payload to `windbg-mcp.exe`'s architecture, not to the host's.** A process loads DLLs
+of its own architecture, so an x64 binary running under emulation on an ARM64 host needs the
+**`amd64`** engine and cannot load the `arm64` one — it will fail to initialise the debugger rather
+than fall back. Which you need therefore depends on where the binary came from:
+
+| `windbg-mcp.exe` | Store payload | SDK directory |
+| --- | --- | --- |
+| Prebuilt release zip (Option A) — **always x64** | `\amd64` | `Debuggers\x64` |
+| Built from source on an ARM64 host (Option B) | `\arm64` | `Debuggers\arm64` |
+
+The releases this repo publishes are x64 only, so downloading one onto an ARM64 host and reaching
+for `arm64` DLLs — the intuitive move — is the wrong pairing. `cargo build --release` on the host
+is what gets you a native binary worth pairing with `arm64`.
+
+**The store package is not the only source.** If it will not install, the **Windows SDK Debugging
+Tools** — `winsdksetup.exe /features OptionId.WindowsDesktopDebuggers /quiet /norestart` — land in
+`C:\Program Files (x86)\Windows Kits\10\Debuggers\<arch>` and supply every file in the copy below
+**except `msdia140.dll` and `ttd\`**. So `!analyze` and the driver tools work from it and **TTD
+replay does not** ([#132](https://github.com/glslang/windbg-mcp/issues/132)).
+
+Symbols are the interesting omission. `msdia140.dll` is documented below as required for PDB
+parsing, but on the host tested here full private symbols resolved (`nt!RtlpHpVsSlotFreeList`, not
+an export) with **no `msdia140.dll` anywhere on the machine and none registered** — the SDK's own
+`dbghelp.dll` read the PDBs unaided. Treat that requirement as a property of the `dbghelp.dll` you
+bundle rather than a universal one, and check with `lm m <mod>` (`(pdb symbols)` versus
+`(export symbols)`) rather than assuming either way.
 
 That fallback matters because MSIX registration fails from a **non-interactive** session —
 `Add-AppxPackage` returns `0x80070005` even when the session is elevated, leaving the payload
@@ -203,15 +222,19 @@ Invoke-WebRequest $uri -OutFile "$w\b.zip" -UseBasicParsing      # ~1.1 GB
 Expand-Archive "$w\b.zip" "$w\b" -Force
 Copy-Item "$w\b\windbg_win-x64.msix" "$w\p.zip" -Force           # or windbg_win-arm64.msix
 Expand-Archive "$w\p.zip" "$w\p" -Force
-Copy-Item "$w\p\amd64\ttd" "$dst\ttd" -Recurse -Force            # or arm64\ttd, matching the .msix
+Copy-Item "$w\p\amd64\ttd" "$dst\ttd" -Recurse -Force            # amd64 or arm64 — see below
 ```
 
-**Pick the architecture deliberately.** Each package carries `amd64\`, `arm64\` and `x86\` payloads
-— an ARM64 package ships all three — so a copy that takes the first match takes the emulation build.
-That is the same ordering trap as [#131](https://github.com/glslang/windbg-mcp/issues/131), and it
-is easy to walk into twice. [#132](https://github.com/glslang/windbg-mcp/issues/132) is why this is
-written down rather than assumed away; without `ttd\`, `open_trace` says so explicitly rather than
-leaving you with `0x80070057`.
+**Pick the architecture by `windbg-mcp.exe`, exactly as above** — not by the host, and not by which
+`.msix` you happened to unpack. Each package carries `amd64\`, `arm64\` and `x86\` payloads (an
+ARM64 package ships all three), so there is no default to fall back on and a copy that takes the
+first match takes the emulation build. That is the same ordering trap as
+[#131](https://github.com/glslang/windbg-mcp/issues/131), which is easy to walk into twice.
+
+[#132](https://github.com/glslang/windbg-mcp/issues/132) is why this is written down rather than
+assumed away. Note that `open_trace` reports a missing `ttd\` explicitly instead of leaving you with
+`0x80070057` — but it checks that the directory is *there*, not that what is in it matches your
+binary, so a wrong-architecture copy still surfaces as the bare engine error.
 
 ## Symbols — required for `module!func` name resolution
 

--- a/skills/windbg-debugging/setup.md
+++ b/skills/windbg-debugging/setup.md
@@ -34,11 +34,8 @@ staged but unrunnable, since `WindowsApps` denies execute to an unregistered pac
 WinDbg from the machine's own console session rather than over SSH or a remote shell; that is also
 what makes `Get-AppxPackage Microsoft.WinDbg` resolve, which the copy below depends on.
 
-For `ttd\` specifically there is a way out that needs no install at all: the WinDbg `.msixbundle`
-is an ordinary zip and can be unpacked. The README's
-[*When the store package will not install*](../../README.md#when-the-store-package-will-not-install)
-carries the recipe, and the architecture warning that goes with it — the bundle holds `amd64\`,
-`arm64\` and `x86\` payloads, so which one you copy is a choice rather than a default.
+For `ttd\` specifically there is a way out that needs no install at all — see
+[*When the store package will not install*](#when-the-store-package-will-not-install) below.
 
 ## Get the server binary
 
@@ -175,6 +172,41 @@ Copy-Item "$wd\winxp\kdexts.dll" "$dst\winxp" -Force   # !drvobj/!devobj/!irp �
   `.load kdexts` automatically; without the file those tools return *"No export drvobj found"*.
   (Note it lives in `winxp\`, not `winext\`, and the engine already searches a `WINXP` subdir.)
 - `cargo clean` (when building from source) wipes `target\`, so re-copy after one.
+
+### When the store package will not install
+
+`Get-AppxPackage Microsoft.WinDbg` returning nothing is not always a matter of installing it. MSIX
+registration fails from a **non-interactive** session — `Add-AppxPackage` returns `0x80070005` even
+when elevated — and leaves the payload staged but unrunnable, because `WindowsApps` denies execute
+to an unregistered package. So the files can be on disk and every one of them refuse to run.
+Installing from the machine's own console session is the fix and the first thing to reach for.
+
+Where that is not available, two sources cover the same files between them.
+
+**The Windows SDK Debugging Tools** — `winsdksetup.exe /features OptionId.WindowsDesktopDebuggers
+/quiet /norestart` — give a plain directory, `C:\Program Files (x86)\Windows Kits\10\Debuggers\<arch>`,
+holding every file in the copy above **except `msdia140.dll` and `ttd\`**. So `!analyze`, the driver
+tools and symbol resolution all work from it, and TTD replay does not.
+
+**The WinDbg `.msixbundle`**, for `ttd\` itself, is an ordinary zip and can be unpacked without
+being installed:
+
+```pwsh
+$w = "$env:TEMP\wdbg"; New-Item $w -ItemType Directory -Force | Out-Null
+$uri = ([xml](Invoke-WebRequest 'https://aka.ms/windbg/download' -UseBasicParsing).Content).AppInstaller.MainBundle.Uri
+Invoke-WebRequest $uri -OutFile "$w\b.zip" -UseBasicParsing      # ~1.1 GB
+Expand-Archive "$w\b.zip" "$w\b" -Force
+Copy-Item "$w\b\windbg_win-x64.msix" "$w\p.zip" -Force           # or windbg_win-arm64.msix
+Expand-Archive "$w\p.zip" "$w\p" -Force
+Copy-Item "$w\p\amd64\ttd" "$dst\ttd" -Recurse -Force            # or arm64\ttd, matching the .msix
+```
+
+**Pick the architecture deliberately.** Each package carries `amd64\`, `arm64\` and `x86\` payloads
+— an ARM64 package ships all three — so a copy that takes the first match takes the emulation build.
+That is the same ordering trap as [#131](https://github.com/glslang/windbg-mcp/issues/131), and it
+is easy to walk into twice. [#132](https://github.com/glslang/windbg-mcp/issues/132) is why this is
+written down rather than assumed away; without `ttd\`, `open_trace` says so explicitly rather than
+leaving you with `0x80070057`.
 
 ## Symbols — required for `module!func` name resolution
 

--- a/skills/windbg-debugging/setup.md
+++ b/skills/windbg-debugging/setup.md
@@ -159,7 +159,10 @@ Copy-Item "$wd\winxp\kdexts.dll" "$dst\winxp" -Force   # !drvobj/!devobj/!irp �
 - The `ttd\` subdir provides the `@$cursession.TTD` / `@$curprocess.TTD` data model and the
   `!tt` time-travel commands.
 - The `winext\` subdir provides `ext.dll` (which exports `!analyze`) and the other `!`-extensions.
-  Required for crash-dump triage — without it `!analyze` returns *"No export analyze found"*.
+  Required for crash-dump triage — without it `!analyze` returns *"No export analyze found"*. On a
+  minimal engine the **unqualified `!analyze` may not resolve** even with `winext\` present; the
+  module-qualified **`!ext.analyze -v`** does. `crash_triage` tries both and reports which one
+  answered, so its `analysis.command` tells you which case this host is in.
 - The `triage\` subdir provides `triage.ini` and `pooltag.txt`, which `!analyze` reads to attribute
   a crash to a module and to name pool tags. **Its absence does not produce an error**, which is
   what makes it worth listing: `!analyze` runs, and reports `ANALYSIS_INCONCLUSIVE` /

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -5732,7 +5732,8 @@ mod tests {
     /// path was fine would be confidently wrong exactly when the caller most needs it right.
     #[test]
     fn the_note_does_not_pronounce_on_a_failure_it_cannot_see() {
-        let explained = explain_trace_failure("trace load failed: file not found".to_string(), false);
+        let explained =
+            explain_trace_failure("trace load failed: file not found".to_string(), false);
 
         assert!(
             explained.contains("whatever this error turns out to be"),

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -944,7 +944,7 @@ fn execute(e: &DebugEngine, id: u64, op: EngineOp, queued: Duration) -> Result<O
             |commit| {
                 // As in `OpenDump`: commit before the load wait, because a wait that times out
                 // still leaves DbgEng holding the trace.
-                e.open_trace(&path).map_err(es)?;
+                e.open_trace(&path).map_err(trace_open_failure)?;
                 commit();
                 e.wait_for_event(LOAD_WAIT_MS).map_err(es)
             },
@@ -1247,6 +1247,49 @@ fn execute(e: &DebugEngine, id: u64, op: EngineOp, queued: Duration) -> Result<O
 /// Maps any error to a `String` for the wire.
 fn es<E: ToString>(e: E) -> String {
     e.to_string()
+}
+
+/// Whether a TTD replay engine is bundled beside this executable.
+///
+/// DbgEng loads the replay engine — `TTDReplay*.dll`, `TtdExt.dll`, `TTDAnalyze.dll` — out of a
+/// `ttd\` directory next to itself, and System32's `dbgeng.dll` ships none of them. So a host that
+/// never bundled the WinDbg package cannot replay *any* trace, and the only way it says so is
+/// `0x80070057` from `open_trace` — "the parameter is incorrect", which names neither the missing
+/// directory nor the fix, and reads as a complaint about the path the caller passed.
+///
+/// Probed against **this executable's** directory rather than the loaded engine's, because that is
+/// the layout `setup.md` prescribes and the only one this server can reason about without asking
+/// the loader where `dbgeng.dll` came from: the bundle is copied next to `windbg-mcp.exe`, so the
+/// engine and its `ttd\` are both there. It answers correctly for the case that actually happens
+/// too — an engine taken from System32, where there is no `ttd\` anywhere on the host.
+fn replay_engine_bundled() -> bool {
+    std::env::current_exe()
+        .ok()
+        .and_then(|exe| exe.parent().map(|dir| dir.join("ttd").is_dir()))
+        // Say nothing rather than something wrong: an executable that cannot locate itself is no
+        // evidence that the engine is unbundled.
+        .unwrap_or(true)
+}
+
+/// `open_trace`'s failure, told against what this host can actually do.
+fn trace_open_failure<E: ToString>(error: E) -> String {
+    explain_trace_failure(error.to_string(), replay_engine_bundled())
+}
+
+/// The message half of [`trace_open_failure`], split from the probe so it can be tested without
+/// standing up a directory layout around the test binary.
+fn explain_trace_failure(message: String, bundled: bool) -> String {
+    if bundled {
+        return message;
+    }
+    format!(
+        "{message}\n\nAlso worth knowing, whatever this error turns out to be: there is no `ttd\\` \
+         directory beside this server's executable, so this host cannot replay *any* trace — \
+         System32's `dbgeng.dll` ships no replay engine and rejects every `.run` with \
+         `0x80070057`. If the path is right, that is the reason, and no change to it will help. \
+         Copy `ttd\\` from the WinDbg package next to `windbg-mcp.exe`; the skill's `setup.md` \
+         lists the whole engine bundle."
+    )
 }
 
 /// Maps any error onto the wire as the ordinary case: the debugger ran it and it failed.
@@ -5646,5 +5689,62 @@ mod tests {
         assert!(HeapOp::chunk("0x1000".into(), Some(true)).refreshes());
         assert!(!HeapOp::census(None, None, None).refreshes());
         assert!(!HeapOp::diagnostics(None, None, Some(false), None).refreshes());
+    }
+
+    /// A host that *can* replay says only what the debugger said.
+    ///
+    /// The point of the split is that the note is evidence-bearing: appending it to every failed
+    /// `open_trace` would make it noise, and would misdirect the one caller whose path really is
+    /// wrong on a properly bundled host.
+    #[test]
+    fn a_bundled_host_reports_the_engines_own_failure_and_nothing_else() {
+        let engine = "trace load failed: 0x80070057".to_string();
+        assert_eq!(explain_trace_failure(engine.clone(), true), engine);
+    }
+
+    /// A host that cannot replay at all says so, and names the directory to copy.
+    ///
+    /// `0x80070057` is "the parameter is incorrect", which on this path is a lie of omission: the
+    /// parameter is fine and the engine simply has no replay DLLs. A reader who takes the error at
+    /// face value edits the one thing that was never wrong ([#132]).
+    ///
+    /// [#132]: https://github.com/glslang/windbg-mcp/issues/132
+    #[test]
+    fn a_host_with_no_replay_engine_says_so_rather_than_leaving_the_error_bare() {
+        let explained = explain_trace_failure("trace load failed: 0x80070057".to_string(), false);
+
+        assert!(
+            explained.starts_with("trace load failed: 0x80070057"),
+            "the engine's own words stay first; the note is added to them, not substituted for \
+             them: {explained}"
+        );
+        assert!(
+            explained.contains("ttd\\"),
+            "it names the directory to copy: {explained}"
+        );
+    }
+
+    /// And it claims only what it can know.
+    ///
+    /// The probe answers "can this host replay at all", which is a fact about the *host* — it is
+    /// no evidence about why this particular open failed. On a host with no `ttd\`, a genuinely
+    /// mistyped path fails for its own reason and gets this note too, so a note that asserted the
+    /// path was fine would be confidently wrong exactly when the caller most needs it right.
+    #[test]
+    fn the_note_does_not_pronounce_on_a_failure_it_cannot_see() {
+        let explained = explain_trace_failure("trace load failed: file not found".to_string(), false);
+
+        assert!(
+            explained.contains("whatever this error turns out to be"),
+            "it is explicit that it has not diagnosed this failure: {explained}"
+        );
+        assert!(
+            explained.contains("If the path is right"),
+            "and conditions the conclusion on the one thing it cannot check: {explained}"
+        );
+        assert!(
+            !explained.contains("Nothing about the trace or the path needs changing"),
+            "never the unconditional claim, which a mistyped path would falsify: {explained}"
+        );
     }
 }

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -1263,12 +1263,26 @@ fn es<E: ToString>(e: E) -> String {
 /// engine and its `ttd\` are both there. It answers correctly for the case that actually happens
 /// too — an engine taken from System32, where there is no `ttd\` anywhere on the host.
 fn replay_engine_bundled() -> bool {
-    std::env::current_exe()
+    // Say nothing rather than something wrong: an executable that cannot locate itself is no
+    // evidence that the engine is unbundled.
+    let Some(dir) = std::env::current_exe()
         .ok()
-        .and_then(|exe| exe.parent().map(|dir| dir.join("ttd").is_dir()))
-        // Say nothing rather than something wrong: an executable that cannot locate itself is no
-        // evidence that the engine is unbundled.
-        .unwrap_or(true)
+        .and_then(|exe| exe.parent().map(|dir| dir.to_path_buf()))
+    else {
+        return true;
+    };
+    // Non-empty, not merely present. A `New-Item ttd` whose copy then failed leaves a directory
+    // that satisfies `is_dir` and replays nothing, which is a plausible end state for a manual
+    // bundling step.
+    //
+    // What this deliberately does *not* check is that the DLLs match this binary's architecture —
+    // that needs a PE read per file, and the layout it would be reading is WinDbg's to change. A
+    // wrong-architecture `ttd\` therefore still fails with the engine's own error, which is the
+    // behaviour without this diagnostic at all rather than a regression from it; `setup.md` states
+    // the rule where the copy is made, which is the only place it can be acted on.
+    std::fs::read_dir(dir.join("ttd"))
+        .map(|mut entries| entries.next().is_some())
+        .unwrap_or(false)
 }
 
 /// `open_trace`'s failure, told against what this host can actually do.


### PR DESCRIPTION
Standing this server up in a new shape — model and client on a Mac, DbgEng on a Parallels ARM64 guest, MCP tunnelled over an ssh stdio hop with no code changes — turned up one code defect and several documentation gaps. Everything here was measured on that host rather than reasoned about.

## `open_trace` explains itself when the host cannot replay

DbgEng loads the TTD replay engine from a `ttd\` directory beside itself, and System32's `dbgeng.dll` ships none of it. A host that never bundled the WinDbg package therefore cannot replay *any* trace, and the only thing it says is `0x80070057` — "the parameter is incorrect".

That error is a lie of omission on this path. The parameter is fine; there are no replay DLLs. It names neither the missing directory nor the fix, and the reading it invites — bad path — is the one thing that was never wrong.

A failed `open_trace` now checks for `ttd\` beside the executable and, when it is absent, appends what that means. Two properties worth noting:

- **The engine's own words stay first.** The note is added to the failure, never substituted for it, so a genuinely bad path on a properly bundled host reads exactly as before. An unconditional note would be noise on every failure and would misdirect the caller whose path really *is* wrong.
- **It claims only what it can know.** The probe answers "can this host replay at all" — a fact about the host, and no evidence about why *this* open failed. On an unbundled host a mistyped path fails for its own reason and gets the note too. So it says up front that it has not diagnosed the failure and conditions the conclusion on the one thing it cannot check. An earlier draft asserted the path needed no changing; a third test now pins that it never does that again.

Verified end to end on the guest, against a bad path on an unbundled host — the case that caught the first draft out:

```
Operation failed: The system cannot find the file specified. (0x80070002)

Also worth knowing, whatever this error turns out to be: there is no `ttd\` directory beside
this server's executable, so this host cannot replay *any* trace — System32's `dbgeng.dll`
ships no replay engine and rejects every `.run` with `0x80070057`. If the path is right, that
is the reason, and no change to it will help. ...
```

## `triage\` was missing from the engine bundle, in both copies of the list

The kind of omission that does not announce itself: `!analyze` still runs without it and reports `ANALYSIS_INCONCLUSIVE` / `Unknown_Module`, so a missing file reads as an inconclusive crash. Measured on one dump both ways:

| | without `triage\` | with |
| --- | --- | --- |
| `failure_bucket_id` | `0x13a_8_TNf__ANALYSIS_INCONCLUSIVE!unknown_function` | `0x13a_8_TNf__MessageManager!unknown_function` |
| `image_name` | `Unknown_Image` | `MessageManager.sys` |

## The bundling instructions had no answer for "the store package will not install"

Both the README and the skill open with `(Get-AppxPackage Microsoft.WinDbg).InstallLocation`. MSIX registration fails from a non-interactive session with `0x80070005` **even when elevated**, staging the payload without registering it — so the files are on disk and `WindowsApps` denies execute to all of them. Installing from the machine's own console session is the fix and the first thing to reach for; where that is not available, the README now names the SDK Debugging Tools (everything except `msdia140.dll` and `ttd\`) and unpacking the `.msixbundle` as a zip for `ttd\` itself.

## A phase-0 runbook, and two corrections to it

`docs/remote-phase0.md` is the setup, and its value is in the traps — every one of which fails silently:

- an admin user's key belongs in `administrators_authorized_keys` with strict ACLs, and sshd refuses it otherwise without logging anywhere useful;
- the OpenSSH firewall rule ships scoped to Private/Domain while a hypervisor guest network comes up Public, so sshd listens and the SYNs are dropped — which **hangs**, where nothing listening would have refused;
- `WINDBG_MCP_PROFILE_*` set in a shell profile never reaches an ssh session, so profiles belong in the file;
- `ssh host powershell -Command '... | ...'` is parsed by `cmd` first, so a remote pipe fails as `'Select-Object' is not recognized`.

Two claims did not survive contact and are corrected rather than carried:

- **Elevation is not an ssh limitation.** Windows OpenSSH hands an Administrators member a full, unfiltered token, so `record_trace` and `attach_kernel_local` are not blocked by the transport. The Windows service still earns its place — defined `PATH`, boot start, no login session — but not on this argument.
- **"Windows x64 only" is stronger than what holds.** An ARM64 engine read an x64 kernel minidump here in full: `!analyze -v`, symbols, failure bucket, pool tag. The bitness rule is now scoped to live debugging, and dumps are exempted. Live user-mode and live kernel on ARM64 remain untested and are marked as such.

## Follow-up recorded, not fixed

FOLLOWUPS item 20 / #131: `find_ttd` probes x64 before arm64 in both layouts, so on an ARM64 host it returns the emulation recorder for a native target. Deferred deliberately — host-first is the obvious improvement, but the honest selector is the *target's* architecture, which `record_trace` only knows after it decides what to launch. Worth settling before writing either version.

## Verification

`cargo test` — 372 unit + 45 smoke, 0 failed. `cargo clippy --all-targets` clean. Both run on the ARM64 guest (`aarch64-pc-windows-msvc`), since the crate does not build on macOS. `open_trace` and `crash_triage` additionally exercised end to end over the ssh transport against the checked-in sample dump.
