### PR TITLE
Retire the gate that stood in for a boundary the registry now has

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **A lease expiry releases the sessions of the client whose lease ran out**, not every session.
     Before ownership those were the same set, because the gate served one client at a time.
   - **An `Mcp-Session-Id` another client holds is reported unknown**, and the check runs before the
-    caller's own tenancy is consulted. The MCP service keeps one session table for the server, so on
+    caller's own lease is consulted. The MCP service keeps one session table for the server, so on
     a legacy revision the id was the only thing between a client and another's MCP session — and a
     `DELETE` on it closed that session while the lease that minted it still held the id, leaving its
     owner failing every request and refused its own re-`initialize` for a grace period.
@@ -42,17 +42,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     caller from the task-local, which is who is asking; the listener's own diagnostics run after
     that scope has closed and take the client as a parameter, so the one that reports an adoption on
     reconnect counts the reconnecting client's sessions rather than `local`'s.
-  - **The tenancy itself is per client**, so two clients no longer queue behind each other. The gate
-    serialised the server when the registry was global and one client could end another's targets;
-    keeping it shared would have meant one client's four-minute pool walk making every other client
-    wait for a boundary the registry now provides properly — namespaces that cannot be used
-    concurrently. A second *MCP session* for the same token still contends, which is one credential
-    racing itself — and the `409` says so, where it used to report a second client that no longer
-    exists as a category. Further requests carrying a session it already holds are not contention at
-    all and never were: they are served concurrently, which is what lets a `DELETE` arrive while a
-    tool call is still running. The one `409` that means something else — a request arriving while
-    the sweeper releases this credential's expired sessions, when it holds nothing at all — now says
-    so, instead of describing a session the caller does not have.
+  - **The tenancy itself became per client** — the gate serialised the server when the registry was
+    global and one client could end another's targets, and keeping it shared would have meant one
+    client's four-minute pool walk making every other client wait for a boundary the registry now
+    provides properly. It has since been retired outright (see **Changed**, below): with sessions
+    owned, the contention it had left to arbitrate was one credential racing itself, which inside a
+    namespace is not a boundary at all. The `409` it answered with is gone; the one that remains is
+    a request arriving while the sweeper releases this credential's own expired sessions.
   - Under **stdio** everything runs as `local`, so one set of registry rules serves both transports
     rather than one rule and an exception.
   - **Every credential variable is stripped from the processes this server creates** — by prefix,
@@ -107,12 +103,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   library that normalised a `409` into an exception, or hid the `Mcp-Session-Id` header, would be
   asserting on the server's behalf.
 
-  Four assertions need no debugger, because tenancy is decided before any session is opened: the
-  listener refuses to start without a token and says which variable is missing; an unauthenticated
-  request is refused, told nothing about what is here, and **costs the server nothing** (the bearer
-  check runs before the tenancy gate, so a wrong token must not consume a claim); a second client
-  is refused with `409` whether it arrives with a fresh `initialize` or somebody else's session id;
-  and going quiet is not leaving while a `DELETE` is. The fifth is in the debugger tier and waits
+  Four assertions need no debugger, because none of them needs a session to be open: the listener
+  refuses to start without a token and says which variable is missing; an unauthenticated request is
+  refused, told nothing about what is here, and **costs the server nothing** (the bearer check runs
+  before the lease is touched); a credential's second MCP session is served alongside its first,
+  while an id this server never issued is not; and going quiet is not leaving while a `DELETE` is. The fifth is in the debugger tier and waits
   out a real grace against a **parked kernel attach** — a session that exists, holds a worker, and
   cannot be interrupted, so releasing it means terminating a process. See
   [`docs/smoke-test.md`](./docs/smoke-test.md).
@@ -199,20 +194,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   [#61](https://github.com/glslang/windbg-mcp/issues/61) established, quietly lost to a revision
   rather than to a change.
 
-  The gate now distinguishes the two kinds of nothing: a request on a revision that mints no
-  session can never become the holder a reservation arbitrates, so it reserves nothing and is
-  served alongside its client's other work. The one refusal it still meets is a teardown of its own
-  credential's expired sessions — refused with the `409` that says to ask again once the release is
-  done, which is the sweep's rule and not the gate's.
+  The fix was for the gate to distinguish the two kinds of nothing: a request on a revision that
+  mints no session can never become the holder a reservation arbitrates, so it reserved nothing and
+  was served alongside its client's other work. The gate has since been retired altogether (see
+  **Changed**), which deletes that classification rather than refining it — a request now presents a
+  session id or nothing, and the revision does not enter into it. The one refusal such a client still
+  meets is a teardown of its own credential's expired sessions, told to ask again once the release is
+  done, which was always the sweep's rule and not the gate's.
 
   Two lease bugs on the same path came out of review and are fixed here too, both of which end with
   a client losing sessions it was using. A stateless request now **renews** a lease its credential
   already has, since the sweep reads the deadline alone — a credential holding a legacy session and
   since sending stateless requests would otherwise have had those sessions released while it was
-  working. And a reservation that mints no session now gives its **deadline** back along with its
-  claim: a `2026-07-28` `initialize` may omit the `MCP-Protocol-Version` header, so it is
-  classified as an opener, reserves, and takes nothing — leaving a clock running against a tenancy
-  that holds nothing, which one grace later released whatever that client had since opened.
+  working; that rule outlived the gate, and is now simply what every admitted request does. And a
+  reservation that minted no session gave its **deadline** back along with its claim: a `2026-07-28`
+  `initialize` may omit the `MCP-Protocol-Version` header, so it was classified as an opener,
+  reserved, and took nothing — leaving a clock running against a tenancy that held nothing, which one
+  grace later released whatever that client had since opened. With reserving gone, nothing arms a
+  deadline before an MCP session exists, so there is no longer a clock to hand back.
 
   The same issue reported that the listener answered a `2026-07-28` handshake and then `400`d the
   request after it. **It does not** — that was measured with a hand-rolled probe that sent the body
@@ -227,6 +226,54 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [SEP-2567]: https://modelcontextprotocol.io/seps/2567-sessionless-mcp
 
 ### Changed
