### PR TITLE
FOLLOWUPS: mark item 20 done, defer #132 and #134

### DIFF
--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -18,7 +18,10 @@ landed** (process-per-session, 2026-08-02); it is kept here rather than deleted 
 **Items 16, 17 and 18 have landed** (2026-08-10) and are kept for the opposite reason: each turned
 out to need something its entry did not anticipate — item 18 needed much less of item 7 than it
 claimed to, item 17 needed a walk deadline nothing had asked for, and item 16 needed a probe before
-it could measure anything at all. **Item 7 has landed** too (2026-08-10, the `interrupt` tool), and
+it could measure anything at all. **Item 20 has landed** (2026-08-16, #131) and is kept because the fix needed something the entry
+did not see: the two installers spell x64 differently, so the reordering it proposed would have
+picked the wrong architecture by another route. **Item 7 has landed** too (2026-08-10, the
+`interrupt` tool), and
 is kept because item 8 rests on it: what it built is the job binding, and what it deliberately did
 not build is the queued-job half that only `tasks/cancel` can ask for. **Item 12 has landed**
 (2026-08-02) and is kept because what validating it *disproved* outlives what it confirmed: a kernel
@@ -539,26 +542,34 @@ against. The one design question is the budget: a walk step is up to 1024 reads 
 transaction whose whole point is that its rollback still fits, so the step's share has to come out
 of the batch's deadline the way `pool`'s does rather than out of the call's.
 
-## 20. [windbg-mcp] Pick the TTD recorder by architecture, not by a fixed list
+## 20. [windbg-mcp] Pick the TTD recorder by architecture, not by a fixed list — **done** (2026-08-16, #131)
 
-`find_ttd` probes x64 before arm64 in both layouts it knows — `["x64", "arm64"]` for the classic
-SDK, and a list headed by `amd64\TTD\TTD.exe` for the MSIX package. On an ARM64 host that is always
-the wrong answer, because the ARM64 WinDbg package ships **all three** recorders (`amd64`, `arm64`,
-`x86`) and the first probe therefore always hits. `record_trace` picks the x64 recorder on exactly
-the hosts where the choice is not free, and a native ARM64 target cannot be recorded with it.
+`find_ttd` probed x64 before arm64 in both layouts it knows — `["x64", "arm64"]` for the classic
+SDK, and a list headed by `amd64\TTD\TTD.exe` for the MSIX package. On an ARM64 host that was
+always the wrong answer, because the ARM64 WinDbg package ships **all three** recorders (`amd64`,
+`arm64`, `x86`) and the first probe therefore always hit. `record_trace` picked the x64 recorder on
+exactly the hosts where the choice is not free, and a native ARM64 target cannot be recorded with
+it.
 
-Deferred rather than fixed on the spot because the honest selector is not the one the bug suggests.
-Host architecture is the obvious improvement, but x64-on-ARM64 emulation is a real workflow — an
-emulated x64 debuggee genuinely needs the `amd64` recorder — so the choice properly belongs to the
-*target*, which `record_trace` knows only after it has decided what to launch. Host-first is a
-strict improvement and a fine first cut; target-first is the design question worth thinking about
-before writing either.
+Found while setting up a Parallels ARM64 guest for [`docs/remote-phase0.md`](./docs/remote-phase0.md).
 
-Found while setting up a Parallels ARM64 guest for [`docs/remote-phase0.md`](./docs/remote-phase0.md),
-and tracked as [#131](https://github.com/glslang/windbg-mcp/issues/131). Note the workaround is
-already load-bearing on that host: `search_path` runs before both layout probes, so a recorder on
-`PATH` masks the ordering entirely — which also means a host configured that way will not reproduce
-the bug.
+**Resolved as the first cut this entry described**, and the deferral reasoning stands: the probe
+order now leads with *this build's* architecture and keeps the others behind it, because it is an
+ordering and not a filter — an emulated x64 debuggee on an ARM64 host genuinely wants the `amd64`
+recorder. The target's architecture is still the correct selector and still unavailable here:
+`record_trace` receives a command line, and resolving that to a file to read a PE header from is a
+separate problem with its own failure modes. `PATH` is searched first and overrides all of it, which
+is now documented at the point of the guess rather than only in the issue.
 
-Picks up at `ttd::find_ttd` and `ttd::find_in_windowsapps`, both of which are pure path probes with
-no engine dependency, so the fix is testable without a debugger.
+**What the entry did not anticipate** is the reason it is kept rather than deleted. The two
+installers disagree about one spelling — the SDK ships `Debuggers\x64` where the store package's
+payload directory is `amd64` — so reordering the string lists, which is what this entry describes,
+would have selected the wrong architecture by a different route. That is the same class of mistake
+as the ordering itself, and it is why the fix introduced an `Arch` type with the two names as
+separate accessors instead of reordering literals.
+
+Two smaller things it also turned out to need: the bare `TTD\TTD.exe` layout moved from second to
+last, since a package has either an architecture-specific tree or that one; and the ordering is
+covered by unit tests rather than a live probe, because the ARM64 host it was found on no longer has
+a TTD in either layout — its recorder is the `PATH` copy, which is the workaround this removes the
+need for.

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -7,8 +7,8 @@ MCP `2026-07-28` extensions (tasks, apps), item 12 from the opener split
 (#46, 2026-08-02), item 15 from the private worker channel (#65 / #72, 2026-08-04), items 16–18
 from transactional batches (#82, 2026-08-09/10 — item 17 is what validating the tool against the CTF
 session's own transcript turned up, and item 18 what reviewing it did), and item 19 from
-`walk_memory` (#103, 2026-08-13), and item 20 from standing the server up on an ARM64 guest
-(#131, 2026-08-16). Each item notes its repo,
+`walk_memory` (#103, 2026-08-13), and items 20–22 from standing the server up on an ARM64 guest
+(#131, #132, #134, 2026-08-16). Each item notes its repo,
 why it was deferred, and where it picks up. See [`DECISIONS.md`](./DECISIONS.md) for the design rationale (D1–D5) items 1–6 extend,
 and the 2026-08-02 entries that items 13–14 and item 10 extend.
 
@@ -573,3 +573,59 @@ last, since a package has either an architecture-specific tree or that one; and 
 covered by unit tests rather than a live probe, because the ARM64 host it was found on no longer has
 a TTD in either layout — its recorder is the `PATH` copy, which is the workaround this removes the
 need for.
+
+## 21. [windbg-mcp] TTD replay on a host where the store package will not install
+
+`open_trace` needs the replay engine — `TTDReplay*.dll`, `TtdExt.dll`, `TTDAnalyze.dll` — in a
+`ttd\` directory beside `windbg-mcp.exe`. System32's `dbgeng.dll` ships none of it and rejects every
+trace with `0x80070057`, so there is no degraded mode: replay either has the files or does not
+happen.
+
+Two things compound to make that unreachable on some hosts. The **SDK Debugging Tools do not ship
+`ttd\`** (nor `msdia140.dll`), so the one source that installs cleanly from a command line supplies
+everything *except* replay. And **MSIX registration fails from a non-interactive session** —
+`Add-AppxPackage` returns `0x80070005` even when elevated — staging the payload into
+`WindowsApps` without registering it, where the ACLs then deny execute. The result is a host that
+records traces and cannot replay them.
+
+Deferred because the two halves that could be done cheaply already have been, and what is left is a
+judgement call rather than a task. `open_trace` now says *why* a trace will not open instead of
+surfacing `0x80070057`, and `setup.md` carries a recipe for unpacking `ttd\` from the
+`.msixbundle`, which is an ordinary zip. So the failure is legible and there is a way through it.
+
+What is undecided is whether unpacking a Microsoft package by hand should be a **supported** path
+in this project's own documentation — it is currently written down as a fallback, not endorsed — or
+whether the answer is to require an interactive install and say so plainly. That is a maintainer's
+call about what this repo is willing to tell people to do, not an engineering problem.
+
+Picks up at [`setup.md`](./skills/windbg-debugging/setup.md)'s *When the store package will not
+install*, and [#132](https://github.com/glslang/windbg-mcp/issues/132).
+
+## 22. [windbg-mcp] Run the debugger tier on an ARM64 runner
+
+Both CI jobs that touch a debugger are `runs-on: windows-latest`, which is x64. `setup.md` now
+documents ARM64 hosts and states that an ARM64 engine reads an **x64** kernel minidump in full —
+`!analyze -v`, symbols, failure bucket, pool tag — and the only thing behind that claim is one
+manual session. If a future Windows-on-ARM image shipped a `dbgeng.dll` that could not open the
+checked-in sample dump, this repo would hear about it from a user.
+
+Not blocked: `windows-11-arm` runners are available on this account. It is deferred on scope rather
+than feasibility.
+
+The value is concentrated in the **debugger tier** and thin everywhere else. That job's own comment
+already argues the case — *"a runner whose DbgEng cannot open a checked-in dump is something this
+repo wants to hear about: it breaks users the same way"* — and it needs no symbols, no network, and
+opens a dump that is checked in. **Build & test** is a weaker case: the crate is
+architecture-independent Rust, so `cargo fmt`, clippy and the unit tests have no reason to differ,
+and a second entry there mostly buys runtime.
+
+Worth knowing before starting: the `Swatinem/rust-cache` key has to include the architecture, or the
+two matrix entries share one cache and each poisons the other.
+
+Note what an ARM64 runner would *not* have caught, so it does not get oversold. Item 20 (#131) was a
+path-probe ordering bug, caught by unit tests over a fake layout on any runner; and the `triage\`
+and `ttd\` gaps beside it are packaging problems that reproduce on x64 given the same partial
+bundle.
+
+Picks up at `.github/workflows/ci.yml`, the *Smoke test (debugger tier)* job, and
+[#134](https://github.com/glslang/windbg-mcp/issues/134).


### PR DESCRIPTION
Bookkeeping in `FOLLOWUPS.md`; no code change.

## Item 20 — done (#131)

#139 fixed it, leaving the entry describing it as deferred. Marked done and kept rather than deleted, which is what this file already does for landed items that surprised their own entry (items 7, 10, 12, 16, 17, 18).

**The surprise worth recording:** the entry proposed reordering the probe lists, and doing literally that would have selected the wrong architecture by a *different* route — the SDK ships `Debuggers\x64` where the store package's payload directory is `amd64`. Same class of mistake as the ordering it was filed for, which is why the fix introduced a type with the two names as separate accessors. Someone reading the entry alone would have walked into it.

## Items 21 and 22 — deferring #132 and #134

Recorded rather than left as bare issues, because what each is waiting on is not obvious from the issue text.

**#132 (TTD replay) is waiting on a decision, not work.** The cheap halves already landed — `open_trace` explains itself instead of surfacing `0x80070057`, and `setup.md` carries the `.msixbundle` unpacking recipe. What is undecided is whether telling people to unpack a Microsoft package by hand should be a *supported* path here, or whether the answer is to require an interactive install and say so plainly. That is a maintainer's call about what this repo recommends, not an engineering problem.

**#134 (ARM64 CI) is deferred on scope, not feasibility** — the runners are available. The entry narrows it to the debugger tier where the value is, says why Build & test is a weaker case, records the `rust-cache` key trap, and states what an ARM64 runner would *not* have caught so it does not get oversold later.