### PR TITLE
Finish the milestone the answer was racing, instead of dropping it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **The last progress milestone is no longer dropped when it races the answer**
+  ([#163](https://github.com/glslang/windbg-mcp/issues/163)). A client watching a long call would
+  intermittently miss the milestone it most wants — "the target is open", "the rollback finished" —
+  because that is the one arriving beside the result.
+
+  `relay` takes a step out of the channel and then sends it. If the send was not ready on its first
+  poll, which is ordinary for a write to a peer, and the answer was ready beside it, the loop broke
+  and **that message was gone**: the flush at the end re-sends what is still queued, and this one had
+  already been taken. It now finishes the send on the same bounded terms the flush uses, so a client
+  that has stopped reading still loses the courtesy after a second — it just no longer loses it to a
+  scheduling coin toss.
+
+  The result was never affected; it always carried the truth. What was affected is a client that
+  watches progress and sees a long unwind stop at "rolling it back (up to 2m03s)" with no closing
+  word.
+
+  It surfaced as roughly one debugger-tier run in five failing on one of two tests, which is what
+  made it worth chasing: every test in `src/progress.rs` used a notification that completes on its
+  first poll, so the losing arm was unreachable and the bug lived entirely in the gap between the
+  test double and a real write.
+
 - **A session nobody is using is released, whatever the transport did.** The lease answers "has this
   *client* gone away" by identifying it from `Mcp-Session-Id` — and `2026-07-28` removed the protocol-level
   MCP session (SEP-2567), so on the revision most clients now negotiate no holder is ever installed and

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -288,7 +288,23 @@ where
             // throughout, so it never waits on the notification.
             biased;
             () = &mut sending => {}
-            outcome = &mut work => break 'running outcome,
+            outcome = &mut work => {
+                // **This message is already out of the channel**, so abandoning it here loses it
+                // outright — the flush below can only re-send what is still queued, and cannot see
+                // what this arm took. That is how the *last* milestone went missing about one run
+                // in five ([#163]): a send that is not ready on its first poll, beside an answer
+                // that is, and the milestone a client most wants — "the target is open", "the
+                // rollback finished" — is the one dropped, because it is the one racing the result.
+                //
+                // Finished on the same bounded terms as the flush rather than awaited outright: the
+                // result exists by here and nothing may hold it back, so a client that has stopped
+                // reading still loses the courtesy after `FINAL_FLUSH` — it just no longer loses it
+                // to a scheduling coin toss.
+                //
+                // [#163]: https://github.com/glslang/windbg-mcp/issues/163
+                let _ = tokio::time::timeout(FINAL_FLUSH, sending).await;
+                break 'running outcome;
+            }
         }
     };
 
@@ -337,6 +353,56 @@ mod tests {
             .iter()
             .map(|(_, message)| message.clone())
             .collect()
+    }
+
+    /// A notification that is not ready on its *first* poll is still delivered when the answer is
+    /// ready beside it.
+    ///
+    /// [#163](https://github.com/glslang/windbg-mcp/issues/163): the collector above completes
+    /// immediately, so every test here took the happy path through the inner `select!`. A real
+    /// notification is a write to a peer, and one that returns `Pending` once — which is ordinary —
+    /// used to lose the race to an answer that was already ready. The step had *already been taken
+    /// out of the channel* by then, so the flush at the end could not recover it either: the
+    /// milestone was simply gone, and it was always the last one, because that is the one racing
+    /// the result. Roughly one debugger-tier run in five, on two different tests.
+    #[tokio::test(start_paused = true)]
+    async fn a_notification_that_yields_once_still_reaches_the_client() {
+        let sent: Sent = Arc::default();
+        let into = Arc::clone(&sent);
+        // Pending on the first poll, ready on the next — the cheapest stand-in for a write that
+        // does not complete synchronously.
+        let notify = move |progress: f64, message: String| {
+            let into = Arc::clone(&into);
+            async move {
+                tokio::task::yield_now().await;
+                into.lock()
+                    .unwrap_or_else(|e| e.into_inner())
+                    .push((progress, message));
+            }
+        };
+
+        relay(
+            async {
+                report(Step::Opened);
+                // **The yield is the whole test.** Without it the work completes on its first poll,
+                // the step is still in the channel, and the tail flush delivers it — which is a
+                // different path and passes either way. Yielding lets the loop *take* the step and
+                // start sending it, and the answer then becomes ready during that send: the only
+                // arrangement in which a milestone is lost outright.
+                tokio::task::yield_now().await;
+            },
+            Duration::from_secs(10),
+            notify,
+        )
+        .await;
+
+        assert_eq!(
+            messages(&sent).len(),
+            1,
+            "the milestone was taken from the channel and then dropped when its send lost the \
+             race — the flush cannot recover what the loop already took: {:?}",
+            messages(&sent)
+        );
     }
 
     /// A milestone reported in the same turn as the answer is still delivered.


### PR DESCRIPTION
Fixes [#163](https://github.com/glslang/windbg-mcp/issues/163).

A client watching a long call intermittently missed the milestone it most wants — "the target is
open", "the rollback finished" — because that is exactly the one arriving beside the result. It
surfaced as roughly **one debugger-tier run in five** failing, on either of two tests.

## The cause

`relay` takes a step out of the channel and *then* sends it:

```rust
let mut sending = std::pin::pin!(notify(reported, message));
tokio::select! {
    biased;
    () = &mut sending => {}
    outcome = &mut work => break 'running outcome,   // the message is already gone
}
```

If that send is not ready on its first poll — ordinary for a write to a peer — and the answer is
ready beside it, the loop breaks and **the message is lost outright**. The tail flush cannot recover
it, because the flush re-sends what is still *queued* and this one had already been taken. So the
last milestone was delivered or not depending on how the scheduler interleaved two ready futures.

That accounts for both symptoms, including why it is always the last one:

- `an_open_reports_its_milestones_before_it_answers` — got `Spawned` and `Committed`, lost `Opened`
- `ending_a_session_stops_a_running_batch_and_rolls_it_back` — got the promise, lost the retraction

My first diagnosis on the issue blamed the sink being torn down; that was wrong, and the tail flush
comment in the file says why. The corrected analysis is in the issue.

## The fix

Finish the taken send on the same bounded terms the flush already uses. The property the
abandonment existed for is kept — a client that has stopped reading its stream still cannot hold up
the debugger; it loses the courtesy after `FINAL_FLUSH` rather than to a coin toss.

The result was never affected. It always carried the truth, which is why this cost a notification
and not a fact.

## The bug lived in the gap between the test double and a real write

Every test in `src/progress.rs` used a `notify` returning `std::future::ready(())`, so the send
always completed on its first poll and the losing arm was **unreachable**. The new test uses a
notification that yields once, and a `work` future that yields *after* reporting. Both halves are
needed — I wrote the version without the second one first and it passed against the unfixed code,
because the step stayed in the channel and the tail flush delivered it.

Verified both ways, which is the only way to know a regression test is one:

```
with the fix:     a_notification_that_yields_once_still_reaches_the_client ... ok
without the fix:  the milestone was taken from the channel and then dropped when its send lost
                  the race — the flush cannot recover what the loop already took: []
```

## Testing

ARM64 bench: clippy clean, `cargo test --bins` **459 passed** (one new).

`WINDBG_MCP_SMOKE_DUMP=1 cargo test --test mcp_smoke -- --test-threads=1` — **five consecutive runs,
61 passed each**. Against a failure rate of about one in five, that is ~67% confidence on its own;
the regression test is what actually pins it, and the five runs are the corroboration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)