### PR TITLE
Run the debugger tier on ARM64 as well as x64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
           }
 
   smoke-debugger:
-    name: Smoke test (debugger tier)
+    name: Smoke test (debugger tier${{ matrix.suffix }})
     # Runs on every push and PR, not on demand.
     #
     # It was on-demand while the risk (a Windows-image change breaking it for reasons unrelated
@@ -82,7 +82,40 @@ jobs:
     # The risk it was hedging against is still real, and the answer to it is that a runner whose
     # DbgEng cannot open a checked-in dump is something this repo wants to hear about: it breaks
     # users the same way. If that happens, pin the failure here rather than in a bug report.
-    runs-on: windows-latest
+    #
+    # Both architectures, because that argument applies to each of them separately and the ARM64
+    # one had nothing behind it: it was a claim about a `dbgeng.dll` this project does not ship and
+    # cannot test any other way, resting on one manual session (issue #134).
+    #
+    # The four assertions that read the checked-in dump's *virtual memory* are gated to x86_64,
+    # because the dump is x64 and an engine of another architecture cannot follow a pointer into it
+    # (issue #142). They report as `ignored` with that reason on ARM64 rather than failing, and the
+    # equivalent coverage there needs an ARM64 dump of its own — which is a sample to capture, not
+    # a test to write.
+    #
+    # Only this tier is matrixed. The crate is architecture-independent Rust, so `fmt`, clippy and
+    # the unit tests in `build` have no reason to differ and a second entry there would buy runtime
+    # rather than coverage. What differs on ARM64 is the *engine*, and this is the job that loads
+    # one.
+    strategy:
+      # An ARM64 failure must not cancel the x64 run: x64 is the result this repo has trusted for
+      # every release, and a new runner label is exactly the thing most likely to be flaky first.
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x64
+            runner: windows-latest
+            # Empty, so this entry's check keeps the exact name `Smoke test (debugger tier)`.
+            # That string is a *required status check* in the repository ruleset, and a required
+            # context is matched by name: renaming the job does not rename the requirement, it
+            # removes the only job that could ever satisfy it — and every PR in the repo blocks on
+            # a check that will never report again. Adding a matrix is not a rename as long as one
+            # entry keeps the original name.
+            suffix: ""
+          - arch: arm64
+            runner: windows-11-arm
+            suffix: ", arm64"
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 20
     steps:
       - name: Checkout
@@ -97,6 +130,10 @@ jobs:
 
       - name: Cache cargo registry and build
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
+        with:
+          # Keyed by architecture, or the two entries share one cache and each restores the
+          # other's target directory — objects for the wrong triple, rebuilt every run at best.
+          key: ${{ matrix.arch }}
 
       - name: Smoke test against the sample dump
         env:

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -18,8 +18,9 @@ landed** (process-per-session, 2026-08-02); it is kept here rather than deleted 
 **Items 16, 17 and 18 have landed** (2026-08-10) and are kept for the opposite reason: each turned
 out to need something its entry did not anticipate — item 18 needed much less of item 7 than it
 claimed to, item 17 needed a walk deadline nothing had asked for, and item 16 needed a probe before
