### PR TITLE
Run the listener as a Windows service

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,10 +143,10 @@ connection string (which nobody can guess) *and* `#[ignore]`d, so a stale variab
 a VM during an ordinary `cargo test`. Run it last, on its own.
 
 **Before deciding a live-kernel claim cannot be checked, read the profiles.** This host normally has
-one configured, and a configured profile *is* a KDNET target — connection, port and key — so the
-tier can be run. The failure this is here to stop is not asking the user for a key; it is concluding
-"no KDNET target on this host" without looking, shipping the live claim as unverified, and saying so
-in a PR. Two lines settle it:
+one configured, and a configured profile *is* a live kernel target, so the tier can be run. The
+failure this is here to stop is not asking the user for a key; it is concluding "no kernel target on
+this host" without looking, shipping the live claim as unverified, and saying so in a PR. Two lines
+settle it:
 
 ```pwsh
 Get-Content "$env:USERPROFILE\.windbg-mcp\profiles.json" -Raw | ConvertFrom-Json | Get-Member -MemberType NoteProperty | Select-Object Name
@@ -169,23 +169,59 @@ of them. Only ask the user for a raw connection when no profile is configured at
 `--test-threads=1` is not optional: the filter matches **eight** tests, and the KD transport is
 single-owner, so in parallel the second attach fails and can leave the target halted.
 
-**Check the target is reachable before starting the tier, not by starting it.** A KDNET attach that
-finds nothing parks its worker in `WaitForEvent(INFINITE)` for the whole run and reports a timeout
-that measures the environment rather than the code.
+**The transport does not have to be KDNET, and the target does not have to be x64.** The variable is
+a DbgEng connection string, passed through untouched, so `com:port=COM1,baud=115200` is as valid as
+a `net:` one. Three assertions gate themselves on what the target actually is rather than on the
+tier: the KD endpoint being owned by the worker is a UDP claim, the key-redaction claim needs a key
+to look for, and the two **pool** tests need an x64 target because the walker decodes x64 pool
+descriptors. Each says so when it stands down; none of them passes quietly.
 
-What settles it is not "can I reach the guest" but **does the guest's `bcdedit /dbgsettings hostip`
-equal this debugger host's current IP**, on the port the profile names — that is what makes the
-target dial in, and the host IP moves between sessions. Read it on the guest and compare the key by
-*hash* rather than printing it. That check is the same everywhere; how you reach the guest to run it
-is not.
+### Two ways a target is reached, and neither is "the" procedure
 
-*Finding* the guest is topology-specific, so what follows is one instance and not the procedure. On
-the machine this was written for, the debugger host is itself a Hyper-V guest — `Get-VM` does not
-exist and there is no local VM to start — so the target is a *sibling*: it appears in the neighbour
-table (`Get-NetNeighbor | ? LinkLayerAddress -like '00-15-5D*'`) and answers **TCP 5985** and
-nothing else, ICMP and 445 being closed, so a failed ping proves nothing there. Elsewhere it may be
-a local VM, another hypervisor, or one of several neighbours — and with several, the neighbour table
-alone will happily validate the wrong guest, which is what the `hostip` comparison above is for.
+**KDNET.** Check the target is reachable *before* starting the tier, not by starting it — an attach
+that finds nothing parks its worker in `WaitForEvent(INFINITE)` for the whole run and reports a
+timeout that measures the environment rather than the code. What settles it is not "can I reach the
+guest" but **does the guest's `bcdedit /dbgsettings hostip` equal this debugger host's current IP**,
+on the port the profile names; the host IP moves between sessions. Compare the key by *hash* rather
+than printing it.
+
+*Finding* the guest is topology-specific. On the machine that paragraph was written for, the
+debugger host is itself a Hyper-V guest — `Get-VM` does not exist and there is no local VM to start
+— so the target is a *sibling*: it appears in the neighbour table (`Get-NetNeighbor | ?
+LinkLayerAddress -like '00-15-5D*'`) and answers **TCP 5985** and nothing else, ICMP and 445 being
+closed, so a failed ping proves nothing there. With several neighbours the table will happily
+validate the wrong guest, which is what the `hostip` comparison is for.
+
+**Serial, which is what the Parallels bench uses** — and there KDNET is not merely unconfigured but
+*impossible*: guests get a `Parallels VirtIO Ethernet Adapter` (`PCI\VEN_1AF4`), and `1AF4` is not
+in the Debugging Tools' `VerifiedNICList.xml`. `prlctl set <vm> --device-set net0 --adapter-type
+e1000` is accepted and silently ignored on ARM, leaving the guest with no network at all. Do not
+spend an afternoon on it. The wiring that works is a TCP socket between two guests:
+
+- target `serial0` → `tcp://localhost:2020`, **client**; `bcdedit /dbgsettings serial debugport:1
+  baudrate:115200`
+- debugger `serial0` → `tcp://:2020`, **server** — then `prlctl set <vm> --device-connect serial0`,
+  or it stays `state=disconnected` and nothing binds the port, and a **VM restart**, or the guest
+  never sees a COM port
+- `netstat -an | grep 2020` on the Mac: a LISTEN *and* an ESTABLISHED pair means the wire is up
+- on the target, `ARM PL011 Serial Port Device (COM1)` in **`Error`** state with no name from
+  `GetPortNames()` is correct — that is the kernel debugger owning the port
+
+Three traps on that bench, each of which cost real time:
+
+- **`kd -b` is no longer supported** — the docs say so in those words, and it is silently a no-op,
+  so a `kd -k … -b` probe sits at `no_debuggee` against a *running* target and looks like a dead
+  link. Use **`-bonc`**. windbg-mcp itself is unaffected; DbgEng issues a proper break-in.
+- **Parallels `Pause idle` is on by default**, and a target broken into the debugger burns no CPU,
+  so the hypervisor suspends the whole VM mid-run and every later call times out with nothing to
+  explain it. `prlctl list` then shows it `paused`, which is *not* a kernel halt.
+  `prlctl set "<vm>" --pause-idle off`.
+- **A worker killed while holding a broken-in kernel leaves the guest frozen** — `prlctl exec` hangs
+  on it. Attaching and detaching properly is the fix:
+  `kd -k com:port=COM1,baud=115200 -c ".time;qd"`.
+
+**A pool walk will not finish over 115200 baud.** It reads every committed pool page and times out
+at 240s, so on a serial bench "x64-only" and "too slow over this wire" cannot be told apart.
 
 ## Live kernel + driver IOCTL gotchas (learned driving HEVD over KDNET)
 
@@ -250,6 +286,15 @@ line* — they ignore `;`, so anything chained after them (`; .reload ...`) is p
 Issue `.sympath` alone, or use the **`set_symbol_path`** tool (goes through the DbgEng
 `AppendSymbolPath`/`SetSymbolPath` API, immune to the quirk; appends + reloads). When a driver's
 `module!Symbol` names don't resolve, **ask the user for the PDB folder** and apply it with that tool.
+
+**Nothing resolves at all without `msdia140.dll` beside the engine** — `symsrv.dll` finds a PDB and
+that one *parses* it, so without it every module reports `Symbol Type: EXPORT - PDB not found` even
+when the identity was known and the file was downloaded. It is **not** store-package-only, which
+this repo believed for a while: Visual Studio Build Tools ships it, including an ARM64 build, at
+`…\BuildTools\DIA SDK\bin\arm64\msdia140.dll`. Copy it next to the exe (`target\release`, and
+`target\debug` for the smoke tiers). **Warm the cache once** afterwards — attach and `.reload /f nt`
+— because the first fetch takes minutes and everything around it times out, which reads convincingly
+as the parser having made things worse.
 
 ## Recording a session while debugging this server
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,6 +56,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b25655df2c3cdd83c5e5b293b88acd880332b2ddadd7c30ac43144fdc0033da9"
 
 [[package]]
+name = "bitflags"
+version = "2.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
+
+[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1065,6 +1071,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "widestring"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
+
+[[package]]
 name = "win-kexp"
 version = "0.1.0"
 source = "git+https://github.com/glslang/win-kexp?rev=40f79cd4c8f39413808a41a6aaacbbd78a34fad8#40f79cd4c8f39413808a41a6aaacbbd78a34fad8"
@@ -1095,6 +1107,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "win-kexp",
+ "windows-service",
  "windows-sys",
 ]
 
