### PR TITLE
Write down what the service does with a session id, and what a pass count does not say

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,6 +109,11 @@ For a compile/behavior check without touching the locked release exe, use the **
 `cargo clippy --all-targets`. The release
 build differs only in optimization and is exercised by CI on a fresh runner.
 
+**The pass count does not say which tiers ran.** Each gate is inside its test, so
+`cargo test` reports the same **64 passed** with the debugger tier off as with it on; what differs is
+the runtime (~1.3s against ~52s) and the `SKIPPED` lines, which only `--nocapture` prints. Read one
+of those two before believing a run covered a debugger claim.
+
 **The dev exe can be locked too, and the failure is quiet.** A worker left running — a driver
 script that died mid-session, a debugger tier killed partway — holds `target\debug\windbg-mcp.exe`,
 and `cargo build` then fails at the final replace step with `Access is denied (os error 5)` while
@@ -420,6 +425,20 @@ the startup floor in `Lease::new`: a grace longer than the longest a call can ke
 means **no request of that credential's can still be in flight when its lease expires**. That is the
 property the epochs and claim generations were protecting one layer above, and it was already
 enforced.
+
+**What rmcp does with session ids, which the ownership answer now leans on.** Two facts, both in
+`…/rmcp-3.1.2/src/transport/streamable_http_server/tower.rs`:
+
+- a legacy `initialize` **always** mints one — `create_session()` then `spawn_session_worker`, with no
+  check on who is asking — so nothing but this server ever refused a credential a second MCP session,
+  and now nothing does. Hence a client's ids are a **set** (an id this server stops recording is one
+  any credential may present) and an expiry closes **every** one of them (each abandoned handshake
+  otherwise leaves a live service task behind).
+- an id the service does not know — never issued, closed by a `DELETE`, or closed by the sweep —
+  comes back `404 Not Found: Session not found`. That is deliberately the same status
+  `Admission::NotYours` answers with: from the caller's side "not yours" and "not a session here"
+  are indistinguishable, and splitting them into a distinguishable pair would confirm a session the
+  caller may not touch.
 
 **Driving the listener by hand on `2026-07-28` needs three things, and sending one gets a `400`
 that looks like a broken server.** Every request *after the handshake* carries the

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -17,6 +17,11 @@ connected MCP client holds a lock on (see [`CLAUDE.md`](../CLAUDE.md)). The prot
 adding the debugger tier takes it to ~50s, almost all of it two tests waiting out real timers — a
 lease grace, and a call staying silent long enough to have to report that it is still running.
 
+**The pass count is the same either way**, because each gate is inside its own test: 64 passed with
+the tier off, 64 passed with it on. The runtime is what tells them apart, and `--nocapture` is what
+prints the `SKIPPED` reason — a run that reports 64 green having taken a second covered no debugger
+claim at all.
+
 ### Tiers
 
 | Tier | Gate | Needs | Catches |


### PR DESCRIPTION
Handoff for #171: two things retiring the tenancy gate cost a session to establish, neither of them
recorded anywhere a later session would look.

**What rmcp does with session ids is load-bearing here now.** A legacy `initialize` always mints one
— `create_session()` then `spawn_session_worker`, with no check on who is asking
(`rmcp-3.1.2/src/transport/streamable_http_server/tower.rs:1859`) — so nothing but this server ever
refused a credential a second MCP session, and since #171 nothing does. Which is why a client's ids
are tracked as a **set** (an id this server stops recording is one any credential may present) and
why an expiry closes **every** one of them (each abandoned handshake otherwise leaves a live service
task behind). And an id the service does not know — never issued, closed by a `DELETE`, or closed by
the sweep — comes back `404 Not Found: Session not found`, deliberately the same answer
`Admission::NotYours` gives: "not yours" and "not a session here" have to stay indistinguishable, or
the reply confirms a session the caller may not touch.

**A pass count does not say which tiers ran.** Each gate is inside its own test, so `cargo test`
reports the same **64 passed** with the debugger tier off as with it on. The runtime (~1.3s against
~52s) and the `SKIPPED` lines that only `--nocapture` prints are the entire signal. This one was paid
for during #171, reading a green protocol run as though it had covered a debugger claim.

Docs only — no code, no test changes. `CLAUDE.md` takes both (the first in the listener section, the
second beside the local-verification notes); `docs/smoke-test.md` takes the count warning where it
introduces the tiers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
