### PR TITLE
Stop paying for instructions the client throws away

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,7 +125,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **The server instructions now fit what the client reads.** They were 3,147 characters against a
   measured 2,048-character limit, so 1,099 were paid for on every connection and discarded — and
   what fell off the end was the `debug_batch` paragraph, the one instruction there that stops a
-  mutation being left half-applied. Rewritten to 1,996 characters with that guidance inside the
+  mutation being left half-applied. Rewritten to 1,990 characters with that guidance inside the
   budget, kept ASCII so the character and byte counts cannot diverge, and asserted in the protocol
   tier so it cannot grow back unnoticed.
 
@@ -146,7 +146,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   which the same document establishes no model reads. The real model-visible figure was 4,695 B.
   Both the item and [`docs/token-budget.md`](./docs/token-budget.md) are corrected, and the doc
   gains the finding that measurement actually supports — five tools carry a third of the surface,
-  in their *input* schemas, `debug_batch` alone being 15% of it.
+  in their *input* schemas, `debug_batch` alone being 15% of it. The `session_id` wording also gained
+  back what an earlier draft of it dropped: a handle is refused when the target was **replaced** by a
+  raw command, not only when the session closed, and the README explains the asymmetry that makes
+  that guarantee worth having — a retired session refuses its handle while still answering a call
+  that names none.
 
 - **`modules` reports which PDB the engine has for a module** — `guid`, `age`, and the `key` those
   two make, which is the middle element of a symbol server's `<pdb>/<key>/<pdb>` path. It completes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **The server instructions now fit what the client reads.** They were 3,147 characters against a
+  measured 2,048-character limit, so 1,099 were paid for on every connection and discarded — and
+  what fell off the end was the `debug_batch` paragraph, the one instruction there that stops a
+  mutation being left half-applied. Rewritten to 1,996 characters with that guidance inside the
+  budget, kept ASCII so the character and byte counts cannot diverge, and asserted in the protocol
+  tier so it cannot grow back unnoticed.
+
+- **One wording for `session_id`, on every tool that takes one.** It was documented three different
+  ways across 26 tools and not at all on five (`heap_list`, `heap_allocations`, `heap_chunk`,
+  `heap_census`, `heap_diagnostics`), where a caller had no way to know what to pass.
+  `server_log`'s keeps its own wording, because there the field filters records rather than routing
+  a call — a different question that deserves a different sentence.
+
+  The wording also now says what the field *does*. All three originals described only the staleness
+  guard — "pass it to refuse the call if the target has been replaced" — which is the consequence,
+  not the behaviour: the field is a **router**, and omitting it sends the call to the current
+  session, which with several open is not necessarily the one you were last using. That makes this
+  half close to byte-neutral, and the instructions are where the surface actually moves: 67,613 B to
+  **67,076 B** model-visible, plus 1,167 B of instruction text that was being sent and discarded. That is smaller
+  than [`FOLLOWUPS.md`](./FOLLOWUPS.md) item 24 predicted for the `session_id` half, and the reason
+  is worth recording: the 9,514 B that bullet claimed had counted the copies inside `outputSchema`,
+  which the same document establishes no model reads. The real model-visible figure was 4,695 B.
+  Both the item and [`docs/token-budget.md`](./docs/token-budget.md) are corrected, and the doc
+  gains the finding that measurement actually supports — five tools carry a third of the surface,
+  in their *input* schemas, `debug_batch` alone being 15% of it.
+
 - **`modules` reports which PDB the engine has for a module** — `guid`, `age`, and the `key` those
   two make, which is the middle element of a symbol server's `<pdb>/<key>/<pdb>` path. It completes
   the coordinate work: the image was already identified by `timestamp` + `size`, and its *symbols*

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -740,7 +740,7 @@ landed on their own so that each of the items below can be argued, and measured,
   channel it is claimed for is not a finding, which is worth remembering for the rest of this list.
 - **The instructions overran what the client reads** — **done**. 3,147 chars sent against 2,048
   read, so the `debug_batch` paragraph — the one instruction that stops a mutation being left
-  half-applied — was charged for on every connection and discarded. Now 1,996 chars with that
+  half-applied — was charged for on every connection and discarded. Now 1,990 chars with that
   guidance inside the budget, ASCII so characters and bytes cannot diverge, and asserted in the
   protocol tier.
 - **`registers` returns 15.9x more JSON than its own text** (9,804 B vs 618 B), because every row
@@ -748,9 +748,9 @@ landed on their own so that each of the items below can be argued, and measured,
   answer this server gives at 53,875 B. The ratio rule in `tool_results_stay_within_their_budget`
   stops this spreading; it does not fix these two.
 - **Five tools are a third of the model-visible surface**, and it is their input schemas:
-  `debug_batch` 9,728 B (7,962 of it the `StepAction`/`Check` vocabulary), `walk_memory` 4,058,
-  `crash_triage` 2,894, `reachable_from_dispatch` 2,610, `server_log` 2,599 — 21,889 B against a
-  median tool of 882 B. This is where the weight actually is, and unlike the items above it is not
+  `debug_batch` 9,746 B (7,980 of it the `StepAction`/`Check` vocabulary), `walk_memory` 4,076,
+  `crash_triage` 2,912, `reachable_from_dispatch` 2,628, `server_log` 2,599 — 21,961 B against a
+  median tool of 900 B. This is where the weight actually is, and unlike the items above it is not
   waste but one tool honestly describing a rich argument. The levers are design choices: a smaller
   step vocabulary, a `$ref` the client resolves, or a surface that does not offer every tool to
   every caller.

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -730,15 +730,30 @@ landed on their own so that each of the items below can be argued, and measured,
   costs the same again, and fixing this item is what stops that.
 - **Six openers carry a byte-identical 11,093 B output schema**, six step tools a byte-identical
   4,418 B one. 77,555 B of the above, and the cheapest to collapse.
-- **`session_id` is documented 43 times in three wordings** (222 B ×22, 292 B ×15, 41 B ×5) —
-  9,514 B, and this one *is* model-visible. The repetition is deliberate (`src/server.rs:1356`);
-  the three different wordings are not, and one short shared wording costs nothing to adopt.
-- **The instructions overrun what the client reads** — 3,147 chars sent, truncated at 2,048. The
-  1,099 chars that never arrive are where `debug_batch` and `reachable_from_dispatch` are explained.
+- **`session_id` was documented in three wordings** — **done**, and the figure in this bullet was
+  wrong. It counted the copies inside `outputSchema`, which no model reads; the model-visible total
+  was 4,695 B across 32 fields, not 9,514 across 43. One shared wording — plus documenting the five
+  heap tools whose `session_id` had none at all — moved the surface **−537 B**. Review then found
+  that all three original wordings described only the staleness guard and not the field's actual
+  job, which is routing, so the corrected wording gives most of that back: a right description of
+  two behaviours is not shorter than a wrong description of one. A number not measured in the
+  channel it is claimed for is not a finding, which is worth remembering for the rest of this list.
+- **The instructions overran what the client reads** — **done**. 3,147 chars sent against 2,048
+  read, so the `debug_batch` paragraph — the one instruction that stops a mutation being left
+  half-applied — was charged for on every connection and discarded. Now 1,996 chars with that
+  guidance inside the budget, ASCII so characters and bytes cannot diverge, and asserted in the
+  protocol tier.
 - **`registers` returns 15.9x more JSON than its own text** (9,804 B vs 618 B), because every row
   carries `"kind":"int"` and `"subregister":false`. `modules` is 2.7x and is the largest single
   answer this server gives at 53,875 B. The ratio rule in `tool_results_stay_within_their_budget`
   stops this spreading; it does not fix these two.
+- **Five tools are a third of the model-visible surface**, and it is their input schemas:
+  `debug_batch` 9,728 B (7,962 of it the `StepAction`/`Check` vocabulary), `walk_memory` 4,058,
+  `crash_triage` 2,894, `reachable_from_dispatch` 2,610, `server_log` 2,599 — 21,889 B against a
+  median tool of 882 B. This is where the weight actually is, and unlike the items above it is not
+  waste but one tool honestly describing a rich argument. The levers are design choices: a smaller
+  step vocabulary, a `$ref` the client resolves, or a surface that does not offer every tool to
+  every caller.
 - **`modules` has neither a `limit` nor a cap**, alone among the high-volume tools. Everything else
   uncapped is raw debugger text — `ttd_calls`, `ttd_memory`, `threads`,
   `execute`, `dx`, `ioctl_trace`, `reachable_from_dispatch` — and `read_memory` returns up to

--- a/README.md
+++ b/README.md
@@ -368,6 +368,13 @@ terminated, and a terminated kernel session leaves its target halted.
 Omit `session_id` and a call goes to the **current** session: the most recently opened one that will
 still accept work. That is the pre-handle behaviour and it still holds. What supplying the id buys
 is that the call can never land on a target you did not open — it fails loudly instead.
+
+The asymmetry is worth knowing, because it is where the guarantee earns its keep. A raw `execute`
+that replaces or releases the target (`.opendump`, `.attach`, `.detach`) leaves the session
+**retired**: a call naming its handle is refused, while a call naming nothing is still routed there,
+because the worker is genuinely the server's current target and a caller who asked for no guarantee
+gets what is in front of them. So omitting the id is not merely "whatever is current" — it is also
+"whatever that target has since become".
 `decode_ioctl` (pure) and `record_trace` (independent of any debug session) do not take one.
 
 `session_status` lists every session — what it is, what state it is in, how long it has been there,

--- a/docs/token-budget.md
+++ b/docs/token-budget.md
@@ -7,7 +7,7 @@ answer this server returns. That makes payload size a correctness-adjacent prope
 call that spends 13k tokens has not failed, but it has taken the space the investigation needed.
 Nothing measured this until [`tests/mcp_smoke.rs`](../tests/mcp_smoke.rs) grew the two tests below,
 and the numbers turned out to be larger than anyone had guessed — a careful reading of the source
-put the tool surface at 90–130 KB, and the wire is 392 KB.
+put the tool surface at 90–130 KB, and the wire is 391 KB.
 
 ## Two costs, and they are not the same
 
@@ -61,15 +61,15 @@ authority — the tables below are a reading of it at the time of writing.
 
 | Component | Bytes | Reaches the model |
 |---|---:|---|
