### PR TITLE
Say one client per credential everywhere it was still one client per server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     keeping it shared would have meant one client's four-minute pool walk making every other client
     wait for a boundary the registry now provides properly — namespaces that cannot be used
     concurrently. Two connections presenting the *same* token still contend, which is one client
-    racing itself.
+    racing itself — and the `409` says so, where it used to report a second client that no longer
+    exists as a category.
   - Under **stdio** everything runs as `local`, so one set of registry rules serves both transports
     rather than one rule and an exception.
   - **Every credential variable is stripped from the processes this server creates** — by prefix,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,9 +46,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     serialised the server when the registry was global and one client could end another's targets;
     keeping it shared would have meant one client's four-minute pool walk making every other client
     wait for a boundary the registry now provides properly — namespaces that cannot be used
-    concurrently. Two connections presenting the *same* token still contend, which is one client
+    concurrently. A second *MCP session* for the same token still contends, which is one credential
     racing itself — and the `409` says so, where it used to report a second client that no longer
-    exists as a category.
+    exists as a category. Further requests carrying a session it already holds are not contention at
+    all and never were: they are served concurrently, which is what lets a `DELETE` arrive while a
+    tool call is still running.
   - Under **stdio** everything runs as `local`, so one set of registry rules serves both transports
     rather than one rule and an exception.
   - **Every credential variable is stripped from the processes this server creates** — by prefix,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     racing itself — and the `409` says so, where it used to report a second client that no longer
     exists as a category. Further requests carrying a session it already holds are not contention at
     all and never were: they are served concurrently, which is what lets a `DELETE` arrive while a
