### PR TITLE
Measure what this server costs the model driving it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   cannot be interrupted, so releasing it means terminating a process. See
   [`docs/smoke-test.md`](./docs/smoke-test.md).
 
+- **A token budget for the tool surface and for every result.** Two smoke tests measure what this
+  server costs the model driving it — a cost nothing here had ever measured, and one a dependency
+  bump or a widened schema can move without breaking a single assertion.
+
+  `tool_surface_stays_within_its_token_budget` records a per-tool size table in
+  `tests/golden/tool_budget.json` (re-recorded with the same `UPDATE_GOLDEN=1` as the shape golden
+  beside it) and enforces three ceilings, because a golden re-recorded on every diff is a rubber
+  stamp against slow growth. `tool_results_stay_within_their_budget` runs the debugger tier's dump
+  through a fixed set of calls and budgets each answer, plus one rule: a typed answer may not
+  exceed the rendering it replaces by more than 20x.
+
+  The baseline it recorded is in [`docs/token-budget.md`](./docs/token-budget.md), along with two
+  client behaviours it settled by measurement rather than assumption — `outputSchema` never reaches
+  the model (it is ~80% of the `tools/list` payload), and `structuredContent` *replaces* the text
+  block rather than accompanying it. The second qualifies `DECISIONS.md`'s "a second channel, not a
+  replacement": true for a program reading fields, not for the model. What that costs today is
+  itemised as follow-up 24.
+
 ### Changed
 
 - The listener no longer claims a reconnecting client **adopted sessions** when there were none to

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,7 +96,16 @@ build differs only in optimization and is exercised by CI on a fresh runner.
 `cargo test` includes `tests/mcp_smoke.rs`, which spawns the **dev** binary (via
 `CARGO_BIN_EXE_windbg-mcp`) and drives it over stdio — so it is also clear of the release lock.
 After a dependency bump (`rmcp`, `schemars`, `tokio`, `cargo update -p win-kexp`) or an MCP spec
-revision, run it and follow [`docs/smoke-test.md`](./docs/smoke-test.md). To include the tier that
+revision, run it and follow [`docs/smoke-test.md`](./docs/smoke-test.md).
+
+Two of its tests budget **what this server costs the model driving it** — the tool surface, which is
+paid once per conversation, and each result, which is paid every call. Both are recorded in
+`tests/golden/tool_budget.json` and re-recorded with the same `UPDATE_GOLDEN=1 cargo test --test
+mcp_smoke` as the shape golden beside it; read the diff rather than rubber-stamping it, because it
+is the only place the price of a reworded description or a widened schema is visible.
+[`docs/token-budget.md`](./docs/token-budget.md) has the baseline and what it exposed — including
+the two client behaviours it settled by measurement: `outputSchema` never reaches the model, and
+`structuredContent` *replaces* the text block rather than accompanying it. To include the tier that
 opens the sample dump through DbgEng, set the gate first (PowerShell, not `VAR=1 cmd`):
 
 ```pwsh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,11 +98,21 @@ build differs only in optimization and is exercised by CI on a fresh runner.
 After a dependency bump (`rmcp`, `schemars`, `tokio`, `cargo update -p win-kexp`) or an MCP spec
 revision, run it and follow [`docs/smoke-test.md`](./docs/smoke-test.md).
 
-Two of its tests budget **what this server costs the model driving it** — the tool surface, which is
-paid once per conversation, and each result, which is paid every call. Both are recorded in
-`tests/golden/tool_budget.json` and re-recorded with the same `UPDATE_GOLDEN=1 cargo test --test
-mcp_smoke` as the shape golden beside it; read the diff rather than rubber-stamping it, because it
-is the only place the price of a reworded description or a widened schema is visible.
+Two of its tests budget **what this server costs the model driving it** — the tool surface, paid
+once per conversation, and each result, paid every call. They are guarded differently, and the
+difference matters when you change one:
+
+- **The surface** is goldened, in `tests/golden/tool_budget.json`, re-recorded by the same
+  `UPDATE_GOLDEN=1 cargo test --test mcp_smoke` as the shape golden beside it. Read that diff
+  rather than rubber-stamping it: it is the only place the price of a reworded description or a
+  widened schema shows up, and it reports per tool (`modules: modelVisible 2112 -> 4200`).
+- **Results are not goldened** — their sizes move with what symbols a runner resolves, so exact
+  bytes would be flaky. They are per-tool ceilings in the `budgets` slice of
+  `tool_results_stay_within_their_budget`, with a table printed under `--nocapture`. So a result
+  that grows *within* its ceiling produces no diff anywhere; if you need to see the movement, run
+  the tier and read the table. Changing a ceiling is an edit to that slice, not a re-record.
+
+`--nocapture` is what makes either print anything: libtest shows a passing test's output nowhere.
 [`docs/token-budget.md`](./docs/token-budget.md) has the baseline and what it exposed — including
 the two client behaviours it settled by measurement: `outputSchema` never reaches the model, and
 `structuredContent` *replaces* the text block rather than accompanying it. To include the tier that

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -1,6 +1,6 @@
 # Follow-ups
 
-Deferred work, in nine clusters: items 1–6 come from the reachability-confirmation effort (path
+Deferred work, in ten clusters: items 1–6 come from the reachability-confirmation effort (path
 recipe + `run_to_address`, merged 2026-07-04), items 7–11 from surveying this server against the
 MCP `2026-07-28` extensions (tasks, apps), item 12 from the opener split
 (glslang/win-kexp#71, 2026-08-01), items 13–14 from the bounded-command coverage review
@@ -8,8 +8,9 @@ MCP `2026-07-28` extensions (tasks, apps), item 12 from the opener split
 from transactional batches (#82, 2026-08-09/10 — item 17 is what validating the tool against the CTF
 session's own transcript turned up, and item 18 what reviewing it did), item 19 from
 `walk_memory` (#103, 2026-08-13), items 20–22 from standing the server up on an ARM64 guest
-(#131, #132, #134, 2026-08-16), and item 23 from making the listener usable rather than merely
-working (2026-08-17). Each item notes its repo,
+(#131, #132, #134, 2026-08-16), item 23 from making the listener usable rather than merely
+working (2026-08-17), and item 24 from first measuring what this server costs the model driving it
+(2026-08-17). Each item notes its repo,
 why it was deferred, and where it picks up. See [`DECISIONS.md`](./DECISIONS.md) for the design rationale (D1–D5) items 1–6 extend,
 and the 2026-08-02 entries that items 13–14 and item 10 extend.
 
@@ -666,3 +667,48 @@ it would mean making a production constant test-tunable, which is a worse trade 
 revisiting only if that tier's runtime starts to matter.
 
 Picks up at `src/listen.rs` and the tiers in `tests/mcp_smoke.rs`.
+
+## 24. [windbg-mcp] Spend fewer of the caller's tokens
+
+`docs/token-budget.md` and the two budget tests in `tests/mcp_smoke.rs` measured what this server
+costs the model driving it. Nothing had, and the numbers were larger than a careful reading of the
+source predicted — 90–130 KB estimated, 358 KB actual. This item is the list of things the
+measurement found. None of them is a bug; all of them were invisible.
+
+**Why deferred:** the baseline had to be recorded *before* anything was optimised for it, or every
+later fix would be a diff against a number somebody had already tidied. The tests and the golden
+landed on their own so that each of the items below can be argued, and measured, separately.
+
+- **`$defs` are inlined per tool** — `schemars` emits each output schema self-contained, so
+  `ErrorCategory` (2,089 B) ships 31 times and the allocator/pool subtree nine. **200,571 B, 70% of
+  all `outputSchema`.** Wire and client-parse cost only; no model reads it. The lever is
+  `output_schema = schema_for_output::<T>()` on each `#[rmcp::tool]`, or a `list_tools` that emits
+  shared definitions.
+- **Six openers carry a byte-identical 11,093 B output schema**, six step tools a byte-identical
+  4,418 B one. 77,555 B of the above, and the cheapest to collapse.
+- **`session_id` is documented 43 times in three wordings** (222 B ×22, 292 B ×15, 41 B ×5) —
+  9,514 B, and this one *is* model-visible. The repetition is deliberate (`src/server.rs:1356`);
+  the three different wordings are not, and one short shared wording costs nothing to adopt.
+- **The instructions overrun what the client reads** — 3,147 chars sent, truncated at 2,048. The
+  1,099 chars that never arrive are where `debug_batch` and `reachable_from_dispatch` are explained.
+- **`registers` returns 15.9x more JSON than its own text** (9,804 B vs 618 B), because every row
+  carries `"kind":"int"` and `"subregister":false`. `modules` is 2.7x and is the largest single
+  answer this server gives at 53,875 B. The ratio rule in `tool_results_stay_within_their_budget`
+  stops this spreading; it does not fix these two.
+- **`modules` has neither a `limit` nor a cap**, alone among the high-volume tools. Everything else
+  uncapped is raw debugger text — `ttd_calls`, `ttd_memory`, `threads`, `backtrace`, `disassemble`,
+  `execute`, `dx`, `ioctl_trace`, `reachable_from_dispatch` — and `read_memory` returns up to
+  ~4 MiB of hex by design (`src/worker.rs:117`). Every cap that does exist (`MAX_ROWS`,
+  `MAX_NODES`, `MAX_READ_BYTES`) is justified in its own comment as a worker out-of-memory guard.
+  A caller-context guard is a different constraint and does not exist yet.
+
+**Depends on nothing**, but it **collides with item 11**, which proposes adding `structuredContent`
+to `ttd_calls`, `ttd_memory` and `driver_object` — three of the highest-volume text-only tools.
+Under the client rule measured here, structured content *replaces* the text rather than
+supplementing it, so that change is a size decision as much as a typing one, and it also partly
+reverses the reasoning in `DECISIONS.md`'s #84 entry ("a second channel, not a replacement"), which
+was argued against a Python client and never against a model one. Whichever is done first should
+say what it means for the other.
+
+Picks up at [`docs/token-budget.md`](./docs/token-budget.md) and the two budget tests in
+`tests/mcp_smoke.rs`.

--- a/README.md
+++ b/README.md
@@ -117,7 +117,9 @@ cargo build --release
 
 `cargo test` covers the unit tests plus an end-to-end smoke test that drives the built binary over
 stdio. Run it after a dependency bump or an MCP spec revision — see
-[`docs/smoke-test.md`](docs/smoke-test.md).
+[`docs/smoke-test.md`](docs/smoke-test.md). It also budgets what the tool surface and each result
+cost the model driving them, which a schema change can move without breaking anything —
+[`docs/token-budget.md`](docs/token-budget.md).
 
 ### Install with Scoop
 
@@ -665,6 +667,12 @@ Two conventions hold across all of them:
   or a traversal cap — more time changes nothing). Counts from anything but `complete` are floors,
   not totals. A walk that failed outright, or was stopped by `interrupt`, is not a coverage state at
   all: it is the error branch below, with category `debugger` or `interrupted`.
+
+One caveat about "also", measured rather than assumed: a client that understands
+`structuredContent` generally forwards **it** to the model and drops the text block, rather than
+sending both. So for the tools above, the typed answer is what a model reads and the rendering is
+what a program-with-a-terminal reads — they are two audiences, not one audience twice.
+[`docs/token-budget.md`](docs/token-budget.md) has the measurements, and what they cost.
 
 ### Error reporting
 

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -384,6 +384,19 @@ and inherited across the spawn, so a mistake there is not a compile error: the w
 a usable channel, or comes up and is never heard from, and either way every test here that opens a
 target fails on the open. Run it after touching `engine::spawn_worker` or `worker::run`.
 