+
+- **The listener's single-tenancy gate is retired; the lease is now a clock and nothing else**
+  ([#162](https://github.com/glslang/windbg-mcp/issues/162) slice 3b, `FOLLOWUPS.md` item 28). A
+  credential may open a second MCP session, and two of its requests never wait on each other. The
+  `409` that refused one is gone.
+
+  The gate was the boundary between two clients when the registry was one map for the whole server —
+  handles minted from it, the four-session cap shared, `end_session` ending whatever it was handed.
+  Ownership took that job over in the slices above, and what the gate had left to arbitrate was one
+  credential racing *itself*: a fresh `initialize` while it held one, or a request bearing an id that
+  was not the one it held. Inside a namespace neither is a boundary — both MCP sessions reach the
+  same debug sessions, because they are the same client — so what the refusal cost was a client's own
+  concurrency, and what it bought was nothing.
+
+  - **The clock stays, and it is the whole of what the lease was kept for.** Any request renews it;
+    when it runs out, that client's sessions are released exactly as a disconnect would have released
+    them, its MCP sessions are closed in the service, and its requests are refused until the release
+    is done. Idle release (`WINDBG_MCP_SESSION_IDLE_SECS`) does **not** subsume it: it spares a
+    session with a call outstanding, which is precisely the parked `attach_kernel` a vanished client
+    leaves behind, and it knows nothing about MCP sessions.
+  - **The lease is still armed by an MCP session, so a `2026-07-28` client still has no clock** —
+    deliberately, now that it could have one. A lease releases everything that credential holds,
+    busy or not, on the reasoning that a client silent for a grace has gone; a stateless client is
+    legitimately silent for far longer, and releasing a live kernel from under a caller who is
+    thinking is worse than holding an abandoned one for the idle window.
+  - **A credential's MCP sessions are recorded as a set**, not as one holder. An id recorded for
+    nobody is one any credential may present, so tracking only the newest would have handed a client
+    another's older id the moment that client opened a second — the harm the ownership check exists
+    to stop, arriving through the removal of the refusal in front of it.
+  - **Two refusals remain, and neither was ever tenancy.** An `Mcp-Session-Id` another client holds
+    is reported *unknown* (`404`); a request arriving while its own credential's expired sessions are
+    still being released is told to ask again (`409`) — the sweep's refusal, and now the only `409`
+    this server has.
+  - **What went with the gate:** the reservation and its generation counter, the in-flight count and
+    its epoch, the handover that waited on `Sessions::busy` (and `Sessions::busy` itself), the
+    `Stale` settlement that had to close a session minted by a claim that had expired, and every
+    read of `MCP-Protocol-Version`. A request now presents a session id or nothing, and the revision
+    does not enter into it — so the classification behind
+    [#168](https://github.com/glslang/windbg-mcp/issues/168) is deleted rather than fixed, and the
+    trap beside it (a reservation that minted nothing having to hand its deadline back) is
+    unreachable rather than handled: only a settled MCP session arms a deadline.
+  - **The one lease rule that survives is the one that loses sessions if forgotten.** An *admitted*
+    request renews an existing deadline and creates none. A refused one renews nothing, or a stream
+    of wrong session ids would hold an abandoned client's live kernel open for ever. What keeps the
+    sweep from releasing a session mid-call is the startup floor that was always there: a grace
+    longer than the longest a call can keep a client quiet means no request of that credential's can
+    still be in flight when its lease expires — which is what the epochs and claim generations were
+    protecting one layer above.
 
 - **The last progress milestone is no longer dropped when it races the answer**
   ([#163](https://github.com/glslang/windbg-mcp/issues/163)). A client watching a long call would

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -389,35 +389,37 @@ log line reporting `local`'s session count to a named client on reconnect.
 another client's handle is reported *unknown* rather than refused. Two tokens on one host are two
 namespaces — if a session "vanished", check which token the request carried.
 
-**A request with no session id is two different things, and the gate has to tell them apart.**
-`Arriving` names all three: `Holding(id)`, `Opening` — no id and no header naming a sessionless
-revision, chiefly a legacy `initialize` — and `Stateless`, which is `2026-07-28`. Note `Opening` is
-a *fallback*, not a claim about the revision: a `2026-07-28` handshake that omits the header lands
-there too, which is why a reservation must survive minting nothing. **`Stateless` is the one variant that never
-reserves.** Not the same as "only `Opening` reserves": a `Holding` request whose credential has no
-current holder is a client *resuming* inside the grace, and it reserves too, because a resume can
-race a fresh `initialize` and a gate that merely served both would let them both through. Reading
-the absence of an id as "opening" is what made every request of a stateless client a reservation:
-two that overlapped contended, and a call that parked locked its own credential out of
-`session_status` and `end_session`, so a going-nowhere kernel attach was a reason to restart the
-server again for the revision current clients negotiate (#168, fixed 2026-08-19). The revision is
-read from `MCP-Protocol-Version` and matched against `ProtocolVersion::KNOWN_VERSIONS` rather than
-compared as a string — the comparison is lexicographic and correct for ISO dates, but `draft` sorts
-above every date and would be read as the newest thing there is.
+**There is no tenancy gate any more, and stale memory of it is the likeliest thing to mislead you
+here.** Retired 2026-08-20 (`FOLLOWUPS.md` item 28, once #162's ownership had taken the boundary
+over). What `Lease` is now: a clock, plus the two answers that were never tenancy. `admit` refuses an
+`Mcp-Session-Id` **another client** records (`404`, *unknown* — never "someone else's") and a request
+whose own credential is mid-release (`409`, ask again in a moment), and otherwise renews. Gone with
+the gate: the reservation and its generation counter, `Occupied`/`409`, the in-flight count and its
+epoch, the handover that waited on `Sessions::busy` (and `Sessions::busy` itself), `Arriving`, and
+every read of `MCP-Protocol-Version` — the classification behind #168 is deleted rather than fixed,
+so a request now presents an id or nothing and the revision does not enter into it. A credential may
+hold **several** MCP sessions; they are kept in a set, because an id recorded for nobody is one any
+credential may present.
 
-**Two lease rules a stateless request breaks if you forget them**, both ending the same way: a
-client losing sessions it was using. The sweep reads `deadline` alone and zeroes `in_flight` on its
-way past, so work actually running does not save them.
+**One lease rule survives, and forgetting it costs a client sessions it was using.** An **admitted**
+request renews an existing deadline and creates none:
 
-- An **admitted** stateless request renews an existing deadline and never creates one. Refused ones
-  renew nothing, deliberately: a refusal that renewed would let repeated bad requests keep an
-  abandoned client's sessions alive. A credential holding a
-  legacy session and since sending stateless requests would otherwise be swept mid-call; and a
-  deadline created where no holder exists is a lease against nothing, which would release a purely
-  stateless client's sessions on a timer it never set. That abandonment is `IDLE_RELEASE`'s.
-- A reservation that mints nothing gives the **deadline** back along with the claim. A `2026-07-28`
-  `initialize` may legitimately omit `MCP-Protocol-Version` — it is the request that establishes it
-  — so it arrives looking like an opener, reserves, and then takes nothing.
+- *admitted*, because a refusal that renewed would let a stream of wrong session ids hold an
+  abandoned client's live kernel target open for ever — the failure the sweep exists to prevent. Both
+  refusals return before the renewal, and that ordering is the rule.
+- *any* request, not any request of a shape: a credential holding a legacy session can go on to send
+  `2026-07-28` ones (a client that upgraded, or restarted inside the grace), and the sweep reads
+  `deadline` and nothing else.
+- *creates none*, because a clock armed for a credential that holds nothing releases everything it
+  opens one grace later. Only a settled MCP session arms one, which is what makes the trap that used
+  to sit beside this — a reservation minting nothing and having to hand its deadline back —
+  unreachable rather than handled.
+
+The sweep zeroes nothing and waits for nothing, so what keeps it from releasing a session mid-call is
+the startup floor in `Lease::new`: a grace longer than the longest a call can keep a client quiet
+means **no request of that credential's can still be in flight when its lease expires**. That is the
+property the epochs and claim generations were protecting one layer above, and it was already
+enforced.
 
 **Driving the listener by hand on `2026-07-28` needs three things, and sending one gets a `400`
 that looks like a broken server.** Every request *after the handshake* carries the

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -5,6 +5,53 @@ status. Keep entries short; link to code with `file:line` where it helps a futur
 
 ---
 
+## The boundary is ownership, so the gate that stood in for it is gone (2026-08-20, #162)
+
+**Context.** The entry below ("Tenancy is held until the engine is idle") decided that one client
+holds the listener at a time, and it was right for the registry it was written against: handles were
+minted from one map for the whole server, `MAX_SESSIONS` was shared, and `end_session` ended whatever
+it was handed. Nothing in there was scoped to a client, so serving one at a time *was* the boundary —
+"forced by the registry rather than chosen", as it says.
+
+`2026-07-28` removed the protocol-level MCP session (SEP-2567), which removed the identifier that
+gate was keyed on, and #162 answered that by giving the registry the boundary it never had: a session
+belongs to the client that opened it, identified by the credential it authenticated with, and
+routing, the cap, the closed-session history, `server_log` and lease release are all per client.
+
+**Decision.** Retire the gate. Once sessions are owned, the contention it had left to arbitrate was
+one credential racing *itself* — a second `initialize`, or a request bearing an id that is not the
+one it holds — and inside a namespace that is not a boundary: both MCP sessions reach the same debug
+sessions, because they are the same client. A `409` there cost a client its own concurrency and
+bought nothing, and at its sharpest it cost the recovery path: a request that reserved locked its own
+credential out of `session_status` and `end_session` (#168).
+
+**The lease stays, as a clock.** That was the question `FOLLOWUPS.md` item 28 was filed to settle,
+and the answer is not "idle release covers it". Idle release (`WINDBG_MCP_SESSION_IDLE_SECS`, #164)
+deliberately spares a session with a call outstanding, which is exactly the parked `attach_kernel` a
+vanished client leaves behind, and it knows nothing about MCP sessions, so an abandoned one would
+stay resident in the service with its id accepted. So: any request renews the lease, an expiry
+releases that client's sessions and closes its MCP sessions, and a request arriving mid-release is
+told to ask again — the sweep's refusal, which was never tenancy.
+
+**What this deletion vindicates about the entry below.** That one ended with a lesson: seven review
+rounds went on conditions added one layer *above* the resource being protected — a reservation
+needed a lifetime, the lifetime a resolution, the resolution an undo, the in-flight counter an epoch
+— and each answer was true of its level and silent about the one below. Removing the gate removed all
+four, and the property they were approximating turned out to be enforced by the floor that was there
+from the start: a sweep fires only after a whole grace with nothing admitted, and `Lease::new` refuses
+a grace shorter than the longest a call can keep a client quiet, so **no request of that credential's
+can still be in flight when its lease expires**. The corollary for next time is the same lesson with
+the sign flipped: when a chain of conditions keeps needing another link, check whether something
+below it already answers the question — and whether the thing being guarded is a boundary at all.
+
+**Status.** Landed 2026-08-20 (#162 slice 3b, closing item 28). `Presence` replaces `Tenancy`; the
+reservation, `Admission::Occupied`, the `Stale` settlement, the in-flight count and its epoch, the
+`Sessions::busy` handover and every read of `MCP-Protocol-Version` are gone. A credential's MCP
+sessions are a set, because an id recorded for nobody is one any credential may present. Ninety lease
+tests became twenty, and the smoke tier now asserts the opposite of the `409` it used to.
+
+---
+
 ## A service's stop is the only part of it that can break something (2026-08-17)
 
 **Context.** `--listen` as a foreground process dies with the login session, inherits whatever
@@ -43,7 +90,7 @@ console, so the role writes to `%ProgramData%\windbg-mcp\service.log` — `serve
 channel, but only once the listener is up, which is exactly the failure not worth diagnosing that
 way.
 
-**What it does not change.** The lease, the single-tenancy rule and the bearer check are all
+**What it does not change.** The lease, the client boundary and the bearer check are all
 untouched; a service is a way to *run* the listener, not a second one. The foreground path hands
 over a shutdown future that never fires, so its behaviour is byte for byte what it was.
 
@@ -187,7 +234,9 @@ was wrong for a year of nobody noticing because it had no test. It had no test b
 unreachable without an HTTP harness, not because anyone decided to skip it. It is now a named
 predicate (`listen::is_departure`) with the same unit coverage every rule beside it has.
 
-**Status.** Implemented (#135, #137). Three of the four things this listed as missing have since
+**Status.** Implemented (#135, #137); the single-tenancy half was **retired** on 2026-08-20 — see
+the entry above, which is where the reasoning now lives. The lease itself stands, as the clock this
+describes minus the gate. Three of the four things this listed as missing have since
 landed, each with an entry of its own above: the log reaches a remote client (as a tool, not a
 notification), the lease has the smoke tier whose absence made seven rounds of review the way these
 were found rather than the second, and a long call now reports its progress. **Service installation**, the fourth,

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -845,80 +845,73 @@ symbol load to populate it would be strictly worse: that is a `.reload` per modu
 **Depends on nothing.** Picks up at `worker::with_pdb_identity` and
 `win_kexp::DebugEngine::module_pdb`.
 
-## 28. [windbg-mcp] The tenancy gate may no longer earn its place
+## 28. [windbg-mcp] The tenancy gate no longer earned its place — **done** (2026-08-20)
 
-The listener's **lease** was built when the registry was one map for the whole server: handles
-minted from it, the cap shared, `end_session` ending whatever it was handed. Serving one client at a
-time was the only thing standing between two clients and each other's targets, so the gate was
+The listener's **lease** was built when the registry was one map for the whole server: handles minted
+from it, the cap shared, `end_session` ending whatever it was handed. Serving one client at a time
+was the only thing standing between two clients and each other's targets, so the gate was
 load-bearing.
 
 Ownership took that job over ([#162](https://github.com/glslang/windbg-mcp/issues/162), merged
-2026-08-19). A handle routes only for its owner, `session_status` and `server_log` show only the
-caller's, the cap and the closed-session history are per client, a lease expiry releases only that
-client's sessions, and an `Mcp-Session-Id` another client holds is reported unknown. The gate itself
-became per client in the same change, because a shared one would have made namespaces unusable
-concurrently — one client's pool walk stalling every other client for a boundary the registry
-already provides.
+2026-08-19) — a handle routes only for its owner, the cap and the closed-session history are per
+client, and an `Mcp-Session-Id` another client holds is reported unknown — which left the gate
+arbitrating one credential racing *itself*: a second MCP session for one token, refused with a
+`409`. **Inside a namespace that is not a boundary**, because both of that credential's MCP sessions
+reach the same debug sessions. So the gate is gone, and what it cost is gone with it: a client that
+lost its session id to a crash or a restart was told `409` and had to wait out the grace, where
+adopting its own sessions was what it wanted and what ownership had made safe.
 
-**So what is left for it to arbitrate is one credential racing itself**: a second *MCP session* for
-one token — a fresh `initialize` while one is held or being opened, or a request bearing an id that
-is not the one it holds — which gets a `409`. Note what that is *not*: further requests carrying the
-session a credential already holds are served concurrently, `in_flight` and all, because that is how
-a `DELETE` arrives on one connection while a tool call runs on another. Connections were never the
-unit. The question this item is for is whether what remains is worth a gate, and it is a real
-question in both directions:
+**Retired, with the clock kept.** The question this item asked was whether idle release
+(`WINDBG_MCP_SESSION_IDLE_SECS`, #164) already covers the teardown the lease was kept for. It does
+not, and the measurement is two lines of `Sessions`: `release_idle` skips a session with a call
+outstanding — which is exactly the parked `attach_kernel` a vanished client leaves behind, since a
+park is one call that never returns — and it knows nothing about MCP sessions, so an abandoned one
+would stay resident in the service with its id accepted, one per reconnect cycle. `release_leased`
+does both. So the lease stays as a **clock**: any request renews it, an expiry releases that
+client's sessions and closes its MCP sessions, and the `releasing` refusal stays too, since it is
+the sweep's and not the gate's.
 
-- **For keeping it:** the lease is also what *releases* sessions when a client goes away without
-  saying goodbye. That is not tenancy, it is teardown, and a live kernel target left attached is the
-  expensive failure. Retiring the gate must not retire the sweep.
-- **For retiring it:** `2026-07-28` has no session id at all, so a stateless client never becomes
-  the holder — the gate is reasoning about an identifier its newest callers do not send, and since
-  #168 it explicitly stands aside for them. And the
-  contention it does catch is arguably the client's own business: a client that lost its session id
-  (a crash, a restart) and re-`initialize`s inside the grace is told `409` and has to wait the grace
-  out, where adopting its own sessions is what it wanted and what the identity now makes safe.
-- **It used to cost that client concurrency, and the fix is a preview of the deletion.** A request
-  carrying no session id took the *opening* path and held a claim for its whole duration, so two
-  overlapping ones from the same credential contended — and every request of such a client is that
-  path, since there is never an id to carry. At its sharpest, a kernel attach whose target never
-  dialled in locked its own credential out of `session_status` and `end_session`, the two calls that
-  recover it. That was [#168](https://github.com/glslang/windbg-mcp/issues/168), and it is fixed by
-  *not reserving* for a request that can never become the holder — which is this item's argument
-  applied to the one case where it was unarguable. What remains is the same question for the cases
-  that are arguable: a legacy client's second `initialize`, and a resume inside the grace.
+**The lease is still armed by an MCP session**, so a `2026-07-28` client still has no clock —
+deliberately, now that the credential could carry one. A lease releases everything that credential
+holds, busy or not, on the reasoning that a client silent for a grace has gone; a stateless client is
+legitimately silent for far longer than 390 seconds, and releasing a live kernel from under a caller
+who is thinking is worse than holding an abandoned one for the idle window. `docs/remote-listener.md`
+says so where it explains why both mechanisms exist.
 
-**What would settle it:** decide whether idle release (`WINDBG_MCP_SESSION_IDLE_SECS`, added in
-[#164](https://github.com/glslang/windbg-mcp/pull/164)) already covers the teardown the lease is
-kept for. If it does, the gate can go and the sweep stays; if it does not, say why in
-`docs/remote-listener.md` and keep both. Note the `releasing` refusal is *not* part of what would
-go: it is the sweep's, not the gate's, and a stateless request is refused by it like any other —
-told to ask again once the release is done.
+**Both rules this item said the deletion must not take with it survived, one of them by becoming
+unreachable.**
 
-**Two rules the deletion must not take with it**, both learned in review of
-[#169](https://github.com/glslang/windbg-mcp/pull/169) and both ending in a client losing sessions
-it was using — the sweep reads `deadline` alone and zeroes `in_flight` on its way past, so work
-actually running does not save them:
+- An **admitted** request renews an existing deadline and never creates one. It is no longer a rule
+  about stateless requests but the whole of what `admit` does, for every request shape — and both
+  refusals still return before the renewal, so a stream of wrong session ids cannot hold an
+  abandoned client's target open.
+- A reservation that minted nothing had to give its **deadline** back. Nothing arms a deadline before
+  a settled MCP session exists, so there is no clock for a request that takes nothing to hand back.
+  The test that pinned it is now `nothing_arms_a_clock_before_an_mcp_session_exists`.
 
-- a request the gate **admits** renews an existing deadline. The qualifier is load-bearing in both
-  directions: a credential that is plainly alive must not be swept mid-call, and a *refused* request
-  must not renew anything — `NotYours`, `Releasing` and `Occupied` all return before any deadline is
-  touched today. Renewing on arrival instead would let a stream of wrong session ids or repeated
-  `initialize`s hold an abandoned client's live kernel target open for ever, which is the failure
-  the sweep exists to prevent.
-- a reservation that mints nothing gives its **deadline** back, not just its claim. If reserving
-  goes away entirely this stops mattering; if it survives in any form, it still does.
+And the sweep's own safety turned out to be already enforced a layer below the machinery that was
+protecting it: a sweep fires only after a whole grace with nothing admitted, and `Lease::new` refuses
+a grace shorter than the longest a call can keep a client quiet — so no request of that credential's
+can still be in flight when its lease expires. That is what the claim generations and in-flight
+epochs were for, one level above the thing being protected, which is the pattern `DECISIONS.md`
+already named for this code.
 
-**Why deferred:** it is a deletion, and a deletion is the change most worth making on its own,
-against a PR that is not also adding the thing it would delete. Picks up at `src/listen.rs`
-(`Lease::admit`, `Lease::settle`) and the ~90 lease tests beside it.
+**What went:** `Tenancy` (now `Presence`), the reservation and `claims_issued`, `Admission::Occupied`
+and its `409`, `Settled::Stale` and the minted session it had to close, `InFlight`/`leave`/`epoch`,
+`farewell`/`try_give_up_for`, `Sessions::busy`, `Arriving`, `mints_no_session` and every read of
+`MCP-Protocol-Version`. A credential's MCP sessions became a **set**, because an id recorded for
+nobody is one any credential may present — tracking only the newest would have re-opened the hole
+the ownership check closes. Ninety lease tests became twenty; the ones that went were about
+sequencing a handover that no longer happens.
 
 ## 29. [windbg-mcp] The listener smoke tier only ever runs one, unnamed client
 
 Every listener assertion in `tests/mcp_smoke.rs` starts the server with a single
 `WINDBG_MCP_LISTEN_TOKEN`, so everything the tier proves is proved for the `local` client alone. The
 per-client behaviour — routing, the unknown-handle answer, per-client capacity and history, the
-per-client tenancy, the session-id ownership check — is covered by unit tests in `src/engine.rs`,
-`src/listen.rs` and `src/client.rs`, and by nothing end to end.
+per-client lease and the release that refuses only its own client, the session-id ownership check —
+is covered by unit tests in `src/engine.rs`, `src/listen.rs` and `src/client.rs`, and by nothing end
+to end.
 
 The gap has already cost one bug: the adoption diagnostic counted `local`'s sessions for a named
 client reconnecting, because the count was taken after the identity scope had closed. A unit test
@@ -926,7 +919,8 @@ pins the mechanism now, but the call site — an HTTP handler — is still unexe
 
 **What would close it:** a tier that starts the listener with two tokens (`…_TOKEN_CI` beside the
 unnamed one), opens a session as each, and asserts that neither can see, route to or end the
-other's; then walks one client through open → `DELETE` → reconnect-inside-the-grace and reads the
+other's — including the `404` for a request bearing the other's `Mcp-Session-Id`, which is now the
+only cross-client refusal there is; then walks one client through open → `DELETE` → reconnect-inside-the-grace and reads the
 adoption line back out of `server_log`. All of it is dump-tier work — none of it needs a live
 target.
 
@@ -936,26 +930,25 @@ call-site coverage rather than new claims. Picks up at the listener helpers in `
 ## 30. [windbg-mcp] Nothing covers a `2026-07-28` handshake that omits the protocol header
 
 rmcp allows a stateless `initialize` to arrive without `MCP-Protocol-Version` — it is the request
-that establishes the revision, so the header is optional on exactly that one. The listener therefore
-cannot classify it from the header, reads it as an **opener**, reserves, and then mints no session.
+that establishes the revision, so the header is optional on exactly that one. Nothing here drives
+that shape: `Listener::stateless_opening` sends the header, and stdio has no headers to omit.
 
-That path is real and was briefly a bug: the reservation gave back its claim and left its *deadline*
-armed, so a client's own handshake started a clock that released whatever it had since opened one
-grace later. It is fixed and unit-tested at the lease level
-(`a_reservation_that_minted_nothing_leaves_no_clock_running`), but nothing drives it **over HTTP**:
-`Listener::stateless_opening` sends the header, and stdio has no headers to omit, so the shape that
-caused it is the one shape the tier does not send.
+**The mechanism that made it a bug is gone**, which is most of what this item was for. The listener
+used to classify a request by that header, so a headerless handshake was read as an *opener*,
+reserved, minted nothing, and left its *deadline* armed — a client's own handshake starting a clock
+that released whatever it had since opened, one grace later. Item 28 deleted the classification and
+the reservation both: nothing arms a deadline before a settled MCP session exists, and the listener
+does not read the header at all. What is left to cover is that rmcp serves the shape and that the
+server behaves normally afterwards.
 
 **What would close it:** a listener assertion that opens with a headerless `2026-07-28` handshake
-and then works normally — a `tools/list` and a `tools/call`. That much is protocol-tier work and
-needs no target.
+and then works normally — a `tools/list` and a `tools/call`. Protocol-tier work, no target needed.
 
-The half that would exercise the regression *end to end* is not: seeing sessions survive the grace
-means having a session, which means an opener (`open_dump`), which means a real engine worker and
-therefore the **debugger tier** — the same rule the parked test was moved for. Split it that way
-rather than claiming the whole thing is cheap; a protocol-tier version on its own asserts that the
-handshake is served, not that nothing sweeps afterwards.
+The half that would watch a session *survive the grace* after such a handshake is not: having a
+session means an opener (`open_dump`), which means a real engine worker and therefore the **debugger
+tier** — the same rule the parked test was moved for. It is also the half that no longer has a
+mechanism to catch, so it is worth doing only if the arming rule ever grows a second arm.
 
-**Why deferred:** the mechanism is pinned where it is decided, so this buys call-site coverage of a
-path the server now handles correctly rather than a new claim. Picks up at the listener helpers in
-`tests/mcp_smoke.rs`, beside `the_listener_serves_the_stateless_revision_it_negotiates`.
+**Why deferred:** it buys call-site coverage of a path whose hazard has been deleted rather than
+handled. Picks up at the listener helpers in `tests/mcp_smoke.rs`, beside
+`the_listener_serves_the_stateless_revision_it_negotiates`.

--- a/README.md
+++ b/README.md
@@ -234,11 +234,10 @@ target before exiting, because a live kernel that is merely killed is left froze
 against a live kernel, and the token is sent in clear — a hypervisor's guest network is not private
 when the machine being debugged shares it. [`docs/remote-listener.md`](./docs/remote-listener.md)
 covers the tokens — **one per client**, each with its own sessions, so two people or two agents on
-one listener cannot reach each other's targets — the session lease and its grace, and what a `409`
-means (one credential asking for a second MCP session, never a second client, and never a request on
-a second connection — those are served concurrently, as are a `2026-07-28` client's, which have no
-session to ask twice for, except while that credential's own expired sessions are still being
-released). For a one-off, [`docs/remote-phase0.md`](./docs/remote-phase0.md) does the same
+one listener cannot reach each other's targets — the session lease and its grace, and the one thing
+a `409` means: this credential's own expired sessions are still being released, so ask again in a
+moment. Nothing else is refused for contention — a credential may hold several MCP sessions, and
+requests of one client never wait on another's. For a one-off, [`docs/remote-phase0.md`](./docs/remote-phase0.md) does the same
 job over plain `ssh` with no listener.
 
 ### As a Claude Code plugin

--- a/docs/remote-listener.md
+++ b/docs/remote-listener.md
@@ -133,14 +133,12 @@ caller. The bound is the sum because an opener spends up to 30 s bringing a work
 call budget starts. If the server refuses to start, that message is why; raise the grace or lower
 the call timeout.
 
-**Saying goodbye starts the grace; it does not end it.** A `DELETE` gives up the tenancy — the next
-client is served once the departing one's work has drained, rather than after a whole grace period
-(`Lease::try_give_up` holds it while a request is in flight or a worker is still busy, so a `409`
-just after a `DELETE` is that, not a failure) — but the sessions that client opened stay open for
-one more grace period, and its engine worker processes with them. That is the adoption case below,
-reached deliberately: a client that restarts is the common reason a client says goodbye, and making
-it pay a fresh `attach_kernel` would defeat the property this whole arrangement is for. If you are
-really done, end the sessions first: `end_session` releases **one** target — the one you name, or the
+**Saying goodbye starts the grace; it does not end it.** A `DELETE` closes the MCP session it
+names, and the clock starts — but the debug sessions that client opened stay open for one more grace
+period, and their engine worker processes with them. That is the adoption case below, reached
+deliberately: a client that restarts is the common reason a client says goodbye, and making it pay a
+fresh `attach_kernel` would defeat the property this whole arrangement is for. If you are really
+done, end the sessions first: `end_session` releases **one** target — the one you name, or the
 current one — so a client holding several has to call it for each, and `session_status` is what
 lists them. That is the difference between a live kernel that is free and one still owned for the
 next 390 seconds.
@@ -148,8 +146,8 @@ next 390 seconds.
 **A returning client adopts what it left.** Sessions are not released the moment a client goes
 away, so reconnecting inside the grace finds them still open — which is better than stdio, where a
 client restart costs a KDNET attach, and a KDNET attach costs a reboot of the target. The log says
-how many sessions were inherited when that happens — or that nothing was open, since a client can
-also arrive to find the previous one had let go of an empty server.
+how many sessions were inherited when that happens — or that nothing was open, since a credential
+can also come back to find the MCP session it let go of had nothing open behind it.
 
 ## A session nobody is using is released
 
@@ -157,12 +155,19 @@ The lease answers "has this *client* gone away". There is a second question it c
 the revision most clients now negotiate it is the only one left: **has anyone touched this session
 at all?**
 
-`2026-07-28` removed the protocol-level MCP session ([SEP-2567]), so no `Mcp-Session-Id` is minted
-and the lease — which
-identifies a client by exactly that header — never takes a holder. A client that vanishes on that
-revision leaves its targets held until this process exits, which for a live kernel means a machine
-owned by nobody. See [#162](https://github.com/glslang/windbg-mcp/issues/162) for the whole of it;
-this is the half that needs no client identity and so keeps working whatever the transport does.
+`2026-07-28` removed the protocol-level MCP session ([SEP-2567]), and a lease is armed by one — so a
+client on that revision is never given a clock. A client that vanishes there would leave its targets
+held until this process exits, which for a live kernel means a machine owned by nobody. See
+[#162](https://github.com/glslang/windbg-mcp/issues/162) for the whole of it; this is the half that
+needs no client identity and so keeps working whatever the transport does.
+
+**Not fixed by arming the lease from the credential instead**, which is now what identifies a
+client and could perfectly well carry a clock. The two mechanisms answer different questions on
+purpose. A lease releases *everything* that credential holds, busy sessions included, on the
+reasoning that a client silent for a grace has gone; a `2026-07-28` client is legitimately silent
+for far longer than 390 seconds — a model thinking between calls — and releasing a live kernel from
+under a caller who is merely thinking is a worse failure than holding an abandoned one for half an
+hour.
 
 | | |
 | --- | --- |
@@ -211,9 +216,9 @@ What ownership buys, and it is the whole of it:
 | Reclamation | a session is only ever reclaimed to make room for **its own** client |
 | History | a closed session ages out of `session_status` on its **own** client's churn, not the server's |
 | The log | `server_log` shows the caller's sessions' records, plus the supervisor's own, which name no session — and the buffer counts it reports are over the records that caller can read |
-| Lease expiry | releases the sessions of the client whose lease ran out, and no others |
-| Session ids | an `Mcp-Session-Id` another client holds is reported **unknown**, before this caller's own tenancy is consulted |
-| Contention | **within** a client only — one client's long call does not make another wait |
+| Lease expiry | releases the sessions of the client whose lease ran out, and no others — and refuses only that client's requests while the release runs |
+| Session ids | an `Mcp-Session-Id` another client holds is reported **unknown**, before this caller's own lease is consulted at all |
+| Contention | none — no client waits on another, and no client waits on itself |
 
 **Why authentication is the identity.** `2026-07-28` removed the protocol-level MCP session
 ([SEP-2567]), so there is no session id to key on; requests arrive on whatever socket a client's
@@ -222,42 +227,35 @@ requests. The credential is what is left, and it is what every other stateless H
 a client presents for itself would be a label; a name only the holder of a token can present is a
 boundary.
 
-**Two clients do not queue behind each other.** The lease still arbitrates *within* a client — a
-second **MCP session** for one token contends, and gets a `409` — because that is one credential
-racing itself. Across clients there is nothing to arbitrate: a pool walk that keeps one client busy
-for four minutes used to make every other client wait, for a boundary the registry now provides
-properly.
+**Nothing queues behind anything.** Two clients never did after ownership landed, and since
+`FOLLOWUPS.md` item 28 was settled a client does not queue behind *itself* either: the tenancy gate
+is gone. It refused a credential a second **MCP session** — a fresh `initialize` while it held one,
+or a request bearing an id that was not the one it held — with a `409`. That was the whole boundary
+once, when handles were minted from one registry, the cap was shared and `end_session` ended
+whatever it was handed. Ownership took the job over, and what the gate had left to arbitrate was one
+credential racing itself, which inside its own namespace is not a boundary at all: both MCP sessions
+reach the same debug sessions, because they are the same client.
 
-A `409` is never about *connections*. Requests carrying the session a credential already holds are
-served concurrently, which is what lets a `DELETE` arrive on one connection while a tool call runs
-on another — the topology every streamable-HTTP client uses. What it refuses is a second MCP session
-for one credential: a fresh `initialize` while a session is held or being opened, or a request
-bearing an id that is not the one it holds. A request that arrives while another of the same
-credential's is still *opening* one is refused on the same grounds, which is why the body names both.
+So a credential may hold several MCP sessions, and each is recorded — an id owned by nobody is one
+*any* credential may present, and the answer to another client's id is still **unknown**.
 
-**A client on a sessionless revision contends with nothing.** `2026-07-28` removed the session
-([SEP-2567]), so such a client can never become the holder the gate arbitrates — and a request that
-cannot become one reserves nothing. It used to: every stateless request took the *opening* path, so
-any two that overlapped got a `409`, and a call that parked took its whole credential with it. That
-was [#168](https://github.com/glslang/windbg-mcp/issues/168), and it is fixed; the tier that pins it
-runs a `tools/list`, a `session_status` and an `end_session` alongside a kernel attach that never
-comes back.
+**What a `409` means now, and it is the only one left.** After a lease runs out, that credential's
+sessions are released in the background, and a request arriving during the cleanup is refused while
+it holds nothing at all — the body names the release, because the fix is to ask again in a moment
+rather than to go looking for a session you do not have. Nothing else here answers `409`: an id
+this server never issued is a `404` from the MCP service, and one another client holds is the same
+`404`, deliberately — the answer must not confirm a session the caller may not touch.
 
-This is about the revision, not about the header being absent. A client on a revision that *has*
-sessions and sends no id is opening one — an `initialize`, or a resume — and still takes the
-opening path, `409` and all.
-
-What is left of the gate for such a client is the teardown: a request arriving while its own expired
-sessions are being released is refused with the `409` below and should ask again once the release
-is done. Whether the rest of the gate earns its place is `FOLLOWUPS.md` item 28.
+**A client on a sessionless revision is refused less still.** `2026-07-28` sends no id, so it can
+never present one that is not its own, and the only thing it can be told to wait for is its own
+release. It used to be told far more: every request took the gate's *opening* path, so any two that
+overlapped got a `409`, and a kernel attach whose target never dialled in locked its whole
+credential out of `session_status` and `end_session` — the two calls that recover it. That was
+[#168](https://github.com/glslang/windbg-mcp/issues/168), fixed by not reserving for a request that
+could never become the holder, and the classification behind it is gone with the gate.
 
 Such a client also never installs a lease at all, which is why abandonment on this revision is the
 idle release's job rather than the grace's — see *A session nobody is using is released*, above.
-
-**One `409` means the opposite of the others**, and says so: after a lease runs out, the sessions are
-released in the background, and a request arriving during that cleanup is refused while the
-credential holds nothing at all. Its body names the release rather than a session, because the fix
-is to ask again in a moment rather than to go looking for a session you do not have.
 
 **This does not authorise anything beyond separation.** Every client that can authenticate has the
 whole tool surface, including `execute` and `launch`. Tokens separate clients from each other; they

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -414,7 +414,7 @@ reach is the wiring, which is what these assert against a real listener on a loo
 hand-written HTTP client (a library that normalised a `409` into an exception, or hid the session
 header, would be asserting on this server's behalf).
 
-Six of them need no debugger, because tenancy is decided before any session is opened. All six
+Six of them need no debugger, because none of them needs a session to be open. All six
 run a listener holding a **single, unnamed** token, so what they prove they prove for the `local`
 client alone; the per-client rules are unit-tested where they are decided, and closing that
 end-to-end gap is [`FOLLOWUPS.md`](../FOLLOWUPS.md) item 29:
@@ -423,19 +423,23 @@ end-to-end gap is [`FOLLOWUPS.md`](../FOLLOWUPS.md) item 29:
   every tool here, including the ones that write to a live kernel; a quiet default would be a
   server nobody knows is open.
 - *An unauthenticated request is refused, told nothing about what is here, and **costs the server
-  nothing***. The last clause is the one worth a test: the bearer check runs before the tenancy
-  gate, so a wrong token must not reserve or consume a claim — if it did, anything that could
-  reach the port could lock the real client out without ever authenticating.
-- *A second **MCP session** for the same credential is refused with `409`*, whether it asks with a
-  fresh `initialize` or with a session id that is not the one it holds, and the holder is undisturbed
-  by either. Since 2026-08-19 the tenancy is per client, so this is one credential racing itself: a
-  *different* client is served concurrently and shares nothing with this one, and so are further
-  requests carrying the session this one already holds — which is what lets a `DELETE` arrive while
-  a tool call is still running.
+  nothing***. The last clause is the one worth a test: the bearer check runs before the lease is
+  touched, so a wrong token must not renew one or reach the state behind it. It mattered more
+  sharply while the gate existed — a request that reserved kept every other request of that
+  credential out, so anything that could reach the port could lock the real client out without ever
+  authenticating.
+- *A credential's second **MCP session** is served alongside its first.* This was a `409` until the
+  tenancy gate was retired (2026-08-20, [`FOLLOWUPS.md`](../FOLLOWUPS.md) item 28): with sessions
+  owned per client, a credential opening a second MCP session contests nothing — both reach the same
+  debug sessions, because they are the same client. Both are exercised, and the assertion underneath
+  is that an id **this server never issued** is still not served. An id *another client* holds is
+  refused too; that needs two tokens, so it is unit-tested and is part of item 29's gap.
 - *Going quiet is not leaving; saying goodbye is.* Every request is its own connection — which is
-  what a client behind a tunnel looks like — so silence is the resting state, and a server that
-  read it as departure would hand the registry on between two calls of a working client. A
-  `DELETE` does hand it on.
+  what a client behind a tunnel looks like — so silence is the resting state, and a server that read
+  it as departure would release a working client's targets between two of its calls. Returning with
+  the id it left with is served; after a `DELETE` that id is not. The second half used to be read off
+  the `409` a second `initialize` got while the first was held, which is exactly what no longer
+  happens.
 - *`2026-07-28` is served — the handshake **and** everything after it.* The revision current clients
   negotiate has no session id
   ([SEP-2567](https://modelcontextprotocol.io/seps/2567-sessionless-mcp)), so it exercises the
@@ -457,8 +461,9 @@ its own calls is parked*. The park is a **kernel attach nothing will answer**, a
 runs alongside it is the recovery path itself — `tools/list`, `session_status`, `end_session`, the
 last checked for a tool error as well as an HTTP status, since a refusal inside the call also
 arrives on a `200`. It polls the attach to the `attaching` state rather than sleeping towards it: an
-attach that failed fast leaves a kernel record a laxer check would accept, and nothing would be
-holding a claim to contend with. It lives here rather than above because without `dbgeng.dll` the
+attach that failed fast leaves a kernel record a laxer check would accept, and there would be
+nothing parked to contend with. The mechanism that made it contend is gone with the gate; the
+property is the client's, so the test stays. It lives here rather than above because without `dbgeng.dll` the
 attach fails during initialisation instead of parking, which would quietly turn a test about a call
 that does not return into one about a call that failed. Budget ~21s, most of it the worker coming
 up and the `end_session` that terminates it.

--- a/src/client.rs
+++ b/src/client.rs
@@ -17,6 +17,11 @@
 //! client opened it. A name that another client cannot present is a boundary; a name it chooses for
 //! itself would be a label.
 //!
+//! That boundary is the only one left. The gate that served one client at a time has since been
+//! retired outright (`FOLLOWUPS.md` item 28): once a session belongs to a client, one credential
+//! opening a second MCP session contests nothing — both reach the same debug sessions, because
+//! they are the same client.
+//!
 //! # How it reaches a tool
 //!
 //! The same way a progress sink does, and for the same reason: the identity is known at the

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -414,10 +414,11 @@ pub struct Session {
     ///
     /// The registry is one map for the whole server — handles are minted from it, the cap is
     /// shared, and `end_session` ends what it is handed — so two clients on one listener could see
-    /// and end each other's targets. The tenancy gate stood in for a boundary by serving one client
-    /// at a time, and `2026-07-28` removed the identifier that gate was keyed on
+    /// and end each other's targets. The listener's tenancy gate stood in for a boundary by serving
+    /// one client at a time, and `2026-07-28` removed the identifier that gate was keyed on
     /// ([#162](https://github.com/glslang/windbg-mcp/issues/162)). Recording the owner makes the
-    /// separation a property of the registry rather than of how many clients are let in.
+    /// separation a property of the registry rather than of how many clients are let in — which is
+    /// what let the gate be retired entirely.
     ///
     /// Always [`crate::client::Client::LOCAL`] under stdio, so the rules below are uniform rather
     /// than conditional.
@@ -1054,18 +1055,6 @@ impl Sessions {
         }
     }
 
-    /// Every session, newest first, as `session_status` reports them.
-    /// Whether any live session still has work the engine has not finished.
-    ///
-    /// **Not the same question as "is anyone waiting for it".** A job outlives the wait for it —
-    /// [`Self::call_as`] cancels only the waiter, and says so — so a dropped request, a timeout, or
-    /// a client that vanished all leave a job running against a target. Anything deciding it is
-    /// safe to hand that target to somebody else has to ask this, not whether the caller is still
-    /// there. See [`crate::listen`], which is the caller that has to.
-    pub fn busy(&self) -> bool {
-        self.registry().live().iter().any(|session| session.busy())
-    }
-
     /// Every session id the calling client owns, live or settled.
     ///
     /// For `server_log`, which reads one ring for the whole server: a record naming a session is
@@ -1610,9 +1599,10 @@ impl Sessions {
     /// server that can never debug anything again.
     ///
     /// The caller owns the race this leaves open. Nothing stops a session registering behind the
-    /// snapshot, so this must only be called once the tenancy gate says no client holds the
-    /// server — otherwise a client connecting exactly as the grace expires could have the session
-    /// it just opened released underneath it.
+    /// snapshot, so the listener marks that client's lease `releasing` under the same lock that
+    /// read its deadline, and refuses its requests until this returns — otherwise a client
+    /// connecting exactly as its grace expires could have the session it just opened released
+    /// underneath it.
     pub async fn release_leased(&self, owner: &crate::client::Client) {
         self.release_workers_of(Teardown::Lease, Some(owner)).await
     }
@@ -1692,8 +1682,8 @@ impl Sessions {
         // approximate.
         //
         // That guarantee is bought by `closing` and so belongs to shutdown alone; a lease release
-        // does not get it, which is why the tenancy gate has to stand in for it (see
-        // [`Self::release_leased`]).
+        // does not get it, which is why the listener has to shut that client out for the duration
+        // (see [`Self::release_leased`]).
         //
         // Every session that still *owns a worker*, not every live one. A session claimed for
         // reclamation is already `Closed` while its release runs in the background, and a

--- a/src/listen.rs
+++ b/src/listen.rs
@@ -31,16 +31,33 @@
 //!   than stdio, where a client restart costs a KDNET attach — and a KDNET attach costs a reboot
 //!   of the target.
 //!
-//! ## One client at a time
+//! ## A clock, and no longer a gate
 //!
-//! The registry is global: `session_id` handles are minted from it, `MAX_SESSIONS` is shared, and
-//! `end_session` will end anything it is handed. None of that is scoped to a client, so two clients
-//! would silently share — and one could end a target the other was using. Rather than pretend
-//! otherwise, a second client is refused while the first holds the server. The bearer token is the
-//! identity: there is one authorised client, so anyone presenting the token *is* that client, and a
-//! reconnect needs nothing further to prove.
+//! The lease used to arbitrate as well as time. The registry was one map for the whole server —
+//! handles minted from it, `MAX_SESSIONS` shared, `end_session` ending whatever it was handed — so
+//! serving one client at a time *was* the boundary between two clients, and a second one was
+//! refused with a `409`.
+//!
+//! Ownership took that job over ([#162]). A session belongs to the client that opened it, a handle
+//! routes only for its owner, and the cap, the closed-session history and this lease's own release
+//! are all per client. What the gate had left to arbitrate was one credential racing *itself* — a
+//! second `initialize` while it held one, or a request bearing an id that was not the one it
+//! held — and inside a namespace that is not a boundary at all: both MCP sessions reach the same
+//! debug sessions, because they are the same client. So the gate is gone, along with the
+//! reservation, the in-flight count and the handover they existed to sequence.
+//!
+//! Two refusals remain, and neither of them was ever tenancy:
+//!
+//! - an `Mcp-Session-Id` **another client** holds is reported unknown ([`Admission::NotYours`]).
+//!   The MCP service keeps one session table for the whole server, so that id is all that stands
+//!   between a client and another's MCP session — and a `DELETE` on it is the sharp end.
+//! - a request arriving while this credential's own expired sessions are still being released is
+//!   told to ask again ([`Admission::Releasing`]). That is the sweep's, not the gate's: what it
+//!   protects is the window between deciding to release and having released.
+//!
+//! [#162]: https://github.com/glslang/windbg-mcp/issues/162
 
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 use std::convert::Infallible;
 use std::future::Future;
 use std::net::SocketAddr;
@@ -55,7 +72,6 @@ use hyper::header::AUTHORIZATION;
 use hyper::service::service_fn;
 use hyper::{Request, Response, StatusCode};
 use hyper_util::rt::TokioIo;
-use rmcp::model::ProtocolVersion;
 use rmcp::transport::streamable_http_server::SessionManager;
 use rmcp::transport::streamable_http_server::session::local::LocalSessionManager;
 use rmcp::transport::streamable_http_server::{StreamableHttpServerConfig, StreamableHttpService};
@@ -156,11 +172,17 @@ const SWEEP: Duration = Duration::from_secs(5);
 
 /// How long a session may go unused before it is released, and the variable that overrides it.
 ///
-/// **The lease cannot cover this any more.** It identifies a client by `Mcp-Session-Id`, and
-/// SEP-2567 removed sessions from `2026-07-28` — the revision most clients now negotiate — so on
-/// that revision no holder is ever installed and no lease ever expires. A client that vanishes
-/// would leave its targets held until the process ended, which for a live kernel means a machine
-/// owned by nobody ([#162](https://github.com/glslang/windbg-mcp/issues/162)).
+/// **The lease cannot cover this.** A lease is armed by an MCP session, and SEP-2567 removed those
+/// from `2026-07-28` — the revision most clients now negotiate — so a client on that revision never
+/// gets a clock at all. Without this, one that vanished would leave its targets held until the
+/// process ended, which for a live kernel means a machine owned by nobody
+/// ([#162](https://github.com/glslang/windbg-mcp/issues/162)).
+///
+/// Not fixed by identifying the client differently, which the credential now does. The lease
+/// releases *everything* a client has, busy or not, on the reasoning that a client which has said
+/// nothing for a grace has gone; a `2026-07-28` client is quiet for far longer than that
+/// legitimately, and releasing a live kernel under a caller who is merely thinking is worse than
+/// holding an abandoned one for half an hour.
 ///
 /// Deliberately much longer than the lease grace. A lease is renewed by *any* request, so a working
 /// client renews it constantly; this is per session, and a caller reading a stack for twenty minutes
@@ -169,40 +191,15 @@ const SWEEP: Duration = Duration::from_secs(5);
 const IDLE_RELEASE: Duration = Duration::from_secs(30 * 60);
 const IDLE_ENV: &str = "WINDBG_MCP_SESSION_IDLE_SECS";
 
-/// The header carrying a client's MCP session, which is what identifies the holder.
+/// The header carrying an MCP session id, on the revisions that still have one.
+///
+/// Read for two things, both of them ownership rather than tenancy: whether the id a request
+/// presents belongs to some *other* client, and which ids a client that vanished left resident in
+/// the service for the sweep to close. `2026-07-28` sends none ([SEP-2567]) and needs none — the
+/// credential is the identity on every revision, and on both transports ([`crate::client`]).
+///
+/// [SEP-2567]: https://modelcontextprotocol.io/seps/2567-sessionless-mcp
 const SESSION_HEADER: &str = "Mcp-Session-Id";
-
-/// The header naming the revision a request is on.
-///
-/// `2026-07-28` carries in every request what the handshake used to settle once, and this is the
-/// part of that the gate needs: whether a session id is coming.
-const PROTOCOL_HEADER: &str = "MCP-Protocol-Version";
-
-/// Whether this request is on a revision that mints no `Mcp-Session-Id`.
-///
-/// Read from a header because the gate never parses a body — it hands the request to rmcp intact,
-/// and buffering it here to look would be a copy of every tool call's arguments for one bit.
-///
-/// **Matched against the revisions rmcp knows, rather than compared as a string.** The comparison
-/// is lexicographic and that is correct for revisions, which are ISO dates — but a header that is
-/// not a revision at all (`draft`) sorts above every date, and would be read as newer than the
-/// newest thing there is. Anything unrecognised is treated as a revision that has sessions, which
-/// is the answer that costs a wrong guess least: it reserves, as this gate always did.
-///
-/// An `initialize` may legitimately arrive without this header — it is the request that establishes
-/// the revision — so a stateless client's *first* request still reserves. That costs nothing: it
-/// mints no session, so [`Lease::settle`] gives the reservation straight back.
-fn mints_no_session(headers: &hyper::HeaderMap) -> bool {
-    headers
-        .get(PROTOCOL_HEADER)
-        .and_then(|value| value.to_str().ok())
-        .and_then(|value| {
-            ProtocolVersion::KNOWN_VERSIONS
-                .iter()
-                .find(|known| known.as_str() == value)
-        })
-        .is_some_and(|version| *version >= ProtocolVersion::V_2026_07_28)
-}
 
 /// Whether this process was asked to listen, and where.
 pub fn requested(args: &[String]) -> Option<Result<SocketAddr>> {
@@ -217,217 +214,121 @@ pub fn requested(args: &[String]) -> Option<Result<SocketAddr>> {
     })
 }
 
-/// The lease: who holds this server, and until when.
+/// A client's lease: what that credential has open here, and until when.
 ///
-/// One lock over both, because they are one decision. "Is there a holder" and "has it expired" read
-/// together or a request can be admitted against a holder the sweeper is releasing.
+/// One lock over all of it, because the questions are one decision. "Does this credential hold
+/// anything" and "has its clock run out" have to read together, or a request is admitted against
+/// sessions the sweeper has already decided to release.
 struct Lease {
     grace: Duration,
-    /// Consulted before tenancy changes hands, never for anything else.
+    /// Consulted for the adoption line and nothing else.
     ///
-    /// The listener otherwise knows nothing about debug sessions — but "may this client have the
-    /// server" cannot be answered from HTTP alone, because an engine job outlives the request that
-    /// asked for it.
+    /// The listener otherwise knows nothing about debug sessions and does not need to: an expiry
+    /// hands the registry a *client* and lets it find them, and what this reads back is how many
+    /// were still there — the difference between "you picked up three targets" and "nothing was
+    /// open".
     sessions: Sessions,
-    /// One tenancy per client, rather than one for the server.
+    /// One lease per client, rather than one for the server.
     ///
-    /// The gate was written when the registry was global: a second client could see and end the
-    /// first's targets, so serving one at a time *was* the boundary. Sessions are owned now
-    /// ([#162](https://github.com/glslang/windbg-mcp/issues/162)), and a shared gate would only
-    /// mean that one client's long call — a pool walk, an `!analyze` — makes every other client
-    /// wait for a boundary it no longer provides. Contention within a client is still real and
-    /// still arbitrated; contention *between* them was never about safety.
-    state: Mutex<HashMap<crate::client::Client, Tenancy>>,
+    /// Sessions are owned ([#162](https://github.com/glslang/windbg-mcp/issues/162)), so one
+    /// credential's clock says nothing about anybody else's: an expiry releases the sessions of the
+    /// credential whose lease ran out, and a release in flight refuses that credential's requests
+    /// and no others. A shared one would mean a client waiting on a boundary the registry already
+    /// provides.
+    state: Mutex<HashMap<crate::client::Client, Presence>>,
 }
 
+/// What one credential has here, and until when.
 #[derive(Debug, Default)]
-struct Tenancy {
-    /// The MCP session that owns this server. `None` while nobody is attached — which is *not* the
-    /// same as nothing being open, since a departed client's sessions live on until `deadline`.
-    holder: Option<String>,
-    /// The claim currently reserving the server, if any.
+struct Presence {
+    /// The MCP sessions this credential has open in the service.
     ///
-    /// Without a reservation the gate only *observes* tenancy, and two `initialize` requests
-    /// arriving together both see a vacant server, both get sessions, and the second silently
-    /// replaces the first as holder while the first stays serviceable — two clients on a registry
-    /// whose handles, capacity and `end_session` are all global.
+    /// A **set**, rather than the one holder the gate allowed, because nothing refuses a second
+    /// `initialize` any more — and two MCP sessions of one credential reach the same debug
+    /// sessions, since they are the same client. They are recorded all the same, for the two things
+    /// that need to know whose an id is: refusing another client's ([`Admission::NotYours`]), and
+    /// closing what a client that vanished left resident in the service. Tracking only the newest
+    /// would leave its older ids owned by nobody, and an id owned by nobody is one any credential
+    /// may present.
     ///
-    /// It is an **identity** rather than a flag because a reservation can outlive its usefulness: a
-    /// request still inside `mcp.handle` when the grace runs out has its claim cleared, the sweep
-    /// finishes, and a newer client claims the server — and the old request then arrives at
-    /// `settle` with no way to know it is no longer the one being waited for. A generation lets
-    /// `settle` check that the reservation it is resolving is still its own.
-    claim: Option<u64>,
-    /// Source of the generation above. Monotonic, so a cleared claim is never re-issued.
-    claims_issued: u64,
-    /// A lease has run out and its sessions are being released.
+    /// How many it holds is the client's own doing — the service keeps a session apiece regardless,
+    /// so this mirrors rather than accumulates — and an expiry closes the lot.
     ///
-    /// Held across the release, because the teardown is not instant: clearing the holder and then
-    /// releasing would leave a window where the server looks vacant and a new client can start
-    /// using a session the sweeper is about to close underneath it.
+    /// Empty for a `2026-07-28` client, which is sent no id at all — and so is never given a clock
+    /// either. Abandonment there is [`IDLE_RELEASE`]'s, per session and far longer.
+    mcp: BTreeSet<String>,
+    /// This credential's lease has run out and its sessions are being released.
+    ///
+    /// Held across the release, because the teardown is not instant: deciding to release and having
+    /// released are two moments, and in between a request must not be let in to a session this
+    /// sweep is closing. That is the window [`Sessions::release_leased`] warns it does not close
+    /// itself.
     releasing: bool,
-    /// When the sessions are released if nothing renews first. `None` means there is nothing to
-    /// release and nothing to wait for.
+    /// When this credential's sessions are released if nothing renews first. `None` means there is
+    /// nothing to release and nothing to wait for.
+    ///
+    /// Armed only by a request that turned out to have an MCP session behind it
+    /// ([`Lease::settle`]), never by one merely arriving: a deadline with nothing behind it is a
+    /// lease against nothing, and one grace later it releases whatever that credential has since
+    /// opened.
     deadline: Option<Instant>,
-    /// Requests admitted under the current holder that have not finished yet.
+    /// This credential has let go of its last MCP session while its debug sessions are still open,
+    /// waiting to be adopted by its next one or swept.
     ///
-    /// MCP over HTTP is not one connection: a client can send `DELETE` on one while a tool call is
-    /// still running on another. Handing the server to the next client at that moment would leave
-    /// the old call executing against sessions the new client now owns — free to mutate or end a
-    /// target that is no longer its own.
-    in_flight: usize,
-    /// The holder said goodbye while work it admitted was still running.
-    ///
-    /// Tenancy is given up when that work drains, not when the `DELETE` arrives.
-    farewell: bool,
-    /// Which tenancy the counters above belong to.
-    ///
-    /// Bumped whenever a teardown discards them. An in-flight guard carries the epoch it was
-    /// admitted under and subtracts nothing from a later one — without that, a request that
-    /// outlived its grace decrements the *next* holder's count when it finally returns, which can
-    /// drive that count to zero while a tool call is still running and let a concurrent goodbye
-    /// hand the registry to somebody else mid-call.
-    epoch: u64,
-    /// A previous client's sessions are still open, waiting to be adopted or swept.
-    ///
-    /// Tracked rather than inferred from `deadline`. It was inferred, until reserving a claim
-    /// started arming that deadline too — at which point every first client looked like it was
-    /// inheriting sessions that did not exist.
+    /// Tracked rather than inferred from `deadline`, so the adoption line says something true: it
+    /// is the difference between "you picked up what you left" and "you are the first one here".
     left_open: bool,
 }
 
 /// What a swept lease left behind.
 #[derive(Debug, PartialEq, Eq)]
 struct Expired {
-    /// The MCP session still open at the moment the lease ran out — a client that vanished rather
-    /// than saying goodbye. `None` when it sent a DELETE, which already closed it.
+    /// The MCP sessions still open when the lease ran out — a client that vanished rather than
+    /// saying goodbye. Empty when it said goodbye to each of them, since a `DELETE` closes one.
     ///
-    /// Reported so the sweeper can close it in the service too. Releasing the debug sessions alone
-    /// would leave that MCP session resident and its id still accepted, and every reconnect cycle
-    /// would add another.
-    holder: Option<String>,
+    /// Reported so the sweeper can close them in the service too. Releasing the debug sessions
+    /// alone would leave those MCP sessions resident and their ids still accepted, and every
+    /// disconnect-and-reconnect cycle would add another that no lease will ever sweep again.
+    mcp: Vec<String>,
 }
 
-impl Tenancy {
-    /// Reserves the server for a request that is on its way to becoming the holder.
-    ///
-    /// Renewing the deadline is the load-bearing half. A claim admitted near the end of a grace
-    /// would otherwise be adopting sessions the sweeper is entitled to release while
-    /// `mcp.handle` is still running — the client would be handed a target that is being let go.
-    fn claim(&mut self, grace: Duration) -> u64 {
-        self.claims_issued += 1;
-        self.claim = Some(self.claims_issued);
-        self.deadline = Some(Instant::now() + grace);
-        self.claims_issued
-    }
-}
-
-/// Counts an admitted request out again when it ends.
+/// What this listener decided about one request before the MCP service saw it.
 ///
-/// A guard rather than a call at each return, because the path that matters most has no return at
-/// all: a connection dropped inside `mcp.handle` cancels the future, and an explicit decrement
-/// would simply not run — leaving the holder's count permanently above zero and its goodbye
-/// deferred for ever.
-struct InFlight {
-    lease: Arc<Lease>,
-    /// Whose tenancy this request was admitted under — the count it has to be taken out of.
-    owner: crate::client::Client,
-    epoch: u64,
-}
-
-impl Drop for InFlight {
-    fn drop(&mut self) {
-        self.lease.leave(&self.owner, self.epoch);
-    }
-}
-
-/// What became of a request's reservation.
-#[derive(Debug, PartialEq, Eq)]
-enum Settled {
-    /// Tenancy is as this request left it, and the response stands.
-    Kept {
-        /// Whether this client picked up sessions a previous one left open.
-        adopted: bool,
-    },
-    /// This request no longer owns the server: its claim was swept while it was being handled, or
-    /// a teardown started under it. Anything it produced has to be undone — the service may have
-    /// minted a session for a client that is not the holder, and nothing else will ever close it.
-    Stale,
-}
-
-/// A request the gate let through, and what it was let through *as*.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-struct Admitted {
-    /// The claim this request reserved, if it reserved one — which [`Lease::settle`] must present
-    /// to change tenancy.
-    claim: Option<u64>,
-    /// The tenancy it was admitted under, which [`Lease::leave`] must present to count it out.
-    epoch: u64,
-}
-
-/// What a request presents to the gate, which is all tenancy is decided from.
-///
-/// Three cases rather than `Option<&str>`, because the absence of a session id stopped meaning one
-/// thing. It used to mean "a client opening a session"; since [SEP-2567] removed the session from
-/// `2026-07-28` it also means "a client that will never have one", and those two want opposite
-/// answers — the first is the only moment tenancy is contested, and the second contests nothing.
-///
-/// [SEP-2567]: https://modelcontextprotocol.io/seps/2567-sessionless-mcp
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum Arriving<'a> {
-    /// An `Mcp-Session-Id` the client is presenting.
-    Holding(&'a str),
-    /// No session id, and no revision header naming one that has none.
-    ///
-    /// Chiefly a legacy `initialize`. It is also where a `2026-07-28` handshake lands when it omits
-    /// `MCP-Protocol-Version` — legal, since that request is the one *establishing* the revision —
-    /// so an `Opening` claim may mint nothing at all, and [`Lease::settle`] has to give back its
-    /// deadline as well as its claim.
-    ///
-    /// Not a resume: a client picking up what it left inside the grace presents the id it held, so
-    /// it arrives as [`Self::Holding`] even though nobody currently holds the server. That case
-    /// reserves too, and for the same reason this one does.
-    Opening,
-    /// No session id, and none is coming.
-    Stateless,
-}
-
-/// What the tenancy gate decided about one request.
+/// Both refusals are about *whose* sessions are involved, not about how many clients may be served
+/// at once — the question the gate used to answer, and that ownership answers now.
 #[derive(Debug, PartialEq, Eq)]
 enum Admission {
     /// Hand it to the MCP service.
-    Serve(Admitted),
-    /// This credential already has an MCP session here, or is opening one.
-    Occupied,
-    /// This credential's own sessions are being let go after its lease ran out. Separate from
-    /// [`Self::Occupied`] because the advice is the opposite: nothing is held, and the request that
-    /// arrives a moment later is served.
+    Serve,
+    /// This credential's own sessions are being let go after its lease ran out. It holds nothing at
+    /// this moment, and the advice is to ask again once the release is done rather than to change
+    /// anything.
     Releasing,
-    /// The request carried an MCP session id **another client** minted. Reported to the caller as
+    /// The request carried an MCP session id **another client** holds. Reported to the caller as
     /// unknown, for the reason the registry reports another client's handle that way: the answer
     /// must not confirm a session the caller may not use.
     NotYours,
 }
 
-/// A borrow of one client's tenancy, so the rules below read exactly as they did when there was
-/// one tenancy for the server — the difference is entirely in *whose* is being consulted.
-struct TenancyGuard<'a> {
-    all: std::sync::MutexGuard<'a, HashMap<crate::client::Client, Tenancy>>,
+/// A borrow of one client's lease state, so the rules below read as they did when there was one
+/// lease for the server — the difference is entirely in *whose* is being consulted.
+struct PresenceGuard<'a> {
+    all: std::sync::MutexGuard<'a, HashMap<crate::client::Client, Presence>>,
     client: crate::client::Client,
 }
 
-impl std::ops::Deref for TenancyGuard<'_> {
-    type Target = Tenancy;
+impl std::ops::Deref for PresenceGuard<'_> {
+    type Target = Presence;
 
-    fn deref(&self) -> &Tenancy {
+    fn deref(&self) -> &Presence {
         self.all
             .get(&self.client)
             .expect("state_of inserts before handing out a guard")
     }
 }
 
-impl std::ops::DerefMut for TenancyGuard<'_> {
-    fn deref_mut(&mut self) -> &mut Tenancy {
+impl std::ops::DerefMut for PresenceGuard<'_> {
+    fn deref_mut(&mut self) -> &mut Presence {
         self.all
             .get_mut(&self.client)
             .expect("state_of inserts before handing out a guard")
@@ -441,6 +342,11 @@ impl Lease {
     /// sends nothing for minutes, so a grace shorter than the call budget reads it as an absent
     /// client and releases the very session the call is running against. Refusing at startup makes
     /// that a message an operator sees once, instead of a target that goes away mid-analysis.
+    ///
+    /// It carries a second property now that the gate is gone: a sweep fires only after a whole
+    /// grace with nothing admitted, so a floor above the longest call means **no request of that
+    /// credential's can still be in flight when its lease expires**. That is what the reservation's
+    /// claim generations and in-flight epochs were protecting, and it was already enforced here.
     fn new(grace: Duration, call_timeout: Duration, sessions: Sessions) -> Result<Self> {
         let quiet = longest_quiet_call(call_timeout);
         if grace <= quiet {
@@ -460,264 +366,159 @@ impl Lease {
         })
     }
 
-    fn all_tenancies(&self) -> std::sync::MutexGuard<'_, HashMap<crate::client::Client, Tenancy>> {
+    fn all(&self) -> std::sync::MutexGuard<'_, HashMap<crate::client::Client, Presence>> {
         self.state.lock().unwrap_or_else(|e| e.into_inner())
     }
 
-    /// Whether an MCP session id is held by some client other than this one.
+    /// Whether an MCP session id belongs to some client other than this one.
     ///
-    /// Only the *holder* counts. A departed client's id is closed in the MCP service by the
-    /// `DELETE` that departed, and one whose lease expired is closed by the sweep — so an id no
-    /// tenancy holds is already unusable, and treating it as owned would refuse a client its own
-    /// reconnect on the strength of a record nothing backs.
+    /// Only a *recorded* id counts. One closed by a `DELETE` is gone from the service too, and one
+    /// a sweep closed went with the lease that held it — so an id nobody records is already
+    /// unusable, and treating it as owned would refuse a client its own reconnect on the strength
+    /// of a record nothing backs.
     fn held_by_another(&self, caller: &crate::client::Client, session: &str) -> bool {
-        self.all_tenancies()
+        self.all()
             .iter()
-            .any(|(client, tenancy)| client != caller && tenancy.holder.as_deref() == Some(session))
+            .any(|(client, held)| client != caller && held.mcp.contains(session))
     }
 
-    /// One client's tenancy, created empty on first use — a client that has never connected holds
-    /// nothing, which is what a default `Tenancy` says.
-    fn state_of(&self, client: &crate::client::Client) -> TenancyGuard<'_> {
-        let mut all = self.all_tenancies();
+    /// One client's lease state, created empty on first use — a client that has never connected
+    /// holds nothing, which is what a default [`Presence`] says.
+    fn state_of(&self, client: &crate::client::Client) -> PresenceGuard<'_> {
+        let mut all = self.all();
         all.entry(client.clone()).or_default();
-        TenancyGuard {
+        PresenceGuard {
             all,
             client: client.clone(),
         }
     }
 
-    /// Decides whether a request may be served, **reserving** the server when one is taking it.
+    /// Whether this request may be served — and, the part that does the work, **renewing this
+    /// credential's lease when it is**.
     ///
-    /// What the request presents is an [`Arriving`]: the `Mcp-Session-Id` it carries, or which kind
-    /// of nothing it carries instead. Every decision is made under one lock, so the answer a
-    /// request gets is the state it will be served against.
-    fn admit(&self, client: &crate::client::Client, arriving: Arriving<'_>) -> Admission {
-        // **Before this client's own tenancy is consulted at all**, because the id may not be its
-        // to present. The MCP service keeps one session table for the server, so a client that
-        // comes by another's `Mcp-Session-Id` reaches that client's MCP session through it — the
+    /// All a request presents is the `Mcp-Session-Id` it carries, or nothing. There is no third
+    /// thing to know since the gate went: the revision does not change the answer, so this no
+    /// longer reads `MCP-Protocol-Version` and no longer has an opener to tell apart from a client
+    /// that will never have a session. Reading the absence of an id as "a client opening one" is
+    /// what made every request of a `2026-07-28` client a reservation, and every overlapping pair a
+    /// `409` ([#168](https://github.com/glslang/windbg-mcp/issues/168)) — that classification is
+    /// gone rather than fixed.
+    ///
+    /// Every decision is made under one lock, so the answer a request gets is the state it will be
+    /// served against.
+    fn admit(&self, client: &crate::client::Client, session: Option<&str>) -> Admission {
+        // **Before this client's own state is consulted at all**, because the id may not be its to
+        // present. The MCP service keeps one session table for the server, so a client that comes
+        // by another's `Mcp-Session-Id` reaches that client's MCP session through it — the
         // task-local only decides which *debug* sessions the tools then see. A `DELETE` on it is
-        // the sharp end: rmcp closes the session, while the lease that minted it still holds the
-        // id, so the client it belonged to fails every request and its re-`initialize` is refused
-        // for a whole grace period. That is one authenticated client denying another, which is
-        // exactly what ownership is here to stop.
-        if let Arriving::Holding(id) = arriving
+        // the sharp end: rmcp closes the session, and its owner then fails every request it sends.
+        // That is one authenticated client denying another, which is what ownership is here to stop.
+        if let Some(id) = session
             && self.held_by_another(client, id)
         {
             return Admission::NotYours;
         }
         let mut state = self.state_of(client);
         // Nothing is served while a teardown is in flight. Briefly refusing a client that could
-        // have been served costs a reconnect; serving one costs it the session mid-call. Its own
-        // answer, because at this moment the credential holds nothing and is opening nothing — the
-        // reply that says otherwise sends a client looking for a session of its own that it does
-        // not have, when what it has to do is ask again.
+        // have been served costs it a reconnect; serving one costs it the session mid-call.
         if state.releasing {
             return Admission::Releasing;
         }
-        // **Nothing to reserve.** The claim exists so that two requests cannot both become the
-        // holder; a request that will never mint a session cannot become one, so reserving against
-        // it refuses work for a contest that is not happening. It was refusing rather a lot of it:
-        // on `2026-07-28` *every* request takes this path, so any two that overlapped contended,
-        // and a call that parks — a kernel attach whose target never dials in — locked the
-        // credential out of `session_status` and `end_session`, which are the two things that
-        // recover it ([#168](https://github.com/glslang/windbg-mcp/issues/168)).
+        // **Renewed if there is one; never created.** "Any request renews the lease" is what keeps a
+        // working client's sessions alive, and it has to be *any* request rather than any request of
+        // a particular shape: a credential holding a legacy session can go on to send stateless
+        // ones — a client that upgraded, or restarted inside the grace — and the sweep reads the
+        // deadline and nothing else, so a request that skipped this would have those sessions
+        // released out from under it while it was using them.
         //
-        // Counted in-flight all the same: a goodbye still has to wait for the work admitted here.
-        if matches!(arriving, Arriving::Stateless) {
-            // **Renewed if there is one; never created.** "Any request renews the lease" is what
-            // keeps a working client's tenancy alive, and this path skipping it would strand a
-            // credential that holds a legacy session and has since started sending stateless
-            // requests — a client that upgraded or restarted mid-grace. The sweep reads the
-            // deadline and nothing else: it zeroes `in_flight` on the way past, so work actually
-            // running would not save the sessions being released underneath it.
-            //
-            // Not created, because a deadline with no holder is a lease against nothing. It would
-            // fire one grace later and release this client's sessions — which for a client that
-            // only ever sends stateless requests is all of them, on a timer it never touched.
-            // Abandonment on that revision is [`IDLE_RELEASE`]'s to catch, per session and far
-            // longer.
-            if state.deadline.is_some() {
-                state.deadline = Some(Instant::now() + self.grace);
-            }
-            state.in_flight += 1;
-            return Admission::Serve(Admitted {
-                claim: None,
-                epoch: state.epoch,
-            });
+        // Not created, because a deadline with no MCP session behind it is a lease against nothing.
+        // It would fire one grace later and release this credential's sessions — for a client that
+        // is sent no session id, all of them — on a clock it never started. Abandonment there is
+        // [`IDLE_RELEASE`]'s to catch, per session and far longer.
+        //
+        // And only after both refusals above have returned, deliberately. A refusal that renewed
+        // would let a stream of wrong session ids hold an abandoned client's live kernel target
+        // open for ever, which is the failure the sweep exists to prevent.
+        if state.deadline.is_some() {
+            state.deadline = Some(Instant::now() + self.grace);
         }
-        match (arriving, state.holder.as_deref()) {
-            // The holder, still talking.
-            (Arriving::Holding(id), Some(held)) if id == held => {
-                state.deadline = Some(Instant::now() + self.grace);
-                state.in_flight += 1;
-                Admission::Serve(Admitted {
-                    claim: None,
-                    epoch: state.epoch,
-                })
-            }
-            // A session id belonging to someone else. This is the arm that made the race above
-            // persist rather than pass: serving it leaves both clients working.
-            (Arriving::Holding(_), Some(_)) => Admission::Occupied,
-            // A session id with nobody holding the server — a client resuming what it left inside
-            // the grace. Reserved like an `initialize`, because it is the same contest: a lease
-            // expiry leaves the old session id valid in the service, so a resume can race a fresh
-            // client and both would pass a gate that only served them. The holder is still not
-            // taken until `settle` hears the session was real, or a stale id would lock the server
-            // out for a whole grace period.
-            (Arriving::Holding(_), None) if state.claim.is_none() => {
-                state.in_flight += 1;
-                let epoch = state.epoch;
-                Admission::Serve(Admitted {
-                    claim: Some(state.claim(self.grace)),
-                    epoch,
-                })
-            }
-            // A new client, and nobody attached or attaching: it reserves the server here, and
-            // inherits whatever the last one left open.
-            (Arriving::Opening, None) if state.claim.is_none() => {
-                state.in_flight += 1;
-                let epoch = state.epoch;
-                Admission::Serve(Admitted {
-                    claim: Some(state.claim(self.grace)),
-                    epoch,
-                })
-            }
-            // Someone is mid-`initialize`, or holds it already.
-            _ => Admission::Occupied,
-        }
+        Admission::Serve
     }
 
-    /// Records what the service made of a request the gate admitted.
+    /// Records what the service made of a request, and says whether this was an **adoption** — a
+    /// credential picking up debug sessions its previous MCP session left inside the grace. Worth
+    /// saying out loud, since the alternative reading (that these are sessions this MCP session
+    /// opened) is wrong in a way that matters when it ends one.
     ///
-    /// Called for **every** admitted request, because a claim that is never resolved is a server
-    /// nobody can take: an `initialize` that fails has to give the reservation back.
+    /// This is the only thing that starts a clock. Before an MCP session exists there is nothing
+    /// for a lease to be against, which is the whole of the rule in [`Presence::deadline`] — and
+    /// the reason the trap that came with reserving cannot arise here. A reservation armed a
+    /// deadline on arrival and had to hand it back when the request minted nothing, which a
+    /// `2026-07-28` handshake omitting `MCP-Protocol-Version` legitimately does; there is no
+    /// arrival-time deadline to hand back any more.
     ///
-    /// Returns whether this was an **adoption** — a client picking up sessions a previous one left
-    /// inside the grace — which is worth saying out loud, since the alternative reading (that these
-    /// are its own sessions) is wrong in a way that matters when it ends one.
+    /// **And nothing here guards against a teardown running underneath it**, which the claim
+    /// machinery this replaces spent a generation counter and an epoch on. A sweep fires only when
+    /// nothing has been admitted for a whole grace, and [`Self::new`] refuses a grace shorter than
+    /// the longest a single call can take — so when one fires, no request of that credential's is
+    /// still in flight to settle into it.
     fn settle(
         &self,
-        claim: Option<u64>,
         requested: Option<&str>,
         minted: Option<&str>,
         ok: bool,
-        client: crate::client::Client,
-    ) -> Settled {
-        let mut state = self.state_of(&client);
-        match claim {
-            // This request reserved the server. It may only resolve *its own* reservation: one
-            // that outlived the grace has already been cleared and possibly re-issued to somebody
-            // else, and clearing that would hand two clients the registry at once.
-            Some(mine) if state.claim == Some(mine) => state.claim = None,
-            Some(_) => return Settled::Stale,
-            // A request from the established holder reserved nothing and settles nothing.
-            None => return Settled::Kept { adopted: false },
-        }
-        // A teardown that started while this request was being handled has already decided the
-        // sessions are going. Installing a holder now would hand a client something being released
-        // out from under it, and the client is better served by being told to come back.
-        if state.releasing {
-            return Settled::Stale;
-        }
+        client: &crate::client::Client,
+    ) -> bool {
+        // The MCP session this request turned out to have: one the handshake minted, or the one it
+        // presented and the service honoured. A request whose id the service **rejected** records
+        // nothing — an id nothing backs would arm a clock over sessions no client can reach, and
+        // claim an id for a credential that cannot use it.
+        let session = match (minted, requested) {
+            (Some(id), _) => id,
+            (None, Some(id)) if ok => id,
+            _ => return false,
+        };
+        let mut state = self.state_of(client);
         let adopted = state.left_open;
-        match (minted, requested) {
-            // An `initialize` that produced a session: the claim becomes a holder.
-            (Some(id), _) => {
-                state.holder = Some(id.to_string());
-                state.deadline = Some(Instant::now() + self.grace);
-                state.left_open = false;
-                Settled::Kept { adopted }
-            }
-            // A resumed session the service accepted: the returning client is the holder again.
-            (None, Some(id)) if ok && state.holder.is_none() => {
-                state.holder = Some(id.to_string());
-                state.deadline = Some(Instant::now() + self.grace);
-                state.left_open = false;
-                Settled::Kept { adopted }
-            }
-            // Anything else, including an `initialize` that failed: the reservation is already
-            // given back above, and nobody took the server.
-            _ => {
-                // **And the clock it started goes back too.** Reserving arms a deadline, so a
-                // request that reserved and then took nothing would leave one running against a
-                // tenancy that holds nothing — and a deadline is all the sweep reads. One grace
-                // later it would start a teardown with no holder, release this client's sessions,
-                // and refuse its next request with `Releasing` while it was working normally.
-                //
-                // Reachable by an ordinary client: a `2026-07-28` `initialize` may omit the
-                // `MCP-Protocol-Version` header (it is the request that establishes it), so it is
-                // classified as an opener, reserves, and then mints no session — and every session
-                // that client goes on to open is on that clock.
-                //
-                // `left_open` is the exception: a previous client's sessions are waiting to be
-                // adopted or swept, and that deadline is exactly what sweeps them.
-                if state.holder.is_none() && !state.left_open {
-                    state.deadline = None;
-                }
-                Settled::Kept { adopted: false }
-            }
-        }
+        state.mcp.insert(session.to_string());
+        state.deadline = Some(Instant::now() + self.grace);
+        state.left_open = false;
+        adopted
     }
 
-    /// The holder said goodbye. The sessions stay; the clock starts.
+    /// A client said goodbye to one of its MCP sessions. The debug sessions stay; the clock runs.
     fn released(&self, client: &crate::client::Client, id: &str) {
         let mut state = self.state_of(client);
-        if state.holder.as_deref() != Some(id) {
+        // A `DELETE` naming something this credential does not hold changes nothing — including the
+        // clock, which is the half that would matter: a stray goodbye must not extend a lease.
+        if !state.mcp.remove(id) {
             return;
         }
         state.deadline = Some(Instant::now() + self.grace);
-        // The `DELETE` itself is in flight, so this is always the deferred path in practice — and
-        // that is the point: tenancy is given up when the work admitted under it drains, which is
-        // at worst this request and at best a tool call still running on another connection.
-        state.farewell = true;
-        drop(state);
-        self.try_give_up_for(client);
+        // Only once it has let go of *every* MCP session it had. While it still holds one it has
+        // not left, and telling its next request that it adopted what it left would be a sentence
+        // about nothing.
+        state.left_open = state.mcp.is_empty();
     }
 
-    /// One admitted request finished, however it finished.
+    /// Whether this credential's lease has run out, **claiming the teardown** if so.
     ///
-    /// `epoch` is the tenancy it was admitted under. A request that outlived a teardown belongs to
-    /// a tenancy that no longer exists, and counting it out of the current one would subtract work
-    /// it never did — enough for a concurrent goodbye to see zero while a tool call is still
-    /// running.
-    fn leave(&self, client: &crate::client::Client, epoch: u64) {
-        let mut state = self.state_of(client);
-        if state.epoch != epoch {
-            return;
-        }
-        state.in_flight = state.in_flight.saturating_sub(1);
-        drop(state);
-        self.try_give_up_for(client);
-    }
-
-    /// Whether the lease has run out, **claiming the teardown** if so.
-    ///
-    /// The server is marked `releasing` under the same lock that reads the deadline, and stays that
-    /// way until [`Self::released_leases`] says the teardown is done. That is what closes the
+    /// The sessions are marked `releasing` under the same lock that reads the deadline, and stay
+    /// that way until [`Self::released_leases`] says the teardown is done. That is what closes the
     /// window [`Sessions::release_leased`] warns it does not close itself: between deciding to
-    /// release and having released, no client can be admitted to the sessions being released.
+    /// release and having released, this credential cannot be admitted to the sessions being
+    /// released.
     fn expired_for(&self, client: &crate::client::Client) -> Option<Expired> {
         let mut state = self.state_of(client);
         match state.deadline {
             Some(at) if Instant::now() >= at => {
-                let holder = state.holder.take();
+                let mcp = std::mem::take(&mut state.mcp).into_iter().collect();
+                // Consumed by the sweep that acts on it, so an expiry is reported once rather than
+                // on every pass — a second report would release an already-released set.
                 state.deadline = None;
-                // Including a claim. A request whose connection died before `settle` would
-                // otherwise leave this set for ever — no client could take the server, and no
-                // expiry would ever clear it either, because a claim renews the deadline it would
-                // have to outlive. Bounded by one grace, and this is the bound.
-                state.claim = None;
                 state.left_open = false;
-                // Everything admitted under that holder is being torn down with it; a count kept
-                // past this point would defer a goodbye that has already been overtaken.
-                state.in_flight = 0;
-                state.farewell = false;
-                // Anything still out there was admitted under the tenancy being discarded, and may
-                // not count itself out of the next one.
-                state.epoch += 1;
                 state.releasing = true;
-                Some(Expired { holder })
+                Some(Expired { mcp })
             }
             _ => None,
         }
@@ -726,43 +527,14 @@ impl Lease {
     /// The clients this lease holds state for, so the sweeper can ask each in turn without holding
     /// the lock across an `await`.
     fn clients(&self) -> Vec<crate::client::Client> {
-        self.all_tenancies().keys().cloned().collect()
+        self.all().keys().cloned().collect()
     }
 
-    /// Hands the server over, if a goodbye is outstanding and nothing is still using it.
-    ///
-    /// Two conditions, and they are not the same one. `in_flight` is HTTP: the requests this holder
-    /// was admitted for. `Sessions::busy` is the engine: a job survives the request that queued it,
-    /// so a dropped future or a timed-out call leaves work running against a target the next client
-    /// would otherwise be handed. Attempted on every sweep as well as on the two events, because
-    /// the engine going idle is not an event this side can see.
-    fn try_give_up_for(&self, client: &crate::client::Client) {
-        let mut state = self.state_of(client);
-        if !state.farewell || state.in_flight != 0 {
-            return;
-        }
-        drop(state);
-        if self.sessions.busy() {
-            return;
-        }
-        state = self.state_of(client);
-        // Re-checked: the two locks were not held together, so a request could have arrived.
-        if !state.farewell || state.in_flight != 0 {
-            return;
-        }
-        state.farewell = false;
-        state.holder = None;
-        state.deadline = Some(Instant::now() + self.grace);
-        state.left_open = true;
-    }
-
-    /// The teardown is done; the server may be taken again.
+    /// The teardown is done; this credential may open sessions again.
     fn released_leases(&self, client: &crate::client::Client) {
         self.state_of(client).releasing = false;
     }
 }
-
-/// Serves MCP over HTTP until the process is asked to stop.
 /// How long to keep retrying a bind that fails because the address is not there yet.
 ///
 /// Only reached by a **non-loopback** bind at boot: an auto-start service can be launched before
@@ -926,7 +698,6 @@ pub async fn serve(
             },
         };
         let mcp = mcp.clone();
-        let manager = manager.clone();
         let lease = lease.clone();
         let credentials = Arc::clone(&credentials);
         tokio::spawn(async move {
@@ -934,7 +705,6 @@ pub async fn serve(
                 gate(
                     req,
                     mcp.clone(),
-                    manager.clone(),
                     lease.clone(),
                     Arc::clone(&credentials),
                     peer,
@@ -950,11 +720,10 @@ pub async fn serve(
     }
 }
 
-/// Authenticates, decides tenancy, and only then hands the request to MCP.
+/// Authenticates, renews the lease, and only then hands the request to MCP.
 async fn gate(
     req: Request<Incoming>,
     mcp: Arc<StreamableHttpService<WindbgServer, LocalSessionManager>>,
-    manager: Arc<LocalSessionManager>,
     lease: Arc<Lease>,
     credentials: Arc<crate::client::Credentials>,
     peer: SocketAddr,
@@ -972,14 +741,8 @@ async fn gate(
         .and_then(|v| v.to_str().ok())
         .map(str::to_owned);
 
-    let arriving = match session.as_deref() {
-        Some(id) => Arriving::Holding(id),
-        None if mints_no_session(req.headers()) => Arriving::Stateless,
-        None => Arriving::Opening,
-    };
-
-    let admitted = match lease.admit(&caller, arriving) {
-        Admission::Serve(admitted) => admitted,
+    match lease.admit(&caller, session.as_deref()) {
+        Admission::Serve => {}
         // Not a refusal — an id this caller cannot have is an id this server does not have. The
         // status is the one the spec already gives a session that has gone: a client holding a
         // stale id of its own is told to start again, which is also the right advice here.
@@ -990,7 +753,8 @@ async fn gate(
             return Ok(refuse(StatusCode::NOT_FOUND, "unknown session"));
         }
         // The sweeper is letting this credential's own sessions go. Transient, and the fix is to
-        // ask again rather than to change anything.
+        // ask again rather than to change anything. The only `409` this server has left, now that
+        // nothing refuses a credential a second MCP session.
         Admission::Releasing => {
             tracing::warn!(
                 "refused a request from {peer}: this credential's expired sessions are still \
@@ -1002,36 +766,7 @@ async fn gate(
                  out; ask again in a moment",
             ));
         }
-        Admission::Occupied => {
-            // Never another client — tenancy is per client now — and never a *connection* either:
-            // requests carrying the session this credential holds are served concurrently, which
-            // is how a `DELETE` arrives on one while a tool call runs on another. Two things reach
-            // here and the message has to fit both: a second **MCP session** for this credential
-            // (a fresh `initialize`, or an id that is not the one it holds), and a second request
-            // arriving while one of its own is still opening one. Saying "another client" would
-            // send an operator looking for a colleague who is not there, and saying "connection"
-            // for one who has a network problem they do not have.
-            //
-            // A client on a revision with no session id no longer reaches here at all: it opens
-            // nothing, so it contests nothing (#168).
-            tracing::warn!(
-                "refused a request from {peer}: this credential is already being served here"
-            );
-            return Ok(refuse(
-                StatusCode::CONFLICT,
-                "this credential is already using this server: it holds an MCP session, or a \
-                 request of its own is still opening one. Send the session id it holds, or ask \
-                 again once that request has finished.",
-            ));
-        }
-    };
-    // From here every exit — a reply, a refusal, or this future being cancelled — counts the
-    // request out, and a goodbye waiting on it completes when the last one does.
-    let _in_flight = InFlight {
-        lease: lease.clone(),
-        owner: caller.clone(),
-        epoch: admitted.epoch,
-    };
+    }
 
     // A DELETE is the client saying it is done. Read before the service handles it, because
     // afterwards the request is gone; whether it *was* a departure also depends on the answer.
@@ -1040,7 +775,7 @@ async fn gate(
     // The whole MCP call runs as this client: the routing, the worker handshake and the engine
     // call all read the identity from here, rather than from a parameter forty-odd tool bodies
     // would have to carry. See [`crate::client`].
-    // Kept for the settlement below, which records whose tenancy this is — the scope moves the
+    // Kept for the settlement below, which records whose lease this is — the scope moves the
     // identity into the call.
     let caller_for_lease = caller.clone();
     let response = crate::client::as_client(caller, mcp.handle(req)).await;
@@ -1050,51 +785,26 @@ async fn gate(
         .get(SESSION_HEADER)
         .and_then(|v| v.to_str().ok())
         .map(str::to_owned);
-    // Every admitted request settles, so a reservation is never left standing by a request that
-    // did not become a session.
-    match lease.settle(
-        admitted.claim,
+    // Counted rather than asserted. An adoption says a previous MCP session of this credential's
+    // ended inside the grace, which is true whether or not it had opened anything — so the
+    // unconditional version of this line told an operator a client had adopted sessions that did
+    // not exist, on every ordinary reconnect.
+    if lease.settle(
         session.as_deref(),
         minted.as_deref(),
         response.status().is_success(),
-        caller_for_lease.clone(),
+        &caller_for_lease,
     ) {
-        // Counted rather than asserted. `left_open` says a previous tenancy ended inside the
-        // grace, which is true whether or not that client had opened anything — so the
-        // unconditional version of this line told an operator a client had adopted sessions that
-        // did not exist, on every ordinary reconnect.
-        Settled::Kept { adopted: true } => {
-            // Asked *for* this client rather than as it. The call's identity scope has closed by
-            // here, so anything reading the ambient one would count `local`'s sessions — nobody's,
-            // for a named client, which is the reconnect this line exists to describe.
-            match lease.sessions.live_count_for(&caller_for_lease) {
-                0 => tracing::info!(
-                    "a client attached to a server the previous one had let go; nothing was open"
-                ),
-                inherited => tracing::info!(
-                    "a client attached and adopted the {inherited} session(s) the previous one \
-                     left open"
-                ),
-            }
-        }
-        Settled::Kept { adopted: false } => {}
-        // This request lost the server while it was being handled. If the service minted a session
-        // for it, that session belongs to nobody: the holder is someone else, so every request
-        // carrying it would be refused, and no lease will ever sweep it. Close it here and tell the
-        // client what actually happened, rather than handing it an id that cannot be used.
-        Settled::Stale => {
-            if let Some(id) = minted
-                && let Err(e) = manager.close_session(&id.into()).await
-            {
-                tracing::warn!("could not close a session minted by a claim that had expired: {e}");
-            }
-            tracing::warn!(
-                "a request from {peer} outlived its claim on this server; its session was closed"
-            );
-            return Ok(refuse(
-                StatusCode::CONFLICT,
-                "this request outlived its claim on the server; open a new session",
-            ));
+        // Asked *for* this client rather than as it. The call's identity scope has closed by here,
+        // so anything reading the ambient one would count `local`'s sessions — nobody's, for a
+        // named client, which is the reconnect this line exists to describe.
+        match lease.sessions.live_count_for(&caller_for_lease) {
+            0 => tracing::info!(
+                "a client came back to a session this credential had let go; nothing was open"
+            ),
+            inherited => tracing::info!(
+                "a client came back and adopted the {inherited} session(s) it had left open"
+            ),
         }
     }
     if is_departure(&method, response.status())
@@ -1106,16 +816,15 @@ async fn gate(
     Ok(response)
 }
 
-/// Whether this request was the holder actually leaving.
+/// Whether this request was a client actually leaving.
 ///
 /// A `DELETE` is the client saying it is done — **if the service agreed**. rmcp refuses one that
 /// carries an invalid protocol version, and a refused `DELETE` leaves the MCP session open. Taking
-/// it as a departure anyway clears the holder, and the sweep that would have closed that session
-/// then finds `holder: None` and nothing to close: the session survives with no lease owning it and
-/// no sweep that will ever collect it, one per failed attempt
-/// ([#136](https://github.com/glslang/windbg-mcp/issues/136)).
+/// it as a departure anyway forgets that session, so the sweep that would have closed it never
+/// hears of it: it survives with nothing owning it and nothing that will ever collect it, one per
+/// failed attempt ([#136](https://github.com/glslang/windbg-mcp/issues/136)).
 ///
-/// A predicate rather than a condition inline, because it is the one tenancy rule that lives in the
+/// A predicate rather than a condition inline, because it is the one lease rule that lives in the
 /// HTTP handler rather than in [`Lease`] — and so the one that had no test until it had a name.
 fn is_departure(method: &hyper::Method, status: StatusCode) -> bool {
     method == hyper::Method::DELETE && status.is_success()
@@ -1155,18 +864,15 @@ async fn sweep(
 ) {
     loop {
         tokio::time::sleep(SWEEP).await;
-        // Independent of the lease, and checked first, because it is the half that still works on
-        // a stateless transport: the lease needs a client to identify, and on `2026-07-28` there
-        // is no session id to identify one by. See [`IDLE_RELEASE`].
+        // Independent of the lease, and checked first, because it is the half that covers a
+        // `2026-07-28` client: a lease is armed by an MCP session, and that revision has none. See
+        // [`IDLE_RELEASE`].
         if let Some(after) = idle_after {
             sessions.release_idle(after).await;
         }
-        // Per client, because a tenancy is per client: one caller's expiry says nothing about
+        // Per client, because a lease is per client: one caller's expiry says nothing about
         // another's, and a sweep that stopped at the first would starve the rest.
         for client in lease.clients() {
-            // The engine may have gone idle since the last tick, which is not something the HTTP
-            // side is told about.
-            lease.try_give_up_for(&client);
             let Some(expired) = lease.expired_for(&client) else {
                 continue;
             };
@@ -1179,13 +885,15 @@ async fn sweep(
             // (#162).
             sessions.release_leased(&client).await;
             // The debug sessions are the expensive half, but not the whole of it. A client that
-            // vanished never sent the DELETE that closes its MCP session, so without this the
-            // service keeps that session resident and its id accepted — and every
+            // vanished never sent the DELETEs that close its MCP sessions, so without this the
+            // service keeps them resident and their ids accepted — and every
             // disconnect-and-reconnect cycle would add another one no lease will ever sweep again.
-            if let Some(id) = expired.holder
-                && let Err(e) = manager.close_session(&id.into()).await
-            {
-                tracing::warn!("could not close the MCP session of the client that went away: {e}");
+            for id in expired.mcp {
+                if let Err(e) = manager.close_session(&id.into()).await {
+                    tracing::warn!(
+                        "could not close the MCP session of the client that went away: {e}"
+                    );
+                }
             }
             // Only now may this client be admitted again: until here, an arriving request would be
             // let in to sessions this release is closing.
@@ -1198,12 +906,13 @@ async fn sweep(
 mod tests {
     use super::*;
 
-    /// A lease bound to one client, so the rules below read as they did when there was one tenancy
-    /// for the server.
+    /// A lease bound to one client, so the rules below read exactly as they did when there was one
+    /// lease for the whole server.
     ///
-    /// Every test here is about how *a* client's tenancy behaves — claims, adoption, goodbyes,
-    /// expiry — and none of them is about which client it is. Binding the name once keeps that
-    /// distinction visible: a test that needs two clients says so by using two of these.
+    /// Every test here is about how *a* credential's lease behaves — what it records, what renews
+    /// it, what it adopts, what a goodbye and an expiry do to it — and none of them is about which
+    /// client it is. Binding the name once keeps that distinction visible: a test that needs two
+    /// clients says so by using two of these, or by reaching for the lease directly.
     struct For {
         lease: Lease,
         client: crate::client::Client,
@@ -1218,37 +927,15 @@ mod tests {
         }
 
         fn admit(&self, session: Option<&str>) -> Admission {
-            self.lease.admit(
-                &self.client,
-                match session {
-                    Some(id) => Arriving::Holding(id),
-                    None => Arriving::Opening,
-                },
-            )
+            self.lease.admit(&self.client, session)
         }
 
-        /// A request on the revision that has no session id to present.
-        fn admit_stateless(&self) -> Admission {
-            self.lease.admit(&self.client, Arriving::Stateless)
-        }
-
-        fn settle(
-            &self,
-            claim: Option<u64>,
-            requested: Option<&str>,
-            minted: Option<&str>,
-            ok: bool,
-        ) -> Settled {
-            self.lease
-                .settle(claim, requested, minted, ok, self.client.clone())
+        fn settle(&self, requested: Option<&str>, minted: Option<&str>, ok: bool) -> bool {
+            self.lease.settle(requested, minted, ok, &self.client)
         }
 
         fn released(&self, id: &str) {
             self.lease.released(&self.client, id);
-        }
-
-        fn leave(&self, epoch: u64) {
-            self.lease.leave(&self.client, epoch);
         }
 
         fn expired(&self) -> Option<Expired> {
@@ -1259,12 +946,8 @@ mod tests {
             self.lease.released_leases(&self.client);
         }
 
-        fn state(&self) -> TenancyGuard<'_> {
+        fn state(&self) -> PresenceGuard<'_> {
             self.lease.state_of(&self.client)
-        }
-
-        fn sessions(&self) -> &Sessions {
-            &self.lease.sessions
         }
     }
 
@@ -1286,13 +969,18 @@ mod tests {
     /// A lease whose grace expires almost immediately, for the sweep paths.
     fn brief() -> For {
         For::new(
-            Lease {
-                grace: Duration::from_millis(1),
-                sessions: Sessions::new(CALL),
-                state: Mutex::new(HashMap::new()),
-            },
+            unchecked(Duration::from_millis(1)),
             crate::client::Client::LOCAL,
         )
+    }
+
+    /// A lease with a grace [`Lease::new`] would refuse, for the tests that have to wait one out.
+    fn unchecked(grace: Duration) -> Lease {
+        Lease {
+            grace,
+            sessions: Sessions::new(CALL),
+            state: Mutex::new(HashMap::new()),
+        }
     }
 
     /// The floor is the same one the lease refuses to start below, and for the same reason: a
@@ -1337,44 +1025,26 @@ mod tests {
         assert!(why.to_string().contains(IDLE_ENV), "{why}");
     }
 
-    /// The claim an admitted request reserved. Panics if the gate refused, since every caller here
-    /// is testing what happens *after* admission.
-    /// Whether a settlement adopted sessions, asserting it was not rejected.
-    fn adopted(settled: Settled) -> bool {
-        match settled {
-            Settled::Kept { adopted } => adopted,
-            Settled::Stale => panic!("the settlement was rejected as stale"),
-        }
+    /// A request the listener served, asserting it was not one of the two it refuses.
+    fn served(admission: Admission) {
+        assert_eq!(
+            admission,
+            Admission::Serve,
+            "the listener refused a request this test needed served"
+        );
     }
 
-    fn admitted(admission: Admission) -> Admitted {
-        match admission {
-            Admission::Serve(admitted) => admitted,
-            Admission::Occupied => panic!("the gate refused a request this test needed served"),
-            Admission::NotYours => {
-                panic!(
-                    "the gate took a session id for another client's, which no test here sets up"
-                )
-            }
-            Admission::Releasing => panic!("the gate is letting go of sessions this test needs"),
-        }
-    }
-
-    /// One whole request: admitted, settled, and finished. Every admitted request is counted out
-    /// again in `gate` by a guard, so a test that settles without finishing is modelling a request
-    /// that never came back.
-    fn request(lease: &For, session: Option<&str>, minted: Option<&str>, ok: bool) -> Settled {
-        let it = admitted(lease.admit(session));
-        let settled = lease.settle(it.claim, session, minted, ok);
-        lease.leave(it.epoch);
-        settled
+    /// One whole request: admitted, then settled with whatever the service made of it. Returns
+    /// whether it adopted sessions a previous MCP session of that credential's left open.
+    fn request(lease: &For, session: Option<&str>, minted: Option<&str>, ok: bool) -> bool {
+        served(lease.admit(session));
+        lease.settle(session, minted, ok)
     }
 
     /// A client's `DELETE`, which is itself an admitted request.
     fn goodbye(lease: &For, id: &str) {
-        let it = admitted(lease.admit(Some(id)));
+        served(lease.admit(Some(id)));
         lease.released(id);
-        lease.leave(it.epoch);
     }
 
     /// The check that stops a long call from looking like an absent client.
@@ -1407,105 +1077,206 @@ mod tests {
         );
     }
 
-    /// One client at a time — and admission has to *reserve*, not merely observe.
+    /// **Two requests of one credential are both served**, whatever shape they arrive in.
+    ///
+    /// This is what retiring the gate means, and it is the property the gate's last remaining job
+    /// was the negation of. Two overlapping requests with no session id used to be a `409`: the
+    /// absence of an id was read as a client opening one, so each reserved the server, and on
+    /// `2026-07-28` — where there is never an id to carry — that was *every* request. At its
+    /// sharpest a kernel attach whose target never dialled in locked its own credential out of
+    /// `session_status` and `end_session`, the two calls that recover it
+    /// ([#168](https://github.com/glslang/windbg-mcp/issues/168)).
+    ///
+    /// The second half is the one that used to be arguable: a second `initialize` from a credential
+    /// that already holds an MCP session, and a request bearing an id that is not the one it holds.
+    /// Inside a namespace neither is a boundary — both reach the same debug sessions, because they
+    /// are the same client.
     #[test]
-    fn a_second_client_is_refused_while_the_first_holds_the_server() {
+    fn two_requests_from_one_credential_are_both_served() {
+        let lease = lease();
+
+        // Neither of these has finished when the other arrives; the parked case is exactly this.
+        served(lease.admit(None));
+        served(lease.admit(None));
+
+        request(&lease, None, Some("session-a"), true);
+        served(lease.admit(None));
+        served(lease.admit(Some("session-b")));
+        served(lease.admit(Some("session-a")));
+    }
+
+    /// And a credential's second MCP session is recorded beside the first, not instead of it.
+    ///
+    /// The set is not tidiness. An id that is recorded for nobody is one *any* credential may
+    /// present, so keeping only the newest would hand a client another's older session id the
+    /// moment that client opened a second one — which is the harm [`Admission::NotYours`] exists to
+    /// stop, arriving through the change that removed the refusal in front of it.
+    #[test]
+    fn a_second_mcp_session_for_one_credential_joins_the_first() {
         let lease = lease();
         request(&lease, None, Some("session-a"), true);
+        request(&lease, None, Some("session-b"), true);
 
-        assert!(matches!(lease.admit(None), Admission::Occupied));
+        let held = lease.state();
         assert!(
-            matches!(
-                lease.admit(Some("session-a")),
-                Admission::Serve(Admitted { claim: None, .. })
-            ),
-            "the holder is served, and reserves nothing — it already holds the server"
-        );
-        assert!(
-            matches!(lease.admit(Some("session-b")), Admission::Occupied),
-            "another client's session id is refused; serving it is what let the losing side of a \
-             race keep working"
+            held.mcp.contains("session-a") && held.mcp.contains("session-b"),
+            "both of this credential's MCP sessions have to stay recorded: {:?}",
+            held.mcp
         );
     }
 
-    /// The race the reservation exists for: two `initialize`s arriving together.
-    #[test]
-    fn a_claim_in_flight_blocks_a_second_initialize() {
-        let lease = lease();
-        let first = admitted(lease.admit(None));
-        assert!(matches!(lease.admit(None), Admission::Occupied));
-
-        lease.settle(first.claim, None, Some("session-a"), true);
-        assert_eq!(lease.state().holder.as_deref(), Some("session-a"));
-    }
-
-    /// A claim that comes to nothing must give the server back.
-    #[test]
-    fn an_initialize_that_fails_does_not_hold_the_server_for_ever() {
-        let lease = lease();
-        let claim = admitted(lease.admit(None));
-        lease.settle(claim.claim, None, None, false);
-
-        assert!(
-            lease.state().claim.is_none(),
-            "the reservation was returned"
-        );
-        assert!(matches!(lease.admit(None), Admission::Serve(_)));
-    }
-
-    /// **A stale claim may not settle over a newer one.**
+    /// **Every admitted request renews an existing lease, and creates none.**
     ///
-    /// A request still inside `mcp.handle` when the grace runs out has its reservation cleared and
-    /// the sweep completed under it. By the time it returns, another client may hold the server.
-    /// Settling unconditionally there would clear the newer claim and install the stale session,
-    /// and the newer response would then replace it again — two valid MCP sessions overlapping on a
-    /// registry whose handles and capacity are global.
+    /// Both halves are the same rule seen from two sides, and getting either wrong loses a client
+    /// sessions it was using. A credential can hold a legacy session and *then* start sending
+    /// requests with no id — a client that upgraded, or restarted inside the grace — and since the
+    /// sweep reads the deadline and nothing else, a request that did not renew would have those
+    /// sessions released out from under it while it was using them. The other way costs as much: a
+    /// deadline installed for a credential that holds nothing is a lease against nothing, and it
+    /// would release every session a `2026-07-28` client has, one grace after its first call.
     #[test]
-    fn a_claim_that_outlived_its_grace_cannot_settle_over_a_newer_one() {
-        let lease = brief();
-        let stale = admitted(lease.admit(None)).claim;
+    fn every_admitted_request_renews_an_existing_lease_and_creates_none() {
+        let lease = lease();
+
+        // Nothing held: no request of any shape may hand this credential a clock to run out.
+        served(lease.admit(None));
+        assert_eq!(
+            lease.state().deadline,
+            None,
+            "a request that holds nothing must not be given a clock to run out"
+        );
+        served(lease.admit(Some("session-nobodys")));
+        assert_eq!(
+            lease.state().deadline,
+            None,
+            "nor does presenting an id no credential here records"
+        );
+
+        // A legacy session, and then the same credential sending a request with no id at all.
+        request(&lease, None, Some("session-a"), true);
+        let before = lease
+            .state()
+            .deadline
+            .expect("a credential that holds a session has a deadline");
+
         std::thread::sleep(Duration::from_millis(5));
+        served(lease.admit(None));
+        let after = lease
+            .state()
+            .deadline
+            .expect("the lease is still this credential's");
         assert!(
-            lease.expired().is_some(),
-            "the stale request's claim is swept"
-        );
-        lease.released_leases();
-
-        let fresh = admitted(lease.admit(None)).claim;
-        assert_ne!(stale, fresh, "a cleared claim is never re-issued");
-        lease.settle(fresh, None, Some("session-new"), true);
-
-        // Now the request nobody is waiting for finally returns.
-        assert_eq!(
-            lease.settle(stale, None, Some("session-stale"), true),
-            Settled::Stale,
-            "and is told so, because the session it minted has to be closed and its client told to \
-             start again — an id whose every request is refused is worse than an error"
-        );
-        assert_eq!(
-            lease.state().holder.as_deref(),
-            Some("session-new"),
-            "the holder is whoever legitimately took the server, not whoever answered last"
+            after > before,
+            "a request from a credential that holds a session must renew its lease, whatever \
+             revision it is on"
         );
     }
 
-    /// A request from the established holder settles nothing and is never stale.
+    /// A request the listener **refused** renews nothing.
     ///
-    /// It reserved no claim, so there is nothing to resolve — and treating it as stale would close
-    /// the holder's own session out from under it.
+    /// The qualifier on the rule above is load-bearing in both directions. A credential that is
+    /// plainly alive must not be swept mid-call — and a refused request must not renew, or a stream
+    /// of wrong session ids would hold an abandoned client's live kernel target open for ever,
+    /// which is the failure the sweep exists to prevent.
     #[test]
-    fn an_ordinary_request_from_the_holder_is_not_a_settlement() {
-        let lease = lease();
-        let claim = admitted(lease.admit(None));
-        lease.settle(claim.claim, None, Some("session-a"), true);
+    fn a_refused_request_renews_nothing() {
+        // One lease and two clients, so `NotYours` is reachable at all.
+        let lease = Lease::new(
+            longest_quiet_call(CALL) + Duration::from_secs(60),
+            CALL,
+            Sessions::new(CALL),
+        )
+        .expect("workable");
+        let laptop = crate::client::Client::new("laptop");
+        let ci = crate::client::Client::new("ci");
+        for (client, id) in [(&laptop, "session-laptop"), (&ci, "session-ci")] {
+            served(lease.admit(client, None));
+            lease.settle(None, Some(id), true, client);
+        }
 
-        let none = admitted(lease.admit(Some("session-a"))).claim;
-        assert_eq!(none, None, "the holder reserves nothing");
+        let before = lease
+            .state_of(&ci)
+            .deadline
+            .expect("a credential that holds a session has a deadline");
+        std::thread::sleep(Duration::from_millis(5));
         assert_eq!(
-            lease.settle(none, Some("session-a"), None, true),
-            Settled::Kept { adopted: false }
+            lease.admit(&ci, Some("session-laptop")),
+            Admission::NotYours
         );
-        assert_eq!(lease.state().holder.as_deref(), Some("session-a"));
+        assert_eq!(
+            lease.state_of(&ci).deadline,
+            Some(before),
+            "a refused request renewed the lease of the credential that sent it"
+        );
+
+        // And the same for a teardown's refusal, which is the other early return.
+        let releasing = For::new(unchecked(Duration::from_millis(1)), "laptop");
+        request(&releasing, None, Some("session-a"), true);
+        std::thread::sleep(Duration::from_millis(5));
+        assert!(releasing.expired().is_some());
+        assert_eq!(releasing.admit(None), Admission::Releasing);
+        assert_eq!(
+            releasing.state().deadline,
+            None,
+            "a refusal must not arm a clock either"
+        );
+    }
+
+    /// **Nothing arms a clock before an MCP session exists**, which is the trap the reservation
+    /// took with it.
+    ///
+    /// A `2026-07-28` `initialize` may omit the `MCP-Protocol-Version` header — it is the request
+    /// that establishes the revision — so it arrives looking like any other request and mints
+    /// nothing at all. Reserving armed a deadline on arrival, and one that took nothing had to hand
+    /// that deadline back or it would start a teardown one grace later against a credential holding
+    /// nothing, release whatever it had since opened, and refuse its next request while it was
+    /// working normally. There is no arrival-time deadline to hand back any more; this pins that it
+    /// stays that way.
+    #[test]
+    fn nothing_arms_a_clock_before_an_mcp_session_exists() {
+        let lease = lease();
+
+        served(lease.admit(None));
+        assert!(!lease.settle(None, None, true));
+
+        assert_eq!(
+            lease.state().deadline,
+            None,
+            "a request that took nothing must not leave a clock running against a credential that \
+             holds nothing"
+        );
+        assert!(
+            lease.expired().is_none(),
+            "and so there is nothing for the sweep to act on"
+        );
+    }
+
+    /// An id the service rejected is not recorded as this credential's.
+    ///
+    /// A returning client presents the id it left with, and only the service knows whether that
+    /// session is still there. Recording one it rejected would arm a clock over an id nothing
+    /// backs — and claim it for a credential that cannot use it, which is enough to refuse the
+    /// client that can.
+    #[test]
+    fn an_id_the_service_rejected_is_not_recorded_as_this_credentials() {
+        let lease = lease();
+
+        served(lease.admit(Some("session-a")));
+        assert!(!lease.settle(Some("session-a"), None, false));
+        assert!(
+            lease.state().mcp.is_empty(),
+            "a session id the service rejected must not be recorded: {:?}",
+            lease.state().mcp
+        );
+        assert_eq!(lease.state().deadline, None, "and starts no clock");
+
+        served(lease.admit(Some("session-a")));
+        assert!(!lease.settle(Some("session-a"), None, true));
+        assert!(
+            lease.state().mcp.contains("session-a"),
+            "whereas one it honoured is this credential's"
+        );
+        assert!(lease.state().deadline.is_some());
     }
 
     /// A returning client finds what it left, and is told that is what happened.
@@ -1513,66 +1284,19 @@ mod tests {
     fn a_client_returning_inside_the_grace_adopts_rather_than_starts_fresh() {
         let lease = lease();
         assert!(
-            !adopted(request(&lease, None, Some("session-a"), true)),
-            "the first client adopts nothing — there was nothing open"
+            !request(&lease, None, Some("session-a"), true),
+            "the first MCP session adopts nothing — there was nothing open"
         );
 
         goodbye(&lease, "session-a");
         assert!(
-            adopted(request(&lease, None, Some("session-b"), true)),
-            "the next client is told it inherited the sessions still open"
+            request(&lease, None, Some("session-b"), true),
+            "the next one is told it inherited the sessions still open"
         );
-    }
-
-    /// A resume takes the server back only once the service says the session was real.
-    #[test]
-    fn a_resumed_session_takes_the_server_back_only_if_it_existed() {
-        let lease = lease();
-        request(&lease, None, Some("session-a"), true);
-        goodbye(&lease, "session-a");
-
-        request(&lease, Some("session-a"), None, false);
-        assert_eq!(
-            lease.state().holder,
-            None,
-            "a session id the service rejected must not lock the server out for a whole grace"
-        );
-
-        request(&lease, Some("session-a"), None, true);
-        assert_eq!(lease.state().holder.as_deref(), Some("session-a"));
-    }
-
-    /// A resume is a contested claim too, not a free pass.
-    #[test]
-    fn a_resume_reserves_the_server_like_an_initialize_does() {
-        let lease = lease();
-        request(&lease, None, Some("session-a"), true);
-        goodbye(&lease, "session-a");
-
-        assert!(matches!(
-            lease.admit(Some("session-a")),
-            Admission::Serve(Admitted { claim: Some(_), .. })
-        ));
         assert!(
-            matches!(lease.admit(None), Admission::Occupied),
-            "a fresh client cannot slip in while a resume is being confirmed"
-        );
-    }
-
-    /// Whatever a request turns out to be, it hands its reservation back.
-    #[test]
-    fn every_settled_request_resolves_its_reservation() {
-        let lease = lease();
-        request(&lease, None, Some("session-a"), true);
-        goodbye(&lease, "session-a");
-
-        request(&lease, Some("session-a"), None, true);
-        assert!(lease.state().claim.is_none(), "a resume that succeeded");
-
-        goodbye(&lease, "session-a");
-        assert!(
-            matches!(lease.admit(None), Admission::Serve(_)),
-            "so the next client is not refused by a reservation nobody holds"
+            !request(&lease, Some("session-b"), None, true),
+            "and told once: every later request of that MCP session is ordinary work, not another \
+             adoption"
         );
     }
 
@@ -1584,135 +1308,47 @@ mod tests {
         goodbye(&lease, "session-a");
 
         assert!(
+            lease.state().mcp.is_empty(),
+            "the MCP session went with the DELETE that closed it"
+        );
+        assert!(
             lease.expired().is_none(),
             "a client that said goodbye has its whole grace to change its mind"
         );
         assert!(lease.state().deadline.is_some(), "and the clock is running");
+        assert!(
+            lease.state().left_open,
+            "with whatever it opened waiting to be adopted"
+        );
     }
 
-    /// A goodbye does not hand over the server while work admitted under it is still running.
-    ///
-    /// MCP over HTTP is not one connection: a `DELETE` can arrive while a tool call is executing on
-    /// another. Releasing tenancy there would let the next client adopt the debugger sessions while
-    /// the old call is still running against them — free to mutate or end a target it no longer
-    /// owns.
+    /// A goodbye naming something this credential does not hold changes nothing — the clock
+    /// included.
     #[test]
-    fn a_goodbye_waits_for_the_work_it_admitted() {
+    fn a_goodbye_for_a_session_this_credential_does_not_hold_changes_nothing() {
         let lease = lease();
         request(&lease, None, Some("session-a"), true);
+        let before = lease.state().deadline.expect("the lease is running");
 
-        // A tool call is admitted and is still running.
-        let call = admitted(lease.admit(Some("session-a")));
-        // The DELETE arrives on another connection, and is itself in flight.
-        let delete = admitted(lease.admit(Some("session-a")));
-        lease.released("session-a");
-
-        assert_eq!(
-            lease.state().holder.as_deref(),
-            Some("session-a"),
-            "the goodbye is recorded but not acted on — a call is still running"
-        );
-        assert!(matches!(lease.admit(None), Admission::Occupied));
-
-        lease.leave(delete.epoch); // the DELETE's own request ends
-        assert_eq!(
-            lease.state().holder.as_deref(),
-            Some("session-a"),
-            "still held: the tool call has not come back"
-        );
-
-        lease.leave(call.epoch); // and now the tool call does
-        assert_eq!(
-            lease.state().holder,
-            None,
-            "only now is the server given up"
-        );
-        assert!(matches!(lease.admit(None), Admission::Serve(_)));
-    }
-
-    /// A guard from a torn-down tenancy subtracts nothing from the next one.
-    ///
-    /// Without the epoch, a request that outlived its grace decrements the *new* holder's count
-    /// when it finally returns — which can reach zero while that holder's tool call is still
-    /// running, and let a concurrent goodbye hand the registry to somebody else mid-call.
-    #[test]
-    fn a_stale_guard_cannot_count_out_a_later_holders_work() {
-        let lease = brief();
-        let stranded = admitted(lease.admit(None)); // never comes back before the sweep
         std::thread::sleep(Duration::from_millis(5));
-        assert!(lease.expired().is_some());
-        lease.released_leases();
-
-        // A new client takes the server and starts a call.
-        request(&lease, None, Some("session-new"), true);
-        let call = admitted(lease.admit(Some("session-new")));
-        let delete = admitted(lease.admit(Some("session-new")));
-        lease.released("session-new");
-        lease.leave(delete.epoch);
-
-        // The request from the previous tenancy finally returns.
-        lease.leave(stranded.epoch);
-        assert_eq!(
-            lease.state().holder.as_deref(),
-            Some("session-new"),
-            "a guard from a dead tenancy must not drain the live one's count"
+        lease.released("session-b");
+        assert!(
+            lease.state().mcp.contains("session-a"),
+            "a stray DELETE must not forget a session this credential still holds"
         );
-
-        lease.leave(call.epoch);
         assert_eq!(
-            lease.state().holder,
-            None,
-            "only the real work ending gives it up"
+            lease.state().deadline,
+            Some(before),
+            "nor extend its lease, which is the half a client could otherwise do for ever"
         );
-    }
-
-    /// Tenancy waits on the *engine*, not only on the HTTP request that asked.
-    ///
-    /// A job outlives the wait for it — `Sessions::call_as` cancels only the waiter and says so —
-    /// so a dropped future or a timed-out call leaves work running against a target. Handing that
-    /// target to the next client because the HTTP side went quiet is the same overlap the in-flight
-    /// count exists to prevent, one layer down.
-    #[test]
-    fn a_goodbye_waits_for_the_engine_and_not_just_the_request() {
-        let lease = lease();
-        request(&lease, None, Some("session-a"), true);
-        goodbye(&lease, "session-a");
-        assert_eq!(
-            lease.state().holder,
-            None,
-            "with an idle engine the handover is immediate"
-        );
-
-        // `Sessions::busy` is what the lease consults, and an idle registry is not busy — so this
-        // test pins the wiring rather than the debugger, which needs a worker to be busy at all.
-        assert!(!lease.sessions().busy());
-    }
-
-    /// A request that never came back cannot defer a goodbye for ever.
-    #[test]
-    fn a_swept_lease_forgets_work_it_was_waiting_on() {
-        let lease = brief();
-        let claim = admitted(lease.admit(None));
-        lease.settle(claim.claim, None, Some("session-a"), true);
-        admitted(lease.admit(Some("session-a"))); // a call that never returns
-        lease.released("session-a");
-        std::thread::sleep(Duration::from_millis(5));
-
-        assert!(lease.expired().is_some());
-        assert_eq!(
-            lease.state().in_flight,
-            0,
-            "the teardown took the count with it"
-        );
-        lease.released_leases();
-        assert!(matches!(lease.admit(None), Admission::Serve(_)));
+        assert!(!lease.state().left_open);
     }
 
     /// Only a `DELETE` the service accepted is a departure.
     ///
-    /// A refused one leaves the MCP session open. Recording the client as gone then clears the
-    /// holder, so the sweep that would have closed that session finds nothing to close — and it
-    /// survives with no lease owning it and nothing that will ever collect it (#136).
+    /// A refused one leaves the MCP session open. Recording the client as gone then forgets that
+    /// session, so the sweep that would have closed it never hears of it — and it survives with
+    /// nothing owning it and nothing that will ever collect it (#136).
     #[test]
     fn only_an_accepted_delete_is_a_departure() {
         use hyper::Method;
@@ -1734,227 +1370,13 @@ mod tests {
         );
     }
 
-    /// A goodbye from something that is not the holder changes nothing.
-    #[test]
-    fn only_the_holder_can_let_go() {
-        let lease = lease();
-        request(&lease, None, Some("session-a"), true);
-        lease.released("session-b");
-        assert_eq!(
-            lease.state().holder.as_deref(),
-            Some("session-a"),
-            "a stray DELETE must not hand the server to whoever sent it"
-        );
-    }
-
-    /// **Two clients do not contend, on one lease.** The gate serialised the server when the
-    /// registry was global and one client could end another's targets. Sessions are owned now, so a
-    /// shared gate would only mean that one client's long call — a pool walk, an `!analyze` — makes
-    /// every other client wait for a boundary it no longer provides, and per-client namespaces
-    /// would be unusable concurrently ([#162](https://github.com/glslang/windbg-mcp/issues/162)).
-    ///
-    /// Deliberately *not* written with the `For` binding: two bindings would be two leases, which
-    /// cannot contend whatever the code does, and the test would pass against the bug it is for.
-    #[test]
-    fn one_clients_tenancy_does_not_block_another() {
-        let lease = Lease::new(
-            longest_quiet_call(CALL) + Duration::from_secs(60),
-            CALL,
-            Sessions::new(CALL),
-        )
-        .expect("workable");
-        let laptop = crate::client::Client::new("laptop");
-        let ci = crate::client::Client::new("ci");
-
-        // `laptop` takes its tenancy and holds it — the long-call case.
-        let held = admitted(lease.admit(&laptop, Arriving::Opening));
-        lease.settle(
-            held.claim,
-            None,
-            Some("session-laptop"),
-            true,
-            laptop.clone(),
-        );
-
-        // Within that client, a second `initialize` is still refused: that contention is real, and
-        // it is the one the claim machinery exists to arbitrate.
-        assert_eq!(
-            lease.admit(&laptop, Arriving::Opening),
-            Admission::Occupied,
-            "a second session for the same credential still contends"
-        );
-
-        // Across clients, on the same lease, it is not.
-        assert!(
-            matches!(lease.admit(&ci, Arriving::Opening), Admission::Serve(_)),
-            "another client must not wait on a tenancy that no longer bounds anything it can reach"
-        );
-    }
-
-    /// A revision with no session id is not a client opening one, and the gate must not treat it
-    /// as one.
-    ///
-    /// The `2026-07-28` half of [#168](https://github.com/glslang/windbg-mcp/issues/168). Before
-    /// [`Arriving`] existed there was one "no session id" case and it meant *opening*, so it
-    /// reserved — which on a revision that never sends an id made every request a reservation, and
-    /// every overlapping pair a `409`. Two things are asserted, and the second is the one that
-    /// bites: they overlap, and they keep overlapping while one of them never finishes.
-    #[test]
-    fn stateless_requests_do_not_contend_with_each_other() {
-        let lease = lease();
-
-        let first = admitted(lease.admit_stateless());
-        assert_eq!(
-            first.claim, None,
-            "a request that cannot become the holder must reserve nothing"
-        );
-        let second = admitted(lease.admit_stateless());
-        assert_eq!(second.claim, None);
-
-        // The parked case: the first never returns, and the client still has to be able to ask what
-        // is going on and end it.
-        assert!(
-            matches!(lease.admit_stateless(), Admission::Serve(_)),
-            "a call that never comes back must not lock its own credential out"
-        );
-
-        lease.leave(first.epoch);
-        lease.leave(second.epoch);
-    }
-
-    /// A reservation that took nothing gives its deadline back, not just its claim.
-    ///
-    /// A `2026-07-28` `initialize` may omit the `MCP-Protocol-Version` header — it is the request
-    /// that establishes it — so it reaches the gate looking like any other opener, reserves, and
-    /// then mints no session. Reserving arms a deadline; the sweep reads the deadline and nothing
-    /// else. Left armed, it would start a teardown one grace later against a tenancy that holds
-    /// nothing, release whatever that client had since opened, and refuse its next request with
-    /// `Releasing` — a client losing its sessions on a timer started by its own handshake.
-    #[test]
-    fn a_reservation_that_minted_nothing_leaves_no_clock_running() {
-        let lease = lease();
-
-        // The headerless stateless handshake: admitted as an opener, mints nothing.
-        let it = admitted(lease.admit(None));
-        assert!(
-            lease.state().deadline.is_some(),
-            "reserving arms a deadline — that is the thing this test is about giving back"
-        );
-        assert!(!adopted(lease.settle(it.claim, None, None, true)));
-        lease.leave(it.epoch);
-
-        assert_eq!(
-            lease.state().deadline,
-            None,
-            "a reservation that took nothing must not leave a clock running against a tenancy that \
-             holds nothing"
-        );
-        assert!(
-            lease.expired().is_none(),
-            "and so there is nothing for the sweep to act on"
-        );
-    }
-
-    /// A stateless request renews a lease its credential already has, and creates none.
-    ///
-    /// Both halves are the same rule seen from two sides, and getting either wrong loses sessions.
-    /// A credential can hold a legacy session and *then* start sending stateless requests — a
-    /// client that upgraded, or restarted inside the grace — and since the sweep reads the deadline
-    /// alone and zeroes `in_flight` on its way past, a request that did not renew would have those
-    /// sessions released out from under it while it was using them. The other way costs as much: a
-    /// deadline installed for a client that holds nothing is a lease against nothing, and it would
-    /// release every session a purely stateless client has, one grace after its first call.
-    #[test]
-    fn a_stateless_request_renews_a_lease_but_does_not_start_one() {
-        let lease = lease();
-
-        // Nothing held: a stateless request must leave it that way.
-        let opening = admitted(lease.admit_stateless());
-        assert_eq!(
-            lease.state().deadline,
-            None,
-            "a request that holds nothing must not be given a clock to run out"
-        );
-        lease.leave(opening.epoch);
-
-        // A legacy session, and then the same credential going stateless.
-        request(&lease, None, Some("session-a"), true);
-        let before = lease
-            .state()
-            .deadline
-            .expect("a credential that holds a session has a deadline");
-
-        std::thread::sleep(Duration::from_millis(5));
-        let it = admitted(lease.admit_stateless());
-        let after = lease
-            .state()
-            .deadline
-            .expect("the lease is still the credential's");
-        assert!(
-            after > before,
-            "a stateless request from the holder's own credential must renew its lease"
-        );
-        lease.leave(it.epoch);
-    }
-
-    /// Serving them alongside each other does not make them a tenancy.
-    ///
-    /// A stateless request settles nothing and holds nothing, so no lease is ever installed for a
-    /// client that only sends them — which is deliberate, and why abandonment on this revision is
-    /// [`IDLE_RELEASE`]'s to catch rather than the lease's. What must not happen is the middle
-    /// state: a holder recorded for a session that does not exist, which nothing would ever sweep.
-    #[test]
-    fn a_stateless_request_becomes_nobodys_tenancy() {
-        let lease = lease();
-
-        let it = admitted(lease.admit_stateless());
-        assert!(!adopted(lease.settle(it.claim, None, None, true)));
-        lease.leave(it.epoch);
-
-        assert!(
-            lease.expired().is_none(),
-            "a client that holds nothing has no lease to run out"
-        );
-        // And an ordinary opener is still free to take the tenancy afterwards.
-        assert!(
-            matches!(lease.admit(None), Admission::Serve(_)),
-            "a stateless request must leave the server takeable"
-        );
-    }
-
-    /// A teardown still stops one, because what is being released is the sessions behind it.
-    ///
-    /// The claim is what a stateless request stops taking; the `releasing` check is not, and the
-    /// distinction matters: a request admitted mid-teardown reaches a registry whose sessions are
-    /// being closed underneath it.
-    #[test]
-    fn a_stateless_request_waits_for_a_teardown_like_any_other() {
-        let lease = brief();
-        let claim = admitted(lease.admit(None));
-        lease.settle(claim.claim, None, Some("session-a"), true);
-        std::thread::sleep(Duration::from_millis(5));
-
-        assert!(lease.expired().is_some(), "the grace is spent");
-        assert!(
-            matches!(lease.admit_stateless(), Admission::Releasing),
-            "a stateless request must not be let in to sessions that are being closed"
-        );
-
-        lease.released_leases();
-        assert!(
-            matches!(lease.admit_stateless(), Admission::Serve(_)),
-            "and must be served the moment the teardown is done"
-        );
-    }
-
     /// An MCP session id is one client's, and presenting another's is not a way in.
     ///
     /// The service keeps one session table for the whole server, so the id is the only thing
     /// standing between a client and another's MCP session — and a `DELETE` on it closes that
-    /// session while the lease that minted it still holds the id, which leaves its owner failing
-    /// every request and refused its own re-`initialize` for a grace period. One authenticated
-    /// client denying another is the harm ownership exists to stop, so the gate refuses before
-    /// this caller's own tenancy is even consulted.
+    /// session while its owner still believes it has one, which leaves that client failing every
+    /// request it sends. One authenticated client denying another is the harm ownership exists to
+    /// stop, so this is checked before the caller's own lease is consulted at all.
     ///
     /// One lease and two clients, deliberately: two `For` bindings would be two leases, which
     /// cannot reach each other whatever the code does.
@@ -1969,167 +1391,107 @@ mod tests {
         let laptop = crate::client::Client::new("laptop");
         let ci = crate::client::Client::new("ci");
 
-        let held = admitted(lease.admit(&laptop, Arriving::Opening));
-        lease.settle(
-            held.claim,
-            None,
-            Some("session-laptop"),
-            true,
-            laptop.clone(),
-        );
+        served(lease.admit(&laptop, None));
+        lease.settle(None, Some("session-laptop"), true, &laptop);
 
         assert_eq!(
-            lease.admit(&ci, Arriving::Holding("session-laptop")),
+            lease.admit(&ci, Some("session-laptop")),
             Admission::NotYours,
-            "another client's session id was admitted, so its holder could be deleted out from \
+            "another client's session id was admitted, so its owner could be deleted out from \
              under it"
         );
         // And the owner is unaffected — the check must not cost a client its own session.
-        assert!(
-            matches!(
-                lease.admit(&laptop, Arriving::Holding("session-laptop")),
-                Admission::Serve(_)
-            ),
-            "the holder must still be served its own id"
-        );
-        // An id nobody holds is not owned by anybody: a client resuming inside the grace has to
-        // get through, which is the arm this check sits in front of.
-        assert!(
-            matches!(
-                lease.admit(&ci, Arriving::Holding("session-nobodys")),
-                Admission::Serve(_)
-            ),
-            "an id no tenancy holds is unusable in the service anyway, and refusing it would \
-             refuse a legitimate resume"
-        );
+        served(lease.admit(&laptop, Some("session-laptop")));
+        // An id nobody records is not owned by anybody: a client resuming inside the grace has to
+        // get through, which is the case this check sits in front of.
+        served(lease.admit(&ci, Some("session-nobodys")));
     }
 
-    /// A claim keeps alive the sessions it is adopting.
+    /// One client's teardown does not refuse another's requests.
+    ///
+    /// The gate is gone, so the only thing left that can refuse an authenticated client is its own
+    /// release — and it has to stay its own. A shared version would mean one client's expiry
+    /// stopping every other client for a boundary the registry already provides
+    /// ([#162](https://github.com/glslang/windbg-mcp/issues/162)).
+    ///
+    /// Deliberately *not* written with the `For` binding: two bindings would be two leases, which
+    /// cannot interfere whatever the code does, and the test would pass against the bug it is for.
     #[test]
-    fn reserving_the_server_renews_what_the_claim_is_adopting() {
-        let lease = For::new(
-            Lease {
-                grace: Duration::from_millis(60),
-                sessions: Sessions::new(CALL),
-                state: Mutex::new(HashMap::new()),
-            },
-            crate::client::Client::LOCAL,
-        );
-        request(&lease, None, Some("session-a"), true);
-        goodbye(&lease, "session-a");
-        std::thread::sleep(Duration::from_millis(40));
+    fn one_clients_release_does_not_refuse_another() {
+        let lease = unchecked(Duration::from_millis(1));
+        let laptop = crate::client::Client::new("laptop");
+        let ci = crate::client::Client::new("ci");
 
-        assert!(
-            matches!(lease.admit(None), Admission::Serve(_)),
-            "still inside the grace"
-        );
-        std::thread::sleep(Duration::from_millis(40));
-        assert!(
-            lease.expired().is_none(),
-            "the claim pushed the deadline out; without that the sweep would release the sessions \
-             this request is in the middle of adopting"
-        );
-    }
-
-    /// A request that never settles cannot wedge the server for ever.
-    #[test]
-    fn a_claim_whose_request_died_is_cleared_by_the_grace() {
-        let lease = brief();
-        admitted(lease.admit(None));
+        served(lease.admit(&laptop, None));
+        lease.settle(None, Some("session-laptop"), true, &laptop);
         std::thread::sleep(Duration::from_millis(5));
 
-        assert!(
-            lease.expired().is_some(),
-            "the claim's own deadline ran out"
-        );
-        assert!(
-            lease.state().claim.is_none(),
-            "and took the reservation with it"
-        );
-        lease.released_leases();
-        assert!(matches!(lease.admit(None), Admission::Serve(_)));
+        assert!(lease.expired_for(&laptop).is_some(), "the grace is spent");
+        assert_eq!(lease.admit(&laptop, None), Admission::Releasing);
+        served(lease.admit(&ci, None));
     }
 
-    /// A teardown already under way wins over a claim settling into it.
-    #[test]
-    fn a_claim_that_settles_during_a_teardown_does_not_take_the_server() {
-        let lease = brief();
-        request(&lease, None, Some("session-a"), true);
-        // The holder lets go, so the next request is a genuine resume and reserves a claim of its
-        // own — a request from the sitting holder reserves nothing and settles nothing.
-        goodbye(&lease, "session-a");
-        let resumed = admitted(lease.admit(Some("session-a"))).claim;
-        assert!(resumed.is_some(), "a resume reserves the server");
-        std::thread::sleep(Duration::from_millis(5));
-        assert!(lease.expired().is_some());
-
-        assert_eq!(
-            lease.settle(resumed, None, Some("session-b"), true),
-            Settled::Stale
-        );
-        assert_eq!(
-            lease.state().holder,
-            None,
-            "a client must not be handed sessions that are being released out from under it"
-        );
-    }
-
-    /// Nothing is admitted between deciding to release and having released.
+    /// Nothing of this credential's is admitted between deciding to release and having released.
     #[test]
     fn nothing_is_admitted_while_the_teardown_runs() {
         let lease = brief();
-        let claim = admitted(lease.admit(None));
-        lease.settle(claim.claim, None, Some("session-a"), true);
+        request(&lease, None, Some("session-a"), true);
         std::thread::sleep(Duration::from_millis(5));
 
         assert!(lease.expired().is_some(), "the grace is spent");
-        assert!(
-            matches!(lease.admit(None), Admission::Releasing),
-            "the server is not vacant yet — the sessions are still being let go, and saying so is \
-             not the same as saying this credential holds one"
+        assert_eq!(
+            lease.admit(None),
+            Admission::Releasing,
+            "the sessions are still being let go, and saying so is not the same as saying this \
+             credential holds one"
+        );
+        assert_eq!(
+            lease.admit(Some("session-a")),
+            Admission::Releasing,
+            "whatever the request presents: what is being released is the sessions behind it"
         );
 
         lease.released_leases();
-        assert!(matches!(lease.admit(None), Admission::Serve(_)));
+        served(lease.admit(None));
     }
 
     /// Expiry is a one-shot: the deadline is consumed by the sweep that acts on it.
     #[test]
     fn expiry_is_reported_once_rather_than_on_every_sweep() {
         let lease = brief();
-        let claim = admitted(lease.admit(None));
-        lease.settle(claim.claim, None, Some("session-a"), true);
+        request(&lease, None, Some("session-a"), true);
         std::thread::sleep(Duration::from_millis(5));
 
         assert!(lease.expired().is_some(), "the grace is spent");
         assert!(
             lease.expired().is_none(),
-            "and expiry is reported once, not on every sweep — a second `true` would release an \
+            "and expiry is reported once, not on every sweep — a second report would release an \
              already-released set of sessions on each pass"
         );
-        assert_eq!(lease.state().holder, None);
+        assert!(lease.state().mcp.is_empty());
     }
 
     /// A swept lease says what it left in the service, so the sweeper can close that too.
     #[test]
-    fn a_swept_lease_reports_the_session_that_never_said_goodbye() {
+    fn a_swept_lease_reports_the_sessions_that_never_said_goodbye() {
         let lease = brief();
-        let claim = admitted(lease.admit(None));
-        lease.settle(claim.claim, None, Some("session-a"), true);
+        request(&lease, None, Some("session-a"), true);
+        request(&lease, None, Some("session-b"), true);
         std::thread::sleep(Duration::from_millis(5));
         assert_eq!(
-            lease.expired().map(|e| e.holder),
-            Some(Some("session-a".to_string())),
-            "a client that vanished leaves an MCP session nothing else will ever close"
+            lease.expired().map(|e| e.mcp),
+            Some(vec!["session-a".to_string(), "session-b".to_string()]),
+            "a client that vanished leaves MCP sessions nothing else will ever close — all of \
+             them, not the newest"
         );
 
         let lease = brief();
-        request(&lease, None, Some("session-b"), true);
-        goodbye(&lease, "session-b");
+        request(&lease, None, Some("session-c"), true);
+        goodbye(&lease, "session-c");
         std::thread::sleep(Duration::from_millis(5));
         assert_eq!(
-            lease.expired().map(|e| e.holder),
-            Some(None),
+            lease.expired().map(|e| e.mcp),
+            Some(vec![]),
             "whereas one that said goodbye had its session closed by the DELETE"
         );
     }

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -2289,8 +2289,8 @@ fn a_call_that_asked_for_no_progress_is_sent_none() {
 // lease is the only part of this server whose failures cost a *target* rather than a call.
 //
 // Every rule of it has unit tests in `src/listen.rs`, against the state machine directly. What
-// those cannot reach is the wiring: the bearer check that runs before the gate, the
-// `Mcp-Session-Id` header tenancy is keyed on, an HTTP status a client actually branches on, and —
+// those cannot reach is the wiring: the bearer check that runs before any of it, the
+// `Mcp-Session-Id` header ownership is keyed on, an HTTP status a client actually branches on, and —
 // in the debugger tier — the sweep releasing a real engine worker. That had been checked by hand
 // against the guest three times, which is how this tier came to exist.
 //
@@ -2300,7 +2300,9 @@ fn a_call_that_asked_for_no_progress_is_sent_none() {
 
 /// The protocol revision the lease is exercised against.
 ///
-/// Tenancy is keyed on `Mcp-Session-Id`, so this has to be a revision whose handshake mints one.
+/// A lease is armed by an MCP session, so this has to be a revision whose handshake mints one — a
+/// `2026-07-28` client is never given a clock at all, and abandonment there is the idle release's.
+/// [`STATELESS_REVISION`] is what exercises the rest of the wiring on that revision.
 const LEASE_REVISION: &str = "2025-06-18";
 
 /// The revision that removed the session id, and therefore the lease's grip on a client.
@@ -2678,7 +2680,7 @@ impl Listener {
         )
     }
 
-    /// The handshake, answering with the session id the lease keys tenancy on.
+    /// The handshake, answering with the session id a lease is armed by.
     fn initialize(&mut self) -> String {
         let reply = self.call(None, "initialize", Self::opening());
         assert_eq!(
@@ -2920,9 +2922,11 @@ fn service_is_registered() -> bool {
 /// An unauthenticated caller is refused, told nothing about what is here — and costs the server
 /// nothing.
 ///
-/// The last clause is the one worth a test. The bearer check runs *before* the tenancy gate, so a
-/// wrong token must not reserve, renew or consume a claim; if it did, anything that could reach
-/// the port could keep the real client locked out without ever authenticating.
+/// The last clause is the one worth a test. The bearer check runs *before* the lease is touched, so
+/// a wrong token must not renew one or reach the state behind it. It used to matter more sharply
+/// than it does: while the gate existed, a request that reserved kept every other request of that
+/// credential out, so anything that could reach the port could lock the real client out without
+/// ever authenticating.
 #[test]
 fn an_unauthenticated_request_is_refused_and_costs_the_server_nothing() {
     let mut server = Listener::start(&[]);
@@ -2948,52 +2952,54 @@ fn an_unauthenticated_request_is_refused_and_costs_the_server_nothing() {
     );
 }
 
-/// One MCP session at a time **per credential**, refused with `409` rather than served alongside.
+/// A credential's second MCP session is **served alongside** the first, not refused.
 ///
-/// This was once the whole boundary: handles were minted from one registry, `MAX_SESSIONS` was
-/// shared and `end_session` ended whatever it was handed, so two clients would silently share and
-/// one could end a target the other was using. Sessions are owned now
-/// ([#162](https://github.com/glslang/windbg-mcp/issues/162)), and the tenancy is per client — so
-/// what this asserts is a credential racing *itself*, which is the only contention left. The
-/// listener here holds one, unnamed token, so both requests below are that one client.
+/// This was a `409` until the gate was retired, and it was once the whole boundary: handles were
+/// minted from one registry, `MAX_SESSIONS` was shared and `end_session` ended whatever it was
+/// handed, so two clients would silently share and one could end a target the other was using.
+/// Ownership took that job over ([#162](https://github.com/glslang/windbg-mcp/issues/162)), and
+/// what the gate had left to arbitrate was one credential racing *itself* — which inside a
+/// namespace is not a boundary at all: both MCP sessions reach the same debug sessions, because
+/// they are the same client. `FOLLOWUPS.md` item 28 is where that was decided; this is the property
+/// that replaces the refusal.
 ///
-/// Not about *connections*: requests carrying the session this credential already holds are served
-/// concurrently, which is what makes a `DELETE` on one connection while a tool call runs on another
-/// work at all. What is refused is a **second session** — a fresh `initialize`, or an id that is
-/// not the one it holds.
+/// The half underneath still has to hold, and the last assertion is it: an id **this server never
+/// issued** is not served. An id *another client* holds is refused too — that one needs two tokens,
+/// so it is unit-tested in `src/listen.rs` (and is item 29's gap end to end).
 #[test]
-fn a_second_session_for_one_credential_is_refused_while_it_holds_the_server() {
+fn a_second_session_for_one_credential_is_served_alongside_the_first() {
     let mut server = Listener::start(&[]);
-    let holder = server.initialize();
 
-    let intruder = server.call(None, "initialize", Listener::opening());
-    assert_eq!(
-        intruder.status, 409,
-        "a second session for the holder's own credential was not refused: {}",
-        intruder.body
-    );
-    assert!(
-        intruder.body.contains("already using this server"),
-        "the refusal has to say why, or it reads as a bug: {}",
-        intruder.body
+    // Both through the full handshake, ack included: the assertion that each was served lives in
+    // the helper, which panics with the status and the server's stderr if one is refused.
+    let first = server.initialize();
+    let second = server.initialize();
+    assert_ne!(
+        first, second,
+        "each initialize mints an MCP session of its own"
     );
 
-    // A session id that is not the holder's is refused on the same grounds — this is the arm that
-    // makes the refusal a rule about tenancy rather than about `initialize`.
+    // And both are usable, against the one namespace of debug sessions behind them.
+    for (which, id) in [("the first", &first), ("the second", &second)] {
+        let status = server.tool(id, "session_status", json!({}));
+        assert_eq!(
+            status["status"], "ok",
+            "{which} MCP session of one credential was not served: {status}"
+        );
+    }
+
+    // An id nothing here issued is still not served — decided by the service now, which is where
+    // an unknown session belongs once the listener has stopped refusing one on tenancy grounds.
     let stranger = server.call(
         Some("not-a-session-this-server-issued"),
         "tools/list",
         json!({}),
     );
-    assert_eq!(
-        stranger.status, 409,
-        "a stranger's session id was served: {}",
+    assert_ne!(
+        stranger.status, 200,
+        "an MCP session id this server never issued was served: {}",
         stranger.body
     );
-
-    // And the holder is undisturbed by either.
-    let status = server.tool(&holder, "session_status", json!({}));
-    assert_eq!(status["status"], "ok", "{status}");
 }
 
 /// The listener serves `2026-07-28` — the handshake *and* everything after it.
@@ -3024,8 +3030,8 @@ fn the_listener_serves_the_stateless_revision_it_negotiates() {
         "the handshake must negotiate the revision it was offered: {}",
         opening.body
     );
-    // SEP-2567 removed the session id, so there is nothing here for the lease to key tenancy on.
-    // Asserted rather than assumed: every rule the gate has is written in terms of this header,
+    // SEP-2567 removed the session id, so there is nothing here for a lease to be armed by.
+    // Asserted rather than assumed: ownership is what the listener still reads this header for,
     // and its absence is what makes the rest of this test a different client to the ones above.
     assert!(
         opening.session.is_none(),
@@ -3140,8 +3146,8 @@ fn an_under_specified_stateless_request_is_told_which_part_it_is_missing() {
         unheaded.body
     );
 
-    // And the server is undamaged by either — a refusal at this layer must not consume a claim,
-    // for the same reason the unauthenticated one must not.
+    // And the server is undamaged by either — a refusal at this layer must not touch the lease
+    // state behind it, for the same reason the unauthenticated one must not.
     let listed = server.stateless("tools/list", json!({}));
     assert_eq!(
         listed.status, 200,
@@ -3154,23 +3160,16 @@ fn an_under_specified_stateless_request_is_told_which_part_it_is_missing() {
 ///
 /// The distinction is the whole reason a lease exists. Every request here is its own connection —
 /// which is what a client behind a tunnel looks like — so "the client is silent" is the resting
-/// state, and a server that treated silence as departure would hand the registry on between two
-/// calls of a working client.
+/// state, and a server that treated silence as departure would release a working client's targets
+/// between two of its calls.
 #[test]
 fn a_silence_is_not_a_departure_and_a_goodbye_is() {
     let mut server = Listener::start(&[]);
     let holder = server.initialize();
 
-    // Nothing is connected at this moment, and the holder still holds.
-    let too_early = server.call(None, "initialize", Listener::opening());
-    assert_eq!(
-        too_early.status, 409,
-        "silence was read as departure — a client between two calls would lose its targets: {}",
-        too_early.body
-    );
-
-    // Returning with the same id is served: the property stdio cannot offer, where a client
-    // restart costs a KDNET attach and a KDNET attach costs a reboot of the target.
+    // Nothing is connected at this moment, and the client is still here: returning with the id it
+    // left with is served. That is the property stdio cannot offer, where a client restart costs a
+    // KDNET attach and a KDNET attach costs a reboot of the target.
     let resumed = server.call(Some(&holder), "tools/list", json!({}));
     assert_eq!(
         resumed.status, 200,
@@ -3184,6 +3183,17 @@ fn a_silence_is_not_a_departure_and_a_goodbye_is() {
         "the DELETE was refused ({}): {}",
         farewell.status,
         farewell.body
+    );
+
+    // And a goodbye *is* a departure: the id it said goodbye with is gone. This used to be read off
+    // a `409` — a second `initialize` was refused while the first was held, so "still held" was
+    // visible in the refusal — and nothing refuses that since the gate was retired. What says the
+    // client left is the id it left with no longer being served.
+    let stale = server.call(Some(&holder), "tools/list", json!({}));
+    assert_ne!(
+        stale.status, 200,
+        "the id the client said goodbye with was still served: {}",
+        stale.body
     );
 
     let next = server.initialize();
@@ -5859,7 +5869,9 @@ fn two_sessions_coexist_and_do_not_disturb_each_other() {
 /// The second finding of [#168](https://github.com/glslang/windbg-mcp/issues/168), and the one that
 /// survived the first. A request carrying no `Mcp-Session-Id` used to take the gate's *opening*
 /// path and hold a claim for its whole duration — and on `2026-07-28` there is never an id to
-/// carry, so that was **every** request. Two that overlapped contended.
+/// carry, so that was **every** request. Two that overlapped contended. The gate has since been
+/// retired entirely, so there is no classification left to get wrong; this stays because the
+/// property is the client's, not the mechanism's.
 ///
 /// Measured at its sharpest rather than as a race. A kernel attach whose target never dials in
 /// parks in `WaitForEvent(INFINITE)` and does not come back; that is a supported state, and
@@ -6127,10 +6139,10 @@ fn a_lease_that_runs_out_releases_what_the_absent_client_left() {
         }),
     );
     // The *tool* is expected to report a failure — the attach parks, and the call budget here is
-    // one second — but the **listener** has to have admitted it. Without this, a `401` or a `409`
-    // from a tenancy regression would fall through to the skip below and be reported as a busy
-    // port on the host, and the one assertion in this file that costs a target would pass in
-    // silence.
+    // one second — but the **listener** has to have admitted it. Without this, a refusal from a
+    // regression in the listener — a `401`, the `404` an ownership check answers with, the `409` a
+    // teardown does — would fall through to the skip below and be reported as a busy port on the
+    // host, and the one assertion in this file that costs a target would pass in silence.
     assert_eq!(
         requested.status,
         200,


### PR DESCRIPTION
Slice 3b of #162, and the answer to `FOLLOWUPS.md` item 28: the listener's single-tenancy gate is
retired. A credential may open a second MCP session, and two of its requests never wait on each
other. The `409` that refused one is gone.

## Why the gate had nothing left to arbitrate

It was the boundary between two clients when the registry was one map for the whole server — handles
minted from it, the four-session cap shared, `end_session` ending whatever it was handed. Ownership
took that job over in the slices above: a session belongs to the client that opened it, and routing,
the cap, the closed-session history, `server_log` and lease release are all per client.

What the gate had left was one credential racing **itself** — a fresh `initialize` while it held one,
or a request bearing an id that was not the one it held. Inside a namespace neither is a boundary:
both MCP sessions reach the same debug sessions, because they are the same client. The refusal cost
that client its own concurrency and bought nothing, and at its sharpest it cost the recovery path,
since a request that reserved locked its own credential out of `session_status` and `end_session`
(#168).

## The clock stays — idle release does not subsume it

That was the question item 28 was filed to settle, and the answer is measurable rather than a
judgement call:

- `Sessions::release_idle` deliberately spares a session with a call outstanding, which is exactly
  the parked `attach_kernel` a vanished client leaves behind — a park is one call that never returns.
- It knows nothing about MCP sessions, so an abandoned one would stay resident in the service with
  its id accepted, one per reconnect cycle.

`release_leased` does both. So: any request renews the lease, an expiry releases that client's
sessions and closes its MCP sessions, and a request arriving mid-release is told to ask again — the
sweep's refusal, which was never tenancy, and now the only `409` this server has.

The lease is still armed by an MCP session, so a `2026-07-28` client still has no clock —
deliberately, now that the credential could carry one. A lease releases everything that credential
holds, busy or not; a stateless client is legitimately silent for far longer than 390 seconds, and
releasing a live kernel from under a caller who is thinking is worse than holding an abandoned one
for the idle window. `docs/remote-listener.md` says so where it explains why both mechanisms exist.

## What went, and the three things worth reviewing

Deleted: the reservation and its generation counter, `Admission::Occupied` and its `409`, the `Stale`
settlement and the session it had to close on an expired claim, the in-flight count and its epoch,
the handover that waited on `Sessions::busy` (and `Sessions::busy` itself), `Arriving`,
`mints_no_session`, and every read of `MCP-Protocol-Version`. A request now presents a session id or
nothing, so the classification behind #168 is deleted rather than refined.

1. **A credential's MCP sessions became a set**, not one holder. An id recorded for nobody is one any
   credential may present, so tracking only the newest would have handed a client another's older id
   the moment that client opened a second — the harm the ownership check exists to stop, arriving
   through the removal of the refusal in front of it.
2. **One lease rule survives**, and it is the one that loses sessions if forgotten: an *admitted*
   request renews an existing deadline and creates none. The second rule item 28 asked to preserve —
   a reservation that mints nothing handing its deadline back — is unreachable rather than handled,
   since only a settled MCP session arms one.
3. **The property the deleted machinery protected was already enforced below it.** A sweep fires only
   after a whole grace with nothing admitted, and `Lease::new` refuses a grace shorter than the
   longest a call can keep a client quiet, so no request of that credential's can still be in flight
   when its lease expires. That is what the claim generations and epochs were for, added a layer
   above the thing being protected — the pattern `DECISIONS.md` already named for this code, and now
   records the other half of.

## Tests

Ninety lease tests became twenty; the ones that went were sequencing a handover that no longer
happens. Two smoke assertions now say the opposite of what they said — a credential's second MCP
session is served alongside its first, and a goodbye is read off the id no longer working rather than
off the `409` a second `initialize` used to get.

| | |
| --- | --- |
| `cargo fmt --all --check` | clean (Mac) |
| `cargo clippy --all-targets -- -D warnings` | clean (ARM64 Windows) |
| `cargo test` | 64 passed |
| `WINDBG_MCP_SMOKE_DUMP=1 cargo test --test mcp_smoke` | 64 passed, including `a_lease_that_runs_out_releases_what_the_absent_client_left` — the sweep terminating a **real** parked kernel worker — and `a_stateless_client_can_work_while_one_of_its_own_calls_is_parked` |

The live-kernel tier was not run and adds nothing here: every `Listener` assertion lives in the
protocol and dump tiers, nothing in this change reaches worker or engine code, and the one
live-target claim it could touch — the sweep killing a parked attach's worker — is what the dump tier
asserts with a real worker and a real process id.

## Docs

`FOLLOWUPS.md` item 28 closed with the reasoning (29 and 30 adjusted; 30's hazard is deleted rather
than covered), a new `DECISIONS.md` entry with the #135 entry's status pointing at it, plus
`CHANGELOG.md`, `CLAUDE.md`, `docs/remote-listener.md`, `docs/smoke-test.md`, `README.md` and
`src/client.rs`.

This is the last slice of #162, which was already closed once its defect was fixed — the decision
that remained lives in `FOLLOWUPS.md` item 28, and this settles it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
