### PR TITLE
Give each client its own sessions, since the protocol no longer names one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     still report another client's activity.
   - **A lease expiry releases the sessions of the client whose lease ran out**, not every session.
     Before ownership those were the same set, because the gate served one client at a time.
+  - The rule for identity is **ambient inside a call, by name outside one**. A tool body reads the
+    caller from the task-local, which is who is asking; the listener's own diagnostics run after
+    that scope has closed and take the client as a parameter, so the one that reports an adoption on
+    reconnect counts the reconnecting client's sessions rather than `local`'s.
   - **The tenancy itself is per client**, so two clients no longer queue behind each other. The gate
     serialised the server when the registry was global and one client could end another's targets;
     keeping it shared would have meant one client's four-minute pool walk making every other client

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     still report another client's activity.
   - **A lease expiry releases the sessions of the client whose lease ran out**, not every session.
     Before ownership those were the same set, because the gate served one client at a time.
+  - **An `Mcp-Session-Id` another client holds is reported unknown**, and the check runs before the
+    caller's own tenancy is consulted. The MCP service keeps one session table for the server, so on
+    a legacy revision the id was the only thing between a client and another's MCP session — and a
+    `DELETE` on it closed that session while the lease that minted it still held the id, leaving its
+    owner failing every request and refused its own re-`initialize` for a grace period.
   - The rule for identity is **ambient inside a call, by name outside one**. A tool body reads the
     caller from the task-local, which is who is asking; the listener's own diagnostics run after
     that scope has closed and take the client as a parameter, so the one that reports an adoption on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   so there is no connection either; `clientInfo` is not retained. The credential is what is left,
   and a name only the holder of a token can present is a boundary — where a name a client picks for
   itself would be a label. Configuring one token for two names is refused at startup rather than
-  resolved, because the winner would be a hash-map ordering detail.
+  resolved, because the winner would be a hash-map ordering detail. Both refusals name the
+  *variables* to change and never the token: they are printed to stderr, and under the service to a
+  log file, so quoting the credential would leave a working one there.
 
   This separates clients; it does not rank them. Everyone who can authenticate still has the whole
   tool surface.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Per-client session namespaces, so two clients on one listener cannot reach each other's