-| **Whole `tools/list` payload** | **391,709** | partly |
-| — the 51 tools themselves | 391,591 | partly |
+| **Whole `tools/list` payload** | **391,172** | partly |
+| — the 51 tools themselves | 391,054 | partly |
 | — result-level fields (`resultType`, `ttlMs`, `cacheScope`) | 118 | no |
 | `outputSchema` (the 33 tools that have one) | 317,236 | no |
-| `inputSchema` (all 51) | 40,204 | yes |
+| `inputSchema` (all 51) | 39,667 | yes |
 | `description` (all 51) | 24,752 | yes |
 | `annotations` | 5,449 | no |
-| **Model-visible total** | **67,613** (~16k tokens) | — |
-| `initialize` instructions | 3,163 | yes, first 2,048 chars |
+| **Model-visible total** | **67,076** (~16k tokens) | — |
+| `initialize` instructions | 1,996 | yes, **all of it** |
 
 Worst single tool: `debug_batch` at 9,757 model-visible bytes, because its `inputSchema` pulls the
 whole `StepAction`/`Check` vocabulary out of `src/batch.rs`.
@@ -81,8 +81,8 @@ server at two revisions shows what a sum would miss:
 
 | Revision | payload | sum of tools | result-level |
 |---|---:|---:|---|
-| `2026-07-28` | 391,709 | 391,591 | `resultType`, `ttlMs`, `cacheScope` |
-| `2025-06-18` | 391,653 | 391,591 | none |
+| `2026-07-28` | 391,172 | 391,054 | `resultType`, `ttlMs`, `cacheScope` |
+| `2025-06-18` | 391,116 | 391,054 | none |
 
 The sum is **identical** across the two; only the payload figure can tell them apart. The golden
 records both, so the gap stays visible.
@@ -134,13 +134,31 @@ None of these is a bug. They are recorded because they were invisible, and
 
 2. **Whole schemas repeat.** The six openers carry a byte-identical 11,093 B output schema; the six
    step tools a byte-identical 4,418 B one. 77,555 B of the above.
