### PR TITLE
Say which PDB the engine has, so a client elsewhere can fetch that one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`modules` reports which PDB the engine has for a module** — `guid`, `age`, and the `key` those
+  two make, which is the middle element of a symbol server's `<pdb>/<key>/<pdb>` path. It completes
+  the coordinate work: the image was already identified by `timestamp` + `size`, and its *symbols*
+  are identified by a different pair that nothing reported.
+
+  - **`key` is carried already-built** rather than left to the caller, because the age goes in
+    **hex** and getting it wrong produces a URL that 404s — a hard failure to read backwards.
+  - **Absent for a module whose symbols are `deferred`**, which on a freshly opened dump is nearly
+    all of them. This reports the PDB the engine *has*, not one it could find; that is not the same
+    as "this module has no PDB", and the `symbols` state beside it says which.
+  - **`unmatched`** says the engine loaded a PDB that does not belong to the image, which makes
+    every symbol on that module another build's names. Absent when false.
+  - It saves a download rather than enabling something otherwise impossible — the same identity is
+    in the image's own debug directory, and [`docs/coordinates.md`](./docs/coordinates.md) walks
+    the whole chain, including the part where an 11 MB image is selected out of a symbol server by
+    two integers.
+
 - **`disassemble` answers with typed instructions carrying `RVA` and encoding, not just `u`'s
   text.** The second half of the same coordinate work, and the last tool that could only answer
   "what is the code here" as a rendering. Each instruction is now

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1079,7 +1079,7 @@ checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
 [[package]]
 name = "win-kexp"
 version = "0.1.0"
