### PR TITLE
Hand the stateless-revision work over: the traps, not just the result

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -390,8 +390,10 @@ another client's handle is reported *unknown* rather than refused. Two tokens on
 namespaces — if a session "vanished", check which token the request carried.
 
 **A request with no session id is two different things, and the gate has to tell them apart.**
-`Arriving` names all three: `Holding(id)`, `Opening` — a revision that *has* sessions, opening one —
-and `Stateless`, which is `2026-07-28` and has none. **`Stateless` is the one variant that never
+`Arriving` names all three: `Holding(id)`, `Opening` — no id and no header naming a sessionless
+revision, chiefly a legacy `initialize` — and `Stateless`, which is `2026-07-28`. Note `Opening` is
+a *fallback*, not a claim about the revision: a `2026-07-28` handshake that omits the header lands
+there too, which is why a reservation must survive minting nothing. **`Stateless` is the one variant that never
 reserves.** Not the same as "only `Opening` reserves": a `Holding` request whose credential has no
 current holder is a client *resuming* inside the grace, and it reserves too, because a resume can
 race a fresh `initialize` and a gate that merely served both would let them both through. Reading

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -409,7 +409,9 @@ above every date and would be read as the newest thing there is.
 client losing sessions it was using. The sweep reads `deadline` alone and zeroes `in_flight` on its
 way past, so work actually running does not save them.
 
-- A stateless request **renews** an existing deadline and never creates one. A credential holding a
+- An **admitted** stateless request renews an existing deadline and never creates one. Refused ones
+  renew nothing, deliberately: a refusal that renewed would let repeated bad requests keep an
+  abandoned client's sessions alive. A credential holding a
   legacy session and since sending stateless requests would otherwise be swept mid-call; and a
   deadline created where no holder exists is a lease against nothing, which would release a purely
   stateless client's sessions on a timer it never set. That abandonment is `IDLE_RELEASE`'s.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -390,8 +390,11 @@ another client's handle is reported *unknown* rather than refused. Two tokens on
 namespaces — if a session "vanished", check which token the request carried.
 
 **A request with no session id is two different things, and the gate has to tell them apart.**
-`Arriving` names all three: `Holding(id)`, `Opening` — a revision that *has* sessions, opening or
-resuming one — and `Stateless`, which is `2026-07-28` and has none. Only `Opening` reserves. Reading
+`Arriving` names all three: `Holding(id)`, `Opening` — a revision that *has* sessions, opening one —
+and `Stateless`, which is `2026-07-28` and has none. **`Stateless` is the one variant that never
+reserves.** Not the same as "only `Opening` reserves": a `Holding` request whose credential has no
+current holder is a client *resuming* inside the grace, and it reserves too, because a resume can
+race a fresh `initialize` and a gate that merely served both would let them both through. Reading
 the absence of an id as "opening" is what made every request of a stateless client a reservation:
 two that overlapped contended, and a call that parked locked its own credential out of
 `session_status` and `end_session`, so a going-nowhere kernel attach was a reason to restart the
@@ -413,11 +416,18 @@ way past, so work actually running does not save them.
   — so it arrives looking like an opener, reserves, and then takes nothing.
 
 **Driving the listener by hand on `2026-07-28` needs three things, and sending one gets a `400`
