### PR TITLE
Close the listener's two usability gaps: its log, and its untested lease

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`server_log` — the server's own log, readable from wherever the client is.** The supervisor
+  keeps a bounded ring of the most recent records, its own and every engine worker's, and serves
+  them as a tool: filterable by session and level, paged with a `since` cursor, answered without
+  ever touching a session's engine — so it still answers while the session it is about is wedged,
+  like `session_status`.
+
+  This closes a regression the listener introduced. Under stdio the log needs no plumbing: a
+  worker's stderr is inherited by the supervisor, the supervisor's is captured by the MCP client,
+  and the whole stream lands in a file the operator already has. `--listen` moves the server to
+  another machine and the stream stops there.
+
+  - **Records cross the pipe as values.** A worker's `tracing` output is mirrored up the existing
+    protocol channel (`WorkerMessage::Log`) and filed by the supervisor **tagged with the session
+    id** — the one thing the worker itself cannot stamp them with, and the thing that makes two
+    processes' interleaved records readable.
+  - **Worker stderr is untouched.** The bridge is a second copy, not a redirection, so the stdio
+    behaviour it exists to restore is preserved by not touching it — and the local operator's view
+    on the server machine is unchanged.
+  - **It cannot block the debugger.** The worker's queue is bounded and dropped when full, never
+    blocked on: it is fed from the engine thread, inside DbgEng, where a log line must never wait
+    on a pipe. Drops are counted and filed as a record of their own, because a gap in a log that
+    reads as a quiet stretch is worse than no log at all.
+  - **Not built on MCP's logging capability.** rmcp marks `notifications/message` and its whole
+    API `#[deprecated]` for removal (SEP-2577), and this repo asserts that capability is not
+    advertised. See [`DECISIONS.md`](./DECISIONS.md) for the trade — pull rather than push — and
+    for what a tool reaches that stderr never did: the model holding the session.
+
+  `WINDBG_MCP_LOG_BUFFER` sets how many records are kept (1000 by default). The ring is the same
+  stream as stderr, so `RUST_LOG` widens both together.
+
 - **Opt-in session transcripts, and an asciicast renderer for them**
   ([#87](https://github.com/glslang/windbg-mcp/issues/87)). Point `WINDBG_MCP_TRANSCRIPT` at a path
   and the supervisor records what it was asked and what it did, one JSON object per line: the tool

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `WINDBG_MCP_LOG_BUFFER` sets how many records are kept (1000 by default). The ring is the same
   stream as stderr, so `RUST_LOG` widens both together.
 
+- **A smoke tier for the listener's lease.** The lease is the only part of this server whose
+  failures cost a *target* rather than a call, and it was the only part checked by hand. It is now
+  driven over real HTTP against a listener on a loopback port, with a hand-written client — a
+  library that normalised a `409` into an exception, or hid the `Mcp-Session-Id` header, would be
+  asserting on the server's behalf.
+
+  Four assertions need no debugger, because tenancy is decided before any session is opened: the
+  listener refuses to start without a token and says which variable is missing; an unauthenticated
+  request is refused, told nothing about what is here, and **costs the server nothing** (the bearer
+  check runs before the tenancy gate, so a wrong token must not consume a claim); a second client
+  is refused with `409` whether it arrives with a fresh `initialize` or somebody else's session id;
+  and going quiet is not leaving while a `DELETE` is. The fifth is in the debugger tier and waits
+  out a real grace against a **parked kernel attach** — a session that exists, holds a worker, and
+  cannot be interrupted, so releasing it means terminating a process. See
+  [`docs/smoke-test.md`](./docs/smoke-test.md).
+
+### Changed
+
+- The listener no longer claims a reconnecting client **adopted sessions** when there were none to
+  adopt. The flag behind that line says a previous tenancy ended inside the grace, which is true
+  whether or not that client had opened anything — so an ordinary reconnect logged an adoption that
+  had not happened. It now says how many sessions were inherited, or that nothing was open.
+
 - **Opt-in session transcripts, and an asciicast renderer for them**
   ([#87](https://github.com/glslang/windbg-mcp/issues/87)). Point `WINDBG_MCP_TRANSCRIPT` at a path
   and the supervisor records what it was asked and what it did, one JSON object per line: the tool

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,8 +19,15 @@ worker supervision, routing), `src/worker.rs` (the child process and the engine 
 `src/main.rs` (role selection).
 
 Practical consequences when debugging this server: a stack trace or log line can come from either
-role (worker logs are untagged by target and inherit the supervisor's stderr), and killing the
-supervisor leaves no workers behind — they exit when their request channel closes. That channel is
+role (both write to the supervisor's stderr, told apart by `tracing` target — `windbg_mcp::worker`
+against `windbg_mcp::engine` and friends), and killing the supervisor leaves no workers behind —
+they exit when their request channel closes.
+
+The same records are also readable **through the tool surface**: `server_log` serves a bounded ring
+of them (`src/logbridge.rs`), with a worker's tagged by session, which is the only way to see them
+when the client is not on this machine (`--listen`). It is a copy of the stderr stream, not a
+replacement — worker stderr is untouched — so it holds nothing below the level the server was
+started with; `RUST_LOG` widens both together. That channel is
 a pair of inherited anonymous pipes, *not* the worker's stdio: anything a worker prints to stdout
 is drained into the log and cannot reach the protocol.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,9 +27,12 @@ The same records are also readable **through the tool surface**: `server_log` se
 of them (`src/logbridge.rs`), with a worker's tagged by session, which is the only way to see them
 when the client is not on this machine (`--listen`). It is a copy of the stderr stream, not a
 replacement — worker stderr is untouched — so it holds nothing below the level the server was
-started with; `RUST_LOG` widens both together. That channel is
-a pair of inherited anonymous pipes, *not* the worker's stdio: anything a worker prints to stdout
-is drained into the log and cannot reach the protocol.
+started with; `RUST_LOG` widens both together. The ring is bounded, so it holds the run-up to a
+failure rather than a session's history — a transcript (below) is what keeps history.
+
+The **supervisor↔worker protocol channel** is a pair of inherited anonymous pipes, *not* the
+worker's stdio: anything a worker prints to stdout is drained into the log and cannot reach the
+protocol.
 
 ## Updating the running windbg MCP after code changes
 

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -5,6 +5,47 @@ status. Keep entries short; link to code with `file:line` where it helps a futur
 
 ---
 
+## The server's log is a tool, not a protocol notification (2026-08-17)
+
+**Context.** Under stdio the log needs no plumbing: a worker's stderr is inherited by the
+supervisor, the supervisor's is captured by the MCP client, and the whole stream lands in a file
+the operator already has. `--listen` moves the server to another machine and the stream stops
+there — a regression against stdio rather than anything HTTP requires.
+
+**The obvious fix is the wrong one.** MCP has a logging capability (`notifications/message`,
+`logging/setLevel`), and it is a few lines. It is also deprecated: rmcp marks every type in it
+`#[deprecated]` for removal under SEP-2577. And this repo already asserts, in
+`capabilities_advertise_only_what_is_implemented`, that the `logging` capability is *not*
+advertised — advertising what you do not implement routes real calls into `method_not_found`. So
+taking it would mean unpicking a standing test in order to depend on an API the SDK has announced
+it is deleting.
+
+**Decision.** The supervisor keeps a bounded ring of the most recent records — its own and, over
+the pipe as typed values, every worker's — and `server_log` serves it. A worker's records are
+tagged with the session id on arrival, which is the one thing the worker cannot stamp them with.
+
+**Why this shape.** It is transport-agnostic, so stdio and HTTP report the same thing through one
+code path. It is answered by the supervisor and never routed to a worker, like `session_status`, so
+it still answers while the session it is about is wedged — which is the case it exists for. And it
+reaches a reader stderr never did: the model holding the session, which under stdio could not see
+these records at all.
+
+**What it costs.** Pull, not push: nothing arrives unasked, so a client that never calls it learns
+nothing. That is the trade for not building on an API with a removal notice on it, and the ring is
+the same stream either way.
+
+**Two things fell out of building it.** A worker's queue is bounded and **dropped when full**,
+never blocked on — it is fed from the engine thread, inside DbgEng, where a log line must never
+block — and the drops are counted and filed as a record of their own, because a gap that reads as
+quiet is worse than no log. And worker stderr is left exactly as it was: the bridge is a second
+copy, not a redirection, so the stdio behaviour this exists to restore is preserved by not
+touching it.
+
+**Status:** landed. Worker stderr unchanged; `server_log` on both transports; verified over HTTP
+against the listener.
+
+---
+
 ## Tenancy is held until the engine is idle, not until the request ends (2026-08-16, #135)
 
 **Context.** The stdio role gets one property free: when stdin closes the client is *definitively*

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -1,14 +1,15 @@
 # Follow-ups
 
-Deferred work, in six clusters: items 1–6 come from the reachability-confirmation effort (path
+Deferred work, in nine clusters: items 1–6 come from the reachability-confirmation effort (path
 recipe + `run_to_address`, merged 2026-07-04), items 7–11 from surveying this server against the
 MCP `2026-07-28` extensions (tasks, apps), item 12 from the opener split
 (glslang/win-kexp#71, 2026-08-01), items 13–14 from the bounded-command coverage review
 (#46, 2026-08-02), item 15 from the private worker channel (#65 / #72, 2026-08-04), items 16–18
 from transactional batches (#82, 2026-08-09/10 — item 17 is what validating the tool against the CTF
-session's own transcript turned up, and item 18 what reviewing it did), and item 19 from
-`walk_memory` (#103, 2026-08-13), and items 20–22 from standing the server up on an ARM64 guest
-(#131, #132, #134, 2026-08-16). Each item notes its repo,
+session's own transcript turned up, and item 18 what reviewing it did), item 19 from
+`walk_memory` (#103, 2026-08-13), items 20–22 from standing the server up on an ARM64 guest
+(#131, #132, #134, 2026-08-16), and item 23 from making the listener usable rather than merely
+working (2026-08-17). Each item notes its repo,
 why it was deferred, and where it picks up. See [`DECISIONS.md`](./DECISIONS.md) for the design rationale (D1–D5) items 1–6 extend,
 and the 2026-08-02 entries that items 13–14 and item 10 extend.
 
@@ -630,3 +631,29 @@ only job that could satisfy it, and every PR in the repo would have blocked on a
 never report again. It surfaced as a PR that was `MERGEABLE` but `BLOCKED` with nothing failing that
 was required. The x64 entry now keeps the original name exactly, so adding a matrix is not a rename.
 Worth knowing before touching any job name in this repository, not just this one.
+
+## 23. [windbg-mcp] The listener is transport-complete, not usable-complete
+
+The log half of this is **done** (2026-08-17): `server_log` carries every record either process
+made to a client on any machine, and [`DECISIONS.md`](./DECISIONS.md) records why it is a tool
+rather than MCP's deprecated logging capability. What is left of the same gap is the other two
+items [`docs/remote-listener.md`](./docs/remote-listener.md) lists under *Not there yet*, plus one
+this work added.
+
+**No progress notifications.** A long call is silent. The worker already emits the milestones — a
+`Committed`/`Opened` opener pair, `RollingBack` — as protocol messages, so what is missing is the
+mapping onto MCP progress and a `progressToken` to hang it on, not the facts. Under stdio a caller
+watched stderr for this; a remote one has `session_status` and `server_log`, and both are pull.
+
+**No service installation.** The listener runs in whatever shell starts it, so it dies with the
+login session and inherits that shell's `PATH` — which for this server decides whether the engine
+DLLs beside the exe are the ones that load.
+
+**No smoke tier for the lease.** Every rule of it has unit tests
+(`src/listen.rs`), and the ones that matter most — drop and return inside the grace, release past
+it, a second client refused with `409` — have only ever been exercised by hand against the guest.
+That is the shape of gap the lease's seven review rounds kept finding bugs in. This work drove the
+listener over HTTP again to check `server_log` reaches a client that is not on the machine, which
+is a third hand-run of the same setup and an argument for scripting it.
+
+Picks up at `src/listen.rs` and the tiers in `tests/mcp_smoke.rs`.

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -634,9 +634,10 @@ Worth knowing before touching any job name in this repository, not just this one
 
 ## 23. [windbg-mcp] The listener is transport-complete, not usable-complete
 
-Two halves of this are **done** (2026-08-17): `server_log` carries every record either process made
-to a client on any machine ([`DECISIONS.md`](./DECISIONS.md) records why it is a tool rather than
-MCP's deprecated logging capability), and the lease now has a **smoke tier** — four assertions in
+Two halves of this are **done** (2026-08-17): `server_log` reaches a client on any machine with the
+records *both* processes made — bounded, and saying so when a record was dropped or evicted rather
+than leaving a gap to be read as quiet ([`DECISIONS.md`](./DECISIONS.md) records why it is a tool
+rather than MCP's deprecated logging capability), and the lease now has a **smoke tier** — four assertions in
 the protocol tier and one, against a parked kernel attach, in the debugger tier. What is left is
 the other two items [`docs/remote-listener.md`](./docs/remote-listener.md) lists under *Not there
 yet*.

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -634,11 +634,12 @@ Worth knowing before touching any job name in this repository, not just this one
 
 ## 23. [windbg-mcp] The listener is transport-complete, not usable-complete
 
-The log half of this is **done** (2026-08-17): `server_log` carries every record either process
-made to a client on any machine, and [`DECISIONS.md`](./DECISIONS.md) records why it is a tool
-rather than MCP's deprecated logging capability. What is left of the same gap is the other two
-items [`docs/remote-listener.md`](./docs/remote-listener.md) lists under *Not there yet*, plus one
-this work added.
+Two halves of this are **done** (2026-08-17): `server_log` carries every record either process made
+to a client on any machine ([`DECISIONS.md`](./DECISIONS.md) records why it is a tool rather than
+MCP's deprecated logging capability), and the lease now has a **smoke tier** — four assertions in
+the protocol tier and one, against a parked kernel attach, in the debugger tier. What is left is
+the other two items [`docs/remote-listener.md`](./docs/remote-listener.md) lists under *Not there
+yet*.
 
 **No progress notifications.** A long call is silent. The worker already emits the milestones — a
 `Committed`/`Opened` opener pair, `RollingBack` — as protocol messages, so what is missing is the
@@ -649,11 +650,10 @@ watched stderr for this; a remote one has `session_status` and `server_log`, and
 login session and inherits that shell's `PATH` — which for this server decides whether the engine
 DLLs beside the exe are the ones that load.
 
-**No smoke tier for the lease.** Every rule of it has unit tests
-(`src/listen.rs`), and the ones that matter most — drop and return inside the grace, release past
-it, a second client refused with `409` — have only ever been exercised by hand against the guest.
-That is the shape of gap the lease's seven review rounds kept finding bugs in. This work drove the
-listener over HTTP again to check `server_log` reaches a client that is not on the machine, which
-is a third hand-run of the same setup and an argument for scripting it.
+**What the smoke tier does not reach**, now that there is one: the grace is waited out at 32
+seconds because the listener's own floor is the call budget plus `WORKER_READY_TIMEOUT`, and that
+30s constant is not configurable — so the test costs 40s of wall clock to assert a timer. Lowering
+it would mean making a production constant test-tunable, which is a worse trade than the 40s. Worth
+revisiting only if that tier's runtime starts to matter.
 
 Picks up at `src/listen.rs` and the tiers in `tests/mcp_smoke.rs`.

--- a/README.md
+++ b/README.md
@@ -326,6 +326,7 @@ gh attestation verify <zip> --repo glslang/windbg-mcp `
 | Group | Tools |
 |-------|-------|
 | Session | `open_dump`, `open_trace`, `attach_kernel_local`, `attach_kernel`, `attach_process`, `launch`, `interrupt`, `end_session`, `session_status` |
+| Server   | `server_log` — the server's own log, the supervisor's and every engine worker's, tagged with the session each record belongs to |
 | State   | `registers`, `read_memory`, `walk_memory`, `backtrace`, `modules`, `threads`, `disassemble`, `dx` |
 | Crash   | `crash_triage` — a bug check as fields: code and parameters, crashing process, the stack as `module+RVA`, and the faulting driver frame |
 | Control | `go`, `step_over`, `step_into`, `set_breakpoint`, `run_to_address` |
@@ -630,6 +631,7 @@ matching `outputSchema` in `tools/list`, so a program can read a field instead o
 |------|--------------|
 | `open_dump`, `open_trace`, `attach_kernel`, `attach_kernel_local`, `attach_process`, `launch` | `session_id`, `kind`, `target`, `report`, and a `summary` of the target — `kernel_mode`, `modules_loaded`, the `primary_module` (the kernel, or the process's own image) and, for a crash dump, the `bug_check`. On failure, whether a target was created (`target: no \| yes \| pending`), which is what decides whether opening again is a recovery or a second attach |
 | `session_status` | each session's `state` (`opening`/`attaching`/`open`/`failed`/`retired`/`closed`), `engine_pid`, `in_state_for_ms`, and — for an attach — `waits_indefinitely` and `overdue` |
+| `server_log` | `records[]` as `{seq, at, level, session_id, target, message}` — `session_id` absent for the supervisor's own — plus `matched`, the buffer's `held`/`capacity`/`oldest_seq`, and a `next_since` cursor that advances even on an empty page |
 | `end_session` | `released`, `worker_terminated`, `waited_ms` |
 | `registers` | `registers[]` as `{name, kind, …}` plus `instruction_pointer` — `kind: int` and `kind: float` carry `value`, `kind: bytes` carries `bytes` (an x87 or vector register, which no number holds), `kind: non_finite` names a NaN or infinity that JSON has no literal for and carries its bits, `kind: unavailable` carries neither; pass `all: true` for the x87/vector registers and subregister views |
 | `modules` | `modules[]` with `start`/`end`, `size` and a typed `symbols` state (`deferred` is *not* `none`); `unloaded[]` for the images that have since unloaded (listed by image name, since an unloaded module has none of its own); `loaded` (how many the target has in total) and the `filter` a narrowed listing was matched by. The listing text is rendered from these same records rather than pasted from `lm`, so the two halves cannot describe different sets of modules; the filter's grammar is this server's own — a name plus `*` (any run) and `?` (exactly one), **every other character literal** — and `execute { "command": "lm m <pattern>" }` is where WinDbg's fuller wildcard syntax lives |

--- a/docs/remote-listener.md
+++ b/docs/remote-listener.md
@@ -93,13 +93,39 @@ knowing about, because an engine job outlives the request that asked for it — 
 gave up is still running against the target, and the server will not hand that target on until it
 finishes.
 
+## Reading the server's log from the client machine
+
+The listener's `tracing` output still goes to its own stderr, which is now on the *other* machine.
+`server_log` is how it reaches you anyway: the supervisor keeps the last thousand records — its own
+and every engine worker's — and serves them as a tool, so this works the same over stdio and HTTP.
+
+```jsonc
+server_log {}                                   // the last 50, info and above
+server_log { "session_id": "sess-…-1" }         // what that session's engine worker said
+server_log { "level": "warn", "limit": 200 }
+server_log { "since": 412 }                     // only what is new, from the last `next_since`
+```
+
+A worker's records carry the session they belong to; the supervisor's — spawning a worker, timing
+a call out, a worker dying — carry none, so **omit `session_id` when tracing an open that failed**,
+since there was no session for those records to be tagged with.
+
+Two things worth knowing. A healthy session is *quiet*: a worker logs when something goes wrong, not
+as it works, so an empty page usually means nothing went wrong rather than that the bridge is
+broken. And the buffer is the same stream as stderr, so it holds nothing below the level the server
+was started with — widen with `RUST_LOG=windbg_mcp=debug` on the listener (and restart), not with
+`level` on the call. `WINDBG_MCP_LOG_BUFFER` sets how many records are kept.
+
+This is diagnostics about the *server*, not the target, and it is as sensitive as the server's
+stderr — which for a live kernel session can name what the guest was doing. Under stdio those
+records reached a log file; here they reach the client, and therefore the model. Treat a live-kernel
+session accordingly.
+
 ## Not there yet
 
 - **No progress notifications.** A long call is quiet; the SSE keep-alive holds the stream open but
-  nothing reports what the call is doing. `session_status` still answers.
-- **No MCP log notifications.** Worker `tracing` output goes to the listener's own stderr on the
-  server machine, not to the client — so the diagnostics [`CLAUDE.md`](../CLAUDE.md) describes are
-  read there for now.
+  nothing reports what the call is doing. `session_status` still answers, and `server_log` says what
+  the server has been doing — but neither is the call reporting on itself.
 - **No service installation.** The listener runs in whatever shell you start it in. A Windows
   service would give it a defined `PATH` and working directory, boot start, and a life independent
   of a login session.

--- a/docs/remote-listener.md
+++ b/docs/remote-listener.md
@@ -69,7 +69,8 @@ the call timeout.
 **A returning client adopts what it left.** Sessions are not released the moment a client goes
 away, so reconnecting inside the grace finds them still open — which is better than stdio, where a
 client restart costs a KDNET attach, and a KDNET attach costs a reboot of the target. The log says
-`adopted the sessions the previous one left open` when that happens.
+how many sessions were inherited when that happens — or that nothing was open, since a client can
+also arrive to find the previous one had let go of an empty server.
 
 ## One client at a time
 
@@ -100,10 +101,10 @@ The listener's `tracing` output still goes to its own stderr, which is now on th
 and every engine worker's — and serves them as a tool, so this works the same over stdio and HTTP.
 
 ```jsonc
-server_log {}                                   // the last 50, info and above
-server_log { "session_id": "sess-…-1" }         // what that session's engine worker said
-server_log { "level": "warn", "limit": 200 }
-server_log { "since": 412 }                     // only what is new, from the last `next_since`
+server_log {}                                // the last 50, info and above
+server_log { "session_id": "sess-…-1" }      // what that session's engine worker said
+server_log { "level": "warn", "limit": 200 } // 50 records by default, 500 at most
+server_log { "since": 412 }                  // only what is new, from the last `next_since`
 ```
 
 A worker's records carry the session they belong to; the supervisor's — spawning a worker, timing

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -20,7 +20,7 @@ adding the debugger tier takes it to ~40s, almost all of it one test waiting out
 
 | Tier | Gate | Needs | Catches |
 | --- | --- | --- | --- |
-| **Protocol** | always | nothing — no debugger, no target, no network | transport, revision negotiation, tool-surface drift, and the listener's lease up to the point a session is opened |
+| **Protocol** | always | no debugger, no target, and no network off this machine — it does bind a loopback port for the listener | transport, revision negotiation, tool-surface drift, and the listener's lease up to the point a session is opened |
 | **Debugger** | `WINDBG_MCP_SMOKE_DUMP=1` | `dbgeng.dll`, the checked-in sample dump | `win-kexp` / DbgEng regressions, and a lease expiry releasing a real engine worker |
 | **Bounded command** | `--ignored` | `dbgeng.dll`, the sample dump, ~1 minute | the watchdog wiring, which now spans two processes |
 | **Live kernel** | `--ignored` + `WINDBG_MCP_SMOKE_KERNEL` | a KDNET target you can freeze | that a kernel attach *lands*, coexists, and is let go — by `end_session` and by a disconnect; and that a `debug_batch` which patches a byte of the running kernel puts it back |

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -13,14 +13,15 @@ $env:WINDBG_MCP_SMOKE_DUMP = "1"; cargo test --test mcp_smoke   # + the debugger
 ```
 
 It builds and runs against `target/debug`, so it never touches the `target/release` exe a
-connected MCP client holds a lock on (see [`CLAUDE.md`](../CLAUDE.md)). Whole suite is ~1s.
+connected MCP client holds a lock on (see [`CLAUDE.md`](../CLAUDE.md)). The protocol tier is ~2s;
+adding the debugger tier takes it to ~40s, almost all of it one test waiting out a lease grace.
 
 ### Tiers
 
 | Tier | Gate | Needs | Catches |
 | --- | --- | --- | --- |
-| **Protocol** | always | nothing — no debugger, no target, no network | transport, revision negotiation, tool-surface drift |
-| **Debugger** | `WINDBG_MCP_SMOKE_DUMP=1` | `dbgeng.dll`, the checked-in sample dump | `win-kexp` / DbgEng regressions |
+| **Protocol** | always | nothing — no debugger, no target, no network | transport, revision negotiation, tool-surface drift, and the listener's lease up to the point a session is opened |
+| **Debugger** | `WINDBG_MCP_SMOKE_DUMP=1` | `dbgeng.dll`, the checked-in sample dump | `win-kexp` / DbgEng regressions, and a lease expiry releasing a real engine worker |
 | **Bounded command** | `--ignored` | `dbgeng.dll`, the sample dump, ~1 minute | the watchdog wiring, which now spans two processes |
 | **Live kernel** | `--ignored` + `WINDBG_MCP_SMOKE_KERNEL` | a KDNET target you can freeze | that a kernel attach *lands*, coexists, and is let go — by `end_session` and by a disconnect; and that a `debug_batch` which patches a byte of the running kernel puts it back |
 | **MessageManager CTF** | `--ignored` + live-kernel gate + `WINDBG_MCP_SMOKE_CTF=1` | the challenge VM, WinRM, full `nt` symbols | the real driver and retained `Tgsm` pool objects through the shipped MCP transport |
@@ -309,6 +310,42 @@ processes, so they need real ones:
   COMPLETE`, with the target still changed. The batch's `always` block writes a marker when it
   starts and another when it finishes, so the interrupt is staged on the first and the second is the
   proof the rollback ran whole; the refusal has to say it is a rollback, or it reads as a bug.
+
+**The listener's lease.** `--listen` gives up the one property stdio has for free: a closed stdin
+means the client is definitively gone, and every target is released. Over HTTP a silent client is
+indistinguishable from one that is thinking, so a **lease** stands in for that moment — and it is
+the only part of this server whose failures cost a *target* rather than a call. Every rule of it has
+unit tests in [`listen.rs`](../src/listen.rs) against the state machine directly; what those cannot
+reach is the wiring, which is what these assert against a real listener on a loopback port, with a
+hand-written HTTP client (a library that normalised a `409` into an exception, or hid the session
+header, would be asserting on this server's behalf).
+
+Four of them need no debugger, because tenancy is decided before any session is opened:
+
+- *It will not start without a token*, and says which variable is missing. The listener exposes
+  every tool here, including the ones that write to a live kernel; a quiet default would be a
+  server nobody knows is open.
+- *An unauthenticated request is refused, told nothing about what is here, and **costs the server
+  nothing***. The last clause is the one worth a test: the bearer check runs before the tenancy
+  gate, so a wrong token must not reserve or consume a claim — if it did, anything that could
+  reach the port could lock the real client out without ever authenticating.
+- *A second client is refused with `409`*, whether it arrives with a fresh `initialize` or with a
+  session id that is not the holder's, and the holder is undisturbed by either.
+- *Going quiet is not leaving; saying goodbye is.* Every request is its own connection — which is
+  what a client behind a tunnel looks like — so silence is the resting state, and a server that
+  read it as departure would hand the registry on between two calls of a working client. A
+  `DELETE` does hand it on.
+
+The fifth is in the debugger tier, because it is the sweep meeting a real engine worker: *a lease
+that runs out releases what the absent client left*. The target is **a kernel attach nothing will
+answer**, deliberately — a parked attach is the worst case in one move, since the session exists,
+holds a worker, and cannot be interrupted, so releasing it means terminating a process rather than
+asking politely. The test then goes silent for a real grace period (32s, nearly the floor the
+listener enforces: the grace must outlast the call budget plus the 30s an engine worker may take to
+come up, so the budget is shrunk to a second) and watches **stderr**, not HTTP — every admitted
+request renews the lease, so a test that polled would hold open the very thing it is waiting to
+expire. It asserts the worker process is gone, the swept session id is no longer served, and the
+next client gets a server with nothing left over. Budget ~40s.
 
 This tier is also the only end-to-end check of the **protocol channel** — the inherited pipe pair a
 worker speaks on ([`proto.rs`](../src/proto.rs)). Handles are passed on the worker's command line

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -2235,8 +2235,22 @@ fn read_messages(
                             let mut slot = unwinding.lock().unwrap_or_else(|e| e.into_inner());
                             *slot = Some(slot.map_or(named, |had| had.min(named)));
                         }
+                        // Nobody is left to route it to. Stopping here is what **closes the read
+                        // end** — this thread owns it — and that is load-bearing rather than
+                        // incidental: a worker's next write then fails immediately instead of
+                        // blocking in `write_all` on a pipe nothing is emptying.
+                        //
+                        // The distinction decides whether a teardown can hang. Every message a
+                        // worker sends goes through one lock (`worker::emit`), so a write that
+                        // blocked here would hold that lock against the release its EOF is about
+                        // to ask for — the one bounded by `ABRUPT_EXIT_RELEASE` — and for a live
+                        // kernel that is a target left halted because the supervisor stopped
+                        // listening. It cannot: an absent consumer is a *closed* pipe, not a full
+                        // one. Pinned by `the_channel_fails_a_worker_fast_when_nobody_is_left`,
+                        // because "the reader stops" and "the reader stalls" are one line apart
+                        // here and only one of them is safe.
                         if tx.send(message).is_err() {
-                            break; // nobody is left to route it to
+                            break;
                         }
                     }
                     Err(e) => tracing::error!(
@@ -3443,6 +3457,121 @@ mod tests {
             Some(by),
             "a promise overtaken by its own retraction would have a teardown wait out a batch \
              budget that is already spent"
+        );
+    }
+
+    /// A log record is **filed** against its session rather than dispatched, and a worker whose
+    /// consumer has gone is failed **fast** rather than blocked.
+    ///
+    /// The second is the one with teeth, and it is not about the log. Every message a worker sends
+    /// goes through one lock (`worker::emit`), held across the write. If a departed consumer left a
+    /// pipe that was merely *full*, a background writer could hold that lock indefinitely — and the
+    /// release a worker's EOF asks for, bounded by [`ABRUPT_EXIT_RELEASE`], would never get a
+    /// message out. For a live kernel that is a target left halted because the supervisor stopped
+    /// listening.
+    ///
+    /// It cannot happen, and this is why: the reader thread owns the read end, so the moment it
+    /// stops reading it *closes* it, and the worker's next write errors instead of waiting. That is
+    /// one line of `read_messages` — `break` versus carrying on — and the safe answer is the
+    /// unobvious one, which is what makes it worth pinning. Written as "more than any pipe can
+    /// hold, with the consumer gone": against a reader that stalled instead of stopping, the writes
+    /// would never return.
+    #[test]
+    fn the_channel_fails_a_worker_fast_when_nobody_is_left() {
+        let (arriving, mut worker) = std::io::pipe().expect("a pipe to stand in for a worker's");
+        // A session id nothing else uses: the ring this files into is process-wide, and the whole
+        // test suite logs into it.
+        let session = "sess-drain-to-eof";
+        let messages = read_messages(
+            session.to_string(),
+            arriving,
+            Arc::new(Mutex::new(None::<Instant>)),
+        )
+        .expect("start a reader");
+
+        let log = serde_json::to_string(&WorkerMessage::Log {
+            at_ms: 1_700_000_000_000,
+            level: crate::logbridge::Level::Warn,
+            target: "windbg_mcp::worker".to_string(),
+            message: "worker: something worth reading".to_string(),
+            dropped: 0,
+        })
+        .expect("encode a log record");
+        writeln!(worker, "{log}").expect("write it as a worker would");
+
+        let query = || crate::logbridge::Query {
+            session: Some(session.to_string()),
+            level: crate::logbridge::Level::Trace,
+            since: None,
+            limit: 10,
+        };
+        let deadline = Instant::now() + Duration::from_secs(10);
+        let filed = loop {
+            let tail = crate::logbridge::tail(&query());
+            if let Some(entry) = tail.entries.first() {
+                break entry.clone();
+            }
+            assert!(
+                Instant::now() < deadline,
+                "a worker's log record never reached the ring, so `server_log` would show nothing \
+                 of what that worker said"
+            );
+            std::thread::sleep(Duration::from_millis(20));
+        };
+        assert_eq!(filed.message, "worker: something worth reading");
+        assert_eq!(
+            filed.session.as_deref(),
+            Some(session),
+            "filed against the session whose worker sent it — the one thing the worker could not \
+             stamp it with"
+        );
+
+        // Nobody is left to route to.
+        drop(messages);
+
+        // Comfortably more than any pipe buffer, in lines a real worker could send. Written from a
+        // thread of its own so a write that never returns fails this test rather than hanging it.
+        let bulk = serde_json::to_string(&WorkerMessage::Fatal {
+            message: "x".repeat(8192),
+        })
+        .expect("encode a message");
+        let (wrote, written) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            let mut sent = 0usize;
+            let outcome = loop {
+                if sent == 256 {
+                    break Ok(sent);
+                }
+                if let Err(e) = writeln!(worker, "{bulk}") {
+                    break Err((sent, e.kind()));
+                }
+                sent += 1;
+            };
+            let _ = wrote.send(outcome);
+        });
+        let outcome = written.recv_timeout(Duration::from_secs(20)).expect(
+            "a worker writing to a channel nobody is routing blocked inside its write — which in a \
+             real worker is `emit`, holding the lock its teardown needs to report a release",
+        );
+        // And it is an *error*, not 2MB into a void: the read end is gone, which is the property
+        // that makes the block above impossible rather than merely unlikely.
+        let (sent, kind) = match outcome {
+            Err(refused) => refused,
+            Ok(sent) => panic!(
+                "all {sent} line(s) went through, so the reader was still draining a channel it \
+                 had stopped routing — one step from the stall this test exists to rule out"
+            ),
+        };
+        assert!(
+            sent < 256,
+            "the writer should have been refused before it finished, not after"
+        );
+        assert!(
+            matches!(
+                kind,
+                std::io::ErrorKind::BrokenPipe | std::io::ErrorKind::ConnectionAborted
+            ),
+            "expected the closed read end to refuse the write, got {kind:?} after {sent} line(s)"
         );
     }
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -2198,6 +2198,21 @@ fn read_messages(
                     continue;
                 }
                 match serde_json::from_str::<WorkerMessage>(&line) {
+                    // Not protocol, and belonging to no request: one of that worker's own log
+                    // records, mirrored so the supervisor holds every record either process made
+                    // (`crate::logbridge`). Filed here rather than forwarded, because everything
+                    // past this point is routed by request id and this has none — and because
+                    // *here* is where the session id is known, which is the one thing the worker
+                    // could not stamp it with.
+                    Ok(WorkerMessage::Log {
+                        at_ms,
+                        level,
+                        target,
+                        message,
+                        dropped,
+                    }) => {
+                        crate::logbridge::from_worker(&id, at_ms, level, &target, message, dropped);
+                    }
                     Ok(message) => {
                         // Recorded here, before the message is handed on, because a teardown reads
                         // it against a deadline — see [`Session::unwinding`]. Everything this
@@ -2466,8 +2481,10 @@ async fn reader(
                     sessions.reconcile_capacity(&session);
                 }
             }
-            // Both belong to the spawn handshake, which has already happened.
-            WorkerMessage::Ready | WorkerMessage::Fatal { .. } => {}
+            // `Ready` and `Fatal` belong to the spawn handshake, which has already happened.
+            // `Log` never gets this far: it is filed by the reader thread that parsed it, which
+            // is also where the session id it is tagged with lives.
+            WorkerMessage::Ready | WorkerMessage::Fatal { .. } | WorkerMessage::Log { .. } => {}
         }
     }
     // The channel closed: the worker exited, for whatever reason. Nothing else can close it —

--- a/src/listen.rs
+++ b/src/listen.rs
@@ -631,8 +631,26 @@ async fn gate(
         minted.as_deref(),
         response.status().is_success(),
     ) {
+        // Counted rather than asserted. `left_open` says a previous tenancy ended inside the
+        // grace, which is true whether or not that client had opened anything — so the
+        // unconditional version of this line told an operator a client had adopted sessions that
+        // did not exist, on every ordinary reconnect.
         Settled::Kept { adopted: true } => {
-            tracing::info!("a client attached and adopted the sessions the previous one left open");
+            match lease
+                .sessions
+                .snapshot()
+                .iter()
+                .filter(|s| s.state.is_live())
+                .count()
+            {
+                0 => tracing::info!(
+                    "a client attached to a server the previous one had let go; nothing was open"
+                ),
+                inherited => tracing::info!(
+                    "a client attached and adopted the {inherited} session(s) the previous one \
+                     left open"
+                ),
+            }
         }
         Settled::Kept { adopted: false } => {}
         // This request lost the server while it was being handled. If the service minted a session

--- a/src/logbridge.rs
+++ b/src/logbridge.rs
@@ -48,7 +48,7 @@
 use std::cell::Cell;
 use std::collections::VecDeque;
 use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
-use std::sync::mpsc::{Receiver, SyncSender, TrySendError, sync_channel};
+use std::sync::mpsc::{Receiver, SyncSender, sync_channel};
 use std::sync::{Mutex, OnceLock};
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -246,10 +246,11 @@ fn file(level: Level, at_ms: u64, target: String, session: Option<String>, messa
 
 /// Files a record a worker produced, against the session that worker holds.
 ///
-/// `dropped` is what that worker's queue had to throw away since its last record, and it is filed
-/// as a record of its own rather than folded into this one's text. A gap in the log is a fact
+/// `dropped` is what that worker's queue threw away **immediately before this record**, and it is
+/// filed as a record of its own rather than folded into this one's text. A gap in the log is a fact
 /// about the log, and a reader who is not told about it reads a quiet stretch as nothing having
-/// happened.
+/// happened — which is also why the count travels with the record that follows the gap rather than
+/// being read as the writer sends: see [`TO_SUPERVISOR`].
 pub fn from_worker(
     session: &str,
     at_ms: u64,
@@ -318,10 +319,17 @@ pub fn tail(query: &Query) -> Tail {
 // ---- the worker's side of the bridge ---------------------------------------
 
 /// The worker's queue. Created by [`layer`] so a record made before the protocol channel exists
-/// is held rather than lost, and drained by [`take_worker_queue`] once there is somewhere to send
+/// is held rather than lost, and drained by [`run_worker_writer`] once there is somewhere to send
 /// it.
-static TO_SUPERVISOR: OnceLock<SyncSender<Entry>> = OnceLock::new();
-static PENDING: Mutex<Option<Receiver<Entry>>> = Mutex::new(None);
+///
+/// Each record travels with **however many were dropped immediately before it**, rather than the
+/// writer reading a counter as it sends. The difference is where the gap is reported: a full queue
+/// holds up to [`WORKER_QUEUE`] records that were made *before* the drops, so a count picked up at
+/// send time lands against the oldest of those — several hundred records early, which tells a
+/// reader the loss happened somewhere it did not.
+static TO_SUPERVISOR: OnceLock<SyncSender<(Entry, u32)>> = OnceLock::new();
+static PENDING: Mutex<Option<Receiver<(Entry, u32)>>> = Mutex::new(None);
+/// Records dropped since the last one that got through, waiting to be carried by the next.
 static DROPPED: AtomicU32 = AtomicU32::new(0);
 /// Queued and written, so [`flush`] can tell whether the writer has caught up. Counters rather
 /// than a channel depth, which `SyncSender` does not expose.
@@ -348,11 +356,7 @@ pub fn run_worker_writer(mut send: impl FnMut(Entry, u32) -> bool) {
     let Some(queue) = PENDING.lock().unwrap_or_else(|e| e.into_inner()).take() else {
         return;
     };
-    for entry in queue {
-        // Read before the send, and reset: these are the records that were dropped to make room
-        // for the ones already queued ahead of this one, so this is the earliest message that can
-        // truthfully carry them.
-        let dropped = DROPPED.swap(0, Ordering::Relaxed);
+    for (entry, dropped) in queue {
         let usable = send(entry, dropped);
         WRITTEN.fetch_add(1, Ordering::Relaxed);
         if !usable {
@@ -362,12 +366,43 @@ pub fn run_worker_writer(mut send: impl FnMut(Entry, u32) -> bool) {
     WRITER_GONE.store(true, Ordering::Relaxed);
 }
 
+/// Queues one record, carrying however many were dropped since the last one that got through.
+/// `false` when the queue would not take it, which is itself a drop.
+///
+/// The count is **taken** before the attempt and put back if it fails, rather than read and
+/// subtracted afterwards: two threads reading the same count would each attach it, and the second
+/// subtraction would wrap the counter past zero into a very large number of imaginary drops.
+fn enqueue(queue: Option<&SyncSender<(Entry, u32)>>, entry: Entry) -> bool {
+    let carried = DROPPED.swap(0, Ordering::Relaxed);
+    let queued = match queue {
+        Some(queue) => queue.try_send((entry, carried)).is_ok(),
+        None => false,
+    };
+    if queued {
+        QUEUED.fetch_add(1, Ordering::Relaxed);
+    } else {
+        // This record, plus whatever it was going to carry for the ones before it.
+        DROPPED.fetch_add(carried.saturating_add(1), Ordering::Relaxed);
+    }
+    queued
+}
+
 /// Waits, up to `within`, for the writer to have mirrored everything queued so far.
 ///
 /// Called by a worker on its way out. Without it the records that matter most are the ones most
 /// likely to be lost: the teardown path logs *why* a target was released, and then exits the
 /// process — which is not something a background thread survives.
 pub fn flush(within: std::time::Duration) {
+    // A run of drops is carried by the *next* record to get through, and at exit there may not be
+    // one — so this is that record. Taken first, so the count is in the text even if the queue will
+    // not take this one either: stderr has it regardless, which is the fallback everywhere here.
+    let unreported = DROPPED.swap(0, Ordering::Relaxed);
+    if unreported > 0 {
+        tracing::warn!(
+            "worker: {unreported} log record(s) were dropped and this process is exiting, so \
+             nothing later can report them; its log queue had filled"
+        );
+    }
     let deadline = std::time::Instant::now() + within;
     while WRITTEN.load(Ordering::Relaxed) < QUEUED.load(Ordering::Relaxed) {
         if WRITER_GONE.load(Ordering::Relaxed) || std::time::Instant::now() >= deadline {
@@ -425,23 +460,17 @@ where
                 rendered.finish(),
             ),
             Role::Worker => {
-                let entry = Entry {
-                    seq: 0, // the supervisor's ring assigns it; this side has no sequence
-                    at_ms: now_ms(),
-                    level,
-                    target: metadata.target().to_string(),
-                    session: None, // likewise: a worker does not know its session id
-                    message: clip(rendered.finish()),
-                };
-                let queued = match TO_SUPERVISOR.get() {
-                    Some(queue) => queue.try_send(entry),
-                    None => Err(TrySendError::Disconnected(entry)),
-                };
-                if queued.is_ok() {
-                    QUEUED.fetch_add(1, Ordering::Relaxed);
-                } else {
-                    DROPPED.fetch_add(1, Ordering::Relaxed);
-                }
+                enqueue(
+                    TO_SUPERVISOR.get(),
+                    Entry {
+                        seq: 0, // the supervisor's ring assigns it; this side has no sequence
+                        at_ms: now_ms(),
+                        level,
+                        target: metadata.target().to_string(),
+                        session: None, // likewise: a worker does not know its session id
+                        message: clip(rendered.finish()),
+                    },
+                );
             }
         }
     }
@@ -670,6 +699,61 @@ mod tests {
     #[test]
     fn an_ordinary_record_is_untouched() {
         assert_eq!(clip("session 3: open".to_string()), "session 3: open");
+    }
+
+    /// A dropped run is carried by the record that **follows** it, not by whichever record the
+    /// writer happens to be sending when it notices.
+    ///
+    /// The distinction is where the gap is reported, and it is only visible when the queue is full:
+    /// a full queue holds hundreds of records made *before* the drops, so a count picked up at send
+    /// time is attached to the oldest of those and tells a reader the loss happened somewhere it did
+    /// not. Driven through the real `enqueue` with a queue of two, which is the same code path with
+    /// the arithmetic small enough to state.
+    #[test]
+    fn a_dropped_run_is_carried_by_the_record_that_follows_it() {
+        let (tx, rx) = sync_channel::<(Entry, u32)>(2);
+        DROPPED.store(0, Ordering::Relaxed);
+        let record = |message: &str| Entry {
+            seq: 0,
+            at_ms: 1_700_000_000_000,
+            level: Level::Info,
+            target: "windbg_mcp::test".to_string(),
+            session: None,
+            message: message.to_string(),
+        };
+
+        // Two fit.
+        assert!(enqueue(Some(&tx), record("first")));
+        assert!(enqueue(Some(&tx), record("second")));
+        // Three do not, and each refusal is a drop.
+        for lost in ["lost a", "lost b", "lost c"] {
+            assert!(!enqueue(Some(&tx), record(lost)), "the queue was full");
+        }
+        assert_eq!(DROPPED.load(Ordering::Relaxed), 3);
+
+        // Draining one makes room, and the next record through carries the run.
+        let (first, before_first) = rx.recv().expect("the first record");
+        assert_eq!(first.message, "first");
+        assert_eq!(
+            before_first, 0,
+            "the record *ahead* of the gap must not be blamed for it — it was made before the \
+             drops, and marking it moves the reported loss hundreds of records early"
+        );
+        assert!(enqueue(Some(&tx), record("after the gap")));
+        assert_eq!(
+            DROPPED.load(Ordering::Relaxed),
+            0,
+            "the run was handed over, not counted twice"
+        );
+
+        let (second, _) = rx.recv().expect("the second record");
+        assert_eq!(second.message, "second");
+        let (after, carried) = rx.recv().expect("the record after the gap");
+        assert_eq!(after.message, "after the gap");
+        assert_eq!(
+            carried, 3,
+            "the three that were lost, reported where they were lost"
+        );
     }
 
     /// A dropped run is filed as a record of its own, so a gap in a worker's log reads as a gap

--- a/src/logbridge.rs
+++ b/src/logbridge.rs
@@ -522,7 +522,7 @@ mod tests {
         assert!(Level::Debug < Level::Trace);
         let wanted = Level::Warn;
         assert!(Level::Error <= wanted, "an error is at least a warning");
-        assert!(!(Level::Info <= wanted), "info is not at least a warning");
+        assert!(Level::Info > wanted, "info is not at least a warning");
     }
 
     /// The ring drops the oldest, and the drop is *visible*: seq numbers do not restart, so a

--- a/src/logbridge.rs
+++ b/src/logbridge.rs
@@ -1,0 +1,727 @@
+//! Every log record either role produces, in one place a client can read.
+//!
+//! On stdio this was free, and nobody had to build it. A worker's stderr is the supervisor's
+//! (`engine::spawn_worker` inherits it), the supervisor's is the MCP client's, and an operator
+//! asking "why did that session die" finds both in the log file their client already keeps.
+//! `--listen` takes that away: the server is on another machine, and its stderr goes to a console
+//! on that machine. Nothing about HTTP requires that, so it is a regression against stdio rather
+//! than a property of the transport, and it is put back here.
+//!
+//! What is put back is not the stream — it is a **bounded ring of the most recent records**, kept
+//! by the supervisor and served by the `server_log` tool. That shape follows from where the
+//! records have to arrive:
+//!
+//! - **A tool works on both transports.** Nothing here is listener-only, so stdio and HTTP report
+//!   the same thing and there is one code path to be wrong.
+//! - **It answers when the session cannot.** `server_log` is answered by the supervisor and never
+//!   routed to a worker, exactly like `session_status` — which matters, because the case it exists
+//!   for is a session that is wedged, and a tool that queued behind the wedge would be unavailable
+//!   precisely when it is wanted.
+//! - **It reaches a reader stderr never did.** Under stdio these records go to a file the *human*
+//!   can open. The model driving the debugger has never been able to see them at all, and it is
+//!   the one holding the session.
+//!
+//! Deliberately **not** MCP's `notifications/message`. The protocol's logging capability is what
+//! this would otherwise be a few lines of, and it is on its way out: rmcp marks every type in it
+//! `#[deprecated]` for removal (SEP-2577). This server's smoke test also asserts that the
+//! `logging` capability is *not* advertised, on the grounds that advertising what you do not
+//! implement routes real calls into `method_not_found` — so building on it would mean unpicking
+//! that test in order to depend on an API the SDK has announced it is deleting.
+//!
+//! # How a record gets here
+//!
+//! Both roles install [`layer`] under the same [`EnvFilter`](tracing_subscriber::EnvFilter), so
+//! what the ring holds is exactly what stderr shows, and `RUST_LOG` widens both together.
+//!
+//! In the **supervisor** the layer writes straight into the ring. In a **worker** it cannot: the
+//! ring is in the other process. So the layer queues the record and a writer thread mirrors it up
+//! the protocol channel as [`WorkerMessage::Log`](crate::proto::WorkerMessage::Log) — a fact
+//! crossing the pipe as a value, which is the same rule everything else in this server follows.
+//! The supervisor stamps it with the session id on arrival, which is the one thing the worker does
+//! not know and the reader most wants.
+//!
+//! A worker keeps writing to its inherited stderr as well. That copy is not redundant: it is what
+//! an operator standing at the server machine reads, it survives a channel that has already
+//! failed, and — because it is unchanged — the stdio behaviour this module exists to preserve is
+//! preserved by *not touching it*.
+
+use std::cell::Cell;
+use std::collections::VecDeque;
+use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
+use std::sync::mpsc::{Receiver, SyncSender, TrySendError, sync_channel};
+use std::sync::{Mutex, OnceLock};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use tracing::field::{Field, Visit};
+use tracing_subscriber::layer::Context;
+use tracing_subscriber::registry::LookupSpan;
+
+/// Severity, as it crosses the pipe and as `server_log` reports it.
+///
+/// Ordered most severe first, so "at least this severe" is `entry.level <= wanted` — the
+/// comparison the filter actually wants, rather than one spelled backwards at every use.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, JsonSchema,
+)]
+#[serde(rename_all = "lowercase")]
+pub enum Level {
+    Error,
+    Warn,
+    Info,
+    Debug,
+    Trace,
+}
+
+impl Level {
+    fn of(level: &tracing::Level) -> Self {
+        match *level {
+            tracing::Level::ERROR => Self::Error,
+            tracing::Level::WARN => Self::Warn,
+            tracing::Level::INFO => Self::Info,
+            tracing::Level::DEBUG => Self::Debug,
+            tracing::Level::TRACE => Self::Trace,
+        }
+    }
+
+    /// The label a rendered line carries, padded so a column of them lines up.
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Error => "ERROR",
+            Self::Warn => "WARN ",
+            Self::Info => "INFO ",
+            Self::Debug => "DEBUG",
+            Self::Trace => "TRACE",
+        }
+    }
+}
+
+/// One record, as the ring holds it.
+#[derive(Debug, Clone)]
+pub struct Entry {
+    /// Assigned by the ring, in arrival order, and never reused within a run. This is what makes
+    /// `since` paging exact and what makes an eviction visible as a gap.
+    pub seq: u64,
+    /// Milliseconds since the Unix epoch, stamped **where the record happened** — in the worker,
+    /// for a worker's. So `at` and `seq` can disagree by the width of a pipe write, and each is
+    /// right about a different question: `at` when it happened, `seq` the order it was filed.
+    pub at_ms: u64,
+    pub level: Level,
+    /// The `tracing` target, which is what says which half of the server spoke:
+    /// `windbg_mcp::worker` against `windbg_mcp::engine` and friends.
+    pub target: String,
+    /// The session this record is about, for one that came from a worker. `None` is the
+    /// supervisor itself — the registry, the listener, the tool surface.
+    pub session: Option<String>,
+    pub message: String,
+}
+
+/// How many records the ring holds before the oldest is evicted.
+///
+/// Sized for the question it answers — "what happened around the failure I am looking at" — not
+/// for keeping a session's history. A transcript (`WINDBG_MCP_TRANSCRIPT`) is what keeps history,
+/// and it is a file rather than memory for exactly that reason.
+pub const DEFAULT_CAPACITY: usize = 1000;
+
+/// Overrides [`DEFAULT_CAPACITY`], in records. Read once, on first use.
+const CAPACITY_ENV: &str = "WINDBG_MCP_LOG_BUFFER";
+
+/// The most a single record contributes to the ring. A runaway line is clipped rather than
+/// dropped: the point of the cap is that one record cannot cost unbounded memory, and the first
+/// few kilobytes of a line is where its meaning is.
+const MESSAGE_LIMIT: usize = 4096;
+
+/// How many records a worker will hold when the supervisor is not draining fast enough.
+///
+/// Bounded and **dropped when full**, never blocked on. The queue is fed from the engine thread,
+/// which spends its life inside DbgEng, and a log line that could block that thread would be a
+/// worse bug than any it could report.
+const WORKER_QUEUE: usize = 512;
+
+struct Ring {
+    entries: VecDeque<Entry>,
+    next_seq: u64,
+    capacity: usize,
+}
+
+impl Ring {
+    fn new(capacity: usize) -> Self {
+        Self {
+            entries: VecDeque::with_capacity(capacity.min(DEFAULT_CAPACITY)),
+            next_seq: 0,
+            capacity,
+        }
+    }
+
+    /// Files a record, evicting the oldest if the ring is full.
+    fn file(
+        &mut self,
+        level: Level,
+        at_ms: u64,
+        target: String,
+        session: Option<String>,
+        message: String,
+    ) {
+        let seq = self.next_seq;
+        self.next_seq += 1;
+        if self.entries.len() == self.capacity {
+            self.entries.pop_front();
+        }
+        self.entries.push_back(Entry {
+            seq,
+            at_ms,
+            level,
+            target,
+            session,
+            message: clip(message),
+        });
+    }
+
+    fn tail(&self, query: &Query) -> Tail {
+        let matches: Vec<&Entry> = self
+            .entries
+            .iter()
+            .filter(|e| e.level <= query.level)
+            .filter(|e| query.since.is_none_or(|since| e.seq >= since))
+            .filter(|e| match &query.session {
+                Some(wanted) => e.session.as_deref() == Some(wanted.as_str()),
+                None => true,
+            })
+            .collect();
+        let matched = matches.len();
+        let from = matched.saturating_sub(query.limit);
+        Tail {
+            entries: matches[from..].iter().map(|e| (*e).clone()).collect(),
+            matched,
+            next_since: self.next_seq,
+            held: self.entries.len(),
+            capacity: self.capacity,
+            oldest_seq: self.entries.front().map(|e| e.seq),
+        }
+    }
+}
+
+fn ring() -> &'static Mutex<Ring> {
+    static RING: OnceLock<Mutex<Ring>> = OnceLock::new();
+    RING.get_or_init(|| {
+        let capacity = std::env::var(CAPACITY_ENV)
+            .ok()
+            .and_then(|v| v.parse::<usize>().ok())
+            .filter(|n| *n > 0)
+            .unwrap_or(DEFAULT_CAPACITY);
+        Mutex::new(Ring::new(capacity))
+    })
+}
+
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |d| d.as_millis() as u64)
+}
+
+fn clip(mut message: String) -> String {
+    if message.len() <= MESSAGE_LIMIT {
+        return message;
+    }
+    let full = message.len();
+    // On a character boundary, because a message is text and a clip that split a code point would
+    // be a record nothing could read back.
+    let mut cut = MESSAGE_LIMIT;
+    while cut > 0 && !message.is_char_boundary(cut) {
+        cut -= 1;
+    }
+    message.truncate(cut);
+    message.push_str(&format!("… ({full} bytes in all)"));
+    message
+}
+
+/// Files a record in this process's ring.
+fn file(level: Level, at_ms: u64, target: String, session: Option<String>, message: String) {
+    ring()
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .file(level, at_ms, target, session, message);
+}
+
+/// Files a record a worker produced, against the session that worker holds.
+///
+/// `dropped` is what that worker's queue had to throw away since its last record, and it is filed
+/// as a record of its own rather than folded into this one's text. A gap in the log is a fact
+/// about the log, and a reader who is not told about it reads a quiet stretch as nothing having
+/// happened.
+pub fn from_worker(
+    session: &str,
+    at_ms: u64,
+    level: Level,
+    target: &str,
+    message: String,
+    dropped: u32,
+) {
+    if dropped > 0 {
+        file(
+            Level::Warn,
+            at_ms,
+            target.to_string(),
+            Some(session.to_string()),
+            format!(
+                "[windbg-mcp] {dropped} log record(s) from this session's engine worker were \
+                 dropped before the next one — its queue filled faster than the supervisor drained \
+                 it. They are still on the server's stderr."
+            ),
+        );
+    }
+    file(
+        level,
+        at_ms,
+        target.to_string(),
+        Some(session.to_string()),
+        message,
+    );
+}
+
+/// What a reader asked for.
+pub struct Query {
+    /// Only records about this session. A record the supervisor made about a session — spawning
+    /// its worker, timing its call out — carries no session id, so this narrows to what the
+    /// *worker* said.
+    pub session: Option<String>,
+    /// The least severe level to include.
+    pub level: Level,
+    /// Only records filed after this `seq`.
+    pub since: Option<u64>,
+    /// At most this many, taking the most recent.
+    pub limit: usize,
+}
+
+/// What the ring answered with.
+pub struct Tail {
+    /// Oldest first, which is reading order.
+    pub entries: Vec<Entry>,
+    /// How many matched the query before `limit` clipped it.
+    pub matched: usize,
+    /// Pass this as `since` next time to get only what is new. It is the next seq the ring will
+    /// issue, not the last one returned, so a query that matched nothing still advances.
+    pub next_since: u64,
+    /// How many records the ring is holding, and how many it can.
+    pub held: usize,
+    pub capacity: usize,
+    /// The oldest seq still held. A `since` older than this means records were evicted between
+    /// the two calls, which is the only way a reader can find out.
+    pub oldest_seq: Option<u64>,
+}
+
+pub fn tail(query: &Query) -> Tail {
+    ring().lock().unwrap_or_else(|e| e.into_inner()).tail(query)
+}
+
+// ---- the worker's side of the bridge ---------------------------------------
+
+/// The worker's queue. Created by [`layer`] so a record made before the protocol channel exists
+/// is held rather than lost, and drained by [`take_worker_queue`] once there is somewhere to send
+/// it.
+static TO_SUPERVISOR: OnceLock<SyncSender<Entry>> = OnceLock::new();
+static PENDING: Mutex<Option<Receiver<Entry>>> = Mutex::new(None);
+static DROPPED: AtomicU32 = AtomicU32::new(0);
+/// Queued and written, so [`flush`] can tell whether the writer has caught up. Counters rather
+/// than a channel depth, which `SyncSender` does not expose.
+static QUEUED: AtomicU64 = AtomicU64::new(0);
+static WRITTEN: AtomicU64 = AtomicU64::new(0);
+static WRITER_GONE: AtomicBool = AtomicBool::new(false);
+
+thread_local! {
+    /// Set on the worker's log-writer thread. Without it, a failure *inside* the write — which is
+    /// reported with `tracing::error!` — would queue a record for the same thread to write, and a
+    /// broken channel would spin producing reports of itself.
+    static MUTED: Cell<bool> = const { Cell::new(false) };
+}
+
+/// Mirrors this worker's queued records up the protocol channel, on the thread that calls this.
+/// Returns when the channel will take no more, or when the queue's last sender goes — which,
+/// the sender being process-wide, means never in practice: the worker exits under it.
+///
+/// `send` is given a record and however many were dropped before it, and says whether the channel
+/// is still usable. It lives in [`crate::worker`] because the channel does; the accounting lives
+/// here because [`flush`] depends on it.
+pub fn run_worker_writer(mut send: impl FnMut(Entry, u32) -> bool) {
+    MUTED.with(|muted| muted.set(true));
+    let Some(queue) = PENDING.lock().unwrap_or_else(|e| e.into_inner()).take() else {
+        return;
+    };
+    for entry in queue {
+        // Read before the send, and reset: these are the records that were dropped to make room
+        // for the ones already queued ahead of this one, so this is the earliest message that can
+        // truthfully carry them.
+        let dropped = DROPPED.swap(0, Ordering::Relaxed);
+        let usable = send(entry, dropped);
+        WRITTEN.fetch_add(1, Ordering::Relaxed);
+        if !usable {
+            break;
+        }
+    }
+    WRITER_GONE.store(true, Ordering::Relaxed);
+}
+
+/// Waits, up to `within`, for the writer to have mirrored everything queued so far.
+///
+/// Called by a worker on its way out. Without it the records that matter most are the ones most
+/// likely to be lost: the teardown path logs *why* a target was released, and then exits the
+/// process — which is not something a background thread survives.
+pub fn flush(within: std::time::Duration) {
+    let deadline = std::time::Instant::now() + within;
+    while WRITTEN.load(Ordering::Relaxed) < QUEUED.load(Ordering::Relaxed) {
+        if WRITER_GONE.load(Ordering::Relaxed) || std::time::Instant::now() >= deadline {
+            return;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(1));
+    }
+}
+
+// ---- the layer -------------------------------------------------------------
+
+/// Which side of the pipe this process is on.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum Role {
+    /// Files into the ring directly.
+    Supervisor,
+    /// Queues for the writer thread, which mirrors up the protocol channel.
+    Worker,
+}
+
+/// The `tracing` layer both roles install beside the stderr one.
+pub struct Bridge {
+    role: Role,
+}
+
+/// Builds the layer, and — in a worker — the queue behind it.
+pub fn layer(role: Role) -> Bridge {
+    if role == Role::Worker {
+        let (tx, rx) = sync_channel(WORKER_QUEUE);
+        if TO_SUPERVISOR.set(tx).is_ok() {
+            *PENDING.lock().unwrap_or_else(|e| e.into_inner()) = Some(rx);
+        }
+    }
+    Bridge { role }
+}
+
+impl<S> tracing_subscriber::Layer<S> for Bridge
+where
+    S: tracing::Subscriber + for<'a> LookupSpan<'a>,
+{
+    fn on_event(&self, event: &tracing::Event<'_>, _ctx: Context<'_, S>) {
+        if MUTED.with(Cell::get) {
+            return;
+        }
+        let mut rendered = Rendered::default();
+        event.record(&mut rendered);
+        let metadata = event.metadata();
+        let level = Level::of(metadata.level());
+        match self.role {
+            Role::Supervisor => file(
+                level,
+                now_ms(),
+                metadata.target().to_string(),
+                None,
+                rendered.finish(),
+            ),
+            Role::Worker => {
+                let entry = Entry {
+                    seq: 0, // the supervisor's ring assigns it; this side has no sequence
+                    at_ms: now_ms(),
+                    level,
+                    target: metadata.target().to_string(),
+                    session: None, // likewise: a worker does not know its session id
+                    message: clip(rendered.finish()),
+                };
+                let queued = match TO_SUPERVISOR.get() {
+                    Some(queue) => queue.try_send(entry),
+                    None => Err(TrySendError::Disconnected(entry)),
+                };
+                if queued.is_ok() {
+                    QUEUED.fetch_add(1, Ordering::Relaxed);
+                } else {
+                    DROPPED.fetch_add(1, Ordering::Relaxed);
+                }
+            }
+        }
+    }
+}
+
+/// An event's fields as one line, the way the stderr layer would have written them.
+#[derive(Default)]
+struct Rendered {
+    message: String,
+    fields: String,
+}
+
+impl Rendered {
+    fn finish(self) -> String {
+        match (self.message.is_empty(), self.fields.is_empty()) {
+            (_, true) => self.message,
+            (true, false) => self.fields.trim_start().to_string(),
+            (false, false) => format!("{}{}", self.message, self.fields),
+        }
+    }
+
+    fn push(&mut self, field: &Field, value: String) {
+        if field.name() == "message" {
+            self.message = value;
+        } else {
+            self.fields.push_str(&format!(" {}={value}", field.name()));
+        }
+    }
+}
+
+impl Visit for Rendered {
+    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        self.push(field, format!("{value:?}"));
+    }
+
+    fn record_str(&mut self, field: &Field, value: &str) {
+        self.push(field, value.to_string());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A ring of its own, so nothing here depends on the process-wide one — these tests run in
+    /// one process alongside everything else in this crate that logs. It is the *same* type with
+    /// the same `file` and `tail`, so what is asserted below is the shipping code.
+    fn ring_of(capacity: usize, records: &[(Level, Option<&str>, &str)]) -> Ring {
+        let mut ring = Ring::new(capacity);
+        for (level, session, message) in records {
+            ring.file(
+                *level,
+                1_700_000_000_000,
+                "windbg_mcp::test".to_string(),
+                session.map(str::to_string),
+                (*message).to_string(),
+            );
+        }
+        ring
+    }
+
+    fn query() -> Query {
+        Query {
+            session: None,
+            level: Level::Trace,
+            since: None,
+            limit: 100,
+        }
+    }
+
+    /// Severity ordering is what the filter is built on, and it reads backwards from the
+    /// declaration if it is ever reordered: "at least a warning" must include errors.
+    #[test]
+    fn severity_orders_most_severe_first() {
+        assert!(Level::Error < Level::Warn);
+        assert!(Level::Warn < Level::Info);
+        assert!(Level::Info < Level::Debug);
+        assert!(Level::Debug < Level::Trace);
+        let wanted = Level::Warn;
+        assert!(Level::Error <= wanted, "an error is at least a warning");
+        assert!(!(Level::Info <= wanted), "info is not at least a warning");
+    }
+
+    /// The ring drops the oldest, and the drop is *visible*: seq numbers do not restart, so a
+    /// reader holding an older `since` can see that records passed between the two calls.
+    #[test]
+    fn eviction_leaves_a_gap_a_reader_can_see() {
+        let records: Vec<(Level, Option<&str>, String)> = (0..5)
+            .map(|seq| (Level::Info, None, format!("record {seq}")))
+            .collect();
+        let ring = ring_of(
+            3,
+            &records
+                .iter()
+                .map(|(l, s, m)| (*l, *s, m.as_str()))
+                .collect::<Vec<_>>(),
+        );
+        let tail = ring.tail(&query());
+        assert_eq!(tail.held, 3, "the ring holds its capacity and no more");
+        assert_eq!(
+            tail.oldest_seq,
+            Some(2),
+            "0 and 1 were evicted, and the oldest seq says so"
+        );
+        assert_eq!(tail.next_since, 5);
+        let seqs: Vec<u64> = tail.entries.iter().map(|e| e.seq).collect();
+        assert_eq!(seqs, vec![2, 3, 4], "oldest first, which is reading order");
+    }
+
+    /// `since` is the paging contract: a second call with the returned `next_since` must return
+    /// what arrived in between and nothing it has already seen.
+    #[test]
+    fn since_returns_only_what_is_new() {
+        let mut ring = ring_of(10, &[(Level::Info, None, "before")]);
+        let first = ring.tail(&query());
+        assert_eq!(first.entries.len(), 1);
+        assert_eq!(first.next_since, 1);
+
+        ring.file(
+            Level::Info,
+            1_700_000_000_001,
+            "windbg_mcp::test".to_string(),
+            None,
+            "after".to_string(),
+        );
+        let second = ring.tail(&Query {
+            since: Some(first.next_since),
+            ..query()
+        });
+        let messages: Vec<&str> = second.entries.iter().map(|e| e.message.as_str()).collect();
+        assert_eq!(messages, vec!["after"], "only what is new: {messages:?}");
+    }
+
+    /// A query that matches nothing still has to advance, or a caller polling a quiet server
+    /// re-reads the same tail forever.
+    #[test]
+    fn an_empty_page_still_advances() {
+        let ring = ring_of(10, &[(Level::Info, None, "only")]);
+        let tail = ring.tail(&Query {
+            since: Some(1),
+            ..query()
+        });
+        assert!(tail.entries.is_empty());
+        assert_eq!(tail.next_since, 1);
+    }
+
+    /// The level filter is a floor on severity, not an equality test.
+    #[test]
+    fn the_level_filter_is_a_floor() {
+        let ring = ring_of(
+            10,
+            &[
+                (Level::Debug, None, "noise"),
+                (Level::Warn, None, "worth reading"),
+                (Level::Error, None, "worth reading"),
+            ],
+        );
+        let tail = ring.tail(&Query {
+            level: Level::Warn,
+            ..query()
+        });
+        assert_eq!(tail.matched, 2, "warnings and errors, not the debug record");
+        assert!(tail.entries.iter().all(|e| e.level <= Level::Warn));
+    }
+
+    /// Narrowing to a session keeps that worker's records and drops the other's. The
+    /// supervisor's own records carry no session, so they are not "everyone's" — asking about one
+    /// session means asking what that worker said.
+    #[test]
+    fn a_session_filter_keeps_only_that_workers_records() {
+        let ring = ring_of(
+            10,
+            &[
+                (Level::Info, None, "supervisor"),
+                (Level::Info, Some("a"), "worker a"),
+                (Level::Info, Some("b"), "worker b"),
+            ],
+        );
+        let tail = ring.tail(&Query {
+            session: Some("a".to_string()),
+            ..query()
+        });
+        let messages: Vec<&str> = tail.entries.iter().map(|e| e.message.as_str()).collect();
+        assert_eq!(messages, vec!["worker a"]);
+    }
+
+    /// A tail is the *most recent* n, not the first n — the failure being looked at is at the end.
+    #[test]
+    fn a_limit_takes_the_newest_and_says_how_many_it_left() {
+        let records: Vec<String> = (0..5).map(|seq| format!("record {seq}")).collect();
+        let ring = ring_of(
+            10,
+            &records
+                .iter()
+                .map(|m| (Level::Info, None, m.as_str()))
+                .collect::<Vec<_>>(),
+        );
+        let tail = ring.tail(&Query {
+            limit: 2,
+            ..query()
+        });
+        let seqs: Vec<u64> = tail.entries.iter().map(|e| e.seq).collect();
+        assert_eq!(seqs, vec![3, 4]);
+        assert_eq!(tail.matched, 5, "the clip is reported, not hidden");
+    }
+
+    /// A record cannot cost unbounded memory, and clipping must not split a code point — the
+    /// message is text, and half a character is a record nothing can read back.
+    #[test]
+    fn a_runaway_record_is_clipped_on_a_character_boundary() {
+        let long = "é".repeat(MESSAGE_LIMIT);
+        let clipped = clip(long.clone());
+        assert!(clipped.len() < long.len(), "it was clipped");
+        assert!(
+            clipped.contains(&format!("({} bytes in all)", long.len())),
+            "and says what it clipped: {}",
+            &clipped[clipped.len().saturating_sub(40)..]
+        );
+        // The assertion that matters: `clip` returned a `String`, so a split code point would
+        // have panicked in `truncate` — this pins that it did not, in the case that provokes it.
+        assert!(clipped.chars().count() > 1);
+    }
+
+    /// A short record is left exactly alone. Worth pinning because the clip is on the hot path
+    /// for every record the server ever writes.
+    #[test]
+    fn an_ordinary_record_is_untouched() {
+        assert_eq!(clip("session 3: open".to_string()), "session 3: open");
+    }
+
+    /// A dropped run is filed as a record of its own, so a gap in a worker's log reads as a gap
+    /// rather than as a quiet stretch where nothing happened.
+    #[test]
+    fn dropped_worker_records_are_reported_as_a_record() {
+        // Against the process-wide ring, which is the one `from_worker` writes to. Filtered by a
+        // session id nothing else uses, so it does not matter what else has logged.
+        let session = "ring-test-dropped";
+        from_worker(
+            session,
+            1_700_000_000_000,
+            Level::Info,
+            "windbg_mcp::worker",
+            "worker: target released".to_string(),
+            4,
+        );
+        let tail = tail(&Query {
+            session: Some(session.to_string()),
+            ..query()
+        });
+        assert_eq!(tail.entries.len(), 2, "the gap, then the record");
+        assert_eq!(tail.entries[0].level, Level::Warn);
+        assert!(
+            tail.entries[0].message.contains("4 log record(s)"),
+            "it names how many: {}",
+            tail.entries[0].message
+        );
+        assert_eq!(tail.entries[1].message, "worker: target released");
+        assert_eq!(tail.entries[1].session.as_deref(), Some(session));
+    }
+
+    /// An event's own fields are kept beside its message rather than thrown away — the stderr
+    /// layer prints them, so a bridge that dropped them would be reporting less than the log.
+    #[test]
+    fn fields_are_kept_beside_the_message() {
+        let both = Rendered {
+            message: "session ended".to_string(),
+            fields: " id=3".to_string(),
+        };
+        assert_eq!(both.finish(), "session ended id=3");
+
+        let only_fields = Rendered {
+            message: String::new(),
+            fields: " id=3".to_string(),
+        };
+        assert_eq!(only_fields.finish(), "id=3");
+
+        let only_message = Rendered {
+            message: "session ended".to_string(),
+            fields: String::new(),
+        };
+        assert_eq!(only_message.finish(), "session ended");
+    }
+}

--- a/src/logbridge.rs
+++ b/src/logbridge.rs
@@ -366,6 +366,17 @@ pub fn run_worker_writer(mut send: impl FnMut(Entry, u32) -> bool) {
     WRITER_GONE.store(true, Ordering::Relaxed);
 }
 
+/// Serializes taking the drop count with the insertion that carries it.
+///
+/// Not for the counter's sake — the atomics are sound on their own — but for *where the gap is
+/// reported*. Take and insert are two steps, so without this one thread can take a run of drops,
+/// be descheduled, and have another thread enqueue the true first-record-after-the-gap carrying
+/// zero; the marker then lands a record or two late. A lock is affordable precisely because
+/// nothing under it can wait: an atomic swap, a **non-blocking** `try_send`, an atomic add. There
+/// is no I/O in the critical section, and the log-writer thread never enters it (it is muted), so
+/// it cannot be held against the thread that drains it.
+static HANDOFF: Mutex<()> = Mutex::new(());
+
 /// Queues one record, carrying however many were dropped since the last one that got through.
 /// `false` when the queue would not take it, which is itself a drop.
 ///
@@ -373,6 +384,7 @@ pub fn run_worker_writer(mut send: impl FnMut(Entry, u32) -> bool) {
 /// subtracted afterwards: two threads reading the same count would each attach it, and the second
 /// subtraction would wrap the counter past zero into a very large number of imaginary drops.
 fn enqueue(queue: Option<&SyncSender<(Entry, u32)>>, entry: Entry) -> bool {
+    let _in_order = HANDOFF.lock().unwrap_or_else(|e| e.into_inner());
     let carried = DROPPED.swap(0, Ordering::Relaxed);
     let queued = match queue {
         Some(queue) => queue.try_send((entry, carried)).is_ok(),
@@ -387,6 +399,16 @@ fn enqueue(queue: Option<&SyncSender<(Entry, u32)>>, entry: Entry) -> bool {
     queued
 }
 
+/// Takes whatever drops are outstanding, so the caller can report them itself.
+///
+/// Under [`HANDOFF`] like every other transfer of this count: without it, a record being enqueued
+/// concurrently could carry a run this has already taken, and the same drops would be reported
+/// twice.
+fn take_unreported_drops() -> u32 {
+    let _in_order = HANDOFF.lock().unwrap_or_else(|e| e.into_inner());
+    DROPPED.swap(0, Ordering::Relaxed)
+}
+
 /// Waits, up to `within`, for the writer to have mirrored everything queued so far.
 ///
 /// Called by a worker on its way out. Without it the records that matter most are the ones most
@@ -396,7 +418,7 @@ pub fn flush(within: std::time::Duration) {
     // A run of drops is carried by the *next* record to get through, and at exit there may not be
     // one — so this is that record. Taken first, so the count is in the text even if the queue will
     // not take this one either: stderr has it regardless, which is the fallback everywhere here.
-    let unreported = DROPPED.swap(0, Ordering::Relaxed);
+    let unreported = take_unreported_drops();
     if unreported > 0 {
         tracing::warn!(
             "worker: {unreported} log record(s) were dropped and this process is exiting, so \
@@ -514,6 +536,10 @@ impl Visit for Rendered {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The drop counter is process-wide, and two tests below drive it. `cargo test` runs them on
+    /// different threads, so they take turns here rather than reading each other's arithmetic.
+    static COUNTER_TESTS: Mutex<()> = Mutex::new(());
 
     /// A ring of its own, so nothing here depends on the process-wide one — these tests run in
     /// one process alongside everything else in this crate that logs. It is the *same* type with
@@ -711,6 +737,7 @@ mod tests {
     /// the arithmetic small enough to state.
     #[test]
     fn a_dropped_run_is_carried_by_the_record_that_follows_it() {
+        let _mine = COUNTER_TESTS.lock().unwrap_or_else(|e| e.into_inner());
         let (tx, rx) = sync_channel::<(Entry, u32)>(2);
         DROPPED.store(0, Ordering::Relaxed);
         let record = |message: &str| Entry {
@@ -753,6 +780,81 @@ mod tests {
         assert_eq!(
             carried, 3,
             "the three that were lost, reported where they were lost"
+        );
+    }
+
+    /// Under concurrency, every record is either delivered or counted — never both, and never
+    /// neither.
+    ///
+    /// This is the invariant the drop count is *for*, and the one a race would break in the way
+    /// that matters: a double-counted run reports a gap that did not happen, and a lost one reports
+    /// silence where records went missing. Placement can only ever be best-effort — the drops are
+    /// discovered by whoever is refused next — but conservation is exact, and it is what makes the
+    /// number in the marker worth printing.
+    ///
+    /// Driven from several threads against a queue too small for them, which is the only state in
+    /// which any of this arithmetic runs at all.
+    #[test]
+    fn no_record_is_lost_or_counted_twice_when_threads_log_at_once() {
+        const THREADS: usize = 8;
+        const EACH: usize = 250;
+        // Small enough that most attempts are refused, which is the arithmetic under test.
+        let _mine = COUNTER_TESTS.lock().unwrap_or_else(|e| e.into_inner());
+        let (tx, rx) = sync_channel::<(Entry, u32)>(4);
+        DROPPED.store(0, Ordering::Relaxed);
+
+        // Drains as the writers work, so slots keep freeing and the full/not-full boundary is
+        // crossed constantly rather than once.
+        let drained = std::thread::spawn(move || {
+            let mut received = 0u64;
+            let mut reported = 0u64;
+            while let Ok((_, carried)) = rx.recv() {
+                received += 1;
+                reported += u64::from(carried);
+            }
+            (received, reported)
+        });
+
+        let writers: Vec<_> = (0..THREADS)
+            .map(|thread| {
+                let tx = tx.clone();
+                std::thread::spawn(move || {
+                    for n in 0..EACH {
+                        enqueue(
+                            Some(&tx),
+                            Entry {
+                                seq: 0,
+                                at_ms: 1_700_000_000_000,
+                                level: Level::Info,
+                                target: "windbg_mcp::test".to_string(),
+                                session: None,
+                                message: format!("thread {thread} record {n}"),
+                            },
+                        );
+                    }
+                })
+            })
+            .collect();
+        for writer in writers {
+            writer.join().expect("a writer finished");
+        }
+        // The last sender, so the drain ends.
+        drop(tx);
+        let (received, reported) = drained.join().expect("the drain finished");
+        let outstanding = u64::from(take_unreported_drops());
+
+        assert_eq!(
+            received + reported + outstanding,
+            (THREADS * EACH) as u64,
+            "every record made must be delivered, reported as dropped, or still awaiting a report \
+             — {received} delivered + {reported} reported + {outstanding} outstanding is not \
+             {} made",
+            THREADS * EACH
+        );
+        assert!(
+            reported + outstanding > 0,
+            "a queue of 4 against {THREADS} threads must have refused something, or this test is \
+             asserting conservation over a path it never took"
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,7 @@ mod cast;
 mod engine;
 mod kdconn;
 mod listen;
+mod logbridge;
 mod proto;
 mod record;
 mod server;
@@ -63,7 +64,7 @@ fn main() -> Result<()> {
     // engine thread must be free to block in DbgEng indefinitely.
     let args: Vec<String> = std::env::args().collect();
     let is_worker = args.iter().any(|arg| arg == worker::WORKER_FLAG);
-    init_logging();
+    init_logging(is_worker);
     if is_worker {
         // The rest of the command line is the worker's half of the protocol channel — two
         // inherited pipe handles, which is why a worker started by hand cannot get anywhere.
@@ -143,18 +144,31 @@ fn render_cast(args: &[String]) -> Result<()> {
 
 /// stdout is the JSON-RPC transport, so all logging must go to stderr. A worker's stderr is
 /// inherited from the supervisor, so both roles' logs land in the same place an MCP client
-/// already reads.
+/// already reads — when the client is on this machine.
 ///
 /// Targets stay on for both, which is what tells them apart: a worker's records carry
 /// `windbg_mcp::worker`, the supervisor's `windbg_mcp::engine` and friends. Suppressing them for
 /// workers — the first cut here — identified a worker only by the *absence* of a field, which is
 /// no help at all when two processes are interleaving lines in one stream.
-fn init_logging() {
-    tracing_subscriber::fmt()
-        .with_writer(std::io::stderr)
-        .with_env_filter(
-            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
-        )
+///
+/// Two layers, not one, and under a **single** filter. Stderr is unchanged and stays the local
+/// operator's view; [`logbridge`] is the copy a client reads with `server_log`, which is what
+/// makes the records reachable when the client is on another machine (`--listen`). Sharing the
+/// filter is deliberate: the tool then shows exactly what the log shows, and `RUST_LOG` widens
+/// both together rather than one of them silently.
+fn init_logging(is_worker: bool) {
+    use tracing_subscriber::layer::SubscriberExt;
+    use tracing_subscriber::util::SubscriberInitExt;
+
+    let role = if is_worker {
+        logbridge::Role::Worker
+    } else {
+        logbridge::Role::Supervisor
+    };
+    tracing_subscriber::registry()
+        .with(EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")))
+        .with(tracing_subscriber::fmt::layer().with_writer(std::io::stderr))
+        .with(logbridge::layer(role))
         .init();
 }
 

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -673,6 +673,31 @@ pub enum WorkerMessage {
         id: u64,
         result: Result<Output, Failed>,
     },
+    /// One of this worker's own `tracing` records, mirrored so the supervisor owns every record
+    /// either process made — see [`crate::logbridge`] for why that is worth a message.
+    ///
+    /// The only variant that belongs to **no request**, which is what it is: a worker logs from
+    /// its engine thread, from its request reader, and from paths that run after every request is
+    /// answered. It is intercepted where the channel is read and never reaches the routing that
+    /// the rest of these go through, because there is no `id` to route it by.
+    ///
+    /// The worker still writes the same record to its inherited stderr. This copy is not that one
+    /// arriving by another road: it is the one that can be read from the *client's* machine.
+    Log {
+        /// Milliseconds since the Unix epoch, stamped in the worker — where it happened, which is
+        /// not where it is filed.
+        at_ms: u64,
+        level: crate::logbridge::Level,
+        /// The `tracing` target, kept rather than assumed: a worker's records are not all
+        /// `windbg_mcp::worker`, and the one from a dependency is the one worth seeing whole.
+        target: String,
+        message: String,
+        /// Records this worker had to drop before this one, its queue having filled. Zero on
+        /// every ordinary message — a gap in a log has to be reported, or a reader takes it for a
+        /// stretch where nothing happened.
+        #[serde(default)]
+        dropped: u32,
+    },
 }
 
 /// A failed op, as it crosses the pipe.

--- a/src/record.rs
+++ b/src/record.rs
@@ -952,7 +952,7 @@ fn mint_run_id() -> u64 {
 /// Written out rather than pulled in: the crate has no date dependency, this is the only place
 /// that needs one, and the arithmetic below is the whole of it. Days are converted with the
 /// civil-from-days algorithm, which is exact for every date a file's timestamp can hold.
-fn rfc3339(at: SystemTime) -> String {
+pub fn rfc3339(at: SystemTime) -> String {
     let since = at.duration_since(UNIX_EPOCH).unwrap_or(Duration::ZERO);
     let secs = since.as_secs();
     let (days, rem) = ((secs / 86_400) as i64, secs % 86_400);

--- a/src/server.rs
+++ b/src/server.rs
@@ -4437,7 +4437,7 @@ mod tests {
 
     /// Only a tool that structurally cannot reach the network may say so. Everything that
     /// touches a target can trigger a PDB download, and over KDNET the target itself is
-    /// remote — leaving the two that never reach the engine at all.
+    /// remote — leaving the three that never reach the engine at all.
     #[test]
     fn only_the_tools_that_cannot_reach_the_network_are_closed_world() {
         let closed: Vec<String> = WindbgServer::tool_router()
@@ -4451,7 +4451,7 @@ mod tests {
             .map(|t| t.name.to_string())
             .collect();
 
-        assert_eq!(closed, ["decode_ioctl", "session_status"]);
+        assert_eq!(closed, ["decode_ioctl", "server_log", "session_status"]);
     }
 
     /// Session-scoped tools take a handle; the two that are genuinely session-independent
@@ -4474,8 +4474,9 @@ mod tests {
             "end_session",
             "modules",
             "debug_batch",
-            // Takes one to ask *about*, not to be checked against.
+            // These two take one to ask *about*, not to be checked against.
             "session_status",
+            "server_log",
         ] {
             assert!(takes_session(name), "`{name}` should accept session_id");
         }

--- a/src/server.rs
+++ b/src/server.rs
@@ -164,6 +164,114 @@ fn ms(d: Duration) -> u64 {
     d.as_millis().min(u128::from(u64::MAX)) as u64
 }
 
+/// How many records `server_log` returns when the caller does not say.
+const DEFAULT_LOG_RECORDS: u32 = 50;
+
+/// The most it will return in one call.
+///
+/// A page rather than the buffer. The buffer is a thousand records by design — enough to hold the
+/// run-up to a failure — and the reader on the other end of a tool result has a context window.
+const MAX_LOG_RECORDS: u32 = 500;
+
+/// [`crate::logbridge::Tail`] as the typed half of a `server_log` result.
+fn log_report(tail: &crate::logbridge::Tail) -> structured::LogReport {
+    structured::LogReport {
+        records: tail
+            .entries
+            .iter()
+            .map(|e| structured::LogRecord {
+                seq: e.seq,
+                at: crate::record::rfc3339(std::time::UNIX_EPOCH + Duration::from_millis(e.at_ms)),
+                level: e.level,
+                session_id: e.session.clone(),
+                target: e.target.clone(),
+                message: e.message.clone(),
+            })
+            .collect(),
+        matched: tail.matched.min(u32::MAX as usize) as u32,
+        next_since: tail.next_since,
+        held: tail.held.min(u32::MAX as usize) as u32,
+        capacity: tail.capacity.min(u32::MAX as usize) as u32,
+        oldest_seq: tail.oldest_seq,
+    }
+}
+
+/// The module part of a `tracing` target, which is what a reader is actually distinguishing:
+/// `windbg_mcp::worker` against `windbg_mcp::engine`. The full target is kept in the typed half.
+fn short_target(target: &str) -> &str {
+    target.rsplit("::").next().unwrap_or(target)
+}
+
+/// One record as a line: when, how bad, who said it, and what it said.
+fn describe_record(e: &crate::logbridge::Entry) -> String {
+    let at = crate::record::rfc3339(std::time::UNIX_EPOCH + Duration::from_millis(e.at_ms));
+    let source = match &e.session {
+        Some(id) => format!("{}/{id}", short_target(&e.target)),
+        None => short_target(&e.target).to_string(),
+    };
+    format!("{at} {} {source}: {}", e.level.label(), e.message)
+}
+
+/// A page of the log, with the facts about the *buffer* a reader cannot get from the records —
+/// which is what separates "nothing happened" from "it scrolled past".
+///
+/// Free function so the wording tests without a debugger, like [`describe_session`].
+fn describe_log(tail: &crate::logbridge::Tail, query: &crate::logbridge::Query) -> String {
+    let level = query.level.label().trim().to_lowercase();
+    let scope = match &query.session {
+        Some(id) => format!(" about session {id}"),
+        None => String::new(),
+    };
+    let mut out = String::new();
+    if tail.entries.is_empty() {
+        out.push_str(&format!("No log records{scope} at {level} or above.\n"));
+        if query.session.is_some() {
+            out.push_str(
+                "Only what a session's own engine worker logged carries its session id — records \
+                 the supervisor made *about* that session (spawning its worker, timing a call \
+                 out, the worker dying) do not. Ask again without `session_id` to see those; that \
+                 is also the only way to see an open that failed before there was a session.\n",
+            );
+        }
+        if tail.held > 0 {
+            out.push_str(&format!(
+                "The buffer holds {} record(s) that this filter excluded.\n",
+                tail.held
+            ));
+        }
+    } else {
+        out.push_str(&format!(
+            "{} of {} record(s){scope} at {level} or above, oldest first:\n\n",
+            tail.entries.len(),
+            tail.matched
+        ));
+        for e in &tail.entries {
+            out.push_str(&describe_record(e));
+            out.push('\n');
+        }
+    }
+    out.push_str(&format!(
+        "\nBuffer: {} of {} record(s) held. Pass `since: {}` next time for only what is new.\n\
+         This is the same stream as the server's stderr, so it holds nothing below the level the \
+         server was started with — widen it with `RUST_LOG` (and restart) rather than with \
+         `level` here.",
+        tail.held, tail.capacity, tail.next_since
+    ));
+    // The one thing a caller paging through *must* be told, because their next page would
+    // otherwise silently skip a stretch and read as a quiet one.
+    if let (Some(since), Some(oldest)) = (query.since, tail.oldest_seq)
+        && oldest > since
+    {
+        out.push_str(&format!(
+            "\n[!] Records before seq {oldest} were evicted since your last call, so this page \
+             starts later than the `since` you asked for. The buffer holds the most recent \
+             {} records; ask sooner, or raise it with WINDBG_MCP_LOG_BUFFER.",
+            tail.capacity
+        ));
+    }
+    out
+}
+
 /// The session an open ended up with, for the outcomes that have one.
 ///
 /// A `match` rather than a chain of `if let`s, so a new [`OpenError`] variant is a compile error
@@ -1368,6 +1476,29 @@ pub struct SessionArgs {
     pub session_id: Option<String>,
 }
 
+/// Parameters for `server_log`.
+#[derive(Deserialize, JsonSchema)]
+pub struct LogArgs {
+    /// Only records about this session — what its engine worker logged. The supervisor's own
+    /// records about that session (spawning its worker, timing a call out) carry no session id
+    /// and are excluded, so omit this when tracing a session that failed to *open*.
+    #[serde(default)]
+    pub session_id: Option<String>,
+    /// The least severe level to include; more severe records are always included. Defaults to
+    /// `info`, which is what the server logs unless `RUST_LOG` says otherwise — asking for
+    /// `debug` or `trace` on a server started without them returns nothing, because records
+    /// below the filter are never made in the first place.
+    #[serde(default)]
+    pub level: Option<crate::logbridge::Level>,
+    /// How many records to return, most recent last. Defaults to 50, capped at 500.
+    #[serde(default)]
+    pub limit: Option<u32>,
+    /// Return only records filed after this point — pass back the `next_since` from the previous
+    /// call to see what has happened since, without re-reading what you already have.
+    #[serde(default)]
+    pub since: Option<u64>,
+}
+
 /// Parameters for `modules`.
 #[derive(Deserialize, JsonSchema)]
 pub struct ModulesArgs {
@@ -2297,15 +2428,15 @@ impl WindbgServer {
 // ---- Tools ---------------------------------------------------------------
 //
 // On `open_world_hint`: everything that touches a debug target is open-world, and only
-// `decode_ioctl` (pure arithmetic on a control code) and `session_status` (a read of this
-// server's own state) are not. Two independent reasons put the rest over the line. A symbol server on the symbol
+// `decode_ioctl` (pure arithmetic on a control code), `session_status` and `server_log` (reads of
+// this server's own state) are not. Two independent reasons put the rest over the line. A symbol server on the symbol
 // path (the documented, recommended setup) means almost any command can make DbgEng
 // download a PDB, and not only the obvious symbol-pattern queries: `r` symbolizes the
 // current instruction, `k` symbolizes every frame, `bp module!Symbol` resolves a name.
 // And a session opened over KDNET puts the *target itself* on the far side of a network
 // link, so even `read_memory` fetching raw bytes, or `end_session` releasing the target,
-// is remote traffic. That leaves `decode_ioctl` and `session_status`, the two that never
-// reach the engine at all. Claiming otherwise would tell a client the tool cannot touch
+// is remote traffic. That leaves `decode_ioctl`, `session_status` and `server_log`, the three
+// that never reach the engine at all. Claiming otherwise would tell a client the tool cannot touch
 // the network and let it skip whatever consent that decision gates.
 
 #[rmcp::tool_router]
@@ -2966,6 +3097,49 @@ impl WindbgServer {
             describe_session(session),
             sessions_report(&[session], Some(asked), false),
         )
+    }
+
+    /// Read this server's own log — the supervisor's records and every engine worker's, tagged
+    /// with the session each one belongs to. This is the *server's* diagnostics, not the target's.
+    ///
+    /// Ask when something happened that a tool result cannot explain: a call that timed out, a
+    /// session that failed to open, a worker that died, a target released by a path nobody asked
+    /// for. The records name which of the two processes spoke and when.
+    ///
+    /// Answers even while a session is parked or wedged: it reads a buffer this server keeps and
+    /// never queues on any session's engine. Only the most recent records are held (1000 by
+    /// default) — `next_since` pages forward, and a `since` older than `oldest_seq` means records
+    /// were evicted in between.
+    ///
+    /// The level filter cannot reach below what the server was started to log, which is `info`
+    /// unless `RUST_LOG` says otherwise: records below that are never made, so asking for them
+    /// returns nothing rather than more.
+    #[rmcp::tool(
+        annotations(
+            title = "Read the server's log",
+            read_only_hint = true,
+            open_world_hint = false
+        ),
+        output_schema = schema_for_output::<Outcome<structured::LogReport>>()
+    )]
+    async fn server_log(
+        &self,
+        Parameters(args): Parameters<LogArgs>,
+    ) -> Result<CallToolResult, ErrorData> {
+        // Never routed to a worker, for the same reason `session_status` is not: the case this
+        // exists for is a session nothing can be asked of, and a tool that queued behind it would
+        // be unavailable exactly when it is wanted.
+        let query = crate::logbridge::Query {
+            session: args.session_id.clone(),
+            level: args.level.unwrap_or(crate::logbridge::Level::Info),
+            since: args.since,
+            limit: args
+                .limit
+                .unwrap_or(DEFAULT_LOG_RECORDS)
+                .min(MAX_LOG_RECORDS) as usize,
+        };
+        let tail = crate::logbridge::tail(&query);
+        structured_result(describe_log(&tail, &query), log_report(&tail))
     }
 
     /// Stop the operation a session is currently running, **keeping the session and its target**.

--- a/src/server.rs
+++ b/src/server.rs
@@ -196,10 +196,16 @@ fn log_report(tail: &crate::logbridge::Tail) -> structured::LogReport {
     }
 }
 
-/// The module part of a `tracing` target, which is what a reader is actually distinguishing:
-/// `windbg_mcp::worker` against `windbg_mcp::engine`. The full target is kept in the typed half.
+/// A `tracing` target as a line prefix: this crate's own shortened to the module, everything
+/// else left whole.
+///
+/// Only the leading `windbg_mcp::` comes off, and the asymmetry is the point. Taking the *last*
+/// segment of every target reads well until a dependency logs — `rmcp::handler::server` and this
+/// crate's `server` then both render as `server`, which is worse than long, because the reader
+/// cannot tell whose record they are looking at. The full target is kept in the typed half either
+/// way.
 fn short_target(target: &str) -> &str {
-    target.rsplit("::").next().unwrap_or(target)
+    target.strip_prefix("windbg_mcp::").unwrap_or(target)
 }
 
 /// One record as a line: when, how bad, who said it, and what it said.
@@ -4725,6 +4731,135 @@ mod tests {
         ));
         assert!(out.contains("0x80070002"), "{out}");
         assert!(out.contains("Nothing was created"), "{out}");
+    }
+
+    // ---- the server's own log ------------------------------------------
+
+    fn log_entry(
+        level: crate::logbridge::Level,
+        session: Option<&str>,
+        target: &str,
+    ) -> crate::logbridge::Entry {
+        crate::logbridge::Entry {
+            seq: 7,
+            at_ms: 1_770_000_000_000,
+            level,
+            target: target.to_string(),
+            session: session.map(str::to_string),
+            message: "a thing happened".to_string(),
+        }
+    }
+
+    /// Only this crate's own targets are shortened. Taking the last segment of every target — the
+    /// first cut here — rendered `rmcp::handler::server` and this crate's `server` identically,
+    /// which loses the one thing the prefix is there to say.
+    #[test]
+    fn a_foreign_target_is_not_shortened_into_one_of_ours() {
+        assert_eq!(short_target("windbg_mcp::worker"), "worker");
+        assert_eq!(short_target("windbg_mcp::server"), "server");
+        assert_eq!(
+            short_target("rmcp::handler::server"),
+            "rmcp::handler::server"
+        );
+        assert_ne!(
+            short_target("rmcp::handler::server"),
+            short_target("windbg_mcp::server"),
+            "two different sources must not render as the same prefix"
+        );
+    }
+
+    /// A record says which session it belongs to in the line itself, not only in the typed half —
+    /// the text is what a person reads, and a worker's record is meaningless without it.
+    #[test]
+    fn a_workers_record_carries_its_session_in_the_line() {
+        let line = describe_record(&log_entry(
+            crate::logbridge::Level::Warn,
+            Some("sess-abc-1"),
+            "windbg_mcp::worker",
+        ));
+        assert!(line.contains("worker/sess-abc-1"), "{line}");
+        assert!(line.contains("WARN"), "{line}");
+        assert!(line.contains("a thing happened"), "{line}");
+        // The supervisor's own records have no session, and must not invent one.
+        let supervisor = describe_record(&log_entry(
+            crate::logbridge::Level::Info,
+            None,
+            "windbg_mcp::engine",
+        ));
+        assert!(
+            supervisor.contains("engine: a thing happened"),
+            "{supervisor}"
+        );
+        assert!(!supervisor.contains('/'), "{supervisor}");
+    }
+
+    /// An empty page is the answer most likely to be misread, so it has to explain itself: why
+    /// there is nothing, and what to ask instead.
+    #[test]
+    fn an_empty_page_says_why_it_is_empty() {
+        let tail = crate::logbridge::Tail {
+            entries: Vec::new(),
+            matched: 0,
+            next_since: 12,
+            held: 12,
+            capacity: 1000,
+            oldest_seq: Some(0),
+        };
+        let query = crate::logbridge::Query {
+            session: Some("sess-abc-1".to_string()),
+            level: crate::logbridge::Level::Info,
+            since: None,
+            limit: 50,
+        };
+        let out = describe_log(&tail, &query);
+        assert!(
+            out.contains("No log records about session sess-abc-1"),
+            "{out}"
+        );
+        assert!(
+            out.contains("without `session_id`"),
+            "an empty session page has to name the filter that would show the supervisor's own \
+             records about that session: {out}"
+        );
+        assert!(
+            out.contains("12 record(s) that this filter excluded"),
+            "{out}"
+        );
+    }
+
+    /// A caller paging with `since` has to be told when the buffer moved past them, or their next
+    /// page silently skips a stretch and reads as a quiet one.
+    #[test]
+    fn a_page_that_missed_records_says_so() {
+        let tail = crate::logbridge::Tail {
+            entries: vec![log_entry(
+                crate::logbridge::Level::Info,
+                None,
+                "windbg_mcp::engine",
+            )],
+            matched: 1,
+            next_since: 400,
+            held: 100,
+            capacity: 100,
+            oldest_seq: Some(300),
+        };
+        let caught_up = crate::logbridge::Query {
+            session: None,
+            level: crate::logbridge::Level::Info,
+            since: Some(350),
+            limit: 50,
+        };
+        assert!(
+            !describe_log(&tail, &caught_up).contains("were evicted"),
+            "a cursor the buffer still covers is not a gap"
+        );
+        let left_behind = crate::logbridge::Query {
+            since: Some(2),
+            ..caught_up
+        };
+        let out = describe_log(&tail, &left_behind);
+        assert!(out.contains("before seq 300 were evicted"), "{out}");
+        assert!(out.contains("WINDBG_MCP_LOG_BUFFER"), "{out}");
     }
 
     #[test]

--- a/src/structured.rs
+++ b/src/structured.rs
@@ -285,6 +285,48 @@ pub struct SessionsReport {
     pub unknown_handle: bool,
 }
 
+/// What `server_log` reports: a page of the server's own log, and enough about the ring behind it
+/// to tell "nothing happened" from "it scrolled past".
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct LogReport {
+    /// Oldest first, which is reading order.
+    pub records: Vec<LogRecord>,
+    /// How many matched the filter before `limit` clipped it. Greater than `records.len()` means
+    /// the oldest matches were left behind, not that they do not exist.
+    pub matched: u32,
+    /// Pass as `since` next time to get only what is new. It advances even when this page is
+    /// empty, so polling a quiet server does not re-read the same tail.
+    pub next_since: u64,
+    /// How many records the buffer holds, and how many it can. Set the capacity with
+    /// `WINDBG_MCP_LOG_BUFFER`.
+    pub held: u32,
+    pub capacity: u32,
+    /// The oldest `seq` still buffered. A `since` older than this is the only way to find out
+    /// that records were evicted between two calls.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub oldest_seq: Option<u64>,
+}
+
+/// One log record.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct LogRecord {
+    /// Filing order within this server run, gapless unless records were evicted.
+    pub seq: u64,
+    /// When it was logged, in the process that logged it — RFC 3339, UTC, to the millisecond.
+    /// A worker's record is stamped in the worker, so `at` and `seq` can disagree by the width of
+    /// a pipe write: `at` says when, `seq` says in what order it was filed.
+    pub at: String,
+    pub level: crate::logbridge::Level,
+    /// The session a worker's record is about. Absent for the supervisor's own records — the
+    /// session registry, the listener, the tool surface — which are *about* sessions without
+    /// belonging to one.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+    /// The `tracing` target, which says which part of the server spoke.
+    pub target: String,
+    pub message: String,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct SessionInfo {
     pub session_id: String,

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -509,6 +509,7 @@ pub fn run(args: &[String]) -> ! {
     }
     // Installed before the engine thread exists, so nothing can reach `emit` without a channel.
     let _ = MESSAGES.set(Mutex::new(messages));
+    start_log_writer();
 
     // Each request is stamped when it is *read*, so the engine thread can tell how long it then
     // waited its turn — the half of the watchdog budget only this process can measure.
@@ -523,6 +524,7 @@ pub fn run(args: &[String]) -> ! {
         emit(&WorkerMessage::Fatal {
             message: format!("could not start the engine thread: {e}"),
         });
+        crate::logbridge::flush(LOG_FLUSH);
         std::process::exit(1);
     }
 
@@ -631,7 +633,49 @@ pub fn run(args: &[String]) -> ! {
             }
         }
     }
+    // Everything above is the account of a teardown nobody asked for, and it is the account most
+    // worth reading — so it goes up the channel before this process stops existing. Bounded, and
+    // last: a flush that held the exit open would be a worse bug than a lost log line.
+    crate::logbridge::flush(LOG_FLUSH);
     std::process::exit(0);
+}
+
+/// How long a worker will wait, on its way out, for its log records to reach the supervisor.
+///
+/// Small on purpose. The records are already on this process's stderr; what this buys is the
+/// copy a client on another machine can read ([`crate::logbridge`]), and no diagnostic is worth
+/// delaying the release of a debug target for.
+const LOG_FLUSH: Duration = Duration::from_millis(250);
+
+/// Starts the thread that mirrors this worker's `tracing` records up the protocol channel.
+///
+/// A thread of its own because the alternative is writing them from wherever they are logged —
+/// which is mostly the engine thread, inside DbgEng, where a pipe that has filled would block the
+/// debugger on a log line. Queued and dropped when full instead; the drops are counted and
+/// reported rather than swallowed.
+fn start_log_writer() {
+    let started = thread::Builder::new().name("logs".into()).spawn(|| {
+        crate::logbridge::run_worker_writer(|entry, dropped| {
+            !matches!(
+                emit(&WorkerMessage::Log {
+                    at_ms: entry.at_ms,
+                    level: entry.level,
+                    target: entry.target,
+                    message: entry.message,
+                    dropped,
+                }),
+                Emit::Unwritable
+            )
+        });
+    });
+    if let Err(e) = started {
+        // Not fatal, and not silent: the session works, and its records still reach this
+        // process's stderr — they just stop reaching a client that is not on this machine.
+        tracing::warn!(
+            "worker: could not start the log writer ({e}); this session's log records will not \
+             reach the client, only the server's own stderr"
+        );
+    }
 }
 
 /// Owns the [`DebugEngine`] for the life of the process and runs one op at a time.
@@ -648,6 +692,7 @@ fn engine_thread(rx: mpsc::Receiver<Job>) {
                 message: "failed to initialize DbgEng (is dbgeng.dll on the search path?)"
                     .to_string(),
             });
+            crate::logbridge::flush(LOG_FLUSH);
             std::process::exit(1);
         }
     };

--- a/tests/golden/tools_list.json
+++ b/tests/golden/tools_list.json
@@ -3,7 +3,7 @@
     "(none)",
     "https://json-schema.org/draft/2020-12/schema"
   ],
-  "toolCount": 50,
+  "toolCount": 51,
   "tools": [
     {
       "hints": {
@@ -1084,6 +1084,42 @@
         "address"
       ],
       "title": "Run to address"
+    },
+    {
+      "hints": {
+        "destructive": null,
+        "idempotent": null,
+        "openWorld": false,
+        "readOnly": true
+      },
+      "name": "server_log",
+      "output": {
+        "branches": [
+          {
+            "payload": "#/$defs/LogReport",
+            "required": [
+              "status"
+            ],
+            "status": "ok"
+          },
+          {
+            "payload": "#/$defs/Failure",
+            "required": [
+              "status"
+            ],
+            "status": "error"
+          }
+        ],
+        "dialect": "https://json-schema.org/draft/2020-12/schema"
+      },
+      "params": [
+        "level: enum[\"error\"|\"warn\"|\"info\"|\"debug\"|\"trace\"]|null",
+        "limit: integer|null/uint32",
+        "session_id: string|null",
+        "since: integer|null/uint64"
+      ],
+      "required": [],
+      "title": "Read the server's log"
     },
     {
       "hints": {

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -1229,6 +1229,72 @@ fn a_tool_call_round_trips_over_the_wire() {
     }
 }
 
+/// The server's own log, read back through a tool.
+///
+/// In the base tier because the thing being checked is not the debugger: it is that a record this
+/// process wrote to stderr is *also* reachable over the transport. That property is what
+/// `--listen` needs and stdio got for free — the server's stderr is the client's log only while
+/// the two are on one machine — so it has to be asserted somewhere that a client can see, which
+/// means over the wire.
+#[test]
+fn the_servers_own_log_is_readable_over_the_transport() {
+    let mut server = Server::started();
+    let page = server.tool_data("server_log", json!({}), STEP);
+    let records = page["records"]
+        .as_array()
+        .unwrap_or_else(|| panic!("server_log returns records: {page}"))
+        .clone();
+    assert!(
+        !records.is_empty(),
+        "the server logs its own startup, so a bare `server_log` cannot be empty: {page}"
+    );
+    assert!(
+        records.iter().any(|r| r["target"]
+            .as_str()
+            .is_some_and(|t| t.starts_with("windbg_mcp"))),
+        "the records must be this server's own, keyed by tracing target: {records:?}"
+    );
+    assert!(
+        page["capacity"].as_u64().unwrap_or(0) > 0,
+        "a report has to say how much the buffer holds: {page}"
+    );
+
+    // `since` is the paging contract, and it is the half a poller depends on: a second call with
+    // the returned cursor must not re-serve what the first one already handed over.
+    let cursor = page["next_since"]
+        .as_u64()
+        .unwrap_or_else(|| panic!("server_log returns a cursor: {page}"));
+    let next = server.tool_data("server_log", json!({ "since": cursor }), STEP);
+    for record in next["records"].as_array().into_iter().flatten() {
+        assert!(
+            record["seq"].as_u64().unwrap_or(0) >= cursor,
+            "a `since` page must contain nothing older than its cursor: {record}"
+        );
+    }
+
+    // A filter that matches nothing answers with an empty page rather than an error — asking
+    // after a session that is gone is a fair question with a definite answer.
+    let none = server.tool_data(
+        "server_log",
+        json!({ "session_id": "sess-not-a-real-handle" }),
+        STEP,
+    );
+    assert!(
+        none["records"].as_array().is_some_and(Vec::is_empty),
+        "no session, no records: {none}"
+    );
+
+    // The level filter is a floor on severity, so asking for errors must not hand back the info
+    // records above.
+    let errors = server.tool_data("server_log", json!({ "level": "error" }), STEP);
+    for record in errors["records"].as_array().into_iter().flatten() {
+        assert_eq!(
+            record["level"], "error",
+            "`level: error` returned something less severe: {record}"
+        );
+    }
+}
+
 /// The session transcript, end to end through the shipped binary: recorded by a real server
 /// process over a real stdio connection, read back as JSONL, and rendered as an asciicast.
 ///
@@ -1885,6 +1951,72 @@ fn a_dump_session_opens_reads_and_closes() {
         is_tool_error(&after) || !after["error"].is_null(),
         "a handle from an ended session must be refused, got {after}"
     );
+}
+
+/// A record made in the **engine worker** reaches the client, tagged with the session that made
+/// it.
+///
+/// The one claim about the log bridge that only two real processes can settle. A worker's
+/// `tracing` output has always gone to its inherited stderr, which is the supervisor's — and on
+/// stdio that is the client's log, so nothing had to carry it. Under `--listen` the client is on
+/// another machine and that inheritance reaches nobody, so the record has to cross the pipe as a
+/// value (`WorkerMessage::Log`) and be filed against a session id only the supervisor knows. In
+/// process there is no second process, and no session for a record to be tagged with; here there
+/// are both.
+///
+/// Hung off the teardown because that is the path a healthy session is *guaranteed* to log on:
+/// the worker reads EOF, says it is releasing the target before exit, and flushes on its way out
+/// — which is also the record most worth having, being the account of a teardown nobody asked
+/// for.
+#[test]
+fn a_workers_log_records_reach_the_client_tagged_with_their_session() {
+    let Some(dump) = target_tier() else { return };
+    let mut server = Server::started();
+    let session_id = server.open_session("open_dump", json!({ "path": dump }), TARGET_STEP);
+    server.tool_data(
+        "end_session",
+        json!({ "session_id": session_id }),
+        TARGET_STEP,
+    );
+
+    // Polled rather than read once: `end_session` answers when the target is released, and the
+    // worker's exit records are written after that, by a different process. The order of those
+    // two is not something this test gets to assume.
+    let deadline = Instant::now() + Duration::from_secs(15);
+    loop {
+        let page = server.tool_data(
+            "server_log",
+            json!({ "session_id": session_id, "limit": 200 }),
+            STEP,
+        );
+        let records = page["records"].as_array().cloned().unwrap_or_default();
+        if !records.is_empty() {
+            for record in &records {
+                assert_eq!(
+                    record["session_id"], session_id,
+                    "a session filter must not hand back another session's records: {record}"
+                );
+            }
+            assert!(
+                records.iter().any(|r| r["target"] == "windbg_mcp::worker"),
+                "these have to be the worker's own records, not the supervisor's about it: \
+                 {records:?}"
+            );
+            assert!(
+                records
+                    .iter()
+                    .any(|r| r["message"].as_str().is_some_and(|m| m.contains("worker:"))),
+                "and to carry what the worker actually said: {records:?}"
+            );
+            return;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "no record from session {session_id}'s engine worker reached the client within 15s \
+             of its teardown — the bridge is not carrying them: {page}"
+        );
+        std::thread::sleep(Duration::from_millis(250));
+    }
 }
 
 /// An open answers the three questions it is asked every time — which build, where the target's

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -13,12 +13,18 @@
 //! Five tiers, so the cheap one can ride `cargo test` everywhere:
 //!
 //! * **Protocol** (default) — spawns the server, speaks JSON-RPC. No debugger target, no
-//!   symbols, no network.
+//!   symbols, no network. This tier also drives the **listener** (`--listen`) over real HTTP on a
+//!   loopback port: the bearer check, the `409` that keeps it to one client at a time, and the
+//!   difference between a client going quiet and a client saying goodbye. Those need no debugger,
+//!   because the lease is decided before any session is opened — but the sweep meeting a real
+//!   engine worker does, so that half lives in the tier below.
 //! * **Target** (`WINDBG_MCP_SMOKE_DUMP=1`) — opens the sample crash dump through DbgEng, so
 //!   it needs `dbgeng.dll` and may reach a symbol server. Off by default; this is the tier
 //!   that catches a `win-kexp` regression. It also runs a `debug_batch` to both outcomes, and
 //!   through both teardowns — an `end_session` and a client disconnect landing mid-transaction —
-//!   because "the rollback ran inside the worker" is a claim only a real engine can settle.
+//!   because "the rollback ran inside the worker" is a claim only a real engine can settle. And
+//!   it waits out a **lease expiry** against a parked kernel attach, which is the listener's
+//!   answer to a closed stdin and the one claim there that costs a target when it is wrong.
 //! * **Bounded command** (`#[ignore]`d, run by hand) — deliberately runs away and waits out a
 //!   watchdog, so it is measured in minutes rather than seconds. It lives here rather than
 //!   beside the budget arithmetic in `src/engine.rs` because the two halves it proves are now
@@ -1765,6 +1771,495 @@ fn a_profiles_key_never_reaches_a_session_transcript() {
 fn tool_text_refuses_to_hand_back_a_failed_call() {
     let mut server = Server::started();
     server.tool_text("go", json!({}), STEP);
+}
+
+// ---- tier 1: the listener and its lease ---------------------------------------
+//
+// `--listen` gives up the one property stdio has for free: a closed stdin means the client is
+// *definitively* gone, and every target is released. Over HTTP a silent client is
+// indistinguishable from one that is thinking, so a **lease** stands in for that moment — and the
+// lease is the only part of this server whose failures cost a *target* rather than a call.
+//
+// Every rule of it has unit tests in `src/listen.rs`, against the state machine directly. What
+// those cannot reach is the wiring: the bearer check that runs before the gate, the
+// `Mcp-Session-Id` header tenancy is keyed on, an HTTP status a client actually branches on, and —
+// in the debugger tier — the sweep releasing a real engine worker. That had been checked by hand
+// against the guest three times, which is how this tier came to exist.
+//
+// The client here is hand-written for the same reason the stdio one is: what is being asserted is
+// what goes over the wire, and a library that normalises a `409` into an exception, or hides the
+// session header, is a library asserting on this server's behalf.
+
+/// The protocol revision the lease is exercised against.
+///
+/// Tenancy is keyed on `Mcp-Session-Id`, so this has to be a revision whose handshake mints one.
+const LEASE_REVISION: &str = "2025-06-18";
+
+/// A free loopback port, taken by binding and letting go.
+///
+/// Racy in principle and not in practice: the window is microseconds, tests each take their own,
+/// and a collision fails loudly at bind rather than silently sharing a server.
+fn free_port() -> u16 {
+    std::net::TcpListener::bind("127.0.0.1:0")
+        .expect("a loopback port")
+        .local_addr()
+        .expect("a bound address")
+        .port()
+}
+
+/// One HTTP reply, parsed far enough to assert on.
+struct Reply {
+    status: u16,
+    /// `Mcp-Session-Id`, which is what the lease reads a client's identity from.
+    session: Option<String>,
+    /// The JSON-RPC payload, whether it arrived as a plain body or inside an SSE frame.
+    payload: Option<Value>,
+    body: String,
+}
+
+impl Reply {
+    fn result(&self, what: &str) -> Value {
+        let payload = self
+            .payload
+            .as_ref()
+            .unwrap_or_else(|| panic!("`{what}` answered with no JSON-RPC payload: {}", self.body));
+        assert!(
+            payload["error"].is_null(),
+            "`{what}` failed: {}",
+            payload["error"]
+        );
+        payload["result"].clone()
+    }
+}
+
+/// A `--listen` server, and just enough HTTP to drive it.
+struct Listener {
+    child: Child,
+    addr: String,
+    token: String,
+    stderr_log: Arc<Mutex<Vec<String>>>,
+    next_id: i64,
+}
+
+impl Listener {
+    fn start(env: &[(&str, &str)]) -> Self {
+        let addr = format!("127.0.0.1:{}", free_port());
+        // Distinct per listener, so a token left in a stray process cannot reach this one.
+        let token = format!("smoke-{}-{addr}", std::process::id());
+        let mut command = Command::new(EXE);
+        command
+            .arg("--listen")
+            .arg(&addr)
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .env("RUST_LOG", "info")
+            .env("WINDBG_MCP_LISTEN_TOKEN", &token);
+        for (key, value) in env {
+            command.env(key, value);
+        }
+        let mut child = command
+            .spawn()
+            .unwrap_or_else(|e| panic!("failed to spawn {EXE} --listen {addr}: {e}"));
+
+        // Both drained, for the same reason the stdio harness drains stderr: an unread pipe fills
+        // and the server blocks mid-test, which would present as a protocol hang.
+        let stderr_log = Arc::new(Mutex::new(Vec::new()));
+        let err = BufReader::new(child.stderr.take().expect("piped stderr"));
+        let log = Arc::clone(&stderr_log);
+        std::thread::spawn(move || {
+            for line in err.lines().map_while(Result::ok) {
+                log.lock().unwrap().push(line);
+            }
+        });
+        let out = BufReader::new(child.stdout.take().expect("piped stdout"));
+        std::thread::spawn(move || out.lines().map_while(Result::ok).for_each(drop));
+
+        let listener = Self {
+            child,
+            addr,
+            token,
+            stderr_log,
+            next_id: 1,
+        };
+        listener.wait_until_bound();
+        listener
+    }
+
+    fn stderr(&self) -> String {
+        self.stderr_log.lock().unwrap().join("\n")
+    }
+
+    fn wait_for_stderr(&self, needle: &str, budget: Duration) -> bool {
+        let deadline = Instant::now() + budget;
+        loop {
+            if self.stderr().contains(needle) {
+                return true;
+            }
+            if Instant::now() >= deadline {
+                return false;
+            }
+            std::thread::sleep(Duration::from_millis(100));
+        }
+    }
+
+    /// Waits for the bind rather than guessing at it — the alternative is a fixed sleep that is
+    /// either too short on a loaded runner or wasted on every run.
+    fn wait_until_bound(&self) {
+        let deadline = Instant::now() + Duration::from_secs(30);
+        let addr: std::net::SocketAddr = self.addr.parse().expect("a loopback address");
+        loop {
+            if std::net::TcpStream::connect_timeout(&addr, Duration::from_millis(200)).is_ok() {
+                return;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "the listener never bound {}\n--- stderr ---\n{}",
+                self.addr,
+                self.stderr()
+            );
+            std::thread::sleep(Duration::from_millis(100));
+        }
+    }
+
+    /// One request, on a connection of its own.
+    ///
+    /// A connection per request is what a client behind a tunnel looks like anyway, and it makes
+    /// "the client went quiet" the default rather than something the test has to arrange: there is
+    /// no connection left open for the server to mistake for a client still there.
+    fn send(
+        &self,
+        method: &str,
+        token: Option<&str>,
+        session: Option<&str>,
+        body: Option<&Value>,
+    ) -> Reply {
+        use std::io::Read;
+
+        let mut stream = std::net::TcpStream::connect(&self.addr)
+            .unwrap_or_else(|e| panic!("cannot reach the listener at {}: {e}", self.addr));
+        // So a server that never answers fails this test rather than hanging the suite.
+        stream
+            .set_read_timeout(Some(Duration::from_secs(60)))
+            .expect("set a read timeout");
+
+        let mut request = format!(
+            "{method} / HTTP/1.1\r\nHost: {}\r\nAccept: application/json, text/event-stream\r\n\
+             Connection: close\r\n",
+            self.addr
+        );
+        if let Some(token) = token {
+            request.push_str(&format!("Authorization: Bearer {token}\r\n"));
+        }
+        if let Some(session) = session {
+            request.push_str(&format!("Mcp-Session-Id: {session}\r\n"));
+        }
+        match body.map(|b| b.to_string()) {
+            Some(body) => {
+                request.push_str(&format!(
+                    "Content-Type: application/json\r\nContent-Length: {}\r\n\r\n{body}",
+                    body.len()
+                ));
+            }
+            None => request.push_str("\r\n"),
+        }
+        stream.write_all(request.as_bytes()).expect("write request");
+        stream.flush().expect("flush request");
+
+        let mut raw = Vec::new();
+        // A read error is not a failure here: `Connection: close` means the server ends the
+        // stream, and whatever arrived before that is the reply.
+        let _ = stream.read_to_end(&mut raw);
+        parse_reply(&raw)
+    }
+
+    /// A JSON-RPC request from the authorised client.
+    fn call(&mut self, session: Option<&str>, method: &str, params: Value) -> Reply {
+        let id = self.next_id;
+        self.next_id += 1;
+        let body = json!({ "jsonrpc": "2.0", "id": id, "method": method, "params": params });
+        self.send("POST", Some(&self.token.clone()), session, Some(&body))
+    }
+
+    fn opening() -> Value {
+        json!({
+            "protocolVersion": LEASE_REVISION,
+            "capabilities": {},
+            "clientInfo": { "name": "windbg-mcp-lease-smoke", "version": "1" },
+        })
+    }
+
+    /// The handshake, answering with the session id the lease keys tenancy on.
+    fn initialize(&mut self) -> String {
+        let reply = self.call(None, "initialize", Self::opening());
+        assert_eq!(
+            reply.status,
+            200,
+            "initialize was refused ({}): {}\n--- stderr ---\n{}",
+            reply.status,
+            reply.body,
+            self.stderr()
+        );
+        let session = reply
+            .session
+            .clone()
+            .unwrap_or_else(|| panic!("initialize minted no Mcp-Session-Id: {}", reply.body));
+        let ack = self.send(
+            "POST",
+            Some(&self.token.clone()),
+            Some(&session),
+            Some(&json!({ "jsonrpc": "2.0", "method": "notifications/initialized" })),
+        );
+        assert!(
+            (200..300).contains(&ack.status),
+            "the initialized notification was refused ({}): {}",
+            ack.status,
+            ack.body
+        );
+        session
+    }
+
+    /// The typed half of a tool call that worked.
+    fn tool(&mut self, session: &str, name: &str, args: Value) -> Value {
+        let reply = self.call(
+            Some(session),
+            "tools/call",
+            json!({ "name": name, "arguments": args }),
+        );
+        assert_eq!(
+            reply.status, 200,
+            "`{name}` was refused ({}): {}",
+            reply.status, reply.body
+        );
+        reply.result(name)["structuredContent"].clone()
+    }
+
+    /// The client saying it is done, which is the only departure the server is ever told about.
+    fn goodbye(&self, session: &str) -> Reply {
+        self.send("DELETE", Some(&self.token.clone()), Some(session), None)
+    }
+}
+
+impl Drop for Listener {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+/// Splits an HTTP reply into what a test asserts on.
+///
+/// Hand-rolled, and small enough to stay that way: a status, three headers, and a body that is
+/// either a JSON document or an SSE frame carrying one. The chunked decode is not optional —
+/// rmcp answers a tool call as `text/event-stream`, and scanning the raw stream for `data:` would
+/// read a chunk-size line as content the moment a payload spans two chunks.
+fn parse_reply(raw: &[u8]) -> Reply {
+    let Some(split) = raw.windows(4).position(|w| w == b"\r\n\r\n") else {
+        panic!(
+            "not an HTTP reply: {:?}",
+            String::from_utf8_lossy(&raw[..raw.len().min(200)])
+        );
+    };
+    let head = String::from_utf8_lossy(&raw[..split]).into_owned();
+    let status = head
+        .lines()
+        .next()
+        .and_then(|line| line.split_whitespace().nth(1))
+        .and_then(|code| code.parse().ok())
+        .unwrap_or_else(|| panic!("no status line in: {head}"));
+    let header = |name: &str| {
+        head.lines().skip(1).find_map(|line| {
+            let (key, value) = line.split_once(':')?;
+            key.trim()
+                .eq_ignore_ascii_case(name)
+                .then(|| value.trim().to_string())
+        })
+    };
+    let chunked = header("transfer-encoding").is_some_and(|v| v.contains("chunked"));
+    let raw_body = &raw[split + 4..];
+    let body_bytes = if chunked {
+        dechunk(raw_body)
+    } else {
+        raw_body.to_vec()
+    };
+    let body = String::from_utf8_lossy(&body_bytes).into_owned();
+    // An SSE frame first, then a plain body: a tool call comes back as the former and a refusal
+    // as neither, and `None` is a fine answer for a refusal.
+    let payload = body
+        .lines()
+        .filter_map(|line| line.trim().strip_prefix("data: "))
+        .find_map(|data| serde_json::from_str::<Value>(data).ok())
+        .or_else(|| serde_json::from_str::<Value>(&body).ok());
+    Reply {
+        status,
+        session: header("mcp-session-id"),
+        payload,
+        body,
+    }
+}
+
+/// `Transfer-Encoding: chunked`, decoded on bytes — a chunk boundary may split a code point, and
+/// slicing a `&str` there would panic on content this server has no control over.
+fn dechunk(mut rest: &[u8]) -> Vec<u8> {
+    let mut out = Vec::new();
+    while let Some(eol) = rest.windows(2).position(|w| w == b"\r\n") {
+        let header = String::from_utf8_lossy(&rest[..eol]);
+        let size = header.split(';').next().unwrap_or("").trim();
+        let Ok(len) = usize::from_str_radix(size, 16) else {
+            break;
+        };
+        rest = &rest[eol + 2..];
+        if len == 0 {
+            break;
+        }
+        let take = len.min(rest.len());
+        out.extend_from_slice(&rest[..take]);
+        rest = &rest[take..];
+        if rest.starts_with(b"\r\n") {
+            rest = &rest[2..];
+        }
+    }
+    out
+}
+
+/// The listener exposes every tool this server has, including the ones that write to a live
+/// kernel. Starting without a token would put that on a port with no lock at all, so it refuses —
+/// and refuses *loudly*, because the failure mode of a quiet default is a server nobody knows is
+/// open.
+#[test]
+fn the_listener_will_not_start_without_a_token() {
+    let addr = format!("127.0.0.1:{}", free_port());
+    let out = Command::new(EXE)
+        .arg("--listen")
+        .arg(&addr)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .env_remove("WINDBG_MCP_LISTEN_TOKEN")
+        .output()
+        .unwrap_or_else(|e| panic!("failed to spawn {EXE}: {e}"));
+    assert!(
+        !out.status.success(),
+        "the listener started with no token set"
+    );
+    let said = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        said.contains("WINDBG_MCP_LISTEN_TOKEN"),
+        "it has to name the variable that is missing, or nobody can act on it: {said}"
+    );
+}
+
+/// An unauthenticated caller is refused, told nothing about what is here — and costs the server
+/// nothing.
+///
+/// The last clause is the one worth a test. The bearer check runs *before* the tenancy gate, so a
+/// wrong token must not reserve, renew or consume a claim; if it did, anything that could reach
+/// the port could keep the real client locked out without ever authenticating.
+#[test]
+fn an_unauthenticated_request_is_refused_and_costs_the_server_nothing() {
+    let mut server = Listener::start(&[]);
+    let probe = json!({ "jsonrpc": "2.0", "id": 1, "method": "tools/list", "params": {} });
+    for token in [None, Some("not-the-token"), Some("")] {
+        let reply = server.send("POST", token, None, Some(&probe));
+        assert_eq!(
+            reply.status, 401,
+            "a request with token {token:?} was not refused: {}",
+            reply.body
+        );
+        assert!(
+            !reply.body.contains("open_dump") && !reply.body.contains("jsonrpc"),
+            "a refusal must not describe what is here: {}",
+            reply.body
+        );
+    }
+    let session = server.initialize();
+    let status = server.tool(&session, "session_status", json!({}));
+    assert_eq!(
+        status["status"], "ok",
+        "the real client must still be able to take a server that only refused strangers: {status}"
+    );
+}
+
+/// One client at a time, refused with `409` rather than served alongside.
+///
+/// Not a policy choice so much as an admission: `session_id` handles are minted from one registry,
+/// `MAX_SESSIONS` is shared, and `end_session` ends whatever it is handed — so two clients would
+/// silently share, and one could end a target the other was using.
+#[test]
+fn a_second_client_is_refused_while_the_first_holds_the_server() {
+    let mut server = Listener::start(&[]);
+    let holder = server.initialize();
+
+    let intruder = server.call(None, "initialize", Listener::opening());
+    assert_eq!(
+        intruder.status, 409,
+        "a second client was not refused: {}",
+        intruder.body
+    );
+    assert!(
+        intruder.body.contains("one at a time"),
+        "the refusal has to say why, or it reads as a bug: {}",
+        intruder.body
+    );
+
+    // A session id that is not the holder's is refused on the same grounds — this is the arm that
+    // makes the refusal a rule about tenancy rather than about `initialize`.
+    let stranger = server.call(
+        Some("not-a-session-this-server-issued"),
+        "tools/list",
+        json!({}),
+    );
+    assert_eq!(
+        stranger.status, 409,
+        "a stranger's session id was served: {}",
+        stranger.body
+    );
+
+    // And the holder is undisturbed by either.
+    let status = server.tool(&holder, "session_status", json!({}));
+    assert_eq!(status["status"], "ok", "{status}");
+}
+
+/// Going quiet is not leaving; saying goodbye is.
+///
+/// The distinction is the whole reason a lease exists. Every request here is its own connection —
+/// which is what a client behind a tunnel looks like — so "the client is silent" is the resting
+/// state, and a server that treated silence as departure would hand the registry on between two
+/// calls of a working client.
+#[test]
+fn a_silence_is_not_a_departure_and_a_goodbye_is() {
+    let mut server = Listener::start(&[]);
+    let holder = server.initialize();
+
+    // Nothing is connected at this moment, and the holder still holds.
+    let too_early = server.call(None, "initialize", Listener::opening());
+    assert_eq!(
+        too_early.status, 409,
+        "silence was read as departure — a client between two calls would lose its targets: {}",
+        too_early.body
+    );
+
+    // Returning with the same id is served: the property stdio cannot offer, where a client
+    // restart costs a KDNET attach and a KDNET attach costs a reboot of the target.
+    let resumed = server.call(Some(&holder), "tools/list", json!({}));
+    assert_eq!(
+        resumed.status, 200,
+        "a returning client was not let back in: {}",
+        resumed.body
+    );
+
+    let farewell = server.goodbye(&holder);
+    assert!(
+        (200..300).contains(&farewell.status),
+        "the DELETE was refused ({}): {}",
+        farewell.status,
+        farewell.body
+    );
+
+    let next = server.initialize();
+    assert_ne!(next, holder, "the next client gets a session of its own");
+    let status = server.tool(&next, "session_status", json!({}));
+    assert_eq!(status["status"], "ok", "{status}");
 }
 
 // ---- tier 2: a real debugger target -------------------------------------------
@@ -3861,6 +4356,129 @@ fn a_kernel_attach_that_never_connects_costs_one_session_and_can_be_ended() {
         "end_session",
         json!({ "session_id": dump_session }),
         TARGET_STEP,
+    );
+}
+
+/// A lease that runs out releases what the absent client left, and the next client gets a clean
+/// server.
+///
+/// The claim the whole lease exists for, and the only one that costs a *target* when it is wrong.
+/// The unit tests in `src/listen.rs` settle the state machine; the fast listener tier settles the
+/// HTTP wiring. Neither can reach this, because it is the sweep meeting a real engine worker —
+/// which is where the stdio role's teardown lives and where the listener had nothing but a
+/// hand-run check against a guest.
+///
+/// **The target is a kernel attach nothing will answer**, deliberately. A parked attach is the
+/// worst case in one move: the session exists, it holds a worker, and its wait cannot be
+/// interrupted — so releasing it means terminating a process, not asking politely. A dump would
+/// prove the timer and not the teardown.
+///
+/// **The grace is 32 seconds because that is nearly the floor.** The listener refuses to start
+/// with a grace that could expire inside a call, and the bound is the call budget plus the time an
+/// engine worker takes to come up (30s). Shrinking the budget to a second is what makes the floor
+/// small enough to wait out; nothing here needs a longer one, since the attach is meant to park.
+#[test]
+fn a_lease_that_runs_out_releases_what_the_absent_client_left() {
+    if target_tier().is_none() {
+        return;
+    }
+    let mut server = Listener::start(&[
+        ("WINDBG_MCP_CALL_TIMEOUT_SECS", "1"),
+        ("WINDBG_MCP_LEASE_GRACE_SECS", "32"),
+    ]);
+    let client = server.initialize();
+
+    // Its own port, because these tests run in parallel and a KDNET attach takes a UDP port for
+    // the life of its session.
+    server.call(
+        Some(&client),
+        "tools/call",
+        json!({
+            "name": "attach_kernel",
+            "arguments": { "connection": "net:port=50009,key=1.1.1.1" },
+        }),
+    );
+
+    // Wait for the park rather than assuming a timing — and read it as a *state*, since the
+    // sentence describing one is rewritten whenever the advice changes.
+    let deadline = Instant::now() + Duration::from_secs(60);
+    let parked = loop {
+        let status = server.tool(&client, "session_status", json!({}));
+        let found = status["sessions"]
+            .as_array()
+            .into_iter()
+            .flatten()
+            .find(|s| s["kind"] == "kernel" && s["state"]["state"] == "attaching")
+            .and_then(|s| s["session_id"].as_str().map(str::to_string));
+        if found.is_some() {
+            break found;
+        }
+        if Instant::now() >= deadline {
+            break None;
+        }
+        std::thread::sleep(Duration::from_millis(250));
+    };
+    let Some(parked) = parked else {
+        // The attach failed outright instead of parking — most likely the UDP port was already
+        // taken on this host. Nothing to assert about a park that did not happen.
+        skip("attach_kernel did not reach the parked state (port 50009 busy?)");
+        return;
+    };
+    let worker = server.tool(&client, "session_status", json!({ "session_id": parked }))["sessions"]
+        [0]["engine_pid"]
+        .as_u64()
+        .unwrap_or_else(|| panic!("the parked session reports no engine pid"))
+        as u32;
+    assert!(
+        process_alive(worker),
+        "the parked engine worker (pid {worker}) should be running before the lease expires"
+    );
+
+    // And now the client vanishes: no goodbye, no requests. **Nothing below may speak to the
+    // server** — every admitted request renews the lease, so a test that polled over HTTP would
+    // hold the lease open for as long as it watched. The log is the one channel that costs
+    // nothing.
+    assert!(
+        server.wait_for_stderr(
+            "a client's lease ran out; releasing the sessions it left open",
+            Duration::from_secs(120),
+        ),
+        "the lease never expired — a client that vanished would hold this target for ever\n\
+         --- stderr ---\n{}",
+        server.stderr()
+    );
+
+    // The half that matters: the worker is gone. `release_leased` is `shutdown` without closing
+    // the registry, so a parked attach ends the only way it can — its process terminated.
+    let deadline = Instant::now() + Duration::from_secs(60);
+    while process_alive(worker) {
+        assert!(
+            Instant::now() < deadline,
+            "the lease expired but the parked engine worker (pid {worker}) is still running\n\
+             --- stderr ---\n{}",
+            server.stderr()
+        );
+        std::thread::sleep(Duration::from_millis(250));
+    }
+
+    // The old session id is not honoured after the sweep closed it. Without this the service
+    // would keep it resident and every reconnect cycle would leave another behind.
+    let stale = server.call(Some(&client), "tools/list", json!({}));
+    assert_ne!(
+        stale.status, 200,
+        "a session the sweep closed was still served: {}",
+        stale.body
+    );
+
+    // And the server is takeable again, with nothing left over. Both halves: a lease that
+    // released the sessions but stayed `releasing` would refuse every client for ever, and one
+    // that handed over sessions it had just closed would be worse.
+    let next = server.initialize();
+    assert_ne!(next, client);
+    let status = server.tool(&next, "session_status", json!({}));
+    assert!(
+        status["sessions"].as_array().is_none_or(Vec::is_empty),
+        "the next client inherited a session the sweep should have released: {status}"
     );
 }
 

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -1074,8 +1074,11 @@ fn every_tool_with_an_output_schema_answers_with_structured_content() {
             "error",
         ),
         ("attach_kernel", json!({}), "error"),
-        // Answered from this server's own bookkeeping, so it succeeds with nothing open.
+        // Both are answered from this server's own bookkeeping, so they succeed with nothing
+        // open — and `server_log` has records to answer with whatever else has happened, this
+        // server having logged its own startup.
         ("session_status", json!({}), "ok"),
+        ("server_log", json!({}), "ok"),
         // Everything else needs a session, and there is none.
         ("end_session", json!({}), "error"),
         ("registers", json!({}), "error"),

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -1956,35 +1956,13 @@ fn a_dump_session_opens_reads_and_closes() {
     );
 }
 
-/// A record made in the **engine worker** reaches the client, tagged with the session that made
-/// it.
+/// Waits for a record from `session_id`'s **engine worker** whose message contains `needle`, and
+/// hands it back.
 ///
-/// The one claim about the log bridge that only two real processes can settle. A worker's
-/// `tracing` output has always gone to its inherited stderr, which is the supervisor's — and on
-/// stdio that is the client's log, so nothing had to carry it. Under `--listen` the client is on
-/// another machine and that inheritance reaches nobody, so the record has to cross the pipe as a
-/// value (`WorkerMessage::Log`) and be filed against a session id only the supervisor knows. In
-/// process there is no second process, and no session for a record to be tagged with; here there
-/// are both.
-///
-/// Hung off the teardown because that is the path a healthy session is *guaranteed* to log on:
-/// the worker reads EOF, says it is releasing the target before exit, and flushes on its way out
-/// — which is also the record most worth having, being the account of a teardown nobody asked
-/// for.
-#[test]
-fn a_workers_log_records_reach_the_client_tagged_with_their_session() {
-    let Some(dump) = target_tier() else { return };
-    let mut server = Server::started();
-    let session_id = server.open_session("open_dump", json!({ "path": dump }), TARGET_STEP);
-    server.tool_data(
-        "end_session",
-        json!({ "session_id": session_id }),
-        TARGET_STEP,
-    );
-
-    // Polled rather than read once: `end_session` answers when the target is released, and the
-    // worker's exit records are written after that, by a different process. The order of those
-    // two is not something this test gets to assume.
+/// Polled rather than read once, and deliberately not on a fixed sleep: the record is made in
+/// another process, queued there, mirrored up the protocol channel and filed by the supervisor,
+/// none of which is ordered against the tool call that provoked it.
+fn wait_for_log_record(server: &mut Server, session_id: &str, needle: &str) -> Value {
     let deadline = Instant::now() + Duration::from_secs(15);
     loop {
         let page = server.tool_data(
@@ -1992,31 +1970,19 @@ fn a_workers_log_records_reach_the_client_tagged_with_their_session() {
             json!({ "session_id": session_id, "limit": 200 }),
             STEP,
         );
-        let records = page["records"].as_array().cloned().unwrap_or_default();
-        if !records.is_empty() {
-            for record in &records {
-                assert_eq!(
-                    record["session_id"], session_id,
-                    "a session filter must not hand back another session's records: {record}"
-                );
-            }
-            assert!(
-                records.iter().any(|r| r["target"] == "windbg_mcp::worker"),
-                "these have to be the worker's own records, not the supervisor's about it: \
-                 {records:?}"
-            );
-            assert!(
-                records
-                    .iter()
-                    .any(|r| r["message"].as_str().is_some_and(|m| m.contains("worker:"))),
-                "and to carry what the worker actually said: {records:?}"
-            );
-            return;
+        let found = page["records"]
+            .as_array()
+            .into_iter()
+            .flatten()
+            .find(|r| r["message"].as_str().is_some_and(|m| m.contains(needle)))
+            .cloned();
+        if let Some(found) = found {
+            return found;
         }
         assert!(
             Instant::now() < deadline,
-            "no record from session {session_id}'s engine worker reached the client within 15s \
-             of its teardown — the bridge is not carrying them: {page}"
+            "no record containing `{needle}` from session {session_id}'s engine worker reached \
+             the client within 15s — the log bridge is not carrying them: {page}"
         );
         std::thread::sleep(Duration::from_millis(250));
     }
@@ -3343,6 +3309,29 @@ fn interrupting_a_running_batch_stops_it_and_rolls_it_back() {
         "interrupting a batch must not cost the session:\n{}",
         text_of(&after["result"])
     );
+
+    // The **worker's** account of the same interrupt, read back through `server_log` — the one
+    // claim about the log bridge that needs two real processes.
+    //
+    // A worker's `tracing` output has always gone to its inherited stderr, which is the
+    // supervisor's, which under stdio is the client's log; nothing had to carry it. Under
+    // `--listen` the client is on another machine and that inheritance reaches nobody, so the
+    // record has to cross the pipe as a value and be filed against a session id only the
+    // supervisor knows. In process there is neither a second process nor a session to tag.
+    //
+    // Hung off the interrupt because that is a path a worker is *certain* to log on — a healthy
+    // session is quiet by design, which is the point of the level rather than a gap — and because
+    // the session survives it, so this is not racing a teardown.
+    let worker_said = wait_for_log_record(&mut server, &session_id, "interrupt raised for job");
+    assert_eq!(
+        worker_said["target"], "windbg_mcp::worker",
+        "it has to be the worker's own record, not the supervisor's about it: {worker_said}"
+    );
+    assert_eq!(
+        worker_said["session_id"], session_id,
+        "and filed against the session whose worker made it: {worker_said}"
+    );
+
     server.tool_text(
         "end_session",
         json!({ "session_id": session_id }),

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -2129,15 +2129,33 @@ fn dechunk(mut rest: &[u8]) -> Vec<u8> {
 #[test]
 fn the_listener_will_not_start_without_a_token() {
     let addr = format!("127.0.0.1:{}", free_port());
-    let out = Command::new(EXE)
+    let mut child = Command::new(EXE)
         .arg("--listen")
         .arg(&addr)
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .env_remove("WINDBG_MCP_LISTEN_TOKEN")
-        .output()
+        .spawn()
         .unwrap_or_else(|e| panic!("failed to spawn {EXE}: {e}"));
+    // Waited for with a deadline rather than `output()`, because the regression under test is a
+    // listener that *serves*: that one never exits, and a bare wait would hang the suite instead
+    // of failing it.
+    let deadline = Instant::now() + Duration::from_secs(30);
+    loop {
+        match child.try_wait().expect("poll the listener") {
+            Some(_) => break,
+            None if Instant::now() >= deadline => {
+                let _ = child.kill();
+                let _ = child.wait();
+                panic!("the listener started with no token set, and stayed up serving on {addr}");
+            }
+            None => std::thread::sleep(Duration::from_millis(50)),
+        }
+    }
+    let out = child
+        .wait_with_output()
+        .expect("collect the listener's output");
     assert!(
         !out.status.success(),
         "the listener started with no token set"
@@ -4390,13 +4408,26 @@ fn a_lease_that_runs_out_releases_what_the_absent_client_left() {
 
     // Its own port, because these tests run in parallel and a KDNET attach takes a UDP port for
     // the life of its session.
-    server.call(
+    let requested = server.call(
         Some(&client),
         "tools/call",
         json!({
             "name": "attach_kernel",
             "arguments": { "connection": "net:port=50009,key=1.1.1.1" },
         }),
+    );
+    // The *tool* is expected to report a failure — the attach parks, and the call budget here is
+    // one second — but the **listener** has to have admitted it. Without this, a `401` or a `409`
+    // from a tenancy regression would fall through to the skip below and be reported as a busy
+    // port on the host, and the one assertion in this file that costs a target would pass in
+    // silence.
+    assert_eq!(
+        requested.status,
+        200,
+        "the listener refused the attach ({}): {}\n--- stderr ---\n{}",
+        requested.status,
+        requested.body,
+        server.stderr()
     );
 
     // Wait for the park rather than assuming a timing — and read it as a *state*, since the


### PR DESCRIPTION
Two gaps that had the same shape: the listener worked, and the things you need in order to *trust* it working lived only on the server machine.

---

## 1. The server's log reaches the client again

Under stdio the log needs no plumbing: a worker's stderr is inherited by the supervisor, the supervisor's is captured by the MCP client, and the whole stream lands in a file the operator already has. `--listen` moves the server to another machine and the stream stops there. That is a regression against stdio rather than anything HTTP requires.

A worker's `tracing` records now cross the existing protocol channel as typed values (`WorkerMessage::Log`), and the supervisor files them in a bounded ring **tagged with the session id** — the one thing a worker cannot stamp them with, and what makes two processes' interleaved records readable. `server_log` serves that ring: filterable by session and level, paged with a `since` cursor, answered by the supervisor without ever touching a session's engine, so it still answers while the session it is about is wedged.

**Why a tool and not `notifications/message`.** MCP's logging capability is what this would otherwise be a few lines of. It is also deprecated — rmcp marks every type in it `#[deprecated]` for removal under SEP-2577 — and this repo already asserts, in `capabilities_advertise_only_what_is_implemented`, that the capability is *not* advertised. Taking it would mean unpicking a standing test to depend on an API the SDK has announced it is deleting. The trade is pull rather than push; what a tool buys is one code path for both transports and a reader stderr never had — the model holding the session. `DECISIONS.md` records the call.

Three properties worth reviewing for:

- **Worker stderr is untouched.** The bridge is a second copy, not a redirection, so the stdio behaviour this exists to restore is preserved by *not touching it*.
- **It cannot block the debugger.** The worker's queue is bounded and dropped-when-full, never blocked on: it is fed from the engine thread, inside DbgEng, where a log line must never wait on a pipe. Drops are counted and filed as a record of their own.
- **The teardown records survive the exit.** A worker flushes (bounded, 250 ms) before `process::exit`, because the account of a teardown nobody asked for is the record most worth having.

## 2. The lease has a smoke tier

The lease is the only part of this server whose failures cost a **target** rather than a call, and it was the only part checked by hand — three times, most recently while verifying the log fix above. Every rule of it has unit tests against the state machine; none of them reach the wiring.

It is now driven over real HTTP against a listener on a loopback port, with a hand-written client — a library that normalised a `409` into an exception, or hid the `Mcp-Session-Id` header, would be asserting on this server's behalf.

Four assertions need no debugger, because tenancy is decided before any session is opened:

- the listener **will not start without a token**, and names the variable that is missing;
- an unauthenticated request is refused, told nothing about what is here, and **costs the server nothing** — the bearer check runs before the tenancy gate, so a wrong token must not consume a claim, or anything that could reach the port could lock the real client out without ever authenticating;
- a **second client is refused with `409`**, whether it arrives with a fresh `initialize` or with somebody else's session id, and the holder is undisturbed by either;
- **going quiet is not leaving; saying goodbye is.** Every request is its own connection — what a client behind a tunnel looks like — so silence is the resting state, and a server that read it as departure would hand the registry on between two calls of a working client.

The fifth is in the debugger tier, because it is the sweep meeting a real engine worker. The target is **a kernel attach nothing will answer**: a parked attach is the worst case in one move, since the session exists, holds a worker, and cannot be interrupted, so releasing it means terminating a process rather than asking politely. The test then goes silent for a real grace and watches **stderr, not HTTP** — every admitted request renews the lease, so a test that polled would hold open the very thing it is waiting to expire.

## Also

The listener no longer claims a reconnecting client **adopted sessions** when there were none. The flag behind that line says a previous tenancy ended inside the grace, which is true whether or not that client had opened anything — so an ordinary reconnect logged an adoption that had not happened. Found by writing the test above.

## Verification

- `cargo clippy --all-targets` and 414 unit tests clean on the ARM64 guest.
- Protocol tier: 47 tests, still ~2s. Debugger tier green on **both** CI architectures, and the lease expiry demonstrably *ran* rather than skipping — 44.9s on x64 and 41.9s on arm64, both past the 37s floor the grace imposes.
- Driven over HTTP against the listener on the guest, which is the configuration the log regression was about: the full stream came back to a client that is not the server process.

One finding worth stating plainly: **a healthy session is quiet.** A worker logs when something goes wrong, not as it works, so an empty `server_log` page usually means nothing went wrong. It also made the first version of the log smoke test wrong — it hung the assertion on teardown, and a successful release *kills* the worker rather than closing its channel, so the exit records it waited for are never made. It is asserted off `interrupt` now, where a record is certain and the session survives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the read-only `server_log` tool for retrieving buffered server and worker logs.
  * Supports filtering by session and severity, result limits, pagination, and structured output.
  * Reports retained capacity, evictions, and dropped records.
* **Bug Fixes**
  * Reconnect messages now accurately report how many sessions were adopted, including none.
* **Documentation**
  * Added guidance for log visibility, filtering, remote access, and listener lease behaviour.
* **Tests**
  * Expanded coverage for log retrieval, authentication, tenancy, session handover, and lease expiry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->