-source = "git+https://github.com/glslang/win-kexp?rev=c20c69588a3335b747e78fe0745628c96413cdcc#c20c69588a3335b747e78fe0745628c96413cdcc"
+source = "git+https://github.com/glslang/win-kexp?rev=ef8e4cb3e29c7314bce1bf34655068388dcb36c2#ef8e4cb3e29c7314bce1bf34655068388dcb36c2"
 dependencies = [
  "byte-strings",
  "goblin",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.9.0"
 edition = "2024"
 
 [dependencies]
-win-kexp = { git = "https://github.com/glslang/win-kexp", rev = "c20c69588a3335b747e78fe0745628c96413cdcc" }
+win-kexp = { git = "https://github.com/glslang/win-kexp", rev = "ef8e4cb3e29c7314bce1bf34655068388dcb36c2" }
 # 3.1.1 is a floor, not a preference: every 3.x before it generates a `tools/list` that omits
 # SEP-2549's required `ttlMs`/`cacheScope`, which a spec-strict `2026-07-28` client rejects
 # outright — the server connects and appears to expose no tools at all (upstream issue #1114).

--- a/README.md
+++ b/README.md
@@ -302,6 +302,10 @@ gh attestation verify <zip> --repo glslang/windbg-mcp `
 
 ## Walkthroughs
 
+- [`docs/coordinates.md`](docs/coordinates.md) — pairing this server with a disassembler, which is a
+  coordinate rather than an integration: `(module, image identity, RVA)`, the symbol-server key it
+  builds, and a worked join of a `crash_triage` frame to a function in an image fetched on another
+  machine from two integers.
 - [`docs/crash-dump-walkthrough.md`](docs/crash-dump-walkthrough.md) — triaging a real kernel
   minidump ([`docs/samples/052126-34312-01.dmp`](docs/samples/052126-34312-01.dmp)): a
   `0x9F DRIVER_POWER_STATE_FAILURE` traced to `nvlddmkm.sys` — `crash_triage` for the bug check as
@@ -650,7 +654,7 @@ matching `outputSchema` in `tools/list`, so a program can read a field instead o
 | `server_log` | `records[]` as `{seq, at, level, session_id, target, message}` — `session_id` absent for the supervisor's own — plus `matched`, the buffer's `held`/`capacity`/`oldest_seq`, and a `next_since` cursor that advances even on an empty page |
 | `end_session` | `released`, `worker_terminated`, `waited_ms` |
 | `registers` | `registers[]` as `{name, kind, …}` plus `instruction_pointer` — `kind: int` and `kind: float` carry `value`, `kind: bytes` carries `bytes` (an x87 or vector register, which no number holds), `kind: non_finite` names a NaN or infinity that JSON has no literal for and carries its bits, `kind: unavailable` carries neither; pass `all: true` for the x87/vector registers and subregister views |
-| `modules` | `modules[]` with `start`/`end`, `size` and a typed `symbols` state (`deferred` is *not* `none`); `unloaded[]` for the images that have since unloaded (listed by image name, since an unloaded module has none of its own); `loaded` (how many the target has in total) and the `filter` a narrowed listing was matched by. The listing text is rendered from these same records rather than pasted from `lm`, so the two halves cannot describe different sets of modules; the filter's grammar is this server's own — a name plus `*` (any run) and `?` (exactly one), **every other character literal** — and `execute { "command": "lm m <pattern>" }` is where WinDbg's fuller wildcard syntax lives |
+| `modules` | `modules[]` with `start`/`end`, `size`, `timestamp` (the `TimeDateStamp`+`size` pair a symbol server is keyed by — see [`docs/coordinates.md`](docs/coordinates.md)), a typed `symbols` state (`deferred` is *not* `none`) and, for a module whose symbols resolved, the `pdb` identity (`guid`, `age`, and the `key` those two make) plus `unmatched` when the engine loaded a PDB that does not belong to the image; `unloaded[]` for the images that have since unloaded (listed by image name, since an unloaded module has none of its own); `loaded` (how many the target has in total) and the `filter` a narrowed listing was matched by. The listing text is rendered from these same records rather than pasted from `lm`, so the two halves cannot describe different sets of modules; the filter's grammar is this server's own — a name plus `*` (any run) and `?` (exactly one), **every other character literal** — and `execute { "command": "lm m <pattern>" }` is where WinDbg's fuller wildcard syntax lives |
 | `set_breakpoint` | the ids this call `added`, and every breakpoint now set — a successful `bp` prints nothing at all |
 | `run_to_address` | `verdict` (`hit`/`stopped_elsewhere`/`timeout`), `target`, `stopped_at` |
 | `go`, `step_over`, `step_into`, `step_back`, `step_over_back`, `reverse_go` | `stopped_at` |

--- a/docs/coordinates.md
+++ b/docs/coordinates.md
@@ -1,0 +1,143 @@
+# Coordinates — joining a frame to an image somewhere else
+
+A debugger answers in addresses. An address is the least portable thing it knows: it is a fact
+about one boot of one machine, and the same function is somewhere else after a reboot, on another
+host, or in the disassembler you have the image open in. This is what to use instead, and a worked
+example of the join it makes possible.
+
+The tools that emit it are `crash_triage`, `backtrace` and `disassemble`. None of them knows that a
+disassembler exists, and that is the design: the coordinate is a form anything can join against,
+not an integration with something in particular.
+
+## The coordinate
+
+**`(module, image identity, RVA)`** — never a bare virtual address.
+
+- **`module` + `rva`** come back on every frame and every instruction. The RVA is the offset from
+  the image's load base, computed from what the engine reports, and it survives the reboot the
+  address does not.
+- **The image identity** is the PE `TimeDateStamp` + `SizeOfImage` pair, on every `modules` row as
+  `timestamp` and `size`. It is what a symbol server is keyed by, which is not a coincidence: it is
+  the industry's existing answer to "is this the same binary".
+
+Both halves are needed. The RVA says *where*; the identity says *in which build*, and a
+decompilation of the wrong build is a silent wrong answer rather than an error.
+
+**Neither half is promised.** `module` and `rva` travel together and are absent when the engine
+places the address in no loaded module — a freed pool page, an unloaded driver, a corrupted return
+address, which is exactly what a driver bug leaves behind. A frame or instruction whose module
+*lookup failed* says so separately (`attribution_failed`), because that is an absence of
+information rather than a finding about the target.
+
+## The worked example
+
+Every number below is real, from `docs/samples/121524-4703-01.dmp` — an ARM64
+`0xFC ATTEMPTED_EXECUTE_OF_NOEXECUTE_MEMORY`. The debugger ran on a Windows VM; the join ran on a
+Mac that had never seen the image.
+
+**1. Ask the debugger.** `crash_triage` gives the frames:
+
+```json
+{ "index": 1, "address": "0xfffff8013c65c6a4", "module": "nt",
+  "rva": "0x25c6a4", "symbol": "nt!KeBugCheckEx", "displacement": "0x14" }
+```
+
+and `modules { "filter": "nt" }` gives that module's identity:
+
+```json
+{ "name": "nt", "image_name": "ntkrnlmp.exe", "start": "0xfffff8013c400000",
+  "timestamp": 1265362548, "size": 19173376, "symbols": "pdb" }
+```
+
+**2. Build the symbol-server key.** `TimeDateStamp` as eight uppercase hex digits, then
+`SizeOfImage` in hex, unpadded, concatenated:
+
+```text
+1265362548 -> 4B6BE674      19173376 -> 1249000      key: 4B6BE6741249000
+https://msdl.microsoft.com/download/symbols/ntkrnlmp.exe/4B6BE6741249000/ntkrnlmp.exe
+```
+
+**3. Check the image you got is the image you asked for.** Read `TimeDateStamp` and `SizeOfImage`
+back out of the PE header and compare. Both matched here. A mismatch is a refusal, not a warning:
+the whole point of the identity is that it is checkable.
+
+**4. Resolve the coordinate.** The frame is `rva 0x25c6a4` with displacement `0x14`, so its
+function begins at `0x25c690`. That image's export table has `KeBugCheckEx` at exactly `0x25c690`.
+
+The image's own `ImageBase` is `0x140000000`, while the dump had it loaded at `0xfffff8013c400000`.
+Nothing about the address survived; everything about the offset did.
+
+**5. Check the code, not just the name.** `disassemble` at that entry reported four instruction
+encodings, and all four match the file byte-for-byte:
+
+```text
+0x25c690  d503237f  pacibsp
+0x25c694  a9bf7bfd  stp fp,lr,[sp,#-0x10]!
+0x25c698  910003fd  mov fp,sp
+0x25c69c  d2800005  mov x5,#0
+```
+
+That is what `bytes` is for. Two images that disassemble differently are different builds whatever
+their names say — and this check needs no symbols at all.
+
+## What resolves, and what needs a PDB
+
+Of the six frames on that stack, **one** resolved from the image alone: `KeBugCheckEx`, which is
+exported. `KeBugCheck2`, `MiCheckSystemNxFault`, `MiValidFault`, `MiUserFault` and `MmAccessFault`
+are internal, so an export table cannot name them and a disassembler will show them as
+`sub_25b9c0` until it has the PDB.
+
+The PDB is keyed the same way, but by **GUID + age** rather than timestamp and size. `modules`
+reports it as `pdb`, for the modules whose symbols the engine has actually resolved:
+
+```json
+{ "name": "nt", "symbols": "pdb",
+  "pdb": { "guid": "FE3F58BDA39D2FC13C370618D1DBDF22", "age": 1,
+           "key": "FE3F58BDA39D2FC13C370618D1DBDF221" } }
+```
+
+`key` is the path segment already assembled — `<pdb>/<key>/<pdb>` — because the age goes in **hex**
+and getting that wrong produces a URL that 404s, which is a hard failure to read backwards:
+
+```text
+https://msdl.microsoft.com/download/symbols/ntkrnlmp.pdb/FE3F58BDA39D2FC13C370618D1DBDF221/ntkrnlmp.pdb
+```
+
+Put the `.pdb` beside the `.exe` and a disassembler that reads PDBs picks it up.
+
+**It is absent for a module whose symbols are `deferred`**, which on a freshly opened dump is
+almost all of them: this reports the PDB the engine *has*, and a deferred module has none until
+something makes it look. That is not "this module has no PDB". Nor is it a dead end — the identity
+also lives in the image's own debug directory (the CodeView `RSDS` record), so a client that has
+fetched the image by the pair above can read it from there. Reporting it here saves that download,
+and lets a caller check the PDB it already holds is the right one, which the image cannot do.
+
+`pdb.unmatched` is the field to check before trusting any symbol: it means the engine loaded a PDB
+that does not belong to this image, so every name it produces is another build's.
+
+## Four things that will trip you up
+
+**An RVA is per image *and build*.** It is comparable across reboots and across machines for the
+same binary, and means nothing against a different one. This is why step 3 is not optional.
+
+**`bytes` is the engine's spelling, not memory order.** On ARM64 `d503237f` is the instruction
+word; the four bytes in the file are `7f 23 03 d5`. Compare it against another *disassembly*, or
+byte-swap deliberately — do not memcmp it against a file.
+
+**Never reconstruct an image from target memory.** It is relocated, partly paged out, and quite
+possibly patched by the thing you are investigating — three ways to hand a decompiler a lie. Fetch
+the image by identity, as above.
+
+**The engine's own address form has a backtick in it** — ``fffff801`3c677ef0``. `disassemble`
+normalises it out of instruction text, but `execute { "command": "u" }` and everything else raw
+still carries it.
+
+## Where this came from
+
+This is section 06 of the split-plane plan — the reason the correlation layer needs no proxy.
+Converting an address to an RVA and back requires nothing but this server's own module map, so a
+model holding both this server and an analysis server can do the join itself, with no component in
+between knowing about both.
+
+The example above is that claim being tested rather than argued: two machines, one coordinate, and
+an 11 MB image selected out of a symbol server by two integers.

--- a/docs/token-budget.md
+++ b/docs/token-budget.md
@@ -7,7 +7,7 @@ answer this server returns. That makes payload size a correctness-adjacent prope
 call that spends 13k tokens has not failed, but it has taken the space the investigation needed.
 Nothing measured this until [`tests/mcp_smoke.rs`](../tests/mcp_smoke.rs) grew the two tests below,
 and the numbers turned out to be larger than anyone had guessed — a careful reading of the source
-put the tool surface at 90–130 KB, and the wire is 376 KB.
+put the tool surface at 90–130 KB, and the wire is 392 KB.
 
 ## Two costs, and they are not the same
 
@@ -61,10 +61,10 @@ authority — the tables below are a reading of it at the time of writing.
 
 | Component | Bytes | Reaches the model |
 |---|---:|---|
-| **Whole `tools/list` payload** | **376,099** | partly |
-| — the 51 tools themselves | 375,981 | partly |
+| **Whole `tools/list` payload** | **391,709** | partly |
+| — the 51 tools themselves | 391,591 | partly |
 | — result-level fields (`resultType`, `ttlMs`, `cacheScope`) | 118 | no |
-| `outputSchema` (the 33 tools that have one) | 301,626 | no |
+| `outputSchema` (the 33 tools that have one) | 317,236 | no |
 | `inputSchema` (all 51) | 40,204 | yes |
 | `description` (all 51) | 24,752 | yes |
 | `annotations` | 5,449 | no |
@@ -81,8 +81,8 @@ server at two revisions shows what a sum would miss:
 
 | Revision | payload | sum of tools | result-level |
 |---|---:|---:|---|
-| `2026-07-28` | 376,099 | 375,981 | `resultType`, `ttlMs`, `cacheScope` |
-| `2025-06-18` | 376,043 | 375,981 | none |
+| `2026-07-28` | 391,709 | 391,591 | `resultType`, `ttlMs`, `cacheScope` |
+| `2025-06-18` | 391,653 | 391,591 | none |
 
 The sum is **identical** across the two; only the payload figure can tell them apart. The golden
 records both, so the gap stays visible.
@@ -93,22 +93,23 @@ records both, so the gap stays visible.
 
 | Tool | model | wire | text | structured | ratio |
 |---|---:|---:|---:|---:|---:|
-| `modules` | 53,875 | 73,994 | 19,732 | 53,875 | 2.7x |
+| `modules` | 53,897 | 74,016 | 19,732 | 53,897 | 2.7x |
 | `execute` (`lm`) | 19,420 | 19,788 | 19,420 | — | — |
 | `registers` | 9,804 | 10,534 | 618 | 9,804 | **15.9x** |
 | `crash_triage` | 1,855 | 3,133 | 1,159 | 1,855 | 1.6x |
 | `open_dump` | 1,347 | 2,277 | 814 | 1,347 | 1.7x |
-| `disassemble` | 1,808 | 3,219 | 1,291 | 1,808 | 1.4x |
+| `disassemble` | 2,018 | 3,429 | 1,291 | 2,018 | 1.6x |
 | `backtrace` | 945 | 1,588 | 532 | 945 | 1.8x |
 | `session_status` | 297 | 823 | 420 | 297 | 0.7x |
 
-`backtrace`'s and `disassemble`'s rows are the two measured somewhere else: against
-`docs/samples/121524-4703-01.dmp`, on the ARM64 bench, because both became typed after this
-baseline was recorded and that machine opens the sample matching its own architecture. A stack's
-size is the crash's rather than the tool's, and a disassembly's is the code's, so neither is
-comparable to the digit with the row it replaces (572 B of `k` text; `disassemble` had no row at
+**Three rows are measured somewhere else** — `backtrace`, `disassemble` and `modules` — against
+`docs/samples/121524-4703-01.dmp` on the ARM64 bench, because each changed after this baseline was
+recorded and that machine opens the sample matching its own architecture. A stack's size is the
+crash's rather than the tool's and a disassembly's is the code's, so the first two are not
+comparable to the digit with the rows they replace (572 B of `k` text; `disassemble` had no row at
 all, having had no budget). What is comparable is the shape: the model now reads records and not a
-listing.
+listing. `modules` moved by ~100 B for one module's `pdb` object, which is the whole of what that
+field costs a caller — against the 15,610 B it costs the wire in schema, which is finding 1 above.
 
 `registers` is the shape of the problem in miniature: the model reads 9,804 bytes of JSON carrying
 `"kind":"int"` and `"subregister":false` on every row, and never sees the 618-byte `r` output that
@@ -124,6 +125,13 @@ None of these is a bug. They are recorded because they were invisible, and
    `ErrorCategory` (2,089 B) ships **31 times**, `WalkGaps` (2,886 B) and the whole
    allocator/pool subtree nine times each. **200,571 bytes — 70% of all `outputSchema`** — is
    duplicated beyond its first copy.
+1b. **And finding 1 has a price tag now.** Adding `PdbInfo` — one optional four-field type, on one
+   field of `ModuleInfo` — grew the wire by **15,610 B**, because `ModuleInfo` is embedded in the
+   openers' `TargetSummary`, in `modules`, and in the allocator shapes, and `schemars` inlines the
+   new type into every one of them. Model-visible cost: **zero**, since no model reads an
+   `outputSchema`. That ratio — 15 KB of wire for 0 B of context — is the whole of finding 1 in a
+   single change, and it is why the ceiling below moved rather than the type being argued about.
+
 2. **Whole schemas repeat.** The six openers carry a byte-identical 11,093 B output schema; the six
    step tools a byte-identical 4,418 B one. 77,555 B of the above.
 3. **`session_id` is documented 43 times, in three different wordings** (222 B ×22, 292 B ×15,

--- a/src/structured.rs
+++ b/src/structured.rs
@@ -604,14 +604,61 @@ pub struct ModuleInfo {
     #[serde(flatten)]
     pub symbols: SymbolState,
     pub user_mode: bool,
+    /// The PE `TimeDateStamp`. With [`Self::size`] it is what a symbol server is keyed by, and
+    /// what says whether an image somewhere else is *this* image — see
+    /// [`docs/coordinates.md`](https://github.com/glslang/windbg-mcp/blob/main/docs/coordinates.md).
     pub timestamp: u32,
     pub checksum: u32,
+    /// Which **PDB** the engine has for this module, when it has one.
+    ///
+    /// The image is identified by [`Self::timestamp`] + [`Self::size`]; its symbols are identified
+    /// by a different pair, and this is it. Absent for a module whose `symbols` is anything but
+    /// `pdb` — this reports what the engine *has*, and a deferred module has nothing until
+    /// something makes it look. That is not "this module has no PDB".
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pdb: Option<PdbInfo>,
     /// True for a module that has **unloaded** — the rows in [`ModuleList::unloaded`], where
     /// `start`/`end` are where the image *was*. Carried on the row as well as by which list it is
     /// in, from the engine's own flag, so a record that has been lifted out of that list still
     /// says so. Absent from the JSON when false, which is every ordinary module.
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub unloaded: bool,
+}
+
+/// The identity of a module's PDB, in the form a symbol server is keyed by.
+///
+/// Here so that a client on another machine can fetch the **exact** symbols this engine resolved
+/// without first fetching the image. The identity is recoverable from the image's own debug
+/// directory, so this saves a download rather than enabling something otherwise impossible — and
+/// it lets a caller check the PDB it already holds is the right one, which the image cannot do.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct PdbInfo {
+    /// The signature as a symbol server path spells it: 32 uppercase hex digits, no braces and no
+    /// dashes. Not the form a GUID is usually printed in.
+    pub guid: String,
+    /// The age. Note it is appended to the GUID **in hex**, which [`Self::key`] has already done.
+    pub age: u32,
+    /// The path segment those two make — `<guid><age>`, the middle element of
+    /// `<pdb>/<key>/<pdb>`. Carried already-built because assembling it is one line and getting it
+    /// wrong (the age in decimal) produces a URL that 404s, which is a hard failure to read
+    /// backwards.
+    pub key: String,
+    /// Whether the engine matched a PDB it then found does **not** belong to this image. Symbols
+    /// read from it are another build's names, so this is a reason to distrust every symbol on
+    /// this module rather than a detail. Absent from the JSON when false.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub unmatched: bool,
+}
+
+impl From<win_kexp::dbgeng::PdbIdentity> for PdbInfo {
+    fn from(pdb: win_kexp::dbgeng::PdbIdentity) -> Self {
+        Self {
+            key: format!("{}{:X}", pdb.guid, pdb.age),
+            guid: pdb.guid,
+            age: pdb.age,
+            unmatched: pdb.unmatched,
+        }
+    }
 }
 
 /// How much symbol information the engine has for a module.
@@ -698,6 +745,9 @@ impl From<&win_kexp::dbgeng::Module> for ModuleInfo {
             user_mode: module.user_mode,
             timestamp: module.timestamp,
             checksum: module.checksum,
+            // Filled in by the caller for the modules that have symbols: it is a second question
+            // asked of the engine, and a conversion from a value it already holds cannot ask one.
+            pdb: None,
             unloaded: module.unloaded,
         }
     }
@@ -2294,6 +2344,48 @@ mod tests {
     /// then reads the field correctly until the first target that reports something new — which
     /// is the worst possible moment to change shape. Both are tagged and flattened instead, so
     /// the field stays a string and the unnamed code arrives beside it.
+    /// The wire contract of a PDB identity, which is four separate chances to produce a URL that
+    /// 404s: the GUID's spelling, the age in **hex** rather than decimal, the two concatenated in
+    /// that order, and `unmatched` appearing only when it is true.
+    ///
+    /// Offline, and next to the type, because the smoke tier can only assert this against whatever
+    /// PDB a host happens to have resolved — and an age of 1 hides the hex/decimal confusion
+    /// completely, which is exactly the value a real `nt` reports.
+    #[test]
+    fn a_pdb_identity_is_spelled_the_way_a_symbol_server_path_is() {
+        let identity = |age, unmatched| {
+            serde_json::to_value(PdbInfo::from(win_kexp::dbgeng::PdbIdentity {
+                guid: "FE3F58BDA39D2FC13C370618D1DBDF22".into(),
+                age,
+                unmatched,
+                file: r"c:\symbols\ntkrnlmp.pdb".into(),
+            }))
+            .expect("serializes")
+        };
+
+        // Age 26 is 0x1A: decimal and hex differ, which age 1 cannot show.
+        let twenty_six = identity(26, false);
+        assert_eq!(twenty_six["guid"], "FE3F58BDA39D2FC13C370618D1DBDF22");
+        assert_eq!(twenty_six["age"], 26);
+        assert_eq!(
+            twenty_six["key"], "FE3F58BDA39D2FC13C370618D1DBDF221A",
+            "the key appends the age in hex, not decimal"
+        );
+        assert!(
+            twenty_six.get("unmatched").is_none(),
+            "the ordinary case carries no flag: {twenty_six}"
+        );
+
+        assert_eq!(
+            identity(1, true)["unmatched"],
+            true,
+            "a PDB that does not belong to the image has to say so"
+        );
+        // The local path the engine loaded is not on the wire: it is a fact about the debugger's
+        // filesystem, and this record is for a client somewhere else.
+        assert!(identity(1, false).get("file").is_none());
+    }
+
     #[test]
     fn a_named_state_is_a_string_whether_or_not_it_is_one_we_know() {
         let module = |symbols| {
@@ -2308,6 +2400,7 @@ mod tests {
                 user_mode: false,
                 timestamp: 0,
                 checksum: 0,
+                pdb: None,
                 unloaded: false,
             })
             .expect("serializes")

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -1465,6 +1465,36 @@ fn registers(e: &DebugEngine, all: bool) -> Result<Output, Failed> {
     ))
 }
 
+/// A module row with the PDB identity the engine has for it, where it has one.
+///
+/// **One helper for the listing and the opener's summary**, because `TargetSummary::primary_module`
+/// documents itself as exactly the row `modules` returns — and enriching only one of them made
+/// that false, which is a promise breaking rather than a field missing.
+///
+/// **Asked only of the modules the engine has already resolved.** A listing is two hundred rows and
+/// this is a call into the engine per row, so it is asked where the answer will not be empty. Both
+/// PDB-backed states count: `pdb` is the ordinary one, and `dia` is the same PDB reached through
+/// the Debug Interface Access API, which resolves an identity just as well.
+///
+/// A failure costs this one field. A listing must not fail over the provenance of the symbols it
+/// is listing.
+fn with_pdb_identity(
+    e: &DebugEngine,
+    module: &win_kexp::dbgeng::Module,
+    mut info: structured::ModuleInfo,
+) -> structured::ModuleInfo {
+    use win_kexp::dbgeng::SymbolKind;
+    if matches!(module.symbols, SymbolKind::Pdb | SymbolKind::Dia) {
+        match e.module_pdb(module.base) {
+            Ok(pdb) => info.pdb = pdb.map(structured::PdbInfo::from),
+            Err(why) => {
+                tracing::debug!("worker: no PDB identity for {}: {why}", info.listed_name());
+            }
+        }
+    }
+    info
+}
+
 /// The modules, as values and as a listing rendered **from those same values** — optionally
 /// narrowed to the ones whose name matches a pattern.
 ///
@@ -1497,12 +1527,13 @@ fn modules(e: &DebugEngine, filter: Option<&str>) -> Result<Output, Failed> {
     let narrow = |modules: &[win_kexp::dbgeng::Module]| -> Vec<structured::ModuleInfo> {
         modules
             .iter()
-            .map(structured::ModuleInfo::from)
-            .filter(|module| {
+            .map(|module| (structured::ModuleInfo::from(module), module))
+            .filter(|(info, _)| {
                 pattern
                     .as_deref()
-                    .is_none_or(|pattern| matches_module_pattern(pattern, module.listed_name()))
+                    .is_none_or(|pattern| matches_module_pattern(pattern, info.listed_name()))
             })
+            .map(|(info, module)| with_pdb_identity(e, module, info))
             .collect()
     };
     let (matched, matched_unloaded) = (narrow(&loaded), narrow(&unloaded));
@@ -3972,7 +4003,13 @@ fn target_summary(e: &DebugEngine) -> structured::TargetSummary {
         primary_module: modules
             .as_deref()
             .and_then(|modules| primary_module(modules, kernel_mode))
-            .map(|module| Box::new(structured::ModuleInfo::from(module))),
+            .map(|module| {
+                Box::new(with_pdb_identity(
+                    e,
+                    module,
+                    structured::ModuleInfo::from(module),
+                ))
+            }),
         // `Ok(None)` is the target that did not bug check, and `Err` is the target that has no
         // bug check data to read at all (user mode). Both are simply "no bug check here".
         bug_check: e

--- a/tests/golden/tool_budget.json
+++ b/tests/golden/tool_budget.json
@@ -6,8 +6,8 @@
       "inputSchema": 904,
       "modelVisible": 2001,
       "name": "attach_kernel",
-      "outputSchema": 11093,
-      "wire": 13248
+      "outputSchema": 13323,
+      "wire": 15478
     },
     {
       "annotations": 122,
@@ -15,8 +15,8 @@
       "inputSchema": 33,
       "modelVisible": 330,
       "name": "attach_kernel_local",
-      "outputSchema": 11093,
-      "wire": 11576
+      "outputSchema": 13323,
+      "wire": 13806
     },
     {
       "annotations": 117,
@@ -24,8 +24,8 @@
       "inputSchema": 204,
       "modelVisible": 499,
       "name": "attach_process",
-      "outputSchema": 11093,
-      "wire": 11740
+      "outputSchema": 13323,
+      "wire": 13970
     },
     {
       "annotations": 68,
@@ -222,8 +222,8 @@
       "inputSchema": 229,
       "modelVisible": 542,
       "name": "launch",
-      "outputSchema": 11093,
-      "wire": 11795
+      "outputSchema": 13323,
+      "wire": 14025
     },
     {
       "annotations": 65,
@@ -231,8 +231,8 @@
       "inputSchema": 1383,
       "modelVisible": 2112,
       "name": "modules",
-      "outputSchema": 8341,
-      "wire": 10549
+      "outputSchema": 10571,
+      "wire": 12779
     },
     {
       "annotations": 128,
@@ -240,8 +240,8 @@
       "inputSchema": 211,
       "modelVisible": 712,
       "name": "open_dump",
-      "outputSchema": 11093,
-      "wire": 11964
+      "outputSchema": 13323,
+      "wire": 14194
     },
     {
       "annotations": 114,
@@ -249,8 +249,8 @@
       "inputSchema": 211,
       "modelVisible": 534,
       "name": "open_trace",
-      "outputSchema": 11093,
-      "wire": 11772
+      "outputSchema": 13323,
+      "wire": 14002
     },
     {
       "annotations": 123,
@@ -466,10 +466,10 @@
     "inputSchema": 40204,
     "instructions": 3163,
     "modelVisible": 67613,
-    "outputSchema": 301626,
-    "payload": 376099,
+    "outputSchema": 317236,
+    "payload": 391709,
     "tools": 51,
-    "wire": 375981,
+    "wire": 391591,
     "worstTool": "debug_batch",
     "worstToolModelVisible": 9757
   }

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -1341,14 +1341,20 @@ fn budget_report(result: &Value, instructions: &str) -> Value {
 const MODEL_VISIBLE_CEILING: usize = 76_000;
 
 /// Ceiling on the whole `tools/list` payload — the serialized result, not the sum of its tools, so
-/// the array's own punctuation and every result-level field are inside it. 376,099 bytes today,
+/// the array's own punctuation and every result-level field are inside it. 391,709 bytes today,
 /// ~80% of that `outputSchema` no model reads, which is why this is a separate and much looser
 /// number rather than a scaled version of the one above.
 ///
 /// It is a client-side parse and memory cost, and it is the one that grows silently: `schemars`
 /// inlines `$defs` per tool, so adding one shared type to one more output shape can add tens of
 /// kilobytes here while [`MODEL_VISIBLE_CEILING`] does not move.
-const WIRE_CEILING: usize = 412_000;
+///
+/// **Raised from 412,000 once**, when `PdbInfo` — one optional four-field type on `ModuleInfo` —
+/// cost 15,610 B of wire and nothing at all of model context, because `ModuleInfo` is embedded in
+/// half a dozen output shapes and each inlines its own copy. That is `FOLLOWUPS.md` item 24's
+/// first finding priced, and it is recorded in `docs/token-budget.md` rather than absorbed
+/// quietly: this number moving is the only warning that the duplication is compounding.
+const WIRE_CEILING: usize = 460_000;
 
 /// Ceiling on any single tool's model-visible definition. `debug_batch` is the worst at 9,757
 /// bytes, because its `inputSchema` pulls the whole `StepAction`/`Check` vocabulary from
@@ -3324,6 +3330,43 @@ fn a_dump_session_opens_reads_and_closes() {
                      {from_backtrace}"
                 );
             }
+        }
+
+        // The *other* half of the coordinate: which build, and which symbols for it. Its own
+        // premise — reading a target and *resolving* its symbols fail apart, and `pdb` is
+        // documented as absent for a module whose symbols are still deferred, so asserting it on
+        // a host that reads memory and resolves nothing would report a contract as a regression.
+        if engine_resolves_kernel_symbols(&mut server, &session_id) {
+            let nt = nt_module(&mut server, &session_id).expect("nt is in the module list");
+            let pdb = &nt["pdb"];
+            assert!(
+                !pdb.is_null(),
+                "a module whose symbols resolved has a PDB identity to report: {nt}"
+            );
+            let guid = pdb["guid"]
+                .as_str()
+                .unwrap_or_else(|| panic!("`guid` is a string: {pdb}"));
+            assert!(
+                guid.len() == 32
+                    && guid
+                        .chars()
+                        .all(|c| c.is_ascii_hexdigit() && !c.is_lowercase()),
+                "a PDB GUID is spelled as a symbol server path spells it — 32 uppercase hex \
+                 digits, no braces, no dashes: {pdb}"
+            );
+            // The key is what a caller pastes into `<pdb>/<key>/<pdb>`, and the age goes in
+            // **hex**. Read strictly rather than defaulted: a missing `age` defaulted to zero
+            // would agree with a key built from zero, and the schema regression would pass.
+            let age = pdb["age"]
+                .as_u64()
+                .unwrap_or_else(|| panic!("`age` is a number: {pdb}"));
+            assert_eq!(
+                pdb["key"].as_str().unwrap_or_default(),
+                format!("{guid}{age:X}"),
+                "the key is the guid and the age in hex: {pdb}"
+            );
+        } else {
+            skip(NO_KERNEL_SYMBOLS_SKIP);
         }
 
         // The same coordinate, from the third tool that computes one. `disassemble` with no


### PR DESCRIPTION
`win-kexp` is merged and the pin points at
[`ef8e4cb`](https://github.com/glslang/win-kexp/commit/ef8e4cb3e29c7314bce1bf34655068388dcb36c2) on
`main`. Re-verified against that pin rather than the branch it was developed on.

The last piece of phase 2's coordinate work, and it comes with the doc that motivated it.

An image was already identified: `timestamp` + `size` on every `modules` row is the pair a symbol
server is keyed by. [`docs/coordinates.md`](docs/coordinates.md) — new here — walks that end to
end, with real numbers: from those two integers a Mac that had never seen the target fetched a
byte-identical `ntkrnlmp.exe`, confirmed both fields against the PE header, and resolved a
`crash_triage` frame's RVA to `KeBugCheckEx` in the export table at exactly the entry its
displacement predicted. All four instruction encodings `disassemble` reported matched the file
byte-for-byte. **No proxy, no upstream call** — which is what section 06 of the plan predicted.

What that exercise found is that only *exported* frames resolve from the image alone. The internal
ones need the PDB, which is keyed by a different pair — GUID + age — that nothing reported. This
adds it.

## What `modules` now carries

```json
{ "name": "nt", "symbols": "pdb",
  "pdb": { "guid": "FE3F58BDA39D2FC13C370618D1DBDF22", "age": 1,
           "key": "FE3F58BDA39D2FC13C370618D1DBDF221" } }
```

- **`key` is carried already-built** — the middle element of `<pdb>/<key>/<pdb>` — because the age
  goes in **hex**, and getting that wrong produces a URL that 404s.
- **Absent when `symbols` is `deferred`**, which on a freshly opened dump is nearly all modules,
  and asked for only where the engine has already said there is one: a listing is two hundred rows
  and this is a call into the engine per row. The field means "the PDB this engine has", not "the
  PDB that exists".
- **`unmatched`** means the engine loaded a PDB that does not belong to the image, so every symbol
  on that module is another build's names.

**Scoped honestly**: this saves a download rather than enabling something otherwise impossible. The
same identity is in the image's own debug directory, so a client that fetched the image can read it
there. What it adds is skipping that fetch, and being able to check a PDB you already hold is the
right one — which the image cannot do. The acceptance test established that ordering before this
was written, and the doc says so.

## Two things worth keeping from building it

**Do not copy a not-found mapping between calls.** `module_at` treats `E_INVALIDARG` as "no module
holds this offset" because that is measurably what the engine means there; reusing it here would
have turned a broken call into a believable claim about the target.

**One small type cost 15,610 B of wire and no model context at all.** `ModuleInfo` is embedded in
the openers' summary, in `modules` and in the allocator shapes, and `schemars` inlines `PdbInfo`
into every one. That is `FOLLOWUPS.md` item 24's first finding with a price on it. `WIRE_CEILING`
moves 412,000 → 460,000 with the reason recorded in `docs/token-budget.md` rather than absorbed
quietly, because that number moving is the only warning the duplication is compounding.

This PR also corrects `disassemble`'s row in `docs/token-budget.md`, which was measured before
#157's own review redesigned it and has been 210 B light ever since.

## Testing

ARM64 bench: clippy clean, `cargo test --bins` **450 passed**,
`WINDBG_MCP_SMOKE_DUMP=1 cargo test --test mcp_smoke -- --test-threads=1` **61 passed / 0 failed /
12 ignored**. The debugger tier asserts the GUID's spelling and that `key` is the GUID with the age
in hex — the composition whose failure mode is a 404.

Verified by hand against the sample dump: `nt` reports the same GUID and age that `!lmi nt` prints
and that the engine's own symbol cache path uses, which is the key that fetched the correct PDB in
the doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Module listings now include PDB identity details for resolved symbols, including GUID, age, symbol-server key, and unmatched status.
  - Symbol metadata remains omitted when symbol resolution is deferred.

- **Documentation**
  - Added guidance on portable module coordinates, symbol lookup, image verification, crash-frame correlation, and common address pitfalls.
  - Expanded module result documentation with timestamps and symbol information.

- **Chores**
  - Updated supporting diagnostics and output-size limits to accommodate the additional metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