-it could measure anything at all. **Item 20 has landed** (2026-08-16, #131) and is kept because the fix needed something the entry
-did not see: the two installers spell x64 differently, so the reordering it proposed would have
+it could measure anything at all. **Items 20 and 22 have landed** (2026-08-16, #131 and #134) and are kept because each needed
+something its entry did not see — item 22's job rename silently removed a required status check.
+Item 20's fix needed something the entry did not see: the two installers spell x64 differently, so the reordering it proposed would have
 picked the wrong architecture by another route. **Item 7 has landed** too (2026-08-10, the
 `interrupt` tool), and
 is kept because item 8 rests on it: what it built is the job binding, and what it deliberately did
@@ -601,31 +602,31 @@ call about what this repo is willing to tell people to do, not an engineering pr
 Picks up at [`setup.md`](./skills/windbg-debugging/setup.md)'s *When the store package will not
 install*, and [#132](https://github.com/glslang/windbg-mcp/issues/132).
 
-## 22. [windbg-mcp] Run the debugger tier on an ARM64 runner
+## 22. [windbg-mcp] Run the debugger tier on an ARM64 runner — **done** (2026-08-16, #134)
 
-Both CI jobs that touch a debugger are `runs-on: windows-latest`, which is x64. `setup.md` now
-documents ARM64 hosts and states that an ARM64 engine reads an **x64** kernel minidump in full —
-`!analyze -v`, symbols, failure bucket, pool tag — and the only thing behind that claim is one
-manual session. If a future Windows-on-ARM image shipped a `dbgeng.dll` that could not open the
-checked-in sample dump, this repo would hear about it from a user.
+Both CI jobs that touch a debugger were `runs-on: windows-latest`, which is x64, while `setup.md`
+told readers an ARM64 engine reads an **x64** kernel minidump in full — a claim resting on one
+manual session. The debugger tier now runs on both, and only that tier: the crate is
+architecture-independent Rust, so `fmt`, clippy and the unit tests have no reason to differ, and
+what differs on ARM64 is the engine.
 
-Not blocked: `windows-11-arm` runners are available on this account. It is deferred on scope rather
-than feasibility.
+The `Swatinem/rust-cache` key carries the architecture, as this entry said it would have to.
 
-The value is concentrated in the **debugger tier** and thin everywhere else. That job's own comment
-already argues the case — *"a runner whose DbgEng cannot open a checked-in dump is something this
-repo wants to hear about: it breaks users the same way"* — and it needs no symbols, no network, and
-opens a dump that is checked in. **Build & test** is a weaker case: the crate is
-architecture-independent Rust, so `cargo fmt`, clippy and the unit tests have no reason to differ,
-and a second entry there mostly buys runtime.
+**Two things it did not anticipate, which is why it is kept.**
 
-Worth knowing before starting: the `Swatinem/rust-cache` key has to include the architecture, or the
-two matrix entries share one cache and each poisons the other.
+The first is the reason the entry existed and still cost a correction: the ARM64 run **failed on its
+first attempt**, four assertions of forty-five, and the claim in `setup.md` was wrong. The engine
+parses the dump — bug check, module list, stack attribution — and cannot read *virtual memory* out
+of it, so `walk_memory`, `disassemble` and the `EPROCESS` behind `crash_triage`'s `process_name` all
+fail ([#142](https://github.com/glslang/windbg-mcp/issues/142)). Those four are gated to `x86_64`,
+because the constraint belongs to the **sample**: the checked-in dump is x64, and on another
+architecture they have nothing to assert. Equivalent coverage there needs an ARM64 dump of its own
+([#143](https://github.com/glslang/windbg-mcp/issues/143)).
 
-Note what an ARM64 runner would *not* have caught, so it does not get oversold. Item 20 (#131) was a
-path-probe ordering bug, caught by unit tests over a fake layout on any runner; and the `triage\`
-and `ttd\` gaps beside it are packaging problems that reproduce on x64 given the same partial
-bundle.
-
-Picks up at `.github/workflows/ci.yml`, the *Smoke test (debugger tier)* job, and
-[#134](https://github.com/glslang/windbg-mcp/issues/134).
+The second is a trap with nothing to do with architecture. **Renaming the job removed a required
+status check.** `Smoke test (debugger tier)` is a required context in the repository ruleset,
+matched by name — so adding `, ${{ matrix.arch }}` did not rename the requirement, it deleted the
+only job that could satisfy it, and every PR in the repo would have blocked on a check that can
+never report again. It surfaced as a PR that was `MERGEABLE` but `BLOCKED` with nothing failing that
+was required. The x64 entry now keeps the original name exactly, so adding a matrix is not a rename.
+Worth knowing before touching any job name in this repository, not just this one.

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -29,7 +29,20 @@ connected MCP client holds a lock on (see [`CLAUDE.md`](../CLAUDE.md)). Whole su
 The protocol tier rides `cargo test`, so CI already runs it. The debugger tier is opt-in
 *locally* but runs on every push and PR in CI, as the **Smoke test (debugger tier)** job — it is
 the only automated check of the properties process-per-session exists for, and it needs no symbols
-and no network. The bounded-command and live-kernel tiers are `#[ignore]`d — one is measured in
+and no network. It runs **twice, on x64 and on ARM64** (`windows-11-arm`), because the thing it
+exercises that nothing else does is a real `dbgeng.dll`, and there is a different one on each
+([#134](https://github.com/glslang/windbg-mcp/issues/134)). The two entries do not share a cargo
+cache, and an ARM64 failure does not cancel the x64 run.
+
+**Four of its assertions are gated to x86_64**, and the reason is a property of the sample rather
+than of the tests: the checked-in dump is x64, and an engine of another architecture parses its
+structure — bug check, module list, stack attribution — but cannot follow a pointer into the
+captured address space ([#142](https://github.com/glslang/windbg-mcp/issues/142)). So
+`walk_memory`, `disassemble` and the `EPROCESS` read behind `crash_triage`'s `process_name` have
+nothing to assert there. They report as `ignored` with that reason rather than failing, which keeps
+the distinction visible: on ARM64 the tier says what it did not check, instead of passing quietly or
+failing misleadingly. Equivalent coverage on ARM64 needs an **ARM64 dump** of its own — a sample to
+capture, not a test to write. The bounded-command and live-kernel tiers are `#[ignore]`d — one is measured in
 minutes, the other touches another machine; see below. Neither is automated, and the rest of the
 live checklist is not either: no runner has a kernel target, a TTD engine, or elevation.
 

--- a/skills/windbg-debugging/setup.md
+++ b/skills/windbg-debugging/setup.md
@@ -14,9 +14,18 @@ section for the workflow you're about to run before blaming the target.
 ### ARM64 hosts
 
 Crash-dump analysis works on Windows on ARM, and the dump does **not** have to be ARM64: an ARM64
-engine read an x64 kernel minidump here in full — `!analyze -v`, symbols, failure bucket and pool
-tag. Live user-mode and live kernel are untested on ARM64, and the bitness rule above still applies
-to those.
+engine read an x64 kernel minidump here — `!analyze -v`, symbols, failure bucket and pool tag.
+
+**But not everything in it.** CI's ARM64 debugger tier found that the same combination cannot read
+the target's **virtual memory**: `walk_memory` and `disassemble` fail with `0x8007001E` /
+`0x80040205`, and `crash_triage` loses `process_name` because the `EPROCESS` behind it is a virtual
+read ([#142](https://github.com/glslang/windbg-mcp/issues/142)). The dump's *structure* — bug check,
+module list, stack attribution — reads fine; following a pointer into the captured address space
+does not. Whether that is the inbox engine specifically, or cross-architecture dumps generally, is
+still open.
+
+Live user-mode and live kernel are untested on ARM64, and the bitness rule above still applies to
+those.
 
 Two things change when you bundle the engine.
 

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -2310,6 +2310,10 @@ const UNMAPPED: &str = "0x1000";
 ///
 /// Everything here is read-only against the checked-in dump, and the one address it assumes
 /// anything about is [`UNMAPPED`], which is unmapped on every Windows target there is.
+#[cfg_attr(
+    not(target_arch = "x86_64"),
+    ignore = "the checked-in dump is x64 and this reads its virtual memory, which an engine of another architecture cannot — see docs/smoke-test.md and issue #142"
+)]
 #[test]
 fn a_walk_marks_what_it_cannot_read_and_keeps_going() {
     let Some(dump) = target_tier() else { return };
@@ -2461,6 +2465,10 @@ fn a_walk_marks_what_it_cannot_read_and_keeps_going() {
 /// parameters and its `nt`-topped stack are facts about the file, while what `!analyze` concludes
 /// depends on whether this host has `winext\ext.dll` beside the engine — so the analysis is
 /// checked for being coherent, not for having run.
+#[cfg_attr(
+    not(target_arch = "x86_64"),
+    ignore = "the checked-in dump is x64 and this reads its virtual memory, which an engine of another architecture cannot — see docs/smoke-test.md and issue #142"
+)]
 #[test]
 fn a_bug_check_is_triaged_into_its_fields() {
     let Some(dump) = target_tier() else { return };
@@ -2709,6 +2717,10 @@ fn a_bug_check_is_triaged_into_its_fields() {
 /// fixed offset into a fixed image, so it is reproducible across every reboot and load base — five
 /// dumps from the same loop reported it at five different addresses — and a change in it means the
 /// attribution arithmetic moved.
+#[cfg_attr(
+    not(target_arch = "x86_64"),
+    ignore = "the checked-in dump is x64 and this reads its virtual memory, which an engine of another architecture cannot — see docs/smoke-test.md and issue #142"
+)]
 #[test]
 fn a_driver_crash_names_the_driver_frame_that_analyze_cannot() {
     if target_tier().is_none() {
@@ -2849,6 +2861,10 @@ fn a_driver_crash_names_the_driver_frame_that_analyze_cannot() {
 ///
 /// Read-only against the checked-in kernel dump: the mutation the rollback would undo is left to
 /// the live-kernel tier, because a dump has nothing worth restoring.
+#[cfg_attr(
+    not(target_arch = "x86_64"),
+    ignore = "the checked-in dump is x64 and this reads its virtual memory, which an engine of another architecture cannot — see docs/smoke-test.md and issue #142"
+)]
 #[test]
 fn a_batch_commits_or_fails_and_its_rollback_runs_either_way() {
     let Some(dump) = target_tier() else { return };


### PR DESCRIPTION
Closes #134. Refs #142, #143.

`setup.md` told readers an ARM64 engine reads an x64 kernel minidump **in full**, and the only thing behind that was one manual session. It is a claim about a `dbgeng.dll` this project does not ship and cannot test any other way, so a Windows-on-ARM image that regressed it would reach users before it reached this repo.

## It found something on its first run

Forty-one passed, four failed, and the four share one cause: the ARM64 engine parses the dump — bug check, module list, stack attribution — and **cannot read virtual memory** out of it. `walk_memory` gets `0x8007001E`, `disassemble` gets `0x80040205`, and `crash_triage` loses `process_name` because the `EPROCESS` behind it is a virtual read. Filed as #142, and `setup.md`'s claim is corrected to what was actually observed.

## The gate belongs to the sample, not the tests

Those four are gated to `x86_64` because **the checked-in dump is x64** — on another architecture they have nothing to assert. `cfg_attr(…, ignore = …)` rather than `cfg`, so they report as ignored *with the reason* instead of vanishing from the count: the tier says what it did not check rather than passing quietly.

Equivalent coverage on ARM64 needs an ARM64 dump of its own, which is a sample to capture and not a test to write — deferred as #143.

Verified on an `aarch64-pc-windows-msvc` host: **41 passed, 0 failed, 16 ignored**.

## One trap worth reading the workflow comment for

The x64 entry keeps its **exact** job name. `Smoke test (debugger tier)` is a required status check in the repository ruleset, matched by name — renaming the job does not rename the requirement, it removes the only job that could ever satisfy it, and every PR in the repo blocks on a check that can never report again. I hit this: the PR reported `MERGEABLE` but `BLOCKED` with nothing failing that was required. Adding a matrix is not a rename as long as one entry keeps the original name, and that reasoning now sits next to the suffix.