### PR TITLE
Serve MCP over HTTP, with a lease standing in for the disconnect

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
+name = "async-trait"
+version = "0.1.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -87,6 +104,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "rand_core",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -103,6 +131,15 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "darling"
@@ -257,6 +294,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
+ "rand_core",
 ]
 
 [[package]]
@@ -275,6 +313,85 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "http"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23169fe34a5fbcdd3f3862e78fb9b6fccd5f02a6dc6f732547005d45631ce71c"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "bytes",
+ "http",
+ "http-body",
+ "hyper",
+ "pin-project-lite",
+ "tokio",
+]
 
 [[package]]
 name = "iana-time-zone"
@@ -435,6 +552,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
 name = "ref-cast"
 version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -477,18 +611,27 @@ version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8dddc5b1924b9a59fba420166160ca2c4663a4e01803e52eda33070f56d63c8"
 dependencies = [
+ "async-trait",
  "base64",
+ "bytes",
  "chrono",
  "futures",
+ "http",
+ "http-body",
+ "http-body-util",
  "pastey",
  "pin-project-lite",
+ "rand",
  "rmcp-macros",
  "schemars",
  "serde",
  "serde_json",
+ "sse-stream",
  "thiserror",
  "tokio",
+ "tokio-stream",
  "tokio-util",
+ "tower-service",
  "tracing",
  "uuid",
 ]
@@ -650,6 +793,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "socket2"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "sse-stream"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c123f296ade4ec4b8b0f6162116e6629f5146922ca5ab40ca9d3c2e73ab4761e"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http-body",
+ "http-body-util",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -717,6 +883,7 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "signal-hook-registry",
+ "socket2",
  "tokio-macros",
  "windows-sys",
 ]