+  targets** ([#162](https://github.com/glslang/windbg-mcp/issues/162), slices 2 and 3). A listener
+  may now hold several bearer tokens — `WINDBG_MCP_LISTEN_TOKEN_<NAME>` names a client, the unnamed
+  variable names `local` — and a session belongs to whichever client opened it.
+
+  - **Routing** is per client: a handle only routes for its owner, and omitting one finds that
+    client's newest session.
+  - **Another client's handle is reported unknown**, not "someone else's". The answer must not
+    confirm a session the caller may not touch, and there is nothing they could do with the
+    distinction.
+  - **`session_status` lists only the caller's**, and the four-session **cap is per client**, so a
+    busy client cannot deny a quiet one. A session is only ever reclaimed to make room for its own
+    client — reclaiming another's is the precise harm a shared registry did.
+  - **`server_log`** shows the caller's sessions' records and the supervisor's own — one ring serves
+    the whole server, so without this a client could read what another's worker printed.
+  - **A lease expiry releases the sessions of the client whose lease ran out**, not every session.
+    Before ownership those were the same set, because the gate served one client at a time.
+  - **The tenancy itself is per client**, so two clients no longer queue behind each other. The gate
+    serialised the server when the registry was global and one client could end another's targets;
+    keeping it shared would have meant one client's four-minute pool walk making every other client
+    wait for a boundary the registry now provides properly — namespaces that cannot be used
+    concurrently. Two connections presenting the *same* token still contend, which is one client
+    racing itself.
+  - Under **stdio** everything runs as `local`, so one set of registry rules serves both transports
+    rather than one rule and an exception.
+  - **Every credential variable is stripped from the processes this server creates** — by prefix,
+    so a token added later cannot quietly reach a debuggee — and a configured token *file* shuts the
+    environment out entirely, which is the precedence a LocalSystem service depends on.
+
+  **Why authentication is the identity.** `2026-07-28` removed the protocol-level MCP session, so
+  there is no session id to key on; requests arrive on whatever socket a client's pool hands them,
+  so there is no connection either; `clientInfo` is not retained. The credential is what is left,
+  and a name only the holder of a token can present is a boundary — where a name a client picks for
+  itself would be a label. Configuring one token for two names is refused at startup rather than
+  resolved, because the winner would be a hash-map ordering detail.
+
+  This separates clients; it does not rank them. Everyone who can authenticate still has the whole
+  tool surface.
+
 - **`server_log` — the server's own log, readable from wherever the client is.** The supervisor
   keeps a bounded ring of the most recent records, its own and every engine worker's, and serves
   them as a tool: filterable by session and level, paged with a `since` cursor, answered without

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **`session_status` lists only the caller's**, and the four-session **cap is per client**, so a
     busy client cannot deny a quiet one. A session is only ever reclaimed to make room for its own
     client — reclaiming another's is the precise harm a shared registry did.
+  - **Closed-session history is per client too**, so a handle still answers after its target is gone
+    however busy the rest of the server has been. A shared bound is a shared fate: one client's
+    churn would age out another's record of a session that failed, and the answer that client then
+    gets for a handle it is still holding is "unknown" — which reads as "never existed".
   - **`server_log`** shows the caller's sessions' records and the supervisor's own — one ring serves
-    the whole server, so without this a client could read what another's worker printed.
+    the whole server, so without this a client could read what another's worker printed. **Its
+    counts are the caller's too**: how full the buffer is, where the cursor is now and what the
+    oldest record is are all over that client's stream, since numbers about records nobody may read
+    still report another client's activity.
   - **A lease expiry releases the sessions of the client whose lease ran out**, not every session.
     Before ownership those were the same set, because the gate served one client at a time.
   - **The tenancy itself is per client**, so two clients no longer queue behind each other. The gate

--- a/docs/remote-listener.md
+++ b/docs/remote-listener.md
@@ -212,6 +212,7 @@ What ownership buys, and it is the whole of it:
 | History | a closed session ages out of `session_status` on its **own** client's churn, not the server's |
 | The log | `server_log` shows the caller's sessions' records, plus the supervisor's own, which name no session — and the buffer counts it reports are over the records that caller can read |
 | Lease expiry | releases the sessions of the client whose lease ran out, and no others |
+| Session ids | an `Mcp-Session-Id` another client holds is reported **unknown**, before this caller's own tenancy is consulted |
 | Contention | **within** a client only — one client's long call does not make another wait |
 
 **Why authentication is the identity.** `2026-07-28` removed the protocol-level MCP session

--- a/docs/remote-listener.md
+++ b/docs/remote-listener.md
@@ -184,27 +184,61 @@ time, because a live kernel that is merely killed is left halted.
 
 [SEP-2567]: https://modelcontextprotocol.io/seps/2567-sessionless-mcp
 
-## One client at a time
+## A client per token, and sessions that belong to it
 
-A second client is refused with `409`. This is forced by the registry rather than chosen: session
-handles are minted globally, the four-session cap is shared, and `end_session` ends whatever it is
-handed — so two clients would silently share, and one could end a target the other was using.
+A listener may hold several tokens, each naming a client, and **a session belongs to the client that
+opened it**:
 
-The token is the identity. There is one authorised client, so presenting the token *is* the proof,
-and a reconnect needs nothing further.
+```console
+setx WINDBG_MCP_LISTEN_TOKEN        "<a long random string>"   # the client named `local`
+setx WINDBG_MCP_LISTEN_TOKEN_CI     "<another>"                # the client named `ci`
+setx WINDBG_MCP_LISTEN_TOKEN_LAPTOP "<another>"                # `laptop`
+```
 
-A `409` therefore means one of:
+The suffix is the name, lowercased — the same rule a kernel profile's variable follows. The unnamed
+variable still works and names the client `local`, which is also who every stdio call runs as, so
+one set of rules covers both transports. Configuring one token for two names is refused at startup:
+the winner would be a hash-map ordering detail, and a boundary that moves between runs is not one.
 
-- another client holds the server, and has not gone away or timed out yet;
-- a client is mid-`initialize` and has not been given a session id yet;
-- sessions are being released after a lease expired, which finishes within a sweep (5 s);
-- your own request outlived its claim — open a new session.
+What ownership buys, and it is the whole of it:
 
-Tenancy changes hands only when nothing is still using the server: no HTTP request admitted under
-the holder is outstanding, **and** no debug session has work in flight. The second is the one worth
-knowing about, because an engine job outlives the request that asked for it — a call whose client
-gave up is still running against the target, and the server will not hand that target on until it
-finishes.
+| | |
+| --- | --- |
+| Routing | a handle only routes for the client that opened it; omitting one finds *that* client's newest session |
+| Refusal | another client's handle is reported **unknown**, not "someone else's" — the answer must not confirm a session the caller may not touch |
+| Listing | `session_status` shows the caller's sessions and no others |
+| Capacity | the four-session cap is per client, so a busy one cannot deny a quiet one |
+| Reclamation | a session is only ever reclaimed to make room for **its own** client |
+| The log | `server_log` shows the caller's sessions' records, plus the supervisor's own, which name no session |
+| Lease expiry | releases the sessions of the client whose lease ran out, and no others |
+| Contention | **within** a client only — one client's long call does not make another wait |
+
+**Why authentication is the identity.** `2026-07-28` removed the protocol-level MCP session
+([SEP-2567]), so there is no session id to key on; requests arrive on whatever socket a client's
+pool hands them, so there is no connection either; and `clientInfo` is not retained between
+requests. The credential is what is left, and it is what every other stateless HTTP API uses. A name
+a client presents for itself would be a label; a name only the holder of a token can present is a
+boundary.
+
+**Two clients do not queue behind each other.** The lease still arbitrates *within* a client — two
+connections presenting the same token contend, and the second gets a `409` — because that is one
+client racing itself. Across clients there is nothing to arbitrate: a pool walk that keeps one
+client busy for four minutes used to make every other client wait, for a boundary the registry now
+provides properly.
+
+**This does not authorise anything beyond separation.** Every client that can authenticate has the
+whole tool surface, including `execute` and `launch`. Tokens separate clients from each other; they
+do not rank them.
+
+**A token file is the only credential when one is configured.** `WINDBG_MCP_LISTEN_TOKEN_FILE` shuts
+the environment out entirely — named tokens included — rather than merely outranking the unnamed
+variable. That precedence is load-bearing: the service installer ACLs that file to SYSTEM and
+Administrators *because* the machine environment is readable by unprivileged processes, so a
+variable standing beside it would reintroduce exactly what the file was written to avoid.
+
+**Every credential variable is stripped from the processes this server creates** — engine workers
+and the TTD recorder — by prefix rather than by name, so a token added later cannot quietly reach a
+debuggee. See the warning above about what that does and does not protect.
 
 ## Reading the server's log from the client machine
 

--- a/docs/remote-listener.md
+++ b/docs/remote-listener.md
@@ -209,7 +209,8 @@ What ownership buys, and it is the whole of it:
 | Listing | `session_status` shows the caller's sessions and no others |
 | Capacity | the four-session cap is per client, so a busy one cannot deny a quiet one |
 | Reclamation | a session is only ever reclaimed to make room for **its own** client |
-| The log | `server_log` shows the caller's sessions' records, plus the supervisor's own, which name no session |
+| History | a closed session ages out of `session_status` on its **own** client's churn, not the server's |
+| The log | `server_log` shows the caller's sessions' records, plus the supervisor's own, which name no session — and the buffer counts it reports are over the records that caller can read |
 | Lease expiry | releases the sessions of the client whose lease ran out, and no others |
 | Contention | **within** a client only — one client's long call does not make another wait |
 
@@ -229,6 +230,15 @@ provides properly.
 **This does not authorise anything beyond separation.** Every client that can authenticate has the
 whole tool surface, including `execute` and `launch`. Tokens separate clients from each other; they
 do not rank them.
+
+**One thing a client can still infer: that another one is busy.** `server_log`'s sequence numbers
+are assigned across the whole server, and that is what makes a `since` cursor exact under eviction —
+so a client reading two of its own records numbered a hundred apart can tell that *something* was
+filed in between. It learns a count. The records, the sessions they belong to and their text stay
+unreachable, and every number the tool reports — how full the buffer is, where the cursor is now,
+what the oldest record is — is over that client's own stream. Numbering per client would close the
+last of it and cost the cursor its stability, which is a bad trade for a shared debug host and a
+worse one for a hostile tenant, who should not be sharing a listener at all.
 
 **A token file is the only credential when one is configured.** `WINDBG_MCP_LISTEN_TOKEN_FILE` shuts
 the environment out entirely — named tokens included — rather than merely outranking the unnamed

--- a/src/client.rs
+++ b/src/client.rs
@@ -116,13 +116,23 @@ impl Credentials {
         file_token: Option<String>,
     ) -> Result<Self> {
         let mut by_token: HashMap<String, Client> = HashMap::new();
+        // Client name to the *variable* that configured it — never to the token. Both refusals
+        // below are printed at startup, to stderr in the foreground and to the service log under
+        // the SCM, so a message quoting the credential it is complaining about would write a
+        // working listener token into whatever collects those. The variable is also the more useful
+        // half: it is what the operator has to go and change.
         let mut named: HashMap<String, String> = HashMap::new();
-        let mut insert = |token: String, name: &str| -> Result<()> {
+        let mut insert = |token: String, name: &str, from: &str| -> Result<()> {
             if let Some(existing) = by_token.get(&token) {
+                // One client is one credential (the check below), so the variable that configured
+                // this token is the one that configured that client.
+                let first = named
+                    .get(existing.name())
+                    .map_or("another variable", String::as_str);
                 bail!(
-                    "the same token is configured for `{existing}` and `{name}`. One credential \
-                     cannot name two clients: sessions opened with it would belong to whichever \
-                     name happened to win."
+                    "`{from}` and `{first}` are the same token, configured for `{name}` and \
+                     `{existing}`. One credential cannot name two clients: sessions opened with it \
+                     would belong to whichever name happened to win."
                 );
             }
             // **And the other way round.** Two *different* tokens landing on one name is the more
@@ -134,11 +144,11 @@ impl Credentials {
             if let Some(other) = named.get(name) {
                 bail!(
                     "two different tokens are configured for the client `{name}` (`{other}` and \
-                     this one). Each client is one credential: two would share every session, \
+                     `{from}`). Each client is one credential: two would share every session, \
                      which is the isolation this is for, silently absent."
                 );
             }
-            named.insert(name.to_string(), token.clone());
+            named.insert(name.to_string(), from.to_string());
             by_token.insert(token, Client::new(name));
             Ok(())
         };
@@ -151,7 +161,7 @@ impl Credentials {
         // So a file shuts the environment out entirely rather than merely outranking the unnamed
         // variable.
         if let Some(token) = file_token {
-            insert(token, Client::LOCAL)?;
+            insert(token, Client::LOCAL, TOKEN_FILE_ENV)?;
             return Ok(Self { by_token });
         }
         for (key, value) in vars {
@@ -164,7 +174,7 @@ impl Credentials {
             }
             match credential_suffix(&key) {
                 // The unnamed variable, which is what every existing setup uses.
-                Some("") => insert(token, Client::LOCAL)?,
+                Some("") => insert(token, Client::LOCAL, &key)?,
                 // `WINDBG_MCP_LISTEN_TOKEN_CI` names the client `ci`, the same lowercasing a
                 // kernel profile's variable gets.
                 Some(suffix) => {
@@ -172,7 +182,7 @@ impl Credentials {
                     if name.is_empty() {
                         continue;
                     }
-                    insert(token, &name)?;
+                    insert(token, &name, &key)?;
                 }
                 None => {}
             }
@@ -315,6 +325,43 @@ mod tests {
         );
         let why = clash.expect_err("a duplicate token is a configuration error");
         assert!(why.to_string().contains("cannot name two clients"), "{why}");
+        assert!(
+            why.to_string().contains("WINDBG_MCP_LISTEN_TOKEN_A")
+                && why.to_string().contains("WINDBG_MCP_LISTEN_TOKEN_B"),
+            "the refusal has to name the two variables, since they are what has to change: {why}"
+        );
+    }
+
+    /// **Neither refusal may quote the credential it is refusing.** Both are printed at startup —
+    /// to stderr in the foreground, to `%ProgramData%\windbg-mcp\service.log` under the SCM — so a
+    /// message carrying the token would leave a working listener credential in whatever collects
+    /// those, which outlives the misconfiguration by as long as the file does.
+    #[test]
+    fn a_refusal_never_quotes_the_token_it_refuses() {
+        let secrets = ["s3cret-alpha", "s3cret-beta"];
+        let refusals = [
+            // One credential, two names.
+            vec![
+                ("WINDBG_MCP_LISTEN_TOKEN_A", secrets[0]),
+                ("WINDBG_MCP_LISTEN_TOKEN_B", secrets[0]),
+            ],
+            // Two credentials, one name.
+            vec![
+                ("WINDBG_MCP_LISTEN_TOKEN_CI", secrets[0]),
+                ("WINDBG_MCP_LISTEN_TOKEN__CI", secrets[1]),
+            ],
+        ];
+        for pairs in refusals {
+            let why = Credentials::from_entries(vars(&pairs), None)
+                .expect_err("a configuration error")
+                .to_string();
+            for secret in secrets {
+                assert!(
+                    !why.contains(secret),
+                    "a startup refusal wrote a bearer token into the log: {why}"
+                );
+            }
+        }
     }
 
     /// Windows environment names are case-insensitive, and `std::env::var` honours that — so a host

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,0 +1,267 @@
+//! Which client a call belongs to, and how this server knows.
+//!
+//! # Why this exists
+//!
+//! The listener used to answer "whose call is this?" with the MCP session id, and serve one client
+//! at a time so the answer was always "the only one". `2026-07-28` removed the protocol-level
+//! session (SEP-2567), so that identifier is gone on the revision most clients now negotiate, and
+//! with it both properties the tenancy gate provided: two clients are served, and neither can be
+//! told apart ([#162](https://github.com/glslang/windbg-mcp/issues/162)).
+//!
+//! **In a stateless protocol the only sound identity is authentication.** There is no connection to
+//! key on — requests arrive on whatever socket the client's pool hands them — no session id by
+//! design, and `clientInfo` is not retained between requests. What is left is the credential the
+//! caller presents, which is exactly how every other stateless HTTP API knows who is asking.
+//!
+//! So a listener may hold several tokens, each naming a client, and a session belongs to whichever
+//! client opened it. A name that another client cannot present is a boundary; a name it chooses for
+//! itself would be a label.
+//!
+//! # How it reaches a tool
+//!
+//! The same way a progress sink does, and for the same reason: the identity is known at the
+//! transport and needed forty-odd tool bodies away, and threading it through every signature would
+//! name something none of them uses. It is a task-local, set around the whole MCP call so the
+//! routing, the worker handshake and the engine call all run inside the scope.
+//!
+//! Under stdio there is nothing to authenticate and nothing to separate — one process, one client,
+//! by construction — so calls there run as [`Client::LOCAL`] and every lookup behaves as it always
+//! has.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use anyhow::{Result, bail};
+
+/// The unnamed token, and the prefix of a named one.
+const TOKEN_ENV: &str = "WINDBG_MCP_LISTEN_TOKEN";
+
+/// The variable naming a *file* to read a token from, which shares that prefix and is not one.
+///
+/// Excluded by name rather than by shape: its value is a path, so without this it would configure
+/// a client called `file` whose credential is `C:\...\token` — a token nobody holds, under a name
+/// nobody chose, and the real token silently absent.
+const TOKEN_FILE_ENV: &str = "WINDBG_MCP_LISTEN_TOKEN_FILE";
+
+/// Who a call belongs to.
+///
+/// A name rather than an opaque id so it can be said out loud — in a log line, in `session_status`,
+/// in the message a caller gets when it asks for a session that is not its own. It is chosen by
+/// whoever configured the token, never by the client presenting it.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct Client(Arc<str>);
+
+impl Client {
+    /// The client every stdio call belongs to.
+    ///
+    /// Not a placeholder: under stdio there is exactly one client by construction — it owns the
+    /// process's standard handles — so naming it is what lets one set of registry rules serve both
+    /// transports rather than one rule and an exception.
+    pub const LOCAL: &'static str = "local";
+
+    pub fn new(name: impl AsRef<str>) -> Self {
+        Self(Arc::from(name.as_ref()))
+    }
+
+    pub fn local() -> Self {
+        Self::new(Self::LOCAL)
+    }
+
+    pub fn name(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for Client {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// The tokens this listener accepts, and the client each one names.
+#[derive(Debug, Clone, Default)]
+pub struct Credentials {
+    by_token: HashMap<String, Client>,
+}
+
+impl Credentials {
+    /// The client presenting `token`, or `None` if nothing here accepts it.
+    pub fn client_for(&self, token: &str) -> Option<&Client> {
+        self.by_token.get(token)
+    }
+
+    pub fn len(&self) -> usize {
+        self.by_token.len()
+    }
+
+    /// Every configured name, sorted — for the one log line that says who may connect.
+    pub fn names(&self) -> Vec<&str> {
+        let mut names: Vec<&str> = self.by_token.values().map(Client::name).collect();
+        names.sort_unstable();
+        names
+    }
+
+    /// Builds the set from `(variable, value)` pairs and the file token, if there is one.
+    ///
+    /// Takes the variables rather than reading the environment for the reason
+    /// [`crate::kdconn::env_entries`] does: `set_var` is `unsafe` in edition 2024 and mutates state
+    /// the whole test binary shares, so the only way to assert that
+    /// `WINDBG_MCP_LISTEN_TOKEN_CI` names the client `ci` is to hand the scan its variables.
+    ///
+    /// A token appearing twice is refused rather than resolved. Two names for one credential means
+    /// a caller's sessions land under whichever name won a `HashMap` insertion, which is a rule
+    /// nobody could predict and a boundary that would move.
+    pub fn from_entries(
+        vars: impl Iterator<Item = (String, String)>,
+        file_token: Option<String>,
+    ) -> Result<Self> {
+        let mut by_token: HashMap<String, Client> = HashMap::new();
+        let mut insert = |token: String, name: &str| -> Result<()> {
+            if let Some(existing) = by_token.get(&token) {
+                bail!(
+                    "the same token is configured for `{existing}` and `{name}`. One credential \
+                     cannot name two clients: sessions opened with it would belong to whichever \
+                     name happened to win."
+                );
+            }
+            by_token.insert(token, Client::new(name));
+            Ok(())
+        };
+
+        if let Some(token) = file_token {
+            insert(token, Client::LOCAL)?;
+        }
+        for (key, value) in vars {
+            let token = value.trim().to_string();
+            if token.is_empty() {
+                continue;
+            }
+            if key == TOKEN_FILE_ENV {
+                continue;
+            }
+            match key.strip_prefix(TOKEN_ENV) {
+                // The unnamed variable, which is what every existing setup uses.
+                Some("") => insert(token, Client::LOCAL)?,
+                // `WINDBG_MCP_LISTEN_TOKEN_CI` names the client `ci`, the same lowercasing a
+                // kernel profile's variable gets.
+                Some(suffix) => {
+                    let name = suffix.trim_start_matches('_').to_ascii_lowercase();
+                    if name.is_empty() {
+                        continue;
+                    }
+                    insert(token, &name)?;
+                }
+                None => {}
+            }
+        }
+        Ok(Self { by_token })
+    }
+}
+
+tokio::task_local! {
+    /// The client whose call is running on this task.
+    ///
+    /// Set by the transport — the listener around each MCP call, once it knows which token was
+    /// presented — and read wherever a session is opened or looked up. Unset outside a call, and
+    /// under stdio, where [`current`] answers [`Client::local`].
+    static CALLER: Client;
+}
+
+/// The client this call belongs to.
+///
+/// [`Client::local`] when nothing set one, which is stdio and every in-process test: a server with
+/// no authentication has exactly one client, and giving it a name is what keeps the registry rules
+/// uniform instead of conditional.
+pub fn current() -> Client {
+    CALLER
+        .try_with(Clone::clone)
+        .unwrap_or_else(|_| Client::local())
+}
+
+/// Runs `work` as `client`.
+pub async fn as_client<F: std::future::Future>(client: Client, work: F) -> F::Output {
+    CALLER.scope(client, work).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn vars(pairs: &[(&str, &str)]) -> impl Iterator<Item = (String, String)> + use<> {
+        pairs
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .collect::<Vec<_>>()
+            .into_iter()
+    }
+
+    /// The unnamed variable is what every existing listener uses, so it keeps working and names the
+    /// same client stdio calls run as.
+    #[test]
+    fn the_unnamed_token_names_the_local_client() {
+        let creds = Credentials::from_entries(vars(&[(TOKEN_ENV, "s3cret")]), None).expect("valid");
+        assert_eq!(creds.client_for("s3cret").map(Client::name), Some("local"));
+        assert_eq!(creds.client_for("wrong"), None);
+    }
+
+    /// A suffix names a client, lowercased — the same rule a kernel profile's variable follows.
+    #[test]
+    fn a_suffixed_token_names_its_client() {
+        let creds = Credentials::from_entries(
+            vars(&[
+                ("WINDBG_MCP_LISTEN_TOKEN_CI", "ci-token"),
+                ("WINDBG_MCP_LISTEN_TOKEN_Laptop", "laptop-token"),
+            ]),
+            None,
+        )
+        .expect("valid");
+        assert_eq!(creds.client_for("ci-token").map(Client::name), Some("ci"));
+        assert_eq!(
+            creds.client_for("laptop-token").map(Client::name),
+            Some("laptop")
+        );
+        assert_eq!(creds.names(), vec!["ci", "laptop"]);
+    }
+
+    /// One credential naming two clients is refused at startup rather than resolved, because the
+    /// winner would be a `HashMap` ordering detail and the boundary would move between runs.
+    #[test]
+    fn one_token_may_not_name_two_clients() {
+        let clash = Credentials::from_entries(
+            vars(&[
+                ("WINDBG_MCP_LISTEN_TOKEN_A", "same"),
+                ("WINDBG_MCP_LISTEN_TOKEN_B", "same"),
+            ]),
+            None,
+        );
+        let why = clash.expect_err("a duplicate token is a configuration error");
+        assert!(why.to_string().contains("cannot name two clients"), "{why}");
+    }
+
+    /// An empty value is not a token — it is a variable somebody exported and never set.
+    #[test]
+    fn an_empty_value_configures_nothing() {
+        let creds = Credentials::from_entries(vars(&[("WINDBG_MCP_LISTEN_TOKEN_CI", "   ")]), None)
+            .expect("valid");
+        assert_eq!(creds.len(), 0);
+    }
+
+    /// Unrelated variables are ignored, including the one naming the *file* to read a token from —
+    /// its contents are a token, its path is not.
+    #[test]
+    fn only_the_token_variables_are_read() {
+        let creds = Credentials::from_entries(
+            vars(&[
+                ("WINDBG_MCP_LISTEN_TOKEN_FILE", r"C:\somewhere\token"),
+                ("PATH", "/usr/bin"),
+            ]),
+            Some("from-the-file".to_string()),
+        )
+        .expect("valid");
+        assert_eq!(
+            creds.client_for("from-the-file").map(Client::name),
+            Some("local")
+        );
+        assert_eq!(creds.client_for(r"C:\somewhere\token"), None);
+    }
+}

--- a/src/client.rs
+++ b/src/client.rs
@@ -116,6 +116,7 @@ impl Credentials {
         file_token: Option<String>,
     ) -> Result<Self> {
         let mut by_token: HashMap<String, Client> = HashMap::new();
+        let mut named: HashMap<String, String> = HashMap::new();
         let mut insert = |token: String, name: &str| -> Result<()> {
             if let Some(existing) = by_token.get(&token) {
                 bail!(
@@ -124,22 +125,44 @@ impl Credentials {
                      name happened to win."
                 );
             }
+            // **And the other way round.** Two *different* tokens landing on one name is the more
+            // insidious half: nothing looks wrong, both callers authenticate, and they silently
+            // share a namespace — routing, listing, capacity, teardown rights, the lot. Names are
+            // folded before comparison, so `WINDBG_MCP_LISTEN_TOKEN` and `…_TOKEN_LOCAL` collide
+            // (both `local`), as do `…_CI` and `…__CI`. A boundary two credentials can stand on is
+            // not a boundary, so this is a configuration error rather than a merge.
+            if let Some(other) = named.get(name) {
+                bail!(
+                    "two different tokens are configured for the client `{name}` (`{other}` and \
+                     this one). Each client is one credential: two would share every session, \
+                     which is the isolation this is for, silently absent."
+                );
+            }
+            named.insert(name.to_string(), token.clone());
             by_token.insert(token, Client::new(name));
             Ok(())
         };
 
+        // **A configured file is the *only* credential.** That precedence predates named tokens
+        // and is load-bearing: the service installer writes the token to `%ProgramData%` with an
+        // ACL of SYSTEM and Administrators precisely because the machine environment is readable by
+        // unprivileged processes. Letting an environment token stand beside it would mean a stale
+        // or planted variable authenticating to a LocalSystem listener — which has `launch` on it.
+        // So a file shuts the environment out entirely rather than merely outranking the unnamed
+        // variable.
         if let Some(token) = file_token {
             insert(token, Client::LOCAL)?;
+            return Ok(Self { by_token });
         }
         for (key, value) in vars {
             let token = value.trim().to_string();
             if token.is_empty() {
                 continue;
             }
-            if key == TOKEN_FILE_ENV {
+            if is_token_file(&key) {
                 continue;
             }
-            match key.strip_prefix(TOKEN_ENV) {
+            match credential_suffix(&key) {
                 // The unnamed variable, which is what every existing setup uses.
                 Some("") => insert(token, Client::LOCAL)?,
                 // `WINDBG_MCP_LISTEN_TOKEN_CI` names the client `ci`, the same lowercasing a
@@ -155,6 +178,62 @@ impl Credentials {
             }
         }
         Ok(Self { by_token })
+    }
+}
+
+/// The part of a credential variable's name after the prefix, if it is one.
+///
+/// **Compared case-insensitively, because Windows environment names are.** `std::env::var` finds
+/// `Windbg_Mcp_Listen_Token` for a lookup of `WINDBG_MCP_LISTEN_TOKEN`, and a host configured that
+/// way worked until this scan replaced that lookup. Getting it wrong is two failures at once: a
+/// listener that refuses to start because it can no longer see its own token, and — worse — a
+/// mixed-case variable that [`token_file`]'s `var_os` still resolves while the strip below walks
+/// past it, handing a debuggee the credential.
+///
+/// Length-preserving on ASCII, which every variable here is, so the suffix is taken from the
+/// original name rather than the folded copy.
+fn credential_suffix(name: &str) -> Option<&str> {
+    name.to_ascii_uppercase()
+        .starts_with(TOKEN_ENV)
+        .then(|| &name[TOKEN_ENV.len()..])
+}
+
+/// Whether this variable names the token *file* rather than carrying a token.
+fn is_token_file(name: &str) -> bool {
+    name.eq_ignore_ascii_case(TOKEN_FILE_ENV)
+}
+
+/// Every environment variable that configures a credential, for a process that must not inherit
+/// one.
+///
+/// **Prefix, not a list.** `Credentials::from_entries` accepts anything starting with
+/// `WINDBG_MCP_LISTEN_TOKEN`, so a strip that named the variables it knew about would let the next
+/// named token through — and the failure would be silent, a debuggee holding a credential nobody
+/// meant to hand it. The path in `…_TOKEN_FILE` is stripped for the same reason: a target that
+/// knows where the token lives can read it if the file is reachable at all.
+pub fn strip_credentials(command: &mut impl EnvRemove) {
+    for (name, _) in std::env::vars() {
+        if credential_suffix(&name).is_some() {
+            command.remove(&name);
+        }
+    }
+}
+
+/// The one thing [`strip_credentials`] needs of a command, so it can serve both the worker spawn
+/// (which uses tokio's) and the TTD recorder (which uses the standard library's).
+pub trait EnvRemove {
+    fn remove(&mut self, name: &str);
+}
+
+impl EnvRemove for std::process::Command {
+    fn remove(&mut self, name: &str) {
+        self.env_remove(name);
+    }
+}
+
+impl EnvRemove for tokio::process::Command {
+    fn remove(&mut self, name: &str) {
+        self.env_remove(name);
     }
 }
 
@@ -236,6 +315,76 @@ mod tests {
         );
         let why = clash.expect_err("a duplicate token is a configuration error");
         assert!(why.to_string().contains("cannot name two clients"), "{why}");
+    }
+
+    /// Windows environment names are case-insensitive, and `std::env::var` honours that — so a host
+    /// configured as `Windbg_Mcp_Listen_Token` worked before this scan existed and has to keep
+    /// working. The same fold is what makes the child-process strip see a mixed-case variable that
+    /// `var_os` can still resolve.
+    #[test]
+    fn credential_variables_are_matched_however_they_are_cased() {
+        let creds = Credentials::from_entries(
+            vars(&[
+                ("Windbg_Mcp_Listen_Token", "unnamed"),
+                ("windbg_mcp_listen_token_ci", "for-ci"),
+            ]),
+            None,
+        )
+        .expect("valid");
+        assert_eq!(creds.client_for("unnamed").map(Client::name), Some("local"));
+        assert_eq!(creds.client_for("for-ci").map(Client::name), Some("ci"));
+        // And the file variable is still not a token, whatever its casing.
+        assert!(is_token_file("Windbg_Mcp_Listen_Token_File"));
+        assert!(credential_suffix("Windbg_Mcp_Listen_Token_File").is_some());
+    }
+
+    /// A token file shuts the environment out completely, named tokens included.
+    ///
+    /// The file exists because the environment is not trusted on that host — the service installer
+    /// ACLs it to SYSTEM and Administrators for exactly that reason — so a variable standing beside
+    /// it would reintroduce what it was written to avoid.
+    #[test]
+    fn a_token_file_is_the_only_credential() {
+        let creds = Credentials::from_entries(
+            vars(&[
+                (TOKEN_ENV, "from-the-environment"),
+                ("WINDBG_MCP_LISTEN_TOKEN_CI", "also-from-the-environment"),
+            ]),
+            Some("from-the-file".to_string()),
+        )
+        .expect("valid");
+        assert_eq!(
+            creds.client_for("from-the-file").map(Client::name),
+            Some("local")
+        );
+        assert_eq!(creds.len(), 1, "the environment must not add credentials");
+        assert_eq!(creds.client_for("from-the-environment"), None);
+        assert_eq!(creds.client_for("also-from-the-environment"), None);
+    }
+
+    /// Two credentials normalising to one name is refused, and it is the quieter half of the same
+    /// mistake: nothing looks wrong, both tokens authenticate, and their holders silently share a
+    /// namespace. `WINDBG_MCP_LISTEN_TOKEN` and `…_TOKEN_LOCAL` are both `local`; `…_CI` and
+    /// `…__CI` are both `ci`.
+    #[test]
+    fn two_tokens_may_not_name_one_client() {
+        for pairs in [
+            vec![
+                (TOKEN_ENV, "unnamed"),
+                ("WINDBG_MCP_LISTEN_TOKEN_LOCAL", "named"),
+            ],
+            vec![
+                ("WINDBG_MCP_LISTEN_TOKEN_CI", "one"),
+                ("WINDBG_MCP_LISTEN_TOKEN__CI", "two"),
+            ],
+        ] {
+            let why = Credentials::from_entries(vars(&pairs), None)
+                .expect_err("a shared namespace is a configuration error");
+            assert!(
+                why.to_string().contains("two different tokens"),
+                "{why} (from {pairs:?})"
+            );
+        }
     }
 
     /// An empty value is not a token — it is a variable somebody exported and never set.

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1082,6 +1082,18 @@ impl Sessions {
             .collect()
     }
 
+    /// How many live sessions one client holds, **named rather than inferred**.
+    ///
+    /// Every other question about "the caller's sessions" reads the identity from the task-local
+    /// [`crate::client::current`], because it is asked from inside a tool call, where that is
+    /// exactly who is asking. This one is asked by the listener *after* the call has finished and
+    /// its scope has ended, so the ambient answer there is the default `local` — which for a named
+    /// client is either nobody's sessions or somebody else's. So the owner is a parameter: the
+    /// caller of this method is the only thing that still knows.
+    pub fn live_count_for(&self, owner: &crate::client::Client) -> usize {
+        self.registry().live_for(owner).len()
+    }
+
     pub fn snapshot(&self) -> Vec<SessionSnapshot> {
         let registry = self.registry();
         // A caller is shown its own sessions and told which of *those* is current. Another client's
@@ -3155,6 +3167,42 @@ mod tests {
     }
 
     // ---- one registry, several clients ---------------------------------------------
+
+    /// The listener counts a reconnecting client's sessions **after** its identity scope has
+    /// closed — the adoption line is written once the MCP call has been handled — so the count has
+    /// to be asked for by name. Reading the ambient identity there answers about `local`, which for
+    /// a named client is nobody, and the line then reports an adoption of nothing on exactly the
+    /// reconnect it exists to describe.
+    #[tokio::test]
+    async fn a_clients_live_count_is_asked_for_by_name_not_inferred() {
+        let ci = crate::client::Client::new("ci");
+        let sessions = Sessions::new(Duration::from_secs(1));
+        let theirs = crate::client::as_client(ci.clone(), async {
+            (0..2)
+                .map(|n| dormant(&format!("sess-ci-{n}"), SessionState::Open))
+                .collect::<Vec<_>>()
+        })
+        .await;
+        {
+            let mut registry = sessions.registry();
+            for session in theirs {
+                registry.all.push_back(session);
+            }
+        }
+
+        // No scope here, which is the listener's position after the call it just served.
+        assert_eq!(
+            sessions.live_count_for(&ci),
+            2,
+            "a client's sessions have to be countable from outside its own call"
+        );
+        assert_eq!(sessions.live_count_for(&crate::client::Client::local()), 0);
+        assert!(
+            sessions.snapshot().is_empty(),
+            "the ambient answer here is `local`, which is the mistake the parameter exists to \
+             make unavailable"
+        );
+    }
 
     /// The property the whole owner field exists for: a handle is only usable by the client that
     /// opened it, and to anyone else it is not "refused" but *unknown* — saying otherwise would

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -404,6 +404,18 @@ pub struct Session {
     /// Whether `open` has finished with this session and told its caller about it. Until then it
     /// is not reclaimable however idle it looks — see [`Session::busy`].
     delivered: AtomicBool,
+    /// Which client opened this session.
+    ///
+    /// The registry is one map for the whole server — handles are minted from it, the cap is
+    /// shared, and `end_session` ends what it is handed — so two clients on one listener could see
+    /// and end each other's targets. The tenancy gate stood in for a boundary by serving one client
+    /// at a time, and `2026-07-28` removed the identifier that gate was keyed on
+    /// ([#162](https://github.com/glslang/windbg-mcp/issues/162)). Recording the owner makes the
+    /// separation a property of the registry rather than of how many clients are let in.
+    ///
+    /// Always [`crate::client::Client::LOCAL`] under stdio, so the rules below are uniform rather
+    /// than conditional.
+    pub owner: crate::client::Client,
     /// When a call was last submitted against this session.
     ///
     /// The transport's disconnect is what normally releases a target, and under the revision of
@@ -807,12 +819,19 @@ pub enum OpenError {
 /// holding it for the life of the process.
 struct Slot {
     registry: Arc<Mutex<Registry>>,
+    /// Whose open this is, so releasing the slot decrements the right client's count.
+    owner: crate::client::Client,
 }
 
 impl Drop for Slot {
     fn drop(&mut self) {
         let mut registry = self.registry.lock().unwrap_or_else(|e| e.into_inner());
-        registry.opening = registry.opening.saturating_sub(1);
+        if let Some(count) = registry.opening.get_mut(&self.owner) {
+            *count = count.saturating_sub(1);
+            if *count == 0 {
+                registry.opening.remove(&self.owner);
+            }
+        }
     }
 }
 
@@ -845,7 +864,7 @@ struct Registry {
     /// Without this the capacity check is blind to opens already in flight, and two of them can
     /// each look at the same four live sessions, each conclude there is room, and each spawn —
     /// so the bound is only enforced against sessions that finished opening.
-    opening: usize,
+    opening: HashMap<crate::client::Client, usize>,
     /// Set once the client has disconnected. Refuses new opens, so the set of workers to release
     /// stops growing while shutdown is walking it.
     closing: bool,
@@ -856,11 +875,11 @@ impl Registry {
     ///
     /// Computed rather than stored, so ending the newest session falls back to the one before it
     /// instead of leaving the server with no default while a perfectly good target is loaded.
-    fn current(&self) -> Option<Arc<Session>> {
+    fn current(&self, owner: &crate::client::Client) -> Option<Arc<Session>> {
         self.all
             .iter()
             .rev()
-            .find(|s| s.state().accepts_default())
+            .find(|s| s.state().accepts_default() && &s.owner == owner)
             .cloned()
     }
 
@@ -872,6 +891,20 @@ impl Registry {
         self.all
             .iter()
             .filter(|s| s.state().is_live())
+            .cloned()
+            .collect()
+    }
+
+    /// The live sessions belonging to one client.
+    ///
+    /// Every question a *caller* asks is this one rather than [`Self::live`]: which session is
+    /// current, whether there is room to open another, what `session_status` lists. `live` stays
+    /// the server's own view, for the sweeps and the shutdown that are about workers rather than
+    /// about who owns them.
+    fn live_for(&self, owner: &crate::client::Client) -> Vec<Arc<Session>> {
+        self.all
+            .iter()
+            .filter(|s| s.state().is_live() && &s.owner == owner)
             .cloned()
             .collect()
     }
@@ -968,8 +1001,9 @@ impl Sessions {
     /// them, from being missed.
     pub fn resolve(&self, supplied: Option<&str>) -> Result<Arc<Session>, EngineError> {
         let registry = self.registry();
+        let caller = crate::client::current();
         let Some(want) = supplied else {
-            let current = registry.current().ok_or_else(|| {
+            let current = registry.current(&caller).ok_or_else(|| {
                 EngineError::Stale(
                     "no debug session is open. Start one with open_dump / open_trace / \
                      attach_process / attach_kernel / attach_kernel_local / launch."
@@ -980,16 +1014,20 @@ impl Sessions {
             return Ok(current);
         };
         match registry.find(want) {
+            // **Another client's handle is not "refused", it is unknown.** Saying "that session
+            // belongs to someone else" would confirm the handle exists and leak that a second
+            // client is here, and there is nothing this caller could do with the answer. The
+            // message below is the one a handle this server never issued gets, which is exactly
+            // what this handle is from where the caller stands.
+            Some(session) if session.owner != caller => {
+                Err(EngineError::Stale(unknown_handle(want)))
+            }
             Some(session) if session.state().accepts_handle() => {
                 crate::record::routed_to(&session.id);
                 Ok(session)
             }
             Some(session) => Err(EngineError::Stale(stale_handle(want, &session.state()))),
-            None => Err(EngineError::Stale(format!(
-                "unknown session handle `{want}`: this server is not holding it. Either it was \
-                 never issued here, or it closed a while ago and has aged out of the session \
-                 history. A session still in flight is never forgotten, so opening again is safe."
-            ))),
+            None => Err(EngineError::Stale(unknown_handle(want))),
         }
     }
 
@@ -1007,10 +1045,15 @@ impl Sessions {
 
     pub fn snapshot(&self) -> Vec<SessionSnapshot> {
         let registry = self.registry();
-        let current = registry.current().map(|s| s.id.clone());
+        // A caller is shown its own sessions and told which of *those* is current. Another client's
+        // are not listed: the handles would be unusable, and reporting them would say how many
+        // clients this server has and what they are debugging.
+        let caller = crate::client::current();
+        let current = registry.current(&caller).map(|s| s.id.clone());
         registry
             .all
             .iter()
+            .filter(|s| s.owner == caller)
             .rev()
             .map(|s| SessionSnapshot {
                 id: s.id.clone(),
@@ -1685,12 +1728,17 @@ impl Sessions {
         if registry.closing {
             return Err(shutting_down());
         }
-        let live = registry.live();
+        // **This client's sessions, not the server's.** The cap is what stops one caller filling
+        // the machine with engine processes; applying it across clients would let a busy one deny
+        // a quiet one, which is the shared-registry harm this separation exists to end.
+        let caller = crate::client::current();
+        let live = registry.live_for(&caller);
+        let in_flight_for_caller = registry.opening.get(&caller).copied().unwrap_or(0);
         // How many sessions would have to be reclaimed to be back at the limit once this open,
         // and every open already in flight, has landed — against how many *can* be. Counting the
         // opens in flight is what stops two of them spending the same idle session: the first
         // needs one reclaimable, the second needs two.
-        let needed = (live.len() + registry.opening + 1).saturating_sub(MAX_SESSIONS);
+        let needed = (live.len() + in_flight_for_caller + 1).saturating_sub(MAX_SESSIONS);
         let reclaimable = live.iter().filter(|s| !s.busy()).count();
         if needed > reclaimable {
             let listed: Vec<String> = live
@@ -1700,7 +1748,7 @@ impl Sessions {
                     format!("  {} — {} ({}){busy}", s.id, s.kind.label(), s.what)
                 })
                 .collect();
-            let in_flight = match registry.opening {
+            let in_flight = match in_flight_for_caller {
                 0 => String::new(),
                 n => format!(
                     " ({n} more open{} already in flight)",
@@ -1718,9 +1766,10 @@ impl Sessions {
                 listed.join("\n")
             ));
         }
-        registry.opening += 1;
+        *registry.opening.entry(caller.clone()).or_default() += 1;
         Ok(Slot {
             registry: Arc::clone(&self.inner),
+            owner: caller,
         })
     }
 
@@ -1756,7 +1805,7 @@ impl Sessions {
             );
             victims.push(victim);
         }
-        let over = self.registry().live().len();
+        let over = self.registry().live_for(&keeping.owner).len();
         if over > MAX_SESSIONS {
             // The honest outcome when nothing is reclaimable: the alternatives are ending
             // someone's live target or discarding one that already opened. It does not compound —
@@ -1795,7 +1844,10 @@ impl Sessions {
     /// one cannot see the same session as live-and-idle, pick it too, and free nothing.
     fn claim_overage_victim(&self, keeping: &Arc<Session>) -> Option<Arc<Session>> {
         let registry = self.registry();
-        let live = registry.live();
+        // **The owner's own sessions.** Reclaiming another client's idle target to make room for
+        // this one is precisely the harm a shared registry did: it ends a session its owner still
+        // holds a handle to, for a reason that has nothing to do with them.
+        let live = registry.live_for(&keeping.owner);
         if live.len() <= MAX_SESSIONS {
             return None;
         }
@@ -1896,6 +1948,7 @@ impl Sessions {
             what,
             pid,
             created: Instant::now(),
+            owner: crate::client::current(),
             last_used: Mutex::new(Instant::now()),
             state: Mutex::new((SessionState::Opening, Instant::now())),
             tx,
@@ -1987,6 +2040,19 @@ fn promote_opened(session: &Session) {
         matches!(state, SessionState::Opening | SessionState::Attaching)
             .then_some(SessionState::Open)
     });
+}
+
+/// What a caller is told about a handle this server will not route.
+///
+/// One message for two cases — a handle that was never issued, and one belonging to another client
+/// — because from where the caller stands they are the same fact, and distinguishing them would
+/// confirm the existence of a session it may not touch.
+fn unknown_handle(want: &str) -> String {
+    format!(
+        "unknown session handle `{want}`: this server is not holding it. Either it was never \
+         issued here, or it closed a while ago and has aged out of the session history. A session \
+         still in flight is never forgotten, so opening again is safe."
+    )
 }
 
 /// Settles a session whose opener failed **without creating anything**, and ends its worker
@@ -3033,6 +3099,114 @@ mod tests {
         assert!(closed.contains("open_dump"), "{closed}");
     }
 
+    // ---- one registry, several clients ---------------------------------------------
+
+    /// The property the whole owner field exists for: a handle is only usable by the client that
+    /// opened it, and to anyone else it is not "refused" but *unknown* — saying otherwise would
+    /// confirm a session exists that the caller may not touch.
+    #[tokio::test]
+    async fn a_handle_is_not_usable_by_another_client() {
+        let sessions = Sessions::new(Duration::from_secs(300));
+        let opener = crate::client::Client::new("laptop");
+        let session = crate::client::as_client(opener.clone(), async {
+            let session = dormant("sess-laptop", SessionState::Open);
+            sessions.registry().all.push_back(Arc::clone(&session));
+            session
+        })
+        .await;
+        assert_eq!(session.owner, opener);
+
+        // Its own client routes to it, by handle and by default.
+        crate::client::as_client(opener, async {
+            assert!(sessions.resolve(Some("sess-laptop")).is_ok());
+            assert_eq!(sessions.resolve(None).expect("current").id, "sess-laptop");
+        })
+        .await;
+
+        crate::client::as_client(crate::client::Client::new("ci"), async {
+            let by_handle = sessions
+                .resolve(Some("sess-laptop"))
+                .expect_err("another client's handle must not route");
+            assert!(
+                by_handle.to_string().contains("unknown session handle"),
+                "the refusal must not confirm the session exists: {by_handle}"
+            );
+            let by_default = sessions
+                .resolve(None)
+                .expect_err("another client's session is not this one's current");
+            assert!(
+                by_default.to_string().contains("no debug session is open"),
+                "{by_default}"
+            );
+        })
+        .await;
+    }
+
+    /// And it is not listed either. Reporting another client's sessions would hand over handles it
+    /// cannot use, and say how many clients this server has and what they are debugging.
+    #[tokio::test]
+    async fn session_status_shows_only_the_callers_own() {
+        let sessions = Sessions::new(Duration::from_secs(300));
+        for (client, id) in [("laptop", "sess-laptop"), ("ci", "sess-ci")] {
+            crate::client::as_client(crate::client::Client::new(client), async {
+                sessions
+                    .registry()
+                    .all
+                    .push_back(dormant(id, SessionState::Open));
+            })
+            .await;
+        }
+
+        let listed = crate::client::as_client(crate::client::Client::new("laptop"), async {
+            sessions
+                .snapshot()
+                .into_iter()
+                .map(|s| s.id)
+                .collect::<Vec<_>>()
+        })
+        .await;
+        assert_eq!(listed, vec!["sess-laptop".to_string()]);
+    }
+
+    /// The cap is per client, so a caller that fills its own quota cannot deny another one — the
+    /// shared-limit version of the same harm.
+    #[tokio::test]
+    async fn one_clients_sessions_do_not_fill_anothers_quota() {
+        let sessions = Sessions::new(Duration::from_secs(300));
+        crate::client::as_client(crate::client::Client::new("hog"), async {
+            for n in 0..MAX_SESSIONS {
+                sessions
+                    .registry()
+                    .all
+                    .push_back(dormant(&format!("sess-hog-{n}"), SessionState::Attaching));
+            }
+            assert!(
+                sessions.take_slot().is_err(),
+                "the client at its own limit is refused"
+            );
+        })
+        .await;
+
+        crate::client::as_client(crate::client::Client::new("quiet"), async {
+            assert!(
+                sessions.take_slot().is_ok(),
+                "a client with no sessions has room, whatever another client is holding"
+            );
+        })
+        .await;
+    }
+
+    /// Opens in flight for the client these tests run as, which is the local one: the counter is
+    /// per client now, so a bare total would answer a question the registry no longer asks.
+    fn in_flight_opens(sessions: &Sessions) -> usize {
+        sessions
+            .registry()
+            .opening
+            .get(&crate::client::current())
+            .copied()
+            .unwrap_or(0)
+    }
+
     // ---- releasing what nobody is using -------------------------------------------
 
     /// The clock alone is not the question. A session with a call outstanding is in use however
@@ -3107,6 +3281,7 @@ mod tests {
             what: "test".to_string(),
             pid: 0,
             created: Instant::now(),
+            owner: crate::client::current(),
             last_used: Mutex::new(Instant::now()),
             state: Mutex::new((state, Instant::now())),
             tx,
@@ -3455,7 +3630,7 @@ mod tests {
         );
         // The open failed on the way, so the slot goes back.
         drop(slot);
-        assert_eq!(sessions.registry().opening, 0);
+        assert_eq!(in_flight_opens(&sessions), 0);
         assert_eq!(sessions.registry().live().len(), MAX_SESSIONS);
     }
 
@@ -3472,7 +3647,7 @@ mod tests {
         let _first = sessions
             .take_slot()
             .expect("the idle session pays for this one");
-        assert_eq!(sessions.registry().opening, 1);
+        assert_eq!(in_flight_opens(&sessions), 1);
         // Hmm — the same idle session cannot pay twice, but it is still idle, so the check has to
         // reason about the open already in flight rather than about the sessions alone.
         let second = sessions.take_slot();

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -49,8 +49,14 @@ use crate::worker::{MESSAGES_FLAG, REQUESTS_FLAG, WORKER_FLAG};
 /// a client leaking sessions notices.
 pub const MAX_SESSIONS: usize = 4;
 
-/// How many *closed* sessions to remember, so `session_status` can still answer for a handle
-/// after its target is gone. Live sessions are never evicted, whatever this says.
+/// How many *closed* sessions to remember **per client**, so `session_status` can still answer
+/// for a handle after its target is gone. Live sessions are never evicted, whatever this says.
+///
+/// Per client rather than per server, because a shared bound is a shared fate: one client opening
+/// and closing sessions would age out another client's history, and the answer that client then
+/// gets for its own handle is "unknown" — which reads as "never existed" and advises opening
+/// again. The clients are the configured credentials, a set fixed at startup, so this is still a
+/// bound and not a hole.
 const CLOSED_HISTORY: usize = 8;
 
 /// How long to wait for a freshly spawned worker to report [`WorkerMessage::Ready`]. This covers
@@ -925,10 +931,15 @@ impl Registry {
             .collect()
     }
 
-    /// Drops the oldest settled sessions once the history bound is exceeded. Live sessions are
-    /// never evicted — forgetting one would report its handle as unknown, and the advice that
+    /// Drops the oldest settled sessions once a client's history bound is exceeded. Live sessions
+    /// are never evicted — forgetting one would report its handle as unknown, and the advice that
     /// follows from "unknown" is "open again", which for an attach or a launch means a second
     /// target.
+    ///
+    /// **The bound is per owner**, walked client by client, so what ages a client's history out is
+    /// that client's own churn. A single deque bounded once would have let a busy client evict a
+    /// quiet one's record of a session that failed an hour ago, which is exactly the answer
+    /// `session_status` exists to keep.
     ///
     /// Nor is one that still owns a worker, whatever its state says. A session claimed for
     /// reclamation is `Closed` at once and released in the background, and evicting it in that
@@ -937,14 +948,26 @@ impl Registry {
     /// on its own rather than being asked properly, which is the weaker of the two guarantees a
     /// halted kernel can be given.
     fn trim(&mut self) {
-        while self.all.len() > CLOSED_HISTORY + MAX_SESSIONS {
-            let evictable = self.all.iter().position(|s| {
-                !s.state().is_live() && s.child.lock().unwrap_or_else(|e| e.into_inner()).is_none()
-            });
-            let Some(oldest_settled) = evictable else {
-                return;
-            };
-            self.all.remove(oldest_settled);
+        let mut owners: Vec<crate::client::Client> = Vec::new();
+        for session in &self.all {
+            if !owners.contains(&session.owner) {
+                owners.push(session.owner.clone());
+            }
+        }
+        for owner in owners {
+            while self.all.iter().filter(|s| s.owner == owner).count()
+                > CLOSED_HISTORY + MAX_SESSIONS
+            {
+                let evictable = self.all.iter().position(|s| {
+                    s.owner == owner
+                        && !s.state().is_live()
+                        && s.child.lock().unwrap_or_else(|e| e.into_inner()).is_none()
+                });
+                let Some(oldest_settled) = evictable else {
+                    break;
+                };
+                self.all.remove(oldest_settled);
+            }
         }
     }
 }
@@ -3494,6 +3517,52 @@ mod tests {
         assert!(
             sessions.registry().all.len() <= CLOSED_HISTORY + MAX_SESSIONS,
             "settled sessions should have been trimmed to the bound"
+        );
+    }
+
+    /// History ages out on a client's *own* churn, not the server's. A shared bound would let a
+    /// busy client evict a quiet one's settled sessions, and `session_status` would then answer
+    /// "unknown" for a handle that client is still holding — the one answer that tells a caller to
+    /// open again, which for an attach or a launch means a second target.
+    #[tokio::test]
+    async fn one_clients_history_is_not_evicted_by_anothers_churn() {
+        let sessions = Sessions::new(Duration::from_secs(1));
+        // Mine go in first, so they are the oldest in the deque and a single global bound would
+        // reach them before it reached any of theirs.
+        let mine = crate::client::as_client(crate::client::Client::new("laptop"), async {
+            (0..2)
+                .map(|n| dormant(&format!("mine-{n}"), SessionState::Closed("x".into())))
+                .collect::<Vec<_>>()
+        })
+        .await;
+        let theirs = crate::client::as_client(crate::client::Client::new("ci"), async {
+            (0..(CLOSED_HISTORY + MAX_SESSIONS) * 3)
+                .map(|n| dormant(&format!("theirs-{n}"), SessionState::Closed("x".into())))
+                .collect::<Vec<_>>()
+        })
+        .await;
+        {
+            let mut registry = sessions.registry();
+            for session in mine.into_iter().chain(theirs) {
+                registry.all.push_back(session);
+            }
+            registry.trim();
+        }
+        let registry = sessions.registry();
+        assert!(
+            registry.all.iter().any(|s| s.id == "mine-0")
+                && registry.all.iter().any(|s| s.id == "mine-1"),
+            "another client's churn evicted this client's settled sessions, so its own history \
+             aged out on someone else's activity"
+        );
+        assert_eq!(
+            registry
+                .all
+                .iter()
+                .filter(|s| s.owner == crate::client::Client::new("ci"))
+                .count(),
+            CLOSED_HISTORY + MAX_SESSIONS,
+            "the busy client's own history should still be bounded"
         );
     }
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1043,6 +1043,22 @@ impl Sessions {
         self.registry().live().iter().any(|session| session.busy())
     }
 
+    /// Every session id the calling client owns, live or settled.
+    ///
+    /// For `server_log`, which reads one ring for the whole server: a record naming a session is
+    /// only this caller's to read if the session is. Settled ones are included deliberately —
+    /// the run-up to a session's *failure* is exactly what a caller asks the log for, and it is
+    /// their own failure to read.
+    pub fn visible_session_ids(&self) -> Vec<String> {
+        let caller = crate::client::current();
+        self.registry()
+            .all
+            .iter()
+            .filter(|s| s.owner == caller)
+            .map(|s| s.id.clone())
+            .collect()
+    }
+
     pub fn snapshot(&self) -> Vec<SessionSnapshot> {
         let registry = self.registry();
         // A caller is shown its own sessions and told which of *those* is current. Another client's
@@ -1562,8 +1578,8 @@ impl Sessions {
     /// snapshot, so this must only be called once the tenancy gate says no client holds the
     /// server — otherwise a client connecting exactly as the grace expires could have the session
     /// it just opened released underneath it.
-    pub async fn release_leased(&self) {
-        self.release_every_worker(Teardown::Lease).await
+    pub async fn release_leased(&self, owner: &crate::client::Client) {
+        self.release_workers_of(Teardown::Lease, Some(owner)).await
     }
 
     /// Releases every session nobody has used for `after`, and says how many.
@@ -1621,6 +1637,18 @@ impl Sessions {
     }
 
     async fn release_every_worker(&self, teardown: Teardown) {
+        self.release_workers_of(teardown, None).await
+    }
+
+    /// Releases every worker, or only those belonging to one client.
+    ///
+    /// `None` is the whole server going away, which is shutdown's question. `Some` is one client's
+    /// lease running out, which since [#162] is emphatically not the same set: another client's
+    /// sessions sit in the same registry and must survive a teardown that has nothing to do with
+    /// them.
+    ///
+    /// [#162]: https://github.com/glslang/windbg-mcp/issues/162
+    async fn release_workers_of(&self, teardown: Teardown, owner: Option<&crate::client::Client>) {
         // Closing the gate and taking the snapshot under **one** lock acquisition is what makes
         // one pass enough. [`Self::admit`] re-checks `closing` under this same lock after its
         // worker's handshake, so every open is on one side or the other of this moment: either it
@@ -1641,7 +1669,11 @@ impl Sessions {
         let owners = {
             let mut registry = self.registry();
             registry.closing |= teardown.closes_registry();
-            registry.owning_workers()
+            let owning = registry.owning_workers();
+            match owner {
+                Some(owner) => owning.into_iter().filter(|s| &s.owner == owner).collect(),
+                None => owning,
+            }
         };
         // Recorded before the releases rather than after them, and even when there are none: this
         // is the record that says the transcript ends here on purpose. Without it a file that
@@ -2321,7 +2353,7 @@ fn spawn_worker(exe: &Path) -> std::io::Result<(Child, Channel)> {
     // never authenticates anything, so it has no use for the token — but a `launch`ed debuggee
     // inheriting it could dial the listener on loopback, wait for the holder to go quiet, and take
     // over the very sessions being used to debug it. The credential does not cross this boundary.
-    command.env_remove(crate::listen::TOKEN_ENV);
+    crate::client::strip_credentials(&mut command);
     let child = command
         .arg(WORKER_FLAG)
         .arg(format!(
@@ -4001,6 +4033,9 @@ mod tests {
         writeln!(worker, "{log}").expect("write it as a worker would");
 
         let query = || crate::logbridge::Query {
+            // The test reads the ring directly, as the supervisor does: no client, nothing to
+            // narrow to.
+            visible: None,
             session: Some(session.to_string()),
             level: crate::logbridge::Level::Trace,
             since: None,

--- a/src/listen.rs
+++ b/src/listen.rs
@@ -339,6 +339,10 @@ enum Admission {
     Serve(Admitted),
     /// Someone else holds the server, is taking it, or is being cleaned up after.
     Occupied,
+    /// The request carried an MCP session id **another client** minted. Reported to the caller as
+    /// unknown, for the reason the registry reports another client's handle that way: the answer
+    /// must not confirm a session the caller may not use.
+    NotYours,
 }
 
 /// A borrow of one client's tenancy, so the rules below read exactly as they did when there was
@@ -396,6 +400,18 @@ impl Lease {
         self.state.lock().unwrap_or_else(|e| e.into_inner())
     }
 
+    /// Whether an MCP session id is held by some client other than this one.
+    ///
+    /// Only the *holder* counts. A departed client's id is closed in the MCP service by the
+    /// `DELETE` that departed, and one whose lease expired is closed by the sweep — so an id no
+    /// tenancy holds is already unusable, and treating it as owned would refuse a client its own
+    /// reconnect on the strength of a record nothing backs.
+    fn held_by_another(&self, caller: &crate::client::Client, session: &str) -> bool {
+        self.all_tenancies()
+            .iter()
+            .any(|(client, tenancy)| client != caller && tenancy.holder.as_deref() == Some(session))
+    }
+
     /// One client's tenancy, created empty on first use — a client that has never connected holds
     /// nothing, which is what a default `Tenancy` says.
     fn state_of(&self, client: &crate::client::Client) -> TenancyGuard<'_> {
@@ -413,6 +429,19 @@ impl Lease {
     /// session, which is the only moment tenancy is contested. Every decision is made under one
     /// lock, so the answer a request gets is the state it will be served against.
     fn admit(&self, client: &crate::client::Client, session: Option<&str>) -> Admission {
+        // **Before this client's own tenancy is consulted at all**, because the id may not be its
+        // to present. The MCP service keeps one session table for the server, so a client that
+        // comes by another's `Mcp-Session-Id` reaches that client's MCP session through it — the
+        // task-local only decides which *debug* sessions the tools then see. A `DELETE` on it is
+        // the sharp end: rmcp closes the session, while the lease that minted it still holds the
+        // id, so the client it belonged to fails every request and its re-`initialize` is refused
+        // for a whole grace period. That is one authenticated client denying another, which is
+        // exactly what ownership is here to stop.
+        if let Some(id) = session
+            && self.held_by_another(client, id)
+        {
+            return Admission::NotYours;
+        }
         let mut state = self.state_of(client);
         // Nothing is served while a teardown is in flight. Briefly refusing a client that could
         // have been served costs a reconnect; serving one costs it the session mid-call.
@@ -829,6 +858,15 @@ async fn gate(
 
     let admitted = match lease.admit(&caller, session.as_deref()) {
         Admission::Serve(admitted) => admitted,
+        // Not a refusal — an id this caller cannot have is an id this server does not have. The
+        // status is the one the spec already gives a session that has gone: a client holding a
+        // stale id of its own is told to start again, which is also the right advice here.
+        Admission::NotYours => {
+            tracing::warn!(
+                "refused a request from {peer} carrying an MCP session id another client holds"
+            );
+            return Ok(refuse(StatusCode::NOT_FOUND, "unknown session"));
+        }
         Admission::Occupied => {
             tracing::warn!("refused a second client from {peer}: this server is already held");
             return Ok(refuse(
@@ -1152,6 +1190,11 @@ mod tests {
         match admission {
             Admission::Serve(admitted) => admitted,
             Admission::Occupied => panic!("the gate refused a request this test needed served"),
+            Admission::NotYours => {
+                panic!(
+                    "the gate took a session id for another client's, which no test here sets up"
+                )
+            }
         }
     }
 
@@ -1583,6 +1626,63 @@ mod tests {
         assert!(
             matches!(lease.admit(&ci, None), Admission::Serve(_)),
             "another client must not wait on a tenancy that no longer bounds anything it can reach"
+        );
+    }
+
+    /// An MCP session id is one client's, and presenting another's is not a way in.
+    ///
+    /// The service keeps one session table for the whole server, so the id is the only thing
+    /// standing between a client and another's MCP session — and a `DELETE` on it closes that
+    /// session while the lease that minted it still holds the id, which leaves its owner failing
+    /// every request and refused its own re-`initialize` for a grace period. One authenticated
+    /// client denying another is the harm ownership exists to stop, so the gate refuses before
+    /// this caller's own tenancy is even consulted.
+    ///
+    /// One lease and two clients, deliberately: two `For` bindings would be two leases, which
+    /// cannot reach each other whatever the code does.
+    #[test]
+    fn one_clients_session_id_is_not_a_way_into_anothers() {
+        let lease = Lease::new(
+            longest_quiet_call(CALL) + Duration::from_secs(60),
+            CALL,
+            Sessions::new(CALL),
+        )
+        .expect("workable");
+        let laptop = crate::client::Client::new("laptop");
+        let ci = crate::client::Client::new("ci");
+
+        let held = admitted(lease.admit(&laptop, None));
+        lease.settle(
+            held.claim,
+            None,
+            Some("session-laptop"),
+            true,
+            laptop.clone(),
+        );
+
+        assert_eq!(
+            lease.admit(&ci, Some("session-laptop")),
+            Admission::NotYours,
+            "another client's session id was admitted, so its holder could be deleted out from \
+             under it"
+        );
+        // And the owner is unaffected — the check must not cost a client its own session.
+        assert!(
+            matches!(
+                lease.admit(&laptop, Some("session-laptop")),
+                Admission::Serve(_)
+            ),
+            "the holder must still be served its own id"
+        );
+        // An id nobody holds is not owned by anybody: a client resuming inside the grace has to
+        // get through, which is the arm this check sits in front of.
+        assert!(
+            matches!(
+                lease.admit(&ci, Some("session-nobodys")),
+                Admission::Serve(_)
+            ),
+            "an id no tenancy holds is unusable in the service anyway, and refusing it would \
+             refuse a legitimate resume"
         );
     }
 

--- a/src/listen.rs
+++ b/src/listen.rs
@@ -876,13 +876,10 @@ async fn gate(
         // unconditional version of this line told an operator a client had adopted sessions that
         // did not exist, on every ordinary reconnect.
         Settled::Kept { adopted: true } => {
-            match lease
-                .sessions
-                .snapshot()
-                .iter()
-                .filter(|s| s.state.is_live())
-                .count()
-            {
+            // Asked *for* this client rather than as it. The call's identity scope has closed by
+            // here, so anything reading the ambient one would count `local`'s sessions — nobody's,
+            // for a named client, which is the reconnect this line exists to describe.
+            match lease.sessions.live_count_for(&caller_for_lease) {
                 0 => tracing::info!(
                     "a client attached to a server the previous one had let go; nothing was open"
                 ),

--- a/src/listen.rs
+++ b/src/listen.rs
@@ -40,6 +40,7 @@
 //! identity: there is one authorised client, so anyone presenting the token *is* that client, and a
 //! reconnect needs nothing further to prove.
 
+use std::collections::HashMap;
 use std::convert::Infallible;
 use std::future::Future;
 use std::net::SocketAddr;
@@ -195,7 +196,15 @@ struct Lease {
     /// server" cannot be answered from HTTP alone, because an engine job outlives the request that
     /// asked for it.
     sessions: Sessions,
-    state: Mutex<Tenancy>,
+    /// One tenancy per client, rather than one for the server.
+    ///
+    /// The gate was written when the registry was global: a second client could see and end the
+    /// first's targets, so serving one at a time *was* the boundary. Sessions are owned now
+    /// ([#162](https://github.com/glslang/windbg-mcp/issues/162)), and a shared gate would only
+    /// mean that one client's long call — a pool walk, an `!analyze` — makes every other client
+    /// wait for a boundary it no longer provides. Contention within a client is still real and
+    /// still arbitrated; contention *between* them was never about safety.
+    state: Mutex<HashMap<crate::client::Client, Tenancy>>,
 }
 
 #[derive(Debug, Default)]
@@ -288,12 +297,14 @@ impl Tenancy {
 /// deferred for ever.
 struct InFlight {
     lease: Arc<Lease>,
+    /// Whose tenancy this request was admitted under — the count it has to be taken out of.
+    owner: crate::client::Client,
     epoch: u64,
 }
 
 impl Drop for InFlight {
     fn drop(&mut self) {
-        self.lease.leave(self.epoch);
+        self.lease.leave(&self.owner, self.epoch);
     }
 }
 
@@ -330,6 +341,31 @@ enum Admission {
     Occupied,
 }
 
+/// A borrow of one client's tenancy, so the rules below read exactly as they did when there was
+/// one tenancy for the server — the difference is entirely in *whose* is being consulted.
+struct TenancyGuard<'a> {
+    all: std::sync::MutexGuard<'a, HashMap<crate::client::Client, Tenancy>>,
+    client: crate::client::Client,
+}
+
+impl std::ops::Deref for TenancyGuard<'_> {
+    type Target = Tenancy;
+
+    fn deref(&self) -> &Tenancy {
+        self.all
+            .get(&self.client)
+            .expect("state_of inserts before handing out a guard")
+    }
+}
+
+impl std::ops::DerefMut for TenancyGuard<'_> {
+    fn deref_mut(&mut self) -> &mut Tenancy {
+        self.all
+            .get_mut(&self.client)
+            .expect("state_of inserts before handing out a guard")
+    }
+}
+
 impl Lease {
     /// Fails rather than starting when the grace could expire inside a call.
     ///
@@ -352,12 +388,23 @@ impl Lease {
         Ok(Self {
             grace,
             sessions,
-            state: Mutex::new(Tenancy::default()),
+            state: Mutex::new(HashMap::new()),
         })
     }
 
-    fn state(&self) -> std::sync::MutexGuard<'_, Tenancy> {
+    fn all_tenancies(&self) -> std::sync::MutexGuard<'_, HashMap<crate::client::Client, Tenancy>> {
         self.state.lock().unwrap_or_else(|e| e.into_inner())
+    }
+
+    /// One client's tenancy, created empty on first use — a client that has never connected holds
+    /// nothing, which is what a default `Tenancy` says.
+    fn state_of(&self, client: &crate::client::Client) -> TenancyGuard<'_> {
+        let mut all = self.all_tenancies();
+        all.entry(client.clone()).or_default();
+        TenancyGuard {
+            all,
+            client: client.clone(),
+        }
     }
 
     /// Decides whether a request may be served, **reserving** the server when one is taking it.
@@ -365,8 +412,8 @@ impl Lease {
     /// `session` is the request's `Mcp-Session-Id`; its absence means a client opening a new
     /// session, which is the only moment tenancy is contested. Every decision is made under one
     /// lock, so the answer a request gets is the state it will be served against.
-    fn admit(&self, session: Option<&str>) -> Admission {
-        let mut state = self.state();
+    fn admit(&self, client: &crate::client::Client, session: Option<&str>) -> Admission {
+        let mut state = self.state_of(client);
         // Nothing is served while a teardown is in flight. Briefly refusing a client that could
         // have been served costs a reconnect; serving one costs it the session mid-call.
         if state.releasing {
@@ -428,8 +475,9 @@ impl Lease {
         requested: Option<&str>,
         minted: Option<&str>,
         ok: bool,
+        client: crate::client::Client,
     ) -> Settled {
-        let mut state = self.state();
+        let mut state = self.state_of(&client);
         match claim {
             // This request reserved the server. It may only resolve *its own* reservation: one
             // that outlived the grace has already been cleared and possibly re-issued to somebody
@@ -468,8 +516,8 @@ impl Lease {
     }
 
     /// The holder said goodbye. The sessions stay; the clock starts.
-    fn released(&self, id: &str) {
-        let mut state = self.state();
+    fn released(&self, client: &crate::client::Client, id: &str) {
+        let mut state = self.state_of(client);
         if state.holder.as_deref() != Some(id) {
             return;
         }
@@ -479,7 +527,7 @@ impl Lease {
         // at worst this request and at best a tool call still running on another connection.
         state.farewell = true;
         drop(state);
-        self.try_give_up();
+        self.try_give_up_for(client);
     }
 
     /// One admitted request finished, however it finished.
@@ -488,14 +536,14 @@ impl Lease {
     /// a tenancy that no longer exists, and counting it out of the current one would subtract work
     /// it never did — enough for a concurrent goodbye to see zero while a tool call is still
     /// running.
-    fn leave(&self, epoch: u64) {
-        let mut state = self.state();
+    fn leave(&self, client: &crate::client::Client, epoch: u64) {
+        let mut state = self.state_of(client);
         if state.epoch != epoch {
             return;
         }
         state.in_flight = state.in_flight.saturating_sub(1);
         drop(state);
-        self.try_give_up();
+        self.try_give_up_for(client);
     }
 
     /// Whether the lease has run out, **claiming the teardown** if so.
@@ -504,8 +552,8 @@ impl Lease {
     /// way until [`Self::released_leases`] says the teardown is done. That is what closes the
     /// window [`Sessions::release_leased`] warns it does not close itself: between deciding to
     /// release and having released, no client can be admitted to the sessions being released.
-    fn expired(&self) -> Option<Expired> {
-        let mut state = self.state();
+    fn expired_for(&self, client: &crate::client::Client) -> Option<Expired> {
+        let mut state = self.state_of(client);
         match state.deadline {
             Some(at) if Instant::now() >= at => {
                 let holder = state.holder.take();
@@ -530,6 +578,12 @@ impl Lease {
         }
     }
 
+    /// The clients this lease holds state for, so the sweeper can ask each in turn without holding
+    /// the lock across an `await`.
+    fn clients(&self) -> Vec<crate::client::Client> {
+        self.all_tenancies().keys().cloned().collect()
+    }
+
     /// Hands the server over, if a goodbye is outstanding and nothing is still using it.
     ///
     /// Two conditions, and they are not the same one. `in_flight` is HTTP: the requests this holder
@@ -537,8 +591,8 @@ impl Lease {
     /// so a dropped future or a timed-out call leaves work running against a target the next client
     /// would otherwise be handed. Attempted on every sweep as well as on the two events, because
     /// the engine going idle is not an event this side can see.
-    fn try_give_up(&self) {
-        let mut state = self.state();
+    fn try_give_up_for(&self, client: &crate::client::Client) {
+        let mut state = self.state_of(client);
         if !state.farewell || state.in_flight != 0 {
             return;
         }
@@ -546,7 +600,7 @@ impl Lease {
         if self.sessions.busy() {
             return;
         }
-        state = self.state();
+        state = self.state_of(client);
         // Re-checked: the two locks were not held together, so a request could have arrived.
         if !state.farewell || state.in_flight != 0 {
             return;
@@ -558,8 +612,8 @@ impl Lease {
     }
 
     /// The teardown is done; the server may be taken again.
-    fn released_leases(&self) {
-        self.state().releasing = false;
+    fn released_leases(&self, client: &crate::client::Client) {
+        self.state_of(client).releasing = false;
     }
 }
 
@@ -773,7 +827,7 @@ async fn gate(
         .and_then(|v| v.to_str().ok())
         .map(str::to_owned);
 
-    let admitted = match lease.admit(session.as_deref()) {
+    let admitted = match lease.admit(&caller, session.as_deref()) {
         Admission::Serve(admitted) => admitted,
         Admission::Occupied => {
             tracing::warn!("refused a second client from {peer}: this server is already held");
@@ -787,6 +841,7 @@ async fn gate(
     // request out, and a goodbye waiting on it completes when the last one does.
     let _in_flight = InFlight {
         lease: lease.clone(),
+        owner: caller.clone(),
         epoch: admitted.epoch,
     };
 
@@ -797,6 +852,9 @@ async fn gate(
     // The whole MCP call runs as this client: the routing, the worker handshake and the engine
     // call all read the identity from here, rather than from a parameter forty-odd tool bodies
     // would have to carry. See [`crate::client`].
+    // Kept for the settlement below, which records whose tenancy this is — the scope moves the
+    // identity into the call.
+    let caller_for_lease = caller.clone();
     let response = crate::client::as_client(caller, mcp.handle(req)).await;
 
     let minted = response
@@ -811,6 +869,7 @@ async fn gate(
         session.as_deref(),
         minted.as_deref(),
         response.status().is_success(),
+        caller_for_lease.clone(),
     ) {
         // Counted rather than asserted. `left_open` says a previous tenancy ended inside the
         // grace, which is true whether or not that client had opened anything — so the
@@ -856,7 +915,7 @@ async fn gate(
     if is_departure(&method, response.status())
         && let Some(id) = session
     {
-        lease.released(&id);
+        lease.released(&caller_for_lease, &id);
         tracing::info!("the client let go; its sessions are held for the grace period");
     }
     Ok(response)
@@ -917,26 +976,36 @@ async fn sweep(
         if let Some(after) = idle_after {
             sessions.release_idle(after).await;
         }
-        // The engine may have gone idle since the last tick, which is not something the HTTP side
-        // is told about.
-        lease.try_give_up();
-        let Some(expired) = lease.expired() else {
-            continue;
-        };
-        tracing::info!("a client's lease ran out; releasing the sessions it left open");
-        sessions.release_leased().await;
-        // The debug sessions are the expensive half, but not the whole of it. A client that
-        // vanished never sent the DELETE that closes its MCP session, so without this the service
-        // keeps that session resident and its id accepted — and every disconnect-and-reconnect
-        // cycle would add another one that no lease will ever sweep again.
-        if let Some(id) = expired.holder
-            && let Err(e) = manager.close_session(&id.into()).await
-        {
-            tracing::warn!("could not close the MCP session of the client that went away: {e}");
+        // Per client, because a tenancy is per client: one caller's expiry says nothing about
+        // another's, and a sweep that stopped at the first would starve the rest.
+        for client in lease.clients() {
+            // The engine may have gone idle since the last tick, which is not something the HTTP
+            // side is told about.
+            lease.try_give_up_for(&client);
+            let Some(expired) = lease.expired_for(&client) else {
+                continue;
+            };
+            tracing::info!(
+                "the lease of client `{client}` ran out; releasing the sessions it left open"
+            );
+            // **That client's sessions, not every session.** Before ownership this was the same
+            // set, because the gate served one client at a time. It is not any more: another
+            // client's targets are in the same registry, and this expiry says nothing about them
+            // (#162).
+            sessions.release_leased(&client).await;
+            // The debug sessions are the expensive half, but not the whole of it. A client that
+            // vanished never sent the DELETE that closes its MCP session, so without this the
+            // service keeps that session resident and its id accepted — and every
+            // disconnect-and-reconnect cycle would add another one no lease will ever sweep again.
+            if let Some(id) = expired.holder
+                && let Err(e) = manager.close_session(&id.into()).await
+            {
+                tracing::warn!("could not close the MCP session of the client that went away: {e}");
+            }
+            // Only now may this client be admitted again: until here, an arriving request would be
+            // let in to sessions this release is closing.
+            lease.released_leases(&client);
         }
-        // Only now may the server be taken again: until this, an arriving client would be admitted
-        // to sessions this release is closing.
-        lease.released_leases();
     }
 }
 
@@ -944,25 +1013,90 @@ async fn sweep(
 mod tests {
     use super::*;
 
+    /// A lease bound to one client, so the rules below read as they did when there was one tenancy
+    /// for the server.
+    ///
+    /// Every test here is about how *a* client's tenancy behaves — claims, adoption, goodbyes,
+    /// expiry — and none of them is about which client it is. Binding the name once keeps that
+    /// distinction visible: a test that needs two clients says so by using two of these.
+    struct For {
+        lease: Lease,
+        client: crate::client::Client,
+    }
+
+    impl For {
+        fn new(lease: Lease, name: &str) -> Self {
+            Self {
+                lease,
+                client: crate::client::Client::new(name),
+            }
+        }
+
+        fn admit(&self, session: Option<&str>) -> Admission {
+            self.lease.admit(&self.client, session)
+        }
+
+        fn settle(
+            &self,
+            claim: Option<u64>,
+            requested: Option<&str>,
+            minted: Option<&str>,
+            ok: bool,
+        ) -> Settled {
+            self.lease
+                .settle(claim, requested, minted, ok, self.client.clone())
+        }
+
+        fn released(&self, id: &str) {
+            self.lease.released(&self.client, id);
+        }
+
+        fn leave(&self, epoch: u64) {
+            self.lease.leave(&self.client, epoch);
+        }
+
+        fn expired(&self) -> Option<Expired> {
+            self.lease.expired_for(&self.client)
+        }
+
+        fn released_leases(&self) {
+            self.lease.released_leases(&self.client);
+        }
+
+        fn state(&self) -> TenancyGuard<'_> {
+            self.lease.state_of(&self.client)
+        }
+
+        fn sessions(&self) -> &Sessions {
+            &self.lease.sessions
+        }
+    }
+
     const CALL: Duration = Duration::from_secs(300);
 
     /// A grace comfortably past the opener's end-to-end bound.
-    fn lease() -> Lease {
-        Lease::new(
-            longest_quiet_call(CALL) + Duration::from_secs(60),
-            CALL,
-            Sessions::new(CALL),
+    fn lease() -> For {
+        For::new(
+            Lease::new(
+                longest_quiet_call(CALL) + Duration::from_secs(60),
+                CALL,
+                Sessions::new(CALL),
+            )
+            .expect("workable"),
+            crate::client::Client::LOCAL,
         )
-        .expect("workable")
     }
 
     /// A lease whose grace expires almost immediately, for the sweep paths.
-    fn brief() -> Lease {
-        Lease {
-            grace: Duration::from_millis(1),
-            sessions: Sessions::new(CALL),
-            state: Mutex::new(Tenancy::default()),
-        }
+    fn brief() -> For {
+        For::new(
+            Lease {
+                grace: Duration::from_millis(1),
+                sessions: Sessions::new(CALL),
+                state: Mutex::new(HashMap::new()),
+            },
+            crate::client::Client::LOCAL,
+        )
     }
 
     /// The floor is the same one the lease refuses to start below, and for the same reason: a
@@ -1027,7 +1161,7 @@ mod tests {
     /// One whole request: admitted, settled, and finished. Every admitted request is counted out
     /// again in `gate` by a guard, so a test that settles without finishing is modelling a request
     /// that never came back.
-    fn request(lease: &Lease, session: Option<&str>, minted: Option<&str>, ok: bool) -> Settled {
+    fn request(lease: &For, session: Option<&str>, minted: Option<&str>, ok: bool) -> Settled {
         let it = admitted(lease.admit(session));
         let settled = lease.settle(it.claim, session, minted, ok);
         lease.leave(it.epoch);
@@ -1035,7 +1169,7 @@ mod tests {
     }
 
     /// A client's `DELETE`, which is itself an admitted request.
-    fn goodbye(lease: &Lease, id: &str) {
+    fn goodbye(lease: &For, id: &str) {
         let it = admitted(lease.admit(Some(id)));
         lease.released(id);
         lease.leave(it.epoch);
@@ -1349,7 +1483,7 @@ mod tests {
 
         // `Sessions::busy` is what the lease consults, and an idle registry is not busy — so this
         // test pins the wiring rather than the debugger, which needs a worker to be busy at all.
-        assert!(!lease.sessions.busy());
+        assert!(!lease.sessions().busy());
     }
 
     /// A request that never came back cannot defer a goodbye for ever.
@@ -1411,14 +1545,61 @@ mod tests {
         );
     }
 
+    /// **Two clients do not contend, on one lease.** The gate serialised the server when the
+    /// registry was global and one client could end another's targets. Sessions are owned now, so a
+    /// shared gate would only mean that one client's long call — a pool walk, an `!analyze` — makes
+    /// every other client wait for a boundary it no longer provides, and per-client namespaces
+    /// would be unusable concurrently ([#162](https://github.com/glslang/windbg-mcp/issues/162)).
+    ///
+    /// Deliberately *not* written with the `For` binding: two bindings would be two leases, which
+    /// cannot contend whatever the code does, and the test would pass against the bug it is for.
+    #[test]
+    fn one_clients_tenancy_does_not_block_another() {
+        let lease = Lease::new(
+            longest_quiet_call(CALL) + Duration::from_secs(60),
+            CALL,
+            Sessions::new(CALL),
+        )
+        .expect("workable");
+        let laptop = crate::client::Client::new("laptop");
+        let ci = crate::client::Client::new("ci");
+
+        // `laptop` takes its tenancy and holds it — the long-call case.
+        let held = admitted(lease.admit(&laptop, None));
+        lease.settle(
+            held.claim,
+            None,
+            Some("session-laptop"),
+            true,
+            laptop.clone(),
+        );
+
+        // Within that client, a second `initialize` is still refused: that contention is real, and
+        // it is the one the claim machinery exists to arbitrate.
+        assert_eq!(
+            lease.admit(&laptop, None),
+            Admission::Occupied,
+            "a second connection from the same client still contends"
+        );
+
+        // Across clients, on the same lease, it is not.
+        assert!(
+            matches!(lease.admit(&ci, None), Admission::Serve(_)),
+            "another client must not wait on a tenancy that no longer bounds anything it can reach"
+        );
+    }
+
     /// A claim keeps alive the sessions it is adopting.
     #[test]
     fn reserving_the_server_renews_what_the_claim_is_adopting() {
-        let lease = Lease {
-            grace: Duration::from_millis(60),
-            sessions: Sessions::new(CALL),
-            state: Mutex::new(Tenancy::default()),
-        };
+        let lease = For::new(
+            Lease {
+                grace: Duration::from_millis(60),
+                sessions: Sessions::new(CALL),
+                state: Mutex::new(HashMap::new()),
+            },
+            crate::client::Client::LOCAL,
+        );
         request(&lease, None, Some("session-a"), true);
         goodbye(&lease, "session-a");
         std::thread::sleep(Duration::from_millis(40));

--- a/src/listen.rs
+++ b/src/listen.rs
@@ -606,7 +606,20 @@ async fn bind_when_ready(addr: SocketAddr) -> Result<TcpListener> {
 ///
 /// Trimmed, because a token in a file arrives with whatever line ending wrote it, and a token that
 /// works from an editor but not from `Set-Content` would be an unpleasant afternoon.
-fn bearer_token() -> Result<String> {
+fn credentials() -> Result<crate::client::Credentials> {
+    let creds = crate::client::Credentials::from_entries(std::env::vars(), token_file()?)?;
+    if creds.len() == 0 {
+        bail!(
+            "neither {TOKEN_FILE_ENV} nor {TOKEN_ENV} is set, and no {TOKEN_ENV}_<NAME> either. \
+             The listener will not start without a bearer token: it exposes every tool this server \
+             has, including the ones that write to a live kernel."
+        );
+    }
+    Ok(creds)
+}
+
+/// The token in the file [`TOKEN_FILE_ENV`] names, if it names one.
+fn token_file() -> Result<Option<String>> {
     if let Some(path) = std::env::var_os(TOKEN_FILE_ENV) {
         let path = std::path::PathBuf::from(path);
         let token = std::fs::read_to_string(&path).with_context(|| {
@@ -618,19 +631,9 @@ fn bearer_token() -> Result<String> {
         if token.trim().is_empty() {
             bail!("{} is empty; that is not a token.", path.display());
         }
-        return Ok(token.trim().to_string());
+        return Ok(Some(token.trim().to_string()));
     }
-    let token = std::env::var(TOKEN_ENV).map_err(|_| {
-        anyhow::anyhow!(
-            "neither {TOKEN_FILE_ENV} nor {TOKEN_ENV} is set. The listener will not start without \
-             a bearer token: it exposes every tool this server has, including the ones that write \
-             to a live kernel."
-        )
-    })?;
-    if token.trim().is_empty() {
-        bail!("{TOKEN_ENV} is set but empty; that is not a token.");
-    }
-    Ok(token.trim().to_string())
+    Ok(None)
 }
 
 pub async fn serve(
@@ -640,7 +643,7 @@ pub async fn serve(
     shutdown: impl Future<Output = ()>,
     ready: impl FnOnce(),
 ) -> Result<()> {
-    let token = bearer_token()?;
+    let credentials = Arc::new(credentials()?);
 
     let grace = match std::env::var(GRACE_ENV).ok().and_then(|v| v.parse().ok()) {
         Some(secs) if secs > 0 => Duration::from_secs(secs),
@@ -690,11 +693,12 @@ pub async fn serve(
     // *now*. See [`crate::service`], where "started" is a thing the SCM and its dependants act on.
     ready();
     tracing::info!(
-        "windbg-mcp listening on http://{addr} (lease grace {grace:?}, {}, one client at a time)",
+        "windbg-mcp listening on http://{addr} (lease grace {grace:?}, {}, clients: {})",
         match idle_after {
             Some(after) => format!("idle sessions released after {}m", after.as_secs() / 60),
             None => "idle sessions never released".to_string(),
-        }
+        },
+        credentials.names().join(", ")
     );
 
     tokio::spawn(sweep(
@@ -725,7 +729,7 @@ pub async fn serve(
         let mcp = mcp.clone();
         let manager = manager.clone();
         let lease = lease.clone();
-        let token = token.clone();
+        let credentials = Arc::clone(&credentials);
         tokio::spawn(async move {
             let serve = service_fn(move |req| {
                 gate(
@@ -733,7 +737,7 @@ pub async fn serve(
                     mcp.clone(),
                     manager.clone(),
                     lease.clone(),
-                    token.clone(),
+                    Arc::clone(&credentials),
                     peer,
                 )
             });
@@ -753,15 +757,15 @@ async fn gate(
     mcp: Arc<StreamableHttpService<WindbgServer, LocalSessionManager>>,
     manager: Arc<LocalSessionManager>,
     lease: Arc<Lease>,
-    token: String,
+    credentials: Arc<crate::client::Credentials>,
     peer: SocketAddr,
 ) -> Result<Response<BoxBody<Bytes, Infallible>>, Infallible> {
-    if !authorised(&req, &token) {
+    let Some(caller) = authorised(&req, &credentials) else {
         // No detail: an unauthenticated caller learns that it is unauthenticated and nothing about
-        // what is here.
+        // what is here — including how many credentials this listener holds.
         tracing::warn!("rejected an unauthenticated request from {peer}");
         return Ok(refuse(StatusCode::UNAUTHORIZED, "unauthorized"));
-    }
+    };
 
     let session = req
         .headers()
@@ -790,7 +794,10 @@ async fn gate(
     // afterwards the request is gone; whether it *was* a departure also depends on the answer.
     let method = req.method().clone();
 
-    let response = mcp.handle(req).await;
+    // The whole MCP call runs as this client: the routing, the worker handshake and the engine
+    // call all read the identity from here, rather than from a parameter forty-odd tool bodies
+    // would have to carry. See [`crate::client`].
+    let response = crate::client::as_client(caller, mcp.handle(req)).await;
 
     let minted = response
         .headers()
@@ -870,12 +877,21 @@ fn is_departure(method: &hyper::Method, status: StatusCode) -> bool {
     method == hyper::Method::DELETE && status.is_success()
 }
 
-fn authorised(req: &Request<Incoming>, token: &str) -> bool {
+/// The client whose token this request presented, or `None` if it presented none this listener
+/// knows.
+///
+/// The credential *is* the identity — see [`crate::client`] for why nothing else can be, on a
+/// transport whose protocol no longer has sessions in it.
+fn authorised(
+    req: &Request<Incoming>,
+    credentials: &crate::client::Credentials,
+) -> Option<crate::client::Client> {
     req.headers()
         .get(AUTHORIZATION)
         .and_then(|v| v.to_str().ok())
         .and_then(|v| v.strip_prefix("Bearer "))
-        .is_some_and(|presented| presented == token)
+        .and_then(|presented| credentials.client_for(presented))
+        .cloned()
 }
 
 fn refuse(status: StatusCode, why: &str) -> Response<BoxBody<Bytes, Infallible>> {

--- a/src/logbridge.rs
+++ b/src/logbridge.rs
@@ -102,6 +102,14 @@ impl Level {
 pub struct Entry {
     /// Assigned by the ring, in arrival order, and never reused within a run. This is what makes
     /// `since` paging exact and what makes an eviction visible as a gap.
+    ///
+    /// **Numbered across the whole server, not per client**, and that is a deliberate limit rather
+    /// than an oversight: the counter is what makes a cursor stable under eviction, and the ring
+    /// cannot number per client without knowing which client each session belongs to — a fact that
+    /// lives in the registry and arrives here only as [`Query::visible`], one query at a time. So a
+    /// client reading two of its own records a hundred apart can tell that *something* was filed in
+    /// between. It learns a count and nothing else; the records themselves, their sessions and
+    /// their text stay unreachable.
     pub seq: u64,
     /// Milliseconds since the Unix epoch, stamped **where the record happened** — in the worker,
     /// for a worker's. So `at` and `seq` can disagree by the width of a pipe write, and each is
@@ -179,21 +187,32 @@ impl Ring {
     }
 
     fn tail(&self, query: &Query) -> Tail {
-        let matches: Vec<&Entry> = self
+        // What this caller may read at all, before any filter they asked for. A record about
+        // *someone else's* session is not theirs to read; the supervisor's own records carry no
+        // session id and stay visible to everyone, being about this process rather than about any
+        // client's target.
+        //
+        // Everything below is counted over *this* stream rather than over the ring, because a
+        // number about records the caller cannot read is still a report of another client's
+        // activity: a `held` that climbs while nothing of theirs is filed says another client is
+        // busy, and an `oldest_seq` that moves says its records are being evicted. Neither leaks
+        // content, and both are answers to a question the boundary says a client may not ask.
+        let visible: Vec<&Entry> = self
             .entries
             .iter()
+            .filter(|e| match (&query.visible, e.session.as_deref()) {
+                (Some(mine), Some(about)) => mine.iter().any(|id| id == about),
+                _ => true,
+            })
+            .collect();
+        let matches: Vec<&Entry> = visible
+            .iter()
+            .copied()
             .filter(|e| e.level <= query.level)
             .filter(|e| query.since.is_none_or(|since| e.seq >= since))
             .filter(|e| match &query.session {
                 Some(wanted) => e.session.as_deref() == Some(wanted.as_str()),
                 None => true,
-            })
-            // A record about *someone else's* session is not this caller's to read. The
-            // supervisor's own records carry no session id and stay visible to everyone: they are
-            // about this process rather than about any client's target.
-            .filter(|e| match (&query.visible, e.session.as_deref()) {
-                (Some(mine), Some(about)) => mine.iter().any(|id| id == about),
-                _ => true,
             })
             .collect();
         let matched = matches.len();
@@ -201,10 +220,16 @@ impl Ring {
         Tail {
             entries: matches[from..].iter().map(|e| (*e).clone()).collect(),
             matched,
-            next_since: self.next_seq,
-            held: self.entries.len(),
+            // One past the newest record this caller can see, rather than one past the newest the
+            // ring has filed. It still advances past everything they could have been shown — which
+            // is what the cursor promises — and a caller who can see nothing keeps the cursor they
+            // came with rather than being handed a count of what happened elsewhere.
+            next_since: visible
+                .last()
+                .map_or_else(|| query.since.unwrap_or(0), |e| e.seq + 1),
+            held: visible.len(),
             capacity: self.capacity,
-            oldest_seq: self.entries.front().map(|e| e.seq),
+            oldest_seq: visible.first().map(|e| e.seq),
         }
     }
 }
@@ -313,20 +338,24 @@ pub struct Query {
     pub visible: Option<Vec<String>>,
 }
 
-/// What the ring answered with.
+/// What the ring answered with — **as this caller sees it**. Every count here is over the records
+/// [`Query::visible`] admits, so a client is told about the buffer it can read rather than about
+/// the buffer the server keeps.
 pub struct Tail {
     /// Oldest first, which is reading order.
     pub entries: Vec<Entry>,
     /// How many matched the query before `limit` clipped it.
     pub matched: usize,
-    /// Pass this as `since` next time to get only what is new. It is the next seq the ring will
-    /// issue, not the last one returned, so a query that matched nothing still advances.
+    /// Pass this as `since` next time to get only what is new. It is one past the newest record
+    /// this caller can see, not the last one returned, so a query that matched nothing still
+    /// advances.
     pub next_since: u64,
-    /// How many records the ring is holding, and how many it can.
+    /// How many records the caller can read, and how many the ring can hold in all. The capacity
+    /// is a configured constant and says nothing about anyone's activity, so it stays as it is.
     pub held: usize,
     pub capacity: usize,
-    /// The oldest seq still held. A `since` older than this means records were evicted between
-    /// the two calls, which is the only way a reader can find out.
+    /// The oldest seq this caller can still see. A `since` older than this means records were
+    /// evicted between the two calls, which is the only way a reader can find out.
     pub oldest_seq: Option<u64>,
 }
 
@@ -633,6 +662,63 @@ mod tests {
             ..query()
         });
         assert!(theirs.entries.is_empty(), "{:?}", theirs.entries);
+    }
+
+    /// The filter is only half the boundary. A caller who is told how full the buffer is, how far
+    /// its cursor has moved and what its oldest record is can watch all three climb while nothing
+    /// of theirs is filed — which is a report of another client's activity, arrived at without
+    /// reading a single one of its records.
+    #[test]
+    fn the_buffers_own_numbers_do_not_report_another_clients_activity() {
+        let mut ring = Ring::new(100);
+        ring.file(
+            Level::Info,
+            1,
+            "windbg_mcp::worker".into(),
+            Some("sess-mine".into()),
+            "mine".into(),
+        );
+        let mine = Query {
+            visible: Some(vec!["sess-mine".to_string()]),
+            ..query()
+        };
+        let before = ring.tail(&mine);
+        assert_eq!(before.held, 1, "one record of this caller's is in the ring");
+
+        // A busy neighbour, filing steadily and telling this caller nothing.
+        for n in 0..7 {
+            ring.file(
+                Level::Info,
+                2,
+                "windbg_mcp::worker".into(),
+                Some("sess-theirs".into()),
+                format!("theirs {n}"),
+            );
+        }
+        let after = ring.tail(&Query {
+            since: Some(before.next_since),
+            ..mine
+        });
+
+        assert!(
+            after.entries.is_empty(),
+            "nothing of this caller's was filed: {:?}",
+            after.entries
+        );
+        assert_eq!(
+            after.held, before.held,
+            "the buffer looked seven records fuller, so a caller polling it can count another \
+             client's records without reading one"
+        );
+        assert_eq!(
+            after.next_since, before.next_since,
+            "the cursor advanced past records this caller was never shown, which is the same \
+             count arriving as a gap"
+        );
+        assert_eq!(
+            after.oldest_seq, before.oldest_seq,
+            "the oldest record moved, which reports eviction pressure this caller did not cause"
+        );
     }
 
     /// Severity ordering is what the filter is built on, and it reads backwards from the

--- a/src/logbridge.rs
+++ b/src/logbridge.rs
@@ -188,6 +188,13 @@ impl Ring {
                 Some(wanted) => e.session.as_deref() == Some(wanted.as_str()),
                 None => true,
             })
+            // A record about *someone else's* session is not this caller's to read. The
+            // supervisor's own records carry no session id and stay visible to everyone: they are
+            // about this process rather than about any client's target.
+            .filter(|e| match (&query.visible, e.session.as_deref()) {
+                (Some(mine), Some(about)) => mine.iter().any(|id| id == about),
+                _ => true,
+            })
             .collect();
         let matched = matches.len();
         let from = matched.saturating_sub(query.limit);
@@ -293,6 +300,17 @@ pub struct Query {
     pub since: Option<u64>,
     /// At most this many, taking the most recent.
     pub limit: usize,
+    /// The session ids the caller owns, when the caller is one of several clients.
+    ///
+    /// **The ring is one buffer for the whole server**, so without this a client could read what
+    /// another client's worker said — its session ids, the target it opened, whatever the debugger
+    /// printed on the way to a failure. That is the boundary
+    /// ([#162](https://github.com/glslang/windbg-mcp/issues/162)) leaking through a different tool
+    /// than the one it was written for.
+    ///
+    /// `None` means "everything", which is stdio and the supervisor's own use: one client by
+    /// construction, so there is nothing to separate.
+    pub visible: Option<Vec<String>>,
 }
 
 /// What the ring answered with.
@@ -564,7 +582,57 @@ mod tests {
             level: Level::Trace,
             since: None,
             limit: 100,
+            visible: None,
         }
+    }
+
+    /// One ring serves the whole server, so a client may only read the records of sessions it
+    /// owns. The supervisor's own records carry no session id and stay visible to everyone: they
+    /// are about this process rather than about anyone's target.
+    #[test]
+    fn a_client_reads_only_its_own_sessions_records() {
+        let mut ring = Ring::new(100);
+        ring.file(
+            Level::Info,
+            1,
+            "windbg_mcp::worker".into(),
+            Some("sess-mine".into()),
+            "mine".into(),
+        );
+        ring.file(
+            Level::Info,
+            2,
+            "windbg_mcp::worker".into(),
+            Some("sess-theirs".into()),
+            "theirs".into(),
+        );
+        ring.file(
+            Level::Info,
+            3,
+            "windbg_mcp::engine".into(),
+            None,
+            "the supervisor's".into(),
+        );
+
+        let mine = ring.tail(&Query {
+            visible: Some(vec!["sess-mine".to_string()]),
+            ..query()
+        });
+        let messages: Vec<&str> = mine.entries.iter().map(|e| e.message.as_str()).collect();
+        assert_eq!(
+            messages,
+            vec!["mine", "the supervisor's"],
+            "another client's records are not this caller's to read: {messages:?}"
+        );
+
+        // And naming their session explicitly narrows to a set this caller is not in, so it comes
+        // back empty — the same answer a handle this server never issued gets.
+        let theirs = ring.tail(&Query {
+            session: Some("sess-theirs".to_string()),
+            visible: Some(vec!["sess-mine".to_string()]),
+            ..query()
+        });
+        assert!(theirs.entries.is_empty(), "{:?}", theirs.entries);
     }
 
     /// Severity ordering is what the filter is built on, and it reads backwards from the

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@
 
 mod batch;
 mod cast;
+mod client;
 mod engine;
 mod kdconn;
 mod listen;

--- a/src/server.rs
+++ b/src/server.rs
@@ -3181,6 +3181,11 @@ impl WindbgServer {
         // Never routed to a worker, for the same reason `session_status` is not: the case this
         // exists for is a session nothing can be asked of, and a tool that queued behind it would
         // be unavailable exactly when it is wanted.
+        // What this caller may read: the records its own sessions produced, plus the
+        // supervisor's, which carry no session id and are about the process rather than any
+        // target. A handle belonging to another client narrows to a set it is not in, so it comes
+        // back empty — the same answer an id this server never issued gets, and for the same
+        // reason as `resolve`: the reply must not confirm a session the caller may not touch.
         let query = crate::logbridge::Query {
             session: args.session_id.clone(),
             level: args.level.unwrap_or(crate::logbridge::Level::Info),
@@ -3189,6 +3194,7 @@ impl WindbgServer {
                 .limit
                 .unwrap_or(DEFAULT_LOG_RECORDS)
                 .min(MAX_LOG_RECORDS) as usize,
+            visible: Some(self.sessions.visible_session_ids()),
         };
         let tail = crate::logbridge::tail(&query);
         structured_result(describe_log(&tail, &query), log_report(&tail))
@@ -4892,6 +4898,7 @@ mod tests {
             level: crate::logbridge::Level::Info,
             since: None,
             limit: 50,
+            visible: None,
         };
         let out = describe_log(&tail, &query);
         assert!(
@@ -4930,6 +4937,7 @@ mod tests {
             level: crate::logbridge::Level::Info,
             since: Some(350),
             limit: 50,
+            visible: None,
         };
         assert!(
             !describe_log(&tail, &caught_up).contains("were evicted"),

--- a/src/ttd.rs
+++ b/src/ttd.rs
@@ -202,7 +202,7 @@ pub fn record_launch(
     // credential handed to an arbitrary binary. With it, that binary could dial the listener on
     // loopback and claim the server once the current holder goes quiet. Stripped in both places
     // this server creates a process, because either one is enough to leak it.
-    cmd.env_remove(crate::listen::TOKEN_ENV);
+    crate::client::strip_credentials(&mut cmd);
     // Pass through the validated environment (e.g. an anti-analysis env guard) and cwd to the
     // recorded target. TTD.exe launches `target` with this environment inherited. Applied after
     // the scrub above, so an entry the caller passed deliberately still wins.

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -5737,8 +5737,10 @@ fn a_lease_that_runs_out_releases_what_the_absent_client_left() {
     // hold the lease open for as long as it watched. The log is the one channel that costs
     // nothing.
     assert!(
+        // The stable half of the line: the message now names *which* client's lease ran out, since
+        // an expiry releases that client's sessions and no others.
         server.wait_for_stderr(
-            "a client's lease ran out; releasing the sessions it left open",
+            "ran out; releasing the sessions it left open",
             Duration::from_secs(120),
         ),
         "the lease never expired — a client that vanished would hold this target for ever\n\


### PR DESCRIPTION
Slices 2 and 3 of [#162](https://github.com/glslang/windbg-mcp/issues/162).

The registry is one map for the whole server — handles minted from it, the cap shared,
`end_session` ending whatever it is handed — and the listener stood in for a boundary by serving one
client at a time. `2026-07-28` removed the protocol-level MCP session (SEP-2567), so the identifier
that gate was keyed on is gone, and on the revision most clients now negotiate **two clients are
both served and neither can be told from the other**.

## Identity

**In a stateless protocol the only sound identity is authentication.** No session id by design; no
connection to key on, since requests arrive on whatever socket a client's pool hands them; and
`clientInfo` is not retained between requests. The credential is what is left.

```console
setx WINDBG_MCP_LISTEN_TOKEN        "<a long random string>"   # names the client `local`
setx WINDBG_MCP_LISTEN_TOKEN_CI     "<another>"                # names `ci`
```

A name only the holder of a token can present is a boundary. A name a client picks for itself — a
header, `clientInfo` — would be a label, which is why neither was an option.

## What ownership changes

| | |
| --- | --- |
| Routing | a handle routes only for its owner; omitting one finds *that* client's newest session |
| Refusal | another client's handle comes back **unknown**, not "someone else's" |
| Listing | `session_status` shows the caller's sessions and no others |
| Capacity | the four-session cap is per client |
| Reclamation | only ever takes the **same** client's idle session |

The refusal wording is deliberate: confirming that a handle exists but belongs to someone else would
leak that a second client is here and what it holds, and there is nothing the caller could do with
the distinction.

Reclamation is the sharpest of these. Ending another client's target to make room for mine is
exactly the harm a shared registry did — and a shared *cap* is the same harm spelled as denial,
which is why the limit moved too.

## Two details worth keeping

**Stdio calls run as `local`** rather than as a special case, so one set of registry rules serves
both transports instead of one rule and an exception.

**One token configured for two names is refused at startup.** The winner would be a `HashMap`
ordering detail, so the same configuration could put a client's sessions under a different name from
one run to the next.

The identity reaches the engine the way a progress sink does — a task-local set around the whole MCP
call — because threading it through would put a parameter on every tool signature naming something
none of them uses.

## Scope

This separates clients; it does not rank them. Everyone who can authenticate still has the whole
tool surface, `execute` and `launch` included.

The tenancy gate is now **redundant rather than wrong**, so retiring it — with the 409, the lease
and the machinery that exists only because the registry was global — is the next change rather than
this one.

## Testing

ARM64 bench: clippy clean, `cargo test --bins` **467 passed**, including eight new. The three that
carry the claim:

- `a_handle_is_not_usable_by_another_client` — routes for its owner by handle and by default, and
  for anyone else is *unknown* rather than refused;
- `session_status_shows_only_the_callers_own`;
- `one_clients_sessions_do_not_fill_anothers_quota` — a client at its own limit is refused while a
  quiet one still has room.

Plus five for the credential parsing, including the one that caught a real bug while I wrote it:
`WINDBG_MCP_LISTEN_TOKEN_FILE` shares the prefix and would otherwise have configured a client called
`file` whose token is a *path* — with the real token silently absent.

`WINDBG_MCP_SMOKE_DUMP=1 cargo test --test mcp_smoke -- --test-threads=1`: **61 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for multiple authenticated clients using named bearer tokens.
  * Isolated sessions, routing, status, capacity limits, reclamation and logs per client.
  * Added optional token-file support and retained local identity for standard input/output connections.
  * Preserved the full tool set for every authenticated client.

* **Bug Fixes**
  * Prevented access to sessions and activity owned by other clients.
  * Rejected duplicate token assignments at startup.
  * Removed credential variables from spawned processes.

* **Documentation**
  * Updated remote listener guidance for multi-client token ownership and session handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->