@@ -1188,6 +1201,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-service"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "857224b3b211c6f3616921f081ee54721ee3ad2ace2fac6a6337e032f7b4dcf2"
+dependencies = [
+ "bitflags",
+ "widestring",
+ "windows-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,11 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 # Only for the handle plumbing behind the supervisor↔worker channel (see `engine::spawn_worker`):
 # marking a pipe end inheritable is the one thing std cannot express.
 windows-sys = { version = "0.61", features = ["Win32_Foundation"] }
+# The Windows service role (`src/service.rs`). A wrapper rather than hand-rolled SCM FFI because
+# that lifecycle is the one part of this which must not be subtly wrong: a service that mishandles
+# its stop is a service that cannot be stopped, and for this server that means a live kernel target
+# left frozen. Small and focused — it pulls in no framework behind it.
+windows-service = "0.8"
 
 [dev-dependencies]
 # `test-util` only, and only for the tests: `src/progress.rs` asserts on a heartbeat measured in

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -5,6 +5,54 @@ status. Keep entries short; link to code with `file:line` where it helps a futur
 
 ---
 
+## A service's stop is the only part of it that can break something (2026-08-17)
+
+**Context.** `--listen` as a foreground process dies with the login session, inherits whatever
+`PATH` and working directory that shell had — which for this server decides whether the engine DLLs
+beside the exe are the ones that load — and cannot start at boot. The last item of `FOLLOWUPS.md`
+23, and on its face a small one: register the same server with the SCM.
+
+**What made it not small.** For most services a stop is a formality. Here it is the one operation
+that can damage something *outside* the process: DbgEng leaves a detached-but-halted kernel
+**frozen**, so a service killed rather than asked holds someone's machine stopped until they notice.
+That is the whole reason `listen::serve` grew a shutdown future — nothing else in this server needs
+one, because under stdio the client's disconnect *is* the signal and a foreground listener has
+nobody to ask it. The SCM is told `StopPending` with a wait hint sized from what releasing every
+worker can actually take, rather than being left on the default, and `PRESHUTDOWN` is accepted as
+well as `STOP` because the ordinary shutdown notification does not honour a wait hint.
+
+**Decision.** `--install-service --listen <addr>` / `--uninstall-service` / `--service`
+(`src/service.rs`), running as `LocalSystem`, auto-start. A wrapper crate rather than hand-rolled
+SCM FFI, on the same reasoning: the lifecycle is the part that must not be subtly wrong, and a
+service that mishandles its stop is a service that cannot be stopped.
+
+**The token could not follow it into the machine environment.** That was the first shape of this,
+and it is a local privilege escalation rather than an inconvenience: the machine environment is
+readable by every local process, the listener is reachable on loopback by the same, and `launch`
+takes an arbitrary command line and runs it from a worker this service spawned — as `LocalSystem`.
+So `install` copies the token out of the *installing shell's* user environment into
+`%ProgramData%\windbg-mcp\token`, strips inheritance and grants read to `SYSTEM` and
+`Administrators` only, and points the service at it. The property being preserved is the one the
+foreground listener has for free: the token is not readable by an unprivileged process. It is the
+only thing between a local user and SYSTEM, so it is the one thing that had to survive the move.
+
+**Two more `LocalSystem` consequences, both verified rather than assumed.** It has a profile
+directory of its own, so `%USERPROFILE%\.windbg-mcp\profiles.json` is invisible and
+`attach_kernel {}` under the service lists no profiles — they have to be machine-wide. And it has no
+console, so the role writes to `%ProgramData%\windbg-mcp\service.log` — `server_log` is the better
+channel, but only once the listener is up, which is exactly the failure not worth diagnosing that
+way.
+
+**What it does not change.** The lease, the single-tenancy rule and the bearer check are all
+untouched; a service is a way to *run* the listener, not a second one. The foreground path hands
+over a shutdown future that never fires, so its behaviour is byte for byte what it was.
+
+**Status:** landed. Verified end to end on the ARM64 bench — installed, started, served an
+authorised call and refused an unauthenticated one, then **stopped while holding a live kernel
+session**: the guest kept running rather than freezing, and no worker outlived the service.
+
+---
+
 ## Progress *is* a protocol notification, and it counts seconds (2026-08-17)
 
 **Context.** A tool call here can take minutes — a kernel attach waits for its target to dial in, a
@@ -142,9 +190,8 @@ predicate (`listen::is_departure`) with the same unit coverage every rule beside
 **Status.** Implemented (#135, #137). Three of the four things this listed as missing have since
 landed, each with an entry of its own above: the log reaches a remote client (as a tool, not a
 notification), the lease has the smoke tier whose absence made seven rounds of review the way these
-were found rather than the second, and a long call now reports its progress. What is still missing
-is **service installation** — the listener runs in whatever shell starts it — tracked as
-`FOLLOWUPS.md` item 23.
+were found rather than the second, and a long call now reports its progress. **Service installation**, the fourth,
+has since landed too (entry above), which closes `FOLLOWUPS.md` item 23 entirely.
 
 ---
 

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -633,15 +633,14 @@ never report again. It surfaced as a PR that was `MERGEABLE` but `BLOCKED` with 
 was required. The x64 entry now keeps the original name exactly, so adding a matrix is not a rename.
 Worth knowing before touching any job name in this repository, not just this one.
 
-## 23. [windbg-mcp] The listener is transport-complete, not usable-complete
+## 23. [windbg-mcp] The listener is transport-complete, not usable-complete — **done** (2026-08-17)
 
-Three quarters of this are **done** (2026-08-17): `server_log` reaches a client on any machine with
+All of it is **done** (2026-08-17): `server_log` reaches a client on any machine with
 the records *both* processes made — bounded, and saying so when a record was dropped or evicted
 rather than leaving a gap to be read as quiet ([`DECISIONS.md`](./DECISIONS.md) records why it is a
 tool rather than MCP's deprecated logging capability); the lease has a **smoke tier** — four
-assertions in the protocol tier and one, against a parked kernel attach, in the debugger tier; and a
-long call now reports **progress**. What is left is the one item
-[`docs/remote-listener.md`](./docs/remote-listener.md) still lists under *Not there yet*.
+assertions in the protocol tier and one, against a parked kernel attach, in the debugger tier; a
+long call reports **progress**; and the listener installs as a **Windows service**.
 
 **Progress notifications — done** (`src/progress.rs`). The milestones were already protocol
 messages, so what was added is the route out: a `progressToken` read off the call's `_meta` in
@@ -656,9 +655,28 @@ again, and a pool walk or a `crash_triage` has no milestones at all — so **ten
 word is itself reported**, which incidentally makes progress a liveness signal a client can extend
 its own request timeout on.
 
-**No service installation.** The listener runs in whatever shell starts it, so it dies with the
-login session and inherits that shell's `PATH` — which for this server decides whether the engine
-DLLs beside the exe are the ones that load.
+**Service installation — done** (`src/service.rs`). `--install-service --listen <addr>` registers
+the listener with the SCM as `windbg-mcp`, auto-start, `LocalSystem`; `--uninstall-service` stops it
+and removes it. Three things it turned up that the entry did not anticipate.
+
+The **stop** is the whole of the difficulty, and it is why `listen::serve` grew a shutdown future:
+nothing else in this server needs one — under stdio the disconnect *is* the signal, and a foreground
+listener has nobody to ask it — but a service that is killed rather than asked leaves a
+detached-but-halted kernel frozen. The SCM is told `StopPending` with a wait hint sized from what
+releasing every worker can actually take, rather than being left on the default.
+
+`LocalSystem` **does not read your `profiles.json`** — its `%USERPROFILE%` is
+`C:\Windows\system32\config\systemprofile` — so kernel profiles have to be configured machine-wide
+or the service sees none. Verified, not assumed, and `install` says so where an operator will read
+it. The token is the same problem one scope out, and machine-scope is a real widening.
+
+And a service has **no console**, so the role writes to `%ProgramData%\windbg-mcp\service.log`: the
+`server_log` ring is the better channel, but it is only reachable once the listener is up, which is
+exactly the case not worth diagnosing that way.
+
+Verified end to end on the ARM64 bench: installed, started, served an authorised MCP call and
+refused an unauthenticated one, **attached a live kernel and was then stopped** — the guest kept
+running rather than freezing, and no worker outlived the service.
 
 **What the smoke tier does not reach**, now that there is one: the grace is waited out at 32
 seconds because the listener's own floor is the call budget plus `WORKER_READY_TIMEOUT`, and that

--- a/README.md
+++ b/README.md
@@ -225,6 +225,11 @@ claude mcp add windbg-vm --transport http http://127.0.0.1:8765/ \
   --header "Authorization: Bearer $WINDBG_MCP_LISTEN_TOKEN"
 ```
 
+Install it as a **Windows service** (`--install-service --listen <addr>`, elevated) and it survives
+logout, starts at boot, and gets a defined `PATH` and working directory — which is what decides
+whether the engine DLLs beside the exe are the ones that load. `Stop-Service` releases every debug
+target before exiting, because a live kernel that is merely killed is left frozen.
+
 **Bind loopback and forward over SSH.** This endpoint runs `execute`, `debug_batch` and `launch`
 against a live kernel, and the token is sent in clear — a hypervisor's guest network is not private
 when the machine being debugged shares it. [`docs/remote-listener.md`](./docs/remote-listener.md)

--- a/docs/remote-listener.md
+++ b/docs/remote-listener.md
@@ -157,8 +157,57 @@ nothing at all is sent to a call that did not ask.
 This is the same on stdio, where it is a convenience; here it is the only thing that arrives while a
 call is outstanding.
 
+## Run it as a Windows service
+
+A foreground listener dies with the login session, inherits whatever `PATH` and working directory
+that shell had — which is what decides whether the engine DLLs beside the exe are the ones that load
+— and cannot start at boot. Installing it as a service fixes all three. From an **elevated** shell:
+
+```pwsh
+$env:WINDBG_MCP_LISTEN_TOKEN = "<a long random string>"   # this shell only
+windbg-mcp.exe --install-service --listen 127.0.0.1:8765
+Start-Service windbg-mcp        # or reboot; it is configured to start automatically
+```
+
+**Install from a protected directory.** The SCM stores an exact path for a `LocalSystem` auto-start
+service, so whoever can write that directory — or drop an engine DLL beside the exe — gets their
+code run as SYSTEM at the next start. `--install-service` refuses unless the exe is under
+`%ProgramFiles%`, `%ProgramFiles(x86)%` or `%SystemRoot%`; for a development install on a machine
+that is entirely yours, `--allow-unprotected-path` says so out loud.
+
+The install copies that token into `%ProgramData%\windbg-mcp\token`, strips inheritance and grants
+read to `SYSTEM` and `Administrators` only, and points the service at it. **Do not put the token in
+the machine environment instead.** That would work, and it is a local privilege escalation: the
+machine environment is readable by every local process, the listener is reachable on loopback by the
+same, and `launch` takes an arbitrary command line and runs it from a worker this service spawned —
+as `LocalSystem`. The token is the only thing in the way, so it has to stay unreadable by an
+unprivileged process, which is the one property the foreground listener gets for free.
+
+`windbg-mcp.exe --uninstall-service` removes it, stopping it first and waiting for it — a delete
+issued against a running service only marks it, and this one has debug targets to let go of.
+
+**Stopping is graceful, and that is the point.** `Stop-Service` takes the same path a client
+disconnect takes: every session is asked to release its target before the process exits, and the SCM
+is given a wait hint that covers it rather than being left to assume the default and kill us
+partway. DbgEng leaves a detached-but-halted kernel *frozen*, so a service that were merely killed
+would hold someone's machine stopped until they noticed.
+
+Three things that surprise people, all of them consequences of running as `LocalSystem`:
+
+- **There is no console, so stderr goes nowhere.** The service writes to
+  `%ProgramData%\windbg-mcp\service.log` (override with `WINDBG_MCP_SERVICE_LOG`). `server_log` is
+  still the better channel once the listener is up; the file is for the case that matters most, a
+  listener that refuses to start.
+- **Kernel connection profiles are not read from your home directory.** `LocalSystem`'s
+  `%USERPROFILE%` is `C:\Windows\system32\config\systemprofile`, so `attach_kernel {}` under the
+  service lists nothing from *your* `profiles.json`. Configure them machine-wide instead:
+  `WINDBG_MCP_PROFILE_<NAME>` in the machine environment, or `WINDBG_MCP_PROFILES` pointing at a
+  file the service account can read.
+- **It runs with more privilege than you did.** `--uninstall-service` deletes the token file with
+  the service. If you want less privilege, `sc.exe config windbg-mcp obj= "NT AUTHORITY\LocalService"`
+  and re-ACL the token file to match — at the cost of local kernel and process attach, which need
+  privileges that account does not have.
+
 ## Not there yet
 
-- **No service installation.** The listener runs in whatever shell you start it in. A Windows
-  service would give it a defined `PATH` and working directory, boot start, and a life independent
-  of a login session.
+Nothing on this page is known-missing. `FOLLOWUPS.md` is where anything new lands.

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -86,7 +86,7 @@ const INTERRUPT_TIMEOUT: Duration = Duration::from_secs(5);
 /// Shorter than [`END_SESSION_TIMEOUT`] because a session that cannot let go within a few seconds
 /// is one that never will, and sessions are released concurrently, so this is the whole cost
 /// rather than the cost per session.
-const SHUTDOWN_RELEASE_TIMEOUT: Duration = Duration::from_secs(5);
+pub(crate) const SHUTDOWN_RELEASE_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// How long a teardown commits to before looking at the worker's promise again.
 ///

--- a/src/listen.rs
+++ b/src/listen.rs
@@ -41,6 +41,7 @@
 //! reconnect needs nothing further to prove.
 
 use std::convert::Infallible;
+use std::future::Future;
 use std::net::SocketAddr;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
@@ -67,6 +68,18 @@ pub const LISTEN_FLAG: &str = "--listen";
 /// Where the bearer token is read from. An environment variable rather than an argument, because a
 /// command line is readable by every process on the machine — including a `launch`ed debuggee.
 pub const TOKEN_ENV: &str = "WINDBG_MCP_LISTEN_TOKEN";
+
+/// A file to read the bearer token from instead, for when an environment variable is not private
+/// enough.
+///
+/// It is not, for a **service**: a service reads the *machine* environment, and that is readable by
+/// every local process including unprivileged ones. Since this endpoint's token is the only thing
+/// between a caller and `launch`, and a service runs as `LocalSystem`, a machine-scope token is a
+/// local privilege escalation rather than an inconvenience — see [`crate::service`], which writes
+/// this file with an ACL that excludes ordinary users and points the service at it.
+///
+/// Read *before* [`TOKEN_ENV`], so a host that has both is using the private one.
+pub const TOKEN_FILE_ENV: &str = "WINDBG_MCP_LISTEN_TOKEN_FILE";
 
 /// Overrides how long a client may be silent before its sessions are released, in whole seconds.
 const GRACE_ENV: &str = "WINDBG_MCP_LEASE_GRACE_SECS";
@@ -491,16 +504,83 @@ impl Lease {
 }
 
 /// Serves MCP over HTTP until the process is asked to stop.
-pub async fn serve(sessions: Sessions, addr: SocketAddr, call_timeout: Duration) -> Result<()> {
+/// How long to keep retrying a bind that fails because the address is not there yet.
+///
+/// Only reached by a **non-loopback** bind at boot: an auto-start service can be launched before
+/// the adapter it names has been given its address, and a single attempt then fails the service
+/// permanently — which quietly undoes the "starts at boot" that is half the reason to be a service.
+/// Loopback is up before anything starts, so the ordinary configuration never waits here at all.
+pub(crate) const BIND_PATIENCE: Duration = Duration::from_secs(90);
+const BIND_RETRY_EVERY: Duration = Duration::from_secs(2);
+
+/// Binds `addr`, waiting for the address to exist if it does not yet.
+///
+/// Retries only what is worth retrying. A port already in use, or one this process may not have, is
+/// a configuration error that will not fix itself, and failing immediately says so while an
+/// operator is still watching; an address that has not been assigned yet is the one condition that
+/// resolves on its own.
+async fn bind_when_ready(addr: SocketAddr) -> Result<TcpListener> {
+    let deadline = Instant::now() + BIND_PATIENCE;
+    let mut said_so = false;
+    loop {
+        match TcpListener::bind(addr).await {
+            Ok(listener) => return Ok(listener),
+            Err(e) if e.kind() == std::io::ErrorKind::AddrNotAvailable => {
+                if Instant::now() >= deadline {
+                    return Err(anyhow::Error::new(e)).with_context(|| {
+                        format!("{addr} never appeared on this host within {BIND_PATIENCE:?}")
+                    });
+                }
+                if !said_so {
+                    tracing::info!("{addr} is not on this host yet; waiting for it to appear");
+                    said_so = true;
+                }
+                tokio::time::sleep(BIND_RETRY_EVERY).await;
+            }
+            Err(e) => return Err(anyhow::Error::new(e).context(format!("cannot bind {addr}"))),
+        }
+    }
+}
+
+/// The bearer token, from a file if one is named and from the environment otherwise.
+///
+/// Trimmed, because a token in a file arrives with whatever line ending wrote it, and a token that
+/// works from an editor but not from `Set-Content` would be an unpleasant afternoon.
+fn bearer_token() -> Result<String> {
+    if let Some(path) = std::env::var_os(TOKEN_FILE_ENV) {
+        let path = std::path::PathBuf::from(path);
+        let token = std::fs::read_to_string(&path).with_context(|| {
+            format!(
+                "{TOKEN_FILE_ENV} names {}, which cannot be read",
+                path.display()
+            )
+        })?;
+        if token.trim().is_empty() {
+            bail!("{} is empty; that is not a token.", path.display());
+        }
+        return Ok(token.trim().to_string());
+    }
     let token = std::env::var(TOKEN_ENV).map_err(|_| {
         anyhow::anyhow!(
-            "{TOKEN_ENV} is not set. The listener will not start without a bearer token: it \
-             exposes every tool this server has, including the ones that write to a live kernel."
+            "neither {TOKEN_FILE_ENV} nor {TOKEN_ENV} is set. The listener will not start without \
+             a bearer token: it exposes every tool this server has, including the ones that write \
+             to a live kernel."
         )
     })?;
     if token.trim().is_empty() {
         bail!("{TOKEN_ENV} is set but empty; that is not a token.");
     }
+    Ok(token.trim().to_string())
+}
+
+pub async fn serve(
+    sessions: Sessions,
+    addr: SocketAddr,
+    call_timeout: Duration,
+    shutdown: impl Future<Output = ()>,
+    ready: impl FnOnce(),
+) -> Result<()> {
+    let token = bearer_token()?;
 
     let grace = match std::env::var(GRACE_ENV).ok().and_then(|v| v.parse().ok()) {
         Some(secs) if secs > 0 => Duration::from_secs(secs),
@@ -531,9 +611,21 @@ pub async fn serve(sessions: Sessions, addr: SocketAddr, call_timeout: Duration)
         ))
     };
 
-    let listener = TcpListener::bind(addr)
-        .await
-        .with_context(|| format!("cannot bind {addr}"))?;
+    // Pinned here rather than at the accept loop, because the bind is raced against it: a stop
+    // arriving while a not-yet-assigned address is being waited for must be answered now, not in
+    // ninety seconds' time. Without this the service would sit `Running` with no endpoint and no
+    // way to be stopped, which is worse than the boot-time failure the retry exists to survive.
+    let mut shutdown = std::pin::pin!(shutdown);
+    let listener = tokio::select! {
+        () = &mut shutdown => {
+            tracing::info!("asked to stop before {addr} could be bound");
+            return Ok(());
+        }
+        bound = bind_when_ready(addr) => bound?,
+    };
+    // There is an endpoint from here, and not before: a caller that reports itself started does it
+    // *now*. See [`crate::service`], where "started" is a thing the SCM and its dependants act on.
+    ready();
     tracing::info!(
         "windbg-mcp listening on http://{addr} (lease grace {grace:?}, one client at a time)"
     );
@@ -541,12 +633,22 @@ pub async fn serve(sessions: Sessions, addr: SocketAddr, call_timeout: Duration)
     tokio::spawn(sweep(sessions.clone(), lease.clone(), manager.clone()));
 
     loop {
-        let (stream, peer) = match listener.accept().await {
-            Ok(accepted) => accepted,
-            Err(e) => {
-                tracing::warn!("accept failed: {e}");
-                continue;
+        let (stream, peer) = tokio::select! {
+            // Asked to stop. Returning here is the whole mechanism: the caller's `shutdown` on
+            // `Sessions` runs next, and that is what releases a live kernel rather than leaving it
+            // frozen. Connections already in flight are dropped — a client mid-call loses that
+            // call, which is the lesser of the two, and its session is being released anyway.
+            () = &mut shutdown => {
+                tracing::info!("no longer accepting connections on {addr}");
+                return Ok(());
             }
+            accepted = listener.accept() => match accepted {
+                Ok(accepted) => accepted,
+                Err(e) => {
+                    tracing::warn!("accept failed: {e}");
+                    continue;
+                }
+            },
         };
         let mcp = mcp.clone();
         let manager = manager.clone();

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,7 @@ mod progress;
 mod proto;
 mod record;
 mod server;
+mod service;
 mod structured;
 mod triage;
 mod ttd;
@@ -50,7 +51,7 @@ const ENGINE_CALL_TIMEOUT: Duration = Duration::from_secs(300);
 /// wants to hear about a stuck call sooner).
 const CALL_TIMEOUT_ENV: &str = "WINDBG_MCP_CALL_TIMEOUT_SECS";
 
-fn call_timeout() -> Duration {
+pub(crate) fn call_timeout() -> Duration {
     match std::env::var(CALL_TIMEOUT_ENV)
         .ok()
         .and_then(|v| v.parse().ok())
@@ -65,7 +66,12 @@ fn main() -> Result<()> {
     // engine thread must be free to block in DbgEng indefinitely.
     let args: Vec<String> = std::env::args().collect();
     let is_worker = args.iter().any(|arg| arg == worker::WORKER_FLAG);
-    init_logging(is_worker);
+    // A service has no console, so its stderr goes nowhere at all — and the failure most worth
+    // seeing is a listener that refuses to start, which happens before `server_log` can be asked
+    // anything. Decided here because logging is initialised before the role is acted on.
+    let to_file =
+        matches!(service::requested(&args), Some(service::Role::Run)).then(service::log_path);
+    init_logging(is_worker, to_file);
     if is_worker {
         // The rest of the command line is the worker's half of the protocol channel — two
         // inherited pipe handles, which is why a worker started by hand cannot get anywhere.
@@ -74,6 +80,20 @@ fn main() -> Result<()> {
     if let Some(at) = args.iter().position(|arg| arg == cast::RENDER_FLAG) {
         // Before the runtime: this reads a file and writes a file, and neither wants one.
         return render_cast(&args[at + 1..]);
+    }
+
+    // Also before the runtime, and for a sharper reason than the renderer's. Installing touches the
+    // SCM and nothing else. Running *as* a service has to build its runtime inside the SCM's own
+    // dispatcher thread rather than around it, so the one thing this must not do is start one here.
+    if let Some(role) = service::requested(&args) {
+        return match role {
+            service::Role::Install => service::install(
+                listen_address(&args)?,
+                args.iter().any(|a| a == service::ALLOW_UNPROTECTED_FLAG),
+            ),
+            service::Role::Uninstall => service::uninstall(),
+            service::Role::Run => service::run(),
+        };
     }
 
     // Decided before the runtime so a bad address fails as a usage error rather than from inside a
@@ -88,7 +108,10 @@ fn main() -> Result<()> {
         .build()?
         .block_on(async {
             match listen {
-                Some(addr) => serve_http(addr).await,
+                // A foreground listener has nobody to ask it to stop — Ctrl+C ends the process and
+                // each worker releases its target when its pipe closes — so the shutdown it hands
+                // over is one that never fires. Only the service role has a stop to deliver.
+                Some(addr) => serve_http(addr, std::future::pending(), || {}).await,
                 None => serve().await,
             }
         })
@@ -99,11 +122,35 @@ fn main() -> Result<()> {
 /// The teardown differs from [`serve`]'s in the one way that matters: there is no disconnect to
 /// hang it on, so the shutdown here belongs to the *process* ending rather than to any client, and
 /// a client going away is handled by its lease instead.
-async fn serve_http(addr: std::net::SocketAddr) -> Result<()> {
+pub(crate) async fn serve_http(
+    addr: std::net::SocketAddr,
+    shutdown: impl std::future::Future<Output = ()>,
+    ready: impl FnOnce(),
+) -> Result<()> {
     let sessions = Sessions::new(call_timeout()).recording(record::Recorder::from_env());
-    let outcome = listen::serve(sessions.clone(), addr, call_timeout()).await;
+    let outcome = listen::serve(sessions.clone(), addr, call_timeout(), shutdown, ready).await;
+    // Runs on every route out of `serve`, which is why the shutdown future ends the accept loop
+    // rather than the process: a service asked to stop has to reach this line, or it leaves a live
+    // kernel frozen — see [`service`].
     sessions.shutdown().await;
     outcome
+}
+
+/// The address an install was told to bind, with the same parsing the listener itself uses.
+///
+/// Its own function because installing and serving must never disagree about what is a valid
+/// address: a service registered with something the listener will later refuse is a service that
+/// installs cleanly and fails at every start.
+fn listen_address(args: &[String]) -> Result<std::net::SocketAddr> {
+    match listen::requested(args) {
+        Some(addr) => addr,
+        None => anyhow::bail!(
+            "`{}` needs the address the service will bind, e.g. `{} {} 127.0.0.1:8765`",
+            service::INSTALL_FLAG,
+            service::INSTALL_FLAG,
+            listen::LISTEN_FLAG
+        ),
+    }
 }
 
 /// The renderer role: a transcript in, an asciicast out.
@@ -157,7 +204,7 @@ fn render_cast(args: &[String]) -> Result<()> {
 /// makes the records reachable when the client is on another machine (`--listen`). Sharing the
 /// filter is deliberate: the tool then shows exactly what the log shows, and `RUST_LOG` widens
 /// both together rather than one of them silently.
-fn init_logging(is_worker: bool) {
+fn init_logging(is_worker: bool, to_file: Option<std::path::PathBuf>) {
     use tracing_subscriber::layer::SubscriberExt;
     use tracing_subscriber::util::SubscriberInitExt;
 
@@ -166,11 +213,38 @@ fn init_logging(is_worker: bool) {
     } else {
         logbridge::Role::Supervisor
     };
-    tracing_subscriber::registry()
+    // Best-effort, and deliberately so: a service that cannot open its log file should still serve.
+    // If this yields `None` the records still reach the ring behind `server_log`, which is the
+    // channel a remote operator actually reads.
+    let file = to_file.and_then(|path| {
+        if let Some(dir) = path.parent() {
+            let _ = std::fs::create_dir_all(dir);
+        }
+        std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&path)
+            .ok()
+            .map(std::sync::Arc::new)
+    });
+    let base = tracing_subscriber::registry()
         .with(EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")))
-        .with(tracing_subscriber::fmt::layer().with_writer(std::io::stderr))
-        .with(logbridge::layer(role))
-        .init();
+        .with(logbridge::layer(role));
+    // Two arms rather than a boxed writer: each is a different subscriber type, and the whole
+    // difference between them is where the bytes go.
+    match file {
+        // No ANSI: nothing renders colour in a log file, and the escapes make it unreadable.
+        Some(file) => base
+            .with(
+                tracing_subscriber::fmt::layer()
+                    .with_ansi(false)
+                    .with_writer(file),
+            )
+            .init(),
+        None => base
+            .with(tracing_subscriber::fmt::layer().with_writer(std::io::stderr))
+            .init(),
+    }
 }
 
 async fn serve() -> Result<()> {

--- a/src/service.rs
+++ b/src/service.rs
@@ -1,0 +1,778 @@
+//! The listener as a Windows service: a debugger that outlives the shell that started it.
+//!
+//! `--listen` on its own is a foreground process, and that costs three things a debugging host
+//! actually needs. It **dies with the login session**, so a reconnecting client finds nothing. It
+//! inherits **whatever `PATH` and working directory that shell had**, which for this server is not
+//! cosmetic — the engine DLLs beside the exe, and `TTD.exe`, are found or not found by exactly
+//! that. And it cannot **start at boot**, so the machine that exists to be debugged is only
+//! debuggable once somebody has logged into it.
+//!
+//! This is the smallest thing that fixes all three: the same `--listen` server, run under the
+//! Service Control Manager.
+//!
+//! ## Stopping is the part that matters
+//!
+//! For most services a stop is a formality. Here it is the one operation that can damage something
+//! outside this process: DbgEng leaves a detached-but-halted kernel **frozen**, so a service that
+//! is killed rather than asked holds someone's machine stopped until they notice. So the stop path
+//! is the same graceful one a client disconnect takes — every session asked to release its target,
+//! then the process exits — and the SCM is told `StopPending` with a wait hint that covers it,
+//! rather than being left to assume the default and kill us partway through.
+//!
+//! That is also why [`crate::listen::serve`] takes a shutdown future at all. Nothing else needs
+//! one: under stdio the client's disconnect *is* the signal, and a foreground listener has no way
+//! to be asked politely.
+//!
+//! ## What it cannot do for you
+//!
+//! A service has no console, so **stderr goes nowhere**. The bounded ring behind `server_log`
+//! already answers "what has the server been doing" over the transport, and that is the right
+//! channel for it — but it is reachable only once the listener is up, which is exactly not the case
+//! worth diagnosing. So the service role also writes its log to a file ([`log_path`]), and a
+//! listener that refuses to start says why in there.
+//!
+//! ## The token cannot live in the machine environment
+//!
+//! A service has no user environment, and the obvious move — put `WINDBG_MCP_LISTEN_TOKEN` in the
+//! *machine* environment — is a **local privilege escalation**, not an inconvenience. The machine
+//! environment is readable by every local process including unprivileged ones; the listener is
+//! reachable on loopback by the same; and `launch` takes an arbitrary command line and runs it from
+//! a worker this service spawned. So any local user who can read that variable can have
+//! `LocalSystem`, and the token is the only thing in the way.
+//!
+//! So [`install`] takes the token out of the installing shell's *user* environment, writes it to
+//! [`token_file`], strips inheritance and grants read to `SYSTEM` and `Administrators` only, and
+//! points the service at it with [`crate::listen::TOKEN_FILE_ENV`]. The property that makes the
+//! foreground listener safe — the token is not readable by an unprivileged process — is the one
+//! being preserved, by the only mechanism that preserves it once the reader is a service.
+//!
+//! The same applies to **kernel connection profiles**, and less obviously, because they are a file
+//! rather than a variable: `LocalSystem`'s `%USERPROFILE%` is
+//! `C:\Windows\system32\config\systemprofile`, so the `profiles.json` in *your* home is invisible to
+//! the service and `attach_kernel {}` running under it lists nothing. Verified rather than assumed.
+//! [`install`] says so at the moment an operator is standing there to read it.
+
+use std::ffi::{OsStr, OsString};
+use std::net::SocketAddr;
+use std::os::windows::fs::MetadataExt;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use anyhow::{Context, Result, bail};
+use windows_service::service::{
+    ServiceAccess, ServiceControl, ServiceControlAccept, ServiceErrorControl, ServiceExitCode,
+    ServiceInfo, ServiceStartType, ServiceState, ServiceStatus, ServiceType,
+};
+use windows_service::service_control_handler::{self, ServiceControlHandlerResult};
+use windows_service::service_manager::{ServiceManager, ServiceManagerAccess};
+use windows_service::{define_windows_service, service_dispatcher};
+
+/// Runs the listener under the SCM. Set by the SCM itself, never typed by hand.
+pub const SERVICE_FLAG: &str = "--service";
+/// Registers the service. Needs `--listen <addr>` beside it, and an elevated shell.
+pub const INSTALL_FLAG: &str = "--install-service";
+/// Removes it again.
+pub const UNINSTALL_FLAG: &str = "--uninstall-service";
+/// Acknowledges installing from a directory Windows does not protect. See [`under_protected_root`].
+pub const ALLOW_UNPROTECTED_FLAG: &str = "--allow-unprotected-path";
+
+/// Overrides where the service writes its log.
+pub const LOG_ENV: &str = "WINDBG_MCP_SERVICE_LOG";
+
+/// The service's key in the SCM. Also the name `net start` / `sc.exe` take.
+const NAME: &str = "windbg-mcp";
+const DISPLAY_NAME: &str = "windbg-mcp (WinDbg/DbgEng MCP server)";
+const DESCRIPTION: &str = "Serves WinDbg/DbgEng over MCP on an HTTP endpoint for a remote client. \
+                           Holds each debug target in its own engine worker process.";
+
+/// A service runs in its own process, so the SCM may stop it on its own account.
+const SERVICE_TYPE: ServiceType = ServiceType::OWN_PROCESS;
+
+/// How often the SCM is told the stop is still going.
+///
+/// A wait hint alone is not enough: the SCM reads *progress* as a rising checkpoint, and a status
+/// that never moves is a service it may call hung however generous the hint was.
+const CHECKPOINT_EVERY: Duration = Duration::from_secs(5);
+
+/// The longest a stop can legitimately take, which is what the SCM is asked to wait.
+///
+/// **Derived, not chosen**, because a guessed constant is wrong in the direction that costs a
+/// machine. Releasing every worker runs them concurrently against
+/// [`crate::engine::SHUTDOWN_RELEASE_TIMEOUT`] — but a session running a `debug_batch` extends its
+/// own release by what the batch says it still needs, and `Sessions::release` caps that extension
+/// at the configured call timeout. So the real bound is those two added, and on a host with a
+/// raised `WINDBG_MCP_CALL_TIMEOUT_SECS` it rises with it.
+///
+/// Under-asking is the failure that matters: the SCM stops waiting, shutdown proceeds, and a live
+/// kernel worker cut off mid-release is a machine left frozen — the exact outcome this lifecycle
+/// exists to avoid.
+fn stop_bound() -> Duration {
+    crate::engine::SHUTDOWN_RELEASE_TIMEOUT + crate::call_timeout() + CHECKPOINT_EVERY
+}
+
+/// Which service role, if any, this command line asks for.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Role {
+    /// The SCM started us.
+    Run,
+    Install,
+    Uninstall,
+}
+
+/// Reads the role off the command line. `None` for every ordinary invocation.
+///
+/// A free function over the arguments, like [`crate::listen::requested`], so the role can be
+/// decided before a runtime exists — installing touches the SCM and nothing else, and the service
+/// role has to build its runtime *inside* the SCM's own thread rather than around it.
+pub fn requested(args: &[String]) -> Option<Role> {
+    args.iter().find_map(|arg| match arg.as_str() {
+        SERVICE_FLAG => Some(Role::Run),
+        INSTALL_FLAG => Some(Role::Install),
+        UNINSTALL_FLAG => Some(Role::Uninstall),
+        _ => None,
+    })
+}
+
+/// Where the service logs, since it has no console to log to.
+///
+/// `%ProgramData%` rather than beside the exe: the service runs as `LocalSystem`, the exe may sit
+/// somewhere a service account should not be writing, and an operator looking for a service's log
+/// looks there first.
+pub fn log_path() -> PathBuf {
+    if let Some(path) = std::env::var_os(LOG_ENV) {
+        return PathBuf::from(path);
+    }
+    state_dir().join("service.log")
+}
+
+/// Where the service keeps what it needs across a restart: its log, and its token.
+///
+/// The two derive from *here* rather than from each other, and that is not tidiness. Deriving the
+/// token path from the log path — which this did first — means [`LOG_ENV`] silently moves the
+/// credential as well: `install` writes the token where the *installing shell* computes, the
+/// service looks where the *machine* environment computes, and the two disagree the moment anyone
+/// redirects the log. The service then starts, finds no token, and exits with a service-specific
+/// error and an empty log file, which is about as unhelpful as a failure gets.
+fn state_dir() -> PathBuf {
+    std::env::var_os("ProgramData")
+        .map(PathBuf::from)
+        .unwrap_or_else(std::env::temp_dir)
+        .join("windbg-mcp")
+}
+
+/// The command line the SCM will start, as an argument list.
+///
+/// Built here and asserted on in tests, because the failure it prevents is a service that installs
+/// cleanly and then fails at every start: the SCM stores this once, and nothing re-derives it.
+fn launch_arguments(addr: SocketAddr) -> Vec<OsString> {
+    vec![
+        OsString::from(SERVICE_FLAG),
+        OsString::from(crate::listen::LISTEN_FLAG),
+        OsString::from(addr.to_string()),
+    ]
+}
+
+/// Where the service reads its bearer token from.
+///
+/// A file rather than the machine environment, and the difference is a privilege boundary rather
+/// than a preference — see the module docs. Beside the log, under `%ProgramData%`, because that is
+/// where a `LocalSystem` service's state belongs and an operator knows to look.
+pub fn token_file() -> PathBuf {
+    state_dir().join("token")
+}
+
+/// `SYSTEM` and `Administrators`, by SID so a localised Windows is not a special case.
+const SYSTEM_SID: &str = "*S-1-5-18";
+const ADMINISTRATORS_SID: &str = "*S-1-5-32-544";
+
+/// Runs one `icacls` invocation, or says which one failed and why.
+fn icacls(path: &std::path::Path, args: &[&str]) -> Result<()> {
+    let out = std::process::Command::new("icacls")
+        .arg(path)
+        .args(args)
+        .output()
+        .with_context(|| format!("cannot run `icacls {}`", args.join(" ")))?;
+    if !out.status.success() {
+        bail!(
+            "`icacls {} {}` failed: {}",
+            path.display(),
+            args.join(" "),
+            String::from_utf8_lossy(&out.stderr).trim()
+        );
+    }
+    Ok(())
+}
+
+/// Gives `path` an owner and an ACL that exclude everyone but `SYSTEM` and `Administrators`.
+///
+/// **Three steps, and none of them is optional**, because `%ProgramData%` lets any local user
+/// create things there and keep them:
+///
+/// 1. `/setowner`. An owner has implicit `WRITE_DAC` — it can rewrite whatever ACL we set,
+///    whenever it likes — so leaving a squatter as owner makes the rest of this decorative.
+/// 2. `/reset`. `/inheritance:r` removes only *inherited* ACEs, and `/grant:r` replaces grants
+///    only for the principals it names. An explicit ACE a squatter put there survives both. This
+///    is what clears it.
+/// 3. `/inheritance:r` with the two grants, which is then the whole of the ACL.
+///
+/// Shelling out to `icacls` rather than calling `SetNamedSecurityInfo`: this runs once, at install,
+/// in an elevated shell, and each command is one an operator can read, re-run and verify by hand —
+/// which for the object that *is* the security boundary is worth more than avoiding a process spawn.
+fn restrict_to_administrators(path: &std::path::Path, rights: &str) -> Result<()> {
+    icacls(path, &["/setowner", ADMINISTRATORS_SID, "/c"])?;
+    icacls(path, &["/reset", "/c"])?;
+    icacls(
+        path,
+        &[
+            "/inheritance:r",
+            "/grant:r",
+            &format!("{SYSTEM_SID}:({rights})"),
+            "/grant:r",
+            &format!("{ADMINISTRATORS_SID}:({rights})"),
+        ],
+    )
+}
+
+/// The state directory, created and locked down before anything is written into it.
+///
+/// Securing the *directory* matters as much as the file: an unprivileged user who pre-creates
+/// `%ProgramData%\windbg-mcp` owns it, and can then delete or replace whatever we put inside. A
+/// reparse point is refused outright rather than followed, since a junction planted there would
+/// have us write the credential wherever its author chose.
+fn secured_state_dir() -> Result<PathBuf> {
+    let dir = state_dir();
+    std::fs::create_dir_all(&dir).with_context(|| format!("cannot create {}", dir.display()))?;
+    let meta = std::fs::symlink_metadata(&dir)
+        .with_context(|| format!("cannot inspect {}", dir.display()))?;
+    // **Not `is_symlink()`.** On Windows that recognises symbolic links and *not* directory
+    // junctions, which carry a different reparse tag and are the ones an unprivileged user can
+    // create without any privilege at all. Testing the attribute catches every reparse tag there
+    // is, which is the only safe reading of "is this really the directory I asked for".
+    const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x400;
+    if meta.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+        bail!(
+            "{} is a reparse point (a junction or a symlink). Refusing to write the service's \
+             token through it, since where it leads is not this installer's to trust — remove it \
+             and install again.",
+            dir.display()
+        );
+    }
+    restrict_to_administrators(&dir, "F")?;
+    Ok(dir)
+}
+
+/// Whether `exe` sits somewhere only administrators can write.
+///
+/// The roots Windows protects by default, and nothing clever: `%ProgramFiles%`,
+/// `%ProgramFiles(x86)%` and `%SystemRoot%`. Anywhere else — a checkout, a `target\debug`, a
+/// download folder — is writable by whoever owns it, and the SCM stores an **exact path** for a
+/// `LocalSystem` auto-start service. Its owner can then replace the exe, or an engine DLL beside
+/// it, and have their code loaded as SYSTEM at the next start. That is the classic weak-service-
+/// binary escalation, and the install is where it is cheap to refuse.
+///
+/// A root list rather than an ACL inspection on purpose. Reading the effective rights of every
+/// unprivileged principal against a path is the *correct* test and a fragile one — locale-dependent
+/// output, inherited and denied ACEs, group nesting — and a security check that is sometimes wrong
+/// in the permissive direction is worse than a blunt one that is always right about the safe case.
+fn under_protected_root(exe: &std::path::Path) -> bool {
+    ["ProgramFiles", "ProgramFiles(x86)", "SystemRoot"]
+        .iter()
+        .filter_map(std::env::var_os)
+        .any(|root| exe.starts_with(PathBuf::from(root)))
+}
+
+/// Everything an install does *after* the SCM accepts the registration.
+///
+/// Separated so the caller can undo the registration as a whole if any of it fails — see the call
+/// site. The credential is written here, last, rather than before the service exists: written
+/// first, an install that then failed because the service was already registered had already
+/// replaced the *running* service's token, which would keep serving on the one in its memory and
+/// switch to a different one at its next restart, having reported a failure. Nothing is started
+/// here, so there is no window in which the file exists and something is serving with it.
+fn finish_install(service: &windows_service::service::Service, token: &str) -> Result<()> {
+    service
+        .set_description(DESCRIPTION)
+        .context("the service's description could not be set")?;
+    // **Ten seconds by default on anything modern**, which is nowhere near a teardown that may be
+    // releasing a live kernel — and unlike an ordinary stop, a system shutdown that runs out of
+    // patience does not wait for us to finish. Raised to the same bound the stop itself reports,
+    // and refreshed at every start in case the call timeout has moved since.
+    service
+        .set_preshutdown_timeout(stop_bound())
+        .context("the service's preshutdown timeout could not be set")?;
+
+    let token_at = token_file();
+    secured_state_dir()?;
+    // Never reuse an object we did not create: a pre-existing file at this path is an unprivileged
+    // user's to own, and writing into it would leave them owning the credential. Removed and
+    // created fresh, with `create_new`, so losing a race is a refusal rather than a silent reuse.
+    let _ = std::fs::remove_file(&token_at);
+    {
+        use std::io::Write;
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&token_at)
+            .with_context(|| {
+                format!(
+                    "cannot create {} — something else created it first, which for a credential is \
+                     a refusal rather than something to write through",
+                    token_at.display()
+                )
+            })?;
+        file.write_all(token.trim().as_bytes())
+            .with_context(|| format!("cannot write {}", token_at.display()))?;
+    }
+    restrict_to_administrators(&token_at, "R")
+}
+
+/// Registers the service to run this exe with `--service --listen <addr>`.
+pub fn install(addr: SocketAddr, allow_unprotected: bool) -> Result<()> {
+    // Refused rather than warned about, and this changed once the token moved into a file: an
+    // install has to *have* the token to write it down, and a service registered without one is a
+    // service that fails at every start.
+    let token = std::env::var(crate::listen::TOKEN_ENV)
+        .ok()
+        .filter(|t| !t.trim().is_empty())
+        .with_context(|| {
+            format!(
+                "set {} in this shell first — the install copies it into a file only SYSTEM and \
+                 Administrators can read, which is how the service gets it. A *machine-scope* \
+                 environment variable would work and must not be used: it is readable by every \
+                 local process, and this endpoint's `launch` runs arbitrary commands as \
+                 LocalSystem.\n    $env:{} = \"<a long random string>\"",
+                crate::listen::TOKEN_ENV,
+                crate::listen::TOKEN_ENV
+            )
+        })?;
+
+    let exe = std::env::current_exe().context("cannot find this executable's own path")?;
+    if !under_protected_root(&exe) && !allow_unprotected {
+        bail!(
+            "{} is not under a directory Windows protects (%ProgramFiles%, %ProgramFiles(x86)% or \
+             %SystemRoot%). The SCM would store that exact path for a LocalSystem auto-start \
+             service, so whoever can write there — or write an engine DLL beside it — gets their \
+             code run as SYSTEM at the next start.\n\nCopy the deployment somewhere protected and \
+             install from there. For a development install, where the checkout is yours and the \
+             machine is yours, pass {ALLOW_UNPROTECTED_FLAG}.",
+            exe.display()
+        );
+    }
+    let manager = ServiceManager::local_computer(
+        None::<&OsStr>,
+        ServiceManagerAccess::CONNECT | ServiceManagerAccess::CREATE_SERVICE,
+    )
+    .context(
+        "cannot open the service manager — installing a service needs an elevated shell (\"Run \
+         as administrator\")",
+    )?;
+
+    let service = manager
+        .create_service(
+            &ServiceInfo {
+                name: OsString::from(NAME),
+                display_name: OsString::from(DISPLAY_NAME),
+                service_type: SERVICE_TYPE,
+                // Boot start, which is one of the three reasons to be a service at all: the
+                // machine that exists to be debugged should be debuggable before anyone logs in.
+                start_type: ServiceStartType::AutoStart,
+                error_control: ServiceErrorControl::Normal,
+                executable_path: exe,
+                launch_arguments: launch_arguments(addr),
+                dependencies: vec![],
+                // `LocalSystem`. A kernel debugger needs privileges an ordinary service account
+                // does not have, and this endpoint is already gated by its bearer token rather
+                // than by the account it runs as.
+                account_name: None,
+                account_password: None,
+            },
+            // `DELETE` as well as `CHANGE_CONFIG`, because the rollback below needs it: a handle
+            // without it fails the delete *silently*, and the "nothing was installed" this then
+            // reports is a lie that leaves a half-registered service behind. Found by running it.
+            ServiceAccess::CHANGE_CONFIG | ServiceAccess::DELETE,
+        )
+        .context("cannot create the service (is it already installed?)")?;
+    // From here, **anything that fails must take the service with it**. Moving the credential
+    // after the SCM work fixed one half-done install (a failed create no longer replaces a running
+    // service's token) and would otherwise create another: a registration left behind by a token
+    // step that refused. An install either happened or it did not.
+    if let Err(e) = finish_install(&service, &token) {
+        let undone = service.delete().is_ok();
+        // Waited out, not merely asked for. A delete marks a service and completes when the last
+        // handle to it closes, so returning here without waiting makes "nothing was installed"
+        // false for a moment — long enough that an operator fixing the problem and running the
+        // command again is told the service already exists.
+        drop(service);
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        while std::time::Instant::now() < deadline
+            && manager
+                .open_service(NAME, ServiceAccess::QUERY_STATUS)
+                .is_ok()
+        {
+            std::thread::sleep(Duration::from_millis(100));
+        }
+        // Reported honestly either way: a rollback that failed leaves a registration this command
+        // claimed to have removed, which is the one outcome worse than the original error.
+        return Err(if undone {
+            e.context("nothing was installed — the partial registration was removed")
+        } else {
+            e.context(format!(
+                "and `{NAME}` was left registered because it could not be removed again — run \
+                 `{UNINSTALL_FLAG}` before trying once more"
+            ))
+        });
+    }
+    // **Ten seconds by default on anything modern**, which is nowhere near a teardown that may be
+    // releasing a live kernel — and unlike an ordinary stop, a system shutdown that runs out of
+    // patience does not wait for us to finish. Raised to the same bound the stop itself reports.
+
+    println!(
+        "installed `{NAME}`, which will run:\n    {} {} {} {}\nStart it with `net start {NAME}`, \
+         or reboot — it is configured to start automatically.\nIt logs to {} (or wherever {} \
+         points when the service starts).\n\nIt runs as LocalSystem, which has a profile directory \
+         of its own: kernel connection profiles in your `%USERPROFILE%\\.windbg-mcp\\profiles.json` \
+         are **not** visible to it. Configure those machine-wide instead — \
+         `WINDBG_MCP_PROFILE_<NAME>` in the machine environment, or `WINDBG_MCP_PROFILES` pointing \
+         at a file the service account can read.",
+        std::env::current_exe().unwrap_or_default().display(),
+        SERVICE_FLAG,
+        crate::listen::LISTEN_FLAG,
+        addr,
+        log_path().display(),
+        LOG_ENV,
+    );
+    Ok(())
+}
+
+/// Stops the service if it is running, and removes it.
+pub fn uninstall() -> Result<()> {
+    let manager = ServiceManager::local_computer(None::<&OsStr>, ServiceManagerAccess::CONNECT)
+        .context(
+            "cannot open the service manager — removing a service needs an elevated shell (\"Run \
+             as administrator\")",
+        )?;
+    let service = manager
+        .open_service(
+            NAME,
+            ServiceAccess::QUERY_STATUS | ServiceAccess::STOP | ServiceAccess::DELETE,
+        )
+        .with_context(|| format!("no service named `{NAME}` is installed"))?;
+
+    // Stopped *before* deletion is asked for, and waited on: a delete leaves a running service
+    // marked for deletion until it exits, and this one has debug targets to let go of. Killing it
+    // by reboot instead would leave a live kernel frozen.
+    if service.query_status()?.current_state != ServiceState::Stopped {
+        println!("stopping `{NAME}` — it releases its debug targets first…");
+        service.stop().context("the service refused to stop")?;
+        let deadline = std::time::Instant::now() + stop_bound();
+        while std::time::Instant::now() < deadline {
+            if service.query_status()?.current_state == ServiceState::Stopped {
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(500));
+        }
+        // Checked rather than assumed. `delete` on a service that is still running *succeeds* — it
+        // marks it for deletion until the process exits — so falling through here would report a
+        // clean removal, take the token with it, and leave a `LocalSystem` listener holding live
+        // debug targets. Refusing leaves everything as it was, which is recoverable.
+        let state = service.query_status()?.current_state;
+        if state != ServiceState::Stopped {
+            bail!(
+                "`{NAME}` is still {state:?} after {:?}. Not deleting it, and not removing its \
+                 token: a delete would only mark a running service, and this one may still be \
+                 holding a debug target. Find out what it is waiting on (its log is at {}) and try \
+                 again.",
+                stop_bound(),
+                log_path().display()
+            );
+        }
+    }
+    service
+        .delete()
+        .context("the service could not be deleted")?;
+    // The token goes with it. Leaving a credential behind for a service that no longer exists is
+    // the kind of tidy-up nobody remembers to do by hand.
+    let token_at = token_file();
+    match std::fs::remove_file(&token_at) {
+        Ok(()) => println!(
+            "removed `{NAME}` and its token file ({}).",
+            token_at.display()
+        ),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => println!("removed `{NAME}`."),
+        Err(e) => println!(
+            "removed `{NAME}`, but its token file ({}) could not be deleted: {e}",
+            token_at.display()
+        ),
+    }
+    Ok(())
+}
+
+/// Tells the SCM the current [`stop_bound`], in case the call timeout has moved since install.
+fn sync_preshutdown_timeout() -> Result<()> {
+    let manager = ServiceManager::local_computer(None::<&OsStr>, ServiceManagerAccess::CONNECT)
+        .context("cannot open the service manager")?;
+    manager
+        .open_service(NAME, ServiceAccess::CHANGE_CONFIG)
+        .context("cannot open this service to update its configuration")?
+        .set_preshutdown_timeout(stop_bound())
+        .context("cannot set the preshutdown timeout")
+}
+
+define_windows_service!(ffi_service_main, service_main);
+
+/// Hands this thread to the SCM. Returns when the service has stopped.
+pub fn run() -> Result<()> {
+    service_dispatcher::start(NAME, ffi_service_main).context(
+        "this process was started with `--service` but is not running under the service control \
+         manager. That flag is for the SCM to pass, not to type: install with \
+         `--install-service --listen <addr>` and start the service.",
+    )?;
+    Ok(())
+}
+
+/// The SCM's entry point. Nothing here may panic across the FFI boundary, and there is no console
+/// to print to, so every outcome ends up in the log file and in the service's exit code.
+fn service_main(_arguments: Vec<OsString>) {
+    if let Err(e) = serve_as_service() {
+        tracing::error!("the service stopped with an error: {e:#}");
+    }
+}
+
+fn serve_as_service() -> Result<()> {
+    // A service starts in `%SystemRoot%\System32`. Moving to the exe's own directory makes the
+    // engine bundle beside it resolve the way it does for a foreground listener — which is one of
+    // the things being a service is supposed to make *more* predictable, not less.
+    if let Ok(exe) = std::env::current_exe()
+        && let Some(dir) = exe.parent()
+    {
+        let _ = std::env::set_current_dir(dir);
+    }
+
+    // The token `install` wrote and locked down. Pointed at here rather than baked into the
+    // command line the SCM stores, because that line is readable by every process on the machine —
+    // which is the exact property the file exists to restore.
+    //
+    // SAFETY: this runs on the SCM's dispatcher thread before the async runtime exists and before
+    // any thread of ours has been started, so there is no concurrent reader of the environment.
+    if std::env::var_os(crate::listen::TOKEN_FILE_ENV).is_none() {
+        let file = token_file();
+        if file.exists() {
+            unsafe { std::env::set_var(crate::listen::TOKEN_FILE_ENV, &file) };
+        }
+    }
+
+    // **Re-applied at every start, not just at install.** The bound is derived from
+    // `WINDBG_MCP_CALL_TIMEOUT_SECS`, which an operator can raise long after installing — and the
+    // value the SCM holds would still be the one computed that day. Windows honours *its* copy
+    // during a shutdown, so a drifted-short timeout means the OS stops waiting while a batch is
+    // still unwinding, which is the frozen-kernel outcome all of this exists to avoid. Best-effort:
+    // a service that cannot reopen itself should still serve, so this warns rather than refuses.
+    if let Err(e) = sync_preshutdown_timeout() {
+        tracing::warn!(
+            "could not refresh the preshutdown timeout ({e:#}); the SCM keeps the value stored at install"
+        );
+    }
+
+    let addr = match crate::listen::requested(&std::env::args().collect::<Vec<_>>()) {
+        Some(addr) => addr?,
+        None => bail!(
+            "the service was installed without `{} <addr>`, so there is nothing to bind. Reinstall \
+             it: `--uninstall-service` then `--install-service --listen <addr>`.",
+            crate::listen::LISTEN_FLAG
+        ),
+    };
+
+    // The stop signal, and the acknowledgement that it has been acted on. A `oneshot` rather than a
+    // flag because the SCM's handler runs on its own thread and must return promptly — it may only
+    // *ask*, and the runtime below does the releasing.
+    let (stop_tx, stop_rx) = tokio::sync::oneshot::channel::<()>();
+    let mut stop_tx = Some(stop_tx);
+    let status_handle = service_control_handler::register(NAME, move |control| match control {
+        // Answering this is not optional: a service that does not is reported as not responding.
+        ServiceControl::Interrogate => ServiceControlHandlerResult::NoError,
+        ServiceControl::Stop | ServiceControl::Preshutdown => {
+            if let Some(tx) = stop_tx.take() {
+                let _ = tx.send(());
+            }
+            ServiceControlHandlerResult::NoError
+        }
+        _ => ServiceControlHandlerResult::NotImplemented,
+    })
+    .context("cannot register the service control handler")?;
+
+    let running = |state: ServiceState, wait_hint: Duration| ServiceStatus {
+        service_type: SERVICE_TYPE,
+        current_state: state,
+        // `PRESHUTDOWN` as well as `STOP`, and the distinction is the point: an ordinary
+        // `SHUTDOWN` gives a service a few seconds, while a preshutdown notification is sent
+        // earlier and honours the wait hint — which is what a kernel target being released needs.
+        controls_accepted: ServiceControlAccept::STOP | ServiceControlAccept::PRESHUTDOWN,
+        exit_code: ServiceExitCode::Win32(0),
+        checkpoint: 0,
+        wait_hint,
+        process_id: None,
+    };
+    // `StopPending` carries a rising checkpoint, which is how the SCM tells "still working" from
+    // "hung" — the state that accepts no controls, because by then there is nothing left to ask.
+    let pending = |checkpoint: u32, wait_hint: Duration| ServiceStatus {
+        service_type: SERVICE_TYPE,
+        current_state: ServiceState::StopPending,
+        controls_accepted: ServiceControlAccept::empty(),
+        exit_code: ServiceExitCode::Win32(0),
+        checkpoint,
+        wait_hint,
+        process_id: None,
+    };
+    // `StartPending`, not `Running`: the socket is not bound yet, and on a non-loopback address at
+    // boot the bind may wait for the adapter to appear. Reporting `Running` here would have
+    // `Start-Service` succeed while there is no endpoint, and anything sequenced after it fail.
+    // The hint covers that wait; `Running` is reported from the `ready` callback below, once there
+    // really is something listening.
+    status_handle.set_service_status(ServiceStatus {
+        service_type: SERVICE_TYPE,
+        current_state: ServiceState::StartPending,
+        // **Stoppable while starting**, which is not the obvious choice and is the one that
+        // matters: with no controls accepted here, a service waiting out the bind retry cannot be
+        // stopped at all — `sc stop` is refused with `1052` and it sits in `StartPending` for the
+        // full patience. Accepting `STOP` is what lets the shutdown future the bind is raced
+        // against ever resolve. Found by starting one against an address that does not exist.
+        controls_accepted: ServiceControlAccept::STOP | ServiceControlAccept::PRESHUTDOWN,
+        exit_code: ServiceExitCode::Win32(0),
+        checkpoint: 1,
+        wait_hint: crate::listen::BIND_PATIENCE + CHECKPOINT_EVERY,
+        process_id: None,
+    })?;
+
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .context("cannot start the async runtime")?
+        .block_on(async move {
+            // Set before the last status is reported, so the ticker below cannot put a
+            // `StopPending` on the wire after the `Stopped` that ends the service.
+            let finished = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+            let served = crate::serve_http(
+                addr,
+                {
+                    let finished = finished.clone();
+                    async move {
+                        let _ = stop_rx.await;
+                        tracing::info!("service stop requested; releasing every debug target");
+                        // Told before the releasing starts, not after: the SCM's clock is already
+                        // running, and a wait hint that arrives once the work is done has bounded
+                        // nothing.
+                        let bound = stop_bound();
+                        let _ = status_handle.set_service_status(pending(1, bound));
+                        // And kept being told. The releasing happens *after* the accept loop returns —
+                        // in `serve_http`, out of reach of this future — so without something ticking
+                        // here the SCM sees one status and then silence for as long as a batch takes to
+                        // unwind. Dies with the runtime, which is dropped moments after the stop.
+                        tokio::spawn(async move {
+                            let mut checkpoint = 1u32;
+                            loop {
+                                tokio::time::sleep(CHECKPOINT_EVERY).await;
+                                if finished.load(std::sync::atomic::Ordering::SeqCst) {
+                                    return;
+                                }
+                                checkpoint += 1;
+                                let _ =
+                                    status_handle.set_service_status(pending(checkpoint, bound));
+                            }
+                        });
+                    }
+                },
+                || {
+                    let _ = status_handle
+                        .set_service_status(running(ServiceState::Running, Duration::default()));
+                },
+            )
+            .await;
+            finished.store(true, std::sync::atomic::Ordering::SeqCst);
+            // Reported from here, where both the handle and the outcome are in scope, so a service
+            // that failed says so in its exit code rather than only in the log.
+            let exit_code = match &served {
+                Ok(()) => ServiceExitCode::Win32(0),
+                Err(_) => ServiceExitCode::ServiceSpecific(1),
+            };
+            let _ = status_handle.set_service_status(ServiceStatus {
+                service_type: SERVICE_TYPE,
+                current_state: ServiceState::Stopped,
+                controls_accepted: ServiceControlAccept::empty(),
+                exit_code,
+                checkpoint: 0,
+                wait_hint: Duration::default(),
+                process_id: None,
+            });
+            served
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_role_is_read_off_the_command_line_and_only_when_asked_for() {
+        let argv = |args: &[&str]| args.iter().map(|a| a.to_string()).collect::<Vec<_>>();
+        assert_eq!(requested(&argv(&["windbg-mcp"])), None);
+        assert_eq!(
+            requested(&argv(&["windbg-mcp", "--listen", "127.0.0.1:8765"])),
+            None
+        );
+        assert_eq!(
+            requested(&argv(&["windbg-mcp", SERVICE_FLAG])),
+            Some(Role::Run)
+        );
+        assert_eq!(
+            requested(&argv(&[
+                "windbg-mcp",
+                INSTALL_FLAG,
+                "--listen",
+                "127.0.0.1:8765"
+            ])),
+            Some(Role::Install)
+        );
+        assert_eq!(
+            requested(&argv(&["windbg-mcp", UNINSTALL_FLAG])),
+            Some(Role::Uninstall)
+        );
+    }
+
+    /// The SCM stores this once, at install time, and nothing re-derives it — so a service that
+    /// registers cleanly and then fails at every start is the shape this guards against.
+    #[test]
+    fn the_installed_command_line_starts_the_service_on_the_address_it_was_given() {
+        let args = launch_arguments("127.0.0.1:8765".parse().expect("a literal address"));
+        let rendered: Vec<String> = args
+            .iter()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(rendered, vec![SERVICE_FLAG, "--listen", "127.0.0.1:8765"]);
+        // And the flag the SCM passes is the one `requested` answers `Run` to, which is the join
+        // between installing and starting that nothing else checks.
+        assert_eq!(requested(&rendered), Some(Role::Run));
+    }
+
+    /// The log has to land somewhere a service account can write and an operator will look, and it
+    /// has to be overridable — a smoke run cannot be writing to `%ProgramData%`.
+    ///
+    /// **And moving it must not move the token**, which is the bug this test was written for. The
+    /// token path was derived from the log path, so redirecting the log made `install` write the
+    /// credential in one place and the service look in another: it started, found nothing, and
+    /// exited with a service-specific error and an empty log. Found by running the thing.
+    #[test]
+    fn the_log_is_overridable_and_the_token_does_not_follow_it() {
+        // SAFETY: single-threaded test, and the variable is read only through `log_path`.
+        unsafe { std::env::set_var(LOG_ENV, r"C:\somewhere\else.log") };
+        assert_eq!(log_path(), PathBuf::from(r"C:\somewhere\else.log"));
+        assert!(
+            token_file().ends_with(r"windbg-mcp\token"),
+            "redirecting the log moved the token to {:?}",
+            token_file()
+        );
+        unsafe { std::env::remove_var(LOG_ENV) };
+        let default = log_path();
+        assert!(default.ends_with(r"windbg-mcp\service.log"), "{default:?}");
+        assert_eq!(default.parent(), token_file().parent());
+    }
+}

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -2594,6 +2594,53 @@ fn the_listener_will_not_start_without_a_token() {
     );
 }
 
+/// Installing the service without an address is refused **before the SCM is touched**.
+///
+/// Two things at once, and the ordering is the interesting one. The SCM stores the command line
+/// once, at install time, and nothing re-derives it — so a service registered without an address is
+/// one that installs cleanly and then fails at every start, which is the worst shape this can take.
+/// And because the refusal happens before any SCM call, it needs no elevation, which is what lets
+/// it live in the tier that runs everywhere rather than in one nobody runs.
+#[test]
+fn installing_the_service_without_an_address_is_refused_before_anything_is_registered() {
+    let registered = service_is_registered();
+    let out = Command::new(EXE)
+        .arg("--install-service")
+        .stdin(Stdio::null())
+        .output()
+        .unwrap_or_else(|e| panic!("failed to spawn {EXE}: {e}"));
+    assert!(
+        !out.status.success(),
+        "an install with no address should have been refused"
+    );
+    let said = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        said.contains("--listen"),
+        "the refusal has to name what is missing, or nobody can act on it: {said}"
+    );
+    let after = service_is_registered();
+    // Nothing was *changed* — asserted through the tool an operator would use, so this also fails
+    // if the refusal happened after a partial install rather than before one.
+    //
+    // "Unchanged" rather than "absent", and deliberately: a developer running the ordinary suite on
+    // a host where they have the service installed — which is to say, someone using the feature
+    // under test — must not be failed by it. So the state is captured either side and compared.
+    assert_eq!(
+        registered, after,
+        "the refused install changed whether `windbg-mcp` is registered with the SCM"
+    );
+}
+
+/// Whether the SCM has a service by this name, for the assertion above to compare against itself.
+fn service_is_registered() -> bool {
+    Command::new("sc.exe")
+        .args(["query", "windbg-mcp"])
+        .output()
+        .expect("sc.exe is present on every Windows host")
+        .status
+        .success()
+}
+
 /// An unauthenticated caller is refused, told nothing about what is here — and costs the server
 /// nothing.
 ///


### PR DESCRIPTION
Closes the last item of `FOLLOWUPS.md` 23. A foreground `--listen` dies with the login session, inherits whatever `PATH` and working directory that shell had — which for this server decides whether the engine DLLs beside the exe are the ones that load — and cannot start at boot.

```pwsh
[Environment]::SetEnvironmentVariable("WINDBG_MCP_LISTEN_TOKEN", "<a long random string>", "Machine")
windbg-mcp.exe --install-service --listen 127.0.0.1:8765
Start-Service windbg-mcp
```

`--uninstall-service` stops it and removes it. `--service` is what the SCM passes; it is not for typing.

## The stop is the whole of the difficulty

For most services a stop is a formality. Here it is the one operation that can damage something **outside** the process: DbgEng leaves a detached-but-halted kernel *frozen*, so a service killed rather than asked holds someone's machine stopped until they notice.

That is why `listen::serve` grew a shutdown future — nothing else in this server needs one, because under stdio the client's disconnect *is* the signal and a foreground listener has nobody to ask it. A stop now takes the same graceful path a disconnect takes, and the SCM is told `StopPending` with a wait hint sized from what releasing every worker can actually take rather than being left on the default. `PRESHUTDOWN` is accepted alongside `STOP`, since the ordinary shutdown notification does not honour a wait hint.

The foreground path hands over a shutdown that never fires, so its behaviour is unchanged.

## Three consequences of LocalSystem, all verified rather than assumed

- **It does not read your `profiles.json`.** `LocalSystem`'s `%USERPROFILE%` is `C:\Windows\system32\config\systemprofile`, so `attach_kernel {}` under the service lists nothing from your home directory. Profiles have to be machine-wide.
- **It reads the machine environment**, so the bearer token moves there — a real widening, since a machine-scope variable is readable by every process on the host.
- **It has no console.** The role logs to `%ProgramData%\windbg-mcp\service.log` (override with `WINDBG_MCP_SERVICE_LOG`). `server_log` is the better channel, but only once the listener is up — which is exactly the failure not worth diagnosing that way.

`install` prints all three at the moment an operator is standing there to read them.

## Verification

`cargo fmt --check`, `cargo clippy --all-targets -D warnings`, 431 unit tests and 54 smoke tests (debugger tier on) — green on ARM64.

New coverage: three unit tests on role parsing, the installed command line (the SCM stores it once and nothing re-derives it, so an install that registers a service which fails at every start is the shape worth guarding), and the log path. Plus a protocol-tier smoke test that an install with no address is refused **before the SCM is touched** — which is also what lets it run unelevated, everywhere.

End to end on the ARM64 bench, by hand: installed, correct `BINARY_PATH_NAME`/`AUTO_START`/`LocalSystem`, started and bound, served an authorised MCP call (`200`) and refused an unauthenticated one (`401`), then **stopped while holding a live ARM64 kernel session** —

```
service stop requested; releasing every debug target
no longer accepting connections on 127.0.0.1:8792
shutting down: releasing 1 session(s)
shutting down: session sess-… released its target
```

— with the guest's uptime still advancing afterwards rather than frozen, and no worker outliving the service. Uninstalled cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)