+## What it costs the caller
+
+Two tests measure size rather than behaviour: `tool_surface_stays_within_its_token_budget`
+(protocol tier) and `tool_results_stay_within_their_budget` (debugger tier). They exist because a
+dependency bump or a widened schema can move what this server spends of the *model's* context
+without breaking a single assertion — `schemars` inlining one more shared type across 31 output
+schemas is tens of kilobytes and no test failure.
+
+Both print their numbers on a green run, and the surface one is pinned in
+`tests/golden/tool_budget.json`, re-recorded by the same `UPDATE_GOLDEN=1` as the shape golden
+beside it. Read the diff; it is the only place the price of a reworded description shows up. See
+[`token-budget.md`](./token-budget.md) for the baseline, the ceilings and how to raise one.
+
 ## When to run it
 
 ### A dependency moved

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -394,10 +394,18 @@ schemas is tens of kilobytes and no test failure.
 
 Both print their numbers **under `--nocapture`** — libtest shows a passing test's output nowhere,
 so without the flag they pass in silence. The debugger tier's CI job passes it and the result table
-is in its log; the `build` job does not, so the surface figures live in
-`tests/golden/tool_budget.json` instead, re-recorded by the same `UPDATE_GOLDEN=1` as the shape
-golden beside it. Read that diff — it is the only place the price of a reworded description shows
-up. See [`token-budget.md`](./token-budget.md) for the baseline, the ceilings and how to raise one.
+is in its log; the `build` job does not.
+
+Only the **surface** is goldened, in `tests/golden/tool_budget.json`, re-recorded by the same
+`UPDATE_GOLDEN=1` as the shape golden beside it and diffed per tool rather than per line
+(`modules: modelVisible 2112 -> 4200`), so a tool added or removed does not blame the tools after
+it. Read that diff — it is the only place the price of a reworded description shows up.
+
+**Result budgets are not goldened**, because their sizes move with what symbols a runner resolves.
+They are per-tool ceilings in the `budgets` slice of `tool_results_stay_within_their_budget`, so a
+result that grows within its ceiling leaves no diff anywhere and is only visible in the printed
+table. Adjusting one is an edit to that slice, not a re-record. See
+[`token-budget.md`](./token-budget.md) for the baseline, the ceilings and how to raise one.
 
 ## When to run it
 

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -392,10 +392,12 @@ dependency bump or a widened schema can move what this server spends of the *mod
 without breaking a single assertion — `schemars` inlining one more shared type across 31 output
 schemas is tens of kilobytes and no test failure.
 
-Both print their numbers on a green run, and the surface one is pinned in
-`tests/golden/tool_budget.json`, re-recorded by the same `UPDATE_GOLDEN=1` as the shape golden
-beside it. Read the diff; it is the only place the price of a reworded description shows up. See
-[`token-budget.md`](./token-budget.md) for the baseline, the ceilings and how to raise one.
+Both print their numbers **under `--nocapture`** — libtest shows a passing test's output nowhere,
+so without the flag they pass in silence. The debugger tier's CI job passes it and the result table
+is in its log; the `build` job does not, so the surface figures live in
+`tests/golden/tool_budget.json` instead, re-recorded by the same `UPDATE_GOLDEN=1` as the shape
+golden beside it. Read that diff — it is the only place the price of a reworded description shows
+up. See [`token-budget.md`](./token-budget.md) for the baseline, the ceilings and how to raise one.
 
 ## When to run it
 