-3. **`session_id` is documented 43 times, in three different wordings** (222 B ×22, 292 B ×15,
-   41 B ×5) — 9,514 B, and unlike the two above this one *is* model-visible. The repetition is
-   deliberate (`src/server.rs:1356`: flattening "renders as a schema composition that clients
-   handle unevenly"); the three wordings are not.
-4. **The instructions overrun what the client reads.** 3,147 chars sent, truncated at 2,048 — the
-   last 1,099 chars, which is where `debug_batch` and `reachable_from_dispatch` are explained, are
-   paid for and never seen.
+3. **`session_id` was documented in three different wordings** — **fixed**, and the original figure
+   here was wrong in an instructive way. It said 9,514 B across 43 sites; the model-visible total was
+   **4,695 B across 32**, because the count had included the copies inside `outputSchema`, which the
+   table two sections up says no model reads. Unifying the wording — and documenting the five heap
+   tools whose `session_id` had *no* description at all — moved the model-visible surface by
+   **−537 B**, not the ~9 KB this bullet implied.
+
+   Most of even that is explained by a second correction, from review. All three original wordings
+   described only the staleness guard ("pass it to refuse the call if the target has been replaced"),
+   which is the *consequence*. The field is a **router**: omitted, the call goes to the current
+   session — the newest still open — and a handle sends it to that one. Unifying on the old phrasing
+   would have propagated a description implying omission is safe when several sessions are open,
+   which is precisely when it is not. A correct description of two behaviours is not shorter than an
+   incomplete description of one, so this half is close to byte-neutral by construction. The
+   repetition itself stays deliberate (`src/server.rs`: flattening "renders as a schema composition
+   that clients handle unevenly").
+
+   The lesson is the one this whole document exists for: a number that has not been measured in the
+   channel it is claimed for is not a finding. The weight is elsewhere — see finding 8.
+4. **The instructions overran what the client reads** — **fixed**. 3,147 chars were sent and 2,048
+   read, so 1,099 were paid for on every connection and discarded, and what fell off the end was the
+   `debug_batch` paragraph: the one instruction there that stops a mutation being left half-applied.
+   Rewritten to 1,996 characters with the batch guidance inside the budget, kept ASCII so the
+   character and byte counts cannot diverge, and pinned by an assertion in the protocol tier so it
+   cannot grow back unnoticed.
 5. **`modules` has neither a `limit` nor a cap**, alone among the high-volume tools. 53,875 B here;
    more on a live kernel.
 6. **Several tools have no bound at all** — `ttd_calls`, `ttd_memory`, `threads`,
@@ -153,6 +171,17 @@ None of these is a bug. They are recorded because they were invisible, and
    own text, because every row carries `"kind":"int"` and `"subregister":false`. This is the one
    finding that is purely model-visible and purely this server's to fix, and it is what the ratio
    rule below exists to stop spreading.
+8. **Five tools are a third of the model-visible surface**, and it is their *input* schemas rather
+   than their prose. `debug_batch` alone is 9,728 B — 15% of everything a model is given before it
+   asks anything — of which 7,962 B is the `StepAction`/`Check` vocabulary its schema pulls out of
+   `src/batch.rs`. Then `walk_memory` 4,058, `crash_triage` 2,894, `reachable_from_dispatch` 2,610,
+   `server_log` 2,599: **21,889 B, 33%**, against a median tool of 882 B.
+
+   This is where the weight is, and it is a different kind of problem from findings 1–4. Those were
+   duplication and waste — the same string paid for repeatedly, or a tail nobody reads. This is one
+   tool honestly describing a rich argument, and the levers are real design choices: a smaller step
+   vocabulary, a `$ref` the client resolves, or a tool surface that does not offer every tool to
+   every caller. Worth measuring before choosing, which is what this table is for.
 
 One interaction worth flagging before acting on any of it: `FOLLOWUPS.md` item 11 proposes *adding*
 `structuredContent` to `ttd_calls`, `ttd_memory` and `driver_object` — three of the highest-volume

--- a/docs/token-budget.md
+++ b/docs/token-budget.md
@@ -156,7 +156,7 @@ None of these is a bug. They are recorded because they were invisible, and
 4. **The instructions overran what the client reads** — **fixed**. 3,147 chars were sent and 2,048
    read, so 1,099 were paid for on every connection and discarded, and what fell off the end was the
    `debug_batch` paragraph: the one instruction there that stops a mutation being left half-applied.
-   Rewritten to 1,996 characters with the batch guidance inside the budget, kept ASCII so the
+   Rewritten to 1,990 characters with the batch guidance inside the budget, kept ASCII so the
    character and byte counts cannot diverge, and pinned by an assertion in the protocol tier so it
    cannot grow back unnoticed.
 5. **`modules` has neither a `limit` nor a cap**, alone among the high-volume tools. 53,875 B here;
@@ -172,10 +172,10 @@ None of these is a bug. They are recorded because they were invisible, and
    finding that is purely model-visible and purely this server's to fix, and it is what the ratio
    rule below exists to stop spreading.
 8. **Five tools are a third of the model-visible surface**, and it is their *input* schemas rather
-   than their prose. `debug_batch` alone is 9,728 B — 15% of everything a model is given before it
-   asks anything — of which 7,962 B is the `StepAction`/`Check` vocabulary its schema pulls out of
-   `src/batch.rs`. Then `walk_memory` 4,058, `crash_triage` 2,894, `reachable_from_dispatch` 2,610,
-   `server_log` 2,599: **21,889 B, 33%**, against a median tool of 882 B.
+   than their prose. `debug_batch` alone is 9,746 B — 15% of everything a model is given before it
+   asks anything — of which 7,980 B is the `StepAction`/`Check` vocabulary its schema pulls out of
+   `src/batch.rs`. Then `walk_memory` 4,076, `crash_triage` 2,912, `reachable_from_dispatch` 2,628,
+   `server_log` 2,599: **21,961 B, 33%**, against a median tool of 900 B.
 
    This is where the weight is, and it is a different kind of problem from findings 1–4. Those were
    duplication and waste — the same string paid for repeatedly, or a tail nobody reads. This is one

--- a/src/server.rs
+++ b/src/server.rs
@@ -1475,8 +1475,8 @@ pub(crate) fn format_recipe(recipes: &[SegmentRecipe]) -> String {
 /// Parameters for tools that take no arguments beyond the session handle.
 #[derive(Deserialize, JsonSchema)]
 pub struct SessionArgs {
-    /// Which session to act on. Omit for the current one — the newest still open. Pass an
-    /// opener's handle to route to that session, refused if it has closed.
+    /// Which session to act on. Omit for the current one; pass an opener's handle to route to that
+    /// session and be refused if its target was replaced or closed.
     #[serde(default)]
     pub session_id: Option<String>,
 }
@@ -1520,8 +1520,8 @@ pub struct ModulesArgs {
     /// matcher.
     #[serde(default)]
     pub filter: Option<String>,
-    /// Which session to act on. Omit for the current one — the newest still open. Pass an
-    /// opener's handle to route to that session, refused if it has closed.
+    /// Which session to act on. Omit for the current one; pass an opener's handle to route to that
+    /// session and be refused if its target was replaced or closed.
     #[serde(default)]
     pub session_id: Option<String>,
 }
@@ -1534,8 +1534,8 @@ pub struct RegistersArgs {
     /// x64 that is several hundred entries — the `r` text is unaffected either way.
     #[serde(default)]
     pub all: Option<bool>,
-    /// Which session to act on. Omit for the current one — the newest still open. Pass an
-    /// opener's handle to route to that session, refused if it has closed.
+    /// Which session to act on. Omit for the current one; pass an opener's handle to route to that
+    /// session and be refused if its target was replaced or closed.
     #[serde(default)]
     pub session_id: Option<String>,
 }
@@ -1580,8 +1580,8 @@ pub struct CommandLineArgs {
 pub struct ExecuteArgs {
     /// Raw debugger command to run (e.g. "!analyze -v", "u rip", "dt nt!_EPROCESS").
     pub command: String,
-    /// Which session to act on. Omit for the current one — the newest still open. Pass an
-    /// opener's handle to route to that session, refused if it has closed.
+    /// Which session to act on. Omit for the current one; pass an opener's handle to route to that
+    /// session and be refused if its target was replaced or closed.
     #[serde(default)]
     pub session_id: Option<String>,
 }
@@ -1592,8 +1592,8 @@ pub struct ReadMemoryArgs {
     pub address: String,
     /// Number of bytes to read.
     pub size: u32,
-    /// Which session to act on. Omit for the current one — the newest still open. Pass an
-    /// opener's handle to route to that session, refused if it has closed.
+    /// Which session to act on. Omit for the current one; pass an opener's handle to route to that
+    /// session and be refused if its target was replaced or closed.
     #[serde(default)]
     pub session_id: Option<String>,
 }
@@ -1625,8 +1625,8 @@ pub struct WalkMemoryArgs {
     /// nothing beyond the links it already reports.
     #[serde(default)]
     pub fields: Option<Vec<walk::FieldArg>>,
-    /// Which session to act on. Omit for the current one — the newest still open. Pass an
-    /// opener's handle to route to that session, refused if it has closed.
+    /// Which session to act on. Omit for the current one; pass an opener's handle to route to that
+    /// session and be refused if its target was replaced or closed.
     #[serde(default)]
     pub session_id: Option<String>,
 }
@@ -1639,8 +1639,8 @@ pub struct DisassembleArgs {
     /// How many instructions to disassemble (default 16, maximum 128).
     #[serde(default)]
     pub count: Option<u32>,
-    /// Which session to act on. Omit for the current one — the newest still open. Pass an
-    /// opener's handle to route to that session, refused if it has closed.
+    /// Which session to act on. Omit for the current one; pass an opener's handle to route to that
+    /// session and be refused if its target was replaced or closed.
     #[serde(default)]
     pub session_id: Option<String>,
 }
@@ -1659,8 +1659,8 @@ const DEFAULT_DISASSEMBLE_COUNT: u32 = 16;
 pub struct DxArgs {
     /// Data-model (LINQ) expression, e.g. "@$cursession.TTD.Calls(\"ntdll!*\")".
     pub expression: String,
-    /// Which session to act on. Omit for the current one — the newest still open. Pass an
-    /// opener's handle to route to that session, refused if it has closed.
+    /// Which session to act on. Omit for the current one; pass an opener's handle to route to that
+    /// session and be refused if its target was replaced or closed.
     #[serde(default)]
     pub session_id: Option<String>,
 }
@@ -1669,8 +1669,8 @@ pub struct DxArgs {
 pub struct BreakpointArgs {
     /// Breakpoint location: symbol, address, or expression (e.g. "nt!NtCreateFile").
     pub expression: String,
-    /// Which session to act on. Omit for the current one — the newest still open. Pass an
-    /// opener's handle to route to that session, refused if it has closed.
+    /// Which session to act on. Omit for the current one; pass an opener's handle to route to that
+    /// session and be refused if its target was replaced or closed.
     #[serde(default)]
     pub session_id: Option<String>,
 }
@@ -1679,8 +1679,8 @@ pub struct BreakpointArgs {
 pub struct PositionArgs {
     /// TTD position to travel to, e.g. "12:0" or "0" for the start of the trace.
     pub position: String,
-    /// Which session to act on. Omit for the current one — the newest still open. Pass an
-    /// opener's handle to route to that session, refused if it has closed.
+    /// Which session to act on. Omit for the current one; pass an opener's handle to route to that
+    /// session and be refused if its target was replaced or closed.
     #[serde(default)]
     pub session_id: Option<String>,
 }
@@ -1707,8 +1707,8 @@ pub struct TtdCallsArgs {
     /// Function symbol or wildcard pattern to find calls to, e.g.
     /// "kernelbase!CreateFileW" or "ntdll!Nt*".
     pub function: String,
-    /// Which session to act on. Omit for the current one — the newest still open. Pass an
-    /// opener's handle to route to that session, refused if it has closed.
+    /// Which session to act on. Omit for the current one; pass an opener's handle to route to that
+    /// session and be refused if its target was replaced or closed.
     #[serde(default)]
     pub session_id: Option<String>,
 }
@@ -1723,8 +1723,8 @@ pub struct TtdMemoryArgs {
     /// Omit to report every access.
     #[serde(default)]
     pub mode: Option<String>,
-    /// Which session to act on. Omit for the current one — the newest still open. Pass an
-    /// opener's handle to route to that session, refused if it has closed.
+    /// Which session to act on. Omit for the current one; pass an opener's handle to route to that
+    /// session and be refused if its target was replaced or closed.
     #[serde(default)]
     pub session_id: Option<String>,
 }
@@ -1751,8 +1751,8 @@ pub struct SymbolPathArgs {
     /// force-load one module's symbols. Omit to reload all deferred modules.
     #[serde(default)]
     pub reload: Option<String>,
-    /// Which session to act on. Omit for the current one — the newest still open. Pass an
-    /// opener's handle to route to that session, refused if it has closed.
+    /// Which session to act on. Omit for the current one; pass an opener's handle to route to that
+    /// session and be refused if its target was replaced or closed.
     #[serde(default)]
     pub session_id: Option<String>,
 }
@@ -1774,8 +1774,8 @@ pub struct PoolFindTagArgs {
     /// Maximum rows to print (default 64).
     #[serde(default)]
     pub limit: Option<u32>,
-    /// Which session to act on. Omit for the current one — the newest still open. Pass an
-    /// opener's handle to route to that session, refused if it has closed.
+    /// Which session to act on. Omit for the current one; pass an opener's handle to route to that
+    /// session and be refused if its target was replaced or closed.
     #[serde(default)]
     pub session_id: Option<String>,
 }
@@ -1789,8 +1789,8 @@ pub struct PoolChunkArgs {
     /// Force a fresh walk instead of reusing this session's cached snapshot (default false).
     #[serde(default)]
     pub refresh: Option<bool>,
-    /// Which session to act on. Omit for the current one — the newest still open. Pass an
-    /// opener's handle to route to that session, refused if it has closed.
+    /// Which session to act on. Omit for the current one; pass an opener's handle to route to that
+    /// session and be refused if its target was replaced or closed.
     #[serde(default)]
     pub session_id: Option<String>,
 }
@@ -1803,8 +1803,8 @@ pub struct PoolCensusArgs {
     /// Maximum tags to print (default 40).
     #[serde(default)]
     pub limit: Option<u32>,
-    /// Which session to act on. Omit for the current one — the newest still open. Pass an
-    /// opener's handle to route to that session, refused if it has closed.
+    /// Which session to act on. Omit for the current one; pass an opener's handle to route to that
+    /// session and be refused if its target was replaced or closed.
     #[serde(default)]
     pub session_id: Option<String>,
 }
@@ -1821,8 +1821,8 @@ pub struct PoolDiagnosticsArgs {
     /// Force a fresh walk instead of reusing this session's cached snapshot (default false).
     #[serde(default)]
     pub refresh: Option<bool>,
-    /// Which session to act on. Omit for the current one — the newest still open. Pass an
-    /// opener's handle to route to that session, refused if it has closed.
+    /// Which session to act on. Omit for the current one; pass an opener's handle to route to that
+    /// session and be refused if its target was replaced or closed.
     #[serde(default)]
     pub session_id: Option<String>,
 }
@@ -1832,8 +1832,8 @@ pub struct HeapListArgs {
     /// Force a fresh snapshot instead of reusing the one cached for this stopped target.
     #[serde(default)]
     pub refresh: Option<bool>,
-    /// Which session to act on. Omit for the current one — the newest still open. Pass an
-    /// opener's handle to route to that session, refused if it has closed.
+    /// Which session to act on. Omit for the current one; pass an opener's handle to route to that
+    /// session and be refused if its target was replaced or closed.
     #[serde(default)]
     pub session_id: Option<String>,
 }
@@ -1875,8 +1875,8 @@ pub struct HeapAllocationsArgs {
     /// Maximum rows to return (default 64, maximum 2000).
     #[serde(default)]
     pub limit: Option<u32>,
-    /// Which session to act on. Omit for the current one — the newest still open. Pass an
-    /// opener's handle to route to that session, refused if it has closed.
+    /// Which session to act on. Omit for the current one; pass an opener's handle to route to that
+    /// session and be refused if its target was replaced or closed.
     #[serde(default)]
     pub session_id: Option<String>,
 }
@@ -1887,8 +1887,8 @@ pub struct HeapChunkArgs {
     pub address: String,
     #[serde(default)]
     pub refresh: Option<bool>,
-    /// Which session to act on. Omit for the current one — the newest still open. Pass an
-    /// opener's handle to route to that session, refused if it has closed.
+    /// Which session to act on. Omit for the current one; pass an opener's handle to route to that
+    /// session and be refused if its target was replaced or closed.
     #[serde(default)]
     pub session_id: Option<String>,
 }
@@ -1903,8 +1903,8 @@ pub struct HeapCensusArgs {
     /// Maximum groups to return (default 40, maximum 2000).
     #[serde(default)]
     pub limit: Option<u32>,
-    /// Which session to act on. Omit for the current one — the newest still open. Pass an
-    /// opener's handle to route to that session, refused if it has closed.
+    /// Which session to act on. Omit for the current one; pass an opener's handle to route to that
+    /// session and be refused if its target was replaced or closed.
     #[serde(default)]
     pub session_id: Option<String>,
 }
@@ -1922,8 +1922,8 @@ pub struct HeapDiagnosticsArgs {
     /// Maximum rows to return (default 60, maximum 2000).
     #[serde(default)]
     pub limit: Option<u32>,
-    /// Which session to act on. Omit for the current one — the newest still open. Pass an
-    /// opener's handle to route to that session, refused if it has closed.
+    /// Which session to act on. Omit for the current one; pass an opener's handle to route to that
+    /// session and be refused if its target was replaced or closed.
     #[serde(default)]
     pub session_id: Option<String>,
 }
@@ -1944,8 +1944,8 @@ pub struct CrashTriageArgs {
     /// where the context has been moved (`.thread`, `~Ns`, `.cxr`) they are not.
     #[serde(default)]
     pub analyze: Option<bool>,
-    /// Which session to act on. Omit for the current one — the newest still open. Pass an
-    /// opener's handle to route to that session, refused if it has closed.
+    /// Which session to act on. Omit for the current one; pass an opener's handle to route to that
+    /// session and be refused if its target was replaced or closed.
     #[serde(default)]
     pub session_id: Option<String>,
 }
@@ -1964,8 +1964,8 @@ pub struct BacktraceArgs {
     /// How many frames to walk (default 32, maximum 256).
     #[serde(default)]
     pub frames: Option<u32>,
-    /// Which session to act on. Omit for the current one — the newest still open. Pass an
-    /// opener's handle to route to that session, refused if it has closed.
+    /// Which session to act on. Omit for the current one; pass an opener's handle to route to that
+    /// session and be refused if its target was replaced or closed.
     #[serde(default)]
     pub session_id: Option<String>,
 }
@@ -1985,8 +1985,8 @@ const DEFAULT_BACKTRACE_FRAMES: u32 = 32;
 pub struct DriverObjectArgs {
     /// Driver object name, e.g. "mydriver" or "\\Driver\\mydriver".
     pub name: String,
-    /// Which session to act on. Omit for the current one — the newest still open. Pass an
-    /// opener's handle to route to that session, refused if it has closed.
+    /// Which session to act on. Omit for the current one; pass an opener's handle to route to that
+    /// session and be refused if its target was replaced or closed.
     #[serde(default)]
     pub session_id: Option<String>,
 }
@@ -1995,8 +1995,8 @@ pub struct DriverObjectArgs {
 pub struct DeviceObjectArgs {
     /// Device object: a name (e.g. "\\Device\\MyDevice") or an address (0x-hex).
     pub device: String,
-    /// Which session to act on. Omit for the current one — the newest still open. Pass an
-    /// opener's handle to route to that session, refused if it has closed.
+    /// Which session to act on. Omit for the current one; pass an opener's handle to route to that
+    /// session and be refused if its target was replaced or closed.
     #[serde(default)]
     pub session_id: Option<String>,
 }
@@ -2008,8 +2008,8 @@ pub struct IrpStackArgs {
     /// clobbers the register.
     #[serde(default)]
     pub irp: Option<String>,
-    /// Which session to act on. Omit for the current one — the newest still open. Pass an
-    /// opener's handle to route to that session, refused if it has closed.
+    /// Which session to act on. Omit for the current one; pass an opener's handle to route to that
+    /// session and be refused if its target was replaced or closed.
     #[serde(default)]
     pub session_id: Option<String>,
 }
@@ -2019,8 +2019,8 @@ pub struct IoctlTraceArgs {
     /// Virtual address of the IRP_MJ_DEVICE_CONTROL dispatch routine, rebased to the
     /// live load base. Recover it via `driver_object` (MajorFunction[0x0e]).
     pub dispatch: String,
-    /// Which session to act on. Omit for the current one — the newest still open. Pass an
-    /// opener's handle to route to that session, refused if it has closed.
+    /// Which session to act on. Omit for the current one; pass an opener's handle to route to that
+    /// session and be refused if its target was replaced or closed.
     #[serde(default)]
     pub session_id: Option<String>,
 }
@@ -2056,8 +2056,8 @@ pub struct ReachabilityArgs {
     /// the bare verdict + call path.
     #[serde(default)]
     pub recipe: Option<bool>,
-    /// Which session to act on. Omit for the current one — the newest still open. Pass an
-    /// opener's handle to route to that session, refused if it has closed.
+    /// Which session to act on. Omit for the current one; pass an opener's handle to route to that
+    /// session and be refused if its target was replaced or closed.
     #[serde(default)]
     pub session_id: Option<String>,
 }
@@ -2072,8 +2072,8 @@ pub struct RunToAddressArgs {
     /// (milliseconds). Defaults to the standard execution wait.
     #[serde(default)]
     pub timeout_ms: Option<u32>,
-    /// Which session to act on. Omit for the current one — the newest still open. Pass an
-    /// opener's handle to route to that session, refused if it has closed.
+    /// Which session to act on. Omit for the current one; pass an opener's handle to route to that
+    /// session and be refused if its target was replaced or closed.
     #[serde(default)]
     pub session_id: Option<String>,
 }
@@ -2115,8 +2115,8 @@ pub struct DebugBatchArgs {
     /// is left of this call's budget — it can only make the batch shorter, never longer.
     #[serde(default)]
     pub timeout_ms: Option<u32>,
-    /// Which session to act on. Omit for the current one — the newest still open. Pass an
-    /// opener's handle to route to that session, refused if it has closed.
+    /// Which session to act on. Omit for the current one; pass an opener's handle to route to that
+    /// session and be refused if its target was replaced or closed.
     #[serde(default)]
     pub session_id: Option<String>,
 }
@@ -4337,23 +4337,23 @@ impl WindbgServer {
     instructions = "Drive WinDbg/DbgEng for live user-mode, kernel, crash-dump and Time Travel Debugging (TTD) work: open a \
 dump or .run trace, attach to a process or the kernel, inspect registers/memory/stacks/modules, set \
 breakpoints. Each open target is a separate session in its own engine process, so up to 4 coexist \
-without disturbing each other: pass the `session_id` an opener returns on every later call to route it \
-to that target, and `end_session` when done. An opener answers with a summary of the target rather than \
-its module table; `modules` lists that when you need it, and `crash_triage` reads a bug check with its \
-stack. If an open reports a timeout, ask `session_status` rather than running the open again - a second \
-open attaches or launches a second time. To stop a call that is overrunning, `interrupt` its session \
-while it is still outstanding: it returns what it had reached and frees the session. A live kernel \
-attach cannot be interrupted - it waits indefinitely, and `end_session` reclaims that session alone. \
-Stack frames and instructions carry `module`+`rva` beside their address, and `modules` carries each \
-image's identity - the coordinate that survives a reboot and joins a disassembler. TTD: \
-go/step_over/step_into forward, reverse_go/step_over_back/step_back backward, goto_position to jump; \
-ttd_calls, ttd_memory and ttd_events query a trace, dx runs any data-model expression. Driver IOCTL: \
-decode_ioctl, driver_object, device_object, irp_stack, ioctl_trace, and reachable_from_dispatch - is a \
-block reachable from the dispatch routine, where REACHABLE is sound and NOT REACHABLE is best-effort; \
-confirm one live with run_to_address. When a sequence *mutates* the target - a patched byte, an armed \
-breakpoint, a resumed thread - run it as one `debug_batch`: its `always` block runs in the engine \
-process on every path, including a failed assertion, an expired deadline and a client disconnect, so \
-cleanup cannot be lost. Use `execute` for any raw command without a dedicated tool."
+independently: pass the `session_id` an opener returns on every later call to route it to that target, \
+and `end_session` when done. An opener answers with a summary rather than the module table; `modules` \
+lists that, and `crash_triage` reads a bug check with its stack. If an open reports a timeout, ask \
+`session_status` rather than running the open again - a second open attaches or launches a second time. \
+To stop a call that is overrunning, `interrupt` its session while the call is still outstanding: the \
+interrupt returns at once, and the partial result comes back on the original call. A live kernel attach \
+cannot be interrupted - it waits indefinitely, and `end_session` reclaims that session alone. Stack \
+frames and instructions carry `module`+`rva` beside their address, and `modules` carries each image's \
+identity - the coordinate that survives a reboot and joins a disassembler. TTD: go/step_over/step_into \
+forward, reverse_go/step_over_back/step_back backward, goto_position to jump; ttd_calls, ttd_memory and \
+ttd_events query a trace, dx runs any data-model expression. Driver IOCTL: decode_ioctl, driver_object, \
+device_object, irp_stack, ioctl_trace, and reachable_from_dispatch - is a block reachable from the \
+dispatch routine. Confirm a verdict live with run_to_address, which needs a KDNET/VM kernel target, not \
+a local one. When a sequence *mutates* the target - a patched byte, an armed breakpoint, a resumed \
+thread - run it as one `debug_batch`: its `always` block runs in the engine process on every path, \
+including a failed assertion, an expired deadline and a client disconnect, so cleanup cannot be lost. \
+Use `execute` for any raw command without a dedicated tool."
 )]
 impl rmcp::ServerHandler for WindbgServer {
     /// Every tool call, recorded on its way through.

--- a/src/server.rs
+++ b/src/server.rs
@@ -1475,9 +1475,8 @@ pub(crate) fn format_recipe(recipes: &[SegmentRecipe]) -> String {
 /// Parameters for tools that take no arguments beyond the session handle.
 #[derive(Deserialize, JsonSchema)]
 pub struct SessionArgs {
-    /// Session handle returned by open_dump/open_trace/attach_*/launch. Optional: omit it
-    /// to act on whatever session is current, or pass it to have the call refuse to run if
-    /// this server's debug target has been replaced since you opened it.
+    /// Which session to act on. Omit for the current one — the newest still open. Pass an
+    /// opener's handle to route to that session, refused if it has closed.
     #[serde(default)]
     pub session_id: Option<String>,
 }
@@ -1521,9 +1520,8 @@ pub struct ModulesArgs {
     /// matcher.
     #[serde(default)]
     pub filter: Option<String>,
-    /// Session handle returned by open_dump/open_trace/attach_*/launch. Optional: omit it
-    /// to act on whatever session is current, or pass it to have the call refuse to run if
-    /// this server's debug target has been replaced since you opened it.
+    /// Which session to act on. Omit for the current one — the newest still open. Pass an
+    /// opener's handle to route to that session, refused if it has closed.
     #[serde(default)]
     pub session_id: Option<String>,
 }
@@ -1536,9 +1534,8 @@ pub struct RegistersArgs {
     /// x64 that is several hundred entries — the `r` text is unaffected either way.
     #[serde(default)]
     pub all: Option<bool>,
-    /// Session handle returned by open_dump/open_trace/attach_*/launch. Optional: omit it
-    /// to act on whatever session is current, or pass it to have the call refuse to run if
-    /// this server's debug target has been replaced since you opened it.
+    /// Which session to act on. Omit for the current one — the newest still open. Pass an
+    /// opener's handle to route to that session, refused if it has closed.
     #[serde(default)]
     pub session_id: Option<String>,
 }
@@ -1583,8 +1580,8 @@ pub struct CommandLineArgs {
 pub struct ExecuteArgs {
     /// Raw debugger command to run (e.g. "!analyze -v", "u rip", "dt nt!_EPROCESS").
     pub command: String,
-    /// Session handle from open_dump/open_trace/attach_*/launch. Optional; pass it to
-    /// refuse the call if this server's debug target has been replaced since you opened it.
+    /// Which session to act on. Omit for the current one — the newest still open. Pass an
+    /// opener's handle to route to that session, refused if it has closed.
     #[serde(default)]
     pub session_id: Option<String>,
 }
@@ -1595,8 +1592,8 @@ pub struct ReadMemoryArgs {
     pub address: String,
     /// Number of bytes to read.
     pub size: u32,
-    /// Session handle from open_dump/open_trace/attach_*/launch. Optional; pass it to
-    /// refuse the call if this server's debug target has been replaced since you opened it.
+    /// Which session to act on. Omit for the current one — the newest still open. Pass an
+    /// opener's handle to route to that session, refused if it has closed.
     #[serde(default)]
     pub session_id: Option<String>,
 }
@@ -1628,8 +1625,8 @@ pub struct WalkMemoryArgs {
     /// nothing beyond the links it already reports.
     #[serde(default)]
     pub fields: Option<Vec<walk::FieldArg>>,
-    /// Session handle from open_dump/open_trace/attach_*/launch. Optional; pass it to
-    /// refuse the call if this server's debug target has been replaced since you opened it.
+    /// Which session to act on. Omit for the current one — the newest still open. Pass an
+    /// opener's handle to route to that session, refused if it has closed.
     #[serde(default)]
     pub session_id: Option<String>,
 }
@@ -1642,8 +1639,8 @@ pub struct DisassembleArgs {
     /// How many instructions to disassemble (default 16, maximum 128).
     #[serde(default)]
     pub count: Option<u32>,
-    /// Session handle from open_dump/open_trace/attach_*/launch. Optional; pass it to
-    /// refuse the call if this server's debug target has been replaced since you opened it.
+    /// Which session to act on. Omit for the current one — the newest still open. Pass an
+    /// opener's handle to route to that session, refused if it has closed.
     #[serde(default)]
     pub session_id: Option<String>,
 }
@@ -1662,8 +1659,8 @@ const DEFAULT_DISASSEMBLE_COUNT: u32 = 16;
 pub struct DxArgs {
     /// Data-model (LINQ) expression, e.g. "@$cursession.TTD.Calls(\"ntdll!*\")".
     pub expression: String,
-    /// Session handle from open_dump/open_trace/attach_*/launch. Optional; pass it to
-    /// refuse the call if this server's debug target has been replaced since you opened it.
+    /// Which session to act on. Omit for the current one — the newest still open. Pass an
+    /// opener's handle to route to that session, refused if it has closed.
     #[serde(default)]
     pub session_id: Option<String>,
 }
@@ -1672,8 +1669,8 @@ pub struct DxArgs {
 pub struct BreakpointArgs {
     /// Breakpoint location: symbol, address, or expression (e.g. "nt!NtCreateFile").
     pub expression: String,
-    /// Session handle from open_dump/open_trace/attach_*/launch. Optional; pass it to
-    /// refuse the call if this server's debug target has been replaced since you opened it.
+    /// Which session to act on. Omit for the current one — the newest still open. Pass an
+    /// opener's handle to route to that session, refused if it has closed.
     #[serde(default)]
     pub session_id: Option<String>,
 }
@@ -1682,8 +1679,8 @@ pub struct BreakpointArgs {
 pub struct PositionArgs {
     /// TTD position to travel to, e.g. "12:0" or "0" for the start of the trace.
     pub position: String,
-    /// Session handle from open_dump/open_trace/attach_*/launch. Optional; pass it to
-    /// refuse the call if this server's debug target has been replaced since you opened it.
+    /// Which session to act on. Omit for the current one — the newest still open. Pass an
+    /// opener's handle to route to that session, refused if it has closed.
     #[serde(default)]
     pub session_id: Option<String>,
 }
@@ -1710,8 +1707,8 @@ pub struct TtdCallsArgs {
     /// Function symbol or wildcard pattern to find calls to, e.g.
     /// "kernelbase!CreateFileW" or "ntdll!Nt*".
     pub function: String,
-    /// Session handle from open_dump/open_trace/attach_*/launch. Optional; pass it to
-    /// refuse the call if this server's debug target has been replaced since you opened it.
+    /// Which session to act on. Omit for the current one — the newest still open. Pass an
+    /// opener's handle to route to that session, refused if it has closed.
     #[serde(default)]
     pub session_id: Option<String>,
 }
@@ -1726,8 +1723,8 @@ pub struct TtdMemoryArgs {
     /// Omit to report every access.
     #[serde(default)]
     pub mode: Option<String>,
-    /// Session handle from open_dump/open_trace/attach_*/launch. Optional; pass it to
-    /// refuse the call if this server's debug target has been replaced since you opened it.
+    /// Which session to act on. Omit for the current one — the newest still open. Pass an
+    /// opener's handle to route to that session, refused if it has closed.
     #[serde(default)]
     pub session_id: Option<String>,
 }
@@ -1754,8 +1751,8 @@ pub struct SymbolPathArgs {
     /// force-load one module's symbols. Omit to reload all deferred modules.
     #[serde(default)]
     pub reload: Option<String>,
-    /// Session handle from open_dump/open_trace/attach_*/launch. Optional; pass it to
-    /// refuse the call if this server's debug target has been replaced since you opened it.
+    /// Which session to act on. Omit for the current one — the newest still open. Pass an
+    /// opener's handle to route to that session, refused if it has closed.
     #[serde(default)]
     pub session_id: Option<String>,
 }
@@ -1777,8 +1774,8 @@ pub struct PoolFindTagArgs {
     /// Maximum rows to print (default 64).
     #[serde(default)]
     pub limit: Option<u32>,
-    /// Session handle from open_dump/open_trace/attach_*/launch. Optional; pass it to
-    /// refuse the call if this server's debug target has been replaced since you opened it.
+    /// Which session to act on. Omit for the current one — the newest still open. Pass an
+    /// opener's handle to route to that session, refused if it has closed.
     #[serde(default)]
     pub session_id: Option<String>,
 }
@@ -1792,8 +1789,8 @@ pub struct PoolChunkArgs {
     /// Force a fresh walk instead of reusing this session's cached snapshot (default false).
     #[serde(default)]
     pub refresh: Option<bool>,
-    /// Session handle from open_dump/open_trace/attach_*/launch. Optional; pass it to
-    /// refuse the call if this server's debug target has been replaced since you opened it.
+    /// Which session to act on. Omit for the current one — the newest still open. Pass an
+    /// opener's handle to route to that session, refused if it has closed.
     #[serde(default)]
     pub session_id: Option<String>,
 }
@@ -1806,8 +1803,8 @@ pub struct PoolCensusArgs {
     /// Maximum tags to print (default 40).
     #[serde(default)]
     pub limit: Option<u32>,
-    /// Session handle from open_dump/open_trace/attach_*/launch. Optional; pass it to
-    /// refuse the call if this server's debug target has been replaced since you opened it.
+    /// Which session to act on. Omit for the current one — the newest still open. Pass an
+    /// opener's handle to route to that session, refused if it has closed.
     #[serde(default)]
     pub session_id: Option<String>,
 }
@@ -1824,8 +1821,8 @@ pub struct PoolDiagnosticsArgs {
     /// Force a fresh walk instead of reusing this session's cached snapshot (default false).
     #[serde(default)]
     pub refresh: Option<bool>,
-    /// Session handle from open_dump/open_trace/attach_*/launch. Optional; pass it to
-    /// refuse the call if this server's debug target has been replaced since you opened it.
+    /// Which session to act on. Omit for the current one — the newest still open. Pass an
+    /// opener's handle to route to that session, refused if it has closed.
     #[serde(default)]
     pub session_id: Option<String>,
 }
@@ -1835,6 +1832,8 @@ pub struct HeapListArgs {
     /// Force a fresh snapshot instead of reusing the one cached for this stopped target.
     #[serde(default)]
     pub refresh: Option<bool>,
+    /// Which session to act on. Omit for the current one — the newest still open. Pass an
+    /// opener's handle to route to that session, refused if it has closed.
     #[serde(default)]
     pub session_id: Option<String>,
 }
@@ -1876,6 +1875,8 @@ pub struct HeapAllocationsArgs {
     /// Maximum rows to return (default 64, maximum 2000).
     #[serde(default)]
     pub limit: Option<u32>,
+    /// Which session to act on. Omit for the current one — the newest still open. Pass an
+    /// opener's handle to route to that session, refused if it has closed.
     #[serde(default)]
     pub session_id: Option<String>,
 }
@@ -1886,6 +1887,8 @@ pub struct HeapChunkArgs {
     pub address: String,
     #[serde(default)]
     pub refresh: Option<bool>,
+    /// Which session to act on. Omit for the current one — the newest still open. Pass an
+    /// opener's handle to route to that session, refused if it has closed.
     #[serde(default)]
     pub session_id: Option<String>,
 }
@@ -1900,6 +1903,8 @@ pub struct HeapCensusArgs {
     /// Maximum groups to return (default 40, maximum 2000).
     #[serde(default)]
     pub limit: Option<u32>,
+    /// Which session to act on. Omit for the current one — the newest still open. Pass an
+    /// opener's handle to route to that session, refused if it has closed.
     #[serde(default)]
     pub session_id: Option<String>,
 }
@@ -1917,6 +1922,8 @@ pub struct HeapDiagnosticsArgs {
     /// Maximum rows to return (default 60, maximum 2000).
     #[serde(default)]
     pub limit: Option<u32>,
+    /// Which session to act on. Omit for the current one — the newest still open. Pass an
+    /// opener's handle to route to that session, refused if it has closed.
     #[serde(default)]
     pub session_id: Option<String>,
 }
@@ -1937,8 +1944,8 @@ pub struct CrashTriageArgs {
     /// where the context has been moved (`.thread`, `~Ns`, `.cxr`) they are not.
     #[serde(default)]
     pub analyze: Option<bool>,
-    /// Session handle from open_dump/open_trace/attach_*/launch. Optional; pass it to
-    /// refuse the call if this server's debug target has been replaced since you opened it.
+    /// Which session to act on. Omit for the current one — the newest still open. Pass an
+    /// opener's handle to route to that session, refused if it has closed.
     #[serde(default)]
     pub session_id: Option<String>,
 }
@@ -1957,8 +1964,8 @@ pub struct BacktraceArgs {
     /// How many frames to walk (default 32, maximum 256).
     #[serde(default)]
     pub frames: Option<u32>,
-    /// Session handle from open_dump/open_trace/attach_*/launch. Optional; pass it to
-    /// refuse the call if this server's debug target has been replaced since you opened it.
+    /// Which session to act on. Omit for the current one — the newest still open. Pass an
+    /// opener's handle to route to that session, refused if it has closed.
     #[serde(default)]
     pub session_id: Option<String>,
 }
@@ -1978,8 +1985,8 @@ const DEFAULT_BACKTRACE_FRAMES: u32 = 32;
 pub struct DriverObjectArgs {
     /// Driver object name, e.g. "mydriver" or "\\Driver\\mydriver".
     pub name: String,
-    /// Session handle from open_dump/open_trace/attach_*/launch. Optional; pass it to
-    /// refuse the call if this server's debug target has been replaced since you opened it.
+    /// Which session to act on. Omit for the current one — the newest still open. Pass an
+    /// opener's handle to route to that session, refused if it has closed.
     #[serde(default)]
     pub session_id: Option<String>,
 }
@@ -1988,8 +1995,8 @@ pub struct DriverObjectArgs {
 pub struct DeviceObjectArgs {
     /// Device object: a name (e.g. "\\Device\\MyDevice") or an address (0x-hex).
     pub device: String,
-    /// Session handle from open_dump/open_trace/attach_*/launch. Optional; pass it to
-    /// refuse the call if this server's debug target has been replaced since you opened it.
+    /// Which session to act on. Omit for the current one — the newest still open. Pass an
+    /// opener's handle to route to that session, refused if it has closed.
     #[serde(default)]
     pub session_id: Option<String>,
 }
@@ -2001,8 +2008,8 @@ pub struct IrpStackArgs {
     /// clobbers the register.
     #[serde(default)]
     pub irp: Option<String>,
-    /// Session handle from open_dump/open_trace/attach_*/launch. Optional; pass it to
-    /// refuse the call if this server's debug target has been replaced since you opened it.
+    /// Which session to act on. Omit for the current one — the newest still open. Pass an
+    /// opener's handle to route to that session, refused if it has closed.
     #[serde(default)]
     pub session_id: Option<String>,
 }
@@ -2012,8 +2019,8 @@ pub struct IoctlTraceArgs {
     /// Virtual address of the IRP_MJ_DEVICE_CONTROL dispatch routine, rebased to the
     /// live load base. Recover it via `driver_object` (MajorFunction[0x0e]).
     pub dispatch: String,
-    /// Session handle from open_dump/open_trace/attach_*/launch. Optional; pass it to
-    /// refuse the call if this server's debug target has been replaced since you opened it.
+    /// Which session to act on. Omit for the current one — the newest still open. Pass an
+    /// opener's handle to route to that session, refused if it has closed.
     #[serde(default)]
     pub session_id: Option<String>,
 }
@@ -2049,8 +2056,8 @@ pub struct ReachabilityArgs {
     /// the bare verdict + call path.
     #[serde(default)]
     pub recipe: Option<bool>,
-    /// Session handle from open_dump/open_trace/attach_*/launch. Optional; pass it to
-    /// refuse the call if this server's debug target has been replaced since you opened it.
+    /// Which session to act on. Omit for the current one — the newest still open. Pass an
+    /// opener's handle to route to that session, refused if it has closed.
     #[serde(default)]
     pub session_id: Option<String>,
 }
@@ -2065,8 +2072,8 @@ pub struct RunToAddressArgs {
     /// (milliseconds). Defaults to the standard execution wait.
     #[serde(default)]
     pub timeout_ms: Option<u32>,
-    /// Session handle from open_dump/open_trace/attach_*/launch. Optional; pass it to
-    /// refuse the call if this server's debug target has been replaced since you opened it.
+    /// Which session to act on. Omit for the current one — the newest still open. Pass an
+    /// opener's handle to route to that session, refused if it has closed.
     #[serde(default)]
     pub session_id: Option<String>,
 }
@@ -2108,8 +2115,8 @@ pub struct DebugBatchArgs {
     /// is left of this call's budget — it can only make the batch shorter, never longer.
     #[serde(default)]
     pub timeout_ms: Option<u32>,
-    /// Session handle from open_dump/open_trace/attach_*/launch. Optional; pass it to
-    /// refuse the call if this server's debug target has been replaced since you opened it.
+    /// Which session to act on. Omit for the current one — the newest still open. Pass an
+    /// opener's handle to route to that session, refused if it has closed.
     #[serde(default)]
     pub session_id: Option<String>,
 }
@@ -4320,38 +4327,33 @@ impl WindbgServer {
 // that expands in this crate. Pass `name` only: the attribute takes a string literal, so
 // `version = env!(...)` would not even parse, and spelling the version out by hand would just be a
 // second place to forget to bump.
+// **Sized to what the client actually reads.** Measured at 2,048 characters, and the previous text
+// was 3,147 — so 1,099 characters were paid for on every connection and never arrived, taking the
+// whole `debug_batch` paragraph with them, which is the one instruction here that prevents a
+// half-applied mutation. Kept ASCII so the count cannot differ between characters and bytes, and
+// `the_instructions_fit_what_the_client_reads` fails if it grows back.
 #[rmcp::tool_handler(
     name = "windbg-mcp",
-    instructions = "Drive WinDbg/DbgEng for live user-mode, kernel, crash-dump, and Time Travel Debugging (TTD) analysis. \
-Open a dump or .run trace, attach to a process or the kernel, inspect registers/memory/stacks/modules, and set breakpoints. \
-Each open target is a separate session in its own engine process, so several can be open at once (up to 4) without \
-disturbing each other; pass the `session_id` an opener returns on later calls to route them to that target, and \
-`end_session` when done. An opener answers with a summary of the target — the build, the kernel or primary image and \
-its base, how many modules are loaded, and a crash dump's bug check — rather than the module table; `modules` lists \
-that table when you actually need it, and `crash_triage` reads a bug check with its stack. \
-`session_status` lists what is open and what state each session is in — ask it when an open \
-reports a timeout rather than re-running the open, which would attach or launch a second time. To stop a call that is \
-taking too long without losing the target, call `interrupt` on its session while it is still outstanding: it Ctrl+Breaks \
-the engine, the running call returns whatever it had reached, and the session is free for the next one. A live kernel \
-attach is the exception — it waits for its target indefinitely and cannot be interrupted; if it has been waiting far \
-longer than a healthy link takes, `end_session` reclaims that session (and only that session) by terminating its engine \
-process. \
-Navigate a TTD trace in both directions: go/step_over/step_into forward, and reverse_go/step_over_back/step_back backward, \
-or jump with goto_position. Analyze a trace with the data-model tools ttd_calls (calls to a function), ttd_memory (accesses \
-to an address range), and ttd_events (module/thread/exception events), or run any data-model query with dx. Record new traces \
-with record_trace (needs elevation). For driver IOCTL work: decode_ioctl (decode a control code), driver_object \
-and device_object (walk the driver/device tree and security), irp_stack (dump an IRP's IO_STACK_LOCATION), \
-ioctl_trace (log every dispatched IOCTL), and reachable_from_dispatch (statically test, via a bounded \
-uf-based call-graph walk, whether a code block — by address or module+RVA — is reachable from the IOCTL \
-dispatch routine; REACHABLE is sound, NOT REACHABLE is best-effort, and a REACHABLE verdict includes a \
-directional path recipe of the on-path branch conditions). Confirm a static verdict live with \
-run_to_address (run to a block on a KDNET/VM kernel target and report HIT/STOPPED ELSEWHERE/TIMEOUT). \
-When a sequence *mutates* the target — a patched byte, an armed breakpoint, a resumed thread — run it as \
-one `debug_batch` rather than as separate calls: its `always` block runs inside the engine process on \
-every path, including a failed assertion and an expired deadline, so cleanup cannot be lost to a call \
-that times out or a client that disconnects, and the result names the exact failing step, what each step \
-changed, whether the rollback completed, and whether the target is left stopped, running or gone. \
-Use `execute` for any raw command not covered by a dedicated tool."
+    instructions = "Drive WinDbg/DbgEng for live user-mode, kernel, crash-dump and Time Travel Debugging (TTD) work: open a \
+dump or .run trace, attach to a process or the kernel, inspect registers/memory/stacks/modules, set \
+breakpoints. Each open target is a separate session in its own engine process, so up to 4 coexist \
+without disturbing each other: pass the `session_id` an opener returns on every later call to route it \
+to that target, and `end_session` when done. An opener answers with a summary of the target rather than \
+its module table; `modules` lists that when you need it, and `crash_triage` reads a bug check with its \
+stack. If an open reports a timeout, ask `session_status` rather than running the open again - a second \
+open attaches or launches a second time. To stop a call that is overrunning, `interrupt` its session \
+while it is still outstanding: it returns what it had reached and frees the session. A live kernel \
+attach cannot be interrupted - it waits indefinitely, and `end_session` reclaims that session alone. \
+Stack frames and instructions carry `module`+`rva` beside their address, and `modules` carries each \
+image's identity - the coordinate that survives a reboot and joins a disassembler. TTD: \
+go/step_over/step_into forward, reverse_go/step_over_back/step_back backward, goto_position to jump; \
+ttd_calls, ttd_memory and ttd_events query a trace, dx runs any data-model expression. Driver IOCTL: \
+decode_ioctl, driver_object, device_object, irp_stack, ioctl_trace, and reachable_from_dispatch - is a \
+block reachable from the dispatch routine, where REACHABLE is sound and NOT REACHABLE is best-effort; \
+confirm one live with run_to_address. When a sequence *mutates* the target - a patched byte, an armed \
+breakpoint, a resumed thread - run it as one `debug_batch`: its `always` block runs in the engine \
+process on every path, including a failed assertion, an expired deadline and a client disconnect, so \
+cleanup cannot be lost. Use `execute` for any raw command without a dedicated tool."
 )]
 impl rmcp::ServerHandler for WindbgServer {
     /// Every tool call, recorded on its way through.

--- a/tests/golden/tool_budget.json
+++ b/tests/golden/tool_budget.json
@@ -30,29 +30,29 @@
     {
       "annotations": 68,
       "description": 610,
-      "inputSchema": 474,
-      "modelVisible": 1134,
+      "inputSchema": 463,
+      "modelVisible": 1123,
       "name": "backtrace",
       "outputSchema": 7733,
-      "wire": 8966
+      "wire": 8955
     },
     {
       "annotations": 117,
       "description": 1551,
-      "inputSchema": 1319,
-      "modelVisible": 2923,
+      "inputSchema": 1308,
+      "modelVisible": 2912,
       "name": "crash_triage",
       "outputSchema": 13663,
-      "wire": 16734
+      "wire": 16723
     },
     {
       "annotations": 134,
       "description": 1714,
-      "inputSchema": 7991,
-      "modelVisible": 9757,
+      "inputSchema": 7980,
+      "modelVisible": 9746,
       "name": "debug_batch",
       "outputSchema": 9458,
-      "wire": 19380
+      "wire": 19369
     },
     {
       "annotations": 79,
@@ -66,155 +66,155 @@
     {
       "annotations": 74,
       "description": 299,
-      "inputSchema": 470,
-      "modelVisible": 823,
+      "inputSchema": 459,
+      "modelVisible": 812,
       "name": "device_object",
-      "outputSchema": 0,
-      "wire": 912
-    },
-    {
-      "annotations": 64,
-      "description": 790,
-      "inputSchema": 640,
-      "modelVisible": 1482,
-      "name": "disassemble",
-      "outputSchema": 7136,
-      "wire": 8713
-    },
-    {
-      "annotations": 74,
-      "description": 211,
-      "inputSchema": 455,
-      "modelVisible": 720,
-      "name": "driver_object",
-      "outputSchema": 0,
-      "wire": 809
-    },
-    {
-      "annotations": 130,
-      "description": 256,
-      "inputSchema": 478,
-      "modelVisible": 777,
-      "name": "dx",
-      "outputSchema": 0,
-      "wire": 922
-    },
-    {
-      "annotations": 116,
-      "description": 715,
-      "inputSchema": 395,
-      "modelVisible": 1162,
-      "name": "end_session",
-      "outputSchema": 4216,
-      "wire": 5525
-    },
-    {
-      "annotations": 124,
-      "description": 238,
-      "inputSchema": 476,
-      "modelVisible": 762,
-      "name": "execute",
       "outputSchema": 0,
       "wire": 901
     },
     {
+      "annotations": 64,
+      "description": 790,
+      "inputSchema": 629,
+      "modelVisible": 1471,
+      "name": "disassemble",
+      "outputSchema": 7136,
+      "wire": 8702
+    },
+    {
+      "annotations": 74,
+      "description": 211,
+      "inputSchema": 444,
+      "modelVisible": 709,
+      "name": "driver_object",
+      "outputSchema": 0,
+      "wire": 798
+    },
+    {
+      "annotations": 130,
+      "description": 256,
+      "inputSchema": 467,
+      "modelVisible": 766,
+      "name": "dx",
+      "outputSchema": 0,
+      "wire": 911
+    },
+    {
+      "annotations": 116,
+      "description": 715,
+      "inputSchema": 314,
+      "modelVisible": 1081,
+      "name": "end_session",
+      "outputSchema": 4216,
+      "wire": 5444
+    },
+    {
+      "annotations": 124,
+      "description": 238,
+      "inputSchema": 465,
+      "modelVisible": 751,
+      "name": "execute",
+      "outputSchema": 0,
+      "wire": 890
+    },
+    {
       "annotations": 118,
       "description": 83,
-      "inputSchema": 395,
-      "modelVisible": 521,
+      "inputSchema": 314,
+      "modelVisible": 440,
       "name": "go",
       "outputSchema": 4418,
-      "wire": 5088
+      "wire": 5007
     },
     {
       "annotations": 118,
       "description": 66,
-      "inputSchema": 472,
-      "modelVisible": 592,
+      "inputSchema": 461,
+      "modelVisible": 581,
       "name": "goto_position",
       "outputSchema": 0,
-      "wire": 725
+      "wire": 714
     },
     {
       "annotations": 128,
       "description": 220,
-      "inputSchema": 983,
-      "modelVisible": 1260,
+      "inputSchema": 1153,
+      "modelVisible": 1430,
       "name": "heap_allocations",
       "outputSchema": 12627,
-      "wire": 14046
+      "wire": 14216
     },
     {
       "annotations": 124,
       "description": 194,
-      "inputSchema": 448,
-      "modelVisible": 694,
+      "inputSchema": 618,
+      "modelVisible": 864,
       "name": "heap_census",
       "outputSchema": 12461,
-      "wire": 13310
+      "wire": 13480
     },
     {
       "annotations": 126,
       "description": 356,
-      "inputSchema": 323,
-      "modelVisible": 730,
+      "inputSchema": 493,
+      "modelVisible": 900,
       "name": "heap_chunk",
       "outputSchema": 13342,
-      "wire": 14229
+      "wire": 14399
     },
     {
       "annotations": 130,
       "description": 259,
-      "inputSchema": 592,
-      "modelVisible": 908,
+      "inputSchema": 762,
+      "modelVisible": 1078,
       "name": "heap_diagnostics",
       "outputSchema": 12568,
-      "wire": 13637
+      "wire": 13807
     },
     {
       "annotations": 119,
       "description": 306,
-      "inputSchema": 295,
-      "modelVisible": 651,
+      "inputSchema": 465,
+      "modelVisible": 821,
       "name": "heap_list",
       "outputSchema": 12157,
-      "wire": 12958
+      "wire": 13128
     },
     {
       "annotations": 120,
       "description": 858,
-      "inputSchema": 395,
-      "modelVisible": 1305,
+      "inputSchema": 314,
+      "modelVisible": 1224,
       "name": "index_trace",
       "outputSchema": 0,
-      "wire": 1440
+      "wire": 1359
     },
     {
       "annotations": 132,
       "description": 2110,
-      "inputSchema": 395,
-      "modelVisible": 2555,
+      "inputSchema": 314,
+      "modelVisible": 2474,
       "name": "interrupt",
       "outputSchema": 0,
-      "wire": 2702
+      "wire": 2621
     },
     {
       "annotations": 124,
       "description": 422,
-      "inputSchema": 543,
-      "modelVisible": 1017,
+      "inputSchema": 532,
+      "modelVisible": 1006,
       "name": "ioctl_trace",
       "outputSchema": 0,
-      "wire": 1156
+      "wire": 1145
     },
     {
       "annotations": 76,
       "description": 243,
-      "inputSchema": 570,
-      "modelVisible": 863,
+      "inputSchema": 559,
+      "modelVisible": 852,
       "name": "irp_stack",
       "outputSchema": 0,
-      "wire": 954
+      "wire": 943
     },
     {
       "annotations": 129,
@@ -228,11 +228,11 @@
     {
       "annotations": 65,
       "description": 681,
-      "inputSchema": 1383,
-      "modelVisible": 2112,
+      "inputSchema": 1302,
+      "modelVisible": 2031,
       "name": "modules",
       "outputSchema": 10571,
-      "wire": 12779
+      "wire": 12698
     },
     {
       "annotations": 128,
@@ -255,56 +255,56 @@
     {
       "annotations": 123,
       "description": 371,
-      "inputSchema": 613,
-      "modelVisible": 1036,
+      "inputSchema": 602,
+      "modelVisible": 1025,
       "name": "pool_census",
       "outputSchema": 12311,
-      "wire": 13501
+      "wire": 13490
     },
     {
       "annotations": 129,
       "description": 941,
-      "inputSchema": 771,
-      "modelVisible": 1763,
+      "inputSchema": 760,
+      "modelVisible": 1752,
       "name": "pool_chunk",
       "outputSchema": 14042,
-      "wire": 15965
+      "wire": 15954
     },
     {
       "annotations": 127,
       "description": 1095,
-      "inputSchema": 842,
-      "modelVisible": 1994,
+      "inputSchema": 831,
+      "modelVisible": 1983,
       "name": "pool_diagnostics",
       "outputSchema": 12945,
-      "wire": 15097
+      "wire": 15086
     },
     {
       "annotations": 122,
       "description": 511,
-      "inputSchema": 1229,
-      "modelVisible": 1794,
+      "inputSchema": 1218,
+      "modelVisible": 1783,
       "name": "pool_find_tag",
       "outputSchema": 13964,
-      "wire": 15911
+      "wire": 15900
     },
     {
       "annotations": 90,
       "description": 556,
-      "inputSchema": 2019,
-      "modelVisible": 2639,
+      "inputSchema": 2008,
+      "modelVisible": 2628,
       "name": "reachable_from_dispatch",
       "outputSchema": 0,
-      "wire": 2744
+      "wire": 2733
     },
     {
       "annotations": 64,
       "description": 59,
-      "inputSchema": 533,
-      "modelVisible": 644,
+      "inputSchema": 522,
+      "modelVisible": 633,
       "name": "read_memory",
       "outputSchema": 0,
-      "wire": 723
+      "wire": 712
     },
     {
       "annotations": 120,
@@ -318,29 +318,29 @@
     {
       "annotations": 67,
       "description": 328,
-      "inputSchema": 711,
-      "modelVisible": 1089,
+      "inputSchema": 630,
+      "modelVisible": 1008,
       "name": "registers",
       "outputSchema": 6379,
-      "wire": 7566
+      "wire": 7485
     },
     {
       "annotations": 123,
       "description": 86,
-      "inputSchema": 395,
-      "modelVisible": 532,
+      "inputSchema": 314,
+      "modelVisible": 451,
       "name": "reverse_go",
       "outputSchema": 4418,
-      "wire": 5104
+      "wire": 5023
     },
     {
       "annotations": 114,
       "description": 460,
-      "inputSchema": 802,
-      "modelVisible": 1317,
+      "inputSchema": 791,
+      "modelVisible": 1306,
       "name": "run_to_address",
       "outputSchema": 4520,
-      "wire": 5982
+      "wire": 5971
     },
     {
       "annotations": 75,
@@ -354,123 +354,123 @@
     {
       "annotations": 73,
       "description": 1020,
-      "inputSchema": 395,
-      "modelVisible": 1470,
+      "inputSchema": 314,
+      "modelVisible": 1389,
       "name": "session_status",
       "outputSchema": 7201,
-      "wire": 8775
+      "wire": 8694
     },
     {
       "annotations": 115,
       "description": 330,
-      "inputSchema": 478,
-      "modelVisible": 863,
+      "inputSchema": 467,
+      "modelVisible": 852,
       "name": "set_breakpoint",
       "outputSchema": 6777,
-      "wire": 7786
+      "wire": 7775
     },
     {
       "annotations": 123,
       "description": 465,
-      "inputSchema": 1136,
-      "modelVisible": 1657,
+      "inputSchema": 1125,
+      "modelVisible": 1646,
       "name": "set_symbol_path",
       "outputSchema": 0,
-      "wire": 1795
+      "wire": 1784
     },
     {
       "annotations": 116,
       "description": 76,
-      "inputSchema": 395,
-      "modelVisible": 521,
+      "inputSchema": 314,
+      "modelVisible": 440,
       "name": "step_back",
       "outputSchema": 4418,
-      "wire": 5086
+      "wire": 5005
     },
     {
       "annotations": 109,
       "description": 34,
-      "inputSchema": 395,
-      "modelVisible": 479,
+      "inputSchema": 314,
+      "modelVisible": 398,
       "name": "step_into",
       "outputSchema": 4418,
-      "wire": 5037
+      "wire": 4956
     },
     {
       "annotations": 109,
       "description": 46,
-      "inputSchema": 395,
-      "modelVisible": 491,
+      "inputSchema": 314,
+      "modelVisible": 410,
       "name": "step_over",
       "outputSchema": 4418,
-      "wire": 5049
+      "wire": 4968
     },
     {
       "annotations": 121,
       "description": 74,
-      "inputSchema": 395,
-      "modelVisible": 524,
+      "inputSchema": 314,
+      "modelVisible": 443,
       "name": "step_over_back",
       "outputSchema": 4418,
-      "wire": 5094
+      "wire": 5013
     },
     {
       "annotations": 65,
       "description": 21,
-      "inputSchema": 395,
-      "modelVisible": 464,
+      "inputSchema": 314,
+      "modelVisible": 383,
       "name": "threads",
       "outputSchema": 0,
-      "wire": 544
+      "wire": 463
     },
     {
       "annotations": 82,
       "description": 260,
-      "inputSchema": 499,
-      "modelVisible": 809,
+      "inputSchema": 488,
+      "modelVisible": 798,
       "name": "ttd_calls",
       "outputSchema": 0,
-      "wire": 906
+      "wire": 895
     },
     {
       "annotations": 75,
       "description": 213,
-      "inputSchema": 395,
-      "modelVisible": 659,
+      "inputSchema": 314,
+      "modelVisible": 578,
       "name": "ttd_events",
       "outputSchema": 0,
-      "wire": 749
+      "wire": 668
     },
     {
       "annotations": 89,
       "description": 169,
-      "inputSchema": 735,
-      "modelVisible": 955,
+      "inputSchema": 724,
+      "modelVisible": 944,
       "name": "ttd_memory",
       "outputSchema": 0,
-      "wire": 1059
+      "wire": 1048
     },
     {
       "annotations": 125,
       "description": 1311,
-      "inputSchema": 2724,
-      "modelVisible": 4087,
+      "inputSchema": 2713,
+      "modelVisible": 4076,
       "name": "walk_memory",
       "outputSchema": 10566,
-      "wire": 14809
+      "wire": 14798
     }
   ],
   "totals": {
     "annotations": 5449,
     "description": 24752,
-    "inputSchema": 40204,
-    "instructions": 3163,
-    "modelVisible": 67613,
+    "inputSchema": 39667,
+    "instructions": 1996,
+    "modelVisible": 67076,
     "outputSchema": 317236,
-    "payload": 391709,
+    "payload": 391172,
     "tools": 51,
-    "wire": 391591,
+    "wire": 391054,
     "worstTool": "debug_batch",
-    "worstToolModelVisible": 9757
+    "worstToolModelVisible": 9746
   }
 }

--- a/tests/golden/tool_budget.json
+++ b/tests/golden/tool_budget.json
@@ -464,7 +464,7 @@
     "annotations": 5449,
     "description": 24752,
     "inputSchema": 39667,
-    "instructions": 1996,
+    "instructions": 1990,
     "modelVisible": 67076,
     "outputSchema": 317236,
     "payload": 391172,

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -769,6 +769,26 @@ fn discover_opens_a_session_without_initialize() {
         instructions.contains("WinDbg"),
         "instructions should be this server's, got {instructions:?}"
     );
+    // **What the client reads, not what the server sends.** Measured at 2,048 characters; the text
+    // was 3,147 for a long time, so a third of it was paid for on every connection and never
+    // arrived — and what fell off the end was the `debug_batch` paragraph, the one instruction here
+    // that stops a mutation being left half-applied. Asserted on both counts because they are the
+    // same number only while the text stays ASCII, and an em dash is three bytes.
+    const INSTRUCTIONS_BUDGET: usize = 2_048;
+    assert!(
+        instructions.chars().count() <= INSTRUCTIONS_BUDGET
+            && instructions.len() <= INSTRUCTIONS_BUDGET,
+        "the instructions are {} chars / {} bytes, past the {INSTRUCTIONS_BUDGET} a client reads — \
+         the tail is charged for and discarded, so trim it rather than letting it fall off:\n\
+         {instructions}",
+        instructions.chars().count(),
+        instructions.len(),
+    );
+    assert!(
+        instructions.contains("debug_batch"),
+        "the batch guidance is the part that used to be truncated away; it has to survive any \
+         future trim: {instructions:?}"
+    );
 
     // Tools have to be reachable on a session opened this way, not merely listed by discover.
     let tools = server.stateless_request("tools/list", json!({}), STEP);
@@ -1335,13 +1355,13 @@ fn budget_report(result: &Value, instructions: &str) -> Value {
     })
 }
 
-/// Ceiling on the tool surface a model is given before it has asked anything. 67,613 bytes across
+/// Ceiling on the tool surface a model is given before it has asked anything. 67,076 bytes across
 /// 51 tools today (~16k tokens), +12% headroom — sized so that rewording a description passes and
 /// a new tool arriving with a `debug_batch`-scale schema does not.
 const MODEL_VISIBLE_CEILING: usize = 76_000;
 
 /// Ceiling on the whole `tools/list` payload — the serialized result, not the sum of its tools, so
-/// the array's own punctuation and every result-level field are inside it. 391,709 bytes today,
+/// the array's own punctuation and every result-level field are inside it. 391,172 bytes today,
 /// ~80% of that `outputSchema` no model reads, which is why this is a separate and much looser
 /// number rather than a scaled version of the one above.
 ///


### PR DESCRIPTION
Two of `FOLLOWUPS.md` item 24's findings, and one correction to the item itself.

## The instructions overran what a client reads

3,147 characters sent, **2,048 read** — so a third of the text was charged for on every connection
and discarded. What fell off the end was the `debug_batch` paragraph: the one instruction there
that stops a mutation being left half-applied. A model was being told about transactional batches
in bytes it never received.

Now **1,996 characters** with that guidance inside the budget, and kept ASCII so the character count
and the byte count cannot diverge — an em dash is three bytes, and a limit stated in characters is
not one to test with multi-byte punctuation. The protocol tier asserts both counts *and* that the
batch guidance survives, so the next edit cannot quietly push it back over.

## `session_id` had three wordings, and five tools had none

`heap_list`, `heap_allocations`, `heap_chunk`, `heap_census` and `heap_diagnostics` documented their
`session_id` not at all — a caller reading those had nothing telling them what to pass. One wording
everywhere now. `server_log`'s keeps its own, because there the field filters records rather than
routing a call.

Together: **67,613 B → 66,320 B** of model-visible surface.

## The item's own number was wrong, instructively

Item 24 claimed **9,514 B** for `session_id` across 43 sites. The model-visible total was
**4,695 B across 32** — the count had included the copies inside `outputSchema`, which the same
document establishes, two sections earlier and from measurement, that no model reads. So the
achievable saving was never ~9 KB, and this change is −1,293 B rather than the ~14% I would have
claimed from the bullet.

A number not measured in the channel it is claimed for is not a finding. Both the item and
`docs/token-budget.md` now say so.

## What the measurement does support

`docs/token-budget.md` gains finding 8: **five tools are a third of the model-visible surface**, and
it is their *input* schemas rather than their prose.

| tool | model-visible | of which inputSchema |
|---|---:|---:|
| `debug_batch` | 9,728 | 7,962 |
| `walk_memory` | 4,058 | 2,695 |
| `crash_triage` | 2,894 | 1,290 |
| `reachable_from_dispatch` | 2,610 | 1,990 |
| `server_log` | 2,599 | 1,608 |
| **total** | **21,889 (33%)** | |

Median tool: 882 B. `debug_batch` alone is 15% of everything a model is handed before it asks
anything, and 7,962 B of that is the `StepAction`/`Check` vocabulary its schema pulls out of
`src/batch.rs`. That is a different kind of problem from the duplication above it — one tool
honestly describing a rich argument — and the levers are design choices (a smaller step vocabulary,
a `$ref` the client resolves, a surface that does not offer every tool to every caller) rather than
tidying.

## Testing

ARM64 bench: clippy clean, `cargo test --test mcp_smoke` **61 passed**,
`WINDBG_MCP_SMOKE_DUMP=1 … --test-threads=1` **61 passed / 0 failed / 12 ignored**. Goldens
re-recorded; `docs/token-budget.md` re-stated from this run with the `2025-06-18` payload
re-measured. `markdownlint-cli2`: 0 issues in 20 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)