-that looks like a broken server.** Every request carries the `MCP-Protocol-Version` header,
-`params._meta` with `io.modelcontextprotocol/protocolVersion` *and* `…/clientCapabilities`
-(SEP-2567 moved them there when it removed the session that held them), and SEP-2243's `Mcp-Method`
-— plus `Mcp-Name`, which is mapped **per method**: `params.name` for `tools/call` and `prompts/get`,
-`params.uri` for `resources/read`, nothing for the rest. `PowerShell`'s `Invoke-WebRequest` throws
+that looks like a broken server.** Every request *after the handshake* carries the
+`MCP-Protocol-Version` header, `params._meta` with `io.modelcontextprotocol/protocolVersion` *and*
+`…/clientCapabilities` (SEP-2567 moved them there when it removed the session that held them), and
+SEP-2243's `Mcp-Method` — plus `Mcp-Name`, which is mapped **per method**: `params.name` for
+`tools/call` and `prompts/get`, `params.uri` for `resources/read`, nothing for the rest.
+
+`initialize` is the exception and is exempt from all three: it is the request that *establishes*
+the revision, so it carries the version in its body, needs no `_meta` and no `Mcp-Method`, and may
+omit the header as well. Sending the header anyway is legal and is what `Listener::stateless_opening`
+does — which is precisely why the headerless handshake is untested (`FOLLOWUPS.md` item 30). Send
+the recipe above on a handshake and you will take the ordinary path rather than the one that
+carried the bug. `PowerShell`'s `Invoke-WebRequest` throws
 on a 4xx and leaves the body on the exception, so those refusals read as empty when they in fact
 name what is missing. Before believing any protocol-level claim about `--listen`, read the validator
 that produced it: the rmcp source is on the Mac and needs no Windows build, at

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -389,6 +389,46 @@ log line reporting `local`'s session count to a named client on reconnect.
 another client's handle is reported *unknown* rather than refused. Two tokens on one host are two
 namespaces — if a session "vanished", check which token the request carried.
 