--- a/docs/token-budget.md
+++ b/docs/token-budget.md
@@ -1,0 +1,177 @@
+# Token budget
+
+What this server costs the model driving it, and how that is kept from drifting.
+
+A debugging session shares one context window between the transcript, the reasoning and every
+answer this server returns. That makes payload size a correctness-adjacent property: a `modules`
+call that spends 13k tokens has not failed, but it has taken the space the investigation needed.
+Nothing measured this until [`tests/mcp_smoke.rs`](../tests/mcp_smoke.rs) grew the two tests below,
+and the numbers turned out to be larger than anyone had guessed — a careful reading of the source
+put the tool surface at 90–130 KB, and the wire is 358 KB.
+
+## Two costs, and they are not the same
+
+**The tool surface** is paid once per conversation, before anything is debugged. **A result** is
+paid on every call. They need separate budgets because they grow for different reasons and are
+fixed in different places.
+
+There is a second split inside the first, and it is the one that matters most:
+
+| | On the wire | Reaches the model |
+|---|---|---|
+| `name`, `description`, `inputSchema` | yes | **yes** |
+| `outputSchema`, `annotations` | yes | no |
+| `content[].text` | yes | only when there is no `structuredContent` |
+| `structuredContent` | yes | **yes, and it wins** |
+
+Both rows in the second half were measured against a real client rather than assumed:
+
+- A tool definition reaching the model carries name, description and input schema only. The
+  Anthropic tool spec has no field for an output schema, so the 286 KB of `outputSchema` this
+  server emits is a client-side parse, validation and memory cost — never a context cost.
+- `structuredContent` **replaces** the text block rather than accompanying it. A `session_status`
+  call arrives as `{"max_sessions":4,…}` with the human summary dropped; `decode_ioctl`, which
+  emits no structured content, arrives as text.
+
+The second point reverses an assumption in [`DECISIONS.md`](../DECISIONS.md) ("A typed result is a
+second channel, not a replacement", 2026-08-12, #84). That decision was argued for machine
+parseability, against a Python client scraping prose, and it is still right for that reader. What
+it did not consider is that a *model* client picks one — so for the 31 tools with an output schema,
+the rendering is paid for on the wire and read by nobody, and the half the model does read is the
+larger one. `src/structured.rs:1651` already made the other call for `debug_batch`, and states the
+reason: carrying both "would make the typed answer the larger of the two channels while adding no
+fact this does not already name".
+
+## Why bytes and not tokens
+
+Every figure here is **bytes of minified UTF-8 JSON**. No tokenizer exists in this crate's
+dependency tree, and adding one would pull in BPE data to produce a number that varies by model and
+would churn the golden on a tokenizer bump rather than on a change to this server. Bytes are
+deterministic, diff cleanly, and move with tokens for a fixed content style.
+
+For reporting, **≈4 bytes per token** is the rule of thumb used in this document. It is an
+approximation for JSON of this shape, not a measurement.
+
+## The baseline
+
+Recorded in [`tests/golden/tool_budget.json`](../tests/golden/tool_budget.json), which is the
+authority — the tables below are a reading of it at the time of writing.
+
+### Tool surface (51 tools)
+
+| Component | Bytes | Reaches the model |
+|---|---:|---|
+| **Whole `tools/list` payload** | **358,533** | partly |
+| `outputSchema` (the 31 tools that have one) | 285,745 | no |
+| `inputSchema` (all 51) | 39,964 | yes |
+| `description` (all 51) | 23,457 | yes |
+| `annotations` | 5,449 | no |
+| **Model-visible total** | **66,078** (~16k tokens) | — |
+| `initialize` instructions | 3,163 | yes, first 2,048 chars |
+
+Worst single tool: `debug_batch` at 9,757 model-visible bytes, because its `inputSchema` pulls the
+whole `StepAction`/`Check` vocabulary out of `src/batch.rs`.
+
+### Results, against `docs/samples/052126-34312-01.dmp`
+
+`model` is whichever half the client forwards.
+
+| Tool | model | text | structured | ratio |
+|---|---:|---:|---:|---:|
+| `modules` | 53,875 | 19,732 | 53,875 | 2.7x |
+| `execute` (`lm`) | 19,420 | 19,420 | — | — |
+| `registers` | 9,804 | 618 | 9,804 | **15.9x** |
+| `crash_triage` | 1,855 | 1,159 | 1,855 | 1.6x |
+| `open_dump` | 1,347 | 814 | 1,347 | 1.7x |
+| `backtrace` | 572 | 572 | — | — |
+| `session_status` | 297 | 420 | 297 | 0.7x |
+
+`registers` is the shape of the problem in miniature: the model reads 9,804 bytes of JSON carrying
+`"kind":"int"` and `"subregister":false` on every row, and never sees the 618-byte `r` output that
+says the same thing better. `modules` is the largest single answer this server gives — roughly
+13k tokens, a fifth of a whole tool surface, for one question.
+
+## What the baseline exposes
+
+None of these is a bug. They are recorded because they were invisible, and
+[`FOLLOWUPS.md`](../FOLLOWUPS.md) item 24 tracks them.
+
+1. **`$defs` are inlined per tool.** `schemars` emits each output schema self-contained, so
+   `ErrorCategory` (2,089 B) ships **31 times**, `WalkGaps` (2,886 B) and the whole
+   allocator/pool subtree nine times each. **200,571 bytes — 70% of all `outputSchema`** — is
+   duplicated beyond its first copy.
+2. **Whole schemas repeat.** The six openers carry a byte-identical 11,093 B output schema; the six
+   step tools a byte-identical 4,418 B one. 77,555 B of the above.
+3. **`session_id` is documented 43 times, in three different wordings** (222 B ×22, 292 B ×15,
+   41 B ×5) — 9,514 B, and unlike the two above this one *is* model-visible. The repetition is
+   deliberate (`src/server.rs:1356`: flattening "renders as a schema composition that clients
+   handle unevenly"); the three wordings are not.
+4. **The instructions overrun what the client reads.** 3,147 chars sent, truncated at 2,048 — the
+   last 1,099 chars, which is where `debug_batch` and `reachable_from_dispatch` are explained, are
+   paid for and never seen.
+5. **`modules` has neither a `limit` nor a cap**, alone among the high-volume tools. 53,875 B here;
+   more on a live kernel.
+6. **Several tools have no bound at all** — `ttd_calls`, `ttd_memory`, `threads`, `backtrace`,
+   `disassemble`, `execute`, `dx`, `ioctl_trace`, `reachable_from_dispatch` — and `read_memory`
+   returns up to ~4 MiB of hex by design (`src/worker.rs:117`). Every existing cap in this codebase
+   (`MAX_ROWS`, `MAX_NODES`, `MAX_READ_BYTES`) is justified in its own comment as a **worker
+   out-of-memory guard, not a caller-context guard**. That is not wrong; it means nothing here has
+   ever had the caller's context window as its constraint.
+7. **A typed answer can be much larger than the rendering it replaces.** `registers` is 15.9x its
+   own text, because every row carries `"kind":"int"` and `"subregister":false`. This is the one
+   finding that is purely model-visible and purely this server's to fix, and it is what the ratio
+   rule below exists to stop spreading.
+
+One interaction worth flagging before acting on any of it: `FOLLOWUPS.md` item 11 proposes *adding*
+`structuredContent` to `ttd_calls`, `ttd_memory` and `driver_object` — three of the highest-volume
+text-only tools. Under the rule measured above that replaces their text rather than supplementing
+it, which may well be an improvement, but it is a size decision and should be taken as one.
+
+## Running it
+
+The surface budget needs no debugger and rides the ordinary test run:
+
+```pwsh
+cargo test --test mcp_smoke tool_surface_stays_within_its_token_budget
+```
+
+The result budget needs the debugger tier, and prints its table under `--nocapture`:
+
+```pwsh
+$env:WINDBG_MCP_SMOKE_DUMP = "1"
+cargo test --test mcp_smoke -- --nocapture tool_results_stay_within_their_budget
+```
+
+Both print their numbers on a green run. That is deliberate: a budget nobody ever sees is a budget
+nobody maintains.
+
+## Changing the numbers
+
+Two mechanisms guard the surface, because they fail on different things.
+
+The **golden** shows where the bytes are. Any change to any tool's size lands as a readable diff,
+so the price of a reworded description is visible in review. Re-record it — along with the shape
+golden beside it — with:
+
+```pwsh
+$env:UPDATE_GOLDEN = "1"; cargo test --test mcp_smoke
+```
+
+Then read the diff before committing it. Rows are keyed by tool name rather than sorted by size, so
+a tool that grows shows up as three changed lines rather than shifting every row beneath it.
+
+The **ceilings** (`MODEL_VISIBLE_CEILING`, `WIRE_CEILING`, `WORST_TOOL_CEILING` in
+`tests/mcp_smoke.rs`) stop what the golden cannot: a golden re-recorded on every diff is a rubber
+stamp, and thirty accepted 2% growths are a doubling nobody voted for. They sit ~15% over today's
+figures. Raising one is a normal thing to do — a new tool has to fit somewhere — but do it in its
+own commit, with the reason, and update the tables here.
+
+Result budgets are **not** goldened. Their sizes move with what the runner can resolve: a symbol
+server that answers turns `deferred` into paths and grows `lm` a column, and the debugger tier runs
+on two architectures. Per-tool ceilings with ~35% headroom catch a tool that starts returning an
+order of magnitude more, without pinning a number the environment owns.
+
+One rule is asserted rather than a number: a tool's `structuredContent` may not exceed its own text
+rendering by more than 20x. A typed answer is meant to be the facts behind a rendering, so a large
+multiple means it is carrying scaffolding instead. `registers` is at 15.9x and is finding 7 above,
+not a failure — the rule is there to catch the next one.

--- a/docs/token-budget.md
+++ b/docs/token-budget.md
@@ -163,8 +163,23 @@ golden beside it — with:
 $env:UPDATE_GOLDEN = "1"; cargo test --test mcp_smoke
 ```
 
-Then read the diff before committing it. Rows are keyed by tool name rather than sorted by size, so
-a tool that grows shows up as three changed lines rather than shifting every row beneath it.
+Then read the diff before committing it. It is compared **as values, matched by tool name**, not as
+lines, so it reports what actually moved:
+
+```text
+  + server_log is new: 2599 B to the model, 8858 B on the wire
+  ~ modules: modelVisible 2112 -> 4200 (+2088), description 681 -> 2769 (+2088)
+
+totals:
+  modelVisible 66078 -> 68166 (+2088)
+```
+
+A line diff was tried first and is wrong for this file. Each tool is seven lines, so adding or
+removing one shifts every line below it, and a positional differ blames the first tool whose *line
+numbers* moved rather than the one that changed — dropping one tool from a 51-tool report made the
+failure open with `crash_triage`, which had not changed at all, then truncate before reaching
+anything that had. Keying the JSON by name would not have helped: the rows would still be lines,
+and an insertion would still shift them.
 
 The **ceilings** (`MODEL_VISIBLE_CEILING`, `WIRE_CEILING`, `WORST_TOOL_CEILING` in
 `tests/mcp_smoke.rs`) stop what the golden cannot: a golden re-recorded on every diff is a rubber

--- a/docs/token-budget.md
+++ b/docs/token-budget.md
@@ -132,18 +132,24 @@ it, which may well be an improvement, but it is a size decision and should be ta
 The surface budget needs no debugger and rides the ordinary test run:
 
 ```pwsh
-cargo test --test mcp_smoke tool_surface_stays_within_its_token_budget
+cargo test --test mcp_smoke -- --nocapture tool_surface_stays_within_its_token_budget
 ```
 
-The result budget needs the debugger tier, and prints its table under `--nocapture`:
+The result budget needs the debugger tier:
 
 ```pwsh
 $env:WINDBG_MCP_SMOKE_DUMP = "1"
 cargo test --test mcp_smoke -- --nocapture tool_results_stay_within_their_budget
 ```
 
-Both print their numbers on a green run. That is deliberate: a budget nobody ever sees is a budget
-nobody maintains.
+**`--nocapture` is not optional if you want to read the numbers.** libtest captures a passing
+test's output and prints it only on failure, so without the flag both tests pass in silence — which
+is the opposite of the point. It is in both commands above for that reason, and it is why the
+debugger tier's CI job passes it (`ci.yml`) while the `build` job, which runs the whole suite, does
+not: the surface figures are not in CI's log, they are in `tests/golden/tool_budget.json`.
+
+Which is the more useful record anyway. The printed line tells you where you are; the golden tells
+you what changed, and it is the one a reviewer sees.
 
 ## Changing the numbers
 

--- a/docs/token-budget.md
+++ b/docs/token-budget.md
@@ -74,17 +74,17 @@ whole `StepAction`/`Check` vocabulary out of `src/batch.rs`.
 
 ### Results, against `docs/samples/052126-34312-01.dmp`
 
-`model` is whichever half the client forwards.
+`model` is whichever half the client forwards; `wire` is the whole result, which every client pays.
 
-| Tool | model | text | structured | ratio |
-|---|---:|---:|---:|---:|
-| `modules` | 53,875 | 19,732 | 53,875 | 2.7x |
-| `execute` (`lm`) | 19,420 | 19,420 | — | — |
-| `registers` | 9,804 | 618 | 9,804 | **15.9x** |
-| `crash_triage` | 1,855 | 1,159 | 1,855 | 1.6x |
-| `open_dump` | 1,347 | 814 | 1,347 | 1.7x |
-| `backtrace` | 572 | 572 | — | — |
-| `session_status` | 297 | 420 | 297 | 0.7x |
+| Tool | model | wire | text | structured | ratio |
+|---|---:|---:|---:|---:|---:|
+| `modules` | 53,875 | 73,994 | 19,732 | 53,875 | 2.7x |
+| `execute` (`lm`) | 19,420 | 19,788 | 19,420 | — | — |
+| `registers` | 9,804 | 10,534 | 618 | 9,804 | **15.9x** |
+| `crash_triage` | 1,855 | 3,133 | 1,159 | 1,855 | 1.6x |
+| `open_dump` | 1,347 | 2,277 | 814 | 1,347 | 1.7x |
+| `backtrace` | 572 | 661 | 572 | — | — |
+| `session_status` | 297 | 823 | 420 | 297 | 0.7x |
 
 `registers` is the shape of the problem in miniature: the model reads 9,804 bytes of JSON carrying
 `"kind":"int"` and `"subregister":false` on every row, and never sees the 618-byte `r` output that
@@ -174,27 +174,37 @@ own commit, with the reason, and update the tables here.
 
 Result budgets are **not** goldened. Their sizes move with what the runner can resolve: a symbol
 server that answers turns `deferred` into paths and grows `lm` a column, and the debugger tier runs
-on two architectures. Per-tool ceilings with ~35% headroom catch a tool that starts returning an
-order of magnitude more, without pinning a number the environment owns.
+on two architectures. Per-tool ceilings with ~35–45% headroom catch a tool that starts returning an
+order of magnitude more, without pinning a number the environment owns. `crash_triage` and
+`backtrace` are looser still, deliberately: `!analyze -v` and `k` change *shape* when symbols
+resolve rather than merely growing, and a ceiling tight enough to be interesting offline would make
+the tier flaky about its environment instead of watchful about the code.
 
 One rule is asserted rather than a number: a tool's `structuredContent` may not exceed its own text
 rendering by more than 20x. A typed answer is meant to be the facts behind a rendering, so a large
 multiple means it is carrying scaffolding instead. `registers` is at 15.9x and is finding 7 above,
-not a failure — the rule is there to catch the next one.
+not a failure — the rule is there to catch the next one. Being a ratio, it is only safe to read
+alongside the `wire` ceiling below: on its own, a rendering that grows satisfies it *more*.
 
-### What the result budget does not cover
+### Why each call has two ceilings
 
-It asserts on **one channel per call** — `structuredContent` when a tool has one, its text
-otherwise — because that is what the measured client forwards. That is a forwarding policy rather
-than protocol: MCP does not require a client to drop the text block, and this server is advertised
-for several. So for the 31 typed tools, the text half is measured and printed but never asserted,
-and it could grow unwatched.
+`model` alone would leave the other channel unwatched. It is `structuredContent` when a tool has
+one, and that is a *forwarding policy* rather than protocol — MCP does not require a client to drop
+the text block, and this server is advertised for several — so budgeting only the forwarded half
+means that for the 31 typed tools the rendering could grow with nothing to notice.
 
-Worse, growing it would look like an improvement. Text is the *denominator* of the ratio rule
-above, so doubling a rendering lowers the ratio and leaves `model` untouched — the one assertion
-that mentions text is the one that would wave it through. Nothing is oversized today (the text
-halves are the small halves), but the harness would not be the thing that noticed.
-[#150](https://github.com/glslang/windbg-mcp/issues/150) tracks it. The cheap half of the fix —
-budgeting `text + structured`, the wire total, which no client policy affects — needs nothing this
-document does not already have; the rest wants measurements from a second client rather than a
-guess about one.
+And it would have looked like an improvement. Text is the **denominator** of the ratio rule above,
+so a rendering that doubles *lowers* the ratio while `model` does not move at all: the one
+assertion that mentioned text was the one that would have waved it through. Measured, not argued —
+adding a line of prose per module to `modules` took its text from 19,732 B to 30,385 B, and the
+ratio *fell* from 2.7x to 1.8x while `model` stayed at 53,875 B.
+
+So each call also has a **`wire`** ceiling: the whole result as it crosses the pipe, which no
+client's policy affects. It is measured rather than derived from `text + structured`, because the
+result object also carries content-block scaffolding and JSON escaping — a rendered table's
+newlines cost two bytes there and one in `text`.
+
+What is still missing is per-*channel* ceilings, which would say which half moved. That needs a
+decision about which forwarding policies this server intends to be good under, and that wants
+measurements from a second client rather than a guess about one —
+[#150](https://github.com/glslang/windbg-mcp/issues/150).

--- a/docs/token-budget.md
+++ b/docs/token-budget.md
@@ -181,3 +181,20 @@ One rule is asserted rather than a number: a tool's `structuredContent` may not 
 rendering by more than 20x. A typed answer is meant to be the facts behind a rendering, so a large
 multiple means it is carrying scaffolding instead. `registers` is at 15.9x and is finding 7 above,
 not a failure — the rule is there to catch the next one.
+
+### What the result budget does not cover
+
+It asserts on **one channel per call** — `structuredContent` when a tool has one, its text
+otherwise — because that is what the measured client forwards. That is a forwarding policy rather
+than protocol: MCP does not require a client to drop the text block, and this server is advertised
+for several. So for the 31 typed tools, the text half is measured and printed but never asserted,
+and it could grow unwatched.
+
+Worse, growing it would look like an improvement. Text is the *denominator* of the ratio rule
+above, so doubling a rendering lowers the ratio and leaves `model` untouched — the one assertion
+that mentions text is the one that would wave it through. Nothing is oversized today (the text
+halves are the small halves), but the harness would not be the thing that noticed.
+[#150](https://github.com/glslang/windbg-mcp/issues/150) tracks it. The cheap half of the fix —
+budgeting `text + structured`, the wire total, which no client policy affects — needs nothing this
+document does not already have; the rest wants measurements from a second client rather than a
+guess about one.

--- a/docs/token-budget.md
+++ b/docs/token-budget.md
@@ -61,7 +61,9 @@ authority — the tables below are a reading of it at the time of writing.
 
 | Component | Bytes | Reaches the model |
 |---|---:|---|
-| **Whole `tools/list` payload** | **358,533** | partly |
+| **Whole `tools/list` payload** | **358,651** | partly |
+| — the 51 tools themselves | 358,533 | partly |
+| — result-level fields (`resultType`, `ttlMs`, `cacheScope`) | 118 | no |
 | `outputSchema` (the 31 tools that have one) | 285,745 | no |
 | `inputSchema` (all 51) | 39,964 | yes |
 | `description` (all 51) | 23,457 | yes |
@@ -71,6 +73,19 @@ authority — the tables below are a reading of it at the time of writing.
 
 Worst single tool: `debug_batch` at 9,757 model-visible bytes, because its `inputSchema` pulls the
 whole `StepAction`/`Check` vocabulary out of `src/batch.rs`.
+
+The payload is measured as the **serialized result**, not as the sum of its tools, and the 118-byte
+gap between those two is the reason. Result-level fields live in it, and on `2026-07-28` those are
+SEP-2549's `ttlMs`/`cacheScope` — the fields the `rmcp = "3.1.1"` floor exists for. Asking the same
+server at two revisions shows what a sum would miss:
+
+| Revision | payload | sum of tools | result-level |
+|---|---:|---:|---|
+| `2026-07-28` | 358,651 | 358,533 | `resultType`, `ttlMs`, `cacheScope` |
+| `2025-06-18` | 358,595 | 358,533 | none |
+
+The sum is **identical** across the two; only the payload figure can tell them apart. The golden
+records both, so the gap stays visible.
 
 ### Results, against `docs/samples/052126-34312-01.dmp`
 

--- a/tests/golden/tool_budget.json
+++ b/tests/golden/tool_budget.json
@@ -1,0 +1,475 @@
+{
+  "tools": [
+    {
+      "annotations": 123,
+      "description": 1043,
+      "inputSchema": 904,
+      "modelVisible": 2001,
+      "name": "attach_kernel",
+      "outputSchema": 11093,
+      "wire": 13248
+    },
+    {
+      "annotations": 122,
+      "description": 237,
+      "inputSchema": 33,
+      "modelVisible": 330,
+      "name": "attach_kernel_local",
+      "outputSchema": 11093,
+      "wire": 11576
+    },
+    {
+      "annotations": 117,
+      "description": 240,
+      "inputSchema": 204,
+      "modelVisible": 499,
+      "name": "attach_process",
+      "outputSchema": 11093,
+      "wire": 11740
+    },
+    {
+      "annotations": 68,
+      "description": 50,
+      "inputSchema": 395,
+      "modelVisible": 495,
+      "name": "backtrace",
+      "outputSchema": 0,
+      "wire": 578
+    },
+    {
+      "annotations": 117,
+      "description": 1551,
+      "inputSchema": 1319,
+      "modelVisible": 2923,
+      "name": "crash_triage",
+      "outputSchema": 12651,
+      "wire": 15722
+    },
+    {
+      "annotations": 134,
+      "description": 1714,
+      "inputSchema": 7991,
+      "modelVisible": 9757,
+      "name": "debug_batch",
+      "outputSchema": 9458,
+      "wire": 19380
+    },
+    {
+      "annotations": 79,
+      "description": 219,
+      "inputSchema": 215,
+      "modelVisible": 487,
+      "name": "decode_ioctl",
+      "outputSchema": 0,
+      "wire": 581
+    },
+    {
+      "annotations": 74,
+      "description": 299,
+      "inputSchema": 470,
+      "modelVisible": 823,
+      "name": "device_object",
+      "outputSchema": 0,
+      "wire": 912
+    },
+    {
+      "annotations": 64,
+      "description": 55,
+      "inputSchema": 479,
+      "modelVisible": 586,
+      "name": "disassemble",
+      "outputSchema": 0,
+      "wire": 665
+    },
+    {
+      "annotations": 74,
+      "description": 211,
+      "inputSchema": 455,
+      "modelVisible": 720,
+      "name": "driver_object",
+      "outputSchema": 0,
+      "wire": 809
+    },
+    {
+      "annotations": 130,
+      "description": 256,
+      "inputSchema": 478,
+      "modelVisible": 777,
+      "name": "dx",
+      "outputSchema": 0,
+      "wire": 922
+    },
+    {
+      "annotations": 116,
+      "description": 715,
+      "inputSchema": 395,
+      "modelVisible": 1162,
+      "name": "end_session",
+      "outputSchema": 4216,
+      "wire": 5525
+    },
+    {
+      "annotations": 124,
+      "description": 238,
+      "inputSchema": 476,
+      "modelVisible": 762,
+      "name": "execute",
+      "outputSchema": 0,
+      "wire": 901
+    },
+    {
+      "annotations": 118,
+      "description": 83,
+      "inputSchema": 395,
+      "modelVisible": 521,
+      "name": "go",
+      "outputSchema": 4418,
+      "wire": 5088
+    },
+    {
+      "annotations": 118,
+      "description": 66,
+      "inputSchema": 472,
+      "modelVisible": 592,
+      "name": "goto_position",
+      "outputSchema": 0,
+      "wire": 725
+    },
+    {
+      "annotations": 128,
+      "description": 220,
+      "inputSchema": 983,
+      "modelVisible": 1260,
+      "name": "heap_allocations",
+      "outputSchema": 12627,
+      "wire": 14046
+    },
+    {
+      "annotations": 124,
+      "description": 194,
+      "inputSchema": 448,
+      "modelVisible": 694,
+      "name": "heap_census",
+      "outputSchema": 12461,
+      "wire": 13310
+    },
+    {
+      "annotations": 126,
+      "description": 356,
+      "inputSchema": 323,
+      "modelVisible": 730,
+      "name": "heap_chunk",
+      "outputSchema": 13342,
+      "wire": 14229
+    },
+    {
+      "annotations": 130,
+      "description": 259,
+      "inputSchema": 592,
+      "modelVisible": 908,
+      "name": "heap_diagnostics",
+      "outputSchema": 12568,
+      "wire": 13637
+    },
+    {
+      "annotations": 119,
+      "description": 306,
+      "inputSchema": 295,
+      "modelVisible": 651,
+      "name": "heap_list",
+      "outputSchema": 12157,
+      "wire": 12958
+    },
+    {
+      "annotations": 120,
+      "description": 858,
+      "inputSchema": 395,
+      "modelVisible": 1305,
+      "name": "index_trace",
+      "outputSchema": 0,
+      "wire": 1440
+    },
+    {
+      "annotations": 132,
+      "description": 2110,
+      "inputSchema": 395,
+      "modelVisible": 2555,
+      "name": "interrupt",
+      "outputSchema": 0,
+      "wire": 2702
+    },
+    {
+      "annotations": 124,
+      "description": 422,
+      "inputSchema": 543,
+      "modelVisible": 1017,
+      "name": "ioctl_trace",
+      "outputSchema": 0,
+      "wire": 1156
+    },
+    {
+      "annotations": 76,
+      "description": 243,
+      "inputSchema": 570,
+      "modelVisible": 863,
+      "name": "irp_stack",
+      "outputSchema": 0,
+      "wire": 954
+    },
+    {
+      "annotations": 129,
+      "description": 266,
+      "inputSchema": 229,
+      "modelVisible": 542,
+      "name": "launch",
+      "outputSchema": 11093,
+      "wire": 11795
+    },
+    {
+      "annotations": 65,
+      "description": 681,
+      "inputSchema": 1383,
+      "modelVisible": 2112,
+      "name": "modules",
+      "outputSchema": 8341,
+      "wire": 10549
+    },
+    {
+      "annotations": 128,
+      "description": 451,
+      "inputSchema": 211,
+      "modelVisible": 712,
+      "name": "open_dump",
+      "outputSchema": 11093,
+      "wire": 11964
+    },
+    {
+      "annotations": 114,
+      "description": 272,
+      "inputSchema": 211,
+      "modelVisible": 534,
+      "name": "open_trace",
+      "outputSchema": 11093,
+      "wire": 11772
+    },
+    {
+      "annotations": 123,
+      "description": 371,
+      "inputSchema": 613,
+      "modelVisible": 1036,
+      "name": "pool_census",
+      "outputSchema": 12311,
+      "wire": 13501
+    },
+    {
+      "annotations": 129,
+      "description": 941,
+      "inputSchema": 771,
+      "modelVisible": 1763,
+      "name": "pool_chunk",
+      "outputSchema": 14042,
+      "wire": 15965
+    },
+    {
+      "annotations": 127,
+      "description": 1095,
+      "inputSchema": 842,
+      "modelVisible": 1994,
+      "name": "pool_diagnostics",
+      "outputSchema": 12945,
+      "wire": 15097
+    },
+    {
+      "annotations": 122,
+      "description": 511,
+      "inputSchema": 1229,
+      "modelVisible": 1794,
+      "name": "pool_find_tag",
+      "outputSchema": 13964,
+      "wire": 15911
+    },
+    {
+      "annotations": 90,
+      "description": 556,
+      "inputSchema": 2019,
+      "modelVisible": 2639,
+      "name": "reachable_from_dispatch",
+      "outputSchema": 0,
+      "wire": 2744
+    },
+    {
+      "annotations": 64,
+      "description": 59,
+      "inputSchema": 533,
+      "modelVisible": 644,
+      "name": "read_memory",
+      "outputSchema": 0,
+      "wire": 723
+    },
+    {
+      "annotations": 120,
+      "description": 476,
+      "inputSchema": 845,
+      "modelVisible": 1374,
+      "name": "record_trace",
+      "outputSchema": 0,
+      "wire": 1509
+    },
+    {
+      "annotations": 67,
+      "description": 328,
+      "inputSchema": 711,
+      "modelVisible": 1089,
+      "name": "registers",
+      "outputSchema": 6379,
+      "wire": 7566
+    },
+    {
+      "annotations": 123,
+      "description": 86,
+      "inputSchema": 395,
+      "modelVisible": 532,
+      "name": "reverse_go",
+      "outputSchema": 4418,
+      "wire": 5104
+    },
+    {
+      "annotations": 114,
+      "description": 460,
+      "inputSchema": 802,
+      "modelVisible": 1317,
+      "name": "run_to_address",
+      "outputSchema": 4520,
+      "wire": 5982
+    },
+    {
+      "annotations": 75,
+      "description": 940,
+      "inputSchema": 1608,
+      "modelVisible": 2599,
+      "name": "server_log",
+      "outputSchema": 6153,
+      "wire": 8858
+    },
+    {
+      "annotations": 73,
+      "description": 1020,
+      "inputSchema": 395,
+      "modelVisible": 1470,
+      "name": "session_status",
+      "outputSchema": 7201,
+      "wire": 8775
+    },
+    {
+      "annotations": 115,
+      "description": 330,
+      "inputSchema": 478,
+      "modelVisible": 863,
+      "name": "set_breakpoint",
+      "outputSchema": 6777,
+      "wire": 7786
+    },
+    {
+      "annotations": 123,
+      "description": 465,
+      "inputSchema": 1136,
+      "modelVisible": 1657,
+      "name": "set_symbol_path",
+      "outputSchema": 0,
+      "wire": 1795
+    },
+    {
+      "annotations": 116,
+      "description": 76,
+      "inputSchema": 395,
+      "modelVisible": 521,
+      "name": "step_back",
+      "outputSchema": 4418,
+      "wire": 5086
+    },
+    {
+      "annotations": 109,
+      "description": 34,
+      "inputSchema": 395,
+      "modelVisible": 479,
+      "name": "step_into",
+      "outputSchema": 4418,
+      "wire": 5037
+    },
+    {
+      "annotations": 109,
+      "description": 46,
+      "inputSchema": 395,
+      "modelVisible": 491,
+      "name": "step_over",
+      "outputSchema": 4418,
+      "wire": 5049
+    },
+    {
+      "annotations": 121,
+      "description": 74,
+      "inputSchema": 395,
+      "modelVisible": 524,
+      "name": "step_over_back",
+      "outputSchema": 4418,
+      "wire": 5094
+    },
+    {
+      "annotations": 65,
+      "description": 21,
+      "inputSchema": 395,
+      "modelVisible": 464,
+      "name": "threads",
+      "outputSchema": 0,
+      "wire": 544
+    },
+    {
+      "annotations": 82,
+      "description": 260,
+      "inputSchema": 499,
+      "modelVisible": 809,
+      "name": "ttd_calls",
+      "outputSchema": 0,
+      "wire": 906
+    },
+    {
+      "annotations": 75,
+      "description": 213,
+      "inputSchema": 395,
+      "modelVisible": 659,
+      "name": "ttd_events",
+      "outputSchema": 0,
+      "wire": 749
+    },
+    {
+      "annotations": 89,
+      "description": 169,
+      "inputSchema": 735,
+      "modelVisible": 955,
+      "name": "ttd_memory",
+      "outputSchema": 0,
+      "wire": 1059
+    },
+    {
+      "annotations": 125,
+      "description": 1311,
+      "inputSchema": 2724,
+      "modelVisible": 4087,
+      "name": "walk_memory",
+      "outputSchema": 10566,
+      "wire": 14809
+    }
+  ],
+  "totals": {
+    "annotations": 5449,
+    "description": 23457,
+    "inputSchema": 39964,
+    "instructions": 3163,
+    "modelVisible": 66078,
+    "outputSchema": 285745,
+    "tools": 51,
+    "wire": 358533,
+    "worstTool": "debug_batch",
+    "worstToolModelVisible": 9757
+  }
+}

--- a/tests/golden/tool_budget.json
+++ b/tests/golden/tool_budget.json
@@ -467,6 +467,7 @@
     "instructions": 3163,
     "modelVisible": 66078,
     "outputSchema": 285745,
+    "payload": 358651,
     "tools": 51,
     "wire": 358533,
     "worstTool": "debug_batch",

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -3068,34 +3068,63 @@ fn an_open_summarises_the_target_instead_of_listing_its_modules() {
 /// that matters (a tool that starts returning an order of magnitude more) without pinning a number
 /// the environment owns.
 ///
-/// Sizes are counted as **model-visible** bytes, which is `structuredContent` when a tool has one
-/// and the text otherwise — a client that understands structured results forwards that and drops
-/// the rendering. That is why `registers` is measured at ~9.8 KB and not at the 600 bytes of `r`
-/// output it also sends: the compact half is the one nobody reads.
+/// **Two ceilings per call, because one number cannot answer both questions.**
+///
+/// `model` is what a model is charged: `structuredContent` when a tool has one and the text
+/// otherwise, since a client that understands structured results forwards that and drops the
+/// rendering. It is why `registers` is measured at ~9.8 KB rather than at the 600 bytes of `r`
+/// output it also sends — the compact half is the one nobody reads.
+///
+/// But that is a *forwarding policy*, not protocol. MCP does not oblige a client to discard the
+/// text block, and this server is advertised for several clients, so budgeting only the forwarded
+/// half leaves the other one unwatched — for the tools with an output schema, that is 31 of them.
+/// `wire` closes it: the whole result as it crosses the pipe, which no client's policy affects.
+///
+/// The gap that needed closing was not merely an absent assertion, it was a self-concealing one.
+/// Text is the *denominator* of the ratio rule at the end of this test, so a rendering that doubles
+/// **lowers** the ratio while `model` does not move at all — the single check that mentioned text
+/// was the one that would have waved it through. Take `registers` from 618 B of text to 6,180 B and
+/// 15.9x becomes 1.59x, and every assertion here passed greener than before.
+///
+/// Per-*channel* ceilings would say which half moved, and are not here: that needs a decision about
+/// which forwarding policies this server intends to be good under, which wants measurements from a
+/// second client rather than a guess about one
+/// ([#150](https://github.com/glslang/windbg-mcp/issues/150)).
 #[test]
 fn tool_results_stay_within_their_budget() {
     let Some(dump) = target_tier() else { return };
     let mut server = Server::started();
 
-    // Ceilings are ~35% over what this dump produces today — looser than the surface budget above,
-    // because these numbers depend on the target and on what symbols resolve, where that one
-    // depends only on this crate's own source.
+    // Ceilings are ~35-45% over what this dump produces today — looser than the surface budget
+    // above, because these numbers depend on the target and on what symbols resolve, where that
+    // one depends only on this crate's own source.
+    //
+    // `crash_triage` and `backtrace` are looser still, and not by oversight: `!analyze -v` and `k`
+    // are the two answers here that change *shape* when symbols resolve rather than merely growing,
+    // and a runner that reaches a symbol server produces several times what an offline one does. A
+    // ceiling tight enough to be interesting on this host would fail on that one, which would make
+    // the tier flaky about the environment instead of watchful about the code.
+    //
+    // `wire` is not `model` plus the text: it is the whole `result` object, so it also carries the
+    // content-block scaffolding and JSON escaping — a rendered table's newlines cost two bytes each
+    // there and one in `text`. It is measured rather than derived for exactly that reason.
     //
     // Only calls that succeed on a *kernel* dump are listed. `threads` is deliberately absent: `~`
     // is a user-mode question and answers with a tool error here, which would measure the size of
     // a failure.
-    let budgets: &[(&str, Value, usize)] = &[
-        ("open_dump", json!({ "path": dump }), 2_000),
-        ("session_status", json!({}), 600),
-        ("crash_triage", json!({}), 6_000),
-        ("registers", json!({}), 13_500),
-        ("backtrace", json!({}), 4_000),
-        ("modules", json!({}), 73_000),
-        ("execute", json!({ "command": "lm" }), 27_000),
+    let budgets: &[(&str, Value, usize, usize)] = &[
+        // tool, args, model ceiling, wire ceiling
+        ("open_dump", json!({ "path": dump }), 2_000, 3_200),
+        ("session_status", json!({}), 600, 1_200),
+        ("crash_triage", json!({}), 6_000, 9_000),
+        ("registers", json!({}), 13_500, 14_500),
+        ("backtrace", json!({}), 4_000, 5_000),
+        ("modules", json!({}), 73_000, 100_000),
+        ("execute", json!({ "command": "lm" }), 27_000, 28_500),
     ];
 
     let mut rows = Vec::new();
-    for (tool, args, ceiling) in budgets {
+    for (tool, args, model_ceiling, wire_ceiling) in budgets {
         let response = server.call_tool(tool, args.clone(), TARGET_STEP);
         assert_no_error(&response, &format!("tools/call {tool}"));
         let result = &response["result"];
@@ -3105,27 +3134,35 @@ fn tool_results_stay_within_their_budget() {
             text_of(result)
         );
 
+        let wire = json_bytes(result);
         let text = text_of(result).len();
         let structured = match &result["structuredContent"] {
             Value::Null => None,
             value => Some(json_bytes(value)),
         };
         let model = structured.unwrap_or(text);
-        rows.push((*tool, model, text, structured, *ceiling));
+        rows.push((*tool, model, wire, text, structured, *model_ceiling));
 
         assert!(
-            model <= *ceiling,
-            "`{tool}` answered with {model} B of model context, over its {ceiling} B budget. \
-             Either it started returning more than it used to, or the budget needs raising with \
-             a reason recorded in docs/token-budget.md."
+            model <= *model_ceiling,
+            "`{tool}` answered with {model} B of model context, over its {model_ceiling} B \
+             budget. Either it started returning more than it used to, or the budget needs \
+             raising with a reason recorded in docs/token-budget.md."
+        );
+        assert!(
+            wire <= *wire_ceiling,
+            "`{tool}` put {wire} B on the wire, over its {wire_ceiling} B budget, while its \
+             model-visible half ({model} B) is inside its own. So the half this client drops \
+             grew — which costs every client that does *not* drop it, and is the case the \
+             model-visible budget alone cannot see. See docs/token-budget.md."
         );
     }
 
     // The table is the deliverable when this passes — the assertions only speak up once something
     // has already gone wrong. Unlike the surface budget, this one *is* visible in CI, because the
     // debugger tier's job passes `--nocapture`; without it libtest would swallow the table.
-    eprintln!("\n  model     text  struct  ratio  ceiling  tool");
-    for (tool, model, text, structured, ceiling) in &rows {
+    eprintln!("\n  model     wire     text  struct  ratio  ceiling  tool");
+    for (tool, model, wire, text, structured, ceiling) in &rows {
         let (shown, ratio) = match structured {
             Some(bytes) if *text > 0 => (
                 bytes.to_string(),
@@ -3134,7 +3171,7 @@ fn tool_results_stay_within_their_budget() {
             Some(bytes) => (bytes.to_string(), "-".to_string()),
             None => ("-".to_string(), "-".to_string()),
         };
-        eprintln!("{model:7} {text:8} {shown:>7} {ratio:>6} {ceiling:8}  {tool}");
+        eprintln!("{model:7} {wire:8} {text:8} {shown:>7} {ratio:>6} {ceiling:8}  {tool}");
     }
 
     // A rule rather than a number, and the one regression class the byte budgets cannot state: a
@@ -3142,8 +3179,11 @@ fn tool_results_stay_within_their_budget() {
     // size of that rendering means it is carrying scaffolding instead — `"kind":"int"` and
     // `"subregister":false` on every row. `registers` is ~16x today and is named in
     // docs/token-budget.md rather than fixed here; this catches the *next* one, not that one.
+    //
+    // It is a ratio, so it is only safe to read alongside the `wire` ceiling above: on its own, a
+    // rendering that grows satisfies it *more*. That is why the wire budget is not optional.
     const WORST_STRUCTURED_RATIO: f64 = 20.0;
-    for (tool, _, text, structured, _) in &rows {
+    for (tool, _, _, text, structured, _) in &rows {
         let (Some(bytes), true) = (structured, *text > 0) else {
             continue;
         };

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -977,29 +977,38 @@ fn tools_list_matches_the_recorded_wire_surface() {
     assert_golden(GOLDEN, &actual, "the tools/list wire surface");
 }
 
-/// Compare a rendered snapshot against its golden file, or re-record it when `UPDATE_GOLDEN` is
-/// set, failing with a line diff that names what moved.
+/// The half every golden shares: re-record when `UPDATE_GOLDEN` is set, otherwise hand back what
+/// was recorded. `None` means it re-recorded, so this run has nothing to compare against.
 ///
-/// Shared by the two goldens in this file so one command records both and one differ explains
-/// both. Splitting the renderer out matters more than it looks: the budget golden below is a wall
-/// of numbers, and a failure that dumped two of those blobs side by side would be unreadable in a
-/// CI log — the line diff is what makes it say "this tool, this many bytes more".
-fn assert_golden(path: &str, actual: &Value, what: &str) {
-    let rendered = format!("{}\n", serde_json::to_string_pretty(actual).unwrap());
-
+/// One env var and one command records every golden in this file, which is the point of it being
+/// shared. How each one *reports* a difference is not shared — see below.
+fn golden_baseline(path: &str, rendered: &str) -> Option<String> {
     if std::env::var_os("UPDATE_GOLDEN").is_some() {
         std::fs::create_dir_all(std::path::Path::new(path).parent().unwrap())
             .expect("create golden dir");
-        std::fs::write(path, &rendered).expect("write golden");
+        std::fs::write(path, rendered).expect("write golden");
         eprintln!("re-recorded {path}");
-        return;
+        return None;
     }
-
-    let expected = std::fs::read_to_string(path).unwrap_or_else(|e| {
+    Some(std::fs::read_to_string(path).unwrap_or_else(|e| {
         panic!(
             "cannot read {path}: {e}\nrecord it with `UPDATE_GOLDEN=1 cargo test --test mcp_smoke`"
         )
-    });
+    }))
+}
+
+/// Compare a rendered snapshot against its golden file, failing with a **line** diff.
+///
+/// Right for the shape golden, whose entries are mostly names and type strings: a changed line is
+/// legible on its own, and the structure only moves when a tool does.
+///
+/// Wrong for a report of numbers keyed by tool — see [`assert_budget_golden`], which does not use
+/// this.
+fn assert_golden(path: &str, actual: &Value, what: &str) {
+    let rendered = format!("{}\n", serde_json::to_string_pretty(actual).unwrap());
+    let Some(expected) = golden_baseline(path, &rendered) else {
+        return;
+    };
     if rendered.replace("\r\n", "\n") == expected.replace("\r\n", "\n") {
         return;
     }
@@ -1027,6 +1036,119 @@ fn assert_golden(path: &str, actual: &Value, what: &str) {
         "{what} changed:\n{diff}\n\
          If this is intended, re-record with `UPDATE_GOLDEN=1 cargo test --test mcp_smoke` \
          and review the diff."
+    );
+}
+
+/// Compare a budget report against its golden **by tool name**, reporting byte deltas.
+///
+/// Deliberately not [`assert_golden`]'s line diff, and the reason is a failure that was measured
+/// rather than imagined. Each tool occupies seven lines of the report, so adding or removing one
+/// shifts every line after it, and a positional differ then blames the first tool whose *line
+/// numbers* moved rather than the one that changed. Dropping `backtrace` from a 51-tool report
+/// made the failure open with `crash_triage` — which had not changed at all — and truncate at its
+/// 60-line cap before reaching anything that had. A report that names the wrong tool is worse than
+/// no report: it sends the reader to audit something that is fine.
+///
+/// Keying the JSON by name instead would not have fixed it. The rows would still be lines, and an
+/// insertion would still shift the ones below. What fixes it is comparing the two documents as
+/// *values* — matching tools by name, so an insertion is an insertion and every other tool is
+/// untouched — which is also how the failure gets to say `modules: modelVisible 2112 -> 4200`
+/// instead of a line number.
+fn assert_budget_golden(path: &str, actual: &Value, what: &str) {
+    let rendered = format!("{}\n", serde_json::to_string_pretty(actual).unwrap());
+    let Some(expected_text) = golden_baseline(path, &rendered) else {
+        return;
+    };
+    if rendered.replace("\r\n", "\n") == expected_text.replace("\r\n", "\n") {
+        return;
+    }
+    let expected: Value = serde_json::from_str(&expected_text).unwrap_or_else(|e| {
+        panic!("{path} is not readable as JSON ({e}); re-record it with `UPDATE_GOLDEN=1`")
+    });
+
+    let by_name = |report: &Value| -> std::collections::BTreeMap<String, Value> {
+        report["tools"]
+            .as_array()
+            .into_iter()
+            .flatten()
+            .filter_map(|row| Some((row["name"].as_str()?.to_string(), row.clone())))
+            .collect()
+    };
+    let (was, now) = (by_name(&expected), by_name(actual));
+
+    // Per-tool figures, most consequential first, so a truncated report keeps what matters.
+    const FIELDS: &[&str] = &[
+        "modelVisible",
+        "wire",
+        "description",
+        "inputSchema",
+        "outputSchema",
+        "annotations",
+    ];
+    let mut lines: Vec<String> = Vec::new();
+    for (name, row) in &now {
+        if !was.contains_key(name) {
+            lines.push(format!(
+                "  + {name} is new: {} B to the model, {} B on the wire",
+                row["modelVisible"], row["wire"]
+            ));
+        }
+    }
+    for (name, row) in &was {
+        if !now.contains_key(name) {
+            lines.push(format!(
+                "  - {name} is gone: was {} B to the model",
+                row["modelVisible"]
+            ));
+        }
+    }
+    for (name, new_row) in &now {
+        let Some(old_row) = was.get(name) else {
+            continue;
+        };
+        let deltas: Vec<String> = FIELDS
+            .iter()
+            .filter_map(|field| {
+                let (a, b) = (old_row[*field].as_i64()?, new_row[*field].as_i64()?);
+                (a != b).then(|| format!("{field} {a} -> {b} ({:+})", b - a))
+            })
+            .collect();
+        if !deltas.is_empty() {
+            lines.push(format!("  ~ {name}: {}", deltas.join(", ")));
+        }
+    }
+
+    let mut totals: Vec<String> = Vec::new();
+    if let Some(recorded) = expected["totals"].as_object() {
+        for (key, old) in recorded {
+            let new = &actual["totals"][key];
+            if old == new {
+                continue;
+            }
+            totals.push(match (old.as_i64(), new.as_i64()) {
+                (Some(a), Some(b)) => format!("  {key} {a} -> {b} ({:+})", b - a),
+                _ => format!("  {key} {old} -> {new}"),
+            });
+        }
+    }
+
+    const MAX_LINES: usize = 25;
+    let hidden = lines.len().saturating_sub(MAX_LINES);
+    lines.truncate(MAX_LINES);
+    if hidden > 0 {
+        lines.push(format!("  ... and {hidden} more tool(s)"));
+    }
+
+    panic!(
+        "{what} changed:\n{}\n\ntotals:\n{}\n\n\
+         If this is intended, re-record with `UPDATE_GOLDEN=1 cargo test --test mcp_smoke` \
+         and review the diff.",
+        lines.join("\n"),
+        if totals.is_empty() {
+            "  (unchanged)".to_string()
+        } else {
+            totals.join("\n")
+        },
     );
 }
 
@@ -1202,7 +1324,7 @@ fn tool_surface_stays_within_its_token_budget() {
          per-tool ceiling."
     );
 
-    assert_golden(BUDGET_GOLDEN, &report, "the tools/list token budget");
+    assert_budget_golden(BUDGET_GOLDEN, &report, "the tools/list token budget");
 }
 
 /// Clients validate arguments against these schemas before ever calling. A `$ref` that points

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -79,6 +79,11 @@ const SUPPORTED_REVISIONS: &[&str] = &[
 const FALLBACK_REVISION: &str = "2025-11-25";
 
 const GOLDEN: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/golden/tools_list.json");
+/// Companion to [`GOLDEN`], and deliberately the thing it is blind to. That one digests the tool
+/// surface down to its *shape* — `digest_tool` drops every `description` on purpose — which is
+/// what makes it readable, and what makes it unable to see the bytes. This one records only
+/// sizes. See `docs/token-budget.md`.
+const BUDGET_GOLDEN: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/golden/tool_budget.json");
 const SAMPLE_DUMP: &str = concat!(
     env!("CARGO_MANIFEST_DIR"),
     "/docs/samples/052126-34312-01.dmp"
@@ -969,18 +974,31 @@ fn tools_list_matches_the_recorded_wire_surface() {
         .clone();
 
     let actual = digest_tool_list(&tools);
-    let rendered = format!("{}\n", serde_json::to_string_pretty(&actual).unwrap());
+    assert_golden(GOLDEN, &actual, "the tools/list wire surface");
+}
+
+/// Compare a rendered snapshot against its golden file, or re-record it when `UPDATE_GOLDEN` is
+/// set, failing with a line diff that names what moved.
+///
+/// Shared by the two goldens in this file so one command records both and one differ explains
+/// both. Splitting the renderer out matters more than it looks: the budget golden below is a wall
+/// of numbers, and a failure that dumped two of those blobs side by side would be unreadable in a
+/// CI log — the line diff is what makes it say "this tool, this many bytes more".
+fn assert_golden(path: &str, actual: &Value, what: &str) {
+    let rendered = format!("{}\n", serde_json::to_string_pretty(actual).unwrap());
 
     if std::env::var_os("UPDATE_GOLDEN").is_some() {
-        std::fs::create_dir_all(std::path::Path::new(GOLDEN).parent().unwrap())
+        std::fs::create_dir_all(std::path::Path::new(path).parent().unwrap())
             .expect("create golden dir");
-        std::fs::write(GOLDEN, &rendered).expect("write golden");
-        eprintln!("re-recorded {GOLDEN}");
+        std::fs::write(path, &rendered).expect("write golden");
+        eprintln!("re-recorded {path}");
         return;
     }
 
-    let expected = std::fs::read_to_string(GOLDEN).unwrap_or_else(|e| {
-        panic!("cannot read {GOLDEN}: {e}\nrecord it with `UPDATE_GOLDEN=1 cargo test --test mcp_smoke`")
+    let expected = std::fs::read_to_string(path).unwrap_or_else(|e| {
+        panic!(
+            "cannot read {path}: {e}\nrecord it with `UPDATE_GOLDEN=1 cargo test --test mcp_smoke`"
+        )
     });
     if rendered.replace("\r\n", "\n") == expected.replace("\r\n", "\n") {
         return;
@@ -1006,10 +1024,184 @@ fn tools_list_matches_the_recorded_wire_surface() {
         }
     }
     panic!(
-        "the tools/list wire surface changed:\n{diff}\n\
+        "{what} changed:\n{diff}\n\
          If this is intended, re-record with `UPDATE_GOLDEN=1 cargo test --test mcp_smoke` \
          and review the diff."
     );
+}
+
+// ---- what the surface costs its caller ----------------------------------------
+//
+// Every other assertion in this file is about whether the server is *correct*. These are about
+// what it *costs*, which nothing here measured before: a client pays for the whole tool surface
+// at the start of every conversation, and then for each result, out of the same context window
+// the debugging itself has to fit in. `docs/token-budget.md` has the findings; this is the part
+// that keeps them from drifting unnoticed.
+
+/// Bytes a value occupies as minified JSON — the unit every budget here is counted in.
+///
+/// Bytes, not tokens, and deliberately. No tokenizer exists in this crate's dependency tree, a
+/// real one would pull in BPE data to produce a figure that varies by model, and the golden would
+/// then churn on a tokenizer bump rather than on a change to this server. Bytes are
+/// deterministic, diff cleanly, and move with tokens for a fixed content style.
+/// `docs/token-budget.md` records the ≈4 bytes/token convention used when quoting these as tokens.
+fn json_bytes(value: &Value) -> usize {
+    serde_json::to_string(value)
+        .expect("a value read off the wire re-serializes")
+        .len()
+}
+
+/// The part of a tool definition that reaches the **model**.
+///
+/// `outputSchema` and `annotations` are not in it: the Anthropic tool spec carries name,
+/// description and input schema, and the rest of a `tools/list` entry is the client's own
+/// business — validation, display — never spent on a context window. That split is why this
+/// report has two totals instead of one, and it is not a detail: ~80% of what this server puts on
+/// the wire is `outputSchema`, and none of it is read by a model. Optimising the two halves means
+/// optimising for different things, so conflating them would point any future work at the wrong
+/// 280 KB.
+fn model_visible_bytes(tool: &Value) -> usize {
+    json_bytes(&json!({
+        "name": tool["name"],
+        "description": tool["description"],
+        "inputSchema": tool["inputSchema"],
+    }))
+}
+
+/// Bytes of one field of a tool definition, or 0 when the tool does not carry it.
+fn field_bytes(tool: &Value, field: &str) -> usize {
+    match tool.get(field) {
+        None | Some(Value::Null) => 0,
+        Some(value) => json_bytes(value),
+    }
+}
+
+/// The per-tool size table.
+///
+/// Ordered **by name**, which is worth stating because the obvious choice is worse: sorting by
+/// cost makes the golden read as a ranking, and then a tool that grows moves up it and shifts
+/// every row below, so the diff cascades through a dozen untouched tools instead of naming the one
+/// that changed. A stable key is what makes the failure legible. The ranking is not lost — the
+/// totals carry the worst tool by name.
+fn budget_report(tools: &[Value], instructions: &str) -> Value {
+    let mut rows: Vec<Value> = tools
+        .iter()
+        .map(|tool| {
+            json!({
+                "name": tool["name"],
+                "modelVisible": model_visible_bytes(tool),
+                "wire": json_bytes(tool),
+                "description": field_bytes(tool, "description"),
+                "inputSchema": field_bytes(tool, "inputSchema"),
+                "outputSchema": field_bytes(tool, "outputSchema"),
+                "annotations": field_bytes(tool, "annotations"),
+            })
+        })
+        .collect();
+    rows.sort_by(|a, b| a["name"].as_str().cmp(&b["name"].as_str()));
+
+    let sum = |field: &str| -> u64 { rows.iter().filter_map(|r| r[field].as_u64()).sum() };
+    let worst = rows
+        .iter()
+        .max_by_key(|row| row["modelVisible"].as_u64().unwrap_or(0))
+        .expect("tools/list is never empty");
+    json!({
+        "totals": {
+            "tools": rows.len(),
+            "modelVisible": sum("modelVisible"),
+            "wire": sum("wire"),
+            "description": sum("description"),
+            "inputSchema": sum("inputSchema"),
+            "outputSchema": sum("outputSchema"),
+            "annotations": sum("annotations"),
+            "instructions": instructions.len(),
+            "worstTool": worst["name"],
+            "worstToolModelVisible": worst["modelVisible"],
+        },
+        "tools": rows,
+    })
+}
+
+/// Ceiling on the tool surface a model is given before it has asked anything. 66,078 bytes across
+/// 51 tools today (~16k tokens), +15% headroom — sized so that rewording a description passes and
+/// a new tool arriving with a `debug_batch`-scale schema does not.
+const MODEL_VISIBLE_CEILING: usize = 76_000;
+
+/// Ceiling on the whole `tools/list` payload. 358,533 bytes today, ~80% of it `outputSchema` that
+/// no model reads — which is why this is a separate, much looser number rather than a scaled
+/// version of the one above. It is a client-side parse and memory cost, and it is the one that
+/// grows silently: `schemars` inlines `$defs` per tool, so adding one shared type to one more
+/// output shape can add tens of kilobytes here while [`MODEL_VISIBLE_CEILING`] does not move.
+const WIRE_CEILING: usize = 412_000;
+
+/// Ceiling on any single tool's model-visible definition. `debug_batch` is the worst at 9,757
+/// bytes, because its `inputSchema` pulls the whole `StepAction`/`Check` vocabulary from
+/// `src/batch.rs`. A tool costing more than this is not necessarily wrong, but it should be a
+/// decision somebody made rather than a schema that grew.
+const WORST_TOOL_CEILING: usize = 11_200;
+
+/// What the tool surface costs a caller, pinned per tool.
+///
+/// Two mechanisms, because they fail on different things and neither covers the other:
+///
+/// * The **golden** shows *where* the bytes are. Any change to any tool's size lands as a
+///   readable diff, so the price of a reworded description is visible in review rather than
+///   discovered later.
+/// * The **ceilings** stop what the golden cannot: a golden re-recorded on every diff is a rubber
+///   stamp, and thirty accepted +2% changes are a doubling nobody ever voted for.
+///
+/// The numbers themselves are recorded, not argued for — this test exists so that changing them
+/// is a deliberate act, not so that today's figures are correct.
+#[test]
+fn tool_surface_stays_within_its_token_budget() {
+    let mut server = Server::spawn();
+    let initialized = server.initialize(SUPPORTED_REVISIONS[0]);
+    let instructions = initialized["instructions"].as_str().unwrap_or_default();
+
+    let response = server.request("tools/list", json!({}), STEP);
+    assert_no_error(&response, "tools/list");
+    let tools = response["result"]["tools"]
+        .as_array()
+        .expect("tools/list returns an array")
+        .clone();
+
+    let report = budget_report(&tools, instructions);
+    let totals = &report["totals"];
+    let model_visible = totals["modelVisible"].as_u64().unwrap() as usize;
+    let wire = totals["wire"].as_u64().unwrap() as usize;
+
+    // Print unconditionally: on a green run this is the only place the numbers are visible, and a
+    // budget nobody ever sees is a budget nobody maintains.
+    eprintln!(
+        "tool surface: {} tools, {model_visible} B to the model (ceiling {MODEL_VISIBLE_CEILING}), \
+         {wire} B on the wire (ceiling {WIRE_CEILING}), instructions {} B",
+        totals["tools"], totals["instructions"],
+    );
+
+    let worst = totals["worstTool"].as_str().unwrap_or("?").to_string();
+    let worst_bytes = totals["worstToolModelVisible"].as_u64().unwrap() as usize;
+
+    assert!(
+        model_visible <= MODEL_VISIBLE_CEILING,
+        "the tool surface now costs {model_visible} B of model context, over its \
+         {MODEL_VISIBLE_CEILING} B ceiling. That is paid at the start of every conversation, \
+         before anything is debugged. The worst single tool is `{worst}` at {worst_bytes} B. \
+         Trim a description or an input schema, or raise the ceiling deliberately and say why \
+         in docs/token-budget.md."
+    );
+    assert!(
+        wire <= WIRE_CEILING,
+        "tools/list is now {wire} B, over its {WIRE_CEILING} B ceiling. This is mostly \
+         outputSchema, which no model reads — check whether a shared type just got inlined into \
+         another tool's $defs before raising the ceiling."
+    );
+    assert!(
+        worst_bytes <= WORST_TOOL_CEILING,
+        "`{worst}` alone costs {worst_bytes} B of model context, over the {WORST_TOOL_CEILING} B \
+         per-tool ceiling."
+    );
+
+    assert_golden(BUDGET_GOLDEN, &report, "the tools/list token budget");
 }
 
 /// Clients validate arguments against these schemas before ever calling. A `$ref` that points
@@ -2859,6 +3051,109 @@ fn an_open_summarises_the_target_instead_of_listing_its_modules() {
         "the text says it too, and points at the tool that reads the rest:\n{report}"
     );
     assert!(report.contains("crash_triage"), "{report}");
+}
+
+/// What one call costs the caller, per tool, against the checked-in dump.
+///
+/// The tool surface above is paid once a conversation; this is paid every time, and it is the
+/// larger number in practice — a single `modules` on this dump is ~54 KB, roughly a fifth of a
+/// whole tool surface, for one question. The test that precedes this one already defends the
+/// principle for openers (#105: an open summarises rather than lists); this generalises it to a
+/// recorded figure per tool.
+///
+/// **Not a golden.** Result sizes move with what the runner can resolve — a symbol server that
+/// answers turns `deferred` into paths, and `lm` grows a column — so exact bytes would be flaky in
+/// the one tier that runs on two architectures. Ceilings with real headroom catch the regression
+/// that matters (a tool that starts returning an order of magnitude more) without pinning a number
+/// the environment owns.
+///
+/// Sizes are counted as **model-visible** bytes, which is `structuredContent` when a tool has one
+/// and the text otherwise — a client that understands structured results forwards that and drops
+/// the rendering. That is why `registers` is measured at ~9.8 KB and not at the 600 bytes of `r`
+/// output it also sends: the compact half is the one nobody reads.
+#[test]
+fn tool_results_stay_within_their_budget() {
+    let Some(dump) = target_tier() else { return };
+    let mut server = Server::started();
+
+    // Ceilings are ~35% over what this dump produces today — looser than the surface budget above,
+    // because these numbers depend on the target and on what symbols resolve, where that one
+    // depends only on this crate's own source.
+    //
+    // Only calls that succeed on a *kernel* dump are listed. `threads` is deliberately absent: `~`
+    // is a user-mode question and answers with a tool error here, which would measure the size of
+    // a failure.
+    let budgets: &[(&str, Value, usize)] = &[
+        ("open_dump", json!({ "path": dump }), 2_000),
+        ("session_status", json!({}), 600),
+        ("crash_triage", json!({}), 6_000),
+        ("registers", json!({}), 13_500),
+        ("backtrace", json!({}), 4_000),
+        ("modules", json!({}), 73_000),
+        ("execute", json!({ "command": "lm" }), 27_000),
+    ];
+
+    let mut rows = Vec::new();
+    for (tool, args, ceiling) in budgets {
+        let response = server.call_tool(tool, args.clone(), TARGET_STEP);
+        assert_no_error(&response, &format!("tools/call {tool}"));
+        let result = &response["result"];
+        assert!(
+            !is_tool_error(&response),
+            "`{tool}` reported a tool error, so its size would measure a failure:\n{}",
+            text_of(result)
+        );
+
+        let text = text_of(result).len();
+        let structured = match &result["structuredContent"] {
+            Value::Null => None,
+            value => Some(json_bytes(value)),
+        };
+        let model = structured.unwrap_or(text);
+        rows.push((*tool, model, text, structured, *ceiling));
+
+        assert!(
+            model <= *ceiling,
+            "`{tool}` answered with {model} B of model context, over its {ceiling} B budget. \
+             Either it started returning more than it used to, or the budget needs raising with \
+             a reason recorded in docs/token-budget.md."
+        );
+    }
+
+    // The table is the deliverable on a green run — the assertions only fire when something has
+    // already gone wrong, and a budget nobody ever sees is a budget nobody maintains.
+    eprintln!("\n  model     text  struct  ratio  ceiling  tool");
+    for (tool, model, text, structured, ceiling) in &rows {
+        let (shown, ratio) = match structured {
+            Some(bytes) if *text > 0 => (
+                bytes.to_string(),
+                format!("{:.1}x", *bytes as f64 / *text as f64),
+            ),
+            Some(bytes) => (bytes.to_string(), "-".to_string()),
+            None => ("-".to_string(), "-".to_string()),
+        };
+        eprintln!("{model:7} {text:8} {shown:>7} {ratio:>6} {ceiling:8}  {tool}");
+    }
+
+    // A rule rather than a number, and the one regression class the byte budgets cannot state: a
+    // typed answer is supposed to be the *facts* behind a rendering, so it being many times the
+    // size of that rendering means it is carrying scaffolding instead — `"kind":"int"` and
+    // `"subregister":false` on every row. `registers` is ~16x today and is named in
+    // docs/token-budget.md rather than fixed here; this catches the *next* one, not that one.
+    const WORST_STRUCTURED_RATIO: f64 = 20.0;
+    for (tool, _, text, structured, _) in &rows {
+        let (Some(bytes), true) = (structured, *text > 0) else {
+            continue;
+        };
+        let ratio = *bytes as f64 / *text as f64;
+        assert!(
+            ratio <= WORST_STRUCTURED_RATIO,
+            "`{tool}`'s structured answer is {ratio:.1}x its own text rendering ({bytes} B vs \
+             {text} B). A typed result should be the facts behind the rendering, not a larger \
+             restatement of it — see src/structured.rs:1651 for the case where this server \
+             already made the other call."
+        );
+    }
 }
 
 /// Every row a `modules` listing prints, as `(start, end, name)` read back out of its text.

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -1198,15 +1198,23 @@ fn field_bytes(tool: &Value, field: &str) -> usize {
     }
 }
 
-/// The per-tool size table.
+/// The per-tool size table, plus the totals.
 ///
-/// Ordered **by name**, which is worth stating because the obvious choice is worse: sorting by
-/// cost makes the golden read as a ranking, and then a tool that grows moves up it and shifts
-/// every row below, so the diff cascades through a dozen untouched tools instead of naming the one
-/// that changed. A stable key is what makes the failure legible. The ranking is not lost — the
-/// totals carry the worst tool by name.
-fn budget_report(tools: &[Value], instructions: &str) -> Value {
-    let mut rows: Vec<Value> = tools
+/// Takes the whole **`tools/list` result** rather than its `tools` array, so the payload figure is
+/// the payload rather than a reconstruction of it. Summing the tools misses the array's own commas
+/// and every result-level field — and on `2026-07-28` those are `resultType`, `ttlMs` and
+/// `cacheScope`, which is not a hypothetical omission in this repo: the `rmcp = "3.1.1"` floor
+/// exists *because* of `ttlMs`/`cacheScope`, and a revision that adds another such field is
+/// precisely the change a wire budget should notice. 118 bytes today; the number matters less than
+/// which side of the boundary it is measured on.
+///
+/// Rows are ordered **by name**, which is worth stating because the obvious choice is worse:
+/// sorting by cost makes the golden read as a ranking, and then a tool that grows moves up it and
+/// shifts every row below. The ranking is not lost — the totals carry the worst tool by name.
+fn budget_report(result: &Value, instructions: &str) -> Value {
+    let mut rows: Vec<Value> = result["tools"]
+        .as_array()
+        .expect("tools/list returns an array")
         .iter()
         .map(|tool| {
             json!({
@@ -1231,7 +1239,12 @@ fn budget_report(tools: &[Value], instructions: &str) -> Value {
         "totals": {
             "tools": rows.len(),
             "modelVisible": sum("modelVisible"),
+            // `wire` is the sum of the rows, and exists for attribution: it is what the per-tool
+            // figures add up to, so a total that moves can be traced to a tool. `payload` is the
+            // serialized result — the actual answer — and is what the ceiling guards. Keeping both
+            // means the gap between them is visible, and that gap is the result-level fields.
             "wire": sum("wire"),
+            "payload": json_bytes(result),
             "description": sum("description"),
             "inputSchema": sum("inputSchema"),
             "outputSchema": sum("outputSchema"),
@@ -1249,11 +1262,14 @@ fn budget_report(tools: &[Value], instructions: &str) -> Value {
 /// a new tool arriving with a `debug_batch`-scale schema does not.
 const MODEL_VISIBLE_CEILING: usize = 76_000;
 
-/// Ceiling on the whole `tools/list` payload. 358,533 bytes today, ~80% of it `outputSchema` that
-/// no model reads — which is why this is a separate, much looser number rather than a scaled
-/// version of the one above. It is a client-side parse and memory cost, and it is the one that
-/// grows silently: `schemars` inlines `$defs` per tool, so adding one shared type to one more
-/// output shape can add tens of kilobytes here while [`MODEL_VISIBLE_CEILING`] does not move.
+/// Ceiling on the whole `tools/list` payload — the serialized result, not the sum of its tools, so
+/// the array's own punctuation and every result-level field are inside it. 358,651 bytes today,
+/// ~80% of that `outputSchema` no model reads, which is why this is a separate and much looser
+/// number rather than a scaled version of the one above.
+///
+/// It is a client-side parse and memory cost, and it is the one that grows silently: `schemars`
+/// inlines `$defs` per tool, so adding one shared type to one more output shape can add tens of
+/// kilobytes here while [`MODEL_VISIBLE_CEILING`] does not move.
 const WIRE_CEILING: usize = 412_000;
 
 /// Ceiling on any single tool's model-visible definition. `debug_batch` is the worst at 9,757
@@ -1282,22 +1298,20 @@ fn tool_surface_stays_within_its_token_budget() {
 
     let response = server.request("tools/list", json!({}), STEP);
     assert_no_error(&response, "tools/list");
-    let tools = response["result"]["tools"]
-        .as_array()
-        .expect("tools/list returns an array")
-        .clone();
 
-    let report = budget_report(&tools, instructions);
+    // The whole result, not its `tools` array: what the payload figure has to measure is the
+    // answer this server actually sent, result-level fields and all.
+    let report = budget_report(&response["result"], instructions);
     let totals = &report["totals"];
     let model_visible = totals["modelVisible"].as_u64().unwrap() as usize;
-    let wire = totals["wire"].as_u64().unwrap() as usize;
+    let payload = totals["payload"].as_u64().unwrap() as usize;
 
     // Where you are, next to the ceiling you are under — for a run made by hand, which needs
     // `--nocapture` to see it: libtest prints a passing test's output nowhere. That is why the
     // golden rather than this line is what CI leaves behind.
     eprintln!(
         "tool surface: {} tools, {model_visible} B to the model (ceiling {MODEL_VISIBLE_CEILING}), \
-         {wire} B on the wire (ceiling {WIRE_CEILING}), instructions {} B",
+         {payload} B on the wire (ceiling {WIRE_CEILING}), instructions {} B",
         totals["tools"], totals["instructions"],
     );
 
@@ -1313,10 +1327,12 @@ fn tool_surface_stays_within_its_token_budget() {
          in docs/token-budget.md."
     );
     assert!(
-        wire <= WIRE_CEILING,
-        "tools/list is now {wire} B, over its {WIRE_CEILING} B ceiling. This is mostly \
+        payload <= WIRE_CEILING,
+        "the tools/list payload is now {payload} B, over its {WIRE_CEILING} B ceiling ({} B of \
+         that is the tools themselves, the rest result-level fields). This is mostly \
          outputSchema, which no model reads — check whether a shared type just got inlined into \
-         another tool's $defs before raising the ceiling."
+         another tool's $defs before raising the ceiling.",
+        totals["wire"],
     );
     assert!(
         worst_bytes <= WORST_TOOL_CEILING,

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -1170,8 +1170,9 @@ fn tool_surface_stays_within_its_token_budget() {
     let model_visible = totals["modelVisible"].as_u64().unwrap() as usize;
     let wire = totals["wire"].as_u64().unwrap() as usize;
 
-    // Print unconditionally: on a green run this is the only place the numbers are visible, and a
-    // budget nobody ever sees is a budget nobody maintains.
+    // Where you are, next to the ceiling you are under — for a run made by hand, which needs
+    // `--nocapture` to see it: libtest prints a passing test's output nowhere. That is why the
+    // golden rather than this line is what CI leaves behind.
     eprintln!(
         "tool surface: {} tools, {model_visible} B to the model (ceiling {MODEL_VISIBLE_CEILING}), \
          {wire} B on the wire (ceiling {WIRE_CEILING}), instructions {} B",
@@ -3120,8 +3121,9 @@ fn tool_results_stay_within_their_budget() {
         );
     }
 
-    // The table is the deliverable on a green run — the assertions only fire when something has
-    // already gone wrong, and a budget nobody ever sees is a budget nobody maintains.
+    // The table is the deliverable when this passes — the assertions only speak up once something
+    // has already gone wrong. Unlike the surface budget, this one *is* visible in CI, because the
+    // debugger tier's job passes `--nocapture`; without it libtest would swallow the table.
     eprintln!("\n  model     text  struct  ratio  ceiling  tool");
     for (tool, model, text, structured, ceiling) in &rows {
         let (shown, ratio) = match structured {


### PR DESCRIPTION
Nothing in this repo measured what the server spends of the caller's context window. A debugging session shares one window between the transcript, the reasoning and every answer this server returns, so payload size is a correctness-adjacent property — and it can move on a dependency bump or a widened schema without breaking a single assertion. The existing golden cannot see it: `digest_tool` drops every `description` on purpose, which is what makes it readable and what makes it blind to the bytes.

## What this adds

Two tests in `tests/mcp_smoke.rs`, plus an `assert_golden` helper extracted from the existing shape golden so one `UPDATE_GOLDEN=1` run re-records both.

- **`tool_surface_stays_within_its_token_budget`** (protocol tier, rides plain `cargo test`) — pins a per-tool size table in `tests/golden/tool_budget.json` and enforces three ceilings at ~15% headroom.
- **`tool_results_stay_within_their_budget`** (`WINDBG_MCP_SMOKE_DUMP` tier) — per-tool ceilings on model-visible bytes against the checked-in dump, a table printed under `--nocapture`, and one rule: a typed answer may not exceed the rendering it replaces by more than 20×.

Both print their numbers under `--nocapture` — libtest shows a passing test's output nowhere, so the flag is not optional if you want to read them. The debugger tier's CI job passes it and its result table is in the log; the `build` job runs the whole suite and does not, so the surface figures live in the golden instead. (This was Codex's P2 on the first push, and it was right: the documented surface command passed in silence, which is exactly what the print was added to prevent.)

**No behaviour changes.** The findings are follow-up 24, so the baseline stays a number recorded before anything was optimised for it.

## Two design points worth review

**The golden alone is not enough.** Re-recorded on every diff it is a rubber stamp, and thirty accepted 2% growths are a doubling nobody voted for — hence three coarse ceilings that fail independently of it.

**Rows are keyed by tool name, not sorted by size.** Sorting by cost reads better and diffs far worse: a tool that grows moves up the ranking and shifts every row beneath it, turning one change into a cascade through a dozen untouched tools. This was caught by running the regression probe, not by reasoning about it.

**Bytes, not tokens.** No tokenizer is in the dependency tree, and adding one would pull in BPE data for a figure that varies by model and churns the golden on a tokenizer bump rather than on a change here. `docs/token-budget.md` records the ≈4 bytes/token reporting convention and marks it approximate.

## What measuring first settled

Two client behaviours that had been assumed the other way round, and they decide which half of a dual-channel result is worth optimising:

- **`outputSchema` never reaches the model.** The Anthropic tool spec has no field for it. That is 285,745 of 358,533 bytes — 80% of the wire, zero context cost.
- **`structuredContent` *replaces* `content[].text`** rather than accompanying it. So for the 31 typed tools the hand-written rendering is paid for on the wire and read by nobody, while the larger half is what the model sees. `registers` sends 9,804 bytes of JSON carrying `"kind":"int"` and `"subregister":false` on every row, and hides its own 618-byte `r` output behind it.

The second qualifies `DECISIONS.md`'s "a typed result is a second channel, not a replacement" (#84). That was argued against a Python client scraping prose and is still right for that reader — but a model client picks one. README now says so; `src/structured.rs:1651` had already made the other call for `debug_batch`.

Estimating would not have done: a careful read of the source put the surface at 90–130 KB, and the wire is 358,533 bytes.

## The baseline

| | Bytes | Reaches the model |
|---|---:|---|
| Whole `tools/list` payload (51 tools) | 358,533 | partly |
| `outputSchema` (31 tools) | 285,745 | no |
| `inputSchema` | 39,964 | yes |
| `description` | 23,457 | yes |
| **Model-visible total** | **66,078** (~16k tokens) | — |
| `initialize` instructions | 3,163 | first 2,048 chars only |

Largest single answer: `modules` at 53,875 bytes — roughly 13k tokens, a fifth of a whole tool surface, for one question.

Headline findings (all itemised in follow-up 24): 200,571 bytes of `$defs` duplicated beyond their first copy (`ErrorCategory` ships 31 times); `modules` alone among the high-volume tools has neither a `limit` nor a cap; `session_id` documented 43 times in three wordings (9,514 bytes, model-visible); instructions truncated at 2,048 of 3,147 chars.

One interaction worth knowing before acting on any of it: **follow-up 11** proposes adding `structuredContent` to `ttd_calls`, `ttd_memory` and `driver_object` — three of the highest-volume text-only tools. Under the rule measured here that replaces their text rather than supplementing it, which may well be an improvement, but it is a size decision and should be taken as one.

## Verification

- `cargo fmt --check` clean, `cargo clippy --all-targets` clean, 417 unit + 53 smoke tests pass.
- Debugger tier green: `WINDBG_MCP_SMOKE_DUMP=1 cargo test --test mcp_smoke -- --nocapture`.
- `markdownlint-cli2` clean over the CI globs.
- **The gate was proven to fire, not assumed to.** Adding 2 KB of doc text to one tool failed the golden naming `threads` and three lines; a 12 KB version tripped `MODEL_VISIBLE_CEILING` with the total, the ceiling and the worst tool in the message. Both probes reverted — `src/` is untouched in this PR.
- **The golden agrees byte-for-byte with an independent capture** of the server's raw stdout (66,078 / 358,533 / 3,163), which is what proves it measures the wire rather than its own serialisation round-trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

