### PR TITLE
Hand the ARM64 target work over: what is covered, what is not

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,7 +124,14 @@ $env:WINDBG_MCP_SMOKE_DUMP = "1"; cargo test --test mcp_smoke
 
 That tier now also covers the process-per-session behaviour end to end: two sessions coexisting, a
 kernel attach parked on a dead port being reclaimed by `end_session`, and no worker process
-outliving the connection. A third tier is `#[ignore]`d because it runs commands out to a watchdog
+outliving the connection. It opens the **dump matching this host's architecture** — an ARM64 one is
+checked in beside the two x64 samples — and the four assertions that read a *target* rather than
+the dump's structure check first that this host can: `nt`'s base has to read, plus a resolved PDB
+for the two that walk `nt`'s types. Where it cannot they print `SKIPPED` and pass, so a green tier
+on a machine without symbols is not the same claim as a green tier here; read the `SKIPPED` lines
+(`--nocapture`) before concluding a change is covered. `docs/smoke-test.md` has the measurements
+behind that gate, and the driver-attribution claim still has **no ARM64 fixture at all**
+(issue #154). A third tier is `#[ignore]`d because it runs commands out to a watchdog
 deadline (minutes, not seconds) — run it by hand after a win-kexp watchdog change:
 
 ```pwsh
@@ -225,6 +232,21 @@ at 240s, so on a serial bench "x64-only" and "too slow over this wire" cannot be
 
 ## Live kernel + driver IOCTL gotchas (learned driving HEVD over KDNET)
 
+**Loading HEVD on an ARM64 bench takes two things, and the error names neither.**
+`StartService FAILED 577` ("cannot verify the digital signature") means both `bcdedit /set
+testsigning on` (a reboot) *and* the driver's signing certificate imported into
+`Cert:\LocalMachine\Root` — test signing has nothing to chain to otherwise, and an unexpired cert
+that is simply untrusted looks identical to an expired one. `TrustedPublisher` refuses with
+`E_ACCESSDENIED` and is not needed for `sc start` of a non-PnP driver. Check HVCI
+(`(Get-CimInstance Win32_DeviceGuard -Namespace root\Microsoft\Windows\DeviceGuard).SecurityServicesRunning`)
+before blaming signing; `0` means it is not the cause.
+
+**A crash out of an exploit client is usually not a driver bug.** HEVD's stack-overflow client on
+this bench bug-checks `0xFC` with the kernel faulting at the *user-mode payload* — its ROP chain
+never disables privileged execution of a user page — so the stack is `nt`-only and carries no
+`HEVD` frame at all. A fixture that needs a driver frame wants a path that faults **inside** the
+driver (issue #154), not a failed exploit.
+
 **Attach by `profile`, not by connection string — always, for any live target.** `attach_kernel
 { "profile": "<name>" }` resolves the connection inside the server (`src/kdconn.rs`), so the
 target's debug key never lands in a tool argument — and therefore never in the *client's*
@@ -289,7 +311,12 @@ Issue `.sympath` alone, or use the **`set_symbol_path`** tool (goes through the 
 
 **Nothing resolves at all without `msdia140.dll` beside the engine** — `symsrv.dll` finds a PDB and
 that one *parses* it, so without it every module reports `Symbol Type: EXPORT - PDB not found` even
-when the identity was known and the file was downloaded. It is **not** store-package-only, which
+when the identity was known and the file was downloaded. **`symsrv.dll` is the other half, and
+System32 does not ship it**: on a machine with neither, a `srv*` path downloads nothing. Worth
+knowing because of how that presents on a *dump* — not as missing symbols but as a **memory read
+failing** (`0x8007001E`), since a kernel dump's virtual addresses are translated through structures
+the engine locates with `nt`'s symbols. That symptom was read as an ARM64 engine limitation for a
+while (issue #142); it is not one, and an engine with symbols reads x64 and ARM64 dumps alike. It is **not** store-package-only, which
 this repo believed for a while: Visual Studio Build Tools ships it, including an ARM64 build, at
 `…\BuildTools\DIA SDK\bin\arm64\msdia140.dll`. Copy it next to the exe (`target\release`, and
 `target\debug` for the smoke tiers). **Warm the cache once** afterwards — attach and `.reload /f nt`

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -9,8 +9,9 @@ from transactional batches (#82, 2026-08-09/10 — item 17 is what validating th
 session's own transcript turned up, and item 18 what reviewing it did), item 19 from
 `walk_memory` (#103, 2026-08-13), items 20–22 from standing the server up on an ARM64 guest
 (#131, #132, #134, 2026-08-16), item 23 from making the listener usable rather than merely
-working (2026-08-17), and item 24 from first measuring what this server costs the model driving it
-(2026-08-17). Each item notes its repo,
+working (2026-08-17), item 24 from first measuring what this server costs the model driving it
+(2026-08-17), and items 25–26 from giving the debugger tier an ARM64 *target* (#143, #152,
+2026-08-18). Each item notes its repo,
 why it was deferred, and where it picks up. See [`DECISIONS.md`](./DECISIONS.md) for the design rationale (D1–D5) items 1–6 extend,
 and the 2026-08-02 entries that items 13–14 and item 10 extend.
 
@@ -747,3 +748,47 @@ say what it means for the other.
 
 Picks up at [`docs/token-budget.md`](./docs/token-budget.md) and the two budget tests in
 `tests/mcp_smoke.rs`.
+
+## 25. [windbg-mcp] The ARM64 CI runner resolves no symbols, so its target reads never run
+
+Since #152 the debugger tier's target-reading assertions decide for themselves whether the host can
+support them, and the two CI entries decide differently: on `windows-latest` all four run and pass,
+on `windows-11-arm` all four print `SKIPPED`. Same code, same dumps. Windows ships `dbghelp.dll` in
+System32 and **no `symsrv.dll`** outside the Debugging Tools, so a runner without them downloads no
+PDB — and without `nt`'s symbols a kernel dump's pointers cannot be followed at all
+([#142](https://github.com/glslang/windbg-mcp/issues/142)).
+
+- **Why deferred:** the job's stated position is that it runs the runner's *stock* engine, on the
+  reasoning that "a runner whose DbgEng cannot open a checked-in dump is something this repo wants
+  to hear about". Provisioning symbols moves it away from what a bare machine gets — and toward
+  what a user following this repo's own setup gets, since that setup copies the engine bundle
+  beside the exe. That is a decision about what the job is *for*, not a fix.
+- **What it costs today:** `docs/samples/121524-4703-01.dmp`, added so an ARM64 run reads an ARM64
+  target, is exercised only on a bench with the engine bundle. CI proves the protocol and the
+  session machinery there and nothing about reading.
+- **Picks up at** [#153](https://github.com/glslang/windbg-mcp/issues/153), which lists the two
+  probes (`dir` of the arm64 Debuggers directory, `where.exe symsrv.dll`) that would confirm this
+  is an image difference rather than something this repo can fix in the workflow.
+
+## 26. [windbg-mcp] No ARM64 driver crash, so frame attribution is asserted only on x64 stacks
+
+`a_driver_crash_names_the_driver_frame_that_analyze_cannot` opens the x64 `MessageManager` dump on
+every architecture. It passes there — an engine with symbols reads either dump either way round —
+but the arithmetic that turns a captured frame into `module+RVA` off the load base has never been
+run against an **ARM64** stack. #143 closed the other three assertions this way and left this one.
+
+- **Why deferred:** it needs a crash to be produced rather than a sample to be found, and the two
+  obvious candidates are already ruled out. The checked-in ARM64 sample and every one of its
+  siblings on that bench are `0xFC` faults at a *user-mode payload* — HEVD's stack-overflow client
+  with an incomplete ROP chain, so nothing disables privileged execution of a user page and the
+  stack carries no `HEVD` frame at all. Completing that chain would remove the crash rather than
+  reshape it.
+- **What it needs:** an HEVD path that faults **inside** the driver (null dereference, pool
+  corruption), plus a few lines of client to send that IOCTL — `hevd-exp` on the bench holds only
+  the stack-overflow one. The driver itself loads again as of 2026-08-18 (`testsigning` on, its
+  certificate in `LocalMachine\Root`; see `CLAUDE.md`).
+- **One decision first:** `HEVD.pdb` ships beside the driver, so its frame *will* symbolize if that
+  PDB is reachable — the opposite of the x64 assertion, which pins `symbol` absent because
+  `MessageManager` has no PDB. Either keep the PDB off the path so both tests make one claim, or
+  assert the symbolized form and let the pair cover both.
+- **Picks up at** [#154](https://github.com/glslang/windbg-mcp/issues/154).

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -250,7 +250,10 @@ user-mode process jumped into memory that is not executable, and the kernel bug-
 because every clone carries it for ever.
 
 What it adds is an **ARM64 `_EPROCESS`, an ARM64 image's headers and an ARM64 stack's frames**,
-read through the same three claims the x64 samples make. It also pins the one branch of the process
+read through the same three claims the x64 samples make. The fourth claim — attributing a frame to
+a third-party driver — is still asserted only against an x64 stack, because there is no ARM64
+driver crash to assert it on; that is [#154](https://github.com/glslang/windbg-mcp/issues/154), and
+it needs a crash produced rather than a sample found. It also pins the one branch of the process
 read that nothing else reaches: this dump does not capture the pool page `SeAuditProcessCreationInfo`
 points at, so the engine falls back to the 15-byte `_EPROCESS::ImageFileName` and the answer is the
 truncated `stack_buffer_o` — the fallback that the driver crash above, with its full


### PR DESCRIPTION
Documentation only. Everything here is state that this session established and that a later one would otherwise rediscover the slow way — the two open threads left by #143/#152, and two traps that cost real time in getting there.

### `CLAUDE.md`

- **A green debugger tier is no longer a single claim.** It now opens the dump matching the host's architecture and stands its four target-reading assertions down where the host cannot support them. On a machine without symbols, green means the protocol and the session machinery; the `SKIPPED` lines say which reads went unchecked, and `--nocapture` is what prints them.
- **The symbol note names `symsrv.dll` beside `msdia140.dll`.** System32 ships neither, and the way that presents on a dump is the trap: not "no symbols" but a **memory read failing** with `0x8007001E`, because a kernel dump's virtual addresses are translated through structures the engine locates with `nt`'s symbols. That symptom was read as an ARM64 engine limitation for a while (#142) and is not one.
- **The HEVD section gains the ARM64 half of the same lesson.** `StartService FAILED 577` means test signing *and* the driver's certificate in `LocalMachine\Root` — an untrusted-but-valid certificate is indistinguishable from an expired one at that error. And a crash out of an exploit client is usually not a driver bug: a chain that never disables privileged execution of a user page faults at the payload, leaving no driver frame on the stack.

### `FOLLOWUPS.md`

Items 25 and 26, each with the reason it was *not* done rather than a note that it wasn't:

- **25 — the ARM64 runner resolves no symbols** ([#153](https://github.com/glslang/windbg-mcp/issues/153)), so its target reads never run and the ARM64 sample is exercised only on a bench with the engine bundle. The argument against fixing it is the job's own stock-engine stance, which is a decision about what the job is for.
- **26 — no ARM64 driver crash** ([#154](https://github.com/glslang/windbg-mcp/issues/154)), so frame attribution is asserted only on x64 stacks. The obvious candidates are ruled out by measurement, not assumption: every ARM64 crash on the bench is a `0xFC` fault at a user-mode payload with no `HEVD` frame, and completing that exploit's chain would remove the crash rather than reshape it. The `HEVD.pdb` question has to be settled before anything is captured, since it decides what the test can assert.

`docs/smoke-test.md` gains one sentence saying the fourth claim is x64-only for that reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