-    tool call is still running.
+    tool call is still running. The one `409` that means something else — a request arriving while
+    the sweeper releases this credential's expired sessions, when it holds nothing at all — now says
+    so, instead of describing a session the caller does not have.
   - Under **stdio** everything runs as `local`, so one set of registry rules serves both transports
     rather than one rule and an exception.
   - **Every credential variable is stripped from the processes this server creates** — by prefix,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -377,9 +377,10 @@ so there is one set of rules and no transport exception. `docs/remote-listener.m
 half; what follows is what bites while editing.
 
 **Identity is ambient inside a call and by name outside one.** `crate::client::current()` reads a
-task-local that `listen::serve_one` sets around the whole MCP call, which is why no tool signature
-carries a caller. Anything running *outside* that scope — the listener's own diagnostics, a sweep, a
-shutdown — gets the default `local` instead of an error, so it must take the client as a parameter
+task-local that `listen::gate` sets — with `client::as_client`, around the `mcp.handle(req)` that
+is the whole MCP call — which is why no tool signature carries a caller. Anything running *outside*
+that scope — the listener's own diagnostics, a sweep, a shutdown — gets the default `local` instead
+of an error, so it must take the client as a parameter
 (`Sessions::live_count_for` against `Sessions::snapshot`). The bug this rule is written from was a
 log line reporting `local`'s session count to a named client on reconnect.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -368,6 +368,38 @@ this repo believed for a while: Visual Studio Build Tools ships it, including an
 — because the first fetch takes minutes and everything around it times out, which reads convincingly
 as the parser having made things worse.
 
+## Several clients on one listener (`src/client.rs`)
+
+A `--listen` server holds **one bearer token per client**: `WINDBG_MCP_LISTEN_TOKEN_<NAME>` names
+one, the unnamed variable names `local`, and a configured `WINDBG_MCP_LISTEN_TOKEN_FILE` shuts the
+environment out entirely rather than merely outranking it. Under stdio everything runs as `local`,
+so there is one set of rules and no transport exception. `docs/remote-listener.md` is the operator's
+half; what follows is what bites while editing.
+
+**Identity is ambient inside a call and by name outside one.** `crate::client::current()` reads a
+task-local that `listen::serve_one` sets around the whole MCP call, which is why no tool signature
+carries a caller. Anything running *outside* that scope — the listener's own diagnostics, a sweep, a
+shutdown — gets the default `local` instead of an error, so it must take the client as a parameter
+(`Sessions::live_count_for` against `Sessions::snapshot`). The bug this rule is written from was a
+log line reporting `local`'s session count to a named client on reconnect.
+
+**A caller sees only its own sessions**, and that is not a fault to debug: routing, `session_status`,
+`server_log`, the four-session cap, closed-session history and lease release are all per client, and
+another client's handle is reported *unknown* rather than refused. Two tokens on one host are two
+namespaces — if a session "vanished", check which token the request carried.
+
+**Credentials are built from variables handed in, not read from the environment**
+(`Credentials::from_entries`), for the same reason as `kdconn::env_entries`: `set_var` is `unsafe` in
+edition 2024 and mutates state the whole test binary shares. And they are **stripped from every
+child process by prefix** (`client::strip_credentials`), so a token variable added later cannot
+quietly reach an engine worker or a `launch`ed debuggee — but a credential under a *different*
+prefix would need its own strip.
+
+Two collisions are refused at startup rather than resolved, because the winner would be a `HashMap`
+ordering detail: one token naming two clients, and two tokens naming one (names are folded, so
+`…_TOKEN` and `…_TOKEN_LOCAL` collide, as do `…_CI` and `…__CI`). **Neither refusal may quote a
+token** — they are printed to stderr and, under the service, to a log file.
+
 ## Recording a session while debugging this server
 
 `WINDBG_MCP_TRANSCRIPT=<path>` makes the supervisor write a JSONL record of every tool call, every

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -881,7 +881,11 @@ question in both directions:
   overlapping ones from the same credential contend: measured against a listener on the bench,
   `409`s appear as soon as two stateless requests overlap. Every request of such a client is that
   path, since there is never an id to carry. `server_log` while a pool walk runs — the workflow this
-  server documents for a wedged session — is exactly the overlap in question.
+  server documents for a wedged session — is exactly the overlap in question. The same measurement
+  turned up something larger and separate, filed as
+  [#168](https://github.com/glslang/windbg-mcp/issues/168): the listener answers a `2026-07-28`
+  handshake and then `400`s the request after it. Settle that first — if the newest revision is not
+  served at all, what its clients do to this gate is the second question.
 
 **What would settle it:** decide whether idle release (`WINDBG_MCP_SESSION_IDLE_SECS`, added in
 [#164](https://github.com/glslang/windbg-mcp/pull/164)) already covers the teardown the lease is

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -1,6 +1,6 @@
 # Follow-ups
 
-Deferred work, in ten clusters: items 1–6 come from the reachability-confirmation effort (path
+Deferred work, in eleven clusters: items 1–6 come from the reachability-confirmation effort (path
 recipe + `run_to_address`, merged 2026-07-04), items 7–11 from surveying this server against the
 MCP `2026-07-28` extensions (tasks, apps), item 12 from the opener split
 (glslang/win-kexp#71, 2026-08-01), items 13–14 from the bounded-command coverage review
@@ -11,7 +11,8 @@ session's own transcript turned up, and item 18 what reviewing it did), item 19 
 (#131, #132, #134, 2026-08-16), item 23 from making the listener usable rather than merely
 working (2026-08-17), item 24 from first measuring what this server costs the model driving it
 (2026-08-17), items 25–26 from giving the debugger tier an ARM64 *target* (#143, #152,
-2026-08-18), and item 27 from completing the coordinate work (#156–#158, 2026-08-18). Each item
+2026-08-18), item 27 from completing the coordinate work (#156–#158, 2026-08-18), and items 28–29
+from giving each client its own sessions (#162, #164–#166, 2026-08-19). Each item
 notes its repo,
 why it was deferred, and where it picks up. See [`DECISIONS.md`](./DECISIONS.md) for the design rationale (D1–D5) items 1–6 extend,
 and the 2026-08-02 entries that items 13–14 and item 10 extend.
@@ -843,3 +844,60 @@ symbol load to populate it would be strictly worse: that is a `.reload` per modu
 
 **Depends on nothing.** Picks up at `worker::with_pdb_identity` and
 `win_kexp::DebugEngine::module_pdb`.
+
+## 28. [windbg-mcp] The tenancy gate may no longer earn its place
+
+The listener's **lease** was built when the registry was one map for the whole server: handles
+minted from it, the cap shared, `end_session` ending whatever it was handed. Serving one client at a
+time was the only thing standing between two clients and each other's targets, so the gate was
+load-bearing.
+
+Ownership took that job over ([#162](https://github.com/glslang/windbg-mcp/issues/162), merged
+2026-08-19). A handle routes only for its owner, `session_status` and `server_log` show only the
+caller's, the cap and the closed-session history are per client, a lease expiry releases only that
+client's sessions, and an `Mcp-Session-Id` another client holds is reported unknown. The gate itself
+became per client in the same change, because a shared one would have made namespaces unusable
+concurrently — one client's pool walk stalling every other client for a boundary the registry
+already provides.
+
+**So what is left for it to arbitrate is one client racing itself**: two connections presenting the
+same token, where the second gets a `409`. The question this item is for is whether that is worth a
+gate — and it is a real question in both directions:
+
+- **For keeping it:** the lease is also what *releases* sessions when a client goes away without
+  saying goodbye. That is not tenancy, it is teardown, and a live kernel target left attached is the
+  expensive failure. Retiring the gate must not retire the sweep.
+- **For retiring it:** a client legitimately has more than one connection in flight — that is how
+  streamable HTTP works — and every `409` it earns is a reconnect the protocol did not ask for.
+  `2026-07-28` has no session id at all, so a stateless client cannot even become the holder; the
+  gate is reasoning about an identifier its newest callers do not send.
+
+**What would settle it:** decide whether idle release (`WINDBG_MCP_SESSION_IDLE_SECS`, added in
+[#164](https://github.com/glslang/windbg-mcp/pull/164)) already covers the teardown the lease is
+kept for. If it does, the gate can go and the sweep stays; if it does not, say why in
+`docs/remote-listener.md` and keep both.
+
+**Why deferred:** it is a deletion, and a deletion is the change most worth making on its own,
+against a PR that is not also adding the thing it would delete. Picks up at `src/listen.rs`
+(`Lease::admit`, `Lease::settle`) and the ~90 lease tests beside it.
+
+## 29. [windbg-mcp] The listener smoke tier only ever runs one, unnamed client
+
+Every listener assertion in `tests/mcp_smoke.rs` starts the server with a single
+`WINDBG_MCP_LISTEN_TOKEN`, so everything the tier proves is proved for the `local` client alone. The
+per-client behaviour — routing, the unknown-handle answer, per-client capacity and history, the
+per-client tenancy, the session-id ownership check — is covered by unit tests in `src/engine.rs`,
+`src/listen.rs` and `src/client.rs`, and by nothing end to end.
+
+The gap has already cost one bug: the adoption diagnostic counted `local`'s sessions for a named
+client reconnecting, because the count was taken after the identity scope had closed. A unit test
+pins the mechanism now, but the call site — an HTTP handler — is still unexercised.
+
+**What would close it:** a tier that starts the listener with two tokens (`…_TOKEN_CI` beside the
+unnamed one), opens a session as each, and asserts that neither can see, route to or end the
+other's; then walks one client through open → `DELETE` → reconnect-inside-the-grace and reads the
+adoption line back out of `server_log`. All of it is dump-tier work — none of it needs a live
+target.
+
+**Why deferred:** the per-client rules are unit-tested at the level they are decided, so this buys
+call-site coverage rather than new claims. Picks up at the listener helpers in `tests/mcp_smoke.rs`.

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -876,6 +876,12 @@ question in both directions:
   contention it does catch is arguably the client's own business: a client that lost its session id
   (a crash, a restart) and re-`initialize`s inside the grace is told `409` and has to wait the grace
   out, where adopting its own sessions is what it wanted and what the identity now makes safe.
+- **And it actively costs that client concurrency**, which is no longer a prediction. A request
+  carrying no session id takes the *opening* path and holds a claim for its whole duration, so two
+  overlapping ones from the same credential contend: measured against a listener on the bench,
+  `409`s appear as soon as two stateless requests overlap. Every request of such a client is that
+  path, since there is never an id to carry. `server_log` while a pool walk runs — the workflow this
+  server documents for a wedged session — is exactly the overlap in question.
 
 **What would settle it:** decide whether idle release (`WINDBG_MCP_SESSION_IDLE_SECS`, added in
 [#164](https://github.com/glslang/windbg-mcp/pull/164)) already covers the teardown the lease is

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -860,17 +860,22 @@ became per client in the same change, because a shared one would have made names
 concurrently — one client's pool walk stalling every other client for a boundary the registry
 already provides.
 
-**So what is left for it to arbitrate is one client racing itself**: two connections presenting the
-same token, where the second gets a `409`. The question this item is for is whether that is worth a
-gate — and it is a real question in both directions:
+**So what is left for it to arbitrate is one credential racing itself**: a second *MCP session* for
+one token — a fresh `initialize` while one is held or being opened, or a request bearing an id that
+is not the one it holds — which gets a `409`. Note what that is *not*: further requests carrying the
+session a credential already holds are served concurrently, `in_flight` and all, because that is how
+a `DELETE` arrives on one connection while a tool call runs on another. Connections were never the
+unit. The question this item is for is whether what remains is worth a gate, and it is a real
+question in both directions:
 
 - **For keeping it:** the lease is also what *releases* sessions when a client goes away without
   saying goodbye. That is not tenancy, it is teardown, and a live kernel target left attached is the
   expensive failure. Retiring the gate must not retire the sweep.
-- **For retiring it:** a client legitimately has more than one connection in flight — that is how
-  streamable HTTP works — and every `409` it earns is a reconnect the protocol did not ask for.
-  `2026-07-28` has no session id at all, so a stateless client cannot even become the holder; the
-  gate is reasoning about an identifier its newest callers do not send.
+- **For retiring it:** `2026-07-28` has no session id at all, so a stateless client never becomes
+  the holder — the gate is reasoning about an identifier its newest callers do not send. And the
+  contention it does catch is arguably the client's own business: a client that lost its session id
+  (a crash, a restart) and re-`initialize`s inside the grace is told `409` and has to wait the grace
+  out, where adopting its own sessions is what it wanted and what the identity now makes safe.
 
 **What would settle it:** decide whether idle release (`WINDBG_MCP_SESSION_IDLE_SECS`, added in
 [#164](https://github.com/glslang/windbg-mcp/pull/164)) already covers the teardown the lease is

--- a/README.md
+++ b/README.md
@@ -235,7 +235,8 @@ against a live kernel, and the token is sent in clear — a hypervisor's guest n
 when the machine being debugged shares it. [`docs/remote-listener.md`](./docs/remote-listener.md)
 covers the tokens — **one per client**, each with its own sessions, so two people or two agents on
 one listener cannot reach each other's targets — the session lease and its grace, and what a `409`
-means (one client's second connection, not a second client). For a one-off, [`docs/remote-phase0.md`](./docs/remote-phase0.md) does the same
+means (one credential asking for a second MCP session, never a second client, and never a request on
+a second connection — those are served concurrently). For a one-off, [`docs/remote-phase0.md`](./docs/remote-phase0.md) does the same
 job over plain `ssh` with no listener.
 
 ### As a Claude Code plugin

--- a/README.md
+++ b/README.md
@@ -233,8 +233,9 @@ target before exiting, because a live kernel that is merely killed is left froze
 **Bind loopback and forward over SSH.** This endpoint runs `execute`, `debug_batch` and `launch`
 against a live kernel, and the token is sent in clear — a hypervisor's guest network is not private
 when the machine being debugged shares it. [`docs/remote-listener.md`](./docs/remote-listener.md)
-covers the token, the session lease and its grace, why only one client is served at a time, and
-what a `409` means. For a one-off, [`docs/remote-phase0.md`](./docs/remote-phase0.md) does the same
+covers the tokens — **one per client**, each with its own sessions, so two people or two agents on
+one listener cannot reach each other's targets — the session lease and its grace, and what a `409`
+means (one client's second connection, not a second client). For a one-off, [`docs/remote-phase0.md`](./docs/remote-phase0.md) does the same
 job over plain `ssh` with no listener.
 
 ### As a Claude Code plugin

--- a/docs/remote-listener.md
+++ b/docs/remote-listener.md
@@ -222,11 +222,17 @@ requests. The credential is what is left, and it is what every other stateless H
 a client presents for itself would be a label; a name only the holder of a token can present is a
 boundary.
 
-**Two clients do not queue behind each other.** The lease still arbitrates *within* a client — two
-connections presenting the same token contend, and the second gets a `409` — because that is one
-client racing itself. Across clients there is nothing to arbitrate: a pool walk that keeps one
-client busy for four minutes used to make every other client wait, for a boundary the registry now
-provides properly.
+**Two clients do not queue behind each other.** The lease still arbitrates *within* a client — a
+second **MCP session** for one token contends, and gets a `409` — because that is one credential
+racing itself. Across clients there is nothing to arbitrate: a pool walk that keeps one client busy
+for four minutes used to make every other client wait, for a boundary the registry now provides
+properly.
+
+A `409` is never about *connections*. Requests carrying the session a credential already holds are
+served concurrently, which is what lets a `DELETE` arrive on one connection while a tool call runs
+on another — the topology every streamable-HTTP client uses. What it refuses is a fresh
+`initialize` while a session is held or being opened, or a request bearing an id that is not the one
+this credential holds.
 
 **This does not authorise anything beyond separation.** Every client that can authenticate has the
 whole tool surface, including `execute` and `launch`. Tokens separate clients from each other; they

--- a/docs/remote-listener.md
+++ b/docs/remote-listener.md
@@ -234,6 +234,11 @@ on another — the topology every streamable-HTTP client uses. What it refuses i
 `initialize` while a session is held or being opened, or a request bearing an id that is not the one
 this credential holds.
 
+**One `409` means the opposite of the others**, and says so: after a lease runs out, the sessions are
+released in the background, and a request arriving during that cleanup is refused while the
+credential holds nothing at all. Its body names the release rather than a session, because the fix
+is to ask again in a moment rather than to go looking for a session you do not have.
+
 **This does not authorise anything beyond separation.** Every client that can authenticate has the
 whole tool surface, including `execute` and `launch`. Tokens separate clients from each other; they
 do not rank them.

--- a/docs/remote-listener.md
+++ b/docs/remote-listener.md
@@ -230,9 +230,15 @@ properly.
 
 A `409` is never about *connections*. Requests carrying the session a credential already holds are
 served concurrently, which is what lets a `DELETE` arrive on one connection while a tool call runs
-on another — the topology every streamable-HTTP client uses. What it refuses is a fresh
-`initialize` while a session is held or being opened, or a request bearing an id that is not the one
-this credential holds.
+on another — the topology every streamable-HTTP client uses. What it refuses is a second MCP session
+for one credential: a fresh `initialize` while a session is held or being opened, or a request
+bearing an id that is not the one it holds. A request that arrives while another of the same
+credential's is still *opening* one is refused on the same grounds, which is why the body names both.
+
+**A client that sends no session id at all is the case to watch.** `2026-07-28` removed the session
+([SEP-2567]), so every one of its requests takes the opening path, and two that overlap contend with
+each other — measured on the bench, and recorded as `FOLLOWUPS.md` item 28, which is where the
+question of retiring this gate lives.
 
 **One `409` means the opposite of the others**, and says so: after a lease runs out, the sessions are
 released in the background, and a request arriving during that cleanup is refused while the

--- a/docs/remote-listener.md
+++ b/docs/remote-listener.md
@@ -238,7 +238,10 @@ credential's is still *opening* one is refused on the same grounds, which is why
 **A client that sends no session id at all is the case to watch.** `2026-07-28` removed the session
 ([SEP-2567]), so every one of its requests takes the opening path, and two that overlap contend with
 each other — measured on the bench, and recorded as `FOLLOWUPS.md` item 28, which is where the
-question of retiring this gate lives.
+question of retiring this gate lives. Measuring it also turned up
+[#168](https://github.com/glslang/windbg-mcp/issues/168), which is the bigger question standing
+behind it: this listener answers a `2026-07-28` handshake and then refuses the request after it, so
+**use a client that negotiates a legacy revision until that is settled**.
 
 **One `409` means the opposite of the others**, and says so: after a lease runs out, the sessions are
 released in the background, and a request arriving during that cleanup is refused while the

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -414,7 +414,10 @@ reach is the wiring, which is what these assert against a real listener on a loo
 hand-written HTTP client (a library that normalised a `409` into an exception, or hid the session
 header, would be asserting on this server's behalf).
 
-Four of them need no debugger, because tenancy is decided before any session is opened:
+Four of them need no debugger, because tenancy is decided before any session is opened. All four
+run a listener holding a **single, unnamed** token, so what they prove they prove for the `local`
+client alone; the per-client rules are unit-tested where they are decided, and closing that
+end-to-end gap is [`FOLLOWUPS.md`](../FOLLOWUPS.md) item 29:
 
 - *It will not start without a token*, and says which variable is missing. The listener exposes
   every tool here, including the ones that write to a live kernel; a quiet default would be a
@@ -423,8 +426,10 @@ Four of them need no debugger, because tenancy is decided before any session is 
   nothing***. The last clause is the one worth a test: the bearer check runs before the tenancy
   gate, so a wrong token must not reserve or consume a claim — if it did, anything that could
   reach the port could lock the real client out without ever authenticating.
-- *A second client is refused with `409`*, whether it arrives with a fresh `initialize` or with a
-  session id that is not the holder's, and the holder is undisturbed by either.
+- *A second connection **from the same client** is refused with `409`*, whether it arrives with a
+  fresh `initialize` or with a session id that is not the holder's, and the holder is undisturbed by
+  either. Since 2026-08-19 the tenancy is per client, so this is one client racing itself — a
+  *different* client is served concurrently and shares nothing with this one.
 - *Going quiet is not leaving; saying goodbye is.* Every request is its own connection — which is
   what a client behind a tunnel looks like — so silence is the resting state, and a server that
   read it as departure would hand the registry on between two calls of a working client. A

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -426,10 +426,12 @@ end-to-end gap is [`FOLLOWUPS.md`](../FOLLOWUPS.md) item 29:
   nothing***. The last clause is the one worth a test: the bearer check runs before the tenancy
   gate, so a wrong token must not reserve or consume a claim — if it did, anything that could
   reach the port could lock the real client out without ever authenticating.
-- *A second connection **from the same client** is refused with `409`*, whether it arrives with a
-  fresh `initialize` or with a session id that is not the holder's, and the holder is undisturbed by
-  either. Since 2026-08-19 the tenancy is per client, so this is one client racing itself — a
-  *different* client is served concurrently and shares nothing with this one.
+- *A second **MCP session** for the same credential is refused with `409`*, whether it asks with a
+  fresh `initialize` or with a session id that is not the one it holds, and the holder is undisturbed
+  by either. Since 2026-08-19 the tenancy is per client, so this is one credential racing itself: a
+  *different* client is served concurrently and shares nothing with this one, and so are further
+  requests carrying the session this one already holds — which is what lets a `DELETE` arrive while
+  a tool call is still running.
 - *Going quiet is not leaving; saying goodbye is.* Every request is its own connection — which is
   what a client behind a tunnel looks like — so silence is the resting state, and a server that
   read it as departure would hand the registry on between two calls of a working client. A

--- a/src/listen.rs
+++ b/src/listen.rs
@@ -868,10 +868,15 @@ async fn gate(
             return Ok(refuse(StatusCode::NOT_FOUND, "unknown session"));
         }
         Admission::Occupied => {
-            tracing::warn!("refused a second client from {peer}: this server is already held");
+            // Same client, second connection: tenancy is per client now, so this is never another
+            // client being turned away — and a message saying it was would send an operator
+            // looking for a colleague who is not there.
+            tracing::warn!(
+                "refused a second connection from {peer}: this client already holds a session here"
+            );
             return Ok(refuse(
                 StatusCode::CONFLICT,
-                "another client holds this server; it serves one at a time",
+                "this credential already holds a session here; one at a time per client",
             ));
         }
     };

--- a/src/listen.rs
+++ b/src/listen.rs
@@ -890,17 +890,21 @@ async fn gate(
         Admission::Occupied => {
             // Never another client — tenancy is per client now — and never a *connection* either:
             // requests carrying the session this credential holds are served concurrently, which
-            // is how a `DELETE` arrives on one while a tool call runs on another. What is refused
-            // is a second **MCP session** for the same credential: a fresh `initialize` while one
-            // is held or being opened, or a request bearing an id that is not the one it holds.
+            // is how a `DELETE` arrives on one while a tool call runs on another. Two things reach
+            // here and the message has to fit both: a second **MCP session** for this credential
+            // (a fresh `initialize`, or an id that is not the one it holds), and a request arriving
+            // while another of its own still holds the claim — which is every overlapping request
+            // from a client that sends no session id at all, since `2026-07-28` removed it.
             // Saying "another client" would send an operator looking for a colleague who is not
             // there, and saying "connection" for one who has a network problem they do not have.
             tracing::warn!(
-                "refused a request from {peer}: this credential already holds a session here"
+                "refused a request from {peer}: this credential is already being served here"
             );
             return Ok(refuse(
                 StatusCode::CONFLICT,
-                "this credential already holds a session here, or is opening one;                  one MCP session per credential at a time",
+                "this credential is already using this server: it holds an MCP session, or a \
+                 request of its own is still opening one. Send the session id it holds, or ask \
+                 again once that request has finished.",
             ));
         }
     };

--- a/src/listen.rs
+++ b/src/listen.rs
@@ -337,8 +337,12 @@ struct Admitted {
 enum Admission {
     /// Hand it to the MCP service.
     Serve(Admitted),
-    /// Someone else holds the server, is taking it, or is being cleaned up after.
+    /// This credential already has an MCP session here, or is opening one.
     Occupied,
+    /// This credential's own sessions are being let go after its lease ran out. Separate from
+    /// [`Self::Occupied`] because the advice is the opposite: nothing is held, and the request that
+    /// arrives a moment later is served.
+    Releasing,
     /// The request carried an MCP session id **another client** minted. Reported to the caller as
     /// unknown, for the reason the registry reports another client's handle that way: the answer
     /// must not confirm a session the caller may not use.
@@ -444,9 +448,12 @@ impl Lease {
         }
         let mut state = self.state_of(client);
         // Nothing is served while a teardown is in flight. Briefly refusing a client that could
-        // have been served costs a reconnect; serving one costs it the session mid-call.
+        // have been served costs a reconnect; serving one costs it the session mid-call. Its own
+        // answer, because at this moment the credential holds nothing and is opening nothing — the
+        // reply that says otherwise sends a client looking for a session of its own that it does
+        // not have, when what it has to do is ask again.
         if state.releasing {
-            return Admission::Occupied;
+            return Admission::Releasing;
         }
         match (session, state.holder.as_deref()) {
             // The holder, still talking.
@@ -867,6 +874,19 @@ async fn gate(
             );
             return Ok(refuse(StatusCode::NOT_FOUND, "unknown session"));
         }
+        // The sweeper is letting this credential's own sessions go. Transient, and the fix is to
+        // ask again rather than to change anything.
+        Admission::Releasing => {
+            tracing::warn!(
+                "refused a request from {peer}: this credential's expired sessions are still \
+                 being released"
+            );
+            return Ok(refuse(
+                StatusCode::CONFLICT,
+                "this credential's previous sessions are still being released after its lease ran \
+                 out; ask again in a moment",
+            ));
+        }
         Admission::Occupied => {
             // Never another client — tenancy is per client now — and never a *connection* either:
             // requests carrying the session this credential holds are served concurrently, which
@@ -1204,6 +1224,7 @@ mod tests {
                     "the gate took a session id for another client's, which no test here sets up"
                 )
             }
+            Admission::Releasing => panic!("the gate is letting go of sessions this test needs"),
         }
     }
 
@@ -1775,8 +1796,9 @@ mod tests {
 
         assert!(lease.expired().is_some(), "the grace is spent");
         assert!(
-            matches!(lease.admit(None), Admission::Occupied),
-            "the server is not vacant yet — the sessions are still being let go"
+            matches!(lease.admit(None), Admission::Releasing),
+            "the server is not vacant yet — the sessions are still being let go, and saying so is \
+             not the same as saying this credential holds one"
         );
 
         lease.released_leases();

--- a/src/listen.rs
+++ b/src/listen.rs
@@ -868,15 +868,19 @@ async fn gate(
             return Ok(refuse(StatusCode::NOT_FOUND, "unknown session"));
         }
         Admission::Occupied => {
-            // Same client, second connection: tenancy is per client now, so this is never another
-            // client being turned away — and a message saying it was would send an operator
-            // looking for a colleague who is not there.
+            // Never another client — tenancy is per client now — and never a *connection* either:
+            // requests carrying the session this credential holds are served concurrently, which
+            // is how a `DELETE` arrives on one while a tool call runs on another. What is refused
+            // is a second **MCP session** for the same credential: a fresh `initialize` while one
+            // is held or being opened, or a request bearing an id that is not the one it holds.
+            // Saying "another client" would send an operator looking for a colleague who is not
+            // there, and saying "connection" for one who has a network problem they do not have.
             tracing::warn!(
-                "refused a second connection from {peer}: this client already holds a session here"
+                "refused a request from {peer}: this credential already holds a session here"
             );
             return Ok(refuse(
                 StatusCode::CONFLICT,
-                "this credential already holds a session here; one at a time per client",
+                "this credential already holds a session here, or is opening one;                  one MCP session per credential at a time",
             ));
         }
     };
@@ -1624,7 +1628,7 @@ mod tests {
         assert_eq!(
             lease.admit(&laptop, None),
             Admission::Occupied,
-            "a second connection from the same client still contends"
+            "a second session for the same credential still contends"
         );
 
         // Across clients, on the same lease, it is not.

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -2803,7 +2803,7 @@ fn a_second_session_for_one_credential_is_refused_while_it_holds_the_server() {
         intruder.body
     );
     assert!(
-        intruder.body.contains("one MCP session per credential"),
+        intruder.body.contains("already using this server"),
         "the refusal has to say why, or it reads as a bug: {}",
         intruder.body
     );

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -14,7 +14,7 @@
 //!
 //! * **Protocol** (default) — spawns the server, speaks JSON-RPC. No debugger target, no
 //!   symbols, no network. This tier also drives the **listener** (`--listen`) over real HTTP on a
-//!   loopback port: the bearer check, the `409` that keeps a client to one connection at a time,
+//!   loopback port: the bearer check, the `409` that keeps a credential to one MCP session,
 //!   and the difference between a client going quiet and a client saying goodbye. Those need no
 //!   debugger, because the lease is decided before any session is opened — but the sweep meeting a
 //!   real engine worker does, so that half lives in the tier below.
@@ -2778,27 +2778,32 @@ fn an_unauthenticated_request_is_refused_and_costs_the_server_nothing() {
     );
 }
 
-/// One connection at a time **per client**, refused with `409` rather than served alongside.
+/// One MCP session at a time **per credential**, refused with `409` rather than served alongside.
 ///
 /// This was once the whole boundary: handles were minted from one registry, `MAX_SESSIONS` was
 /// shared and `end_session` ended whatever it was handed, so two clients would silently share and
 /// one could end a target the other was using. Sessions are owned now
 /// ([#162](https://github.com/glslang/windbg-mcp/issues/162)), and the tenancy is per client — so
-/// what this asserts is a client racing *itself*, which is the only contention left. The listener
-/// here holds one, unnamed token, so both connections below are that one client.
+/// what this asserts is a credential racing *itself*, which is the only contention left. The
+/// listener here holds one, unnamed token, so both requests below are that one client.
+///
+/// Not about *connections*: requests carrying the session this credential already holds are served
+/// concurrently, which is what makes a `DELETE` on one connection while a tool call runs on another
+/// work at all. What is refused is a **second session** — a fresh `initialize`, or an id that is
+/// not the one it holds.
 #[test]
-fn a_second_connection_from_one_client_is_refused_while_it_holds_the_server() {
+fn a_second_session_for_one_credential_is_refused_while_it_holds_the_server() {
     let mut server = Listener::start(&[]);
     let holder = server.initialize();
 
     let intruder = server.call(None, "initialize", Listener::opening());
     assert_eq!(
         intruder.status, 409,
-        "a second connection from the holder's own client was not refused: {}",
+        "a second session for the holder's own credential was not refused: {}",
         intruder.body
     );
     assert!(
-        intruder.body.contains("one at a time"),
+        intruder.body.contains("one MCP session per credential"),
         "the refusal has to say why, or it reads as a bug: {}",
         intruder.body
     );

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -14,10 +14,10 @@
 //!
 //! * **Protocol** (default) — spawns the server, speaks JSON-RPC. No debugger target, no
 //!   symbols, no network. This tier also drives the **listener** (`--listen`) over real HTTP on a
-//!   loopback port: the bearer check, the `409` that keeps it to one client at a time, and the
-//!   difference between a client going quiet and a client saying goodbye. Those need no debugger,
-//!   because the lease is decided before any session is opened — but the sweep meeting a real
-//!   engine worker does, so that half lives in the tier below.
+//!   loopback port: the bearer check, the `409` that keeps a client to one connection at a time,
+//!   and the difference between a client going quiet and a client saying goodbye. Those need no
+//!   debugger, because the lease is decided before any session is opened — but the sweep meeting a
+//!   real engine worker does, so that half lives in the tier below.
 //! * **Target** (`WINDBG_MCP_SMOKE_DUMP=1`) — opens the sample crash dump through DbgEng, so
 //!   it needs `dbgeng.dll` and may reach a symbol server. Off by default; this is the tier
 //!   that catches a `win-kexp` regression. It also runs a `debug_batch` to both outcomes, and
@@ -2778,20 +2778,23 @@ fn an_unauthenticated_request_is_refused_and_costs_the_server_nothing() {
     );
 }
 
-/// One client at a time, refused with `409` rather than served alongside.
+/// One connection at a time **per client**, refused with `409` rather than served alongside.
 ///
-/// Not a policy choice so much as an admission: `session_id` handles are minted from one registry,
-/// `MAX_SESSIONS` is shared, and `end_session` ends whatever it is handed — so two clients would
-/// silently share, and one could end a target the other was using.
+/// This was once the whole boundary: handles were minted from one registry, `MAX_SESSIONS` was
+/// shared and `end_session` ended whatever it was handed, so two clients would silently share and
+/// one could end a target the other was using. Sessions are owned now
+/// ([#162](https://github.com/glslang/windbg-mcp/issues/162)), and the tenancy is per client — so
+/// what this asserts is a client racing *itself*, which is the only contention left. The listener
+/// here holds one, unnamed token, so both connections below are that one client.
 #[test]
-fn a_second_client_is_refused_while_the_first_holds_the_server() {
+fn a_second_connection_from_one_client_is_refused_while_it_holds_the_server() {
     let mut server = Listener::start(&[]);
     let holder = server.initialize();
 
     let intruder = server.call(None, "initialize", Listener::opening());
     assert_eq!(
         intruder.status, 409,
-        "a second client was not refused: {}",
+        "a second connection from the holder's own client was not refused: {}",
         intruder.body
     );
     assert!(


### PR DESCRIPTION
Handoff pass after #166. That PR documented the boundary it built; this one fixes the places that
still describe the boundary it replaced — and adds the section a future agent needs before touching
the code.

### The rule worth writing down

`CLAUDE.md` gains a section on serving several clients, whose load-bearing part is:

> **Identity is ambient inside a call and by name outside one.**

`client::current()` reads a task-local that `serve_one` sets around the whole MCP call, which is why
no tool signature carries a caller. Anything running *outside* that scope — the listener's own
diagnostics, a sweep, a shutdown — gets the default `local` rather than an error, so it has to take
the client as a parameter. That is not a hypothetical: it is where #166's last review round found a
log line reporting `local`'s session count to a named client on reconnect.

The section also covers what bites: two tokens on one host are two namespaces, so a session that
"vanished" is usually a request that carried the other token; credentials are built from variables
handed in rather than read from the environment (`set_var` is `unsafe` in edition 2024); they are
stripped from child processes **by prefix**; and neither startup collision may quote a token.

### Claims that were true and are not

- **The `409` body** said `another client holds this server; it serves one at a time`. Tenancy is
  per client now, so that response is only ever one client racing itself — the old wording sends an
  operator looking for a colleague who is not there. It now says
  `this credential already holds a session here; one at a time per client`.
- **`README.md`** pointed at the listener doc for "why only one client is served at a time".
- **The smoke tier's tenancy test** was named `a_second_client_is_refused_…`, where its listener
  holds one token and both connections are therefore the same client. Renamed to what it asserts,
  and its rationale — "two clients would silently share, and one could end a target the other was
  using" — is now history rather than the reason.
- **`docs/smoke-test.md`** now says out loud that every listener assertion runs a single, unnamed
  token, so what they prove they prove for `local` alone.

### Two follow-ups filed rather than fixed

- **28 — the tenancy gate may no longer earn its place.** What is left for it to arbitrate is one
  client racing itself. The item is written with the argument on both sides, because the lease is
  *also* what releases a vanished client's targets, and retiring the gate must not retire the sweep.
- **29 — the listener tier has never run a named client.** Which is how the adoption-count bug got
  as far as review. The item says what a two-token tier would assert, and that all of it is
  dump-tier work.

Verified on the ARM64 bench: clippy clean, 477 unit tests, dump-gated smoke tier 61 passed / 0
failed — including the renamed test and the `409` body assertion, which matches on the stable
substring rather than the sentence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
