### PR TITLE
Release a session nobody is using, since no disconnect is coming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **A session nobody is using is released, whatever the transport did.** The lease answers "has this
+  *client* gone away" by identifying it from `Mcp-Session-Id` — and `2026-07-28` removed the protocol-level
+  MCP session (SEP-2567), so on the revision most clients now negotiate no holder is ever installed and
+  no lease ever expires. A client that vanished left its targets held until the process exited,
+  which for a live kernel is a machine owned by nobody
+  ([#162](https://github.com/glslang/windbg-mcp/issues/162)).
+
+  The listener now also releases any session that has gone unused for **30 minutes** (
+  `WINDBG_MCP_SESSION_IDLE_SECS`, `0` disables), through the same orderly `EndSession` an explicit
+  `end_session` uses. It needs no notion of a client, which is the point: it is the half of the
+  lease's job that survives a protocol with no sessions in it.
+
+  - **Far longer than the lease grace, deliberately.** A lease is renewed by any request; this is
+    per session, and twenty minutes of reading a stack before the next question is ordinary work.
+  - **A session with a call outstanding is never idle**, however old the call — which is exactly an
+    `attach_kernel` parked in `WaitForEvent(INFINITE)` waiting for its target to dial in, the one
+    session that must never be released. Nor is an opener that has not yet handed back its handle.
+  - The floor is the same one the lease refuses to start below: longer than a single call can run,
+    or a session is released underneath its own caller.
+
+  This is the first of the slices in #162. It does not make two clients safe from each other — that
+  needs a client identity, which a stateless protocol only gets from authentication — but it stops
+  the leak that has no workaround today.
+
 - **The server instructions now fit what the client reads.** They were 3,147 characters against a
   measured 2,048-character limit, so 1,099 were paid for on every connection and discarded — and
   what fell off the end was the `debug_batch` paragraph, the one instruction there that stops a

--- a/docs/remote-listener.md
+++ b/docs/remote-listener.md
@@ -151,6 +151,39 @@ client restart costs a KDNET attach, and a KDNET attach costs a reboot of the ta
 how many sessions were inherited when that happens — or that nothing was open, since a client can
 also arrive to find the previous one had let go of an empty server.
 
+## A session nobody is using is released
+
+The lease answers "has this *client* gone away". There is a second question it cannot answer, and on
+the revision most clients now negotiate it is the only one left: **has anyone touched this session
+at all?**
+
+`2026-07-28` removed the protocol-level MCP session ([SEP-2567]), so no `Mcp-Session-Id` is minted
+and the lease — which
+identifies a client by exactly that header — never takes a holder. A client that vanishes on that
+revision leaves its targets held until this process exits, which for a live kernel means a machine
+owned by nobody. See [#162](https://github.com/glslang/windbg-mcp/issues/162) for the whole of it;
+this is the half that needs no client identity and so keeps working whatever the transport does.
+
+| | |
+| --- | --- |
+| Default | **30 minutes** since the last call naming that session |
+| Override | `WINDBG_MCP_SESSION_IDLE_SECS`, whole seconds; `0` disables it |
+| Floor | must exceed the longest a single call can run, or the server refuses to start |
+
+It is deliberately far longer than the lease grace. A lease is renewed by *any* request, so a
+working client renews it constantly; this is per session, and reading a stack for twenty minutes
+before asking the next question is ordinary work, not abandonment.
+
+**A session with a call outstanding is never idle**, however old that call is. That is not a
+detail: an `attach_kernel` parked in `WaitForEvent(INFINITE)` waiting for its target to dial in has
+one call outstanding and nothing else for as long as it takes, and it is precisely the session that
+must not be released. Nor is an opener that has not yet handed its handle back.
+
+Each one is released through the same orderly `EndSession` an explicit `end_session` uses, one at a
+time, because a live kernel that is merely killed is left halted.
+
+[SEP-2567]: https://modelcontextprotocol.io/seps/2567-sessionless-mcp
+
 ## One client at a time
 
 A second client is refused with `409`. This is forced by the registry rather than chosen: session

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -404,6 +404,14 @@ pub struct Session {
     /// Whether `open` has finished with this session and told its caller about it. Until then it
     /// is not reclaimable however idle it looks — see [`Session::busy`].
     delivered: AtomicBool,
+    /// When a call was last submitted against this session.
+    ///
+    /// The transport's disconnect is what normally releases a target, and under the revision of
+    /// MCP this server now speaks over HTTP there is no disconnect to have: sessions were removed
+    /// from the protocol (SEP-2567), so a client that vanishes is indistinguishable from one that
+    /// is thinking, for ever. This is the only signal left that nobody is coming back
+    /// ([#162](https://github.com/glslang/windbg-mcp/issues/162)).
+    last_used: Mutex<Instant>,
     /// How far the opener got, as [`OpenPhase`]. Separate from the state on purpose.
     phase: AtomicU8,
     /// Whether *some* teardown got a successful `EndSession` out of this worker.
@@ -563,6 +571,22 @@ impl Session {
     /// admitted at the limit, the later one's reconciliation could reclaim the earlier one and
     /// its caller would be handed a `session_id` that was already `Closed`. Undelivered means
     /// in flight as far as anyone outside is concerned.
+    /// Whether nobody has asked this session for anything in `after`, so it can be let go.
+    ///
+    /// **`busy` first, and it is not a formality.** A live kernel attach parked in
+    /// `WaitForEvent(INFINITE)` submits one call and then waits — possibly for hours, legitimately,
+    /// until its target dials in. It has a waiter outstanding the whole time, so `busy()` covers
+    /// it; reading the clock alone would release the one session whose whole job is to wait.
+    fn idle_for(&self, after: Duration) -> bool {
+        !self.busy()
+            && self
+                .last_used
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .elapsed()
+                >= after
+    }
+
     fn busy(&self) -> bool {
         !self.delivered.load(Ordering::Acquire)
             || !self
@@ -1041,6 +1065,10 @@ impl Sessions {
         // `pump`'s thread, the worker's reader — belongs to the session rather than to this call.
         {
             let _reclamation = self.registry();
+            // Touched on submission rather than on completion: a call that is still running keeps
+            // the session `busy()` anyway, and the question this answers is when someone last
+            // *wanted* it.
+            *session.last_used.lock().unwrap_or_else(|e| e.into_inner()) = Instant::now();
             session
                 .waiters
                 .lock()
@@ -1495,6 +1523,60 @@ impl Sessions {
         self.release_every_worker(Teardown::Lease).await
     }
 
+    /// Releases every session nobody has used for `after`, and says how many.
+    ///
+    /// The transport-independent half of what a disconnect used to do. `release_leased` releases
+    /// *a client's* sessions when its lease runs out, which needs a client to identify; this asks
+    /// only whether anyone is still using a target, which is answerable with no notion of a client
+    /// at all — and so keeps working on a stateless transport where there is nothing to identify
+    /// ([#162](https://github.com/glslang/windbg-mcp/issues/162)).
+    ///
+    /// **Claimed under the registry lock, released outside it**, exactly as
+    /// [`Self::claim_overage_victim`] does and for a sharper version of the same reason. Deciding a
+    /// session is idle and then ending it are two moments, and [`Self::call_as`] takes that same
+    /// lock to register a waiter: without the claim, a call arriving in the gap would be routed to
+    /// a session this sweep is about to tear down, and a caller would lose an operation it had
+    /// just started — against a live kernel, mid-command. Closing the state under the lock is what
+    /// makes the gap unreachable: [`Sessions::resolve`] refuses a `Closed` session, so a call is on
+    /// one side of the claim or the other.
+    pub async fn release_idle(&self, after: Duration) -> usize {
+        let claimed = {
+            let registry = self.registry();
+            let stale: Vec<Arc<Session>> = registry
+                .live()
+                .iter()
+                .filter(|session| session.idle_for(after))
+                .cloned()
+                .collect();
+            for session in &stale {
+                session.set_state(SessionState::Closed(format!(
+                    "released after {}s with nobody using it — this server holds no target for a \
+                     client that has stopped asking, because on a stateless transport there is no \
+                     disconnect to notice",
+                    after.as_secs()
+                )));
+            }
+            stale
+        };
+        for session in &claimed {
+            tracing::info!(
+                "releasing session {} — nobody has used it for {}s",
+                session.id,
+                after.as_secs()
+            );
+            // The supervisor's own teardown rather than a caller's call, so it runs past the gate
+            // the claim just closed — and orderly, because a live kernel that is merely killed is
+            // left halted.
+            self.release(
+                &session.clone(),
+                Call::supervisor(EngineOp::EndSession),
+                END_SESSION_TIMEOUT,
+            )
+            .await;
+        }
+        claimed.len()
+    }
+
     async fn release_every_worker(&self, teardown: Teardown) {
         // Closing the gate and taking the snapshot under **one** lock acquisition is what makes
         // one pass enough. [`Self::admit`] re-checks `closing` under this same lock after its
@@ -1814,6 +1896,7 @@ impl Sessions {
             what,
             pid,
             created: Instant::now(),
+            last_used: Mutex::new(Instant::now()),
             state: Mutex::new((SessionState::Opening, Instant::now())),
             tx,
             // Job ids start *past* the opener's, which is reserved — see [`OPENER_JOB`].
@@ -2950,6 +3033,52 @@ mod tests {
         assert!(closed.contains("open_dump"), "{closed}");
     }
 
+    // ---- releasing what nobody is using -------------------------------------------
+
+    /// The clock alone is not the question. A session with a call outstanding is in use however
+    /// long ago that call was submitted — which is the parked kernel attach exactly: one call, then
+    /// a wait for a target that may take hours to dial in.
+    #[test]
+    fn a_session_with_a_call_outstanding_is_never_idle() {
+        let session = dormant("sess-waiting", SessionState::Open);
+        // Backdate it well past any timeout, so only `busy()` can save it.
+        *session.last_used.lock().unwrap() = Instant::now() - Duration::from_secs(3600);
+        assert!(
+            session.idle_for(Duration::from_secs(1)),
+            "with nothing outstanding it is idle"
+        );
+
+        session.waiters.lock().unwrap().insert(
+            1,
+            Waiting {
+                done: oneshot::channel().0,
+                progress: None,
+                unwound: false,
+            },
+        );
+        assert!(
+            !session.idle_for(Duration::from_secs(1)),
+            "a call is outstanding: the session is in use, whatever the clock says"
+        );
+    }
+
+    /// An opener that has not yet been handed back is not idle either, however long the spawn
+    /// takes — the caller has not been told the handle yet, so nobody could have used it.
+    #[test]
+    fn a_session_not_yet_delivered_is_never_idle() {
+        let session = dormant("sess-opening", SessionState::Open);
+        session.delivered.store(false, Ordering::Release);
+        *session.last_used.lock().unwrap() = Instant::now() - Duration::from_secs(3600);
+        assert!(!session.idle_for(Duration::from_secs(1)));
+    }
+
+    /// And the ordinary case: used recently, so left alone.
+    #[test]
+    fn a_session_used_recently_is_left_alone() {
+        let session = dormant("sess-busy", SessionState::Open);
+        assert!(!session.idle_for(Duration::from_secs(60)));
+    }
+
     // ---- the registry (no workers involved) ---------------------------------------
 
     /// A `Session` with no worker behind it, for the routing tests. Its queue has no consumer,
@@ -2978,6 +3107,7 @@ mod tests {
             what: "test".to_string(),
             pid: 0,
             created: Instant::now(),
+            last_used: Mutex::new(Instant::now()),
             state: Mutex::new((state, Instant::now())),
             tx,
             next_id: AtomicU64::new(1),

--- a/src/listen.rs
+++ b/src/listen.rs
@@ -81,6 +81,51 @@ pub const TOKEN_ENV: &str = "WINDBG_MCP_LISTEN_TOKEN";
 /// Read *before* [`TOKEN_ENV`], so a host that has both is using the private one.
 pub const TOKEN_FILE_ENV: &str = "WINDBG_MCP_LISTEN_TOKEN_FILE";
 
+/// How long a session may go unused before it is released, from [`IDLE_ENV`] or [`IDLE_RELEASE`].
+///
+/// `0` turns it off, which is a supported answer for a host where every client is trusted to hang
+/// up — and a footgun anywhere else, so it says so once at startup rather than silently.
+fn idle_release(call_timeout: Duration) -> Result<Option<Duration>> {
+    idle_release_from(std::env::var(IDLE_ENV).ok().as_deref(), call_timeout)
+}
+
+/// The mapping behind [`idle_release`], given the variable's value rather than reading it.
+///
+/// Split out for the reason `kdconn::env_entries` is: `std::env::set_var` is `unsafe` in edition
+/// 2024 and mutates state every other test in this binary shares, so three tests setting the same
+/// variable race each other under the default parallel runner. Handing the value in is the only way
+/// to assert the floor, the `0` case and the default without that.
+fn idle_release_from(configured: Option<&str>, call_timeout: Duration) -> Result<Option<Duration>> {
+    let after = match configured {
+        Some(raw) => {
+            let secs: u64 = raw.trim().parse().with_context(|| {
+                format!("`{IDLE_ENV}` must be whole seconds (0 disables), not `{raw}`")
+            })?;
+            if secs == 0 {
+                tracing::warn!(
+                    "{IDLE_ENV}=0: a session nobody uses is never released, so a client that goes \
+                     away without saying so leaves its target held until this process ends"
+                );
+                return Ok(None);
+            }
+            Duration::from_secs(secs)
+        }
+        None => IDLE_RELEASE,
+    };
+    // The same floor the lease refuses to start below, and for the same reason: a call can keep a
+    // session quiet for its whole budget, and releasing one underneath its own caller is worse than
+    // holding an abandoned one.
+    let quiet = longest_quiet_call(call_timeout);
+    if after <= quiet {
+        bail!(
+            "`{IDLE_ENV}` ({after:?}) must be longer than the longest a single call can run \
+             ({quiet:?}), or a session is released while a call is still using it. Raise it, or \
+             set 0 to disable the release entirely."
+        );
+    }
+    Ok(Some(after))
+}
+
 /// Overrides how long a client may be silent before its sessions are released, in whole seconds.
 const GRACE_ENV: &str = "WINDBG_MCP_LEASE_GRACE_SECS";
 
@@ -106,6 +151,21 @@ const SSE_KEEP_ALIVE: Duration = Duration::from_secs(15);
 /// How often the sweeper looks for a lease that has run out. Fine enough that a released target is
 /// released promptly, coarse enough to cost nothing while idle.
 const SWEEP: Duration = Duration::from_secs(5);
+
+/// How long a session may go unused before it is released, and the variable that overrides it.
+///
+/// **The lease cannot cover this any more.** It identifies a client by `Mcp-Session-Id`, and
+/// SEP-2567 removed sessions from `2026-07-28` — the revision most clients now negotiate — so on
+/// that revision no holder is ever installed and no lease ever expires. A client that vanishes
+/// would leave its targets held until the process ended, which for a live kernel means a machine
+/// owned by nobody ([#162](https://github.com/glslang/windbg-mcp/issues/162)).
+///
+/// Deliberately much longer than the lease grace. A lease is renewed by *any* request, so a working
+/// client renews it constantly; this is per session, and a caller reading a stack for twenty minutes
+/// before asking the next question is doing nothing wrong. It is a backstop against abandonment,
+/// not a scheduler.
+const IDLE_RELEASE: Duration = Duration::from_secs(30 * 60);
+const IDLE_ENV: &str = "WINDBG_MCP_SESSION_IDLE_SECS";
 
 /// The header carrying a client's MCP session, which is what identifies the holder.
 const SESSION_HEADER: &str = "Mcp-Session-Id";
@@ -587,6 +647,9 @@ pub async fn serve(
         _ => longest_quiet_call(call_timeout) + GRACE_HEADROOM,
     };
     let lease = Arc::new(Lease::new(grace, call_timeout, sessions.clone())?);
+    // Read before the bind, like the grace above: a misconfigured backstop should be a message at
+    // startup rather than a target nobody releases, discovered hours later.
+    let idle_after = idle_release(call_timeout)?;
 
     if !addr.ip().is_loopback() {
         // Not refused: a host-only adapter is a legitimate choice and this server does not know
@@ -627,10 +690,19 @@ pub async fn serve(
     // *now*. See [`crate::service`], where "started" is a thing the SCM and its dependants act on.
     ready();
     tracing::info!(
-        "windbg-mcp listening on http://{addr} (lease grace {grace:?}, one client at a time)"
+        "windbg-mcp listening on http://{addr} (lease grace {grace:?}, {}, one client at a time)",
+        match idle_after {
+            Some(after) => format!("idle sessions released after {}m", after.as_secs() / 60),
+            None => "idle sessions never released".to_string(),
+        }
     );
 
-    tokio::spawn(sweep(sessions.clone(), lease.clone(), manager.clone()));
+    tokio::spawn(sweep(
+        sessions.clone(),
+        lease.clone(),
+        manager.clone(),
+        idle_after,
+    ));
 
     loop {
         let (stream, peer) = tokio::select! {
@@ -815,9 +887,20 @@ fn refuse(status: StatusCode, why: &str) -> Response<BoxBody<Bytes, Infallible>>
 }
 
 /// Releases what an absent client left behind, once its lease runs out.
-async fn sweep(sessions: Sessions, lease: Arc<Lease>, manager: Arc<LocalSessionManager>) {
+async fn sweep(
+    sessions: Sessions,
+    lease: Arc<Lease>,
+    manager: Arc<LocalSessionManager>,
+    idle_after: Option<Duration>,
+) {
     loop {
         tokio::time::sleep(SWEEP).await;
+        // Independent of the lease, and checked first, because it is the half that still works on
+        // a stateless transport: the lease needs a client to identify, and on `2026-07-28` there
+        // is no session id to identify one by. See [`IDLE_RELEASE`].
+        if let Some(after) = idle_after {
+            sessions.release_idle(after).await;
+        }
         // The engine may have gone idle since the last tick, which is not something the HTTP side
         // is told about.
         lease.try_give_up();
@@ -864,6 +947,48 @@ mod tests {
             sessions: Sessions::new(CALL),
             state: Mutex::new(Tenancy::default()),
         }
+    }
+
+    /// The floor is the same one the lease refuses to start below, and for the same reason: a
+    /// single call can keep a session quiet for its whole budget, so a release shorter than that
+    /// ends a session while its own caller is still waiting on it.
+    #[test]
+    fn an_idle_release_shorter_than_a_call_is_refused() {
+        let too_short = (longest_quiet_call(CALL) - Duration::from_secs(1))
+            .as_secs()
+            .to_string();
+        let why = idle_release_from(Some(&too_short), CALL)
+            .expect_err("a release inside the call budget must be refused");
+        assert!(
+            why.to_string().contains(IDLE_ENV),
+            "the message has to name the variable to change: {why}"
+        );
+    }
+
+    /// Zero is a supported answer — a host where every client hangs up properly — and it disables
+    /// the backstop rather than failing.
+    #[test]
+    fn zero_disables_the_idle_release() {
+        assert_eq!(
+            idle_release_from(Some("0"), CALL).expect("zero is allowed"),
+            None
+        );
+    }
+
+    /// And an unconfigured host gets a default that clears the floor, so it starts.
+    #[test]
+    fn the_default_idle_release_clears_the_floor() {
+        assert_eq!(
+            idle_release_from(None, CALL).expect("the default has to be workable"),
+            Some(IDLE_RELEASE)
+        );
+    }
+
+    /// A value that is not seconds is refused by name rather than silently taking the default.
+    #[test]
+    fn an_unparseable_idle_release_is_refused() {
+        let why = idle_release_from(Some("half an hour"), CALL).expect_err("not a number");
+        assert!(why.to_string().contains(IDLE_ENV), "{why}");
     }
 
     /// The claim an admitted request reserved. Panics if the gate refused, since every caller here


### PR DESCRIPTION
First slice of [#162](https://github.com/glslang/windbg-mcp/issues/162), and deliberately the one
that needs no design decision.

## The problem

`2026-07-28` removed sessions from MCP (SEP-2567). The lease identifies a client by
`Mcp-Session-Id`, so on the revision most clients now negotiate there is no holder to install, no
lease to expire, and **no moment at which a client can be said to have gone away**. A client that
vanishes leaves its targets held until the process exits — for a live kernel, a machine owned by
nobody, which is the property phase 1 was built to rebuild.

Measured, not inferred:

```
Two independent clients at 2026-07-28 (sessions removed from the spec):
  client A tools/call -> HTTP 200
  client B tools/call -> HTTP 200      (2025-06-18 gives B a 409)
```

## What this adds

The lease was doing two jobs and only one needs a client identity. "Has *this client* gone" cannot
be answered without one. "Is anyone still using this target" can, and that is this: a session unused
for **30 minutes** is released, through the same orderly `EndSession` an explicit `end_session`
uses, because a live kernel that is merely killed is left halted.

| | |
| --- | --- |
| Default | 30 minutes since the last call naming that session |
| Override | `WINDBG_MCP_SESSION_IDLE_SECS`, whole seconds; `0` disables |
| Floor | must exceed the longest a single call can run, or the server refuses to start |

## Three things it must not get wrong

**A session with a call outstanding is never idle**, however old the call. Not defensive coding: an
`attach_kernel` parked in `WaitForEvent(INFINITE)` submits one call and then waits for its target to
dial in, possibly for hours, and it is exactly the session that must survive. Reading the clock
alone would release the one session whose entire job is to wait. `Session::busy()` already knew
this; the idle check asks it first, and a test backdates a session an hour to prove an outstanding
waiter still saves it.

**Nor is an opener that has not handed its handle back** — nobody can have used a session whose id
its caller has not been told.

**The timeout has the same floor the lease refuses to start below.** A single call can keep a
session quiet for its whole budget, so anything shorter releases a session underneath its own
caller. Misconfiguration is a startup message, not a target that disappears mid-analysis.

## Why 30 minutes rather than the lease's 390 seconds

They measure different things. A lease is renewed by *any* request, so a working client renews it
constantly. This is per session, and twenty minutes of reading a stack before the next question is
ordinary work, not abandonment. A backstop, not a scheduler.

## What it does not do

It does not make two clients safe from each other — that needs the client identity and the
namespaces built on it, slices 2 and 3 in #162. It stops the leak that has no workaround today, on
every transport rather than only the one with sessions in it.

## Testing

ARM64 bench: clippy clean, `cargo test --bins` **457 passed** (six new — three for the idle
decision, three for the configuration floor and the `0` case).

`WINDBG_MCP_SMOKE_DUMP=1 cargo test --test mcp_smoke -- --test-threads=1` hit
[#163](https://github.com/glslang/windbg-mcp/issues/163) once — a pre-existing flake in the batch
rollback's *progress notification*, unrelated to this change and first seen on `main` before it.
That issue now carries the diagnosis: the worker's two `RollingBack` messages come from different
threads, and the retraction can arrive after the `end_session` response, by which point the call's
progress sink is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sessions are now automatically released after 30 minutes of inactivity by default.
  * The idle-release period can be configured with `WINDBG_MCP_SESSION_IDLE_SECS`; setting it to `0` disables the feature.
  * Active calls and unfinished operations are protected from automatic release.

* **Documentation**
  * Added guidance on idle-session release, configuration, validation, and behaviour when session identifiers are unavailable.
  * Documented the new unreleased changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->