### PR TITLE
Report what a long call is doing as MCP progress notifications

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,3 +38,11 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 # Only for the handle plumbing behind the supervisor↔worker channel (see `engine::spawn_worker`):
 # marking a pipe end inheritable is the one thing std cannot express.
 windows-sys = { version = "0.61", features = ["Win32_Foundation"] }
+
+[dev-dependencies]
+# `test-util` only, and only for the tests: `src/progress.rs` asserts on a heartbeat measured in
+# tens of seconds, and the alternative — real sleeps shrunk to milliseconds — is a test that fails
+# on a loaded runner for reasons that have nothing to do with the code. A paused clock makes the
+# timing exact. Kept out of the shipped binary by the edition-2024 resolver, which does not unify
+# dev-dependency features into a normal build.
+tokio = { version = "1", features = ["test-util"] }

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -5,6 +5,59 @@ status. Keep entries short; link to code with `file:line` where it helps a futur
 
 ---
 
+## Progress *is* a protocol notification, and it counts seconds (2026-08-17)
+
+**Context.** A tool call here can take minutes — a kernel attach waits for its target to dial in, a
+pool walk reads every page, `!analyze -v` goes to a symbol server — and every one of them was
+silent from the request until the result. Under stdio an operator could watch stderr scroll; over
+`--listen` those records are on the other machine, and both ways of asking for them
+(`session_status`, `server_log`) are **pull**, so a client has to guess when to ask about a call it
+cannot see.
+
+**Why this one is a notification when the log is a tool.** The entry below took the opposite
+decision for `server_log`, and the reasons do not transfer. MCP's *logging* capability is
+deprecated for removal (SEP-2577) and would have meant unadvertising nothing and depending on a
+dying API; **progress** is not deprecated, is not a capability at all — a client opts in per call,
+by putting a `progressToken` in that call's `_meta` — and is the only mechanism that can say
+anything *while a request is outstanding*, which is precisely what pull cannot do. A log is a
+stream about the server; this is one call reporting on itself.
+
+**Decision.** `call_tool` reads the token off the request and runs the whole tool call inside a
+relay (`src/progress.rs`); the milestones the supervisor and its worker already produce —
+`Committed`/`Opened` from an opener, `RollingBack` from a teardown that found a transaction, plus
+the engine worker coming up — become `notifications/progress`. No new facts crossed the pipe: the
+protocol messages were already there, and what was missing was somewhere to send them.
+
+**The sink travels with the waiter.** A milestone is learned on the task that reads a worker's
+channel, which belongs to the *session*; the peer and the token belong to the *call*, forty-odd
+tool bodies away. So the sink is read from a task-local on the caller's own task — the last place
+the request is still reachable — and left beside that call's waiter in `engine::Waiting`, for the
+reader to find by job id. Removing the waiter, which is how a call stops counting as outstanding,
+is the same act that stops it being reported against.
+
+**`progress` counts seconds and there is no `total`.** Elapsed time increases strictly (which is
+what MCP asks of the field) and is the number a reader of a debugger actually wants. A denominator
+would have to be the call's budget, and that is a different constant per tool — none of which
+covers the up-to-30s worker handshake an opener spends before its budget starts. An absent `total`
+says "unknown", which is true.
+
+**A silence is reported too, and that is the part that is not just plumbing.** Milestones alone
+leave the two longest waits exactly as quiet as before: a parked kernel attach reports `Committed`
+in the first second and may never report again, and a pool walk or a `crash_triage` has no
+milestones at all. So ten seconds without a word is itself a notification. It also makes progress a
+liveness signal a client can extend its own request timeout on, which is what stops a 60s client
+timeout abandoning a five-minute call that is working perfectly.
+
+**What it costs.** Nothing for a client that did not ask: no token, no channel, no timer, no
+notification. For one that did, a send is raced against the call rather than awaited before it, so
+a client that has stopped reading its stream cannot stall a debugger command.
+
+**Status:** landed. Both transports; over HTTP rmcp routes the notification onto the SSE stream the
+call is answered on, keyed by the token. Covered by unit tests on the relay's policy and by smoke
+tiers for the opener sequence over stdio and for a remote client over HTTP.
+
+---
+
 ## The server's log is a tool, not a protocol notification (2026-08-17)
 
 **Context.** Under stdio the log needs no plumbing: a worker's stderr is inherited by the
@@ -86,9 +139,12 @@ was wrong for a year of nobody noticing because it had no test. It had no test b
 unreachable without an HTTP harness, not because anyone decided to skip it. It is now a named
 predicate (`listen::is_departure`) with the same unit coverage every rule beside it has.
 