@@ -733,6 +900,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-stream"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -744,6 +922,12 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
@@ -899,6 +1083,10 @@ name = "windbg-mcp"
 version = "0.9.0"
 dependencies = [
  "anyhow",
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
  "rmcp",
  "schemars",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,27 @@ win-kexp = { git = "https://github.com/glslang/win-kexp", rev = "40f79cd4c8f3941
 # 3.1.1 is a floor, not a preference: every 3.x before it generates a `tools/list` that omits
 # SEP-2549's required `ttlMs`/`cacheScope`, which a spec-strict `2026-07-28` client rejects
 # outright — the server connects and appears to expose no tools at all (upstream issue #1114).
-rmcp = { version = "3.1.1", features = ["server", "transport-io", "macros", "schemars"] }
-tokio = { version = "1", features = ["macros", "rt-multi-thread", "io-std", "io-util", "process", "sync", "time"] }
+rmcp = { version = "3.1.1", features = [
+    "server",
+    "transport-io",
+    "macros",
+    "schemars",
+    # The listener (`--listen`, see `src/listen.rs`). `-session` is what makes a client's MCP
+    # session an addressable thing with a close of its own, which is what a lease is hung off.
+    "transport-streamable-http-server",
+    "transport-streamable-http-server-session",
+] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "io-std", "io-util", "net", "process", "sync", "time"] }
+# The listener's HTTP plumbing, and nothing more: rmcp's `StreamableHttpService` is a plain
+# request-to-response handler, so what is missing is a server to call it. hyper rather than a
+# framework because one route with one middleware (the bearer check) is not a router's worth of
+# work — see `src/listen.rs`.
+hyper = { version = "1", features = ["server", "http1"] }
+hyper-util = { version = "0.1", features = ["tokio", "server"] }
+# Bodies for the listener's own responses (401/409): rmcp hands back a boxed body, so refusing a
+# request needs one of the same shape.
+http-body-util = "0.1"
+bytes = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 schemars = "1"

--- a/README.md
+++ b/README.md
@@ -209,6 +209,27 @@ Point your client at the built binary, e.g. Claude Code:
 }
 ```
 
+### On another machine
+
+The server has to run where DbgEng does, but the client and the model do not. `--listen <addr>`
+serves the same tools over HTTP instead of stdio, so a Mac can drive a Windows VM:
+
+```console
+# Windows, with WINDBG_MCP_LISTEN_TOKEN set
+windbg-mcp.exe --listen 127.0.0.1:8765
+# client machine
+ssh -N -L 8765:127.0.0.1:8765 windbg-vm
+claude mcp add windbg-vm --transport http http://127.0.0.1:8765/ \
+  --header "Authorization: Bearer $WINDBG_MCP_LISTEN_TOKEN"
+```
+
+**Bind loopback and forward over SSH.** This endpoint runs `execute`, `debug_batch` and `launch`
+against a live kernel, and the token is sent in clear — a hypervisor's guest network is not private
+when the machine being debugged shares it. [`docs/remote-listener.md`](./docs/remote-listener.md)
+covers the token, the session lease and its grace, why only one client is served at a time, and
+what a `409` means. For a one-off, [`docs/remote-phase0.md`](./docs/remote-phase0.md) does the same
+job over plain `ssh` with no listener.
+
 ### As a Claude Code plugin
 
 This repo is also a single-plugin [Claude Code marketplace](https://code.claude.com/docs/en/plugin-marketplaces):

--- a/docs/remote-listener.md
+++ b/docs/remote-listener.md
@@ -1,0 +1,105 @@
+# The listener — running the server on one machine and the client on another
+
+`windbg-mcp --listen <addr>` serves the same tool surface over HTTP that the default stdio role
+serves over standard handles. It exists so the client and the model can run somewhere other than
+the machine DbgEng needs — a Mac driving a Windows VM, say.
+
+If you only need that once, [`remote-phase0.md`](./remote-phase0.md) does it with no listener at
+all: register the MCP server as an `ssh` command and stdio tunnels for you. The listener is for
+what that arrangement cannot do — sessions that survive a client restart, several connections in
+one session, and a server that is not tied to a login shell.
+
+## Bind loopback, reach it over SSH
+
+**This endpoint is patch-the-kernel-as-a-service.** `execute`, `debug_batch` and `launch` are all
+on it, and the bearer token below is sent in clear. Bind `127.0.0.1` and forward:
+
+```console
+# on the Windows machine
+setx WINDBG_MCP_LISTEN_TOKEN "<a long random string>"
+windbg-mcp.exe --listen 127.0.0.1:8765
+
+# on the client machine
+ssh -N -L 8765:127.0.0.1:8765 windbg-vm
+```
+
+A hypervisor's guest network looks private and often is not: the machine being debugged is
+frequently a sandbox on that same subnet, and it is the least trustworthy host you own. Binding
+anything but loopback logs a warning on every start for that reason. If you do it anyway, put the
+listener behind something that terminates TLS — the server does not.
+
+The token comes from `WINDBG_MCP_LISTEN_TOKEN`, never an argument, because a command line is
+readable by every process on the machine — including a debuggee you `launch`. It is stripped from
+the environment of both processes this server creates (engine workers, and the TTD recorder), so a
+recorded or launched target cannot read it and claim the server.
+
+## Point a client at it
+
+```console
+claude mcp add windbg-vm --scope local --transport http http://127.0.0.1:8765/ \
+  --header "Authorization: Bearer <the same string>"
+```
+
+`--scope local` rather than `project`: an address and a token are machine-specific in exactly the
+way [`AGENTS.md`](../AGENTS.md) says to keep out of version control.
+
+## The lease, and why the grace is what it is
+
+Stdio gets one property free that the listener has to rebuild: when stdin closes, the client is
+*definitively* gone, and every target is released — which for a live kernel is the difference
+between a machine that comes back and one left frozen. Over HTTP there is no such moment. A client
+that has stopped talking is indistinguishable from one that is thinking.
+
+So a client holds a **lease**. Any request renews it; when it runs out, the sessions that client
+opened are released exactly as a disconnect would have released them.
+
+| | |
+| --- | --- |
+| Default grace | `WORKER_READY_TIMEOUT` (30 s) + the call timeout (300 s) + 60 s = **390 s** |
+| Override | `WINDBG_MCP_LEASE_GRACE_SECS` |
+| Floor | must exceed 30 s + `WINDBG_MCP_CALL_TIMEOUT_SECS`, or the server refuses to start |
+
+That floor is not conservatism. A `crash_triage` or a pool walk sends **no HTTP request while it
+runs**, so a grace shorter than the longest a call can keep a client quiet reads a working client
+as an absent one — and releases the session the call is running against, out from under its own
+caller. The bound is the sum because an opener spends up to 30 s bringing a worker up *before* the
+call budget starts. If the server refuses to start, that message is why; raise the grace or lower
+the call timeout.
+
+**A returning client adopts what it left.** Sessions are not released the moment a client goes
+away, so reconnecting inside the grace finds them still open — which is better than stdio, where a
+client restart costs a KDNET attach, and a KDNET attach costs a reboot of the target. The log says
+`adopted the sessions the previous one left open` when that happens.
+
+## One client at a time
+
+A second client is refused with `409`. This is forced by the registry rather than chosen: session
+handles are minted globally, the four-session cap is shared, and `end_session` ends whatever it is
+handed — so two clients would silently share, and one could end a target the other was using.
+
+The token is the identity. There is one authorised client, so presenting the token *is* the proof,
+and a reconnect needs nothing further.
+
+A `409` therefore means one of:
+
+- another client holds the server, and has not gone away or timed out yet;
+- a client is mid-`initialize` and has not been given a session id yet;
+- sessions are being released after a lease expired, which finishes within a sweep (5 s);
+- your own request outlived its claim — open a new session.
+
+Tenancy changes hands only when nothing is still using the server: no HTTP request admitted under
+the holder is outstanding, **and** no debug session has work in flight. The second is the one worth
+knowing about, because an engine job outlives the request that asked for it — a call whose client
+gave up is still running against the target, and the server will not hand that target on until it
+finishes.
+
+## Not there yet
+
+- **No progress notifications.** A long call is quiet; the SSE keep-alive holds the stream open but
+  nothing reports what the call is doing. `session_status` still answers.
+- **No MCP log notifications.** Worker `tracing` output goes to the listener's own stderr on the
+  server machine, not to the client — so the diagnostics [`CLAUDE.md`](../CLAUDE.md) describes are
+  read there for now.
+- **No service installation.** The listener runs in whatever shell you start it in. A Windows
+  service would give it a defined `PATH` and working directory, boot start, and a life independent
+  of a login session.

--- a/docs/remote-phase0.md
+++ b/docs/remote-phase0.md
@@ -237,6 +237,9 @@ Four things push you off phase 0, roughly in the order you will hit them:
 
 All four are the same fix — an HTTP listener running as a service, with leases and progress
 notifications — which is where this stops being a configuration exercise and starts being code.
+The listener exists and covers the first two;
+[`remote-listener.md`](./remote-listener.md) is its setup, and says which of the rest are still
+missing.
 
 Note that **elevation is not on this list**, though an earlier draft of this document had it at the
 top. A Windows service is elevated by construction, which is a real advantage over *some* ways of

--- a/src/cast.rs
+++ b/src/cast.rs
@@ -571,6 +571,11 @@ fn frame(record: &Record, max_lines: usize) -> Option<String> {
             DIM,
             &format!("server shutting down, releasing {sessions} session(s)"),
         ),
+        Event::LeaseExpired { sessions } => note(
+            &mut out,
+            DIM,
+            &format!("client lease expired, releasing {sessions} session(s)"),
+        ),
         // Shown rather than skipped: a viewer has to know a record was here and what it was, or
         // the recording quietly misses a step of the session it claims to be.
         Event::Oversized { of, bytes } => note(

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -2106,6 +2106,11 @@ fn spawn_worker(exe: &Path) -> std::io::Result<(Child, Channel)> {
     for name in kdconn::env_names() {
         command.env_remove(name);
     }
+    // The listener's bearer token, for exactly the same reason and with a sharper edge. A worker
+    // never authenticates anything, so it has no use for the token — but a `launch`ed debuggee
+    // inheriting it could dial the listener on loopback, wait for the holder to go quiet, and take
+    // over the very sessions being used to debug it. The credential does not cross this boundary.
+    command.env_remove(crate::listen::TOKEN_ENV);
     let child = command
         .arg(WORKER_FLAG)
         .arg(format!(

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -56,7 +56,7 @@ const CLOSED_HISTORY: usize = 8;
 /// How long to wait for a freshly spawned worker to report [`WorkerMessage::Ready`]. This covers
 /// process creation and `DebugCreate`, nothing else — a worker that is slower than this is not
 /// going to become usable.
-const WORKER_READY_TIMEOUT: Duration = Duration::from_secs(30);
+pub(crate) const WORKER_READY_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// How long `end_session` gives the worker to release its target cleanly before the process is
 /// killed instead.

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1415,12 +1415,35 @@ impl Sessions {
     /// kernel outright costs. Sessions are released concurrently because they are independent
     /// processes and the client is waiting.
     pub async fn shutdown(&self) {
+        self.release_every_worker(Teardown::Shutdown).await
+    }
+
+    /// Releases every session the way [`Self::shutdown`] does, but **leaves the registry open**.
+    ///
+    /// For the listener ([`crate::listen`]), where a client going away is not the server going
+    /// away: the lease on the sessions it opened expires, those targets are let go, and the next
+    /// client opens its own. Closing the gate here would turn one client's disconnect into a
+    /// server that can never debug anything again.
+    ///
+    /// The caller owns the race this leaves open. Nothing stops a session registering behind the
+    /// snapshot, so this must only be called once the tenancy gate says no client holds the
+    /// server — otherwise a client connecting exactly as the grace expires could have the session
+    /// it just opened released underneath it.
+    pub async fn release_leased(&self) {
+        self.release_every_worker(Teardown::Lease).await
+    }
+
+    async fn release_every_worker(&self, teardown: Teardown) {
         // Closing the gate and taking the snapshot under **one** lock acquisition is what makes
         // one pass enough. [`Self::admit`] re-checks `closing` under this same lock after its
         // worker's handshake, so every open is on one side or the other of this moment: either it
         // registered first and is in `owners`, or it registers never and is refused. The set
         // cannot grow behind this snapshot, which is what earlier versions used a timed drain to
         // approximate.
+        //
+        // That guarantee is bought by `closing` and so belongs to shutdown alone; a lease release
+        // does not get it, which is why the tenancy gate has to stand in for it (see
+        // [`Self::release_leased`]).
         //
         // Every session that still *owns a worker*, not every live one. A session claimed for
         // reclamation is already `Closed` while its release runs in the background, and a
@@ -1430,19 +1453,18 @@ impl Sessions {
         // not.
         let owners = {
             let mut registry = self.registry();
-            registry.closing = true;
+            registry.closing |= teardown.closes_registry();
             registry.owning_workers()
         };
         // Recorded before the releases rather than after them, and even when there are none: this
         // is the record that says the transcript ends here on purpose. Without it a file that
         // stops mid-session is indistinguishable from one whose server was killed.
-        self.rec.write(crate::record::Event::Shutdown {
-            sessions: owners.len(),
-        });
+        self.rec.write(teardown.record(owners.len()));
         if owners.is_empty() {
             return;
         }
-        tracing::info!("shutting down: releasing {} session(s)", owners.len());
+        let label = teardown.label();
+        tracing::info!("{label}: releasing {} session(s)", owners.len());
         let mut releasing = Vec::with_capacity(owners.len());
         for session in owners {
             let sessions = self.clone();
@@ -1450,9 +1472,7 @@ impl Sessions {
                 // Marked first so nothing new is routed to a session on its way out; the release
                 // runs as the supervisor's own teardown and so passes the gate that closes. A
                 // session already closed keeps the reason it closed for.
-                session.set_state(SessionState::Closed(
-                    "the server is shutting down".to_string(),
-                ));
+                session.set_state(SessionState::Closed(teardown.state_reason().to_string()));
                 let outcome = sessions
                     .release(
                         &session,
@@ -1466,15 +1486,14 @@ impl Sessions {
                 // where an operator looks after finding a guest that did not come back.
                 match note {
                     ShutdownNote::Released => {
-                        tracing::info!("shutting down: session {} released its target", session.id)
+                        tracing::info!("{label}: session {} released its target", session.id)
                     }
                     ShutdownNote::ReleasedElsewhere => tracing::info!(
-                        "shutting down: session {}'s target was released by a teardown already in \
-                         flight",
+                        "{label}: session {}'s target was released by a teardown already in flight",
                         session.id
                     ),
                     ShutdownNote::Refused(why) => tracing::warn!(
-                        "shutting down: session {} reported an error releasing its target ({why}); \
+                        "{label}: session {} reported an error releasing its target ({why}); \
                          its worker (pid {}) was terminated anyway — and terminating a debugger \
                          does not resume and detach for it, so a live kernel target may be left \
                          halted",
@@ -1482,13 +1501,13 @@ impl Sessions {
                         session.pid
                     ),
                     ShutdownNote::Unreleased(what) => tracing::warn!(
-                        "shutting down: session {} (pid {}) {what}, and no teardown reported \
+                        "{label}: session {} (pid {}) {what}, and no teardown reported \
                          releasing its target — so a live kernel target may be left halted",
                         session.id,
                         session.pid
                     ),
                     ShutdownNote::Settled(why) => tracing::info!(
-                        "shutting down: session {} was already settled ({why})",
+                        "{label}: session {} was already settled ({why})",
                         session.id
                     ),
                 }
@@ -1500,7 +1519,7 @@ impl Sessions {
             // released by the five-second best effort, and an operator should not have to infer
             // that from a frozen guest.
             if let Err(e) = task.await {
-                tracing::error!("shutting down: a session's release task failed: {e}");
+                tracing::error!("{label}: a session's release task failed: {e}");
             }
         }
     }
@@ -1870,6 +1889,54 @@ fn settle_open(session: &Session, result: &Result<Output, EngineError>) -> bool 
             .then_some(SessionState::Open)
     });
     settled.is_live()
+}
+
+/// Why every session is being released at once.
+///
+/// The two occasions differ in one structural way and several cosmetic ones. The structural one:
+/// **shutdown closes the registry and a lease expiry does not**, because the server is still
+/// serving and the next client will want to open sessions of its own. The rest is saying which
+/// happened — an operator reading a log after finding a guest that did not come back is owed the
+/// difference between "the server stopped" and "your client went away and stayed away", since only
+/// one of those is about them.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Teardown {
+    /// The server itself is going away.
+    Shutdown,
+    /// A client's lease on the sessions it opened ran out. See [`crate::listen`].
+    Lease,
+}
+
+impl Teardown {
+    /// Whether the registry is finished with, or merely between clients.
+    fn closes_registry(self) -> bool {
+        matches!(self, Self::Shutdown)
+    }
+
+    /// The log prefix every line of this teardown carries.
+    fn label(self) -> &'static str {
+        match self {
+            Self::Shutdown => "shutting down",
+            Self::Lease => "lease expired",
+        }
+    }
+
+    /// What a session released this way says when something asks why it closed.
+    fn state_reason(self) -> &'static str {
+        match self {
+            Self::Shutdown => "the server is shutting down",
+            Self::Lease => "the client's lease on this session expired",
+        }
+    }
+
+    /// The transcript record. Two variants rather than one with a reason, so a reader filtering a
+    /// transcript for "the server stopped" does not have to also parse why.
+    fn record(self, sessions: usize) -> crate::record::Event {
+        match self {
+            Self::Shutdown => crate::record::Event::Shutdown { sessions },
+            Self::Lease => crate::record::Event::LeaseExpired { sessions },
+        }
+    }
 }
 
 /// What a session's teardown should be reported as at shutdown.

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -940,6 +940,17 @@ impl Sessions {
     }
 
     /// Every session, newest first, as `session_status` reports them.
+    /// Whether any live session still has work the engine has not finished.
+    ///
+    /// **Not the same question as "is anyone waiting for it".** A job outlives the wait for it —
+    /// [`Self::call_as`] cancels only the waiter, and says so — so a dropped request, a timeout, or
+    /// a client that vanished all leave a job running against a target. Anything deciding it is
+    /// safe to hand that target to somebody else has to ask this, not whether the caller is still
+    /// there. See [`crate::listen`], which is the caller that has to.
+    pub fn busy(&self) -> bool {
+        self.registry().live().iter().any(|session| session.busy())
+    }
+
     pub fn snapshot(&self) -> Vec<SessionSnapshot> {
         let registry = self.registry();
         let current = registry.current().map(|s| s.id.clone());

--- a/src/listen.rs
+++ b/src/listen.rs
@@ -160,6 +160,14 @@ struct Tenancy {
     ///
     /// Tenancy is given up when that work drains, not when the `DELETE` arrives.
     farewell: bool,
+    /// Which tenancy the counters above belong to.
+    ///
+    /// Bumped whenever a teardown discards them. An in-flight guard carries the epoch it was
+    /// admitted under and subtracts nothing from a later one — without that, a request that
+    /// outlived its grace decrements the *next* holder's count when it finally returns, which can
+    /// drive that count to zero while a tool call is still running and let a concurrent goodbye
+    /// hand the registry to somebody else mid-call.
+    epoch: u64,
     /// A previous client's sessions are still open, waiting to be adopted or swept.
     ///
     /// Tracked rather than inferred from `deadline`. It was inferred, until reserving a claim
@@ -210,11 +218,14 @@ impl Tenancy {
 /// all: a connection dropped inside `mcp.handle` cancels the future, and an explicit decrement
 /// would simply not run — leaving the holder's count permanently above zero and its goodbye
 /// deferred for ever.
-struct InFlight(Arc<Lease>);
+struct InFlight {
+    lease: Arc<Lease>,
+    epoch: u64,
+}
 
 impl Drop for InFlight {
     fn drop(&mut self) {
-        self.0.leave();
+        self.lease.leave(self.epoch);
     }
 }
 
@@ -232,12 +243,21 @@ enum Settled {
     Stale,
 }
 
+/// A request the gate let through, and what it was let through *as*.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct Admitted {
+    /// The claim this request reserved, if it reserved one — which [`Lease::settle`] must present
+    /// to change tenancy.
+    claim: Option<u64>,
+    /// The tenancy it was admitted under, which [`Lease::leave`] must present to count it out.
+    epoch: u64,
+}
+
 /// What the tenancy gate decided about one request.
 #[derive(Debug, PartialEq, Eq)]
 enum Admission {
-    /// Hand it to the MCP service. Carries the claim this request reserved, if it reserved one —
-    /// which [`Lease::settle`] must present to change tenancy.
-    Serve(Option<u64>),
+    /// Hand it to the MCP service.
+    Serve(Admitted),
     /// Someone else holds the server, is taking it, or is being cleaned up after.
     Occupied,
 }
@@ -288,7 +308,10 @@ impl Lease {
             (Some(id), Some(held)) if id == held => {
                 state.deadline = Some(Instant::now() + self.grace);
                 state.in_flight += 1;
-                Admission::Serve(None)
+                Admission::Serve(Admitted {
+                    claim: None,
+                    epoch: state.epoch,
+                })
             }
             // A session id belonging to someone else. This is the arm that made the race above
             // persist rather than pass: serving it leaves both clients working.
@@ -301,13 +324,21 @@ impl Lease {
             // out for a whole grace period.
             (Some(_), None) if state.claim.is_none() => {
                 state.in_flight += 1;
-                Admission::Serve(Some(state.claim(self.grace)))
+                let epoch = state.epoch;
+                Admission::Serve(Admitted {
+                    claim: Some(state.claim(self.grace)),
+                    epoch,
+                })
             }
             // A new client, and nobody attached or attaching: it reserves the server here, and
             // inherits whatever the last one left open.
             (None, None) if state.claim.is_none() => {
                 state.in_flight += 1;
-                Admission::Serve(Some(state.claim(self.grace)))
+                let epoch = state.epoch;
+                Admission::Serve(Admitted {
+                    claim: Some(state.claim(self.grace)),
+                    epoch,
+                })
             }
             // Someone is mid-`initialize`, or holds it already.
             _ => Admission::Occupied,
@@ -382,8 +413,16 @@ impl Lease {
     }
 
     /// One admitted request finished, however it finished.
-    fn leave(&self) {
+    ///
+    /// `epoch` is the tenancy it was admitted under. A request that outlived a teardown belongs to
+    /// a tenancy that no longer exists, and counting it out of the current one would subtract work
+    /// it never did — enough for a concurrent goodbye to see zero while a tool call is still
+    /// running.
+    fn leave(&self, epoch: u64) {
         let mut state = self.state();
+        if state.epoch != epoch {
+            return;
+        }
         state.in_flight = state.in_flight.saturating_sub(1);
         state.give_up_if_drained(self.grace);
     }
@@ -410,6 +449,9 @@ impl Lease {
                 // past this point would defer a goodbye that has already been overtaken.
                 state.in_flight = 0;
                 state.farewell = false;
+                // Anything still out there was admitted under the tenancy being discarded, and may
+                // not count itself out of the next one.
+                state.epoch += 1;
                 state.releasing = true;
                 Some(Expired { holder })
             }
@@ -528,8 +570,8 @@ async fn gate(
         .and_then(|v| v.to_str().ok())
         .map(str::to_owned);
 
-    let claim = match lease.admit(session.as_deref()) {
-        Admission::Serve(claim) => claim,
+    let admitted = match lease.admit(session.as_deref()) {
+        Admission::Serve(admitted) => admitted,
         Admission::Occupied => {
             tracing::warn!("refused a second client from {peer}: this server is already held");
             return Ok(refuse(
@@ -540,7 +582,10 @@ async fn gate(
     };
     // From here every exit — a reply, a refusal, or this future being cancelled — counts the
     // request out, and a goodbye waiting on it completes when the last one does.
-    let _in_flight = InFlight(lease.clone());
+    let _in_flight = InFlight {
+        lease: lease.clone(),
+        epoch: admitted.epoch,
+    };
 
     // A DELETE is the client saying it is done. Noted before the service handles it, because
     // afterwards the session is gone and there is nothing left to match the holder against.
@@ -556,7 +601,7 @@ async fn gate(
     // Every admitted request settles, so a reservation is never left standing by a request that
     // did not become a session.
     match lease.settle(
-        claim,
+        admitted.claim,
         session.as_deref(),
         minted.as_deref(),
         response.status().is_success(),
@@ -660,9 +705,9 @@ mod tests {
         }
     }
 
-    fn claim_of(admission: Admission) -> Option<u64> {
+    fn admitted(admission: Admission) -> Admitted {
         match admission {
-            Admission::Serve(claim) => claim,
+            Admission::Serve(admitted) => admitted,
             Admission::Occupied => panic!("the gate refused a request this test needed served"),
         }
     }
@@ -671,17 +716,17 @@ mod tests {
     /// again in `gate` by a guard, so a test that settles without finishing is modelling a request
     /// that never came back.
     fn request(lease: &Lease, session: Option<&str>, minted: Option<&str>, ok: bool) -> Settled {
-        let claim = claim_of(lease.admit(session));
-        let settled = lease.settle(claim, session, minted, ok);
-        lease.leave();
+        let it = admitted(lease.admit(session));
+        let settled = lease.settle(it.claim, session, minted, ok);
+        lease.leave(it.epoch);
         settled
     }
 
     /// A client's `DELETE`, which is itself an admitted request.
     fn goodbye(lease: &Lease, id: &str) {
-        claim_of(lease.admit(Some(id)));
+        let it = admitted(lease.admit(Some(id)));
         lease.released(id);
-        lease.leave();
+        lease.leave(it.epoch);
     }
 
     /// The check that stops a long call from looking like an absent client.
@@ -715,7 +760,10 @@ mod tests {
 
         assert!(matches!(lease.admit(None), Admission::Occupied));
         assert!(
-            matches!(lease.admit(Some("session-a")), Admission::Serve(None)),
+            matches!(
+                lease.admit(Some("session-a")),
+                Admission::Serve(Admitted { claim: None, .. })
+            ),
             "the holder is served, and reserves nothing — it already holds the server"
         );
         assert!(
@@ -729,10 +777,10 @@ mod tests {
     #[test]
     fn a_claim_in_flight_blocks_a_second_initialize() {
         let lease = lease();
-        let claim = claim_of(lease.admit(None));
+        let first = admitted(lease.admit(None));
         assert!(matches!(lease.admit(None), Admission::Occupied));
 
-        lease.settle(claim, None, Some("session-a"), true);
+        lease.settle(first.claim, None, Some("session-a"), true);
         assert_eq!(lease.state().holder.as_deref(), Some("session-a"));
     }
 
@@ -740,8 +788,8 @@ mod tests {
     #[test]
     fn an_initialize_that_fails_does_not_hold_the_server_for_ever() {
         let lease = lease();
-        let claim = claim_of(lease.admit(None));
-        lease.settle(claim, None, None, false);
+        let claim = admitted(lease.admit(None));
+        lease.settle(claim.claim, None, None, false);
 
         assert!(
             lease.state().claim.is_none(),
@@ -760,7 +808,7 @@ mod tests {
     #[test]
     fn a_claim_that_outlived_its_grace_cannot_settle_over_a_newer_one() {
         let lease = brief();
-        let stale = claim_of(lease.admit(None));
+        let stale = admitted(lease.admit(None)).claim;
         std::thread::sleep(Duration::from_millis(5));
         assert!(
             lease.expired().is_some(),
@@ -768,7 +816,7 @@ mod tests {
         );
         lease.released_leases();
 
-        let fresh = claim_of(lease.admit(None));
+        let fresh = admitted(lease.admit(None)).claim;
         assert_ne!(stale, fresh, "a cleared claim is never re-issued");
         lease.settle(fresh, None, Some("session-new"), true);
 
@@ -793,10 +841,10 @@ mod tests {
     #[test]
     fn an_ordinary_request_from_the_holder_is_not_a_settlement() {
         let lease = lease();
-        let claim = claim_of(lease.admit(None));
-        lease.settle(claim, None, Some("session-a"), true);
+        let claim = admitted(lease.admit(None));
+        lease.settle(claim.claim, None, Some("session-a"), true);
 
-        let none = claim_of(lease.admit(Some("session-a")));
+        let none = admitted(lease.admit(Some("session-a"))).claim;
         assert_eq!(none, None, "the holder reserves nothing");
         assert_eq!(
             lease.settle(none, Some("session-a"), None, true),
@@ -848,7 +896,7 @@ mod tests {
 
         assert!(matches!(
             lease.admit(Some("session-a")),
-            Admission::Serve(Some(_))
+            Admission::Serve(Admitted { claim: Some(_), .. })
         ));
         assert!(
             matches!(lease.admit(None), Admission::Occupied),
@@ -899,9 +947,9 @@ mod tests {
         request(&lease, None, Some("session-a"), true);
 
         // A tool call is admitted and is still running.
-        claim_of(lease.admit(Some("session-a")));
+        let call = admitted(lease.admit(Some("session-a")));
         // The DELETE arrives on another connection, and is itself in flight.
-        claim_of(lease.admit(Some("session-a")));
+        let delete = admitted(lease.admit(Some("session-a")));
         lease.released("session-a");
 
         assert_eq!(
@@ -911,14 +959,14 @@ mod tests {
         );
         assert!(matches!(lease.admit(None), Admission::Occupied));
 
-        lease.leave(); // the DELETE's own request ends
+        lease.leave(delete.epoch); // the DELETE's own request ends
         assert_eq!(
             lease.state().holder.as_deref(),
             Some("session-a"),
             "still held: the tool call has not come back"
         );
 
-        lease.leave(); // and now the tool call does
+        lease.leave(call.epoch); // and now the tool call does
         assert_eq!(
             lease.state().holder,
             None,
@@ -927,13 +975,49 @@ mod tests {
         assert!(matches!(lease.admit(None), Admission::Serve(_)));
     }
 
+    /// A guard from a torn-down tenancy subtracts nothing from the next one.
+    ///
+    /// Without the epoch, a request that outlived its grace decrements the *new* holder's count
+    /// when it finally returns — which can reach zero while that holder's tool call is still
+    /// running, and let a concurrent goodbye hand the registry to somebody else mid-call.
+    #[test]
+    fn a_stale_guard_cannot_count_out_a_later_holders_work() {
+        let lease = brief();
+        let stranded = admitted(lease.admit(None)); // never comes back before the sweep
+        std::thread::sleep(Duration::from_millis(5));
+        assert!(lease.expired().is_some());
+        lease.released_leases();
+
+        // A new client takes the server and starts a call.
+        request(&lease, None, Some("session-new"), true);
+        let call = admitted(lease.admit(Some("session-new")));
+        let delete = admitted(lease.admit(Some("session-new")));
+        lease.released("session-new");
+        lease.leave(delete.epoch);
+
+        // The request from the previous tenancy finally returns.
+        lease.leave(stranded.epoch);
+        assert_eq!(
+            lease.state().holder.as_deref(),
+            Some("session-new"),
+            "a guard from a dead tenancy must not drain the live one's count"
+        );
+
+        lease.leave(call.epoch);
+        assert_eq!(
+            lease.state().holder,
+            None,
+            "only the real work ending gives it up"
+        );
+    }
+
     /// A request that never came back cannot defer a goodbye for ever.
     #[test]
     fn a_swept_lease_forgets_work_it_was_waiting_on() {
         let lease = brief();
-        let claim = claim_of(lease.admit(None));
-        lease.settle(claim, None, Some("session-a"), true);
-        claim_of(lease.admit(Some("session-a"))); // a call that never returns
+        let claim = admitted(lease.admit(None));
+        lease.settle(claim.claim, None, Some("session-a"), true);
+        admitted(lease.admit(Some("session-a"))); // a call that never returns
         lease.released("session-a");
         std::thread::sleep(Duration::from_millis(5));
 
@@ -987,7 +1071,7 @@ mod tests {
     #[test]
     fn a_claim_whose_request_died_is_cleared_by_the_grace() {
         let lease = brief();
-        claim_of(lease.admit(None));
+        admitted(lease.admit(None));
         std::thread::sleep(Duration::from_millis(5));
 
         assert!(
@@ -1010,7 +1094,7 @@ mod tests {
         // The holder lets go, so the next request is a genuine resume and reserves a claim of its
         // own — a request from the sitting holder reserves nothing and settles nothing.
         goodbye(&lease, "session-a");
-        let resumed = claim_of(lease.admit(Some("session-a")));
+        let resumed = admitted(lease.admit(Some("session-a"))).claim;
         assert!(resumed.is_some(), "a resume reserves the server");
         std::thread::sleep(Duration::from_millis(5));
         assert!(lease.expired().is_some());
@@ -1030,8 +1114,8 @@ mod tests {
     #[test]
     fn nothing_is_admitted_while_the_teardown_runs() {
         let lease = brief();
-        let claim = claim_of(lease.admit(None));
-        lease.settle(claim, None, Some("session-a"), true);
+        let claim = admitted(lease.admit(None));
+        lease.settle(claim.claim, None, Some("session-a"), true);
         std::thread::sleep(Duration::from_millis(5));
 
         assert!(lease.expired().is_some(), "the grace is spent");
@@ -1048,8 +1132,8 @@ mod tests {
     #[test]
     fn expiry_is_reported_once_rather_than_on_every_sweep() {
         let lease = brief();
-        let claim = claim_of(lease.admit(None));
-        lease.settle(claim, None, Some("session-a"), true);
+        let claim = admitted(lease.admit(None));
+        lease.settle(claim.claim, None, Some("session-a"), true);
         std::thread::sleep(Duration::from_millis(5));
 
         assert!(lease.expired().is_some(), "the grace is spent");
@@ -1065,8 +1149,8 @@ mod tests {
     #[test]
     fn a_swept_lease_reports_the_session_that_never_said_goodbye() {
         let lease = brief();
-        let claim = claim_of(lease.admit(None));
-        lease.settle(claim, None, Some("session-a"), true);
+        let claim = admitted(lease.admit(None));
+        lease.settle(claim.claim, None, Some("session-a"), true);
         std::thread::sleep(Duration::from_millis(5));
         assert_eq!(
             lease.expired().map(|e| e.holder),

--- a/src/listen.rs
+++ b/src/listen.rs
@@ -53,6 +53,7 @@ use hyper::header::AUTHORIZATION;
 use hyper::service::service_fn;
 use hyper::{Request, Response, StatusCode};
 use hyper_util::rt::TokioIo;
+use rmcp::transport::streamable_http_server::SessionManager;
 use rmcp::transport::streamable_http_server::session::local::LocalSessionManager;
 use rmcp::transport::streamable_http_server::{StreamableHttpServerConfig, StreamableHttpService};
 use tokio::net::TcpListener;
@@ -133,6 +134,18 @@ struct Tenancy {
     deadline: Option<Instant>,
 }
 
+/// What a swept lease left behind.
+#[derive(Debug, PartialEq, Eq)]
+struct Expired {
+    /// The MCP session still open at the moment the lease ran out — a client that vanished rather
+    /// than saying goodbye. `None` when it sent a DELETE, which already closed it.
+    ///
+    /// Reported so the sweeper can close it in the service too. Releasing the debug sessions alone
+    /// would leave that MCP session resident and its id still accepted, and every reconnect cycle
+    /// would add another.
+    holder: Option<String>,
+}
+
 /// What the tenancy gate decided about one request.
 #[derive(Debug, PartialEq, Eq)]
 enum Admission {
@@ -190,9 +203,15 @@ impl Lease {
             // persist rather than pass: serving it leaves both clients working.
             (Some(_), Some(_)) => Admission::Occupied,
             // A session id with nobody holding the server — a client resuming what it left inside
-            // the grace. Served, but the holder is not taken until the service says the session was
-            // real, or a stale id would lock the server out for a whole grace period.
-            (Some(_), None) if !state.claiming => Admission::Serve,
+            // the grace. Reserved like an `initialize`, because it is the same contest: a lease
+            // expiry leaves the old session id valid in the service, so a resume can race a fresh
+            // client and both would pass a gate that only served them. The holder is still not
+            // taken until `settle` hears the session was real, or a stale id would lock the server
+            // out for a whole grace period.
+            (Some(_), None) if !state.claiming => {
+                state.claiming = true;
+                Admission::Serve
+            }
             // A new client, and nobody attached or attaching: it reserves the server here, and
             // inherits whatever the last one left open.
             (None, None) if !state.claiming => {
@@ -214,11 +233,14 @@ impl Lease {
     /// are its own sessions) is wrong in a way that matters when it ends one.
     fn settle(&self, requested: Option<&str>, minted: Option<&str>, ok: bool) -> bool {
         let mut state = self.state();
+        // Unconditionally, before anything else: a reservation outliving the request that took it
+        // is a server nobody can claim. Every route out of here has resolved it — the arms below
+        // decide who holds the server, not whether the claim is over.
+        state.claiming = false;
         let adopted = state.holder.is_none() && state.deadline.is_some();
         match (minted, requested) {
             // An `initialize` that produced a session: the claim becomes a holder.
             (Some(id), _) => {
-                state.claiming = false;
                 state.holder = Some(id.to_string());
                 state.deadline = Some(Instant::now() + self.grace);
                 adopted
@@ -229,11 +251,9 @@ impl Lease {
                 state.deadline = Some(Instant::now() + self.grace);
                 adopted
             }
-            // Anything else, including an `initialize` that failed: give the reservation back.
-            _ => {
-                state.claiming = false;
-                false
-            }
+            // Anything else, including an `initialize` that failed: the reservation is already
+            // given back above, and nobody took the server.
+            _ => false,
         }
     }
 
@@ -252,16 +272,16 @@ impl Lease {
     /// way until [`Self::released_leases`] says the teardown is done. That is what closes the
     /// window [`Sessions::release_leased`] warns it does not close itself: between deciding to
     /// release and having released, no client can be admitted to the sessions being released.
-    fn expired(&self) -> bool {
+    fn expired(&self) -> Option<Expired> {
         let mut state = self.state();
         match state.deadline {
             Some(at) if Instant::now() >= at => {
-                state.holder = None;
+                let holder = state.holder.take();
                 state.deadline = None;
                 state.releasing = true;
-                true
+                Some(Expired { holder })
             }
-            _ => false,
+            _ => None,
         }
     }
 
@@ -300,11 +320,12 @@ pub async fn serve(sessions: Sessions, addr: SocketAddr, call_timeout: Duration)
         );
     }
 
+    let manager = Arc::new(LocalSessionManager::default());
     let mcp = {
         let sessions = sessions.clone();
         Arc::new(StreamableHttpService::new(
             move || Ok(WindbgServer::new(sessions.clone())),
-            Arc::new(LocalSessionManager::default()),
+            manager.clone(),
             // A tool call can be quiet for minutes; without a keep-alive the stream looks idle to
             // anything between the two machines and gets collected.
             StreamableHttpServerConfig::default().with_sse_keep_alive(Some(SSE_KEEP_ALIVE)),
@@ -318,7 +339,7 @@ pub async fn serve(sessions: Sessions, addr: SocketAddr, call_timeout: Duration)
         "windbg-mcp listening on http://{addr} (lease grace {grace:?}, one client at a time)"
     );
 
-    tokio::spawn(sweep(sessions.clone(), lease.clone()));
+    tokio::spawn(sweep(sessions.clone(), lease.clone(), manager));
 
     loop {
         let (stream, peer) = match listener.accept().await {
@@ -417,16 +438,26 @@ fn refuse(status: StatusCode, why: &str) -> Response<BoxBody<Bytes, Infallible>>
 }
 
 /// Releases what an absent client left behind, once its lease runs out.
-async fn sweep(sessions: Sessions, lease: Arc<Lease>) {
+async fn sweep(sessions: Sessions, lease: Arc<Lease>, manager: Arc<LocalSessionManager>) {
     loop {
         tokio::time::sleep(SWEEP).await;
-        if lease.expired() {
-            tracing::info!("a client's lease ran out; releasing the sessions it left open");
-            sessions.release_leased().await;
-            // Only now may the server be taken again: until this, an arriving client would be
-            // admitted to sessions this release is closing.
-            lease.released_leases();
+        let Some(expired) = lease.expired() else {
+            continue;
+        };
+        tracing::info!("a client's lease ran out; releasing the sessions it left open");
+        sessions.release_leased().await;
+        // The debug sessions are the expensive half, but not the whole of it. A client that
+        // vanished never sent the DELETE that closes its MCP session, so without this the service
+        // keeps that session resident and its id accepted — and every disconnect-and-reconnect
+        // cycle would add another one that no lease will ever sweep again.
+        if let Some(id) = expired.holder
+            && let Err(e) = manager.close_session(&id.into()).await
+        {
+            tracing::warn!("could not close the MCP session of the client that went away: {e}");
         }
+        // Only now may the server be taken again: until this, an arriving client would be admitted
+        // to sessions this release is closing.
+        lease.released_leases();
     }
 }
 
@@ -565,7 +596,7 @@ mod tests {
         lease.released("session-a");
 
         assert!(
-            !lease.expired(),
+            lease.expired().is_none(),
             "a client that said goodbye has its whole grace to change its mind"
         );
         assert!(lease.state().deadline.is_some(), "and the clock is running");
@@ -585,6 +616,75 @@ mod tests {
         );
     }
 
+    /// A resume is a contested claim too, not a free pass.
+    ///
+    /// After a lease expiry the old session id is still valid in the service, so a resume can race
+    /// a fresh client. Both would pass a gate that only served them, and the stale one could run a
+    /// tool against the global registry while the new client became the holder.
+    #[test]
+    fn a_resume_reserves_the_server_like_an_initialize_does() {
+        let lease = lease();
+        lease.admit(None);
+        lease.settle(None, Some("session-a"), true);
+        lease.released("session-a");
+
+        assert_eq!(lease.admit(Some("session-a")), Admission::Serve);
+        assert_eq!(
+            lease.admit(None),
+            Admission::Occupied,
+            "a fresh client cannot slip in while a resume is being confirmed"
+        );
+    }
+
+    /// Whatever a request turns out to be, it hands the reservation back.
+    ///
+    /// The leak this pins is the one the resume path introduced: taking the holder without
+    /// resolving the claim leaves `claiming` set, and the next goodbye then makes the server
+    /// permanently unclaimable — a server nobody can use and nothing will fix.
+    #[test]
+    fn every_settled_request_resolves_its_reservation() {
+        let lease = lease();
+        lease.admit(None);
+        lease.settle(None, Some("session-a"), true);
+        lease.released("session-a");
+
+        lease.admit(Some("session-a"));
+        lease.settle(Some("session-a"), None, true);
+        assert!(!lease.state().claiming, "a resume that succeeded");
+
+        lease.released("session-a");
+        assert_eq!(
+            lease.admit(None),
+            Admission::Serve,
+            "so the next client is not refused by a reservation nobody holds"
+        );
+    }
+
+    /// A swept lease says what it left in the service, so the sweeper can close that too.
+    #[test]
+    fn a_swept_lease_reports_the_session_that_never_said_goodbye() {
+        let lease = Lease::new(Duration::from_millis(1), Duration::from_micros(1))
+            .expect("a grace longer than the budget");
+        lease.admit(None);
+        lease.settle(None, Some("session-a"), true);
+        std::thread::sleep(Duration::from_millis(5));
+
+        assert_eq!(
+            lease.expired().map(|e| e.holder),
+            Some(Some("session-a".to_string())),
+            "a client that vanished leaves an MCP session nothing else will ever close"
+        );
+
+        // Whereas one that said goodbye had its session closed by the DELETE.
+        let lease = Lease::new(Duration::from_millis(1), Duration::from_micros(1))
+            .expect("a grace longer than the budget");
+        lease.admit(None);
+        lease.settle(None, Some("session-b"), true);
+        lease.released("session-b");
+        std::thread::sleep(Duration::from_millis(5));
+        assert_eq!(lease.expired().map(|e| e.holder), Some(None));
+    }
+
     /// Nothing is admitted between deciding to release and having released.
     ///
     /// The window this closes is narrow and expensive: a client admitted there starts using a
@@ -597,7 +697,7 @@ mod tests {
         lease.settle(None, Some("session-a"), true);
         std::thread::sleep(Duration::from_millis(5));
 
-        assert!(lease.expired(), "the grace is spent");
+        assert!(lease.expired().is_some(), "the grace is spent");
         assert_eq!(
             lease.admit(None),
             Admission::Occupied,
@@ -621,9 +721,9 @@ mod tests {
         lease.settle(None, Some("session-a"), true);
         std::thread::sleep(Duration::from_millis(5));
 
-        assert!(lease.expired(), "the grace is spent");
+        assert!(lease.expired().is_some(), "the grace is spent");
         assert!(
-            !lease.expired(),
+            lease.expired().is_none(),
             "and expiry is reported once, not on every sweep — the sweeper runs every few \
              seconds, and a second `true` would release an already-released set of sessions on \
              each pass"

--- a/src/listen.rs
+++ b/src/listen.rs
@@ -132,6 +132,12 @@ struct Tenancy {
     /// When the sessions are released if nothing renews first. `None` means there is nothing to
     /// release and nothing to wait for.
     deadline: Option<Instant>,
+    /// A previous client's sessions are still open, waiting to be adopted or swept.
+    ///
+    /// Tracked rather than inferred from `deadline`. It was inferred, until reserving a claim
+    /// started arming that deadline too — at which point every first client looked like it was
+    /// inheriting sessions that did not exist.
+    left_open: bool,
 }
 
 /// What a swept lease left behind.
@@ -144,6 +150,18 @@ struct Expired {
     /// would leave that MCP session resident and its id still accepted, and every reconnect cycle
     /// would add another.
     holder: Option<String>,
+}
+
+impl Tenancy {
+    /// Reserves the server for a request that is on its way to becoming the holder.
+    ///
+    /// Renewing the deadline is the load-bearing half. A claim admitted near the end of a grace
+    /// would otherwise be adopting sessions the sweeper is entitled to release while
+    /// `mcp.handle` is still running — the client would be handed a target that is being let go.
+    fn claim(&mut self, grace: Duration) {
+        self.claiming = true;
+        self.deadline = Some(Instant::now() + grace);
+    }
 }
 
 /// What the tenancy gate decided about one request.
@@ -209,13 +227,13 @@ impl Lease {
             // taken until `settle` hears the session was real, or a stale id would lock the server
             // out for a whole grace period.
             (Some(_), None) if !state.claiming => {
-                state.claiming = true;
+                state.claim(self.grace);
                 Admission::Serve
             }
             // A new client, and nobody attached or attaching: it reserves the server here, and
             // inherits whatever the last one left open.
             (None, None) if !state.claiming => {
-                state.claiming = true;
+                state.claim(self.grace);
                 Admission::Serve
             }
             // Someone is mid-`initialize`, or holds it already.
@@ -237,18 +255,26 @@ impl Lease {
         // is a server nobody can claim. Every route out of here has resolved it — the arms below
         // decide who holds the server, not whether the claim is over.
         state.claiming = false;
-        let adopted = state.holder.is_none() && state.deadline.is_some();
+        // A teardown that started while this request was being handled has already decided the
+        // sessions are going. Installing a holder now would hand a client something being released
+        // out from under it, and the client is better served by being told to come back.
+        if state.releasing {
+            return false;
+        }
+        let adopted = state.left_open;
         match (minted, requested) {
             // An `initialize` that produced a session: the claim becomes a holder.
             (Some(id), _) => {
                 state.holder = Some(id.to_string());
                 state.deadline = Some(Instant::now() + self.grace);
+                state.left_open = false;
                 adopted
             }
             // A resumed session the service accepted: the returning client is the holder again.
             (None, Some(id)) if ok && state.holder.is_none() => {
                 state.holder = Some(id.to_string());
                 state.deadline = Some(Instant::now() + self.grace);
+                state.left_open = false;
                 adopted
             }
             // Anything else, including an `initialize` that failed: the reservation is already
@@ -263,6 +289,7 @@ impl Lease {
         if state.holder.as_deref() == Some(id) {
             state.holder = None;
             state.deadline = Some(Instant::now() + self.grace);
+            state.left_open = true;
         }
     }
 
@@ -278,6 +305,12 @@ impl Lease {
             Some(at) if Instant::now() >= at => {
                 let holder = state.holder.take();
                 state.deadline = None;
+                // Including a claim. A request whose connection died before `settle` would
+                // otherwise leave this set for ever — no client could take the server, and no
+                // expiry would ever clear it either, because a claim renews the deadline it would
+                // have to outlive. Bounded by one grace, and this is the bound.
+                state.claiming = false;
+                state.left_open = false;
                 state.releasing = true;
                 Some(Expired { holder })
             }
@@ -683,6 +716,73 @@ mod tests {
         lease.released("session-b");
         std::thread::sleep(Duration::from_millis(5));
         assert_eq!(lease.expired().map(|e| e.holder), Some(None));
+    }
+
+    /// A claim keeps alive the sessions it is adopting.
+    ///
+    /// Admission near the end of a grace would otherwise reserve the server and leave the previous
+    /// client's deadline armed, so the sweeper could release the very sessions the request is being
+    /// admitted to adopt — while `mcp.handle` is still running.
+    #[test]
+    fn reserving_the_server_renews_what_the_claim_is_adopting() {
+        let lease = Lease::new(Duration::from_millis(60), Duration::from_micros(1))
+            .expect("a grace longer than the budget");
+        lease.admit(None);
+        lease.settle(None, Some("session-a"), true);
+        lease.released("session-a");
+        std::thread::sleep(Duration::from_millis(40));
+
+        assert_eq!(
+            lease.admit(None),
+            Admission::Serve,
+            "still inside the grace"
+        );
+        std::thread::sleep(Duration::from_millis(40));
+        assert!(
+            lease.expired().is_none(),
+            "the claim pushed the deadline out; without that the sweep would have released the \
+             sessions this request is in the middle of adopting"
+        );
+    }
+
+    /// A request that never settles cannot wedge the server for ever.
+    ///
+    /// The reservation introduced this: a connection dropped inside `mcp.handle` never reaches
+    /// `settle`, so without expiry clearing the claim, no client could take the server and no sweep
+    /// would ever clear it — a claim renews the deadline an expiry would have to outlive.
+    #[test]
+    fn a_claim_whose_request_died_is_cleared_by_the_grace() {
+        let lease = Lease::new(Duration::from_millis(1), Duration::from_micros(1))
+            .expect("a grace longer than the budget");
+        assert_eq!(lease.admit(None), Admission::Serve);
+        std::thread::sleep(Duration::from_millis(5));
+
+        assert!(
+            lease.expired().is_some(),
+            "the claim's own deadline ran out"
+        );
+        assert!(!lease.state().claiming, "and took the reservation with it");
+        lease.released_leases();
+        assert_eq!(lease.admit(None), Admission::Serve);
+    }
+
+    /// A teardown already under way wins over a claim settling into it.
+    #[test]
+    fn a_claim_that_settles_during_a_teardown_does_not_take_the_server() {
+        let lease = Lease::new(Duration::from_millis(1), Duration::from_micros(1))
+            .expect("a grace longer than the budget");
+        lease.admit(None);
+        lease.settle(None, Some("session-a"), true);
+        std::thread::sleep(Duration::from_millis(5));
+        assert!(lease.expired().is_some());
+
+        // The request that was in flight when the sweep started now comes back.
+        assert!(!lease.settle(None, Some("session-b"), true));
+        assert_eq!(
+            lease.state().holder,
+            None,
+            "a client must not be handed sessions that are being released out from under it"
+        );
     }
 
     /// Nothing is admitted between deciding to release and having released.

--- a/src/listen.rs
+++ b/src/listen.rs
@@ -65,7 +65,7 @@ pub const LISTEN_FLAG: &str = "--listen";
 
 /// Where the bearer token is read from. An environment variable rather than an argument, because a
 /// command line is readable by every process on the machine — including a `launch`ed debuggee.
-const TOKEN_ENV: &str = "WINDBG_MCP_LISTEN_TOKEN";
+pub const TOKEN_ENV: &str = "WINDBG_MCP_LISTEN_TOKEN";
 
 /// Overrides how long a client may be silent before its sessions are released, in whole seconds.
 const GRACE_ENV: &str = "WINDBG_MCP_LEASE_GRACE_SECS";
@@ -115,6 +115,19 @@ struct Tenancy {
     /// The MCP session that owns this server. `None` while nobody is attached — which is *not* the
     /// same as nothing being open, since a departed client's sessions live on until `deadline`.
     holder: Option<String>,
+    /// A client is opening a session and has not been given an id yet.
+    ///
+    /// Without this the gate only *observes* tenancy, and two `initialize` requests arriving
+    /// together both see a vacant server, both get sessions, and the second silently replaces the
+    /// first as holder while the first stays serviceable — two clients on a registry whose handles,
+    /// capacity and `end_session` are all global. Admission has to **reserve**.
+    claiming: bool,
+    /// A lease has run out and its sessions are being released.
+    ///
+    /// Held across the release, because the teardown is not instant: clearing the holder and then
+    /// releasing would leave a window where the server looks vacant and a new client can start
+    /// using a session the sweeper is about to close underneath it.
+    releasing: bool,
     /// When the sessions are released if nothing renews first. `None` means there is nothing to
     /// release and nothing to wait for.
     deadline: Option<Instant>,
@@ -125,7 +138,7 @@ struct Tenancy {
 enum Admission {
     /// Hand it to the MCP service.
     Serve,
-    /// Someone else holds the server.
+    /// Someone else holds the server, is taking it, or is being cleaned up after.
     Occupied,
 }
 
@@ -155,40 +168,73 @@ impl Lease {
         self.state.lock().unwrap_or_else(|e| e.into_inner())
     }
 
-    /// Decides whether a request may be served, and renews the lease if so.
+    /// Decides whether a request may be served, **reserving** the server when one is taking it.
     ///
     /// `session` is the request's `Mcp-Session-Id`; its absence means a client opening a new
-    /// session, which is the only moment tenancy is actually contested.
+    /// session, which is the only moment tenancy is contested. Every decision is made under one
+    /// lock, so the answer a request gets is the state it will be served against.
     fn admit(&self, session: Option<&str>) -> Admission {
         let mut state = self.state();
+        // Nothing is served while a teardown is in flight. Briefly refusing a client that could
+        // have been served costs a reconnect; serving one costs it the session mid-call.
+        if state.releasing {
+            return Admission::Occupied;
+        }
         match (session, state.holder.as_deref()) {
             // The holder, still talking.
             (Some(id), Some(held)) if id == held => {
                 state.deadline = Some(Instant::now() + self.grace);
                 Admission::Serve
             }
-            // A session id nobody holds. Let the service answer — it knows whether that session
-            // exists, and a 404 from it is a better answer than a guess from here.
-            (Some(_), _) => Admission::Serve,
-            // A new client, and nobody is attached: it may take the server, and inherits whatever
-            // the last one left open.
-            (None, None) => Admission::Serve,
-            // A new client while someone holds it.
-            (None, Some(_)) => Admission::Occupied,
+            // A session id belonging to someone else. This is the arm that made the race above
+            // persist rather than pass: serving it leaves both clients working.
+            (Some(_), Some(_)) => Admission::Occupied,
+            // A session id with nobody holding the server — a client resuming what it left inside
+            // the grace. Served, but the holder is not taken until the service says the session was
+            // real, or a stale id would lock the server out for a whole grace period.
+            (Some(_), None) if !state.claiming => Admission::Serve,
+            // A new client, and nobody attached or attaching: it reserves the server here, and
+            // inherits whatever the last one left open.
+            (None, None) if !state.claiming => {
+                state.claiming = true;
+                Admission::Serve
+            }
+            // Someone is mid-`initialize`, or holds it already.
+            _ => Admission::Occupied,
         }
     }
 
-    /// Records that a client took the server, once the service has minted its session id.
+    /// Records what the service made of a request the gate admitted.
     ///
-    /// Returns whether this was an **adoption** — a new client picking up sessions a previous one
-    /// left inside the grace — which is worth a log line because the alternative reading, that
-    /// these are its own sessions, is wrong in a way that matters when it ends one.
-    fn take(&self, id: &str) -> bool {
+    /// Called for **every** admitted request, because a claim that is never resolved is a server
+    /// nobody can take: an `initialize` that fails has to give the reservation back.
+    ///
+    /// Returns whether this was an **adoption** — a client picking up sessions a previous one left
+    /// inside the grace — which is worth saying out loud, since the alternative reading (that these
+    /// are its own sessions) is wrong in a way that matters when it ends one.
+    fn settle(&self, requested: Option<&str>, minted: Option<&str>, ok: bool) -> bool {
         let mut state = self.state();
         let adopted = state.holder.is_none() && state.deadline.is_some();
-        state.holder = Some(id.to_string());
-        state.deadline = Some(Instant::now() + self.grace);
-        adopted
+        match (minted, requested) {
+            // An `initialize` that produced a session: the claim becomes a holder.
+            (Some(id), _) => {
+                state.claiming = false;
+                state.holder = Some(id.to_string());
+                state.deadline = Some(Instant::now() + self.grace);
+                adopted
+            }
+            // A resumed session the service accepted: the returning client is the holder again.
+            (None, Some(id)) if ok && state.holder.is_none() => {
+                state.holder = Some(id.to_string());
+                state.deadline = Some(Instant::now() + self.grace);
+                adopted
+            }
+            // Anything else, including an `initialize` that failed: give the reservation back.
+            _ => {
+                state.claiming = false;
+                false
+            }
+        }
     }
 
     /// The holder said goodbye. The sessions stay; the clock starts.
@@ -200,22 +246,28 @@ impl Lease {
         }
     }
 
-    /// Whether the lease has run out, clearing it if so.
+    /// Whether the lease has run out, **claiming the teardown** if so.
     ///
-    /// Clears under the same lock that reads it, so a client connecting exactly now is either
-    /// admitted before this and renews the deadline, or arrives after and finds a vacant server —
-    /// never admitted against a lease this is about to act on. That is the race
-    /// [`Sessions::release_leased`] warns it does not handle itself.
+    /// The server is marked `releasing` under the same lock that reads the deadline, and stays that
+    /// way until [`Self::released_leases`] says the teardown is done. That is what closes the
+    /// window [`Sessions::release_leased`] warns it does not close itself: between deciding to
+    /// release and having released, no client can be admitted to the sessions being released.
     fn expired(&self) -> bool {
         let mut state = self.state();
         match state.deadline {
             Some(at) if Instant::now() >= at => {
                 state.holder = None;
                 state.deadline = None;
+                state.releasing = true;
                 true
             }
             _ => false,
         }
+    }
+
+    /// The teardown is done; the server may be taken again.
+    fn released_leases(&self) {
+        self.state().releasing = false;
     }
 }
 
@@ -327,12 +379,18 @@ async fn gate(
 
     let response = mcp.handle(req).await;
 
-    if let Some(id) = response
+    let minted = response
         .headers()
         .get(SESSION_HEADER)
         .and_then(|v| v.to_str().ok())
-        && lease.take(id)
-    {
+        .map(str::to_owned);
+    // Every admitted request settles, so a reservation is never left standing by a request that
+    // did not become a session.
+    if lease.settle(
+        session.as_deref(),
+        minted.as_deref(),
+        response.status().is_success(),
+    ) {
         tracing::info!("a client attached and adopted the sessions the previous one left open");
     }
     if goodbye && let Some(id) = session {
@@ -365,6 +423,9 @@ async fn sweep(sessions: Sessions, lease: Arc<Lease>) {
         if lease.expired() {
             tracing::info!("a client's lease ran out; releasing the sessions it left open");
             sessions.release_leased().await;
+            // Only now may the server be taken again: until this, an arriving client would be
+            // admitted to sessions this release is closing.
+            lease.released_leases();
         }
     }
 }
@@ -392,12 +453,12 @@ mod tests {
         assert!(Lease::new(call + Duration::from_secs(1), call).is_ok());
     }
 
-    /// One client at a time, and the contest is only ever over a *new* session.
+    /// One client at a time — and admission has to *reserve*, not merely observe.
     #[test]
     fn a_second_client_is_refused_while_the_first_holds_the_server() {
         let lease = lease();
         assert_eq!(lease.admit(None), Admission::Serve, "nobody holds it yet");
-        lease.take("session-a");
+        lease.settle(None, Some("session-a"), true);
 
         assert_eq!(
             lease.admit(None),
@@ -411,8 +472,43 @@ mod tests {
         );
         assert_eq!(
             lease.admit(Some("session-b")),
+            Admission::Occupied,
+            "and another client's session id is refused too — serving it is what would let a \
+             racing second client keep working"
+        );
+    }
+
+    /// The race the reservation exists for: two `initialize`s arriving together.
+    ///
+    /// Without it both see a vacant server, both get sessions, and the second replaces the first as
+    /// holder while the first stays serviceable — two clients on a registry whose handles, capacity
+    /// and `end_session` are all global.
+    #[test]
+    fn a_claim_in_flight_blocks_a_second_initialize() {
+        let lease = lease();
+        assert_eq!(lease.admit(None), Admission::Serve);
+        assert_eq!(
+            lease.admit(None),
+            Admission::Occupied,
+            "the first claim is not resolved yet, so the server is not free"
+        );
+
+        lease.settle(None, Some("session-a"), true);
+        assert_eq!(lease.state().holder.as_deref(), Some("session-a"));
+    }
+
+    /// A claim that comes to nothing must give the server back.
+    #[test]
+    fn an_initialize_that_fails_does_not_hold_the_server_for_ever() {
+        let lease = lease();
+        assert_eq!(lease.admit(None), Admission::Serve);
+        lease.settle(None, None, false);
+
+        assert!(!lease.state().claiming, "the reservation was returned");
+        assert_eq!(
+            lease.admit(None),
             Admission::Serve,
-            "an unknown session id is the service's to reject, not the gate's"
+            "so the next client can take the server"
         );
     }
 
@@ -422,7 +518,7 @@ mod tests {
         let lease = lease();
         lease.admit(None);
         assert!(
-            !lease.take("session-a"),
+            !lease.settle(None, Some("session-a"), true),
             "the first client adopts nothing — there was nothing open"
         );
 
@@ -433,9 +529,31 @@ mod tests {
             "the server is free again the moment the holder lets go"
         );
         assert!(
-            lease.take("session-b"),
+            lease.settle(None, Some("session-b"), true),
             "and the next client is told it inherited the sessions still open"
         );
+    }
+
+    /// A client resuming the session id it already had becomes the holder again — but only once the
+    /// service has confirmed that session is real.
+    #[test]
+    fn a_resumed_session_takes_the_server_back_only_if_it_existed() {
+        let lease = lease();
+        lease.admit(None);
+        lease.settle(None, Some("session-a"), true);
+        lease.released("session-a");
+
+        assert_eq!(lease.admit(Some("session-a")), Admission::Serve);
+        lease.settle(Some("session-a"), None, false);
+        assert_eq!(
+            lease.state().holder,
+            None,
+            "a session id the service rejected must not lock the server out for a whole grace"
+        );
+
+        assert_eq!(lease.admit(Some("session-a")), Admission::Serve);
+        lease.settle(Some("session-a"), None, true);
+        assert_eq!(lease.state().holder.as_deref(), Some("session-a"));
     }
 
     /// Letting go is not the same as expiring: the sessions are still there to come back to.
@@ -443,7 +561,7 @@ mod tests {
     fn letting_go_starts_the_clock_rather_than_releasing_anything() {
         let lease = lease();
         lease.admit(None);
-        lease.take("session-a");
+        lease.settle(None, Some("session-a"), true);
         lease.released("session-a");
 
         assert!(
@@ -458,7 +576,7 @@ mod tests {
     fn only_the_holder_can_let_go() {
         let lease = lease();
         lease.admit(None);
-        lease.take("session-a");
+        lease.settle(None, Some("session-a"), true);
         lease.released("session-b");
         assert_eq!(
             lease.state().holder.as_deref(),
@@ -467,22 +585,49 @@ mod tests {
         );
     }
 
-    /// Expiry clears the holder as well as the deadline, so the next client is not refused by a
-    /// tenancy nobody is in.
+    /// Nothing is admitted between deciding to release and having released.
+    ///
+    /// The window this closes is narrow and expensive: a client admitted there starts using a
+    /// session the sweeper is in the middle of closing, and the call dies underneath it.
     #[test]
-    fn an_expired_lease_leaves_the_server_vacant() {
+    fn nothing_is_admitted_while_the_teardown_runs() {
         let lease = Lease::new(Duration::from_millis(1), Duration::from_micros(1))
             .expect("a grace longer than the budget");
         lease.admit(None);
-        lease.take("session-a");
+        lease.settle(None, Some("session-a"), true);
+        std::thread::sleep(Duration::from_millis(5));
+
+        assert!(lease.expired(), "the grace is spent");
+        assert_eq!(
+            lease.admit(None),
+            Admission::Occupied,
+            "and the server is not vacant yet — the sessions are still being let go"
+        );
+
+        lease.released_leases();
+        assert_eq!(
+            lease.admit(None),
+            Admission::Serve,
+            "only once the teardown is done"
+        );
+    }
+
+    /// Expiry is a one-shot: the deadline is consumed by the sweep that acts on it.
+    #[test]
+    fn expiry_is_reported_once_rather_than_on_every_sweep() {
+        let lease = Lease::new(Duration::from_millis(1), Duration::from_micros(1))
+            .expect("a grace longer than the budget");
+        lease.admit(None);
+        lease.settle(None, Some("session-a"), true);
         std::thread::sleep(Duration::from_millis(5));
 
         assert!(lease.expired(), "the grace is spent");
         assert!(
             !lease.expired(),
-            "and expiry is reported once, not on every sweep"
+            "and expiry is reported once, not on every sweep — the sweeper runs every few \
+             seconds, and a second `true` would release an already-released set of sessions on \
+             each pass"
         );
         assert_eq!(lease.state().holder, None);
-        assert_eq!(lease.admit(None), Admission::Serve);
     }
 }

--- a/src/listen.rs
+++ b/src/listen.rs
@@ -1,0 +1,488 @@
+//! The listener role: MCP over streamable HTTP, for a client on another machine.
+//!
+//! Started with `--listen <addr>`, this serves the same tool surface as the stdio role over HTTP
+//! instead of standard handles. It exists so the model and the client can run somewhere other than
+//! the machine DbgEng needs — see `docs/remote-phase0.md` for the setup this replaces.
+//!
+//! **Bind loopback and reach it through an ssh tunnel.** The listener is, functionally,
+//! patch-the-kernel-as-a-service: `execute`, `debug_batch` and `launch` are all on it. The bearer
+//! token below is a second lock, not the first one, and it is sent in clear — a routable bind is
+//! never the right answer, and a hypervisor's guest network is not private either when the machine
+//! being debugged is a sandbox sharing that subnet.
+//!
+//! ## What HTTP takes away, and what this puts back
+//!
+//! The stdio role gets one property for free that everything here exists to rebuild. When stdin
+//! closes, the client is *definitively* gone, and [`Sessions::shutdown`] releases every target —
+//! which for a live kernel is the difference between a machine that comes back and one left
+//! frozen. Over HTTP there is no such moment: a client that has stopped talking is
+//! indistinguishable from one thinking, and a connection that dropped is indistinguishable from a
+//! network that will recover.
+//!
+//! So a client holds a **lease**. Any request renews it; when it runs out, the sessions that client
+//! opened are released exactly as a disconnect would have released them
+//! ([`Sessions::release_leased`]). Two consequences worth stating plainly:
+//!
+//! - **The grace must outlast a call**, or a long `!analyze` — which sends no HTTP request while it
+//!   runs — would look like an absent client and have its own session released underneath it. That
+//!   is checked at startup rather than documented and hoped for; see [`Lease::new`].
+//! - **A returning client adopts what it left.** Sessions are not released the instant a client
+//!   goes away, so reconnecting inside the grace finds them still open. That is strictly better
+//!   than stdio, where a client restart costs a KDNET attach — and a KDNET attach costs a reboot
+//!   of the target.
+//!
+//! ## One client at a time
+//!
+//! The registry is global: `session_id` handles are minted from it, `MAX_SESSIONS` is shared, and
+//! `end_session` will end anything it is handed. None of that is scoped to a client, so two clients
+//! would silently share — and one could end a target the other was using. Rather than pretend
+//! otherwise, a second client is refused while the first holds the server. The bearer token is the
+//! identity: there is one authorised client, so anyone presenting the token *is* that client, and a
+//! reconnect needs nothing further to prove.
+
+use std::convert::Infallible;
+use std::net::SocketAddr;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result, bail};
+use bytes::Bytes;
+use http_body_util::{BodyExt, Full, combinators::BoxBody};
+use hyper::body::Incoming;
+use hyper::header::AUTHORIZATION;
+use hyper::service::service_fn;
+use hyper::{Request, Response, StatusCode};
+use hyper_util::rt::TokioIo;
+use rmcp::transport::streamable_http_server::session::local::LocalSessionManager;
+use rmcp::transport::streamable_http_server::{StreamableHttpServerConfig, StreamableHttpService};
+use tokio::net::TcpListener;
+
+use crate::engine::Sessions;
+use crate::server::WindbgServer;
+
+/// Turns this process into the listener instead of the stdio server.
+pub const LISTEN_FLAG: &str = "--listen";
+
+/// Where the bearer token is read from. An environment variable rather than an argument, because a
+/// command line is readable by every process on the machine — including a `launch`ed debuggee.
+const TOKEN_ENV: &str = "WINDBG_MCP_LISTEN_TOKEN";
+
+/// Overrides how long a client may be silent before its sessions are released, in whole seconds.
+const GRACE_ENV: &str = "WINDBG_MCP_LEASE_GRACE_SECS";
+
+/// How much longer than one call's budget a lease lasts, when nothing says otherwise.
+///
+/// The grace has to cover a call that reports nothing while it runs, and the longest of those is
+/// bounded by the call timeout — so the default is defined *from* that timeout rather than as a
+/// figure of its own, and a host that raises one raises the other with it.
+const GRACE_OVER_CALL: Duration = Duration::from_secs(60);
+
+/// How often the SSE stream says it is still there while a call runs quietly.
+const SSE_KEEP_ALIVE: Duration = Duration::from_secs(15);
+
+/// How often the sweeper looks for a lease that has run out. Fine enough that a released target is
+/// released promptly, coarse enough to cost nothing while idle.
+const SWEEP: Duration = Duration::from_secs(5);
+
+/// The header carrying a client's MCP session, which is what identifies the holder.
+const SESSION_HEADER: &str = "Mcp-Session-Id";
+
+/// Whether this process was asked to listen, and where.
+pub fn requested(args: &[String]) -> Option<Result<SocketAddr>> {
+    let at = args.iter().position(|arg| arg == LISTEN_FLAG)?;
+    Some(match args.get(at + 1) {
+        Some(addr) => addr
+            .parse()
+            .with_context(|| format!("`{LISTEN_FLAG} {addr}` is not a host:port to bind")),
+        None => Err(anyhow::anyhow!(
+            "`{LISTEN_FLAG}` needs an address to bind, e.g. `{LISTEN_FLAG} 127.0.0.1:8765`"
+        )),
+    })
+}
+
+/// The lease: who holds this server, and until when.
+///
+/// One lock over both, because they are one decision. "Is there a holder" and "has it expired" read
+/// together or a request can be admitted against a holder the sweeper is releasing.
+#[derive(Debug)]
+struct Lease {
+    grace: Duration,
+    state: Mutex<Tenancy>,
+}
+
+#[derive(Debug, Default)]
+struct Tenancy {
+    /// The MCP session that owns this server. `None` while nobody is attached — which is *not* the
+    /// same as nothing being open, since a departed client's sessions live on until `deadline`.
+    holder: Option<String>,
+    /// When the sessions are released if nothing renews first. `None` means there is nothing to
+    /// release and nothing to wait for.
+    deadline: Option<Instant>,
+}
+
+/// What the tenancy gate decided about one request.
+#[derive(Debug, PartialEq, Eq)]
+enum Admission {
+    /// Hand it to the MCP service.
+    Serve,
+    /// Someone else holds the server.
+    Occupied,
+}
+
+impl Lease {
+    /// Fails rather than starting when the grace could expire inside a call.
+    ///
+    /// The failure mode this prevents is silent and expensive: a `crash_triage` or a pool walk
+    /// sends nothing for minutes, so a grace shorter than the call budget reads it as an absent
+    /// client and releases the very session the call is running against. Refusing at startup makes
+    /// that a message an operator sees once, instead of a target that goes away mid-analysis.
+    fn new(grace: Duration, call_timeout: Duration) -> Result<Self> {
+        if grace <= call_timeout {
+            bail!(
+                "the lease grace ({grace:?}) must be longer than one call's budget \
+                 ({call_timeout:?}), or a call that runs quietly to its deadline looks like a \
+                 client that went away — and its own session would be released underneath it. \
+                 Raise {GRACE_ENV}, or lower WINDBG_MCP_CALL_TIMEOUT_SECS."
+            );
+        }
+        Ok(Self {
+            grace,
+            state: Mutex::new(Tenancy::default()),
+        })
+    }
+
+    fn state(&self) -> std::sync::MutexGuard<'_, Tenancy> {
+        self.state.lock().unwrap_or_else(|e| e.into_inner())
+    }
+
+    /// Decides whether a request may be served, and renews the lease if so.
+    ///
+    /// `session` is the request's `Mcp-Session-Id`; its absence means a client opening a new
+    /// session, which is the only moment tenancy is actually contested.
+    fn admit(&self, session: Option<&str>) -> Admission {
+        let mut state = self.state();
+        match (session, state.holder.as_deref()) {
+            // The holder, still talking.
+            (Some(id), Some(held)) if id == held => {
+                state.deadline = Some(Instant::now() + self.grace);
+                Admission::Serve
+            }
+            // A session id nobody holds. Let the service answer — it knows whether that session
+            // exists, and a 404 from it is a better answer than a guess from here.
+            (Some(_), _) => Admission::Serve,
+            // A new client, and nobody is attached: it may take the server, and inherits whatever
+            // the last one left open.
+            (None, None) => Admission::Serve,
+            // A new client while someone holds it.
+            (None, Some(_)) => Admission::Occupied,
+        }
+    }
+
+    /// Records that a client took the server, once the service has minted its session id.
+    ///
+    /// Returns whether this was an **adoption** — a new client picking up sessions a previous one
+    /// left inside the grace — which is worth a log line because the alternative reading, that
+    /// these are its own sessions, is wrong in a way that matters when it ends one.
+    fn take(&self, id: &str) -> bool {
+        let mut state = self.state();
+        let adopted = state.holder.is_none() && state.deadline.is_some();
+        state.holder = Some(id.to_string());
+        state.deadline = Some(Instant::now() + self.grace);
+        adopted
+    }
+
+    /// The holder said goodbye. The sessions stay; the clock starts.
+    fn released(&self, id: &str) {
+        let mut state = self.state();
+        if state.holder.as_deref() == Some(id) {
+            state.holder = None;
+            state.deadline = Some(Instant::now() + self.grace);
+        }
+    }
+
+    /// Whether the lease has run out, clearing it if so.
+    ///
+    /// Clears under the same lock that reads it, so a client connecting exactly now is either
+    /// admitted before this and renews the deadline, or arrives after and finds a vacant server —
+    /// never admitted against a lease this is about to act on. That is the race
+    /// [`Sessions::release_leased`] warns it does not handle itself.
+    fn expired(&self) -> bool {
+        let mut state = self.state();
+        match state.deadline {
+            Some(at) if Instant::now() >= at => {
+                state.holder = None;
+                state.deadline = None;
+                true
+            }
+            _ => false,
+        }
+    }
+}
+
+/// Serves MCP over HTTP until the process is asked to stop.
+pub async fn serve(sessions: Sessions, addr: SocketAddr, call_timeout: Duration) -> Result<()> {
+    let token = std::env::var(TOKEN_ENV).map_err(|_| {
+        anyhow::anyhow!(
+            "{TOKEN_ENV} is not set. The listener will not start without a bearer token: it \
+             exposes every tool this server has, including the ones that write to a live kernel."
+        )
+    })?;
+    if token.trim().is_empty() {
+        bail!("{TOKEN_ENV} is set but empty; that is not a token.");
+    }
+
+    let grace = match std::env::var(GRACE_ENV).ok().and_then(|v| v.parse().ok()) {
+        Some(secs) if secs > 0 => Duration::from_secs(secs),
+        _ => call_timeout + GRACE_OVER_CALL,
+    };
+    let lease = Arc::new(Lease::new(grace, call_timeout)?);
+
+    if !addr.ip().is_loopback() {
+        // Not refused: a host-only adapter is a legitimate choice and this server does not know
+        // which interface it was handed. Said out loud every time, because the cost of getting it
+        // wrong is not this server's to pay.
+        tracing::warn!(
+            "listening on {addr}, which is not loopback — anything that can route to it can \
+             reach every tool here with the token. Prefer binding loopback and forwarding \
+             (`ssh -L`)."
+        );
+    }
+
+    let mcp = {
+        let sessions = sessions.clone();
+        Arc::new(StreamableHttpService::new(
+            move || Ok(WindbgServer::new(sessions.clone())),
+            Arc::new(LocalSessionManager::default()),
+            // A tool call can be quiet for minutes; without a keep-alive the stream looks idle to
+            // anything between the two machines and gets collected.
+            StreamableHttpServerConfig::default().with_sse_keep_alive(Some(SSE_KEEP_ALIVE)),
+        ))
+    };
+
+    let listener = TcpListener::bind(addr)
+        .await
+        .with_context(|| format!("cannot bind {addr}"))?;
+    tracing::info!(
+        "windbg-mcp listening on http://{addr} (lease grace {grace:?}, one client at a time)"
+    );
+
+    tokio::spawn(sweep(sessions.clone(), lease.clone()));
+
+    loop {
+        let (stream, peer) = match listener.accept().await {
+            Ok(accepted) => accepted,
+            Err(e) => {
+                tracing::warn!("accept failed: {e}");
+                continue;
+            }
+        };
+        let mcp = mcp.clone();
+        let lease = lease.clone();
+        let token = token.clone();
+        tokio::spawn(async move {
+            let serve =
+                service_fn(move |req| gate(req, mcp.clone(), lease.clone(), token.clone(), peer));
+            if let Err(e) = hyper::server::conn::http1::Builder::new()
+                .serve_connection(TokioIo::new(stream), serve)
+                .await
+            {
+                tracing::debug!("connection from {peer} ended: {e}");
+            }
+        });
+    }
+}
+
+/// Authenticates, decides tenancy, and only then hands the request to MCP.
+async fn gate(
+    req: Request<Incoming>,
+    mcp: Arc<StreamableHttpService<WindbgServer, LocalSessionManager>>,
+    lease: Arc<Lease>,
+    token: String,
+    peer: SocketAddr,
+) -> Result<Response<BoxBody<Bytes, Infallible>>, Infallible> {
+    if !authorised(&req, &token) {
+        // No detail: an unauthenticated caller learns that it is unauthenticated and nothing about
+        // what is here.
+        tracing::warn!("rejected an unauthenticated request from {peer}");
+        return Ok(refuse(StatusCode::UNAUTHORIZED, "unauthorized"));
+    }
+
+    let session = req
+        .headers()
+        .get(SESSION_HEADER)
+        .and_then(|v| v.to_str().ok())
+        .map(str::to_owned);
+
+    if lease.admit(session.as_deref()) == Admission::Occupied {
+        tracing::warn!("refused a second client from {peer}: this server is already held");
+        return Ok(refuse(
+            StatusCode::CONFLICT,
+            "another client holds this server; it serves one at a time",
+        ));
+    }
+
+    // A DELETE is the client saying it is done. Noted before the service handles it, because
+    // afterwards the session is gone and there is nothing left to match the holder against.
+    let goodbye = req.method() == hyper::Method::DELETE;
+
+    let response = mcp.handle(req).await;
+
+    if let Some(id) = response
+        .headers()
+        .get(SESSION_HEADER)
+        .and_then(|v| v.to_str().ok())
+        && lease.take(id)
+    {
+        tracing::info!("a client attached and adopted the sessions the previous one left open");
+    }
+    if goodbye && let Some(id) = session {
+        lease.released(&id);
+        tracing::info!("the client let go; its sessions are held for the grace period");
+    }
+    Ok(response)
+}
+
+fn authorised(req: &Request<Incoming>, token: &str) -> bool {
+    req.headers()
+        .get(AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.strip_prefix("Bearer "))
+        .is_some_and(|presented| presented == token)
+}
+
+fn refuse(status: StatusCode, why: &str) -> Response<BoxBody<Bytes, Infallible>> {
+    Response::builder()
+        .status(status)
+        .body(Full::new(Bytes::from(why.to_string())).boxed())
+        // The builder only fails on a malformed status or header, and both are literals here.
+        .expect("a constant response is well-formed")
+}
+
+/// Releases what an absent client left behind, once its lease runs out.
+async fn sweep(sessions: Sessions, lease: Arc<Lease>) {
+    loop {
+        tokio::time::sleep(SWEEP).await;
+        if lease.expired() {
+            tracing::info!("a client's lease ran out; releasing the sessions it left open");
+            sessions.release_leased().await;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn lease() -> Lease {
+        Lease::new(Duration::from_secs(360), Duration::from_secs(300)).expect("a workable grace")
+    }
+
+    /// The check that stops a long call from looking like an absent client.
+    #[test]
+    fn a_grace_that_could_expire_inside_a_call_is_refused_at_startup() {
+        let call = Duration::from_secs(300);
+        assert!(
+            Lease::new(Duration::from_secs(120), call).is_err(),
+            "120s of grace against a 300s call budget releases the session the call is using"
+        );
+        assert!(
+            Lease::new(call, call).is_err(),
+            "equal is not enough: the call may finish at its deadline, not before it"
+        );
+        assert!(Lease::new(call + Duration::from_secs(1), call).is_ok());
+    }
+
+    /// One client at a time, and the contest is only ever over a *new* session.
+    #[test]
+    fn a_second_client_is_refused_while_the_first_holds_the_server() {
+        let lease = lease();
+        assert_eq!(lease.admit(None), Admission::Serve, "nobody holds it yet");
+        lease.take("session-a");
+
+        assert_eq!(
+            lease.admit(None),
+            Admission::Occupied,
+            "a second client opening a session is refused"
+        );
+        assert_eq!(
+            lease.admit(Some("session-a")),
+            Admission::Serve,
+            "while the holder keeps being served"
+        );
+        assert_eq!(
+            lease.admit(Some("session-b")),
+            Admission::Serve,
+            "an unknown session id is the service's to reject, not the gate's"
+        );
+    }
+
+    /// A returning client finds what it left, and is told that is what happened.
+    #[test]
+    fn a_client_returning_inside_the_grace_adopts_rather_than_starts_fresh() {
+        let lease = lease();
+        lease.admit(None);
+        assert!(
+            !lease.take("session-a"),
+            "the first client adopts nothing — there was nothing open"
+        );
+
+        lease.released("session-a");
+        assert_eq!(
+            lease.admit(None),
+            Admission::Serve,
+            "the server is free again the moment the holder lets go"
+        );
+        assert!(
+            lease.take("session-b"),
+            "and the next client is told it inherited the sessions still open"
+        );
+    }
+
+    /// Letting go is not the same as expiring: the sessions are still there to come back to.
+    #[test]
+    fn letting_go_starts_the_clock_rather_than_releasing_anything() {
+        let lease = lease();
+        lease.admit(None);
+        lease.take("session-a");
+        lease.released("session-a");
+
+        assert!(
+            !lease.expired(),
+            "a client that said goodbye has its whole grace to change its mind"
+        );
+        assert!(lease.state().deadline.is_some(), "and the clock is running");
+    }
+
+    /// A goodbye from something that is not the holder changes nothing.
+    #[test]
+    fn only_the_holder_can_let_go() {
+        let lease = lease();
+        lease.admit(None);
+        lease.take("session-a");
+        lease.released("session-b");
+        assert_eq!(
+            lease.state().holder.as_deref(),
+            Some("session-a"),
+            "a stray DELETE must not hand the server to whoever sent it"
+        );
+    }
+
+    /// Expiry clears the holder as well as the deadline, so the next client is not refused by a
+    /// tenancy nobody is in.
+    #[test]
+    fn an_expired_lease_leaves_the_server_vacant() {
+        let lease = Lease::new(Duration::from_millis(1), Duration::from_micros(1))
+            .expect("a grace longer than the budget");
+        lease.admit(None);
+        lease.take("session-a");
+        std::thread::sleep(Duration::from_millis(5));
+
+        assert!(lease.expired(), "the grace is spent");
+        assert!(
+            !lease.expired(),
+            "and expiry is reported once, not on every sweep"
+        );
+        assert_eq!(lease.state().holder, None);
+        assert_eq!(lease.admit(None), Admission::Serve);
+    }
+}

--- a/src/listen.rs
+++ b/src/listen.rs
@@ -149,6 +149,17 @@ struct Tenancy {
     /// When the sessions are released if nothing renews first. `None` means there is nothing to
     /// release and nothing to wait for.
     deadline: Option<Instant>,
+    /// Requests admitted under the current holder that have not finished yet.
+    ///
+    /// MCP over HTTP is not one connection: a client can send `DELETE` on one while a tool call is
+    /// still running on another. Handing the server to the next client at that moment would leave
+    /// the old call executing against sessions the new client now owns — free to mutate or end a
+    /// target that is no longer its own.
+    in_flight: usize,
+    /// The holder said goodbye while work it admitted was still running.
+    ///
+    /// Tenancy is given up when that work drains, not when the `DELETE` arrives.
+    farewell: bool,
     /// A previous client's sessions are still open, waiting to be adopted or swept.
     ///
     /// Tracked rather than inferred from `deadline`. It was inferred, until reserving a claim
@@ -175,11 +186,35 @@ impl Tenancy {
     /// Renewing the deadline is the load-bearing half. A claim admitted near the end of a grace
     /// would otherwise be adopting sessions the sweeper is entitled to release while
     /// `mcp.handle` is still running — the client would be handed a target that is being let go.
+    /// Completes a deferred goodbye once nothing admitted under the holder is still running.
+    fn give_up_if_drained(&mut self, grace: Duration) {
+        if self.farewell && self.in_flight == 0 {
+            self.farewell = false;
+            self.holder = None;
+            self.deadline = Some(Instant::now() + grace);
+            self.left_open = true;
+        }
+    }
+
     fn claim(&mut self, grace: Duration) -> u64 {
         self.claims_issued += 1;
         self.claim = Some(self.claims_issued);
         self.deadline = Some(Instant::now() + grace);
         self.claims_issued
+    }
+}
+
+/// Counts an admitted request out again when it ends.
+///
+/// A guard rather than a call at each return, because the path that matters most has no return at
+/// all: a connection dropped inside `mcp.handle` cancels the future, and an explicit decrement
+/// would simply not run — leaving the holder's count permanently above zero and its goodbye
+/// deferred for ever.
+struct InFlight(Arc<Lease>);
+
+impl Drop for InFlight {
+    fn drop(&mut self) {
+        self.0.leave();
     }
 }
 
@@ -252,6 +287,7 @@ impl Lease {
             // The holder, still talking.
             (Some(id), Some(held)) if id == held => {
                 state.deadline = Some(Instant::now() + self.grace);
+                state.in_flight += 1;
                 Admission::Serve(None)
             }
             // A session id belonging to someone else. This is the arm that made the race above
@@ -264,11 +300,13 @@ impl Lease {
             // taken until `settle` hears the session was real, or a stale id would lock the server
             // out for a whole grace period.
             (Some(_), None) if state.claim.is_none() => {
+                state.in_flight += 1;
                 Admission::Serve(Some(state.claim(self.grace)))
             }
             // A new client, and nobody attached or attaching: it reserves the server here, and
             // inherits whatever the last one left open.
             (None, None) if state.claim.is_none() => {
+                state.in_flight += 1;
                 Admission::Serve(Some(state.claim(self.grace)))
             }
             // Someone is mid-`initialize`, or holds it already.
@@ -332,11 +370,22 @@ impl Lease {
     /// The holder said goodbye. The sessions stay; the clock starts.
     fn released(&self, id: &str) {
         let mut state = self.state();
-        if state.holder.as_deref() == Some(id) {
-            state.holder = None;
-            state.deadline = Some(Instant::now() + self.grace);
-            state.left_open = true;
+        if state.holder.as_deref() != Some(id) {
+            return;
         }
+        state.deadline = Some(Instant::now() + self.grace);
+        // The `DELETE` itself is in flight, so this is always the deferred path in practice — and
+        // that is the point: tenancy is given up when the work admitted under it drains, which is
+        // at worst this request and at best a tool call still running on another connection.
+        state.farewell = true;
+        state.give_up_if_drained(self.grace);
+    }
+
+    /// One admitted request finished, however it finished.
+    fn leave(&self) {
+        let mut state = self.state();
+        state.in_flight = state.in_flight.saturating_sub(1);
+        state.give_up_if_drained(self.grace);
     }
 
     /// Whether the lease has run out, **claiming the teardown** if so.
@@ -357,6 +406,10 @@ impl Lease {
                 // have to outlive. Bounded by one grace, and this is the bound.
                 state.claim = None;
                 state.left_open = false;
+                // Everything admitted under that holder is being torn down with it; a count kept
+                // past this point would defer a goodbye that has already been overtaken.
+                state.in_flight = 0;
+                state.farewell = false;
                 state.releasing = true;
                 Some(Expired { holder })
             }
@@ -485,6 +538,9 @@ async fn gate(
             ));
         }
     };
+    // From here every exit — a reply, a refusal, or this future being cancelled — counts the
+    // request out, and a goodbye waiting on it completes when the last one does.
+    let _in_flight = InFlight(lease.clone());
 
     // A DELETE is the client saying it is done. Noted before the service handles it, because
     // afterwards the session is gone and there is nothing left to match the holder against.
@@ -611,6 +667,23 @@ mod tests {
         }
     }
 
+    /// One whole request: admitted, settled, and finished. Every admitted request is counted out
+    /// again in `gate` by a guard, so a test that settles without finishing is modelling a request
+    /// that never came back.
+    fn request(lease: &Lease, session: Option<&str>, minted: Option<&str>, ok: bool) -> Settled {
+        let claim = claim_of(lease.admit(session));
+        let settled = lease.settle(claim, session, minted, ok);
+        lease.leave();
+        settled
+    }
+
+    /// A client's `DELETE`, which is itself an admitted request.
+    fn goodbye(lease: &Lease, id: &str) {
+        claim_of(lease.admit(Some(id)));
+        lease.released(id);
+        lease.leave();
+    }
+
     /// The check that stops a long call from looking like an absent client.
     ///
     /// The floor is not the call budget: an opener spends up to `WORKER_READY_TIMEOUT` bringing a
@@ -638,8 +711,7 @@ mod tests {
     #[test]
     fn a_second_client_is_refused_while_the_first_holds_the_server() {
         let lease = lease();
-        let claim = claim_of(lease.admit(None));
-        lease.settle(claim, None, Some("session-a"), true);
+        request(&lease, None, Some("session-a"), true);
 
         assert!(matches!(lease.admit(None), Admission::Occupied));
         assert!(
@@ -737,16 +809,14 @@ mod tests {
     #[test]
     fn a_client_returning_inside_the_grace_adopts_rather_than_starts_fresh() {
         let lease = lease();
-        let first = claim_of(lease.admit(None));
         assert!(
-            !adopted(lease.settle(first, None, Some("session-a"), true)),
+            !adopted(request(&lease, None, Some("session-a"), true)),
             "the first client adopts nothing — there was nothing open"
         );
 
-        lease.released("session-a");
-        let next = claim_of(lease.admit(None));
+        goodbye(&lease, "session-a");
         assert!(
-            adopted(lease.settle(next, None, Some("session-b"), true)),
+            adopted(request(&lease, None, Some("session-b"), true)),
             "the next client is told it inherited the sessions still open"
         );
     }
@@ -755,20 +825,17 @@ mod tests {
     #[test]
     fn a_resumed_session_takes_the_server_back_only_if_it_existed() {
         let lease = lease();
-        let first = claim_of(lease.admit(None));
-        lease.settle(first, None, Some("session-a"), true);
-        lease.released("session-a");
+        request(&lease, None, Some("session-a"), true);
+        goodbye(&lease, "session-a");
 
-        let bad = claim_of(lease.admit(Some("session-a")));
-        lease.settle(bad, Some("session-a"), None, false);
+        request(&lease, Some("session-a"), None, false);
         assert_eq!(
             lease.state().holder,
             None,
             "a session id the service rejected must not lock the server out for a whole grace"
         );
 
-        let good = claim_of(lease.admit(Some("session-a")));
-        lease.settle(good, Some("session-a"), None, true);
+        request(&lease, Some("session-a"), None, true);
         assert_eq!(lease.state().holder.as_deref(), Some("session-a"));
     }
 
@@ -776,9 +843,8 @@ mod tests {
     #[test]
     fn a_resume_reserves_the_server_like_an_initialize_does() {
         let lease = lease();
-        let first = claim_of(lease.admit(None));
-        lease.settle(first, None, Some("session-a"), true);
-        lease.released("session-a");
+        request(&lease, None, Some("session-a"), true);
+        goodbye(&lease, "session-a");
 
         assert!(matches!(
             lease.admit(Some("session-a")),
@@ -794,15 +860,13 @@ mod tests {
     #[test]
     fn every_settled_request_resolves_its_reservation() {
         let lease = lease();
-        let first = claim_of(lease.admit(None));
-        lease.settle(first, None, Some("session-a"), true);
-        lease.released("session-a");
+        request(&lease, None, Some("session-a"), true);
+        goodbye(&lease, "session-a");
 
-        let resumed = claim_of(lease.admit(Some("session-a")));
-        lease.settle(resumed, Some("session-a"), None, true);
+        request(&lease, Some("session-a"), None, true);
         assert!(lease.state().claim.is_none(), "a resume that succeeded");
 
-        lease.released("session-a");
+        goodbye(&lease, "session-a");
         assert!(
             matches!(lease.admit(None), Admission::Serve(_)),
             "so the next client is not refused by a reservation nobody holds"
@@ -813,9 +877,8 @@ mod tests {
     #[test]
     fn letting_go_starts_the_clock_rather_than_releasing_anything() {
         let lease = lease();
-        let claim = claim_of(lease.admit(None));
-        lease.settle(claim, None, Some("session-a"), true);
-        lease.released("session-a");
+        request(&lease, None, Some("session-a"), true);
+        goodbye(&lease, "session-a");
 
         assert!(
             lease.expired().is_none(),
@@ -824,12 +887,71 @@ mod tests {
         assert!(lease.state().deadline.is_some(), "and the clock is running");
     }
 
+    /// A goodbye does not hand over the server while work admitted under it is still running.
+    ///
+    /// MCP over HTTP is not one connection: a `DELETE` can arrive while a tool call is executing on
+    /// another. Releasing tenancy there would let the next client adopt the debugger sessions while
+    /// the old call is still running against them — free to mutate or end a target it no longer
+    /// owns.
+    #[test]
+    fn a_goodbye_waits_for_the_work_it_admitted() {
+        let lease = lease();
+        request(&lease, None, Some("session-a"), true);
+
+        // A tool call is admitted and is still running.
+        claim_of(lease.admit(Some("session-a")));
+        // The DELETE arrives on another connection, and is itself in flight.
+        claim_of(lease.admit(Some("session-a")));
+        lease.released("session-a");
+
+        assert_eq!(
+            lease.state().holder.as_deref(),
+            Some("session-a"),
+            "the goodbye is recorded but not acted on — a call is still running"
+        );
+        assert!(matches!(lease.admit(None), Admission::Occupied));
+
+        lease.leave(); // the DELETE's own request ends
+        assert_eq!(
+            lease.state().holder.as_deref(),
+            Some("session-a"),
+            "still held: the tool call has not come back"
+        );
+
+        lease.leave(); // and now the tool call does
+        assert_eq!(
+            lease.state().holder,
+            None,
+            "only now is the server given up"
+        );
+        assert!(matches!(lease.admit(None), Admission::Serve(_)));
+    }
+
+    /// A request that never came back cannot defer a goodbye for ever.
+    #[test]
+    fn a_swept_lease_forgets_work_it_was_waiting_on() {
+        let lease = brief();
+        let claim = claim_of(lease.admit(None));
+        lease.settle(claim, None, Some("session-a"), true);
+        claim_of(lease.admit(Some("session-a"))); // a call that never returns
+        lease.released("session-a");
+        std::thread::sleep(Duration::from_millis(5));
+
+        assert!(lease.expired().is_some());
+        assert_eq!(
+            lease.state().in_flight,
+            0,
+            "the teardown took the count with it"
+        );
+        lease.released_leases();
+        assert!(matches!(lease.admit(None), Admission::Serve(_)));
+    }
+
     /// A goodbye from something that is not the holder changes nothing.
     #[test]
     fn only_the_holder_can_let_go() {
         let lease = lease();
-        let claim = claim_of(lease.admit(None));
-        lease.settle(claim, None, Some("session-a"), true);
+        request(&lease, None, Some("session-a"), true);
         lease.released("session-b");
         assert_eq!(
             lease.state().holder.as_deref(),
@@ -845,9 +967,8 @@ mod tests {
             grace: Duration::from_millis(60),
             state: Mutex::new(Tenancy::default()),
         };
-        let claim = claim_of(lease.admit(None));
-        lease.settle(claim, None, Some("session-a"), true);
-        lease.released("session-a");
+        request(&lease, None, Some("session-a"), true);
+        goodbye(&lease, "session-a");
         std::thread::sleep(Duration::from_millis(40));
 
         assert!(
@@ -885,11 +1006,10 @@ mod tests {
     #[test]
     fn a_claim_that_settles_during_a_teardown_does_not_take_the_server() {
         let lease = brief();
-        let claim = claim_of(lease.admit(None));
-        lease.settle(claim, None, Some("session-a"), true);
+        request(&lease, None, Some("session-a"), true);
         // The holder lets go, so the next request is a genuine resume and reserves a claim of its
         // own — a request from the sitting holder reserves nothing and settles nothing.
-        lease.released("session-a");
+        goodbye(&lease, "session-a");
         let resumed = claim_of(lease.admit(Some("session-a")));
         assert!(resumed.is_some(), "a resume reserves the server");
         std::thread::sleep(Duration::from_millis(5));
@@ -955,9 +1075,8 @@ mod tests {
         );
 
         let lease = brief();
-        let claim = claim_of(lease.admit(None));
-        lease.settle(claim, None, Some("session-b"), true);
-        lease.released("session-b");
+        request(&lease, None, Some("session-b"), true);
+        goodbye(&lease, "session-b");
         std::thread::sleep(Duration::from_millis(5));
         assert_eq!(
             lease.expired().map(|e| e.holder),

--- a/src/listen.rs
+++ b/src/listen.rs
@@ -114,9 +114,14 @@ pub fn requested(args: &[String]) -> Option<Result<SocketAddr>> {
 ///
 /// One lock over both, because they are one decision. "Is there a holder" and "has it expired" read
 /// together or a request can be admitted against a holder the sweeper is releasing.
-#[derive(Debug)]
 struct Lease {
     grace: Duration,
+    /// Consulted before tenancy changes hands, never for anything else.
+    ///
+    /// The listener otherwise knows nothing about debug sessions — but "may this client have the
+    /// server" cannot be answered from HTTP alone, because an engine job outlives the request that
+    /// asked for it.
+    sessions: Sessions,
     state: Mutex<Tenancy>,
 }
 
@@ -194,16 +199,6 @@ impl Tenancy {
     /// Renewing the deadline is the load-bearing half. A claim admitted near the end of a grace
     /// would otherwise be adopting sessions the sweeper is entitled to release while
     /// `mcp.handle` is still running — the client would be handed a target that is being let go.
-    /// Completes a deferred goodbye once nothing admitted under the holder is still running.
-    fn give_up_if_drained(&mut self, grace: Duration) {
-        if self.farewell && self.in_flight == 0 {
-            self.farewell = false;
-            self.holder = None;
-            self.deadline = Some(Instant::now() + grace);
-            self.left_open = true;
-        }
-    }
-
     fn claim(&mut self, grace: Duration) -> u64 {
         self.claims_issued += 1;
         self.claim = Some(self.claims_issued);
@@ -269,7 +264,7 @@ impl Lease {
     /// sends nothing for minutes, so a grace shorter than the call budget reads it as an absent
     /// client and releases the very session the call is running against. Refusing at startup makes
     /// that a message an operator sees once, instead of a target that goes away mid-analysis.
-    fn new(grace: Duration, call_timeout: Duration) -> Result<Self> {
+    fn new(grace: Duration, call_timeout: Duration, sessions: Sessions) -> Result<Self> {
         let quiet = longest_quiet_call(call_timeout);
         if grace <= quiet {
             bail!(
@@ -283,6 +278,7 @@ impl Lease {
         }
         Ok(Self {
             grace,
+            sessions,
             state: Mutex::new(Tenancy::default()),
         })
     }
@@ -409,7 +405,8 @@ impl Lease {
         // that is the point: tenancy is given up when the work admitted under it drains, which is
         // at worst this request and at best a tool call still running on another connection.
         state.farewell = true;
-        state.give_up_if_drained(self.grace);
+        drop(state);
+        self.try_give_up();
     }
 
     /// One admitted request finished, however it finished.
@@ -424,7 +421,8 @@ impl Lease {
             return;
         }
         state.in_flight = state.in_flight.saturating_sub(1);
-        state.give_up_if_drained(self.grace);
+        drop(state);
+        self.try_give_up();
     }
 
     /// Whether the lease has run out, **claiming the teardown** if so.
@@ -459,6 +457,33 @@ impl Lease {
         }
     }
 
+    /// Hands the server over, if a goodbye is outstanding and nothing is still using it.
+    ///
+    /// Two conditions, and they are not the same one. `in_flight` is HTTP: the requests this holder
+    /// was admitted for. `Sessions::busy` is the engine: a job survives the request that queued it,
+    /// so a dropped future or a timed-out call leaves work running against a target the next client
+    /// would otherwise be handed. Attempted on every sweep as well as on the two events, because
+    /// the engine going idle is not an event this side can see.
+    fn try_give_up(&self) {
+        let mut state = self.state();
+        if !state.farewell || state.in_flight != 0 {
+            return;
+        }
+        drop(state);
+        if self.sessions.busy() {
+            return;
+        }
+        state = self.state();
+        // Re-checked: the two locks were not held together, so a request could have arrived.
+        if !state.farewell || state.in_flight != 0 {
+            return;
+        }
+        state.farewell = false;
+        state.holder = None;
+        state.deadline = Some(Instant::now() + self.grace);
+        state.left_open = true;
+    }
+
     /// The teardown is done; the server may be taken again.
     fn released_leases(&self) {
         self.state().releasing = false;
@@ -481,7 +506,7 @@ pub async fn serve(sessions: Sessions, addr: SocketAddr, call_timeout: Duration)
         Some(secs) if secs > 0 => Duration::from_secs(secs),
         _ => longest_quiet_call(call_timeout) + GRACE_HEADROOM,
     };
-    let lease = Arc::new(Lease::new(grace, call_timeout)?);
+    let lease = Arc::new(Lease::new(grace, call_timeout, sessions.clone())?);
 
     if !addr.ip().is_loopback() {
         // Not refused: a host-only adapter is a legitimate choice and this server does not know
@@ -656,6 +681,9 @@ fn refuse(status: StatusCode, why: &str) -> Response<BoxBody<Bytes, Infallible>>
 async fn sweep(sessions: Sessions, lease: Arc<Lease>, manager: Arc<LocalSessionManager>) {
     loop {
         tokio::time::sleep(SWEEP).await;
+        // The engine may have gone idle since the last tick, which is not something the HTTP side
+        // is told about.
+        lease.try_give_up();
         let Some(expired) = lease.expired() else {
             continue;
         };
@@ -684,13 +712,19 @@ mod tests {
 
     /// A grace comfortably past the opener's end-to-end bound.
     fn lease() -> Lease {
-        Lease::new(longest_quiet_call(CALL) + Duration::from_secs(60), CALL).expect("workable")
+        Lease::new(
+            longest_quiet_call(CALL) + Duration::from_secs(60),
+            CALL,
+            Sessions::new(CALL),
+        )
+        .expect("workable")
     }
 
     /// A lease whose grace expires almost immediately, for the sweep paths.
     fn brief() -> Lease {
         Lease {
             grace: Duration::from_millis(1),
+            sessions: Sessions::new(CALL),
             state: Mutex::new(Tenancy::default()),
         }
     }
@@ -737,19 +771,26 @@ mod tests {
     #[test]
     fn a_grace_that_could_expire_inside_a_call_is_refused_at_startup() {
         assert!(
-            Lease::new(Duration::from_secs(120), CALL).is_err(),
+            Lease::new(Duration::from_secs(120), CALL, Sessions::new(CALL)).is_err(),
             "well under the budget"
         );
         assert!(
-            Lease::new(CALL + Duration::from_secs(1), CALL).is_err(),
+            Lease::new(CALL + Duration::from_secs(1), CALL, Sessions::new(CALL)).is_err(),
             "past the call budget but not past the worker handshake in front of it — the case that \
              looks safe and is not"
         );
         assert!(
-            Lease::new(longest_quiet_call(CALL), CALL).is_err(),
+            Lease::new(longest_quiet_call(CALL), CALL, Sessions::new(CALL)).is_err(),
             "equal is not enough: the call may finish at its deadline, not before it"
         );
-        assert!(Lease::new(longest_quiet_call(CALL) + Duration::from_secs(1), CALL).is_ok());
+        assert!(
+            Lease::new(
+                longest_quiet_call(CALL) + Duration::from_secs(1),
+                CALL,
+                Sessions::new(CALL)
+            )
+            .is_ok()
+        );
     }
 
     /// One client at a time — and admission has to *reserve*, not merely observe.
@@ -1011,6 +1052,28 @@ mod tests {
         );
     }
 
+    /// Tenancy waits on the *engine*, not only on the HTTP request that asked.
+    ///
+    /// A job outlives the wait for it — `Sessions::call_as` cancels only the waiter and says so —
+    /// so a dropped future or a timed-out call leaves work running against a target. Handing that
+    /// target to the next client because the HTTP side went quiet is the same overlap the in-flight
+    /// count exists to prevent, one layer down.
+    #[test]
+    fn a_goodbye_waits_for_the_engine_and_not_just_the_request() {
+        let lease = lease();
+        request(&lease, None, Some("session-a"), true);
+        goodbye(&lease, "session-a");
+        assert_eq!(
+            lease.state().holder,
+            None,
+            "with an idle engine the handover is immediate"
+        );
+
+        // `Sessions::busy` is what the lease consults, and an idle registry is not busy — so this
+        // test pins the wiring rather than the debugger, which needs a worker to be busy at all.
+        assert!(!lease.sessions.busy());
+    }
+
     /// A request that never came back cannot defer a goodbye for ever.
     #[test]
     fn a_swept_lease_forgets_work_it_was_waiting_on() {
@@ -1049,6 +1112,7 @@ mod tests {
     fn reserving_the_server_renews_what_the_claim_is_adopting() {
         let lease = Lease {
             grace: Duration::from_millis(60),
+            sessions: Sessions::new(CALL),
             state: Mutex::new(Tenancy::default()),
         };
         request(&lease, None, Some("session-a"), true);

--- a/src/listen.rs
+++ b/src/listen.rs
@@ -183,6 +183,20 @@ impl Tenancy {
     }
 }
 
+/// What became of a request's reservation.
+#[derive(Debug, PartialEq, Eq)]
+enum Settled {
+    /// Tenancy is as this request left it, and the response stands.
+    Kept {
+        /// Whether this client picked up sessions a previous one left open.
+        adopted: bool,
+    },
+    /// This request no longer owns the server: its claim was swept while it was being handled, or
+    /// a teardown started under it. Anything it produced has to be undone — the service may have
+    /// minted a session for a client that is not the holder, and nothing else will ever close it.
+    Stale,
+}
+
 /// What the tenancy gate decided about one request.
 #[derive(Debug, PartialEq, Eq)]
 enum Admission {
@@ -276,22 +290,22 @@ impl Lease {
         requested: Option<&str>,
         minted: Option<&str>,
         ok: bool,
-    ) -> bool {
+    ) -> Settled {
         let mut state = self.state();
         match claim {
             // This request reserved the server. It may only resolve *its own* reservation: one
             // that outlived the grace has already been cleared and possibly re-issued to somebody
             // else, and clearing that would hand two clients the registry at once.
             Some(mine) if state.claim == Some(mine) => state.claim = None,
-            Some(_) => return false,
+            Some(_) => return Settled::Stale,
             // A request from the established holder reserved nothing and settles nothing.
-            None => return false,
+            None => return Settled::Kept { adopted: false },
         }
         // A teardown that started while this request was being handled has already decided the
         // sessions are going. Installing a holder now would hand a client something being released
         // out from under it, and the client is better served by being told to come back.
         if state.releasing {
-            return false;
+            return Settled::Stale;
         }
         let adopted = state.left_open;
         match (minted, requested) {
@@ -300,18 +314,18 @@ impl Lease {
                 state.holder = Some(id.to_string());
                 state.deadline = Some(Instant::now() + self.grace);
                 state.left_open = false;
-                adopted
+                Settled::Kept { adopted }
             }
             // A resumed session the service accepted: the returning client is the holder again.
             (None, Some(id)) if ok && state.holder.is_none() => {
                 state.holder = Some(id.to_string());
                 state.deadline = Some(Instant::now() + self.grace);
                 state.left_open = false;
-                adopted
+                Settled::Kept { adopted }
             }
             // Anything else, including an `initialize` that failed: the reservation is already
             // given back above, and nobody took the server.
-            _ => false,
+            _ => Settled::Kept { adopted: false },
         }
     }
 
@@ -404,7 +418,7 @@ pub async fn serve(sessions: Sessions, addr: SocketAddr, call_timeout: Duration)
         "windbg-mcp listening on http://{addr} (lease grace {grace:?}, one client at a time)"
     );
 
-    tokio::spawn(sweep(sessions.clone(), lease.clone(), manager));
+    tokio::spawn(sweep(sessions.clone(), lease.clone(), manager.clone()));
 
     loop {
         let (stream, peer) = match listener.accept().await {
@@ -415,11 +429,20 @@ pub async fn serve(sessions: Sessions, addr: SocketAddr, call_timeout: Duration)
             }
         };
         let mcp = mcp.clone();
+        let manager = manager.clone();
         let lease = lease.clone();
         let token = token.clone();
         tokio::spawn(async move {
-            let serve =
-                service_fn(move |req| gate(req, mcp.clone(), lease.clone(), token.clone(), peer));
+            let serve = service_fn(move |req| {
+                gate(
+                    req,
+                    mcp.clone(),
+                    manager.clone(),
+                    lease.clone(),
+                    token.clone(),
+                    peer,
+                )
+            });
             if let Err(e) = hyper::server::conn::http1::Builder::new()
                 .serve_connection(TokioIo::new(stream), serve)
                 .await
@@ -434,6 +457,7 @@ pub async fn serve(sessions: Sessions, addr: SocketAddr, call_timeout: Duration)
 async fn gate(
     req: Request<Incoming>,
     mcp: Arc<StreamableHttpService<WindbgServer, LocalSessionManager>>,
+    manager: Arc<LocalSessionManager>,
     lease: Arc<Lease>,
     token: String,
     peer: SocketAddr,
@@ -475,13 +499,34 @@ async fn gate(
         .map(str::to_owned);
     // Every admitted request settles, so a reservation is never left standing by a request that
     // did not become a session.
-    if lease.settle(
+    match lease.settle(
         claim,
         session.as_deref(),
         minted.as_deref(),
         response.status().is_success(),
     ) {
-        tracing::info!("a client attached and adopted the sessions the previous one left open");
+        Settled::Kept { adopted: true } => {
+            tracing::info!("a client attached and adopted the sessions the previous one left open");
+        }
+        Settled::Kept { adopted: false } => {}
+        // This request lost the server while it was being handled. If the service minted a session
+        // for it, that session belongs to nobody: the holder is someone else, so every request
+        // carrying it would be refused, and no lease will ever sweep it. Close it here and tell the
+        // client what actually happened, rather than handing it an id that cannot be used.
+        Settled::Stale => {
+            if let Some(id) = minted
+                && let Err(e) = manager.close_session(&id.into()).await
+            {
+                tracing::warn!("could not close a session minted by a claim that had expired: {e}");
+            }
+            tracing::warn!(
+                "a request from {peer} outlived its claim on this server; its session was closed"
+            );
+            return Ok(refuse(
+                StatusCode::CONFLICT,
+                "this request outlived its claim on the server; open a new session",
+            ));
+        }
     }
     if goodbye && let Some(id) = session {
         lease.released(&id);
@@ -551,6 +596,14 @@ mod tests {
 
     /// The claim an admitted request reserved. Panics if the gate refused, since every caller here
     /// is testing what happens *after* admission.
+    /// Whether a settlement adopted sessions, asserting it was not rejected.
+    fn adopted(settled: Settled) -> bool {
+        match settled {
+            Settled::Kept { adopted } => adopted,
+            Settled::Stale => panic!("the settlement was rejected as stale"),
+        }
+    }
+
     fn claim_of(admission: Admission) -> Option<u64> {
         match admission {
             Admission::Serve(claim) => claim,
@@ -648,12 +701,36 @@ mod tests {
         lease.settle(fresh, None, Some("session-new"), true);
 
         // Now the request nobody is waiting for finally returns.
-        assert!(!lease.settle(stale, None, Some("session-stale"), true));
+        assert_eq!(
+            lease.settle(stale, None, Some("session-stale"), true),
+            Settled::Stale,
+            "and is told so, because the session it minted has to be closed and its client told to \
+             start again — an id whose every request is refused is worse than an error"
+        );
         assert_eq!(
             lease.state().holder.as_deref(),
             Some("session-new"),
             "the holder is whoever legitimately took the server, not whoever answered last"
         );
+    }
+
+    /// A request from the established holder settles nothing and is never stale.
+    ///
+    /// It reserved no claim, so there is nothing to resolve — and treating it as stale would close
+    /// the holder's own session out from under it.
+    #[test]
+    fn an_ordinary_request_from_the_holder_is_not_a_settlement() {
+        let lease = lease();
+        let claim = claim_of(lease.admit(None));
+        lease.settle(claim, None, Some("session-a"), true);
+
+        let none = claim_of(lease.admit(Some("session-a")));
+        assert_eq!(none, None, "the holder reserves nothing");
+        assert_eq!(
+            lease.settle(none, Some("session-a"), None, true),
+            Settled::Kept { adopted: false }
+        );
+        assert_eq!(lease.state().holder.as_deref(), Some("session-a"));
     }
 
     /// A returning client finds what it left, and is told that is what happened.
@@ -662,14 +739,14 @@ mod tests {
         let lease = lease();
         let first = claim_of(lease.admit(None));
         assert!(
-            !lease.settle(first, None, Some("session-a"), true),
+            !adopted(lease.settle(first, None, Some("session-a"), true)),
             "the first client adopts nothing — there was nothing open"
         );
 
         lease.released("session-a");
         let next = claim_of(lease.admit(None));
         assert!(
-            lease.settle(next, None, Some("session-b"), true),
+            adopted(lease.settle(next, None, Some("session-b"), true)),
             "the next client is told it inherited the sessions still open"
         );
     }
@@ -810,11 +887,18 @@ mod tests {
         let lease = brief();
         let claim = claim_of(lease.admit(None));
         lease.settle(claim, None, Some("session-a"), true);
+        // The holder lets go, so the next request is a genuine resume and reserves a claim of its
+        // own — a request from the sitting holder reserves nothing and settles nothing.
+        lease.released("session-a");
         let resumed = claim_of(lease.admit(Some("session-a")));
+        assert!(resumed.is_some(), "a resume reserves the server");
         std::thread::sleep(Duration::from_millis(5));
         assert!(lease.expired().is_some());
 
-        assert!(!lease.settle(resumed, None, Some("session-b"), true));
+        assert_eq!(
+            lease.settle(resumed, None, Some("session-b"), true),
+            Settled::Stale
+        );
         assert_eq!(
             lease.state().holder,
             None,

--- a/src/listen.rs
+++ b/src/listen.rs
@@ -71,12 +71,21 @@ pub const TOKEN_ENV: &str = "WINDBG_MCP_LISTEN_TOKEN";
 /// Overrides how long a client may be silent before its sessions are released, in whole seconds.
 const GRACE_ENV: &str = "WINDBG_MCP_LEASE_GRACE_SECS";
 
-/// How much longer than one call's budget a lease lasts, when nothing says otherwise.
+/// How much longer than the longest possible call a lease lasts, when nothing says otherwise.
 ///
-/// The grace has to cover a call that reports nothing while it runs, and the longest of those is
-/// bounded by the call timeout — so the default is defined *from* that timeout rather than as a
-/// figure of its own, and a host that raises one raises the other with it.
-const GRACE_OVER_CALL: Duration = Duration::from_secs(60);
+/// Defined *from* that bound rather than as a figure of its own, so a host that raises the call
+/// timeout raises the grace with it.
+const GRACE_HEADROOM: Duration = Duration::from_secs(60);
+
+/// The longest a single tool call can keep the client quiet.
+///
+/// Not the call timeout on its own. An opener spends up to `WORKER_READY_TIMEOUT` getting a worker
+/// up *before* the call budget starts running, so a `301s` grace against a `300s` budget still
+/// leaves an attach alive at `301s` — and the sweeper would close the session underneath the very
+/// request that opened it. The bound is the sum, and this is where that is written down once.
+fn longest_quiet_call(call_timeout: Duration) -> Duration {
+    crate::engine::WORKER_READY_TIMEOUT + call_timeout
+}
 
 /// How often the SSE stream says it is still there while a call runs quietly.
 const SSE_KEEP_ALIVE: Duration = Duration::from_secs(15);
@@ -116,13 +125,21 @@ struct Tenancy {
     /// The MCP session that owns this server. `None` while nobody is attached — which is *not* the
     /// same as nothing being open, since a departed client's sessions live on until `deadline`.
     holder: Option<String>,
-    /// A client is opening a session and has not been given an id yet.
+    /// The claim currently reserving the server, if any.
     ///
-    /// Without this the gate only *observes* tenancy, and two `initialize` requests arriving
-    /// together both see a vacant server, both get sessions, and the second silently replaces the
-    /// first as holder while the first stays serviceable — two clients on a registry whose handles,
-    /// capacity and `end_session` are all global. Admission has to **reserve**.
-    claiming: bool,
+    /// Without a reservation the gate only *observes* tenancy, and two `initialize` requests
+    /// arriving together both see a vacant server, both get sessions, and the second silently
+    /// replaces the first as holder while the first stays serviceable — two clients on a registry
+    /// whose handles, capacity and `end_session` are all global.
+    ///
+    /// It is an **identity** rather than a flag because a reservation can outlive its usefulness: a
+    /// request still inside `mcp.handle` when the grace runs out has its claim cleared, the sweep
+    /// finishes, and a newer client claims the server — and the old request then arrives at
+    /// `settle` with no way to know it is no longer the one being waited for. A generation lets
+    /// `settle` check that the reservation it is resolving is still its own.
+    claim: Option<u64>,
+    /// Source of the generation above. Monotonic, so a cleared claim is never re-issued.
+    claims_issued: u64,
     /// A lease has run out and its sessions are being released.
     ///
     /// Held across the release, because the teardown is not instant: clearing the holder and then
@@ -158,17 +175,20 @@ impl Tenancy {
     /// Renewing the deadline is the load-bearing half. A claim admitted near the end of a grace
     /// would otherwise be adopting sessions the sweeper is entitled to release while
     /// `mcp.handle` is still running — the client would be handed a target that is being let go.
-    fn claim(&mut self, grace: Duration) {
-        self.claiming = true;
+    fn claim(&mut self, grace: Duration) -> u64 {
+        self.claims_issued += 1;
+        self.claim = Some(self.claims_issued);
         self.deadline = Some(Instant::now() + grace);
+        self.claims_issued
     }
 }
 
 /// What the tenancy gate decided about one request.
 #[derive(Debug, PartialEq, Eq)]
 enum Admission {
-    /// Hand it to the MCP service.
-    Serve,
+    /// Hand it to the MCP service. Carries the claim this request reserved, if it reserved one —
+    /// which [`Lease::settle`] must present to change tenancy.
+    Serve(Option<u64>),
     /// Someone else holds the server, is taking it, or is being cleaned up after.
     Occupied,
 }
@@ -181,12 +201,15 @@ impl Lease {
     /// client and releases the very session the call is running against. Refusing at startup makes
     /// that a message an operator sees once, instead of a target that goes away mid-analysis.
     fn new(grace: Duration, call_timeout: Duration) -> Result<Self> {
-        if grace <= call_timeout {
+        let quiet = longest_quiet_call(call_timeout);
+        if grace <= quiet {
             bail!(
-                "the lease grace ({grace:?}) must be longer than one call's budget \
-                 ({call_timeout:?}), or a call that runs quietly to its deadline looks like a \
-                 client that went away — and its own session would be released underneath it. \
-                 Raise {GRACE_ENV}, or lower WINDBG_MCP_CALL_TIMEOUT_SECS."
+                "the lease grace ({grace:?}) must be longer than the longest a call can keep a \
+                 client quiet ({quiet:?} — a {call_timeout:?} budget after up to \
+                 {:?} bringing an engine worker up), or a call that runs to its deadline looks \
+                 like a client that went away and its own session is released underneath it. \
+                 Raise {GRACE_ENV}, or lower WINDBG_MCP_CALL_TIMEOUT_SECS.",
+                crate::engine::WORKER_READY_TIMEOUT
             );
         }
         Ok(Self {
@@ -215,7 +238,7 @@ impl Lease {
             // The holder, still talking.
             (Some(id), Some(held)) if id == held => {
                 state.deadline = Some(Instant::now() + self.grace);
-                Admission::Serve
+                Admission::Serve(None)
             }
             // A session id belonging to someone else. This is the arm that made the race above
             // persist rather than pass: serving it leaves both clients working.
@@ -226,15 +249,13 @@ impl Lease {
             // client and both would pass a gate that only served them. The holder is still not
             // taken until `settle` hears the session was real, or a stale id would lock the server
             // out for a whole grace period.
-            (Some(_), None) if !state.claiming => {
-                state.claim(self.grace);
-                Admission::Serve
+            (Some(_), None) if state.claim.is_none() => {
+                Admission::Serve(Some(state.claim(self.grace)))
             }
             // A new client, and nobody attached or attaching: it reserves the server here, and
             // inherits whatever the last one left open.
-            (None, None) if !state.claiming => {
-                state.claim(self.grace);
-                Admission::Serve
+            (None, None) if state.claim.is_none() => {
+                Admission::Serve(Some(state.claim(self.grace)))
             }
             // Someone is mid-`initialize`, or holds it already.
             _ => Admission::Occupied,
@@ -249,12 +270,23 @@ impl Lease {
     /// Returns whether this was an **adoption** — a client picking up sessions a previous one left
     /// inside the grace — which is worth saying out loud, since the alternative reading (that these
     /// are its own sessions) is wrong in a way that matters when it ends one.
-    fn settle(&self, requested: Option<&str>, minted: Option<&str>, ok: bool) -> bool {
+    fn settle(
+        &self,
+        claim: Option<u64>,
+        requested: Option<&str>,
+        minted: Option<&str>,
+        ok: bool,
+    ) -> bool {
         let mut state = self.state();
-        // Unconditionally, before anything else: a reservation outliving the request that took it
-        // is a server nobody can claim. Every route out of here has resolved it — the arms below
-        // decide who holds the server, not whether the claim is over.
-        state.claiming = false;
+        match claim {
+            // This request reserved the server. It may only resolve *its own* reservation: one
+            // that outlived the grace has already been cleared and possibly re-issued to somebody
+            // else, and clearing that would hand two clients the registry at once.
+            Some(mine) if state.claim == Some(mine) => state.claim = None,
+            Some(_) => return false,
+            // A request from the established holder reserved nothing and settles nothing.
+            None => return false,
+        }
         // A teardown that started while this request was being handled has already decided the
         // sessions are going. Installing a holder now would hand a client something being released
         // out from under it, and the client is better served by being told to come back.
@@ -309,7 +341,7 @@ impl Lease {
                 // otherwise leave this set for ever — no client could take the server, and no
                 // expiry would ever clear it either, because a claim renews the deadline it would
                 // have to outlive. Bounded by one grace, and this is the bound.
-                state.claiming = false;
+                state.claim = None;
                 state.left_open = false;
                 state.releasing = true;
                 Some(Expired { holder })
@@ -338,7 +370,7 @@ pub async fn serve(sessions: Sessions, addr: SocketAddr, call_timeout: Duration)
 
     let grace = match std::env::var(GRACE_ENV).ok().and_then(|v| v.parse().ok()) {
         Some(secs) if secs > 0 => Duration::from_secs(secs),
-        _ => call_timeout + GRACE_OVER_CALL,
+        _ => longest_quiet_call(call_timeout) + GRACE_HEADROOM,
     };
     let lease = Arc::new(Lease::new(grace, call_timeout)?);
 
@@ -419,13 +451,16 @@ async fn gate(
         .and_then(|v| v.to_str().ok())
         .map(str::to_owned);
 
-    if lease.admit(session.as_deref()) == Admission::Occupied {
-        tracing::warn!("refused a second client from {peer}: this server is already held");
-        return Ok(refuse(
-            StatusCode::CONFLICT,
-            "another client holds this server; it serves one at a time",
-        ));
-    }
+    let claim = match lease.admit(session.as_deref()) {
+        Admission::Serve(claim) => claim,
+        Admission::Occupied => {
+            tracing::warn!("refused a second client from {peer}: this server is already held");
+            return Ok(refuse(
+                StatusCode::CONFLICT,
+                "another client holds this server; it serves one at a time",
+            ));
+        }
+    };
 
     // A DELETE is the client saying it is done. Noted before the service handles it, because
     // afterwards the session is gone and there is nothing left to match the holder against.
@@ -441,6 +476,7 @@ async fn gate(
     // Every admitted request settles, so a reservation is never left standing by a request that
     // did not become a session.
     if lease.settle(
+        claim,
         session.as_deref(),
         minted.as_deref(),
         response.status().is_success(),
@@ -498,66 +534,80 @@ async fn sweep(sessions: Sessions, lease: Arc<Lease>, manager: Arc<LocalSessionM
 mod tests {
     use super::*;
 
+    const CALL: Duration = Duration::from_secs(300);
+
+    /// A grace comfortably past the opener's end-to-end bound.
     fn lease() -> Lease {
-        Lease::new(Duration::from_secs(360), Duration::from_secs(300)).expect("a workable grace")
+        Lease::new(longest_quiet_call(CALL) + Duration::from_secs(60), CALL).expect("workable")
+    }
+
+    /// A lease whose grace expires almost immediately, for the sweep paths.
+    fn brief() -> Lease {
+        Lease {
+            grace: Duration::from_millis(1),
+            state: Mutex::new(Tenancy::default()),
+        }
+    }
+
+    /// The claim an admitted request reserved. Panics if the gate refused, since every caller here
+    /// is testing what happens *after* admission.
+    fn claim_of(admission: Admission) -> Option<u64> {
+        match admission {
+            Admission::Serve(claim) => claim,
+            Admission::Occupied => panic!("the gate refused a request this test needed served"),
+        }
     }
 
     /// The check that stops a long call from looking like an absent client.
+    ///
+    /// The floor is not the call budget: an opener spends up to `WORKER_READY_TIMEOUT` bringing a
+    /// worker up *before* that budget starts, so a grace one second past the budget still leaves an
+    /// attach running when the sweeper comes for it.
     #[test]
     fn a_grace_that_could_expire_inside_a_call_is_refused_at_startup() {
-        let call = Duration::from_secs(300);
         assert!(
-            Lease::new(Duration::from_secs(120), call).is_err(),
-            "120s of grace against a 300s call budget releases the session the call is using"
+            Lease::new(Duration::from_secs(120), CALL).is_err(),
+            "well under the budget"
         );
         assert!(
-            Lease::new(call, call).is_err(),
+            Lease::new(CALL + Duration::from_secs(1), CALL).is_err(),
+            "past the call budget but not past the worker handshake in front of it — the case that \
+             looks safe and is not"
+        );
+        assert!(
+            Lease::new(longest_quiet_call(CALL), CALL).is_err(),
             "equal is not enough: the call may finish at its deadline, not before it"
         );
-        assert!(Lease::new(call + Duration::from_secs(1), call).is_ok());
+        assert!(Lease::new(longest_quiet_call(CALL) + Duration::from_secs(1), CALL).is_ok());
     }
 
     /// One client at a time — and admission has to *reserve*, not merely observe.
     #[test]
     fn a_second_client_is_refused_while_the_first_holds_the_server() {
         let lease = lease();
-        assert_eq!(lease.admit(None), Admission::Serve, "nobody holds it yet");
-        lease.settle(None, Some("session-a"), true);
+        let claim = claim_of(lease.admit(None));
+        lease.settle(claim, None, Some("session-a"), true);
 
-        assert_eq!(
-            lease.admit(None),
-            Admission::Occupied,
-            "a second client opening a session is refused"
+        assert!(matches!(lease.admit(None), Admission::Occupied));
+        assert!(
+            matches!(lease.admit(Some("session-a")), Admission::Serve(None)),
+            "the holder is served, and reserves nothing — it already holds the server"
         );
-        assert_eq!(
-            lease.admit(Some("session-a")),
-            Admission::Serve,
-            "while the holder keeps being served"
-        );
-        assert_eq!(
-            lease.admit(Some("session-b")),
-            Admission::Occupied,
-            "and another client's session id is refused too — serving it is what would let a \
-             racing second client keep working"
+        assert!(
+            matches!(lease.admit(Some("session-b")), Admission::Occupied),
+            "another client's session id is refused; serving it is what let the losing side of a \
+             race keep working"
         );
     }
 
     /// The race the reservation exists for: two `initialize`s arriving together.
-    ///
-    /// Without it both see a vacant server, both get sessions, and the second replaces the first as
-    /// holder while the first stays serviceable — two clients on a registry whose handles, capacity
-    /// and `end_session` are all global.
     #[test]
     fn a_claim_in_flight_blocks_a_second_initialize() {
         let lease = lease();
-        assert_eq!(lease.admit(None), Admission::Serve);
-        assert_eq!(
-            lease.admit(None),
-            Admission::Occupied,
-            "the first claim is not resolved yet, so the server is not free"
-        );
+        let claim = claim_of(lease.admit(None));
+        assert!(matches!(lease.admit(None), Admission::Occupied));
 
-        lease.settle(None, Some("session-a"), true);
+        lease.settle(claim, None, Some("session-a"), true);
         assert_eq!(lease.state().holder.as_deref(), Some("session-a"));
     }
 
@@ -565,14 +615,44 @@ mod tests {
     #[test]
     fn an_initialize_that_fails_does_not_hold_the_server_for_ever() {
         let lease = lease();
-        assert_eq!(lease.admit(None), Admission::Serve);
-        lease.settle(None, None, false);
+        let claim = claim_of(lease.admit(None));
+        lease.settle(claim, None, None, false);
 
-        assert!(!lease.state().claiming, "the reservation was returned");
+        assert!(
+            lease.state().claim.is_none(),
+            "the reservation was returned"
+        );
+        assert!(matches!(lease.admit(None), Admission::Serve(_)));
+    }
+
+    /// **A stale claim may not settle over a newer one.**
+    ///
+    /// A request still inside `mcp.handle` when the grace runs out has its reservation cleared and
+    /// the sweep completed under it. By the time it returns, another client may hold the server.
+    /// Settling unconditionally there would clear the newer claim and install the stale session,
+    /// and the newer response would then replace it again — two valid MCP sessions overlapping on a
+    /// registry whose handles and capacity are global.
+    #[test]
+    fn a_claim_that_outlived_its_grace_cannot_settle_over_a_newer_one() {
+        let lease = brief();
+        let stale = claim_of(lease.admit(None));
+        std::thread::sleep(Duration::from_millis(5));
+        assert!(
+            lease.expired().is_some(),
+            "the stale request's claim is swept"
+        );
+        lease.released_leases();
+
+        let fresh = claim_of(lease.admit(None));
+        assert_ne!(stale, fresh, "a cleared claim is never re-issued");
+        lease.settle(fresh, None, Some("session-new"), true);
+
+        // Now the request nobody is waiting for finally returns.
+        assert!(!lease.settle(stale, None, Some("session-stale"), true));
         assert_eq!(
-            lease.admit(None),
-            Admission::Serve,
-            "so the next client can take the server"
+            lease.state().holder.as_deref(),
+            Some("session-new"),
+            "the holder is whoever legitimately took the server, not whoever answered last"
         );
     }
 
@@ -580,52 +660,84 @@ mod tests {
     #[test]
     fn a_client_returning_inside_the_grace_adopts_rather_than_starts_fresh() {
         let lease = lease();
-        lease.admit(None);
+        let first = claim_of(lease.admit(None));
         assert!(
-            !lease.settle(None, Some("session-a"), true),
+            !lease.settle(first, None, Some("session-a"), true),
             "the first client adopts nothing — there was nothing open"
         );
 
         lease.released("session-a");
-        assert_eq!(
-            lease.admit(None),
-            Admission::Serve,
-            "the server is free again the moment the holder lets go"
-        );
+        let next = claim_of(lease.admit(None));
         assert!(
-            lease.settle(None, Some("session-b"), true),
-            "and the next client is told it inherited the sessions still open"
+            lease.settle(next, None, Some("session-b"), true),
+            "the next client is told it inherited the sessions still open"
         );
     }
 
-    /// A client resuming the session id it already had becomes the holder again — but only once the
-    /// service has confirmed that session is real.
+    /// A resume takes the server back only once the service says the session was real.
     #[test]
     fn a_resumed_session_takes_the_server_back_only_if_it_existed() {
         let lease = lease();
-        lease.admit(None);
-        lease.settle(None, Some("session-a"), true);
+        let first = claim_of(lease.admit(None));
+        lease.settle(first, None, Some("session-a"), true);
         lease.released("session-a");
 
-        assert_eq!(lease.admit(Some("session-a")), Admission::Serve);
-        lease.settle(Some("session-a"), None, false);
+        let bad = claim_of(lease.admit(Some("session-a")));
+        lease.settle(bad, Some("session-a"), None, false);
         assert_eq!(
             lease.state().holder,
             None,
             "a session id the service rejected must not lock the server out for a whole grace"
         );
 
-        assert_eq!(lease.admit(Some("session-a")), Admission::Serve);
-        lease.settle(Some("session-a"), None, true);
+        let good = claim_of(lease.admit(Some("session-a")));
+        lease.settle(good, Some("session-a"), None, true);
         assert_eq!(lease.state().holder.as_deref(), Some("session-a"));
+    }
+
+    /// A resume is a contested claim too, not a free pass.
+    #[test]
+    fn a_resume_reserves_the_server_like_an_initialize_does() {
+        let lease = lease();
+        let first = claim_of(lease.admit(None));
+        lease.settle(first, None, Some("session-a"), true);
+        lease.released("session-a");
+
+        assert!(matches!(
+            lease.admit(Some("session-a")),
+            Admission::Serve(Some(_))
+        ));
+        assert!(
+            matches!(lease.admit(None), Admission::Occupied),
+            "a fresh client cannot slip in while a resume is being confirmed"
+        );
+    }
+
+    /// Whatever a request turns out to be, it hands its reservation back.
+    #[test]
+    fn every_settled_request_resolves_its_reservation() {
+        let lease = lease();
+        let first = claim_of(lease.admit(None));
+        lease.settle(first, None, Some("session-a"), true);
+        lease.released("session-a");
+
+        let resumed = claim_of(lease.admit(Some("session-a")));
+        lease.settle(resumed, Some("session-a"), None, true);
+        assert!(lease.state().claim.is_none(), "a resume that succeeded");
+
+        lease.released("session-a");
+        assert!(
+            matches!(lease.admit(None), Admission::Serve(_)),
+            "so the next client is not refused by a reservation nobody holds"
+        );
     }
 
     /// Letting go is not the same as expiring: the sessions are still there to come back to.
     #[test]
     fn letting_go_starts_the_clock_rather_than_releasing_anything() {
         let lease = lease();
-        lease.admit(None);
-        lease.settle(None, Some("session-a"), true);
+        let claim = claim_of(lease.admit(None));
+        lease.settle(claim, None, Some("session-a"), true);
         lease.released("session-a");
 
         assert!(
@@ -639,8 +751,8 @@ mod tests {
     #[test]
     fn only_the_holder_can_let_go() {
         let lease = lease();
-        lease.admit(None);
-        lease.settle(None, Some("session-a"), true);
+        let claim = claim_of(lease.admit(None));
+        lease.settle(claim, None, Some("session-a"), true);
         lease.released("session-b");
         assert_eq!(
             lease.state().holder.as_deref(),
@@ -649,135 +761,60 @@ mod tests {
         );
     }
 
-    /// A resume is a contested claim too, not a free pass.
-    ///
-    /// After a lease expiry the old session id is still valid in the service, so a resume can race
-    /// a fresh client. Both would pass a gate that only served them, and the stale one could run a
-    /// tool against the global registry while the new client became the holder.
-    #[test]
-    fn a_resume_reserves_the_server_like_an_initialize_does() {
-        let lease = lease();
-        lease.admit(None);
-        lease.settle(None, Some("session-a"), true);
-        lease.released("session-a");
-
-        assert_eq!(lease.admit(Some("session-a")), Admission::Serve);
-        assert_eq!(
-            lease.admit(None),
-            Admission::Occupied,
-            "a fresh client cannot slip in while a resume is being confirmed"
-        );
-    }
-
-    /// Whatever a request turns out to be, it hands the reservation back.
-    ///
-    /// The leak this pins is the one the resume path introduced: taking the holder without
-    /// resolving the claim leaves `claiming` set, and the next goodbye then makes the server
-    /// permanently unclaimable — a server nobody can use and nothing will fix.
-    #[test]
-    fn every_settled_request_resolves_its_reservation() {
-        let lease = lease();
-        lease.admit(None);
-        lease.settle(None, Some("session-a"), true);
-        lease.released("session-a");
-
-        lease.admit(Some("session-a"));
-        lease.settle(Some("session-a"), None, true);
-        assert!(!lease.state().claiming, "a resume that succeeded");
-
-        lease.released("session-a");
-        assert_eq!(
-            lease.admit(None),
-            Admission::Serve,
-            "so the next client is not refused by a reservation nobody holds"
-        );
-    }
-
-    /// A swept lease says what it left in the service, so the sweeper can close that too.
-    #[test]
-    fn a_swept_lease_reports_the_session_that_never_said_goodbye() {
-        let lease = Lease::new(Duration::from_millis(1), Duration::from_micros(1))
-            .expect("a grace longer than the budget");
-        lease.admit(None);
-        lease.settle(None, Some("session-a"), true);
-        std::thread::sleep(Duration::from_millis(5));
-
-        assert_eq!(
-            lease.expired().map(|e| e.holder),
-            Some(Some("session-a".to_string())),
-            "a client that vanished leaves an MCP session nothing else will ever close"
-        );
-
-        // Whereas one that said goodbye had its session closed by the DELETE.
-        let lease = Lease::new(Duration::from_millis(1), Duration::from_micros(1))
-            .expect("a grace longer than the budget");
-        lease.admit(None);
-        lease.settle(None, Some("session-b"), true);
-        lease.released("session-b");
-        std::thread::sleep(Duration::from_millis(5));
-        assert_eq!(lease.expired().map(|e| e.holder), Some(None));
-    }
-
     /// A claim keeps alive the sessions it is adopting.
-    ///
-    /// Admission near the end of a grace would otherwise reserve the server and leave the previous
-    /// client's deadline armed, so the sweeper could release the very sessions the request is being
-    /// admitted to adopt — while `mcp.handle` is still running.
     #[test]
     fn reserving_the_server_renews_what_the_claim_is_adopting() {
-        let lease = Lease::new(Duration::from_millis(60), Duration::from_micros(1))
-            .expect("a grace longer than the budget");
-        lease.admit(None);
-        lease.settle(None, Some("session-a"), true);
+        let lease = Lease {
+            grace: Duration::from_millis(60),
+            state: Mutex::new(Tenancy::default()),
+        };
+        let claim = claim_of(lease.admit(None));
+        lease.settle(claim, None, Some("session-a"), true);
         lease.released("session-a");
         std::thread::sleep(Duration::from_millis(40));
 
-        assert_eq!(
-            lease.admit(None),
-            Admission::Serve,
+        assert!(
+            matches!(lease.admit(None), Admission::Serve(_)),
             "still inside the grace"
         );
         std::thread::sleep(Duration::from_millis(40));
         assert!(
             lease.expired().is_none(),
-            "the claim pushed the deadline out; without that the sweep would have released the \
-             sessions this request is in the middle of adopting"
+            "the claim pushed the deadline out; without that the sweep would release the sessions \
+             this request is in the middle of adopting"
         );
     }
 
     /// A request that never settles cannot wedge the server for ever.
-    ///
-    /// The reservation introduced this: a connection dropped inside `mcp.handle` never reaches
-    /// `settle`, so without expiry clearing the claim, no client could take the server and no sweep
-    /// would ever clear it — a claim renews the deadline an expiry would have to outlive.
     #[test]
     fn a_claim_whose_request_died_is_cleared_by_the_grace() {
-        let lease = Lease::new(Duration::from_millis(1), Duration::from_micros(1))
-            .expect("a grace longer than the budget");
-        assert_eq!(lease.admit(None), Admission::Serve);
+        let lease = brief();
+        claim_of(lease.admit(None));
         std::thread::sleep(Duration::from_millis(5));
 
         assert!(
             lease.expired().is_some(),
             "the claim's own deadline ran out"
         );
-        assert!(!lease.state().claiming, "and took the reservation with it");
+        assert!(
+            lease.state().claim.is_none(),
+            "and took the reservation with it"
+        );
         lease.released_leases();
-        assert_eq!(lease.admit(None), Admission::Serve);
+        assert!(matches!(lease.admit(None), Admission::Serve(_)));
     }
 
     /// A teardown already under way wins over a claim settling into it.
     #[test]
     fn a_claim_that_settles_during_a_teardown_does_not_take_the_server() {
-        let lease = Lease::new(Duration::from_millis(1), Duration::from_micros(1))
-            .expect("a grace longer than the budget");
-        lease.admit(None);
-        lease.settle(None, Some("session-a"), true);
+        let lease = brief();
+        let claim = claim_of(lease.admit(None));
+        lease.settle(claim, None, Some("session-a"), true);
+        let resumed = claim_of(lease.admit(Some("session-a")));
         std::thread::sleep(Duration::from_millis(5));
         assert!(lease.expired().is_some());
 
-        // The request that was in flight when the sweep started now comes back.
-        assert!(!lease.settle(None, Some("session-b"), true));
+        assert!(!lease.settle(resumed, None, Some("session-b"), true));
         assert_eq!(
             lease.state().holder,
             None,
@@ -786,48 +823,62 @@ mod tests {
     }
 
     /// Nothing is admitted between deciding to release and having released.
-    ///
-    /// The window this closes is narrow and expensive: a client admitted there starts using a
-    /// session the sweeper is in the middle of closing, and the call dies underneath it.
     #[test]
     fn nothing_is_admitted_while_the_teardown_runs() {
-        let lease = Lease::new(Duration::from_millis(1), Duration::from_micros(1))
-            .expect("a grace longer than the budget");
-        lease.admit(None);
-        lease.settle(None, Some("session-a"), true);
+        let lease = brief();
+        let claim = claim_of(lease.admit(None));
+        lease.settle(claim, None, Some("session-a"), true);
         std::thread::sleep(Duration::from_millis(5));
 
         assert!(lease.expired().is_some(), "the grace is spent");
-        assert_eq!(
-            lease.admit(None),
-            Admission::Occupied,
-            "and the server is not vacant yet — the sessions are still being let go"
+        assert!(
+            matches!(lease.admit(None), Admission::Occupied),
+            "the server is not vacant yet — the sessions are still being let go"
         );
 
         lease.released_leases();
-        assert_eq!(
-            lease.admit(None),
-            Admission::Serve,
-            "only once the teardown is done"
-        );
+        assert!(matches!(lease.admit(None), Admission::Serve(_)));
     }
 
     /// Expiry is a one-shot: the deadline is consumed by the sweep that acts on it.
     #[test]
     fn expiry_is_reported_once_rather_than_on_every_sweep() {
-        let lease = Lease::new(Duration::from_millis(1), Duration::from_micros(1))
-            .expect("a grace longer than the budget");
-        lease.admit(None);
-        lease.settle(None, Some("session-a"), true);
+        let lease = brief();
+        let claim = claim_of(lease.admit(None));
+        lease.settle(claim, None, Some("session-a"), true);
         std::thread::sleep(Duration::from_millis(5));
 
         assert!(lease.expired().is_some(), "the grace is spent");
         assert!(
             lease.expired().is_none(),
-            "and expiry is reported once, not on every sweep — the sweeper runs every few \
-             seconds, and a second `true` would release an already-released set of sessions on \
-             each pass"
+            "and expiry is reported once, not on every sweep — a second `true` would release an \
+             already-released set of sessions on each pass"
         );
         assert_eq!(lease.state().holder, None);
+    }
+
+    /// A swept lease says what it left in the service, so the sweeper can close that too.
+    #[test]
+    fn a_swept_lease_reports_the_session_that_never_said_goodbye() {
+        let lease = brief();
+        let claim = claim_of(lease.admit(None));
+        lease.settle(claim, None, Some("session-a"), true);
+        std::thread::sleep(Duration::from_millis(5));
+        assert_eq!(
+            lease.expired().map(|e| e.holder),
+            Some(Some("session-a".to_string())),
+            "a client that vanished leaves an MCP session nothing else will ever close"
+        );
+
+        let lease = brief();
+        let claim = claim_of(lease.admit(None));
+        lease.settle(claim, None, Some("session-b"), true);
+        lease.released("session-b");
+        std::thread::sleep(Duration::from_millis(5));
+        assert_eq!(
+            lease.expired().map(|e| e.holder),
+            Some(None),
+            "whereas one that said goodbye had its session closed by the DELETE"
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,7 @@ mod batch;
 mod cast;
 mod engine;
 mod kdconn;
+mod listen;
 mod proto;
 mod record;
 mod server;
@@ -73,10 +74,34 @@ fn main() -> Result<()> {
         return render_cast(&args[at + 1..]);
     }
 
+    // Decided before the runtime so a bad address fails as a usage error rather than from inside a
+    // task, but acted on inside it: both roles need the runtime, and only one of them needs stdio.
+    let listen = match listen::requested(&args) {
+        Some(addr) => Some(addr?),
+        None => None,
+    };
+
     tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()?
-        .block_on(serve())
+        .block_on(async {
+            match listen {
+                Some(addr) => serve_http(addr).await,
+                None => serve().await,
+            }
+        })
+}
+
+/// The listener role. See [`listen`] for what HTTP takes away and what is put back.
+///
+/// The teardown differs from [`serve`]'s in the one way that matters: there is no disconnect to
+/// hang it on, so the shutdown here belongs to the *process* ending rather than to any client, and
+/// a client going away is handled by its lease instead.
+async fn serve_http(addr: std::net::SocketAddr) -> Result<()> {
+    let sessions = Sessions::new(call_timeout()).recording(record::Recorder::from_env());
+    let outcome = listen::serve(sessions.clone(), addr, call_timeout()).await;
+    sessions.shutdown().await;
+    outcome
 }
 
 /// The renderer role: a transcript in, an asciicast out.

--- a/src/record.rs
+++ b/src/record.rs
@@ -716,6 +716,13 @@ pub enum Event {
     },
     /// The server is going down and every session is being let go.
     Shutdown { sessions: usize },
+    /// A client stayed away past its grace, and the sessions it opened were let go — but the
+    /// server is still running and will serve the next client.
+    ///
+    /// Distinct from [`Self::Shutdown`] rather than a reason on it, because the two answer
+    /// different questions about a transcript that stops: one says the recording ended, the other
+    /// says this client's work did while the file goes on.
+    LeaseExpired { sessions: usize },
     /// A record that would have been past the whole-record ceiling, replaced by its size.
     ///
     /// Present so that a field which is not being capped shows up as a **fact in the transcript**

--- a/src/ttd.rs
+++ b/src/ttd.rs
@@ -125,6 +125,12 @@ pub fn record_launch(
     for name in crate::kdconn::env_names() {
         cmd.env_remove(name);
     }
+    // And the listener's bearer token, which is the same hazard one step further on: the recorded
+    // target is chosen by the caller and inherits this environment, so a token left here is a
+    // credential handed to an arbitrary binary. With it, that binary could dial the listener on
+    // loopback and claim the server once the current holder goes quiet. Stripped in both places
+    // this server creates a process, because either one is enough to leak it.
+    cmd.env_remove(crate::listen::TOKEN_ENV);
     // Pass through the validated environment (e.g. an anti-analysis env guard) and cwd to the
     // recorded target. TTD.exe launches `target` with this environment inherited. Applied after
     // the scrub above, so an entry the caller passed deliberately still wins.


### PR DESCRIPTION
First increment of phase 1 of the split-plane work: `--listen <addr>` serves the same tool surface over streamable HTTP that stdio serves today, so the client and the model can run on a machine that is not the one DbgEng needs. `docs/remote-phase0.md` describes the ssh-stdio arrangement this replaces, and its "where this stops being enough" list is the requirements list for this one.

**This is an increment, not all of phase 1.** What is deliberately not here is listed at the bottom.

## The transport is the easy half

The stdio role gets one property for free that everything here exists to rebuild. When stdin closes the client is *definitively* gone, and `Sessions::shutdown` releases every target — which for a live kernel is the difference between a machine that comes back and one left frozen. Over HTTP there is no such moment: a client that has stopped talking looks exactly like one that is thinking, and a dropped connection looks exactly like a network that will recover.

So a client holds a **lease**. Any request renews it; when it runs out, the sessions that client opened are released the same way a disconnect released them. `Sessions::release_leased` is `shutdown` without closing the registry — the server is still serving, and the next client will want to open sessions of its own. Closing the gate there would turn one client's disconnect into a server that can never debug anything again.

### The grace must outlast a call, and that is enforced

A `crash_triage` or a pool walk sends **no HTTP request for minutes**. A grace shorter than the call budget therefore reads a perfectly healthy client as an absent one, and releases the session the call is running against — the session dies underneath its own caller.

The listener refuses to start rather than let that be found out later, and the default grace is derived from `WINDBG_MCP_CALL_TIMEOUT_SECS` so a host that raises one raises both. This was already written down as a risk in the architecture note; leaving it as prose seemed like the wrong lesson to take from the `triage\` episode in #133, where a documented-but-unenforced detail failed silently.

### A returning client adopts what it left

Sessions are not released the instant a client goes away, so reconnecting inside the grace finds them still open. This is strictly *better* than stdio, where a client restart costs a KDNET attach — and a KDNET attach costs a reboot cycle on the target.

## One client at a time — forced by the registry, not by caution

`session_id` handles are minted globally, `MAX_SESSIONS` is shared, and `end_session` ends whatever it is handed. None of that is scoped to a client. Two clients would silently share the registry, and one could end a target the other was using. Rather than pretend otherwise, a second client is refused with `409`.

The bearer token is the identity: there is one authorised client, so presenting the token *is* the proof, and a reconnect needs nothing further. That is what makes adoption free rather than a new identity mechanism.

## Security posture

- **Bind loopback and reach it through `ssh -L`.** This endpoint is patch-the-kernel-as-a-service — `execute`, `debug_batch` and `launch` are all on it. Binding anything else logs a warning on every start: the token is sent in clear, and a hypervisor's guest network is not private when the machine being debugged is a sandbox sharing that subnet. That last point is why the tunnel came back after the architecture note had argued it away.
- **The token comes from `WINDBG_MCP_LISTEN_TOKEN`, not an argument**, because a command line is readable by every process on the machine — including a `launch`ed debuggee.
- An unauthenticated caller is told it is unauthenticated and nothing else.

## Transcripts

A lease release is its own event rather than a `Shutdown` carrying a reason, so a reader filtering a transcript for "the server stopped" does not have to parse why a session ended to know the recording continues.

## Verification

Unit: 378 passed (six new, covering the lease state machine — the startup check, tenancy, adoption, goodbye-versus-expiry, and that only the holder can let go) + 45 smoke. `cargo clippy --all-targets` and `cargo fmt --all --check` clean. All run on the ARM64 guest, since the crate does not build on macOS.

End to end, from a Mac through an `ssh -L` tunnel to the guest:

| | |
| --- | --- |
| no token / wrong token | `401` |
| correct token, `initialize` | `200`, SSE stream, `mcp-session-id` |
| holder, `tools/list` | full tool surface |
| second client, new `initialize` | `409` "serves one at a time" |
| holder `DELETE` | `202`, server free |
| new client after that | `200` |

## Not in this increment

- **Progress notifications.** The worker already emits `Committed` / `Opened` / `RollingBack` mid-operation; mapping those to MCP progress is what gives a parked `attach_kernel` a visible pulse. SSE keep-alive is configured here, which covers the transport-level half.
- **MCP log notifications.** Worker stderr currently reaches an operator only on the guest, which regresses the diagnostics `CLAUDE.md` assumes.
- **The Windows service.** Wanted for a defined `PATH` and working directory, boot start, and a listener not tied to a login session — *not* for elevation, which #133 established ssh already provides.
- **A smoke tier** for drop-and-return inside the grace, release past it, and refusal of a second client.
- **Docs.** Nothing user-facing describes `--listen` yet.
