### PR TITLE
Serve 2026-07-28 concurrently, and settle what #168 actually found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -182,6 +182,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the x64 entry reads `mm_exploit_v5.exe` out of `SeAuditProcessCreationInfo`, which is a walk
   through `nt`'s types, and its run shows all four running rather than skipping.
 
+### Fixed
+
+- **A listener client on `2026-07-28` can use more than one request at a time**
+  ([#168](https://github.com/glslang/windbg-mcp/issues/168)). [SEP-2567] removed the MCP session id
+  from the revision current clients negotiate, and the listener's tenancy gate read the absence of
+  that id as "a client opening a session" — the one moment it reserves the server. On a revision
+  where the id never comes, that made *every* request a reservation: two that overlapped got a
+  `409`, and `server_log` while a pool walk ran — the workflow this server documents for a wedged
+  session — was exactly that overlap.
+
+  At its sharpest it cost the recovery path: a kernel attach whose target never dials in parks by
+  design, and a parked call held its reservation for as long as it parked, so the client could
+  reach neither `session_status` nor `end_session`. For that revision, a going-nowhere attach was
+  once again a reason to restart the server — the property
+  [#61](https://github.com/glslang/windbg-mcp/issues/61) established, quietly lost to a revision
+  rather than to a change.
+
+  The gate now distinguishes the two kinds of nothing: a request on a revision that mints no
+  session can never become the holder a reservation arbitrates, so it reserves nothing and is
+  served alongside its client's other work. What it still waits for is a teardown of its own
+  credential's expired sessions, which is the sweep's rule and not the gate's.
+
+  The same issue reported that the listener answered a `2026-07-28` handshake and then `400`d the
+  request after it. **It does not** — that was measured with a hand-rolled probe that sent the body
+  and none of the transport contract the revision adds, and the `400`s were the server enforcing
+  the spec. A request on this revision carries three things: the `MCP-Protocol-Version` header,
+  `params._meta` with `io.modelcontextprotocol/protocolVersion` and `…/clientCapabilities`
+  ([SEP-2567] moved them there when it removed the session that used to hold them), and SEP-2243's
+  `Mcp-Method` header naming the body's method. The smoke tier now drives the revision properly and
+  asserts both halves: a handshake and the calls after it are served, and each under-specified
+  shape is refused with a body naming the part that is missing.
+
+[SEP-2567]: https://modelcontextprotocol.io/seps/2567-sessionless-mcp
+
 ### Changed
 
 - **The last progress milestone is no longer dropped when it races the answer**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -201,8 +201,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   The gate now distinguishes the two kinds of nothing: a request on a revision that mints no
   session can never become the holder a reservation arbitrates, so it reserves nothing and is
-  served alongside its client's other work. What it still waits for is a teardown of its own
-  credential's expired sessions, which is the sweep's rule and not the gate's.
+  served alongside its client's other work. The one refusal it still meets is a teardown of its own
+  credential's expired sessions — refused with the `409` that says to ask again once the release is
+  done, which is the sweep's rule and not the gate's.
+
+  Two lease bugs on the same path came out of review and are fixed here too, both of which end with
+  a client losing sessions it was using. A stateless request now **renews** a lease its credential
+  already has, since the sweep reads the deadline alone — a credential holding a legacy session and
+  since sending stateless requests would otherwise have had those sessions released while it was
+  working. And a reservation that mints no session now gives its **deadline** back along with its
+  claim: a `2026-07-28` `initialize` may omit the `MCP-Protocol-Version` header, so it is
+  classified as an opener, reserves, and takes nothing — leaving a clock running against a tenancy
+  that holds nothing, which one grace later released whatever that client had since opened.
 
   The same issue reported that the listener answered a `2026-07-28` handshake and then `400`d the
   request after it. **It does not** — that was measured with a hand-rolled probe that sent the body

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -872,25 +872,26 @@ question in both directions:
   saying goodbye. That is not tenancy, it is teardown, and a live kernel target left attached is the
   expensive failure. Retiring the gate must not retire the sweep.
 - **For retiring it:** `2026-07-28` has no session id at all, so a stateless client never becomes
-  the holder — the gate is reasoning about an identifier its newest callers do not send. And the
+  the holder — the gate is reasoning about an identifier its newest callers do not send, and since
+  #168 it explicitly stands aside for them. And the
   contention it does catch is arguably the client's own business: a client that lost its session id
   (a crash, a restart) and re-`initialize`s inside the grace is told `409` and has to wait the grace
   out, where adopting its own sessions is what it wanted and what the identity now makes safe.
-- **And it actively costs that client concurrency**, which is no longer a prediction. A request
-  carrying no session id takes the *opening* path and holds a claim for its whole duration, so two
-  overlapping ones from the same credential contend: measured against a listener on the bench,
-  `409`s appear as soon as two stateless requests overlap. Every request of such a client is that
-  path, since there is never an id to carry. `server_log` while a pool walk runs — the workflow this
-  server documents for a wedged session — is exactly the overlap in question. The same measurement
-  turned up something larger and separate, filed as
-  [#168](https://github.com/glslang/windbg-mcp/issues/168): the listener answers a `2026-07-28`
-  handshake and then `400`s the request after it. Settle that first — if the newest revision is not
-  served at all, what its clients do to this gate is the second question.
+- **It used to cost that client concurrency, and the fix is a preview of the deletion.** A request
+  carrying no session id took the *opening* path and held a claim for its whole duration, so two
+  overlapping ones from the same credential contended — and every request of such a client is that
+  path, since there is never an id to carry. At its sharpest, a kernel attach whose target never
+  dialled in locked its own credential out of `session_status` and `end_session`, the two calls that
+  recover it. That was [#168](https://github.com/glslang/windbg-mcp/issues/168), and it is fixed by
+  *not reserving* for a request that can never become the holder — which is this item's argument
+  applied to the one case where it was unarguable. What remains is the same question for the cases
+  that are arguable: a legacy client's second `initialize`, and a resume inside the grace.
 
 **What would settle it:** decide whether idle release (`WINDBG_MCP_SESSION_IDLE_SECS`, added in
 [#164](https://github.com/glslang/windbg-mcp/pull/164)) already covers the teardown the lease is
 kept for. If it does, the gate can go and the sweep stays; if it does not, say why in
-`docs/remote-listener.md` and keep both.
+`docs/remote-listener.md` and keep both. Note the `releasing` refusal is *not* part of what would
+go: it is the sweep's, not the gate's, and a stateless request still waits on it.
 
 **Why deferred:** it is a deletion, and a deletion is the change most worth making on its own,
 against a PR that is not also adding the thing it would delete. Picks up at `src/listen.rs`

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -891,7 +891,8 @@ question in both directions:
 [#164](https://github.com/glslang/windbg-mcp/pull/164)) already covers the teardown the lease is
 kept for. If it does, the gate can go and the sweep stays; if it does not, say why in
 `docs/remote-listener.md` and keep both. Note the `releasing` refusal is *not* part of what would
-go: it is the sweep's, not the gate's, and a stateless request still waits on it.
+go: it is the sweep's, not the gate's, and a stateless request is refused by it like any other —
+told to ask again once the release is done.
 
 **Why deferred:** it is a deletion, and a deletion is the change most worth making on its own,
 against a PR that is not also adding the thing it would delete. Picks up at `src/listen.rs`

--- a/docs/remote-listener.md
+++ b/docs/remote-listener.md
@@ -235,13 +235,20 @@ for one credential: a fresh `initialize` while a session is held or being opened
 bearing an id that is not the one it holds. A request that arrives while another of the same
 credential's is still *opening* one is refused on the same grounds, which is why the body names both.
 
-**A client that sends no session id at all is the case to watch.** `2026-07-28` removed the session
-([SEP-2567]), so every one of its requests takes the opening path, and two that overlap contend with
-each other — measured on the bench, and recorded as `FOLLOWUPS.md` item 28, which is where the
-question of retiring this gate lives. Measuring it also turned up
-[#168](https://github.com/glslang/windbg-mcp/issues/168), which is the bigger question standing
-behind it: this listener answers a `2026-07-28` handshake and then refuses the request after it, so
-**use a client that negotiates a legacy revision until that is settled**.
+**A client that sends no session id at all contends with nothing.** `2026-07-28` removed the session
+([SEP-2567]), so such a client can never become the holder the gate arbitrates — and a request that
+cannot become one reserves nothing. It used to: every stateless request took the *opening* path, so
+any two that overlapped got a `409`, and a call that parked took its whole credential with it. That
+was [#168](https://github.com/glslang/windbg-mcp/issues/168), and it is fixed; the tier that pins it
+runs a `tools/list`, a `session_status` and an `end_session` alongside a kernel attach that never
+comes back.
+
+What is left of the gate for such a client is the teardown: a request arriving while its own expired
+sessions are being released still waits, because those sessions are being closed underneath it.
+Whether the rest of the gate earns its place is `FOLLOWUPS.md` item 28.
+
+Such a client also never installs a lease at all, which is why abandonment on this revision is the
+idle release's job rather than the grace's — see *A session nobody is using is released*, above.
 
 **One `409` means the opposite of the others**, and says so: after a lease runs out, the sessions are
 released in the background, and a request arriving during that cleanup is refused while the

--- a/docs/remote-listener.md
+++ b/docs/remote-listener.md
@@ -235,7 +235,7 @@ for one credential: a fresh `initialize` while a session is held or being opened
 bearing an id that is not the one it holds. A request that arrives while another of the same
 credential's is still *opening* one is refused on the same grounds, which is why the body names both.
 
-**A client that sends no session id at all contends with nothing.** `2026-07-28` removed the session
+**A client on a sessionless revision contends with nothing.** `2026-07-28` removed the session
 ([SEP-2567]), so such a client can never become the holder the gate arbitrates — and a request that
 cannot become one reserves nothing. It used to: every stateless request took the *opening* path, so
 any two that overlapped got a `409`, and a call that parked took its whole credential with it. That
@@ -243,9 +243,13 @@ was [#168](https://github.com/glslang/windbg-mcp/issues/168), and it is fixed; t
 runs a `tools/list`, a `session_status` and an `end_session` alongside a kernel attach that never
 comes back.
 
+This is about the revision, not about the header being absent. A client on a revision that *has*
+sessions and sends no id is opening one — an `initialize`, or a resume — and still takes the
+opening path, `409` and all.
+
 What is left of the gate for such a client is the teardown: a request arriving while its own expired
-sessions are being released still waits, because those sessions are being closed underneath it.
-Whether the rest of the gate earns its place is `FOLLOWUPS.md` item 28.
+sessions are being released is refused with the `409` below and should ask again once the release
+is done. Whether the rest of the gate earns its place is `FOLLOWUPS.md` item 28.
 
 Such a client also never installs a lease at all, which is why abandonment on this revision is the
 idle release's job rather than the grace's — see *A session nobody is using is released*, above.

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -414,7 +414,7 @@ reach is the wiring, which is what these assert against a real listener on a loo
 hand-written HTTP client (a library that normalised a `409` into an exception, or hid the session
 header, would be asserting on this server's behalf).
 
-Seven of them need no debugger, because tenancy is decided before any session is opened. All seven
+Six of them need no debugger, because tenancy is decided before any session is opened. All six
 run a listener holding a **single, unnamed** token, so what they prove they prove for the `local`
 client alone; the per-client rules are unit-tested where they are decided, and closing that
 end-to-end gap is [`FOLLOWUPS.md`](../FOLLOWUPS.md) item 29:
@@ -440,22 +440,29 @@ end-to-end gap is [`FOLLOWUPS.md`](../FOLLOWUPS.md) item 29:
   negotiate has no session id
   ([SEP-2567](https://modelcontextprotocol.io/seps/2567-sessionless-mcp)), so it exercises the
   listener as a client that never presents one: the handshake mints nothing, and a `tools/list` and
-  a `tools/call` after it are answered. Its three tests exist because [#168](https://github.com/glslang/windbg-mcp/issues/168)
-  reported the opposite from a hand-rolled probe, so each spells the revision the way it has to be
-  spelled — the `MCP-Protocol-Version` header, `params._meta` carrying the protocol version and the
-  client's capabilities, and SEP-2243's `Mcp-Method` (plus `Mcp-Name` where the method names
-  something).
+  a `tools/call` after it are answered. It exists because
+  [#168](https://github.com/glslang/windbg-mcp/issues/168) reported the opposite from a hand-rolled
+  probe, so it spells the revision the way it has to be spelled — the `MCP-Protocol-Version`
+  header, `params._meta` carrying the protocol version and the client's capabilities, and
+  SEP-2243's `Mcp-Method` (plus `Mcp-Name`, which SEP-2243 maps per method: `params.name` for
+  `tools/call` and `prompts/get`, `params.uri` for `resources/read`, and nothing for the rest).
 - *An under-specified stateless request is told which part it is missing*, rather than merely
   refused. Both shapes the probe sent are pinned here, so the same `400` cannot be read as a broken
   listener a second time.
-- *A stateless client can work while one of its own calls is parked.* The gate reserves the server
-  for a request that is opening a session, and a request with no session id used to look exactly
-  like one — so on this revision every request reserved, and a call that never returned took its
-  whole credential with it. The park is a **kernel attach nothing will answer**, and what runs
-  alongside it is the recovery path itself: `tools/list`, `session_status`, `end_session`. Budget
-  ~23s, nearly all of it the deliberate wait for the attach to be in flight.
 
-The eighth is in the debugger tier, because it is the sweep meeting a real engine worker: *a lease
+Two more are in the debugger tier, because each needs a real engine worker.
+
+The first is the contention half of #168 at its sharpest: *a stateless client can work while one of
+its own calls is parked*. The park is a **kernel attach nothing will answer**, and what
+runs alongside it is the recovery path itself — `tools/list`, `session_status`, `end_session`, the
+last checked for a tool error as well as an HTTP status, since a refusal inside the call also
+arrives on a `200`. It polls the attach to the `attaching` state rather than sleeping towards it: an
+attach that failed fast leaves a kernel record a laxer check would accept, and nothing would be
+holding a claim to contend with. It lives here rather than above because without `dbgeng.dll` the
+attach fails during initialisation instead of parking, which would quietly turn a test about a call
+that does not return into one about a call that failed. Budget ~5s.
+
+The second is the sweep meeting a real engine worker: *a lease
 that runs out releases what the absent client left*. The target is **a kernel attach nothing will
 answer**, deliberately — a parked attach is the worst case in one move, since the session exists,
 holds a worker, and cannot be interrupted, so releasing it means terminating a process rather than

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -460,7 +460,8 @@ arrives on a `200`. It polls the attach to the `attaching` state rather than sle
 attach that failed fast leaves a kernel record a laxer check would accept, and nothing would be
 holding a claim to contend with. It lives here rather than above because without `dbgeng.dll` the
 attach fails during initialisation instead of parking, which would quietly turn a test about a call
-that does not return into one about a call that failed. Budget ~5s.
+that does not return into one about a call that failed. Budget ~21s, most of it the worker coming
+up and the `end_session` that terminates it.
 
 The second is the sweep meeting a real engine worker: *a lease
 that runs out releases what the absent client left*. The target is **a kernel attach nothing will

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -414,7 +414,7 @@ reach is the wiring, which is what these assert against a real listener on a loo
 hand-written HTTP client (a library that normalised a `409` into an exception, or hid the session
 header, would be asserting on this server's behalf).
 
-Four of them need no debugger, because tenancy is decided before any session is opened. All four
+Seven of them need no debugger, because tenancy is decided before any session is opened. All seven
 run a listener holding a **single, unnamed** token, so what they prove they prove for the `local`
 client alone; the per-client rules are unit-tested where they are decided, and closing that
 end-to-end gap is [`FOLLOWUPS.md`](../FOLLOWUPS.md) item 29:
@@ -436,8 +436,26 @@ end-to-end gap is [`FOLLOWUPS.md`](../FOLLOWUPS.md) item 29:
   what a client behind a tunnel looks like — so silence is the resting state, and a server that
   read it as departure would hand the registry on between two calls of a working client. A
   `DELETE` does hand it on.
+- *`2026-07-28` is served — the handshake **and** everything after it.* The revision current clients
+  negotiate has no session id
+  ([SEP-2567](https://modelcontextprotocol.io/seps/2567-sessionless-mcp)), so it exercises the
+  listener as a client that never presents one: the handshake mints nothing, and a `tools/list` and
+  a `tools/call` after it are answered. Its three tests exist because [#168](https://github.com/glslang/windbg-mcp/issues/168)
+  reported the opposite from a hand-rolled probe, so each spells the revision the way it has to be
+  spelled — the `MCP-Protocol-Version` header, `params._meta` carrying the protocol version and the
+  client's capabilities, and SEP-2243's `Mcp-Method` (plus `Mcp-Name` where the method names
+  something).
+- *An under-specified stateless request is told which part it is missing*, rather than merely
+  refused. Both shapes the probe sent are pinned here, so the same `400` cannot be read as a broken
+  listener a second time.
+- *A stateless client can work while one of its own calls is parked.* The gate reserves the server
+  for a request that is opening a session, and a request with no session id used to look exactly
+  like one — so on this revision every request reserved, and a call that never returned took its
+  whole credential with it. The park is a **kernel attach nothing will answer**, and what runs
+  alongside it is the recovery path itself: `tools/list`, `session_status`, `end_session`. Budget
+  ~23s, nearly all of it the deliberate wait for the attach to be in flight.
 
-The fifth is in the debugger tier, because it is the sweep meeting a real engine worker: *a lease
+The eighth is in the debugger tier, because it is the sweep meeting a real engine worker: *a lease
 that runs out releases what the absent client left*. The target is **a kernel attach nothing will
 answer**, deliberately — a parked attach is the worst case in one move, since the session exists,
 holds a worker, and cannot be interrupted, so releasing it means terminating a process rather than

--- a/src/listen.rs
+++ b/src/listen.rs
@@ -966,11 +966,13 @@ async fn gate(
             // requests carrying the session this credential holds are served concurrently, which
             // is how a `DELETE` arrives on one while a tool call runs on another. Two things reach
             // here and the message has to fit both: a second **MCP session** for this credential
-            // (a fresh `initialize`, or an id that is not the one it holds), and a request arriving
-            // while another of its own still holds the claim — which is every overlapping request
-            // from a client that sends no session id at all, since `2026-07-28` removed it.
-            // Saying "another client" would send an operator looking for a colleague who is not
-            // there, and saying "connection" for one who has a network problem they do not have.
+            // (a fresh `initialize`, or an id that is not the one it holds), and a second request
+            // arriving while one of its own is still opening one. Saying "another client" would
+            // send an operator looking for a colleague who is not there, and saying "connection"
+            // for one who has a network problem they do not have.
+            //
+            // A client on a revision with no session id no longer reaches here at all: it opens
+            // nothing, so it contests nothing (#168).
             tracing::warn!(
                 "refused a request from {peer}: this credential is already being served here"
             );

--- a/src/listen.rs
+++ b/src/listen.rs
@@ -517,6 +517,21 @@ impl Lease {
         //
         // Counted in-flight all the same: a goodbye still has to wait for the work admitted here.
         if matches!(arriving, Arriving::Stateless) {
+            // **Renewed if there is one; never created.** "Any request renews the lease" is what
+            // keeps a working client's tenancy alive, and this path skipping it would strand a
+            // credential that holds a legacy session and has since started sending stateless
+            // requests — a client that upgraded or restarted mid-grace. The sweep reads the
+            // deadline and nothing else: it zeroes `in_flight` on the way past, so work actually
+            // running would not save the sessions being released underneath it.
+            //
+            // Not created, because a deadline with no holder is a lease against nothing. It would
+            // fire one grace later and release this client's sessions — which for a client that
+            // only ever sends stateless requests is all of them, on a timer it never touched.
+            // Abandonment on that revision is [`IDLE_RELEASE`]'s to catch, per session and far
+            // longer.
+            if state.deadline.is_some() {
+                state.deadline = Some(Instant::now() + self.grace);
+            }
             state.in_flight += 1;
             return Admission::Serve(Admitted {
                 claim: None,
@@ -1779,6 +1794,48 @@ mod tests {
 
         lease.leave(first.epoch);
         lease.leave(second.epoch);
+    }
+
+    /// A stateless request renews a lease its credential already has, and creates none.
+    ///
+    /// Both halves are the same rule seen from two sides, and getting either wrong loses sessions.
+    /// A credential can hold a legacy session and *then* start sending stateless requests — a
+    /// client that upgraded, or restarted inside the grace — and since the sweep reads the deadline
+    /// alone and zeroes `in_flight` on its way past, a request that did not renew would have those
+    /// sessions released out from under it while it was using them. The other way costs as much: a
+    /// deadline installed for a client that holds nothing is a lease against nothing, and it would
+    /// release every session a purely stateless client has, one grace after its first call.
+    #[test]
+    fn a_stateless_request_renews_a_lease_but_does_not_start_one() {
+        let lease = lease();
+
+        // Nothing held: a stateless request must leave it that way.
+        let opening = admitted(lease.admit_stateless());
+        assert_eq!(
+            lease.state().deadline,
+            None,
+            "a request that holds nothing must not be given a clock to run out"
+        );
+        lease.leave(opening.epoch);
+
+        // A legacy session, and then the same credential going stateless.
+        request(&lease, None, Some("session-a"), true);
+        let before = lease
+            .state()
+            .deadline
+            .expect("a credential that holds a session has a deadline");
+
+        std::thread::sleep(Duration::from_millis(5));
+        let it = admitted(lease.admit_stateless());
+        let after = lease
+            .state()
+            .deadline
+            .expect("the lease is still the credential's");
+        assert!(
+            after > before,
+            "a stateless request from the holder's own credential must renew its lease"
+        );
+        lease.leave(it.epoch);
     }
 
     /// Serving them alongside each other does not make them a tenancy.

--- a/src/listen.rs
+++ b/src/listen.rs
@@ -630,7 +630,25 @@ impl Lease {
             }
             // Anything else, including an `initialize` that failed: the reservation is already
             // given back above, and nobody took the server.
-            _ => Settled::Kept { adopted: false },
+            _ => {
+                // **And the clock it started goes back too.** Reserving arms a deadline, so a
+                // request that reserved and then took nothing would leave one running against a
+                // tenancy that holds nothing — and a deadline is all the sweep reads. One grace
+                // later it would start a teardown with no holder, release this client's sessions,
+                // and refuse its next request with `Releasing` while it was working normally.
+                //
+                // Reachable by an ordinary client: a `2026-07-28` `initialize` may omit the
+                // `MCP-Protocol-Version` header (it is the request that establishes it), so it is
+                // classified as an opener, reserves, and then mints no session — and every session
+                // that client goes on to open is on that clock.
+                //
+                // `left_open` is the exception: a previous client's sessions are waiting to be
+                // adopted or swept, and that deadline is exactly what sweeps them.
+                if state.holder.is_none() && !state.left_open {
+                    state.deadline = None;
+                }
+                Settled::Kept { adopted: false }
+            }
         }
     }
 
@@ -1794,6 +1812,39 @@ mod tests {
 
         lease.leave(first.epoch);
         lease.leave(second.epoch);
+    }
+
+    /// A reservation that took nothing gives its deadline back, not just its claim.
+    ///
+    /// A `2026-07-28` `initialize` may omit the `MCP-Protocol-Version` header — it is the request
+    /// that establishes it — so it reaches the gate looking like any other opener, reserves, and
+    /// then mints no session. Reserving arms a deadline; the sweep reads the deadline and nothing
+    /// else. Left armed, it would start a teardown one grace later against a tenancy that holds
+    /// nothing, release whatever that client had since opened, and refuse its next request with
+    /// `Releasing` — a client losing its sessions on a timer started by its own handshake.
+    #[test]
+    fn a_reservation_that_minted_nothing_leaves_no_clock_running() {
+        let lease = lease();
+
+        // The headerless stateless handshake: admitted as an opener, mints nothing.
+        let it = admitted(lease.admit(None));
+        assert!(
+            lease.state().deadline.is_some(),
+            "reserving arms a deadline — that is the thing this test is about giving back"
+        );
+        assert!(!adopted(lease.settle(it.claim, None, None, true)));
+        lease.leave(it.epoch);
+
+        assert_eq!(
+            lease.state().deadline,
+            None,
+            "a reservation that took nothing must not leave a clock running against a tenancy that \
+             holds nothing"
+        );
+        assert!(
+            lease.expired().is_none(),
+            "and so there is nothing for the sweep to act on"
+        );
     }
 
     /// A stateless request renews a lease its credential already has, and creates none.

--- a/src/listen.rs
+++ b/src/listen.rs
@@ -55,6 +55,7 @@ use hyper::header::AUTHORIZATION;
 use hyper::service::service_fn;
 use hyper::{Request, Response, StatusCode};
 use hyper_util::rt::TokioIo;
+use rmcp::model::ProtocolVersion;
 use rmcp::transport::streamable_http_server::SessionManager;
 use rmcp::transport::streamable_http_server::session::local::LocalSessionManager;
 use rmcp::transport::streamable_http_server::{StreamableHttpServerConfig, StreamableHttpService};
@@ -170,6 +171,38 @@ const IDLE_ENV: &str = "WINDBG_MCP_SESSION_IDLE_SECS";
 
 /// The header carrying a client's MCP session, which is what identifies the holder.
 const SESSION_HEADER: &str = "Mcp-Session-Id";
+
+/// The header naming the revision a request is on.
+///
+/// `2026-07-28` carries in every request what the handshake used to settle once, and this is the
+/// part of that the gate needs: whether a session id is coming.
+const PROTOCOL_HEADER: &str = "MCP-Protocol-Version";
+
+/// Whether this request is on a revision that mints no `Mcp-Session-Id`.
+///
+/// Read from a header because the gate never parses a body — it hands the request to rmcp intact,
+/// and buffering it here to look would be a copy of every tool call's arguments for one bit.
+///
+/// **Matched against the revisions rmcp knows, rather than compared as a string.** The comparison
+/// is lexicographic and that is correct for revisions, which are ISO dates — but a header that is
+/// not a revision at all (`draft`) sorts above every date, and would be read as newer than the
+/// newest thing there is. Anything unrecognised is treated as a revision that has sessions, which
+/// is the answer that costs a wrong guess least: it reserves, as this gate always did.
+///
+/// An `initialize` may legitimately arrive without this header — it is the request that establishes
+/// the revision — so a stateless client's *first* request still reserves. That costs nothing: it
+/// mints no session, so [`Lease::settle`] gives the reservation straight back.
+fn mints_no_session(headers: &hyper::HeaderMap) -> bool {
+    headers
+        .get(PROTOCOL_HEADER)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| {
+            ProtocolVersion::KNOWN_VERSIONS
+                .iter()
+                .find(|known| known.as_str() == value)
+        })
+        .is_some_and(|version| *version >= ProtocolVersion::V_2026_07_28)
+}
 
 /// Whether this process was asked to listen, and where.
 pub fn requested(args: &[String]) -> Option<Result<SocketAddr>> {
@@ -332,6 +365,25 @@ struct Admitted {
     epoch: u64,
 }
 
+/// What a request presents to the gate, which is all tenancy is decided from.
+///
+/// Three cases rather than `Option<&str>`, because the absence of a session id stopped meaning one
+/// thing. It used to mean "a client opening a session"; since [SEP-2567] removed the session from
+/// `2026-07-28` it also means "a client that will never have one", and those two want opposite
+/// answers — the first is the only moment tenancy is contested, and the second contests nothing.
+///
+/// [SEP-2567]: https://modelcontextprotocol.io/seps/2567-sessionless-mcp
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Arriving<'a> {
+    /// An `Mcp-Session-Id` the client is presenting.
+    Holding(&'a str),
+    /// No session id, on a revision that mints them: an `initialize`, or a client resuming inside
+    /// the grace.
+    Opening,
+    /// No session id, and none is coming.
+    Stateless,
+}
+
 /// What the tenancy gate decided about one request.
 #[derive(Debug, PartialEq, Eq)]
 enum Admission {
@@ -429,10 +481,10 @@ impl Lease {
 
     /// Decides whether a request may be served, **reserving** the server when one is taking it.
     ///
-    /// `session` is the request's `Mcp-Session-Id`; its absence means a client opening a new
-    /// session, which is the only moment tenancy is contested. Every decision is made under one
-    /// lock, so the answer a request gets is the state it will be served against.
-    fn admit(&self, client: &crate::client::Client, session: Option<&str>) -> Admission {
+    /// What the request presents is an [`Arriving`]: the `Mcp-Session-Id` it carries, or which kind
+    /// of nothing it carries instead. Every decision is made under one lock, so the answer a
+    /// request gets is the state it will be served against.
+    fn admit(&self, client: &crate::client::Client, arriving: Arriving<'_>) -> Admission {
         // **Before this client's own tenancy is consulted at all**, because the id may not be its
         // to present. The MCP service keeps one session table for the server, so a client that
         // comes by another's `Mcp-Session-Id` reaches that client's MCP session through it — the
@@ -441,7 +493,7 @@ impl Lease {
         // id, so the client it belonged to fails every request and its re-`initialize` is refused
         // for a whole grace period. That is one authenticated client denying another, which is
         // exactly what ownership is here to stop.
-        if let Some(id) = session
+        if let Arriving::Holding(id) = arriving
             && self.held_by_another(client, id)
         {
             return Admission::NotYours;
@@ -455,9 +507,25 @@ impl Lease {
         if state.releasing {
             return Admission::Releasing;
         }
-        match (session, state.holder.as_deref()) {
+        // **Nothing to reserve.** The claim exists so that two requests cannot both become the
+        // holder; a request that will never mint a session cannot become one, so reserving against
+        // it refuses work for a contest that is not happening. It was refusing rather a lot of it:
+        // on `2026-07-28` *every* request takes this path, so any two that overlapped contended,
+        // and a call that parks — a kernel attach whose target never dials in — locked the
+        // credential out of `session_status` and `end_session`, which are the two things that
+        // recover it ([#168](https://github.com/glslang/windbg-mcp/issues/168)).
+        //
+        // Counted in-flight all the same: a goodbye still has to wait for the work admitted here.
+        if matches!(arriving, Arriving::Stateless) {
+            state.in_flight += 1;
+            return Admission::Serve(Admitted {
+                claim: None,
+                epoch: state.epoch,
+            });
+        }
+        match (arriving, state.holder.as_deref()) {
             // The holder, still talking.
-            (Some(id), Some(held)) if id == held => {
+            (Arriving::Holding(id), Some(held)) if id == held => {
                 state.deadline = Some(Instant::now() + self.grace);
                 state.in_flight += 1;
                 Admission::Serve(Admitted {
@@ -467,14 +535,14 @@ impl Lease {
             }
             // A session id belonging to someone else. This is the arm that made the race above
             // persist rather than pass: serving it leaves both clients working.
-            (Some(_), Some(_)) => Admission::Occupied,
+            (Arriving::Holding(_), Some(_)) => Admission::Occupied,
             // A session id with nobody holding the server — a client resuming what it left inside
             // the grace. Reserved like an `initialize`, because it is the same contest: a lease
             // expiry leaves the old session id valid in the service, so a resume can race a fresh
             // client and both would pass a gate that only served them. The holder is still not
             // taken until `settle` hears the session was real, or a stale id would lock the server
             // out for a whole grace period.
-            (Some(_), None) if state.claim.is_none() => {
+            (Arriving::Holding(_), None) if state.claim.is_none() => {
                 state.in_flight += 1;
                 let epoch = state.epoch;
                 Admission::Serve(Admitted {
@@ -484,7 +552,7 @@ impl Lease {
             }
             // A new client, and nobody attached or attaching: it reserves the server here, and
             // inherits whatever the last one left open.
-            (None, None) if state.claim.is_none() => {
+            (Arriving::Opening, None) if state.claim.is_none() => {
                 state.in_flight += 1;
                 let epoch = state.epoch;
                 Admission::Serve(Admitted {
@@ -863,7 +931,13 @@ async fn gate(
         .and_then(|v| v.to_str().ok())
         .map(str::to_owned);
 
-    let admitted = match lease.admit(&caller, session.as_deref()) {
+    let arriving = match session.as_deref() {
+        Some(id) => Arriving::Holding(id),
+        None if mints_no_session(req.headers()) => Arriving::Stateless,
+        None => Arriving::Opening,
+    };
+
+    let admitted = match lease.admit(&caller, arriving) {
         Admission::Serve(admitted) => admitted,
         // Not a refusal — an id this caller cannot have is an id this server does not have. The
         // status is the one the spec already gives a session that has gone: a client holding a
@@ -1101,7 +1175,18 @@ mod tests {
         }
 
         fn admit(&self, session: Option<&str>) -> Admission {
-            self.lease.admit(&self.client, session)
+            self.lease.admit(
+                &self.client,
+                match session {
+                    Some(id) => Arriving::Holding(id),
+                    None => Arriving::Opening,
+                },
+            )
+        }
+
+        /// A request on the revision that has no session id to present.
+        fn admit_stateless(&self) -> Admission {
+            self.lease.admit(&self.client, Arriving::Stateless)
         }
 
         fn settle(
@@ -1639,7 +1724,7 @@ mod tests {
         let ci = crate::client::Client::new("ci");
 
         // `laptop` takes its tenancy and holds it — the long-call case.
-        let held = admitted(lease.admit(&laptop, None));
+        let held = admitted(lease.admit(&laptop, Arriving::Opening));
         lease.settle(
             held.claim,
             None,
@@ -1651,15 +1736,96 @@ mod tests {
         // Within that client, a second `initialize` is still refused: that contention is real, and
         // it is the one the claim machinery exists to arbitrate.
         assert_eq!(
-            lease.admit(&laptop, None),
+            lease.admit(&laptop, Arriving::Opening),
             Admission::Occupied,
             "a second session for the same credential still contends"
         );
 
         // Across clients, on the same lease, it is not.
         assert!(
-            matches!(lease.admit(&ci, None), Admission::Serve(_)),
+            matches!(lease.admit(&ci, Arriving::Opening), Admission::Serve(_)),
             "another client must not wait on a tenancy that no longer bounds anything it can reach"
+        );
+    }
+
+    /// A revision with no session id is not a client opening one, and the gate must not treat it
+    /// as one.
+    ///
+    /// The `2026-07-28` half of [#168](https://github.com/glslang/windbg-mcp/issues/168). Before
+    /// [`Arriving`] existed there was one "no session id" case and it meant *opening*, so it
+    /// reserved — which on a revision that never sends an id made every request a reservation, and
+    /// every overlapping pair a `409`. Two things are asserted, and the second is the one that
+    /// bites: they overlap, and they keep overlapping while one of them never finishes.
+    #[test]
+    fn stateless_requests_do_not_contend_with_each_other() {
+        let lease = lease();
+
+        let first = admitted(lease.admit_stateless());
+        assert_eq!(
+            first.claim, None,
+            "a request that cannot become the holder must reserve nothing"
+        );
+        let second = admitted(lease.admit_stateless());
+        assert_eq!(second.claim, None);
+
+        // The parked case: the first never returns, and the client still has to be able to ask what
+        // is going on and end it.
+        assert!(
+            matches!(lease.admit_stateless(), Admission::Serve(_)),
+            "a call that never comes back must not lock its own credential out"
+        );
+
+        lease.leave(first.epoch);
+        lease.leave(second.epoch);
+    }
+
+    /// Serving them alongside each other does not make them a tenancy.
+    ///
+    /// A stateless request settles nothing and holds nothing, so no lease is ever installed for a
+    /// client that only sends them — which is deliberate, and why abandonment on this revision is
+    /// [`IDLE_RELEASE`]'s to catch rather than the lease's. What must not happen is the middle
+    /// state: a holder recorded for a session that does not exist, which nothing would ever sweep.
+    #[test]
+    fn a_stateless_request_becomes_nobodys_tenancy() {
+        let lease = lease();
+
+        let it = admitted(lease.admit_stateless());
+        assert!(!adopted(lease.settle(it.claim, None, None, true)));
+        lease.leave(it.epoch);
+
+        assert!(
+            lease.expired().is_none(),
+            "a client that holds nothing has no lease to run out"
+        );
+        // And an ordinary opener is still free to take the tenancy afterwards.
+        assert!(
+            matches!(lease.admit(None), Admission::Serve(_)),
+            "a stateless request must leave the server takeable"
+        );
+    }
+
+    /// A teardown still stops one, because what is being released is the sessions behind it.
+    ///
+    /// The claim is what a stateless request stops taking; the `releasing` check is not, and the
+    /// distinction matters: a request admitted mid-teardown reaches a registry whose sessions are
+    /// being closed underneath it.
+    #[test]
+    fn a_stateless_request_waits_for_a_teardown_like_any_other() {
+        let lease = brief();
+        let claim = admitted(lease.admit(None));
+        lease.settle(claim.claim, None, Some("session-a"), true);
+        std::thread::sleep(Duration::from_millis(5));
+
+        assert!(lease.expired().is_some(), "the grace is spent");
+        assert!(
+            matches!(lease.admit_stateless(), Admission::Releasing),
+            "a stateless request must not be let in to sessions that are being closed"
+        );
+
+        lease.released_leases();
+        assert!(
+            matches!(lease.admit_stateless(), Admission::Serve(_)),
+            "and must be served the moment the teardown is done"
         );
     }
 
@@ -1685,7 +1851,7 @@ mod tests {
         let laptop = crate::client::Client::new("laptop");
         let ci = crate::client::Client::new("ci");
 
-        let held = admitted(lease.admit(&laptop, None));
+        let held = admitted(lease.admit(&laptop, Arriving::Opening));
         lease.settle(
             held.claim,
             None,
@@ -1695,7 +1861,7 @@ mod tests {
         );
 
         assert_eq!(
-            lease.admit(&ci, Some("session-laptop")),
+            lease.admit(&ci, Arriving::Holding("session-laptop")),
             Admission::NotYours,
             "another client's session id was admitted, so its holder could be deleted out from \
              under it"
@@ -1703,7 +1869,7 @@ mod tests {
         // And the owner is unaffected — the check must not cost a client its own session.
         assert!(
             matches!(
-                lease.admit(&laptop, Some("session-laptop")),
+                lease.admit(&laptop, Arriving::Holding("session-laptop")),
                 Admission::Serve(_)
             ),
             "the holder must still be served its own id"
@@ -1712,7 +1878,7 @@ mod tests {
         // get through, which is the arm this check sits in front of.
         assert!(
             matches!(
-                lease.admit(&ci, Some("session-nobodys")),
+                lease.admit(&ci, Arriving::Holding("session-nobodys")),
                 Admission::Serve(_)
             ),
             "an id no tenancy holds is unusable in the service anyway, and refusing it would \

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -15,11 +15,12 @@
 //! * **Protocol** (default) — spawns the server, speaks JSON-RPC. No debugger target, no
 //!   symbols, no network. This tier also drives the **listener** (`--listen`) over real HTTP on a
 //!   loopback port: the bearer check, the `409` that keeps a credential to one MCP session, the
-//!   difference between a client going quiet and a client saying goodbye, and `2026-07-28` —
-//!   which has none of those, having removed the session id, and is therefore the revision that
-//!   proves the gate stands aside rather than merely arbitrating well. Those need no debugger,
-//!   because the lease is decided before any session is opened — but the sweep meeting a real
-//!   engine worker does, so that half lives in the tier below.
+//!   difference between a client going quiet and a client saying goodbye, and `2026-07-28` being
+//!   served at all — the revision that removed the session id, and so arrives with none of the
+//!   things the rules above are written in terms of. Those need no debugger, because the lease is
+//!   decided before any session is opened. Two that do — the sweep meeting a real engine worker,
+//!   and a stateless client working alongside a call of its own that parks — live in the tier
+//!   below.
 //! * **Target** (`WINDBG_MCP_SMOKE_DUMP=1`) — opens the sample crash dump through DbgEng, so
 //!   it needs `dbgeng.dll` and may reach a symbol server. Off by default; this is the tier
 //!   that catches a `win-kexp` regression. It also runs a `debug_batch` to both outcomes, and
@@ -2566,27 +2567,89 @@ impl Listener {
     /// Immutable, which is the whole reason it is separate: a request that has to run *alongside*
     /// another cannot be sent through a `&mut self` borrow, and overlap is what the stateless
     /// revision makes ordinary.
-    fn stateless_at(&self, id: i64, method: &str, mut params: Value) -> Reply {
-        params["_meta"] = json!({
-            "io.modelcontextprotocol/protocolVersion": STATELESS_REVISION,
-            "io.modelcontextprotocol/clientCapabilities": {},
-        });
-        let name = params["name"].as_str().map(str::to_owned);
-        let body = json!({ "jsonrpc": "2.0", "id": id, "method": method, "params": params });
-        let mut headers = vec![
-            ("MCP-Protocol-Version", STATELESS_REVISION),
-            ("Mcp-Method", method),
-        ];
-        if let Some(name) = name.as_deref() {
-            headers.push(("Mcp-Name", name));
-        }
+    fn stateless_at(&self, id: i64, method: &str, params: Value) -> Reply {
+        let (body, name) = Self::stateless_body(id, method, params);
         self.send_with(
             "POST",
             Some(&self.token.clone()),
             None,
             Some(&body),
-            &headers,
+            &Self::stateless_headers(method, name.as_deref()),
         )
+    }
+
+    /// The body of a stateless request, and the value its `Mcp-Name` must mirror.
+    ///
+    /// Split out because one request in this tier is sent *without* waiting for a reply, and
+    /// building its shape a second time by hand is how a test ends up measuring something the rest
+    /// of the tier no longer sends.
+    fn stateless_body(id: i64, method: &str, mut params: Value) -> (Value, Option<String>) {
+        params["_meta"] = json!({
+            "io.modelcontextprotocol/protocolVersion": STATELESS_REVISION,
+            "io.modelcontextprotocol/clientCapabilities": {},
+        });
+        // SEP-2243 maps the header per method rather than per parameter: `tools/call` and
+        // `prompts/get` mirror `params.name`, `resources/read` mirrors `params.uri`, and every
+        // other method sends none. Keyed on the method for that reason — a `name` argument that
+        // happens to belong to some other method's parameters is not this header's value.
+        let name = match method {
+            "tools/call" | "prompts/get" => params["name"].as_str().map(str::to_owned),
+            "resources/read" => params["uri"].as_str().map(str::to_owned),
+            _ => None,
+        };
+        let body = json!({ "jsonrpc": "2.0", "id": id, "method": method, "params": params });
+        (body, name)
+    }
+
+    fn stateless_headers<'h>(method: &'h str, name: Option<&'h str>) -> Vec<(&'h str, &'h str)> {
+        let mut headers = vec![
+            ("MCP-Protocol-Version", STATELESS_REVISION),
+            ("Mcp-Method", method),
+        ];
+        if let Some(name) = name {
+            headers.push(("Mcp-Name", name));
+        }
+        headers
+    }
+
+    /// A stateless request sent for its *effect*, whose reply is never waited for.
+    ///
+    /// One request in this tier is not expected to answer at all — a kernel attach parked on a
+    /// target that will never dial in — and it has to stay running while other requests are made
+    /// alongside it. So this neither reads nor parses: it writes the request and hands back the
+    /// **still-open connection**, which the caller holds for as long as the request should live.
+    /// Closing it is what ends the request, so dropping the returned stream is the cleanup.
+    ///
+    /// Waiting for it on a second thread was the obvious shape and the wrong one: the reply never
+    /// comes, so the join at the end of the test blocks for the whole read timeout and then panics
+    /// parsing an empty buffer — reporting the missing reply instead of whichever assertion
+    /// actually failed.
+    #[must_use = "the connection is what keeps the request alive; dropping it ends the request"]
+    fn stateless_unanswered(&self, id: i64, method: &str, params: Value) -> std::net::TcpStream {
+        let (body, name) = Self::stateless_body(id, method, params);
+        let headers = Self::stateless_headers(method, name.as_deref());
+        let body = body.to_string();
+        let mut request = format!(
+            "POST / HTTP/1.1\r\nHost: {}\r\nAccept: application/json, text/event-stream\r\n\
+             Connection: close\r\nAuthorization: Bearer {}\r\n",
+            self.addr, self.token
+        );
+        for (name, value) in &headers {
+            request.push_str(&format!("{name}: {value}\r\n"));
+        }
+        request.push_str(&format!(
+            "Content-Type: application/json\r\nContent-Length: {}\r\n\r\n{body}",
+            body.len()
+        ));
+
+        let mut stream = std::net::TcpStream::connect(&self.addr)
+            .unwrap_or_else(|e| panic!("cannot reach the listener at {}: {e}", self.addr));
+        stream
+            .set_read_timeout(Some(Duration::from_secs(60)))
+            .expect("set a read timeout");
+        stream.write_all(request.as_bytes()).expect("write request");
+        stream.flush().expect("flush request");
+        stream
     }
 
     /// The `2026-07-28` handshake, which mints nothing and is therefore not a session.
@@ -3085,109 +3148,6 @@ fn an_under_specified_stateless_request_is_told_which_part_it_is_missing() {
         "a well-formed request after two refused ones: {}",
         listed.body
     );
-}
-
-/// A stateless client can work while one of its own calls is still running.
-///
-/// The second finding of [#168](https://github.com/glslang/windbg-mcp/issues/168), and the one that
-/// survived the first. A request carrying no `Mcp-Session-Id` takes the gate's *opening* path and
-/// holds a claim for its whole duration — and on `2026-07-28` there is never an id to carry, so
-/// that is **every** request. Two that overlap contend, and the second gets a `409`.
-///
-/// Measured here at its sharpest rather than as a race. A kernel attach whose target never dials in
-/// parks in `WaitForEvent(INFINITE)` and does not come back; that is a supported state, and
-/// `session_status` and `end_session` are how a client is supposed to see it and reclaim it. If the
-/// claim it holds locks its own credential out, a stateless client cannot do either, and the
-/// property [#61](https://github.com/glslang/windbg-mcp/issues/61) established — that a parked
-/// attach costs one session and not the server — is not true for the revision current clients
-/// negotiate.
-#[test]
-fn a_stateless_client_can_work_while_one_of_its_own_calls_is_parked() {
-    let server = Listener::start(&[]);
-    let token = server.token.clone();
-    // Nothing is listening on it, so the attach parks rather than failing. Its own port, so a
-    // stray listener on this host cannot turn the park into an error and the test into a pass.
-    let connection = format!("net:port={},key=1.1.1.1", free_port());
-    let parked = json!({
-        "jsonrpc": "2.0",
-        "id": 9001,
-        "method": "tools/call",
-        "params": {
-            "name": "attach_kernel",
-            "arguments": { "connection": connection },
-            "_meta": {
-                "io.modelcontextprotocol/protocolVersion": STATELESS_REVISION,
-                "io.modelcontextprotocol/clientCapabilities": {},
-            },
-        },
-    });
-
-    std::thread::scope(|scope| {
-        scope.spawn(|| {
-            // Never read: the attach is still waiting for a target when this test ends, and the
-            // listener's `Drop` is what takes it down.
-            let _ = server.send_with(
-                "POST",
-                Some(&token),
-                None,
-                Some(&parked),
-                &[
-                    ("MCP-Protocol-Version", STATELESS_REVISION),
-                    ("Mcp-Method", "tools/call"),
-                    ("Mcp-Name", "attach_kernel"),
-                ],
-            );
-        });
-
-        // Long enough for the attach to be admitted and holding its claim. Not a race the test can
-        // lose in the direction that matters: if it has *not* started yet, the assertions below
-        // pass for the wrong reason rather than failing for the wrong one.
-        std::thread::sleep(Duration::from_secs(3));
-
-        let listed = server.stateless_at(1, "tools/list", json!({}));
-        assert_eq!(
-            listed.status,
-            200,
-            "a second stateless request was refused ({}) while the first was still running: \
-             {}\n--- stderr ---\n{}",
-            listed.status,
-            listed.body,
-            server.stderr()
-        );
-
-        // The two a client actually needs in this state: see the parked session, and end it.
-        let status = server.stateless_at(
-            2,
-            "tools/call",
-            json!({ "name": "session_status", "arguments": {} }),
-        );
-        assert_eq!(
-            status.status, 200,
-            "session_status is how a client sees a parked attach, and it was refused: {}",
-            status.body
-        );
-        let sessions = status.result("tools/call")["structuredContent"]["sessions"].clone();
-        let attaching = sessions
-            .as_array()
-            .into_iter()
-            .flatten()
-            .find(|s| s["kind"] == json!("kernel"))
-            .and_then(|s| s["session_id"].as_str().map(str::to_owned));
-        let Some(attaching) = attaching else {
-            panic!("the parked attach is not in session_status: {sessions}");
-        };
-
-        let ended = server.stateless_at(
-            3,
-            "tools/call",
-            json!({ "name": "end_session", "arguments": { "session_id": attaching } }),
-        );
-        assert_eq!(
-            ended.status, 200,
-            "end_session is the only way out of a parked attach, and it was refused: {}",
-            ended.body
-        );
-    });
 }
 
 /// Going quiet is not leaving; saying goodbye is.
@@ -5891,6 +5851,117 @@ fn two_sessions_coexist_and_do_not_disturb_each_other() {
     );
 
     server.tool_text("end_session", json!({ "session_id": first }), TARGET_STEP);
+}
+
+/// A stateless client can work while one of its own calls is parked — the same property as the
+/// test below, over the listener, for the revision that has no session id.
+///
+/// The second finding of [#168](https://github.com/glslang/windbg-mcp/issues/168), and the one that
+/// survived the first. A request carrying no `Mcp-Session-Id` used to take the gate's *opening*
+/// path and hold a claim for its whole duration — and on `2026-07-28` there is never an id to
+/// carry, so that was **every** request. Two that overlapped contended.
+///
+/// Measured at its sharpest rather than as a race. A kernel attach whose target never dials in
+/// parks in `WaitForEvent(INFINITE)` and does not come back; that is a supported state, and
+/// `session_status` and `end_session` are how a client sees it and reclaims it. If the claim it
+/// held locked its own credential out, a stateless client could do neither, and the property
+/// [#61](https://github.com/glslang/windbg-mcp/issues/61) established — that a parked attach costs
+/// one session and not the server — was not true for the revision current clients negotiate.
+///
+/// In this tier and not the one above it, because a park needs a real engine worker: without
+/// `dbgeng.dll` the attach fails during initialisation instead of parking, and a test whose whole
+/// subject is a call that does not return would quietly become one about a call that failed fast.
+#[test]
+fn a_stateless_client_can_work_while_one_of_its_own_calls_is_parked() {
+    let Some(_) = target_tier() else { return };
+    let server = Listener::start(&[]);
+
+    // Nothing is listening on it, so the attach parks rather than failing. Its own port, so a
+    // stray listener on this host cannot turn the park into an error and the test into a pass.
+    let connection = format!("net:port={},key=1.1.1.1", free_port());
+    // Held for the rest of the test: this connection *is* the parked request.
+    let _parked = server.stateless_unanswered(
+        9001,
+        "tools/call",
+        json!({ "name": "attach_kernel", "arguments": { "connection": connection } }),
+    );
+
+    // **Polled to the `attaching` state, not slept towards it.** A fixed wait would pass for the
+    // wrong reason twice over: too short and nothing is holding a claim yet, and an attach that
+    // failed fast leaves a kernel record behind that a laxer check would accept. Each poll is
+    // itself a second stateless request overlapping the first, so the status asserted here is the
+    // contention this test is about.
+    let deadline = Instant::now() + Duration::from_secs(30);
+    let mut id = 1;
+    let attaching = loop {
+        let status = server.stateless_at(
+            id,
+            "tools/call",
+            json!({ "name": "session_status", "arguments": {} }),
+        );
+        id += 1;
+        assert_eq!(
+            status.status,
+            200,
+            "a second stateless request was refused ({}) while the first was still running:              {}\n--- stderr ---\n{}",
+            status.status,
+            status.body,
+            server.stderr()
+        );
+        let parked = status.result("tools/call")["structuredContent"]["sessions"]
+            .as_array()
+            .into_iter()
+            .flatten()
+            .find(|s| s["kind"] == json!("kernel") && s["state"]["state"] == json!("attaching"))
+            .and_then(|s| s["session_id"].as_str().map(str::to_owned));
+        if let Some(id) = parked {
+            break Some(id);
+        }
+        if Instant::now() >= deadline {
+            break None;
+        }
+        std::thread::sleep(Duration::from_millis(200));
+    };
+    let Some(attaching) = attaching else {
+        // The attach never parked — most likely the UDP port was taken on this host. Nothing to
+        // assert about a park that did not happen, and the same stand-down the test below takes.
+        skip("attach_kernel did not reach the parked state (port busy?)");
+        return;
+    };
+
+    // The plain case, now that the park is established rather than assumed.
+    let listed = server.stateless_at(id, "tools/list", json!({}));
+    id += 1;
+    assert_eq!(
+        listed.status,
+        200,
+        "tools/list was refused ({}) alongside a parked attach: {}\n--- stderr ---\n{}",
+        listed.status,
+        listed.body,
+        server.stderr()
+    );
+
+    // And the way out. `200` is not enough on its own here — a tool error is also carried on a
+    // `200`, so a refusal inside the call would read as success at the HTTP layer.
+    let ended = server.stateless_at(
+        id,
+        "tools/call",
+        json!({ "name": "end_session", "arguments": { "session_id": attaching } }),
+    );
+    assert_eq!(
+        ended.status, 200,
+        "end_session is the only way out of a parked attach, and it was refused: {}",
+        ended.body
+    );
+    let payload = ended
+        .payload
+        .as_ref()
+        .expect("end_session answered with no JSON-RPC payload");
+    assert!(
+        !is_tool_error(payload),
+        "end_session reported a tool error while reclaiming the parked attach: {}",
+        ended.body
+    );
 }
 
 /// Issue #61, end to end: a kernel attach whose target never dials in waits forever, and that

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -14,10 +14,12 @@
 //!
 //! * **Protocol** (default) — spawns the server, speaks JSON-RPC. No debugger target, no
 //!   symbols, no network. This tier also drives the **listener** (`--listen`) over real HTTP on a
-//!   loopback port: the bearer check, the `409` that keeps a credential to one MCP session,
-//!   and the difference between a client going quiet and a client saying goodbye. Those need no
-//!   debugger, because the lease is decided before any session is opened — but the sweep meeting a
-//!   real engine worker does, so that half lives in the tier below.
+//!   loopback port: the bearer check, the `409` that keeps a credential to one MCP session, the
+//!   difference between a client going quiet and a client saying goodbye, and `2026-07-28` —
+//!   which has none of those, having removed the session id, and is therefore the revision that
+//!   proves the gate stands aside rather than merely arbitrating well. Those need no debugger,
+//!   because the lease is decided before any session is opened — but the sweep meeting a real
+//!   engine worker does, so that half lives in the tier below.
 //! * **Target** (`WINDBG_MCP_SMOKE_DUMP=1`) — opens the sample crash dump through DbgEng, so
 //!   it needs `dbgeng.dll` and may reach a symbol server. Off by default; this is the tier
 //!   that catches a `win-kexp` regression. It also runs a `debug_batch` to both outcomes, and
@@ -2300,6 +2302,16 @@ fn a_call_that_asked_for_no_progress_is_sent_none() {
 /// Tenancy is keyed on `Mcp-Session-Id`, so this has to be a revision whose handshake mints one.
 const LEASE_REVISION: &str = "2025-06-18";
 
+/// The revision that removed the session id, and therefore the lease's grip on a client.
+///
+/// [SEP-2567] made `2026-07-28` stateless: the handshake mints no `Mcp-Session-Id`, so a client on
+/// this revision never becomes a holder and never sends an id back. It is also the revision current
+/// clients negotiate, which is why "answered the handshake and then refused everything after it"
+/// was worth a tier of its own.
+///
+/// [SEP-2567]: https://modelcontextprotocol.io/seps/2567-sessionless-mcp
+const STATELESS_REVISION: &str = "2026-07-28";
+
 /// A free loopback port, taken by binding and letting go.
 ///
 /// Racy in principle and not in practice: the window is microseconds, tests each take their own,
@@ -2453,6 +2465,23 @@ impl Listener {
         session: Option<&str>,
         body: Option<&Value>,
     ) -> Reply {
+        self.send_with(method, token, session, body, &[])
+    }
+
+    /// [`Self::send`], plus headers the caller names.
+    ///
+    /// Only `2026-07-28` needs this, and it needs it twice over: that revision carries the
+    /// negotiated protocol in a header on *every* request rather than in a handshake, and SEP-2243
+    /// has each request name its own method in one too. Both are transport-level, so neither is
+    /// expressible in the JSON-RPC body the other helpers build.
+    fn send_with(
+        &self,
+        method: &str,
+        token: Option<&str>,
+        session: Option<&str>,
+        body: Option<&Value>,
+        extra: &[(&str, &str)],
+    ) -> Reply {
         use std::io::Read;
 
         let mut stream = std::net::TcpStream::connect(&self.addr)
@@ -2472,6 +2501,9 @@ impl Listener {
         }
         if let Some(session) = session {
             request.push_str(&format!("Mcp-Session-Id: {session}\r\n"));
+        }
+        for (name, value) in extra {
+            request.push_str(&format!("{name}: {value}\r\n"));
         }
         match body.map(|b| b.to_string()) {
             Some(body) => {
@@ -2506,6 +2538,81 @@ impl Listener {
             "capabilities": {},
             "clientInfo": { "name": "windbg-mcp-lease-smoke", "version": "1" },
         })
+    }
+
+    /// One `2026-07-28` request, spelled the way that revision requires.
+    ///
+    /// Three things travel with a stateless request, and the server rejects it if any is absent —
+    /// which is the whole of [#168](https://github.com/glslang/windbg-mcp/issues/168):
+    ///
+    /// - the `MCP-Protocol-Version` header, since there is no handshake left to remember what was
+    ///   negotiated;
+    /// - `params._meta` carrying `io.modelcontextprotocol/protocolVersion` and
+    ///   `…/clientCapabilities`, which SEP-2567 moved into every request when it removed the
+    ///   session that used to hold them;
+    /// - SEP-2243's `Mcp-Method` header, naming the body's method to whatever is between the two
+    ///   machines without it having to parse the body — and, where the method addresses something
+    ///   by name, an `Mcp-Name` beside it.
+    ///
+    /// `initialize` is exempt from the latter two — it is the request that establishes them.
+    fn stateless(&mut self, method: &str, params: Value) -> Reply {
+        let id = self.next_id;
+        self.next_id += 1;
+        self.stateless_at(id, method, params)
+    }
+
+    /// [`Self::stateless`] with the request id named rather than counted.
+    ///
+    /// Immutable, which is the whole reason it is separate: a request that has to run *alongside*
+    /// another cannot be sent through a `&mut self` borrow, and overlap is what the stateless
+    /// revision makes ordinary.
+    fn stateless_at(&self, id: i64, method: &str, mut params: Value) -> Reply {
+        params["_meta"] = json!({
+            "io.modelcontextprotocol/protocolVersion": STATELESS_REVISION,
+            "io.modelcontextprotocol/clientCapabilities": {},
+        });
+        let name = params["name"].as_str().map(str::to_owned);
+        let body = json!({ "jsonrpc": "2.0", "id": id, "method": method, "params": params });
+        let mut headers = vec![
+            ("MCP-Protocol-Version", STATELESS_REVISION),
+            ("Mcp-Method", method),
+        ];
+        if let Some(name) = name.as_deref() {
+            headers.push(("Mcp-Name", name));
+        }
+        self.send_with(
+            "POST",
+            Some(&self.token.clone()),
+            None,
+            Some(&body),
+            &headers,
+        )
+    }
+
+    /// The `2026-07-28` handshake, which mints nothing and is therefore not a session.
+    ///
+    /// Sent for the same reason a stateless client sends it: to learn what the server is. Nothing
+    /// afterwards depends on it having happened, which is the property being asserted.
+    fn stateless_opening(&mut self) -> Reply {
+        let id = self.next_id;
+        self.next_id += 1;
+        let body = json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": STATELESS_REVISION,
+                "capabilities": {},
+                "clientInfo": { "name": "windbg-mcp-stateless-smoke", "version": "1" },
+            },
+        });
+        self.send_with(
+            "POST",
+            Some(&self.token.clone()),
+            None,
+            Some(&body),
+            &[("MCP-Protocol-Version", STATELESS_REVISION)],
+        )
     }
 
     /// The handshake, answering with the session id the lease keys tenancy on.
@@ -2824,6 +2931,263 @@ fn a_second_session_for_one_credential_is_refused_while_it_holds_the_server() {
     // And the holder is undisturbed by either.
     let status = server.tool(&holder, "session_status", json!({}));
     assert_eq!(status["status"], "ok", "{status}");
+}
+
+/// The listener serves `2026-07-28` — the handshake *and* everything after it.
+///
+/// [#168](https://github.com/glslang/windbg-mcp/issues/168) reported the opposite: the handshake
+/// answered `200` and the next request `400`, which would leave `--listen` usable only by clients
+/// negotiating a legacy revision while advertising the newest one. It was measured with a
+/// hand-rolled probe that sent the body and none of the transport contract that revision adds, so
+/// what it found was the server enforcing the spec rather than failing to implement it. This is the
+/// same sequence, spelled the way the revision requires — and it is the reason
+/// [`Listener::stateless`] carries three things instead of one.
+#[test]
+fn the_listener_serves_the_stateless_revision_it_negotiates() {
+    let mut server = Listener::start(&[]);
+
+    let opening = server.stateless_opening();
+    assert_eq!(
+        opening.status,
+        200,
+        "the {STATELESS_REVISION} handshake was refused ({}): {}\n--- stderr ---\n{}",
+        opening.status,
+        opening.body,
+        server.stderr()
+    );
+    assert_eq!(
+        opening.result("initialize")["protocolVersion"],
+        json!(STATELESS_REVISION),
+        "the handshake must negotiate the revision it was offered: {}",
+        opening.body
+    );
+    // SEP-2567 removed the session id, so there is nothing here for the lease to key tenancy on.
+    // Asserted rather than assumed: every rule the gate has is written in terms of this header,
+    // and its absence is what makes the rest of this test a different client to the ones above.
+    assert!(
+        opening.session.is_none(),
+        "{STATELESS_REVISION} must mint no Mcp-Session-Id: {}",
+        opening.body
+    );
+
+    // The request the issue said was refused.
+    let listed = server.stateless("tools/list", json!({}));
+    assert_eq!(
+        listed.status,
+        200,
+        "tools/list on {STATELESS_REVISION} was refused ({}): {}\n--- stderr ---\n{}",
+        listed.status,
+        listed.body,
+        server.stderr()
+    );
+    let tools = listed.result("tools/list")["tools"].clone();
+    assert!(
+        tools.as_array().is_some_and(|t| !t.is_empty()),
+        "a served tools/list has tools in it: {}",
+        listed.body
+    );
+
+    // And a call, not only a listing: `tools/call` is the method that carries an `Mcp-Name` beside
+    // its `Mcp-Method`, so it exercises a rule `tools/list` cannot reach.
+    let called = server.stateless(
+        "tools/call",
+        json!({ "name": "session_status", "arguments": {} }),
+    );
+    assert_eq!(
+        called.status,
+        200,
+        "a stateless tools/call was refused ({}): {}\n--- stderr ---\n{}",
+        called.status,
+        called.body,
+        server.stderr()
+    );
+    assert_eq!(
+        called.result("tools/call")["structuredContent"]["status"],
+        json!("ok"),
+        "a stateless tools/call must answer like any other: {}",
+        called.body
+    );
+}
+
+/// A stateless request missing part of its contract is refused **and told which part**.
+///
+/// This is the other half of [#168](https://github.com/glslang/windbg-mcp/issues/168): the two
+/// shapes the probe sent, pinned so the same `400` cannot be read as a broken listener a second
+/// time. Both bodies are JSON-RPC errors naming the missing piece — the probe reported them as
+/// empty because `Invoke-WebRequest` throws on a 4xx and leaves the body on the exception, not
+/// because the server sent nothing.
+#[test]
+fn an_under_specified_stateless_request_is_told_which_part_it_is_missing() {
+    let mut server = Listener::start(&[]);
+    let token = server.token.clone();
+    let body = json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/list",
+        "params": {},
+    });
+
+    // The revision in the header and nothing else: SEP-2567 moved the negotiated protocol and the
+    // client's capabilities into every request's `_meta`, and this one has neither.
+    let bare = server.send_with(
+        "POST",
+        Some(&token),
+        None,
+        Some(&body),
+        &[("MCP-Protocol-Version", STATELESS_REVISION)],
+    );
+    assert_eq!(
+        bare.status, 400,
+        "a request with no _meta was served: {}",
+        bare.body
+    );
+    assert!(
+        bare.body
+            .contains("io.modelcontextprotocol/protocolVersion")
+            && bare
+                .body
+                .contains("io.modelcontextprotocol/clientCapabilities"),
+        "the refusal has to name the keys it wanted: {}",
+        bare.body
+    );
+
+    // `_meta` supplied, and still short one thing: SEP-2243 has every request name its own method
+    // in a header. This is the shape the issue's probe sent, and the one that made it look like
+    // the metadata was not the problem.
+    let mut with_meta = body.clone();
+    with_meta["params"]["_meta"] = json!({
+        "io.modelcontextprotocol/protocolVersion": STATELESS_REVISION,
+        "io.modelcontextprotocol/clientCapabilities": {},
+    });
+    let unheaded = server.send_with(
+        "POST",
+        Some(&token),
+        None,
+        Some(&with_meta),
+        &[("MCP-Protocol-Version", STATELESS_REVISION)],
+    );
+    assert_eq!(
+        unheaded.status, 400,
+        "a request with no Mcp-Method header was served: {}",
+        unheaded.body
+    );
+    assert!(
+        unheaded.body.contains("Mcp-Method"),
+        "the refusal has to name the header it wanted: {}",
+        unheaded.body
+    );
+
+    // And the server is undamaged by either — a refusal at this layer must not consume a claim,
+    // for the same reason the unauthenticated one must not.
+    let listed = server.stateless("tools/list", json!({}));
+    assert_eq!(
+        listed.status, 200,
+        "a well-formed request after two refused ones: {}",
+        listed.body
+    );
+}
+
+/// A stateless client can work while one of its own calls is still running.
+///
+/// The second finding of [#168](https://github.com/glslang/windbg-mcp/issues/168), and the one that
+/// survived the first. A request carrying no `Mcp-Session-Id` takes the gate's *opening* path and
+/// holds a claim for its whole duration — and on `2026-07-28` there is never an id to carry, so
+/// that is **every** request. Two that overlap contend, and the second gets a `409`.
+///
+/// Measured here at its sharpest rather than as a race. A kernel attach whose target never dials in
+/// parks in `WaitForEvent(INFINITE)` and does not come back; that is a supported state, and
+/// `session_status` and `end_session` are how a client is supposed to see it and reclaim it. If the
+/// claim it holds locks its own credential out, a stateless client cannot do either, and the
+/// property [#61](https://github.com/glslang/windbg-mcp/issues/61) established — that a parked
+/// attach costs one session and not the server — is not true for the revision current clients
+/// negotiate.
+#[test]
+fn a_stateless_client_can_work_while_one_of_its_own_calls_is_parked() {
+    let server = Listener::start(&[]);
+    let token = server.token.clone();
+    // Nothing is listening on it, so the attach parks rather than failing. Its own port, so a
+    // stray listener on this host cannot turn the park into an error and the test into a pass.
+    let connection = format!("net:port={},key=1.1.1.1", free_port());
+    let parked = json!({
+        "jsonrpc": "2.0",
+        "id": 9001,
+        "method": "tools/call",
+        "params": {
+            "name": "attach_kernel",
+            "arguments": { "connection": connection },
+            "_meta": {
+                "io.modelcontextprotocol/protocolVersion": STATELESS_REVISION,
+                "io.modelcontextprotocol/clientCapabilities": {},
+            },
+        },
+    });
+
+    std::thread::scope(|scope| {
+        scope.spawn(|| {
+            // Never read: the attach is still waiting for a target when this test ends, and the
+            // listener's `Drop` is what takes it down.
+            let _ = server.send_with(
+                "POST",
+                Some(&token),
+                None,
+                Some(&parked),
+                &[
+                    ("MCP-Protocol-Version", STATELESS_REVISION),
+                    ("Mcp-Method", "tools/call"),
+                    ("Mcp-Name", "attach_kernel"),
+                ],
+            );
+        });
+
+        // Long enough for the attach to be admitted and holding its claim. Not a race the test can
+        // lose in the direction that matters: if it has *not* started yet, the assertions below
+        // pass for the wrong reason rather than failing for the wrong one.
+        std::thread::sleep(Duration::from_secs(3));
+
+        let listed = server.stateless_at(1, "tools/list", json!({}));
+        assert_eq!(
+            listed.status,
+            200,
+            "a second stateless request was refused ({}) while the first was still running: \
+             {}\n--- stderr ---\n{}",
+            listed.status,
+            listed.body,
+            server.stderr()
+        );
+
+        // The two a client actually needs in this state: see the parked session, and end it.
+        let status = server.stateless_at(
+            2,
+            "tools/call",
+            json!({ "name": "session_status", "arguments": {} }),
+        );
+        assert_eq!(
+            status.status, 200,
+            "session_status is how a client sees a parked attach, and it was refused: {}",
+            status.body
+        );
+        let sessions = status.result("tools/call")["structuredContent"]["sessions"].clone();
+        let attaching = sessions
+            .as_array()
+            .into_iter()
+            .flatten()
+            .find(|s| s["kind"] == json!("kernel"))
+            .and_then(|s| s["session_id"].as_str().map(str::to_owned));
+        let Some(attaching) = attaching else {
+            panic!("the parked attach is not in session_status: {sessions}");
+        };
+
+        let ended = server.stateless_at(
+            3,
+            "tools/call",
+            json!({ "name": "end_session", "arguments": { "session_id": attaching } }),
+        );
+        assert_eq!(
+            ended.status, 200,
+            "end_session is the only way out of a parked attach, and it was refused: {}",
+            ended.body
+        );
+    });
 }
 
 /// Going quiet is not leaving; saying goodbye is.


### PR DESCRIPTION
Closes #168.

`--listen` **does** serve `2026-07-28` — the handshake and everything after it. What the issue
found was two different things wearing one symptom.

## The headline was the probe

The `400`s came from rmcp enforcing the revision, not failing to implement it. A `2026-07-28`
request carries three things and the hand-rolled probe sent one:

| missing | what answers |
| --- | --- |
| `params._meta` with `io.modelcontextprotocol/protocolVersion` + `…/clientCapabilities` | `400`, *"request _meta is missing or has malformed required fields: …"* |
| SEP-2243's `Mcp-Method` header | `400`, *"missing required Mcp-Method header"* |

Both bodies say exactly this. They read as empty because `Invoke-WebRequest` throws on a 4xx and
leaves the body on the exception rather than on the reply it returns.

The tier now drives the revision properly — handshake, `tools/list`, `tools/call` — and pins both
under-specified shapes against the part each refusal names, so the same `400` cannot be read as a
broken listener a second time.

## The real defect was the gate

The tenancy gate reserves the server for a request opening an MCP session, and read "no
`Mcp-Session-Id`" as exactly that. SEP-2567 removed the session id from `2026-07-28`, so on that
revision **every** request was a reservation: two that overlapped got a `409`, and a call that
parked held it for as long as it parked.

At its sharpest that cost the recovery path. A kernel attach whose target never dials in parks by
design — and its client could then reach neither `session_status` nor `end_session`, the two calls
that reclaim it. For the revision current clients negotiate, a going-nowhere attach was once again
a reason to restart the server: the property [#61](https://github.com/glslang/windbg-mcp/issues/61)
established, lost to a revision rather than to a change.

`Arriving` now names the three things a request can present instead of an `Option<&str>` that had
stopped meaning one thing. A request that can never become the holder reserves nothing. It is still
counted in-flight, so a goodbye waits for it, and it still waits on a teardown of its own
credential's expired sessions — that rule is the sweep's, not the gate's.

## Verified

On the ARM64 bench (`WinArmSandboxDebugger`): `cargo clippy --all-targets -- -D warnings` clean,
480 unit tests, 64 smoke tests, and the dump tier (`WINDBG_MCP_SMOKE_DUMP=1`) all green. The parked
test fails with a `409` against the gate as it stood before the first commit.

Not run: the live-kernel tier, which this change does not touch — the park here is a KDNET port
nothing answers, which is the same fixture the existing `#61` test uses and needs no target.

## Follow-up

`FOLLOWUPS.md` item 28 asked for this to be settled before the question of retiring the gate
entirely. It is, and the fix is one of that item's own arguments applied to the case where it was
unarguable; the item now carries the arguable cases that remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for sessionless MCP requests, allowing concurrent operations without reserving a session lease.
  - Sessionless requests remain available while another connection is waiting, except during session teardown.

- **Bug Fixes**
  - Improved handling of expired sessions and tenancy conflicts.
  - Added validation for required protocol, metadata and method headers, with clearer errors for incomplete requests.

- **Documentation**
  - Updated listener, smoke-test and changelog documentation to describe sessionless requests and the latest MCP protocol revision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->