-**Status.** Implemented (#135, #137). Still missing from the listener: progress notifications, MCP
-log notifications, service installation, and a smoke tier for the lease itself — which is the
-coverage gap that made seven rounds of review the way these were found rather than the second.
+**Status.** Implemented (#135, #137). Three of the four things this listed as missing have since
+landed, each with an entry of its own above: the log reaches a remote client (as a tool, not a
+notification), the lease has the smoke tier whose absence made seven rounds of review the way these
+were found rather than the second, and a long call now reports its progress. What is still missing
+is **service installation** — the listener runs in whatever shell starts it — tracked as
+`FOLLOWUPS.md` item 23.
 
 ---
 

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -634,18 +634,26 @@ Worth knowing before touching any job name in this repository, not just this one
 
 ## 23. [windbg-mcp] The listener is transport-complete, not usable-complete
 
-Two halves of this are **done** (2026-08-17): `server_log` reaches a client on any machine with the
-records *both* processes made — bounded, and saying so when a record was dropped or evicted rather
-than leaving a gap to be read as quiet ([`DECISIONS.md`](./DECISIONS.md) records why it is a tool
-rather than MCP's deprecated logging capability), and the lease now has a **smoke tier** — four assertions in
-the protocol tier and one, against a parked kernel attach, in the debugger tier. What is left is
-the other two items [`docs/remote-listener.md`](./docs/remote-listener.md) lists under *Not there
-yet*.
+Three quarters of this are **done** (2026-08-17): `server_log` reaches a client on any machine with
+the records *both* processes made — bounded, and saying so when a record was dropped or evicted
+rather than leaving a gap to be read as quiet ([`DECISIONS.md`](./DECISIONS.md) records why it is a
+tool rather than MCP's deprecated logging capability); the lease has a **smoke tier** — four
+assertions in the protocol tier and one, against a parked kernel attach, in the debugger tier; and a
+long call now reports **progress**. What is left is the one item
+[`docs/remote-listener.md`](./docs/remote-listener.md) still lists under *Not there yet*.
 
-**No progress notifications.** A long call is silent. The worker already emits the milestones — a
-`Committed`/`Opened` opener pair, `RollingBack` — as protocol messages, so what is missing is the
-mapping onto MCP progress and a `progressToken` to hang it on, not the facts. Under stdio a caller
-watched stderr for this; a remote one has `session_status` and `server_log`, and both are pull.
+**Progress notifications — done** (`src/progress.rs`). The milestones were already protocol
+messages, so what was added is the route out: a `progressToken` read off the call's `_meta` in
+`call_tool`, a task-local sink read on the caller's task and left beside that call's waiter — the
+milestones arrive on the session's reader task, where the peer and the token are out of reach — and
+a relay that turns each step into `notifications/progress`. Two things it settled that this entry
+did not anticipate. `progress` counts **seconds elapsed with no `total`**, because a denominator
+would have to be a per-tool budget that in an opener's case does not even cover the 30s worker
+handshake before it starts. And the milestones alone would have left the two longest silences
+exactly as they were — a parked attach reports `Committed` in the first second and may never report
+again, and a pool walk or a `crash_triage` has no milestones at all — so **ten seconds without a
+word is itself reported**, which incidentally makes progress a liveness signal a client can extend
+its own request timeout on.
 
 **No service installation.** The listener runs in whatever shell starts it, so it dies with the
 login session and inherits that shell's `PATH` — which for this server decides whether the engine

--- a/README.md
+++ b/README.md
@@ -381,6 +381,15 @@ restore cut short would come back `Ok` with partial output and be reported as a 
 completed while the target was still changed — so an `interrupt` aimed at a batch that is unwinding
 says so and sends nothing, as does one repeated while a batch is still stopping.
 
+**Watching a call that is taking a while.** Put a `progressToken` in a call's `_meta` and it reports
+on itself with MCP progress notifications while it runs: the engine worker coming up, the target
+being claimed, the target being open, a teardown unwinding a transaction — and, when there is
+nothing new to say, that it is still running, every ten seconds. `progress` is seconds elapsed and
+there is no `total`, since the budget differs per tool and an opener spends up to 30s bringing a
+worker up before its own budget starts. Nothing is sent to a call that did not ask. This matters
+most over `--listen`, where `session_status` and `server_log` are on the other machine and both are
+pull — see [`docs/remote-listener.md`](./docs/remote-listener.md).
+
 **Recovering a session that is stuck.** A per-call timeout abandons the *wait*, not the job, so a
 call that reports a timeout may still be running. The case that matters is `attach_kernel`: it waits
 for the target to dial in with no timeout, and DbgEng cannot interrupt a wait that has not yet

--- a/docs/remote-listener.md
+++ b/docs/remote-listener.md
@@ -122,11 +122,43 @@ stderr — which for a live kernel session can name what the guest was doing. Un
 records reached a log file; here they reach the client, and therefore the model. Treat a live-kernel
 session accordingly.
 
+## Watching a long call
+
+`session_status` and `server_log` are both **pull**: they answer when asked, which means guessing
+when to ask about a call that has not come back. A call can report on *itself* instead, with MCP's
+progress notifications — opt in per call by putting a `progressToken` in its `_meta`:
+
+```jsonc
+{ "method": "tools/call",
+  "params": { "name": "attach_kernel",
+              "arguments": { "profile": "ctf-vm" },
+              "_meta": { "progressToken": "attach-1" } } }
+```
+
+What comes back on that call's own stream, before its result:
+
+```jsonc
+{"method":"notifications/progress","params":{"progressToken":"attach-1","progress":1.4,
+  "message":"engine worker started (pid 8124); opening the target"}}
+{"method":"notifications/progress","params":{"progressToken":"attach-1","progress":2.1,
+  "message":"the target has been created or claimed; waiting for it to break in"}}
+{"method":"notifications/progress","params":{"progressToken":"attach-1","progress":12.1,
+  "message":"still running (12.1s)"}}
+```
+
+Three things worth knowing. `progress` is **seconds elapsed** and there is no `total` — the budget
+is a different constant per tool and an opener spends up to 30s bringing a worker up before its
+budget even starts, so a denominator here would be a number the server cannot stand behind. A call
+that has nothing new to say reports that it is **still running** every ten seconds, which is what
+covers the two longest silences: a kernel attach whose last real milestone lands in the first second
+and may never be followed, and a pool walk or `crash_triage`, which have no milestones at all. And
+nothing at all is sent to a call that did not ask.
+
+This is the same on stdio, where it is a convenience; here it is the only thing that arrives while a
+call is outstanding.
+
 ## Not there yet
 
-- **No progress notifications.** A long call is quiet; the SSE keep-alive holds the stream open but
-  nothing reports what the call is doing. `session_status` still answers, and `server_log` says what
-  the server has been doing — but neither is the call reporting on itself.
 - **No service installation.** The listener runs in whatever shell you start it in. A Windows
   service would give it a defined `PATH` and working directory, boot start, and a life independent
   of a login session.

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -14,7 +14,8 @@ $env:WINDBG_MCP_SMOKE_DUMP = "1"; cargo test --test mcp_smoke   # + the debugger
 
 It builds and runs against `target/debug`, so it never touches the `target/release` exe a
 connected MCP client holds a lock on (see [`CLAUDE.md`](../CLAUDE.md)). The protocol tier is ~2s;
-adding the debugger tier takes it to ~40s, almost all of it one test waiting out a lease grace.
+adding the debugger tier takes it to ~50s, almost all of it two tests waiting out real timers — a
+lease grace, and a call staying silent long enough to have to report that it is still running.
 
 ### Tiers
 
@@ -346,6 +347,36 @@ come up, so the budget is shrunk to a second) and watches **stderr**, not HTTP �
 request renews the lease, so a test that polled would hold open the very thing it is waiting to
 expire. It asserts the worker process is gone, the swept session id is no longer served, and the
 next client gets a server with nothing left over. Budget ~40s.
+
+**Progress notifications.** The policy — what is reported, when a silence becomes a heartbeat, that
+a send never delays the call — has unit tests in [`progress.rs`](../src/progress.rs) against a
+collector. What those cannot reach is whether any of it leaves the process, so three assertions do:
+
+- *A call that asked for no progress is sent none*, checked against **stdout as a whole**, since
+  that is the transport a stray notification would corrupt. The call is an open that fails, so it
+  exercises the path that would report rather than a tool with nothing to say. Protocol tier.
+- *An open reports its milestones before it answers.* The debugger tier, because the sequence is the
+  point: worker up, target claimed, target open, in that order, one notification each, on the token
+  the call supplied, with `progress` increasing and no `total`. They are read out of the queue of
+  messages that arrived *while the call was outstanding*, which is what makes "before" an assertion.
+- *A remote client is told how a call is going.* The same thing over HTTP, where it is the only
+  channel that exists while a call runs: rmcp routes the notification onto the SSE stream the call
+  is answered on, keyed by the token, so the milestone and the result come back together. A failing
+  open on purpose — one milestone proves the route, and it costs a worker coming up rather than a
+  dump load that may go to a symbol server.
+- *A call with nothing to report still reports that it is running.* The half of this that is not a
+  mapping, and the one that covers a call with **no milestones at all** — a pool walk, a
+  `crash_triage`, a batch. A twelve-second batch of `.sleep`s, asserted to produce a beat and
+  nothing else. The beat is ten seconds and deliberately not tunable, so this costs wall clock;
+  it runs beside the lease grace rather than after it. A parked kernel attach is the other silence
+  and would prove the same thing, at the price of a worker holding a UDP port through a
+  twenty-second teardown.
+
+The third milestone rides an existing test rather than one of its own: *ending a session stops a
+running batch and rolls it back* now watches its own `end_session`, and asserts the teardown said
+it had found a transaction to unwind. That is the only milestone with a *number* a caller can act
+on, and it is only produced when a teardown really does land mid-transaction — which that test is
+already at pains to arrange.
 
 This tier is also the only end-to-end check of the **protocol channel** — the inherited pipe pair a
 worker speaks on ([`proto.rs`](../src/proto.rs)). Handles are passed on the worker's command line

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -438,7 +438,28 @@ pub struct Session {
     rec: crate::record::Recorder,
 }
 
-type Waiters = Arc<Mutex<HashMap<u64, oneshot::Sender<Result<Output, EngineError>>>>>;
+/// A call that has been submitted and not yet answered: where its answer goes, and where the
+/// milestones on the way to it go.
+///
+/// The two travel together because they have the same lifetime and the same lock. A milestone is
+/// only worth reporting while somebody is still waiting for the result, and removing the waiter —
+/// which is how a call stops counting as outstanding — takes the only reporter reachable by that
+/// job id with it. Keeping them in separate maps would be two removals to keep in step, and the one
+/// that got forgotten would report progress against a call already answered.
+#[derive(Debug)]
+struct Waiting {
+    done: oneshot::Sender<Result<Output, EngineError>>,
+    /// Where this call reports what it is doing, when its client asked to be told
+    /// ([`crate::progress`]). `None` for the overwhelming majority: no `progressToken`, or no
+    /// client at all — the shutdown sweep and reclamation call through here too.
+    ///
+    /// Read from the task-local on the **caller's** task, in [`Sessions::call_as`], because that is
+    /// the only place both facts are in hand. The milestones themselves arrive in [`reader`], which
+    /// belongs to the session rather than to any one call and can only find this by job id.
+    progress: Option<crate::progress::Reporter>,
+}
+
+type Waiters = Arc<Mutex<HashMap<u64, Waiting>>>;
 
 impl Session {
     fn state(&self) -> SessionState {
@@ -573,7 +594,7 @@ impl Session {
             .lock()
             .unwrap_or_else(|e| e.into_inner())
             .drain()
-            .map(|(_, tx)| tx)
+            .map(|(_, waiting)| waiting.done)
             .collect();
         for tx in waiters {
             let _ = tx.send(Err(EngineError::Lost(why.to_string())));
@@ -1005,13 +1026,23 @@ impl Sessions {
         // Without taking it here, a call could become in-flight in the gap between that decision
         // and the close, and reclamation would then end a session the caller had just started
         // using. Held only across the insert; the send below is outside it.
+        //
+        // The reporter is read here for a reason of its own: this is the caller's task, and so the
+        // last point at which the client's request is still reachable. Everything past it —
+        // `pump`'s thread, the worker's reader — belongs to the session rather than to this call.
         {
             let _reclamation = self.registry();
             session
                 .waiters
                 .lock()
                 .unwrap_or_else(|e| e.into_inner())
-                .insert(id, tx);
+                .insert(
+                    id,
+                    Waiting {
+                        done: tx,
+                        progress: crate::progress::current(),
+                    },
+                );
         }
         let queued = session.tx.send(Job {
             id,
@@ -1137,6 +1168,16 @@ impl Sessions {
         // Released only now: from here the session is counted in `all` instead, and holding both
         // would count this open twice.
         drop(slot);
+
+        // The supervisor's own milestone, and the only one an opener has before the worker's.
+        // Bringing a worker up takes as long as `WORKER_READY_TIMEOUT` allows, and until this the
+        // client has been told nothing at all — so a client watching progress reads a server that
+        // looks idle for the one part of an open the *supervisor* is responsible for. Reported here
+        // rather than from `spawn`, so it says a worker that was also admitted and registered:
+        // `admit` can still refuse one, and a session that was never routable is not an open that
+        // is under way. See [`crate::progress`] for why this one can be reported directly while the
+        // worker's have to travel with the waiter.
+        crate::progress::report(crate::progress::Step::Spawned { pid: session.pid });
 
         // On the reserved job id, so `reader` can still recognise this open if the caller's
         // timeout means nobody is left to settle it.
@@ -2380,7 +2421,7 @@ fn pump(
                 .unwrap_or_else(|e| e.into_inner())
                 .remove(&job.id);
             if let Some(waiter) = waiter {
-                let _ = waiter.send(result);
+                let _ = waiter.done.send(result);
             }
         };
 
@@ -2423,6 +2464,22 @@ fn pump(
     }
 }
 
+/// Passes a milestone on to the caller waiting for `id`, if that caller asked to be told.
+///
+/// Looked up rather than removed: the call is still running, and this is a thing it is doing on the
+/// way to its answer. Silent when there is no waiter (the caller's budget expired and the job is
+/// still out there) or no reporter (the common case — see [`Waiting::progress`]).
+fn tell(waiters: &Waiters, id: u64, step: crate::progress::Step) {
+    let reporter = waiters
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .get(&id)
+        .and_then(|waiting| waiting.progress.clone());
+    if let Some(reporter) = reporter {
+        reporter.step(step);
+    }
+}
+
 /// Consumes one worker's messages: milestones move the session's state, results answer callers.
 ///
 /// Fed by [`read_messages`]'s thread, so this side stays on the runtime — settling a session
@@ -2450,10 +2507,12 @@ async fn reader(
                 session.update_state(|state| {
                     matches!(state, SessionState::Opening).then_some(SessionState::Attaching)
                 });
+                tell(&waiters, id, crate::progress::Step::Committed);
             }
             WorkerMessage::Opened { id } if id == OPENER_JOB => {
                 session.reach(OpenPhase::Opened);
                 promote_opened(&session);
+                tell(&waiters, id, crate::progress::Step::Opened);
             }
             // Already recorded by the thread that read it — see [`Session::unwinding`] — so this
             // arm only reports it. Nothing here is on the teardown's critical path, which is the
@@ -2465,6 +2524,9 @@ async fn reader(
                      it needs up to {within:?}",
                     session.id
                 );
+                // The one milestone whose *number* the caller can act on: a teardown that looks
+                // stuck is a teardown waiting out a rollback, and this says how long that is.
+                tell(&waiters, id, crate::progress::Step::Unwinding { within });
             }
             WorkerMessage::Committed { id } | WorkerMessage::Opened { id } => {
                 tracing::warn!(
@@ -2477,7 +2539,12 @@ async fn reader(
                     .lock()
                     .unwrap_or_else(|e| e.into_inner())
                     .remove(&id);
-                let Some(waiter) = waiter else { continue };
+                // Taken out of the map, so nothing can report a milestone for this job again: the
+                // only reporter reachable by its id went with it. A call that has an answer is
+                // done saying what it is doing.
+                let Some(Waiting { done: waiter, .. }) = waiter else {
+                    continue;
+                };
                 // A failed send means the receiver is gone: the caller's timeout fired and
                 // nobody is left to act on this result. For an ordinary call that is fine —
                 // removing the entry above is what mattered, and it is how the session stops
@@ -3067,7 +3134,13 @@ mod tests {
         idle.waiters
             .lock()
             .unwrap_or_else(|e| e.into_inner())
-            .insert(1, tx);
+            .insert(
+                1,
+                Waiting {
+                    done: tx,
+                    progress: None,
+                },
+            );
         assert!(idle.busy(), "an abandoned call still owes a reply");
     }
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -2519,14 +2519,28 @@ async fn reader(
             // whole reason the store is not here.
             WorkerMessage::RollingBack { id, within_ms } => {
                 let within = Duration::from_millis(u64::from(within_ms));
-                tracing::info!(
-                    "session {}: job {id} found a transaction in flight and told it to roll back; \
-                     it needs up to {within:?}",
-                    session.id
-                );
-                // The one milestone whose *number* the caller can act on: a teardown that looks
-                // stuck is a teardown waiting out a rollback, and this says how long that is.
-                tell(&waiters, id, crate::progress::Step::Unwinding { within });
+                // **Zero is a retraction, not a shorter promise.** The worker sends this message
+                // twice for one transaction: once when a teardown finds a batch to stop, naming
+                // how long that leaves, and once from the batch's own guard naming zero to say the
+                // transaction is over (`worker::RETRACTED`). Reading the second as another unwind
+                // reports a transaction still in flight at the moment it stopped being one — and
+                // says "up to 0.0s" doing it.
+                if within.is_zero() {
+                    tracing::info!(
+                        "session {}: job {id}'s transaction is unwound; only the release is left",
+                        session.id
+                    );
+                    tell(&waiters, id, crate::progress::Step::Unwound);
+                } else {
+                    tracing::info!(
+                        "session {}: job {id} found a transaction in flight and told it to roll \
+                         back; it needs up to {within:?}",
+                        session.id
+                    );
+                    // The one milestone whose *number* the caller can act on: a teardown that
+                    // looks stuck is a teardown waiting out a rollback, and this says how long.
+                    tell(&waiters, id, crate::progress::Step::Unwinding { within });
+                }
             }
             WorkerMessage::Committed { id } | WorkerMessage::Opened { id } => {
                 tracing::warn!(

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -457,6 +457,15 @@ struct Waiting {
     /// the only place both facts are in hand. The milestones themselves arrive in [`reader`], which
     /// belongs to the session rather than to any one call and can only find this by job id.
     progress: Option<crate::progress::Reporter>,
+    /// Whether this job's transaction has already been reported as unwound.
+    ///
+    /// The worker's two `RollingBack` messages are emitted by *different threads* — the promise by
+    /// its request reader, the retraction by its engine thread — so a teardown landing exactly as a
+    /// batch exits can put them on the wire in either order. [`read_messages`] already defends the
+    /// session's deadline against that by keeping the earlier instant; this is the same defence for
+    /// the words a client reads, which would otherwise go "has been rolled back" and then back to
+    /// "rolling it back".
+    unwound: bool,
 }
 
 type Waiters = Arc<Mutex<HashMap<u64, Waiting>>>;
@@ -1041,6 +1050,7 @@ impl Sessions {
                     Waiting {
                         done: tx,
                         progress: crate::progress::current(),
+                        unwound: false,
                     },
                 );
         }
@@ -2480,6 +2490,39 @@ fn tell(waiters: &Waiters, id: u64, step: crate::progress::Step) {
     }
 }
 
+/// Reports a rollback milestone to the caller waiting for `id`, and refuses to walk one backwards.
+///
+/// Its own function rather than a [`tell`] call because it is the one milestone with *state*: the
+/// worker sends `RollingBack` twice for a single transaction, and the second reading is terminal.
+/// Both the flag and the reporter are read under one lock so the decision cannot straddle another
+/// message; the send happens outside it, as everywhere else here.
+///
+/// See [`Waiting::unwound`] for why arrival order cannot be trusted.
+fn tell_rollback(waiters: &Waiters, id: u64, within: Duration) {
+    let telling = {
+        let mut waiters = waiters.lock().unwrap_or_else(|e| e.into_inner());
+        let Some(waiting) = waiters.get_mut(&id) else {
+            return;
+        };
+        if within.is_zero() {
+            // Terminal for this job: nothing arriving later can put the transaction back in
+            // flight, because there is no longer one to be in flight.
+            waiting.unwound = true;
+        } else if waiting.unwound {
+            return;
+        }
+        let step = if within.is_zero() {
+            crate::progress::Step::Unwound
+        } else {
+            crate::progress::Step::Unwinding { within }
+        };
+        waiting.progress.clone().map(|reporter| (reporter, step))
+    };
+    if let Some((reporter, step)) = telling {
+        reporter.step(step);
+    }
+}
+
 /// Consumes one worker's messages: milestones move the session's state, results answer callers.
 ///
 /// Fed by [`read_messages`]'s thread, so this side stays on the runtime — settling a session
@@ -2530,17 +2573,19 @@ async fn reader(
                         "session {}: job {id}'s transaction is unwound; only the release is left",
                         session.id
                     );
-                    tell(&waiters, id, crate::progress::Step::Unwound);
                 } else {
+                    // The one milestone whose *number* the caller can act on: a teardown that
+                    // looks stuck is a teardown waiting out a rollback, and this says how long.
                     tracing::info!(
                         "session {}: job {id} found a transaction in flight and told it to roll \
                          back; it needs up to {within:?}",
                         session.id
                     );
-                    // The one milestone whose *number* the caller can act on: a teardown that
-                    // looks stuck is a teardown waiting out a rollback, and this says how long.
-                    tell(&waiters, id, crate::progress::Step::Unwinding { within });
                 }
+                // Logged either way and *reported* conditionally, which is the right split: the log
+                // is a faithful record of what arrived on the wire, and progress is a narration of
+                // the call for a client — and a narration may not contradict itself.
+                tell_rollback(&waiters, id, within);
             }
             WorkerMessage::Committed { id } | WorkerMessage::Opened { id } => {
                 tracing::warn!(
@@ -3132,6 +3177,69 @@ mod tests {
         assert_eq!(sessions.registry().live().len(), MAX_SESSIONS);
     }
 
+    /// A rollback promise that arrives *after* its own retraction is not reported.
+    ///
+    /// The two `RollingBack` messages come from different threads in the worker, so a teardown
+    /// landing exactly as a batch exits can put them on the wire in either order — `read_messages`
+    /// says so where it keeps the earlier deadline. Without the same defence here, the client is
+    /// told the transaction is done and then told it is still unwinding, which is the one thing a
+    /// narration of a call must never do.
+    #[test]
+    fn a_rollback_promise_that_arrives_after_its_retraction_is_not_reported() {
+        let (reporter, mut reported) = crate::progress::Reporter::for_test();
+        let waiters: Waiters = Arc::new(Mutex::new(HashMap::new()));
+        let (tx, _caller) = oneshot::channel();
+        waiters.lock().unwrap_or_else(|e| e.into_inner()).insert(
+            7,
+            Waiting {
+                done: tx,
+                progress: Some(reporter),
+                unwound: false,
+            },
+        );
+
+        // Out of order on purpose: the retraction first, then the promise it retracts.
+        tell_rollback(&waiters, 7, Duration::ZERO);
+        tell_rollback(&waiters, 7, Duration::from_secs(12));
+
+        assert_eq!(
+            reported.try_recv(),
+            Ok(crate::progress::Step::Unwound),
+            "the retraction is the milestone worth having"
+        );
+        assert!(
+            reported.try_recv().is_err(),
+            "a stale promise must not put the transaction back in flight"
+        );
+    }
+
+    /// And in the ordinary order both are reported, because both are true in turn.
+    #[test]
+    fn a_rollback_reports_its_promise_and_then_its_retraction() {
+        let (reporter, mut reported) = crate::progress::Reporter::for_test();
+        let waiters: Waiters = Arc::new(Mutex::new(HashMap::new()));
+        let (tx, _caller) = oneshot::channel();
+        waiters.lock().unwrap_or_else(|e| e.into_inner()).insert(
+            7,
+            Waiting {
+                done: tx,
+                progress: Some(reporter),
+                unwound: false,
+            },
+        );
+
+        tell_rollback(&waiters, 7, Duration::from_secs(12));
+        tell_rollback(&waiters, 7, Duration::ZERO);
+
+        assert_eq!(
+            reported.try_recv(),
+            Ok(crate::progress::Step::Unwinding {
+                within: Duration::from_secs(12)
+            })
+        );
+        assert_eq!(reported.try_recv(), Ok(crate::progress::Step::Unwound));
+    }
+
     /// A parked attach is *busy*, so it is never the session reclaimed to make room — and a
     /// caller who gave up waiting does not make it idle either, because the worker still owes a
     /// reply.
@@ -3153,6 +3261,7 @@ mod tests {
                 Waiting {
                     done: tx,
                     progress: None,
+                    unwound: false,
                 },
             );
         assert!(idle.busy(), "an abandoned call still owes a reply");

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ mod engine;
 mod kdconn;
 mod listen;
 mod logbridge;
+mod progress;
 mod proto;
 mod record;
 mod server;

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -1,0 +1,419 @@
+//! What a long call says while it is still running: MCP progress notifications.
+//!
+//! A tool call here can take minutes. A kernel attach waits for its target to dial in, a pool walk
+//! reads every page, `!analyze -v` goes to a symbol server — and every one of them used to be
+//! silent from the request until the result. Under stdio that was survivable, because the operator
+//! could watch the server's stderr scroll past. Over `--listen` it is not: those records are on the
+//! *other* machine, and both ways of asking for them ([`crate::server`]'s `session_status` and
+//! `server_log`) are **pull**, so a client has to guess when to ask about a call it cannot see.
+//!
+//! **The facts were already there.** A worker announces `Committed` and `Opened` as it opens a
+//! target and `RollingBack` when a teardown finds a transaction to unwind
+//! ([`crate::proto::WorkerMessage`]), and the supervisor knows when the engine worker process came
+//! up. What was missing was a `progressToken` to hang them on and a route out to the client. This
+//! module is that route, plus one fact of its own — the heartbeat below.
+//!
+//! ## Four properties worth keeping
+//!
+//! **Nothing is sent unless the client asked for it.** MCP makes progress opt-in per request: a
+//! caller that wants it puts a `progressToken` in the call's `_meta`. Without one there is no
+//! channel, no timer and no notification — the same shape as [`crate::record`], which costs a
+//! server that is not recording nothing at all.
+//!
+//! **A milestone is learned where it cannot be reported.** `Committed` arrives on the task that
+//! reads a worker's channel, which belongs to the session rather than to any one call — while the
+//! peer and the token belong to the *call*, forty-odd tool bodies away. So the sink is read once
+//! from a task-local on the caller's own task, in [`crate::engine::Sessions::call_as`], and left
+//! beside that call's waiter for the reader to find by job id. It is dropped with the waiter, which
+//! is what stops a milestone being reported against a call that has already been answered.
+//!
+//! **Reporting never holds up the work.** A notification is sent while the tool call is still being
+//! polled, never instead of it: a client that has stopped reading its stream must not be able to
+//! stall a debugger command. If the call finishes mid-send, the send is abandoned — the result is
+//! already on its way, and nothing downstream needs the notification that would have preceded it.
+//!
+//! **`progress` counts seconds, and there is no `total`.** Elapsed time is the one measure every
+//! call here shares, it increases strictly (which is what MCP asks of the field), and it is the
+//! number a reader actually wants from a debugger. A denominator would have to be the call's
+//! budget, and that is a different constant per tool — `END_SESSION_TIMEOUT` for a teardown,
+//! `INTERRUPT_TIMEOUT` for an interrupt, the configured call timeout for the rest, none of which
+//! covers the up-to-30s worker handshake an opener spends before its budget even starts. An absent
+//! `total` says "unknown", which is true; a wrong one would say something false.
+
+use std::future::Future;
+use std::time::{Duration, Instant};
+
+use rmcp::model::{ProgressNotificationParam, ProgressToken};
+use rmcp::service::RequestContext;
+use rmcp::{Peer, RoleServer};
+use tokio::sync::mpsc;
+
+use crate::server::fmt_duration;
+
+/// How long a call may say nothing before it reports that it is nonetheless still running.
+///
+/// Not decoration. A client may treat progress as a liveness signal and extend its own request
+/// timeout on each one (rmcp's own client does, as `reset_timeout_on_progress`), so the interval
+/// has to sit well inside any timeout a client would plausibly apply to a single call. It also has
+/// to be long enough that the default 300s budget produces a readable trace rather than a flood:
+/// at ten seconds that is thirty lines for the longest call this server allows, and none at all for
+/// the overwhelming majority, which answer in milliseconds.
+const HEARTBEAT: Duration = Duration::from_secs(10);
+
+/// Something a call did on its way to an answer.
+///
+/// Deliberately a closed set of *milestones* rather than a free-text channel. Each one is a
+/// transition the supervisor already acts on — they decide what an open's failure means and how
+/// long a teardown waits — so a step that stops being reported here is a step that stopped
+/// happening, rather than a log line somebody forgot to write.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Step {
+    /// The engine worker process is up and has an engine; the opener is about to be sent to it.
+    ///
+    /// The supervisor's own, not a worker's: it is what the up-to-[`crate::engine::WORKER_READY_TIMEOUT`]
+    /// handshake before an opener ends with, and without it the whole of that wait looks like a
+    /// server doing nothing.
+    Spawned { pid: u32 },
+    /// The target was created or claimed — the dump handed over, the process spawned, the KD
+    /// connection taken. From here a failure means "do not open again"; see
+    /// [`crate::proto::WorkerMessage::Committed`].
+    Committed,
+    /// The opener's wait returned: the target is loaded and stopped, and only its report is left.
+    Opened,
+    /// A teardown found a transaction in flight and told it to stop and roll back, which it has
+    /// this long to finish ([`crate::proto::WorkerMessage::RollingBack`]).
+    Unwinding { within: Duration },
+}
+
+impl Step {
+    /// What the client is told. Written in the same vocabulary `session_status` uses for the same
+    /// states, so a caller that sees both does not have to learn two names for one thing.
+    fn message(self) -> String {
+        match self {
+            Self::Spawned { pid } => {
+                format!("engine worker started (pid {pid}); opening the target")
+            }
+            Self::Committed => {
+                "the target has been created or claimed; waiting for it to break in".to_string()
+            }
+            Self::Opened => "the target is open; reading its report".to_string(),
+            Self::Unwinding { within } => format!(
+                "a transaction is in flight; rolling it back (up to {})",
+                fmt_duration(within)
+            ),
+        }
+    }
+}
+
+/// Where one call's milestones go while it runs.
+///
+/// Unbounded because the alternative is worse in the one case that matters: this is written from a
+/// worker's message reader, and a bounded channel that filled would block that reader — which is
+/// the thread whose progress a teardown's grace depends on. The bound is inherent instead, and
+/// small: a call reports at most three of these, and the copy the engine holds is dropped when the
+/// call is answered.
+#[derive(Clone, Debug)]
+pub struct Reporter(mpsc::UnboundedSender<Step>);
+
+impl Reporter {
+    /// Reports `step`. A step nobody reads — into a closed channel, or into an open one the relay
+    /// has stopped selecting on because the answer arrived first — is a normal outcome, not an
+    /// error: what supersedes a progress line is the result it would have preceded.
+    pub fn step(&self, step: Step) {
+        let _ = self.0.send(step);
+    }
+}
+
+tokio::task_local! {
+    /// Where the call running on this task reports what it is doing.
+    ///
+    /// A task-local for the mirror image of [`crate::record`]'s `ROUTED`: that one carries a fact
+    /// *out* of a call that forty-odd tool bodies never mention, and this one carries a sink *in*.
+    /// Threading it through would mean a parameter on every tool signature, on `run`, on `run_call`
+    /// and on `opened`, naming something none of them uses — and the tools that would be forgotten
+    /// are the ones added next.
+    ///
+    /// Set only when the client asked for progress, so `try_with` failing is the ordinary case.
+    static REPORTING: Reporter;
+}
+
+/// The reporter for the call running on this task, if it has one.
+///
+/// Read once, by [`crate::engine::Sessions::call_as`], and stored beside the call's waiter — the
+/// milestones themselves arrive on another task entirely, where this would answer `None`.
+pub fn current() -> Option<Reporter> {
+    REPORTING.try_with(Clone::clone).ok()
+}
+
+/// Reports a step for the call running on this task. Silent when there is none — outside a tool
+/// call, or when the client asked for no progress.
+pub fn report(step: Step) {
+    let _ = REPORTING.try_with(|reporter| reporter.step(step));
+}
+
+/// A client's request to be told how a call is going, or the absence of one.
+///
+/// Built from the request before the tool router consumes it, so the whole of a tool call — the
+/// routing, the worker handshake, the engine call — runs inside the scope.
+pub struct Watch(Option<(Peer<RoleServer>, ProgressToken)>);
+
+impl Watch {
+    /// What this request asked for. `_meta.progressToken` is MCP's opt-in, and its absence is the
+    /// common case.
+    pub fn of(context: &RequestContext<RoleServer>) -> Self {
+        Self(
+            context
+                .meta
+                .get_progress_token()
+                .map(|token| (context.peer.clone(), token)),
+        )
+    }
+
+    /// Runs `work`, forwarding what it reports to the client as `notifications/progress`.
+    pub async fn run<F: Future>(self, work: F) -> F::Output {
+        let Some((peer, token)) = self.0 else {
+            return work.await;
+        };
+        relay(work, HEARTBEAT, move |progress, message| {
+            let param =
+                ProgressNotificationParam::new(token.clone(), progress).with_message(message);
+            let peer = peer.clone();
+            async move {
+                // Best-effort by construction: the client is being *told* something, and a
+                // notification that could not be delivered must never turn a debugger call that
+                // worked into one that failed. Logged at debug because the ordinary cause is a
+                // client that has gone away, which every other path already reports.
+                if let Err(e) = peer.notify_progress(param).await {
+                    tracing::debug!("could not send a progress notification: {e}");
+                }
+            }
+        })
+        .await
+    }
+}
+
+/// Drives `work`, turning the steps it reports — and the silences between them — into `notify`
+/// calls carrying seconds elapsed and a message.
+///
+/// Free of rmcp on purpose: the policy (what is reported, when a silence becomes a heartbeat, that
+/// a send never delays the work) is the part worth testing, and it tests against a `Vec` rather
+/// than against a peer that would need a whole service behind it.
+async fn relay<W, N, F>(work: W, beat: Duration, notify: N) -> W::Output
+where
+    W: Future,
+    N: Fn(f64, String) -> F,
+    F: Future<Output = ()>,
+{
+    let started = Instant::now();
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    // Held here *as well as* inside the scope, so the channel cannot close while this loop is still
+    // selecting on it. A `recv()` on a closed channel is instantly ready, and an arm that is
+    // instantly ready inside a loop is a spin.
+    let reporter = Reporter(tx);
+    let mut work = std::pin::pin!(REPORTING.scope(reporter.clone(), work));
+    let mut ticker = tokio::time::interval_at(tokio::time::Instant::now() + beat, beat);
+    // The beat measures silence, not wall clock: a runtime that was busy elsewhere must not make up
+    // the ticks it missed by sending several notifications at once.
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    loop {
+        let message = tokio::select! {
+            outcome = &mut work => return outcome,
+            Some(step) = rx.recv() => step.message(),
+            _ = ticker.tick() => format!("still running ({})", fmt_duration(started.elapsed())),
+        };
+        // Restarted after anything said, so the heartbeat is "nothing for `beat`" rather than a
+        // metronome running beside the milestones.
+        ticker.reset();
+        let mut sending = std::pin::pin!(notify(started.elapsed().as_secs_f64(), message));
+        tokio::select! {
+            // The work is still polled while the notification goes out, and wins if it lands
+            // first: an undelivered progress line costs nothing once the result exists, while a
+            // client that has stopped reading its stream must never be able to stall the debugger.
+            outcome = &mut work => return outcome,
+            () = &mut sending => {}
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use super::*;
+
+    /// Collects what `relay` would have sent.
+    type Sent = Arc<Mutex<Vec<(f64, String)>>>;
+
+    fn collector() -> (Sent, impl Fn(f64, String) -> std::future::Ready<()>) {
+        let sent: Sent = Arc::default();
+        let into = Arc::clone(&sent);
+        (sent, move |progress, message| {
+            into.lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .push((progress, message));
+            std::future::ready(())
+        })
+    }
+
+    fn messages(sent: &Sent) -> Vec<String> {
+        sent.lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .iter()
+            .map(|(_, message)| message.clone())
+            .collect()
+    }
+
+    /// Lets the relay drain what has just been reported before the work returns.
+    ///
+    /// A step reported in the same instant the answer arrives may or may not be delivered — the
+    /// result supersedes it, and `select!` picks between two ready branches at random — so a test
+    /// that asserted on that race would be flaky about behaviour nobody depends on. Every test
+    /// here ends its work with this so what it counts is the steady state.
+    async fn settle() {
+        tokio::time::sleep(Duration::from_millis(1)).await;
+    }
+
+    /// The opener sequence, end to end: what the supervisor and its worker report becomes three
+    /// notifications, in the order the target actually reached those states.
+    #[tokio::test(start_paused = true)]
+    async fn the_milestones_a_call_reports_become_notifications_in_order() {
+        let (sent, notify) = collector();
+        relay(
+            async {
+                report(Step::Spawned { pid: 4242 });
+                // The reporter a worker's reader would be handed: the milestones after the first
+                // arrive on another task, and reach the same channel through the waiter.
+                let reader = current().expect("a call being watched has a reporter");
+                tokio::task::spawn(async move {
+                    reader.step(Step::Committed);
+                    reader.step(Step::Opened);
+                })
+                .await
+                .expect("the reader task");
+                settle().await;
+            },
+            HEARTBEAT,
+            notify,
+        )
+        .await;
+
+        let said = messages(&sent);
+        assert_eq!(said.len(), 3, "one notification per milestone: {said:?}");
+        assert!(said[0].contains("pid 4242"), "{said:?}");
+        assert!(said[1].contains("created or claimed"), "{said:?}");
+        assert!(said[2].contains("target is open"), "{said:?}");
+    }
+
+    /// Progress is seconds elapsed, so it strictly increases and never claims a total it cannot
+    /// know. Two milestones in the same instant would otherwise report the same number, which is
+    /// the one thing MCP asks this field not to do.
+    #[tokio::test(start_paused = true)]
+    async fn progress_increases_and_names_no_total() {
+        let (sent, notify) = collector();
+        relay(
+            async {
+                report(Step::Committed);
+                tokio::time::sleep(Duration::from_millis(250)).await;
+                report(Step::Opened);
+                settle().await;
+            },
+            HEARTBEAT,
+            notify,
+        )
+        .await;
+
+        let sent = sent.lock().unwrap_or_else(|e| e.into_inner()).clone();
+        assert_eq!(sent.len(), 2, "{sent:?}");
+        assert!(
+            sent[1].0 > sent[0].0,
+            "progress must increase between milestones: {sent:?}"
+        );
+    }
+
+    /// A call with nothing to say still says it is running, which is the whole point for a kernel
+    /// attach: `Committed` lands in the first second and the next real event may be minutes away.
+    #[tokio::test(start_paused = true)]
+    async fn a_silent_call_still_reports_that_it_is_running() {
+        let (sent, notify) = collector();
+        relay(
+            tokio::time::sleep(HEARTBEAT * 3 + Duration::from_secs(1)),
+            HEARTBEAT,
+            notify,
+        )
+        .await;
+
+        let said = messages(&sent);
+        assert_eq!(said.len(), 3, "one beat per silent interval: {said:?}");
+        assert!(
+            said.iter().all(|m| m.starts_with("still running")),
+            "{said:?}"
+        );
+    }
+
+    /// And the beat measures silence rather than wall clock, so a call that is reporting normally
+    /// does not also accumulate heartbeats behind it.
+    #[tokio::test(start_paused = true)]
+    async fn a_milestone_restarts_the_beat() {
+        let (sent, notify) = collector();
+        relay(
+            async {
+                for _ in 0..3 {
+                    tokio::time::sleep(HEARTBEAT - Duration::from_secs(1)).await;
+                    report(Step::Committed);
+                }
+                settle().await;
+            },
+            HEARTBEAT,
+            notify,
+        )
+        .await;
+
+        let said = messages(&sent);
+        assert_eq!(
+            said.len(),
+            3,
+            "three milestones and no beat between them: {said:?}"
+        );
+    }
+
+    /// Nothing is reported after the result exists. The work winning the race is what makes a
+    /// stalled client a client's own problem rather than the debugger's.
+    #[tokio::test(start_paused = true)]
+    async fn the_answer_ends_the_reporting() {
+        let (sent, notify) = collector();
+        let reporter: Arc<Mutex<Option<Reporter>>> = Arc::default();
+        let escaped = Arc::clone(&reporter);
+        relay(
+            async move {
+                *escaped.lock().unwrap_or_else(|e| e.into_inner()) = current();
+            },
+            HEARTBEAT,
+            notify,
+        )
+        .await;
+
+        // The waiter this belongs to would be gone by now; a clone that outlived it must not be
+        // able to say anything more.
+        let escaped = reporter
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .take()
+            .expect("the call had a reporter");
+        escaped.step(Step::Opened);
+        tokio::time::advance(HEARTBEAT * 2).await;
+        assert!(
+            messages(&sent).is_empty(),
+            "a finished call reports nothing: {:?}",
+            messages(&sent)
+        );
+    }
+
+    /// Outside a watched call there is nowhere to report to, and that is the common case — a
+    /// client that asked for no progress, the shutdown sweep, the reclamation that ends somebody
+    /// else's session on a task of its own.
+    #[tokio::test]
+    async fn reporting_outside_a_watched_call_is_silent() {
+        assert!(current().is_none(), "no reporter outside a scope");
+        report(Step::Committed);
+    }
+}

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -143,6 +143,17 @@ impl Reporter {
     }
 }
 
+#[cfg(test)]
+impl Reporter {
+    /// A reporter and the receiving end, for tests in *other* modules that need to see what a call
+    /// reported. The field is private on purpose — nothing outside this module should be able to
+    /// invent a sink — so the test seam is explicit rather than a widened visibility.
+    pub fn for_test() -> (Self, mpsc::UnboundedReceiver<Step>) {
+        let (tx, rx) = mpsc::unbounded_channel();
+        (Self(tx), rx)
+    }
+}
+
 tokio::task_local! {
     /// Where the call running on this task reports what it is doing.
     ///
@@ -211,6 +222,23 @@ impl Watch {
     }
 }
 
+/// The next value for `progress`: seconds elapsed, but never a repeat of the last one.
+///
+/// [`Instant`] is only *non-decreasing*, so two notifications sampled in the same tick of the
+/// platform clock can read the same — which the final flush makes likely, since it drains whatever
+/// is queued back to back. MCP asks this field to increase every time progress is made, and a
+/// client that enforces it may discard the later milestone, so the one case where the reading is
+/// not enough is nudged to the smallest value above the last. The number stays honest: it is still
+/// the elapsed seconds to any precision a reader could act on.
+fn strictly_after(reported: f64, elapsed: Duration) -> f64 {
+    let seconds = elapsed.as_secs_f64();
+    if seconds > reported {
+        seconds
+    } else {
+        reported.next_up()
+    }
+}
+
 /// Drives `work`, turning the steps it reports — and the silences between them — into `notify`
 /// calls carrying seconds elapsed and a message.
 ///
@@ -224,6 +252,9 @@ where
     F: Future<Output = ()>,
 {
     let started = Instant::now();
+    // The last value handed to `notify`, so the sequence can be kept strictly increasing even when
+    // two notifications sample the clock in the same tick. See `strictly_after`.
+    let mut reported = 0.0f64;
     let (tx, mut rx) = mpsc::unbounded_channel();
     // Held here *as well as* inside the scope, so the channel cannot close while this loop is still
     // selecting on it. A `recv()` on a closed channel is instantly ready, and an arm that is
@@ -247,7 +278,8 @@ where
         // Restarted after anything said, so the heartbeat is "nothing for `beat`" rather than a
         // metronome running beside the milestones.
         ticker.reset();
-        let mut sending = std::pin::pin!(notify(started.elapsed().as_secs_f64(), message));
+        reported = strictly_after(reported, started.elapsed());
+        let mut sending = std::pin::pin!(notify(reported, message));
         tokio::select! {
             // Biased again, one level down: a send that is ready now completes rather than being
             // dropped on a coin toss. Only a send that actually *stalls* loses to the answer —
@@ -270,7 +302,8 @@ where
     // a courtesy and the result is the contract. A client that has stopped reading its stream
     // loses the courtesy.
     while let Ok(step) = rx.try_recv() {
-        let sent = notify(started.elapsed().as_secs_f64(), step.message());
+        reported = strictly_after(reported, started.elapsed());
+        let sent = notify(reported, step.message());
         if tokio::time::timeout(FINAL_FLUSH, sent).await.is_err() {
             break;
         }
@@ -467,6 +500,25 @@ mod tests {
             "a finished call reports nothing: {:?}",
             messages(&sent)
         );
+    }
+
+    /// `progress` never repeats, even when two notifications read the same clock.
+    ///
+    /// `Instant` is only non-decreasing, and the final flush drains whatever is queued back to
+    /// back, so identical readings are reachable — and MCP asks this field to increase every time,
+    /// with clients entitled to discard a milestone that does not.
+    #[test]
+    fn progress_never_repeats_a_value() {
+        let same = Duration::from_millis(1500);
+        let first = strictly_after(0.0, same);
+        let second = strictly_after(first, same);
+        let third = strictly_after(second, same);
+        assert_eq!(first, 1.5);
+        assert!(second > first && third > second, "{first} {second} {third}");
+        // Nudged by the smallest step there is, so the number a reader acts on is unchanged.
+        assert_eq!(format!("{third:.3}"), "1.500");
+        // A real advance is taken as it comes, rather than accumulating the nudges.
+        assert_eq!(strictly_after(third, Duration::from_secs(9)), 9.0);
     }
 
     /// The two readings of the worker's one rollback message do not sound alike.

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -60,6 +60,14 @@ use crate::server::fmt_duration;
 /// the overwhelming majority, which answer in milliseconds.
 const HEARTBEAT: Duration = Duration::from_secs(10);
 
+/// How long the flush after a call finishes will wait on the transport before giving up on a
+/// milestone the answer arrived with.
+///
+/// Deliberately short. By that point the result exists, and a progress line is a courtesy while the
+/// result is the contract — so a healthy transport wins this comfortably and a client that has
+/// stopped reading its stream delays nobody's answer.
+const FINAL_FLUSH: Duration = Duration::from_secs(1);
+
 /// Something a call did on its way to an answer.
 ///
 /// Deliberately a closed set of *milestones* rather than a free-text channel. Each one is a
@@ -215,10 +223,14 @@ where
     // The beat measures silence, not wall clock: a runtime that was busy elsewhere must not make up
     // the ticks it missed by sending several notifications at once.
     ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
-    loop {
+    let outcome = 'running: loop {
         let message = tokio::select! {
-            outcome = &mut work => return outcome,
+            // Biased so that a step already in the channel is preferred to a result that became
+            // ready beside it, which keeps the order a client sees the natural one. It is not what
+            // makes the last milestone safe — see the flush below, which is.
+            biased;
             Some(step) = rx.recv() => step.message(),
+            outcome = &mut work => break 'running outcome,
             _ = ticker.tick() => format!("still running ({})", fmt_duration(started.elapsed())),
         };
         // Restarted after anything said, so the heartbeat is "nothing for `beat`" rather than a
@@ -226,13 +238,33 @@ where
         ticker.reset();
         let mut sending = std::pin::pin!(notify(started.elapsed().as_secs_f64(), message));
         tokio::select! {
-            // The work is still polled while the notification goes out, and wins if it lands
-            // first: an undelivered progress line costs nothing once the result exists, while a
-            // client that has stopped reading its stream must never be able to stall the debugger.
-            outcome = &mut work => return outcome,
+            // Biased again, one level down: a send that is ready now completes rather than being
+            // dropped on a coin toss. Only a send that actually *stalls* loses to the answer —
+            // which is the property that matters, because a client that has stopped reading its
+            // stream must never be able to hold up the debugger. The work is still polled
+            // throughout, so it never waits on the notification.
+            biased;
             () = &mut sending => {}
+            outcome = &mut work => break 'running outcome,
+        }
+    };
+
+    // **The last milestone is queued by the very poll that produces the answer**, so no polling
+    // order above can catch it: `work` has to run to report `RollingBack`, and the same run
+    // returns `Done`. Selecting more carefully cannot help — only looking again afterwards can.
+    // Without this, an `end_session` that unwinds a transaction tells the client how long that
+    // will take, or does not, depending on scheduling.
+    //
+    // Bounded, because by here the result exists and nothing may hold it back: the notification is
+    // a courtesy and the result is the contract. A client that has stopped reading its stream
+    // loses the courtesy.
+    while let Ok(step) = rx.try_recv() {
+        let sent = notify(started.elapsed().as_secs_f64(), step.message());
+        if tokio::time::timeout(FINAL_FLUSH, sent).await.is_err() {
+            break;
         }
     }
+    outcome
 }
 
 #[cfg(test)]
@@ -263,14 +295,35 @@ mod tests {
             .collect()
     }
 
-    /// Lets the relay drain what has just been reported before the work returns.
+    /// A milestone reported in the same turn as the answer is still delivered.
     ///
-    /// A step reported in the same instant the answer arrives may or may not be delivered — the
-    /// result supersedes it, and `select!` picks between two ready branches at random — so a test
-    /// that asserted on that race would be flaky about behaviour nobody depends on. Every test
-    /// here ends its work with this so what it counts is the steady state.
-    async fn settle() {
-        tokio::time::sleep(Duration::from_millis(1)).await;
+    /// The case the biased `select!` in [`relay`] exists for, and the one that used to need
+    /// scaffolding in every test here to avoid asserting on a coin toss. `end_session` finding a
+    /// transaction to unwind is exactly this shape — the milestone and the reply can land together
+    /// — and the client that asked for progress would have had no way to know it lost one.
+    #[tokio::test(start_paused = true)]
+    async fn a_step_reported_as_the_call_answers_is_not_dropped() {
+        let (sent, notify) = collector();
+        relay(
+            async {
+                report(Step::Unwinding {
+                    within: Duration::from_secs(12),
+                });
+                // and returns immediately: no await between the report and the answer, so both
+                // are ready in the same poll.
+            },
+            HEARTBEAT,
+            notify,
+        )
+        .await;
+
+        let said = messages(&sent);
+        assert_eq!(
+            said.len(),
+            1,
+            "the last milestone must survive the answer arriving with it: {said:?}"
+        );
+        assert!(said[0].contains("rolling it back"), "{said:?}");
     }
 
     /// The opener sequence, end to end: what the supervisor and its worker report becomes three
@@ -290,7 +343,6 @@ mod tests {
                 })
                 .await
                 .expect("the reader task");
-                settle().await;
             },
             HEARTBEAT,
             notify,
@@ -315,7 +367,6 @@ mod tests {
                 report(Step::Committed);
                 tokio::time::sleep(Duration::from_millis(250)).await;
                 report(Step::Opened);
-                settle().await;
             },
             HEARTBEAT,
             notify,
@@ -361,7 +412,6 @@ mod tests {
                     tokio::time::sleep(HEARTBEAT - Duration::from_secs(1)).await;
                     report(Step::Committed);
                 }
-                settle().await;
             },
             HEARTBEAT,
             notify,

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -91,6 +91,14 @@ pub enum Step {
     /// A teardown found a transaction in flight and told it to stop and roll back, which it has
     /// this long to finish ([`crate::proto::WorkerMessage::RollingBack`]).
     Unwinding { within: Duration },
+    /// That transaction is over — stopped, rolled back and reported — and only the release is left.
+    ///
+    /// The same protocol message as [`Self::Unwinding`], carrying zero: the worker names zero to
+    /// say *now* ([`crate::worker`]'s `RETRACTED`), which is a retraction rather than a shorter
+    /// promise. Reporting it as another unwind would tell a client a transaction was still in
+    /// flight at the exact moment it stopped being one — and phrase it "up to 0.0s", which reads
+    /// as a bug in the server rather than as the good news it is.
+    Unwound,
 }
 
 impl Step {
@@ -109,6 +117,9 @@ impl Step {
                 "a transaction is in flight; rolling it back (up to {})",
                 fmt_duration(within)
             ),
+            Self::Unwound => {
+                "the transaction has been rolled back; releasing the target".to_string()
+            }
         }
     }
 }
@@ -456,6 +467,28 @@ mod tests {
             "a finished call reports nothing: {:?}",
             messages(&sent)
         );
+    }
+
+    /// The two readings of the worker's one rollback message do not sound alike.
+    ///
+    /// `RollingBack` is sent twice for a single transaction — a promise with an interval, then a
+    /// retraction naming zero — and rendering both the same way told a client "rolling it back (up
+    /// to 0.0s)" at the moment the rollback had *finished*. `engine::reader` splits them on the
+    /// zero; this pins that the words on the far side are worth splitting them for.
+    #[test]
+    fn a_finished_rollback_does_not_read_as_one_still_running() {
+        let promised = Step::Unwinding {
+            within: Duration::from_secs(12),
+        }
+        .message();
+        let retracted = Step::Unwound.message();
+        assert!(promised.contains("in flight"), "{promised}");
+        assert!(promised.contains("12.0s"), "{promised}");
+        assert!(
+            !retracted.contains("in flight") && !retracted.contains("0.0s"),
+            "a finished rollback must not read as one still running: {retracted}"
+        );
+        assert!(retracted.contains("has been rolled back"), "{retracted}");
     }
 
     /// Outside a watched call there is nowhere to report to, and that is the common case — a

--- a/src/server.rs
+++ b/src/server.rs
@@ -2175,7 +2175,11 @@ fn post_commit_failure(err: &str, session_id: &str) -> String {
 }
 
 /// Renders a duration the way a person reads one: "8.4s", "3m12s", "1h05m".
-fn fmt_duration(d: Duration) -> String {
+///
+/// Shared with [`crate::progress`], which is telling a client about the same waits `session_status`
+/// describes here — a heartbeat that spelled its elapsed time differently would read as a second,
+/// unrelated clock.
+pub(crate) fn fmt_duration(d: Duration) -> String {
     let secs = d.as_secs();
     match secs {
         0..=59 => format!("{:.1}s", d.as_secs_f64()),
@@ -4294,23 +4298,32 @@ impl rmcp::ServerHandler for WindbgServer {
     /// It records the call and its result, and nothing else: the events that say what the *target*
     /// did are derived from the typed half of the result by [`crate::record`], and the ones about
     /// sessions come from the supervisor, which is where sessions live.
+    ///
+    /// It is also where a call's **progress** is hung, for the same reason and with the same shape:
+    /// one place every tool passes, rather than a line in each of forty-odd bodies. See
+    /// [`crate::progress`].
     async fn call_tool(
         &self,
         request: rmcp::model::CallToolRequestParams,
         context: rmcp::service::RequestContext<rmcp::RoleServer>,
     ) -> Result<rmcp::model::CallToolResponse, ErrorData> {
         let tcc = rmcp::handler::server::tool::ToolCallContext::new(self, request, context);
+        // Read before the router takes the context, and wrapped around the whole call rather than
+        // around the engine work inside it: an opener spends up to `WORKER_READY_TIMEOUT` bringing
+        // a worker up before there is any engine call to report on.
+        let watch = crate::progress::Watch::of(&tcc.request_context);
         // Nothing at all when there is no transcript, which is the default: not the argument
         // clone, not the routing scope, and — the one that would actually cost something — not
         // `text_of`, which joins and copies every content block a tool produced. A module listing
         // or a pool census is megabytes, and paying for it on every call of a server that is not
         // recording is the kind of overhead nobody would ever see and everybody would pay.
         if !self.rec.enabled() {
-            return Self::tool_router().call(tcc).await;
+            return watch.run(Self::tool_router().call(tcc)).await;
         }
         let args = tcc.arguments.clone().map(serde_json::Value::Object);
         let mut call = self.rec.tool_request(tcc.name(), args.as_ref());
-        let (outcome, routed) = crate::record::tracking_route(Self::tool_router().call(tcc)).await;
+        let (outcome, routed) =
+            crate::record::tracking_route(watch.run(Self::tool_router().call(tcc))).await;
         // Where it actually went, which for a call that named no session is the only record of
         // which target it read or changed.
         call.routed_to(routed);

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -3983,6 +3983,18 @@ fn ending_a_session_stops_a_running_batch_and_rolls_it_back() {
         said.iter().any(|m| m.contains("rolling it back")),
         "the teardown found a transaction and never said so: {said:?}"
     );
+    // And the *end* of it, which is the same protocol message carrying zero. This is the only
+    // place both readings occur for real, so it is the only place that can catch them being
+    // rendered alike — which they were: the retraction used to report a transaction still in
+    // flight, "up to 0.0s", at the moment the rollback had finished.
+    assert!(
+        said.iter().any(|m| m.contains("has been rolled back")),
+        "the rollback finished and the client was never told: {said:?}"
+    );
+    assert!(
+        !said.iter().any(|m| m.contains("up to 0.0s")),
+        "a finished rollback is being reported as one still running: {said:?}"
+    );
     assert!(
         took < Duration::from_secs(15),
         "end_session took {took:?}: it waited out the batch instead of cutting it short"

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -311,6 +311,42 @@ impl Server {
         )
     }
 
+    /// A tool call that asks to be told how it is going. MCP's opt-in is a `progressToken` in the
+    /// call's own `_meta`, and nothing is sent to a client that did not put one there.
+    fn call_tool_watching(
+        &mut self,
+        name: &str,
+        args: Value,
+        token: &str,
+        budget: Duration,
+    ) -> Value {
+        self.request(
+            "tools/call",
+            json!({
+                "name": name,
+                "arguments": args,
+                "_meta": { "progressToken": token },
+            }),
+            budget,
+        )
+    }
+
+    /// The `notifications/progress` this server sent for `token`, oldest first, taken out of the
+    /// queue of messages read while waiting for something else.
+    ///
+    /// That they are *in* that queue is half the assertion: a progress notification arrives while
+    /// the call is still running, so by the time its result has been matched they are already
+    /// here. One that arrived afterwards would be a notification about a call that was over.
+    fn progress_for(&mut self, token: &str) -> Vec<Value> {
+        let ours = |m: &Value| {
+            m["method"] == json!("notifications/progress")
+                && m["params"]["progressToken"] == json!(token)
+        };
+        let taken: Vec<Value> = self.pending.iter().filter(|m| ours(m)).cloned().collect();
+        self.pending.retain(|m| !ours(m));
+        taken
+    }
+
     /// The text of a tool call that **worked**, for the callers that only proceed if it did.
     ///
     /// Strict about `isError`, not just about protocol errors, and that is the whole point. This
@@ -1773,6 +1809,38 @@ fn tool_text_refuses_to_hand_back_a_failed_call() {
     server.tool_text("go", json!({}), STEP);
 }
 
+/// Progress is opt-in per call, and a client that did not opt in must be sent none.
+///
+/// The rule is MCP's: a `notifications/progress` with no `progressToken` behind it is an
+/// unsolicited message about a request the client never asked to hear about, and a strict client
+/// may treat one as a protocol violation. Asserted on **stdout as a whole** rather than on a
+/// message queue, because that is where a stray notification would actually land — a transport
+/// this server also has to keep free of anything that is not a reply.
+///
+/// The call is an open that fails, deliberately. An opener is the one tool with a milestone to
+/// report before it has done anything (the engine worker coming up), so this exercises the path
+/// that *would* report rather than a tool with nothing to say — on a host with no `dbgeng.dll`
+/// the worker never comes up and the assertion is merely weaker, never wrong.
+#[test]
+fn a_call_that_asked_for_no_progress_is_sent_none() {
+    let mut server = Server::started();
+    let response = server.call_tool("open_dump", json!({ "path": r"Z:\no\such.dmp" }), STEP);
+    assert!(
+        !response["error"].is_null() || is_tool_error(&response),
+        "opening a path that does not exist must fail: {response}"
+    );
+
+    let stray: Vec<String> = server
+        .stdout_lines()
+        .into_iter()
+        .filter(|line| line.contains("notifications/progress"))
+        .collect();
+    assert!(
+        stray.is_empty(),
+        "the client asked for no progress and was sent some anyway: {stray:?}"
+    );
+}
+
 // ---- tier 1: the listener and its lease ---------------------------------------
 //
 // `--listen` gives up the one property stdio has for free: a closed stdin means the client is
@@ -1814,10 +1882,24 @@ struct Reply {
     session: Option<String>,
     /// The JSON-RPC payload, whether it arrived as a plain body or inside an SSE frame.
     payload: Option<Value>,
+    /// Every JSON-RPC message on this reply's stream, in order. More than one when the call asked
+    /// for progress: rmcp routes those notifications onto the stream the call is answered on.
+    frames: Vec<Value>,
     body: String,
 }
 
 impl Reply {
+    /// The `notifications/progress` carried on this reply's own stream, oldest first.
+    fn progress(&self, token: &str) -> Vec<&Value> {
+        self.frames
+            .iter()
+            .filter(|frame| {
+                frame["method"] == json!("notifications/progress")
+                    && frame["params"]["progressToken"] == json!(token)
+            })
+            .collect()
+    }
+
     fn result(&self, what: &str) -> Value {
         let payload = self
             .payload
@@ -2083,17 +2165,31 @@ fn parse_reply(raw: &[u8]) -> Reply {
         raw_body.to_vec()
     };
     let body = String::from_utf8_lossy(&body_bytes).into_owned();
-    // An SSE frame first, then a plain body: a tool call comes back as the former and a refusal
-    // as neither, and `None` is a fine answer for a refusal.
-    let payload = body
+    // SSE frames first, then a plain body: a tool call comes back as the former and a refusal as
+    // neither, and no frames at all is a fine answer for a refusal.
+    let mut frames: Vec<Value> = body
         .lines()
         .filter_map(|line| line.trim().strip_prefix("data: "))
-        .find_map(|data| serde_json::from_str::<Value>(data).ok())
-        .or_else(|| serde_json::from_str::<Value>(&body).ok());
+        .filter_map(|data| serde_json::from_str::<Value>(data).ok())
+        .collect();
+    if frames.is_empty()
+        && let Ok(plain) = serde_json::from_str::<Value>(&body)
+    {
+        frames.push(plain);
+    }
+    // The **response**, which is the frame carrying an id — a call that asked for progress is
+    // answered on a stream whose earlier frames are notifications, and those have none. Taking
+    // the first frame regardless would hand `result` a progress line to look for an answer in.
+    let payload = frames
+        .iter()
+        .find(|frame| !frame["id"].is_null())
+        .or_else(|| frames.first())
+        .cloned();
     Reply {
         status,
         session: header("mcp-session-id"),
         payload,
+        frames,
         body,
     }
 }
@@ -2293,6 +2389,181 @@ fn target_tier() -> Option<&'static str> {
         return None;
     }
     Some(SAMPLE_DUMP)
+}
+
+/// An open reports what it is doing while it is doing it, in the order it actually happened.
+///
+/// The milestones are the supervisor's and the worker's — the engine process coming up, the target
+/// being claimed, the target being open — and each already decides something: which of them arrived
+/// is how an open's failure is told apart from the two others that look identical. This asserts the
+/// mapping onto MCP, which is the only part a client can see: one notification per milestone, on
+/// the token the call supplied, all of them **before** the result rather than summarised after it.
+///
+/// Needs a real target because the sequence is the point. A failed open reports the first milestone
+/// and stops, which proves the route and not the order.
+#[test]
+fn an_open_reports_its_milestones_before_it_answers() {
+    let Some(dump) = target_tier() else { return };
+    let mut server = Server::started();
+
+    let response =
+        server.call_tool_watching("open_dump", json!({ "path": dump }), "open-1", TARGET_STEP);
+    assert_no_error(&response, "open_dump");
+    assert!(
+        !is_tool_error(&response),
+        "opening the sample dump failed:\n{}",
+        text_of(&response["result"])
+    );
+
+    // Read after the result, which is what makes "before" an assertion rather than a hope: these
+    // were taken off the wire while the call was still outstanding.
+    let steps = server.progress_for("open-1");
+    let said: Vec<&str> = steps
+        .iter()
+        .filter_map(|s| s["params"]["message"].as_str())
+        .collect();
+    assert_eq!(
+        said.len(),
+        3,
+        "an open has three milestones — worker up, target claimed, target open: {steps:?}"
+    );
+    assert!(said[0].contains("engine worker started"), "{said:?}");
+    assert!(said[1].contains("created or claimed"), "{said:?}");
+    assert!(said[2].contains("target is open"), "{said:?}");
+
+    // Seconds elapsed, strictly increasing, and no `total` — the budget differs per tool and an
+    // opener spends time outside it, so a denominator here would be a number the server cannot
+    // actually stand behind.
+    let progress: Vec<f64> = steps
+        .iter()
+        .map(|s| {
+            s["params"]["progress"]
+                .as_f64()
+                .unwrap_or_else(|| panic!("progress must be a number: {s}"))
+        })
+        .collect();
+    assert!(
+        progress.windows(2).all(|pair| pair[1] > pair[0]),
+        "progress must increase on every notification: {progress:?}"
+    );
+    assert!(
+        steps.iter().all(|s| s["params"]["total"].is_null()),
+        "an unknown total is absent, not guessed: {steps:?}"
+    );
+
+    let session_id = session_id_of(&response["result"]);
+    server.call_tool(
+        "end_session",
+        json!({ "session_id": session_id }),
+        TARGET_STEP,
+    );
+}
+
+/// And it reaches a client that is not on this machine, which is the whole reason it exists.
+///
+/// Over stdio an operator could watch the server's stderr; over `--listen` those records are on the
+/// far side and everything else this server offers is pull. rmcp routes a progress notification
+/// onto the SSE stream the call itself is being answered on, keyed by the token — so what this
+/// checks is that the milestone and the result come back together, in that order, on one stream.
+///
+/// A **failing** open on purpose: one milestone is enough to prove the route, and it costs a worker
+/// coming up rather than a dump load that may go to a symbol server — which would put this test's
+/// runtime at the mercy of the network for no extra claim.
+#[test]
+fn a_remote_client_is_told_how_a_call_is_going() {
+    if target_tier().is_none() {
+        return;
+    }
+    let mut server = Listener::start(&[]);
+    let client = server.initialize();
+
+    let reply = server.call(
+        Some(&client),
+        "tools/call",
+        json!({
+            "name": "open_dump",
+            "arguments": { "path": r"Z:\no\such.dmp" },
+            "_meta": { "progressToken": "remote-1" },
+        }),
+    );
+    assert_eq!(
+        reply.status,
+        200,
+        "the listener refused the call ({}): {}\n--- stderr ---\n{}",
+        reply.status,
+        reply.body,
+        server.stderr()
+    );
+
+    let steps = reply.progress("remote-1");
+    assert!(
+        steps.iter().any(|s| s["params"]["message"]
+            .as_str()
+            .is_some_and(|m| m.contains("engine worker started"))),
+        "no milestone reached the remote client on the call's own stream: {}",
+        reply.body
+    );
+    // The result is still the last thing on the stream, and still the thing `result` finds.
+    assert!(
+        !reply.result("open_dump")["content"].is_null(),
+        "the call is answered as well as narrated: {}",
+        reply.body
+    );
+}
+
+/// A call with nothing to say still says it is running — the half of this that is not a mapping.
+///
+/// Milestones alone would leave the two longest silences exactly as they were. One is a kernel
+/// attach nothing answers: it claims its connection in the first second and then has nothing
+/// further to report, ever. The other is every long call that has **no milestones at all** — a pool
+/// walk, a `crash_triage`, a batch — and that is the one used here, because it costs twelve seconds
+/// of a sleeping debuggee rather than a parked worker holding a UDP port that then has to be waited
+/// out of a twenty-second teardown to give it back. The behaviour asserted is the same one.
+///
+/// The beat is ten seconds and deliberately not tunable: making a production constant
+/// test-configurable is a worse trade than the wall clock, and this runs beside the lease tier's
+/// own wait rather than after it.
+#[test]
+fn a_call_with_nothing_to_report_still_reports_that_it_is_running() {
+    let Some(dump) = target_tier() else { return };
+    let mut server = Server::started();
+    let session_id = server.open_session("open_dump", json!({ "path": dump }), TARGET_STEP);
+
+    let steps: Vec<Value> =
+        std::iter::repeat_n(json!({ "op": "command", "command": ".sleep 1000" }), 12).collect();
+    let response = server.call_tool_watching(
+        "debug_batch",
+        json!({
+            "session_id": session_id,
+            "steps": steps,
+            "always": [{ "op": "command", "command": "version", "name": "cleanup" }],
+        }),
+        "slow-1",
+        TARGET_STEP,
+    );
+    assert_no_error(&response, "debug_batch");
+
+    let said: Vec<String> = server
+        .progress_for("slow-1")
+        .iter()
+        .filter_map(|step| step["params"]["message"].as_str().map(str::to_string))
+        .collect();
+    assert!(
+        said.iter().any(|m| m.starts_with("still running")),
+        "twelve seconds of silence and the call never said it was alive: {said:?}"
+    );
+    // And nothing else, because a batch announces no milestones — which is exactly why the beat
+    // has to exist for this shape of call.
+    assert!(
+        said.iter().all(|m| m.starts_with("still running")),
+        "a batch has no milestones of its own to report: {said:?}"
+    );
+
+    server.call_tool(
+        "end_session",
+        json!({ "session_id": session_id }),
+        TARGET_STEP,
+    );
 }
 
 /// The end-to-end debugger path, which is what a `win-kexp` or DbgEng change actually moves:
@@ -3686,13 +3957,32 @@ fn ending_a_session_stops_a_running_batch_and_rolls_it_back() {
     }
 
     let asked = Instant::now();
-    let ended = server.tool_text(
+    // Watched, because this is the one call with a milestone of its own to report: a teardown that
+    // finds a transaction says how long unwinding it needs, and a client looking at an
+    // `end_session` that has not come back is exactly who that is for.
+    let response = server.call_tool_watching(
         "end_session",
         json!({ "session_id": session_id }),
+        "unwind-1",
         TARGET_STEP,
     );
     let took = asked.elapsed();
+    assert_no_error(&response, "end_session");
+    let ended = text_of(&response["result"]);
+    assert!(
+        !is_tool_error(&response),
+        "end_session reported a failure: {ended}"
+    );
     assert!(!ended.trim().is_empty(), "end_session said nothing");
+    let said: Vec<String> = server
+        .progress_for("unwind-1")
+        .iter()
+        .filter_map(|step| step["params"]["message"].as_str().map(str::to_string))
+        .collect();
+    assert!(
+        said.iter().any(|m| m.contains("rolling it back")),
+        "the teardown found a transaction and never said so: {said:?}"
+    );
     assert!(
         took < Duration::from_secs(15),
         "end_session took {took:?}: it waited out the batch instead of cutting it short"


### PR DESCRIPTION
Closes the progress-notification half of `FOLLOWUPS.md` item 23. Service installation is what is left.

## Why

A tool call here can take minutes — a kernel attach waits for its target to dial in, a pool walk reads every page, `!analyze -v` goes to a symbol server — and every one of them was silent from the request until the result. Under stdio an operator could watch stderr scroll; over `--listen` those records are on the other machine and both ways of asking for them (`session_status`, `server_log`) are **pull**, so a client has to guess when to ask about a call it cannot see.

## What is added

The facts already existed as protocol messages, so what is new is a route out to the client: a `progressToken` read off the call's `_meta` in `call_tool`, a task-local sink the engine reports into, and a relay that turns each step into `notifications/progress`.

| Step | Source |
| --- | --- |
| engine worker started (pid N) | supervisor, `Sessions::open` |
| target created or claimed | worker's `Committed` |
| target is open | worker's `Opened` |
| rolling back a transaction (up to Xs) | worker's `RollingBack` |

Three decisions go beyond the mapping, and `DECISIONS.md` records them:

- **`progress` counts seconds elapsed, with no `total`.** The denominator would have to be a per-tool budget, and none of them covers the up-to-30s worker handshake an opener spends before its budget starts. Absent says "unknown", which is true.
- **Ten seconds of silence is itself reported.** Milestones alone leave the two longest waits as quiet as before — a parked attach reports `Committed` in the first second and may never report again, and a pool walk, `crash_triage` or batch has no milestones at all. It also makes progress a liveness signal a client can extend its own request timeout on.
- **The sink travels with the waiter.** Milestones arrive on the session's reader task, where the peer and token are out of reach, so the sink is read from a task-local on the caller's task and stored in `engine::Waiting`. Removing the waiter is the same act that stops it being reported against.

Nothing is allocated, timed or sent for a call that did not ask.

## Verification

`cargo fmt --check`, `cargo clippy --all-targets -D warnings`, 423 unit tests, and 51 smoke tests with `WINDBG_MCP_SMOKE_DUMP=1` — all green on ARM64.

New coverage: 6 unit tests on the relay's policy (paused clock, hence a `tokio` `test-util` dev-dependency), plus smoke assertions for no-token-no-notifications, the full opener sequence ordered before the result, a remote client receiving one on the call's own SSE stream, a beat from a call with no milestones, and the unwinding milestone folded into the existing rollback test. The debugger tier goes 41s to 51s.

Also verified by hand against a **live ARM64 kernel** (serial KD): `engine worker started (pid 7468)` then `the target has been created or claimed` then `the target is open`, progress `0.2 → 0.2 → 4.1`, all before the result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)