+**A request with no session id is two different things, and the gate has to tell them apart.**
+`Arriving` names all three: `Holding(id)`, `Opening` — a revision that *has* sessions, opening or
+resuming one — and `Stateless`, which is `2026-07-28` and has none. Only `Opening` reserves. Reading
+the absence of an id as "opening" is what made every request of a stateless client a reservation:
+two that overlapped contended, and a call that parked locked its own credential out of
+`session_status` and `end_session`, so a going-nowhere kernel attach was a reason to restart the
+server again for the revision current clients negotiate (#168, fixed 2026-08-19). The revision is
+read from `MCP-Protocol-Version` and matched against `ProtocolVersion::KNOWN_VERSIONS` rather than
+compared as a string — the comparison is lexicographic and correct for ISO dates, but `draft` sorts
+above every date and would be read as the newest thing there is.
+
+**Two lease rules a stateless request breaks if you forget them**, both ending the same way: a
+client losing sessions it was using. The sweep reads `deadline` alone and zeroes `in_flight` on its
+way past, so work actually running does not save them.
+
+- A stateless request **renews** an existing deadline and never creates one. A credential holding a
+  legacy session and since sending stateless requests would otherwise be swept mid-call; and a
+  deadline created where no holder exists is a lease against nothing, which would release a purely
+  stateless client's sessions on a timer it never set. That abandonment is `IDLE_RELEASE`'s.
+- A reservation that mints nothing gives the **deadline** back along with the claim. A `2026-07-28`
+  `initialize` may legitimately omit `MCP-Protocol-Version` — it is the request that establishes it
+  — so it arrives looking like an opener, reserves, and then takes nothing.
+
+**Driving the listener by hand on `2026-07-28` needs three things, and sending one gets a `400`
+that looks like a broken server.** Every request carries the `MCP-Protocol-Version` header,
+`params._meta` with `io.modelcontextprotocol/protocolVersion` *and* `…/clientCapabilities`
+(SEP-2567 moved them there when it removed the session that held them), and SEP-2243's `Mcp-Method`
+— plus `Mcp-Name`, which is mapped **per method**: `params.name` for `tools/call` and `prompts/get`,
+`params.uri` for `resources/read`, nothing for the rest. `PowerShell`'s `Invoke-WebRequest` throws
+on a 4xx and leaves the body on the exception, so those refusals read as empty when they in fact
+name what is missing. Before believing any protocol-level claim about `--listen`, read the validator
+that produced it: the rmcp source is on the Mac and needs no Windows build, at
+`~/.cargo/registry/src/*/rmcp-<ver>/src/transport/streamable_http_server/tower.rs`.
+
+**A listener test that needs a real engine worker belongs in the debugger tier**, however cheap it
+looks — the protocol tier's contract is "no debugger target". An attach cannot *park* without
+`dbgeng.dll`: it fails during initialisation instead, which turns a test about a call that does not
+return into one about a call that failed fast. CI's Windows runner happens to have the DLL, so
+getting this wrong does not show up as a red build.
+
 **Credentials are built from variables handed in, not read from the environment**
 (`Credentials::from_entries`), for the same reason as `kdconn::env_entries`: `set_var` is `unsafe` in
 edition 2024 and mutates state the whole test binary shares. And they are **stripped from every

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -899,8 +899,12 @@ told to ask again once the release is done.
 it was using — the sweep reads `deadline` alone and zeroes `in_flight` on its way past, so work
 actually running does not save them:
 
-- a request **renews** an existing deadline. Whatever replaces `admit`, a credential that is plainly
-  alive must not be swept mid-call.
+- a request the gate **admits** renews an existing deadline. The qualifier is load-bearing in both
+  directions: a credential that is plainly alive must not be swept mid-call, and a *refused* request
+  must not renew anything — `NotYours`, `Releasing` and `Occupied` all return before any deadline is
+  touched today. Renewing on arrival instead would let a stream of wrong session ids or repeated
+  `initialize`s hold an abandoned client's live kernel target open for ever, which is the failure
+  the sweep exists to prevent.
 - a reservation that mints nothing gives its **deadline** back, not just its claim. If reserving
   goes away entirely this stops mattering; if it survives in any form, it still does.
 

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -943,9 +943,14 @@ grace later. It is fixed and unit-tested at the lease level
 caused it is the one shape the tier does not send.
 
 **What would close it:** a listener assertion that opens with a headerless `2026-07-28` handshake
-and then works normally — a `tools/list` and a `tools/call` — plus, if the grace can be shortened
-far enough to make it quick, that its sessions are still there afterwards. All protocol-tier work;
-none of it needs a target.
+and then works normally — a `tools/list` and a `tools/call`. That much is protocol-tier work and
+needs no target.
+
+The half that would exercise the regression *end to end* is not: seeing sessions survive the grace
+means having a session, which means an opener (`open_dump`), which means a real engine worker and
+therefore the **debugger tier** — the same rule the parked test was moved for. Split it that way
+rather than claiming the whole thing is cheap; a protocol-tier version on its own asserts that the
+handshake is served, not that nothing sweeps afterwards.
 
 **Why deferred:** the mechanism is pinned where it is decided, so this buys call-site coverage of a
 path the server now handles correctly rather than a new claim. Picks up at the listener helpers in

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -1,6 +1,6 @@
 # Follow-ups
 
-Deferred work, in eleven clusters: items 1–6 come from the reachability-confirmation effort (path
+Deferred work, in twelve clusters: items 1–6 come from the reachability-confirmation effort (path
 recipe + `run_to_address`, merged 2026-07-04), items 7–11 from surveying this server against the
 MCP `2026-07-28` extensions (tasks, apps), item 12 from the opener split
 (glslang/win-kexp#71, 2026-08-01), items 13–14 from the bounded-command coverage review
@@ -11,9 +11,9 @@ session's own transcript turned up, and item 18 what reviewing it did), item 19 
 (#131, #132, #134, 2026-08-16), item 23 from making the listener usable rather than merely
 working (2026-08-17), item 24 from first measuring what this server costs the model driving it
 (2026-08-17), items 25–26 from giving the debugger tier an ARM64 *target* (#143, #152,
-2026-08-18), item 27 from completing the coordinate work (#156–#158, 2026-08-18), and items 28–29
-from giving each client its own sessions (#162, #164–#166, 2026-08-19). Each item
-notes its repo,
+2026-08-18), item 27 from completing the coordinate work (#156–#158, 2026-08-18), items 28–29
+from giving each client its own sessions (#162, #164–#166, 2026-08-19), and item 30 from serving
+the stateless revision concurrently (#168 / #169, 2026-08-19). Each item notes its repo,
 why it was deferred, and where it picks up. See [`DECISIONS.md`](./DECISIONS.md) for the design rationale (D1–D5) items 1–6 extend,
 and the 2026-08-02 entries that items 13–14 and item 10 extend.
 
@@ -894,6 +894,16 @@ kept for. If it does, the gate can go and the sweep stays; if it does not, say w
 go: it is the sweep's, not the gate's, and a stateless request is refused by it like any other —
 told to ask again once the release is done.
 
+**Two rules the deletion must not take with it**, both learned in review of
+[#169](https://github.com/glslang/windbg-mcp/pull/169) and both ending in a client losing sessions
+it was using — the sweep reads `deadline` alone and zeroes `in_flight` on its way past, so work
+actually running does not save them:
+
+- a request **renews** an existing deadline. Whatever replaces `admit`, a credential that is plainly
+  alive must not be swept mid-call.
+- a reservation that mints nothing gives its **deadline** back, not just its claim. If reserving
+  goes away entirely this stops mattering; if it survives in any form, it still does.
+
 **Why deferred:** it is a deletion, and a deletion is the change most worth making on its own,
 against a PR that is not also adding the thing it would delete. Picks up at `src/listen.rs`
 (`Lease::admit`, `Lease::settle`) and the ~90 lease tests beside it.
@@ -918,3 +928,25 @@ target.
 
 **Why deferred:** the per-client rules are unit-tested at the level they are decided, so this buys
 call-site coverage rather than new claims. Picks up at the listener helpers in `tests/mcp_smoke.rs`.
+
+## 30. [windbg-mcp] Nothing covers a `2026-07-28` handshake that omits the protocol header
+
+rmcp allows a stateless `initialize` to arrive without `MCP-Protocol-Version` — it is the request
+that establishes the revision, so the header is optional on exactly that one. The listener therefore
+cannot classify it from the header, reads it as an **opener**, reserves, and then mints no session.
+
+That path is real and was briefly a bug: the reservation gave back its claim and left its *deadline*
+armed, so a client's own handshake started a clock that released whatever it had since opened one
+grace later. It is fixed and unit-tested at the lease level
+(`a_reservation_that_minted_nothing_leaves_no_clock_running`), but nothing drives it **over HTTP**:
+`Listener::stateless_opening` sends the header, and stdio has no headers to omit, so the shape that
+caused it is the one shape the tier does not send.
+
+**What would close it:** a listener assertion that opens with a headerless `2026-07-28` handshake
+and then works normally — a `tools/list` and a `tools/call` — plus, if the grace can be shortened
+far enough to make it quick, that its sessions are still there afterwards. All protocol-tier work;
+none of it needs a target.
+
+**Why deferred:** the mechanism is pinned where it is decided, so this buys call-site coverage of a
+path the server now handles correctly rather than a new claim. Picks up at the listener helpers in
+`tests/mcp_smoke.rs`, beside `the_listener_serves_the_stateless_revision_it_negotiates`.

--- a/README.md
+++ b/README.md
@@ -236,7 +236,8 @@ when the machine being debugged shares it. [`docs/remote-listener.md`](./docs/re
 covers the tokens — **one per client**, each with its own sessions, so two people or two agents on
 one listener cannot reach each other's targets — the session lease and its grace, and what a `409`
 means (one credential asking for a second MCP session, never a second client, and never a request on
-a second connection — those are served concurrently). For a one-off, [`docs/remote-phase0.md`](./docs/remote-phase0.md) does the same
+a second connection — those are served concurrently, as is every request of a `2026-07-28` client,
+which has no session to ask twice for). For a one-off, [`docs/remote-phase0.md`](./docs/remote-phase0.md) does the same
 job over plain `ssh` with no listener.
 
 ### As a Claude Code plugin

--- a/README.md
+++ b/README.md
@@ -236,8 +236,9 @@ when the machine being debugged shares it. [`docs/remote-listener.md`](./docs/re
 covers the tokens — **one per client**, each with its own sessions, so two people or two agents on
 one listener cannot reach each other's targets — the session lease and its grace, and what a `409`
 means (one credential asking for a second MCP session, never a second client, and never a request on
-a second connection — those are served concurrently, as is every request of a `2026-07-28` client,
-which has no session to ask twice for). For a one-off, [`docs/remote-phase0.md`](./docs/remote-phase0.md) does the same
+a second connection — those are served concurrently, as are a `2026-07-28` client's, which have no
+session to ask twice for, except while that credential's own expired sessions are still being
+released). For a one-off, [`docs/remote-phase0.md`](./docs/remote-phase0.md) does the same
 job over plain `ssh` with no listener.
 
 ### As a Claude Code plugin

--- a/src/listen.rs
+++ b/src/listen.rs
@@ -377,7 +377,12 @@ struct Admitted {
 enum Arriving<'a> {
     /// An `Mcp-Session-Id` the client is presenting.
     Holding(&'a str),
-    /// No session id, on a revision that mints them — an `initialize`.
+    /// No session id, and no revision header naming one that has none.
+    ///
+    /// Chiefly a legacy `initialize`. It is also where a `2026-07-28` handshake lands when it omits
+    /// `MCP-Protocol-Version` — legal, since that request is the one *establishing* the revision —
+    /// so an `Opening` claim may mint nothing at all, and [`Lease::settle`] has to give back its
+    /// deadline as well as its claim.
     ///
     /// Not a resume: a client picking up what it left inside the grace presents the id it held, so
     /// it arrives as [`Self::Holding`] even though nobody currently holds the server. That case

--- a/src/listen.rs
+++ b/src/listen.rs
@@ -377,8 +377,11 @@ struct Admitted {
 enum Arriving<'a> {
     /// An `Mcp-Session-Id` the client is presenting.
     Holding(&'a str),
-    /// No session id, on a revision that mints them: an `initialize`, or a client resuming inside
-    /// the grace.
+    /// No session id, on a revision that mints them — an `initialize`.
+    ///
+    /// Not a resume: a client picking up what it left inside the grace presents the id it held, so
+    /// it arrives as [`Self::Holding`] even though nobody currently holds the server. That case
+    /// reserves too, and for the same reason this one does.
     Opening,
     /// No session id, and none is coming.
     Stateless,


### PR DESCRIPTION
Docs only, following [#169](https://github.com/glslang/windbg-mcp/pull/169). Three things that work
cost are not currently written anywhere a later session would find them.

**`CLAUDE.md`** — what bites while editing the listener:

- the absence of a session id is now **two** different things (`Arriving::Opening` against
  `Arriving::Stateless`) and only one of them reserves; the revision is matched against
  `ProtocolVersion::KNOWN_VERSIONS` rather than string-compared, because `draft` sorts above every
  ISO date;
- **two lease rules a stateless request breaks if forgotten**, both ending in a client losing
  sessions it was using — the sweep reads `deadline` alone and zeroes `in_flight` on its way past.
  Both were review findings on #169 rather than things the design anticipated;
- the **three things** a `2026-07-28` request carries, since sending one of them gets a `400` that
  reads as a broken server — plus the `Invoke-WebRequest` trap that made those bodies look empty,
  and the fact that rmcp's validators are greppable on the Mac with no Windows build;
- the **tier rule** the parked test moved for: an attach cannot park without `dbgeng.dll`, so a
  listener test needing a real engine worker belongs in the debugger tier. CI's runner happens to
  have the DLL, which is why getting this wrong does not show up as a red build.

**`FOLLOWUPS.md`** — item 28 gains the two rules a future deletion must not take with it, which is
the part of #169 most likely to be lost when the gate is finally retired. New item 30 records the
one gap the work opened: a headerless `2026-07-28` handshake is the shape that *caused* the deadline
bug, is fixed and unit-tested at the lease level, and is the one shape the listener tier does not
send over HTTP.

**`README.md`** said what a `409` means without saying that a stateless client never gets one.

No code changes, so the claims are the deliverable. Each named symbol, test and path was checked to
still exist rather than quoted from the session that wrote them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)