### PR TITLE
Write down how to drive this from a local model, and what decides whether it fits

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,10 +109,12 @@ For a compile/behavior check without touching the locked release exe, use the **
 `cargo clippy --all-targets`. The release
 build differs only in optimization and is exercised by CI on a fresh runner.
 
-**The pass count does not say which tiers ran.** Each gate is inside its test, so
-`cargo test` reports the same **64 passed** with the debugger tier off as with it on; what differs is
-the runtime (~1.3s against ~52s) and the `SKIPPED` lines, which only `--nocapture` prints. Read one
-of those two before believing a run covered a debugger claim.
+**The pass count does not say which tiers ran.** Each gate is inside its test, so the `mcp_smoke`
+harness reports the same **64 passed** with the debugger tier off as with it on — that harness's own
+result line, since a plain `cargo test` runs the crate's several hundred unit tests beside it and
+prints a result line per binary. What differs between the two runs is the runtime (~1.3s against
+~52s for `cargo test --test mcp_smoke`) and the `SKIPPED` lines, which only `--nocapture` prints.
+Read one of those two before believing a run covered a debugger claim.
 
 **The dev exe can be locked too, and the failure is quiet.** A worker left running — a driver
 script that died mid-session, a debugger tier killed partway — holds `target\debug\windbg-mcp.exe`,

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -5,6 +5,42 @@ status. Keep entries short; link to code with `file:line` where it helps a futur
 
 ---
 
+## Ask the component that owns a fact; do not infer it one layer up (2026-08-20)
+
+**Context.** This is the second time a review has walked a correct fix inward one layer at a time,
+and the second time it terminated only when somebody asked the thing that actually knows. Two
+instances make it a rule rather than a war story, which is why it gets an entry of its own.
+
+- **The lease** (#135/#137, entry below). Seven rounds on "is it safe to hand the server over?": a
+  reservation needed a lifetime, the lifetime a resolution, the resolution an undo for what it had
+  minted, the in-flight counter an epoch. It ended at `Sessions::busy` — the engine's own account of
+  whether a session still has work — because a job outlives the request that queued it, so "the HTTP
+  request ended" was never "the target is free".
+- **The local-model driver** (#173). Three rounds on "whose debug session is this?": first
+  `end_session` was fenced to sessions this run opened, then the *scrape* that decided that was
+  narrowed to openers, then the scrape itself turned out to be the bug — an opener refused at the
+  four-session cap builds its error out of **every live handle** (`Sessions::take_slot`), so reading
+  an answer's prose marks sessions the call did not create. It ended at
+  `structuredContent.session_id`, the field whose whole job is to name the session a call is about.
+
+**Decision.** For any question about the ownership or state of a resource, find the component that
+can answer for it authoritatively and ask *that*, before adding a condition at the layer you happen
+to be standing on. In this codebase that has three shapes worth naming: the engine answers for
+whether a session is busy, the credential answers for which client is asking (#162 — not the session
+id, not the connection, neither of which survives a stateless revision), and a typed result answers
+for which session it concerns. **Prose is never the answer**: a message names things the call did not
+create, while the structured field names exactly the one it did.
+
+**Why it keeps happening.** Each intermediate answer is *true at its own level* and silent about the
+one below, so it survives review and passes its tests — and the next round finds the seam it left.
+The tell is a chain of conditions that keeps needing one more link; that is the signal to stop adding
+links and go looking for the component that already knows.
+
+**Status.** Recorded, not enforced — there is nothing to enforce it with. Both instances are in the
+entries below, and #173's is the cheaper one to read: four commits, each fixing the previous fix.
+
+---
+
 ## The boundary is ownership, so the gate that stood in for it is gone (2026-08-20, #162)
 
 **Context.** The entry below ("Tenancy is held until the engine is idle") decided that one client
@@ -226,7 +262,8 @@ It terminated at `Sessions::busy`. An engine job outlives the request that queue
 "the target is free". Asking the engine's own account of whether a session has work outstanding is
 the last question in the chain, because it *is* the resource. **The lesson for anything that
 extends this: name the resource being protected and find who can answer for it authoritatively,
-before adding a condition at the layer you happen to be standing on.**
+before adding a condition at the layer you happen to be standing on.** It recurred in #173 and now
+has an entry of its own — see *Ask the component that owns a fact* above.
 
 **A corollary, from #136.** The one tenancy rule that lived in the HTTP handler rather than in
 `Lease` — whether a `DELETE` counts as the client leaving — was also the one that was wrong, and it

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -974,9 +974,12 @@ hold `local`, `ci` and `laptop`; the service can hold one client, so two agents 
 host share a namespace — which is exactly what ownership was built to stop.
 
 It surfaced from the other end, in review of [#173](https://github.com/glslang/windbg-mcp/pull/173):
-the local-model driver must not open sessions on a borrowed credential, because a client over the
-four-session cap has its oldest idle session reclaimed and the driver's open can evict the editor's
-target. The runbook's answer — give the driver its own token — cannot be followed under the service.
+a local-model driver must not share a credential with the editor, because a client over the
+four-session cap has its oldest idle session reclaimed, so the driver's `open_dump` can evict the
+editor's target with nothing naming it. That driver now **requires** a credential of its own rather
+than defending against sharing one — which is the right shape and makes this item the only thing
+standing between it and the recommended deployment: under the service there is no second credential
+to give it.
 
 **What would close it:** a token file that can name more than one client. The obvious shape is the
 same one `WINDBG_MCP_PROFILES` already uses for kernel profiles — a JSON object of name to token,

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -958,3 +958,31 @@ mechanism to catch, so it is worth doing only if the arming rule ever grows a se
 **Why deferred:** it buys call-site coverage of a path whose hazard has been deleted rather than
 handled. Picks up at the listener helpers in `tests/mcp_smoke.rs`, beside
 `the_listener_serves_the_stateless_revision_it_negotiates`.
+
+## 31. [windbg-mcp] A service-hosted listener can hold only one client
+
+`Credentials::from_entries` treats a configured `WINDBG_MCP_LISTEN_TOKEN_FILE` as the **only**
+credential: it loads that token as `local` and returns, ignoring every environment token including
+named ones. That precedence is deliberate and load-bearing — the service installer ACLs the file to
+SYSTEM and Administrators precisely because the machine environment is readable by unprivileged
+processes, and a variable standing beside it would let a stale or planted one authenticate to a
+LocalSystem listener that has `launch` on it.
+
+The consequence is that **the per-client work of [#162](https://github.com/glslang/windbg-mcp/issues/162)
+is unreachable in the deployment `docs/remote-listener.md` recommends.** A foreground listener can
+hold `local`, `ci` and `laptop`; the service can hold one client, so two agents on one service-hosted
+host share a namespace — which is exactly what ownership was built to stop.
+
+It surfaced from the other end, in review of [#173](https://github.com/glslang/windbg-mcp/pull/173):
+the local-model driver must not open sessions on a borrowed credential, because a client over the
+four-session cap has its oldest idle session reclaimed and the driver's open can evict the editor's
+target. The runbook's answer — give the driver its own token — cannot be followed under the service.
+
+**What would close it:** a token file that can name more than one client. The obvious shape is the
+same one `WINDBG_MCP_PROFILES` already uses for kernel profiles — a JSON object of name to token,
+with a bare string still read as `local` so every existing install keeps working. The ACL story is
+unchanged, since it is one file either way.
+
+**Why deferred:** it is a file-format change to the one file that holds credentials, and it wants to
+land on its own rather than inside a runbook PR. Picks up at `Credentials::from_entries`
+(`src/client.rs`) and `service::install`, which writes the file.

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -762,6 +762,12 @@ landed on their own so that each of the items below can be argued, and measured,
   `MAX_NODES`, `MAX_READ_BYTES`) is justified in its own comment as a worker out-of-memory guard.
   A caller-context guard is a different constraint and does not exist yet.
 
+**Where this bites first is a local model**, whose window is bought in RAM rather than rented:
+[`docs/local-model.md`](./docs/local-model.md) is the runbook, and it names the three client-side
+knobs the split-plane plan proposed — a tool-surface profile, a per-call response budget, a
+text-or-data switch — none of which this server has. The two bullets above are the server-side half
+of the same problem.
+
 **Depends on nothing**, but it **collides with item 11**, which proposes adding `structuredContent`
 to `ttd_calls`, `ttd_memory` and `driver_object` — three of the highest-volume text-only tools.
 Under the client rule measured here, structured content *replaces* the text rather than

--- a/README.md
+++ b/README.md
@@ -238,7 +238,9 @@ one listener cannot reach each other's targets — the session lease and its gra
 a `409` means: this credential's own expired sessions are still being released, so ask again in a
 moment. Nothing else is refused for contention — a credential may hold several MCP sessions, and
 requests of one client never wait on another's. For a one-off, [`docs/remote-phase0.md`](./docs/remote-phase0.md) does the same
-job over plain `ssh` with no listener.
+job over plain `ssh` with no listener; for driving it from a **local model** rather than a hosted
+one, [`docs/local-model.md`](./docs/local-model.md) is the runbook and the numbers that decide
+whether it fits.
 
 ### As a Claude Code plugin
 

--- a/docs/local-model.md
+++ b/docs/local-model.md
@@ -1,0 +1,116 @@
+# Driving this server with a local model
+
+The last plane of the split-plane arrangement: the **model** on your own machine, DbgEng where it
+has to live. Nothing here is a feature of this server — it is a runbook, because the pieces are a
+listener you already have, a tunnel, and a client that happens to be pointed at a local model.
+
+Read [`remote-listener.md`](./remote-listener.md) first for the listener itself; this page is only
+what is different when the thing driving it is not a hosted model.
+
+## The three pieces
+
+**1 — the engine plane.** The Windows machine runs the listener, bound to loopback, with its token
+in the environment rather than on a command line:
+
+```pwsh
+setx WINDBG_MCP_LISTEN_TOKEN "<a long random string>"
+```
+
+**2 — the link.** One ssh channel that both forwards the port and runs the listener, so the server
+lives exactly as long as the tunnel and nothing is left behind:
+
+```console
+ssh -L 8765:127.0.0.1:8765 <vm> 'windbg-mcp.exe --listen 127.0.0.1:8765'
+```
+
+Starting it through `ssh` and letting that command *finish* does not work, and the failure looks
+like a healthy start — see [Do not start it through ssh and then hang
+up](./remote-listener.md#do-not-start-it-through-ssh-and-then-hang-up).
+
+**3 — the control plane.** Register the server once, against the forwarded port:
+
+```console
+claude mcp add windbg-vm --scope local --transport http http://127.0.0.1:8765/ \
+  --header "Authorization: Bearer <the same string>"
+```
+
+Then start the client against a local model. With [ollama](https://ollama.com) 0.32.12 or newer:
+
+```console
+ollama launch claude --model <model-tag>
+```
+
+`ollama launch` wires a local model into a coding harness — `ollama launch --help` lists the
+integrations it knows, of which `claude` is Claude Code. The MCP registration above is unaffected by
+which model is driving: the client is the same client.
+
+## What this server costs a model, measured
+
+[`token-budget.md`](./token-budget.md) has the method and the golden; these are the numbers that
+decide whether a local model can hold this surface at all. Bytes of minified JSON, ≈4 B/token.
+
+| | bytes | ≈tokens |
+|---|---|---|
+| The tool surface, paid once per conversation | 67,076 (51 tools) | ~17k |
+| Its worst single tool (`debug_batch`) | 9,746 | ~2.4k |
+| The largest answer this server gives (`modules`) | 53,875 | ~13k |
+| `read_memory` at its design limit | ~4 MiB of hex | ~1M |
+
+So the surface is a rounding error against a 256k window and roughly twice an 8k one. **The
+question is never the model's advertised maximum — it is what the runtime actually serves.**
+
+## The context your runtime serves is not the model's maximum
+
+ollama's own help says it: `OLLAMA_CONTEXT_LENGTH` — *"Context length to use unless otherwise
+specified (default: 4k/32k/256k based on VRAM)"*. A model whose card says 262,144 can be served at
+4k on a smaller box, and a 51-tool surface does not fit in 4k. Two ways to know rather than assume:
+
+```console
+ollama show <model-tag>          # the model's own maximum, under "context length"
+ollama ps                        # what the *loaded* instance is serving, under CONTEXT
+```
+
+`ollama ps` is the one that answers the question, and it prints nothing until the model is loaded,
+so send it one prompt first — `curl -s localhost:11434/api/generate -d
+'{"model":"<tag>","prompt":"hi","stream":false,"options":{"num_predict":1}}'` is enough. Pin it with
+`OLLAMA_CONTEXT_LENGTH` if two machines have to agree.
+
+Worked example, measured on the bench this page was written on: `ollama show` reports
+`context length 262144` for a 27.8B nvfp4 build, and `ollama ps` reports `CONTEXT 262144` with
+`100% GPU` once it is loaded — so the default did land on the model's maximum there, and the
+17k-token surface is about 6.5% of the window. That is a fact about that machine's memory, not about
+the model: the same tag on a smaller box is served at 4k or 32k by the same default.
+
+## What to measure
+
+The claims worth testing are about the *client's* budget, not this server's correctness, and the
+smoke tiers cannot reach them:
+
+- **Does the surface fit**, at the context the runtime is actually serving.
+- **Does the model pick the right tool out of 51**, which is orthogonal to window size and is the
+  part a bigger context does not fix.
+- **Do individual answers blow the window.** `modules` has no `limit` and `read_memory` returns up
+  to ~4 MiB by design; both are `FOLLOWUPS.md` item 24's last bullets, and both are reachable in one
+  careless call.
+
+If a model does not cope, the knobs are all **client-side** today — a tool-surface profile, a
+per-call response budget, a text-or-data content switch. This server has none of them: every caller
+gets all 51 tools, and there is no way to ask for fewer.
+
+## Picking this up after a break
+
+Four checks, in the order that fails fastest:
+
+```console
+ollama list                                   # is the model still there
+claude mcp list                               # windbg-vm: connected, or ConnectionRefused?
+ssh <vm> 'powershell -c "(Get-NetTCPConnection -State Listen -LocalPort 8765).Count"'
+ssh <vm> 'powershell -c "[bool][Environment]::GetEnvironmentVariable(\"WINDBG_MCP_LISTEN_TOKEN\",\"User\")"'
+```
+
+`ConnectionRefused` from `claude mcp list` means piece 2 is down and nothing else is wrong: the
+registration, the token and the model all survive a reboot; the tunnel does not.
+
+**Rebuild the listener before drawing conclusions about listener behaviour.** `target\release` on
+the Windows machine is whatever was last built there, and this part of the server changes often —
+an exe from last week can predate the client-identity and lease work entirely.

--- a/docs/local-model.md
+++ b/docs/local-model.md
@@ -109,6 +109,7 @@ as a sighting rather than a benchmark.
 | Prompt tokens, first turn of every task | **17,095–17,127**, by the model's own tokenizer |
 | Share of the window | ~6.5% |
 | Tool picks | 9 calls across 6 tasks, **all correct first try** |
+| Largest answer actually taken | `modules`, **53,772 characters**, passed to the model whole |
 
 Three things worth carrying:
 
@@ -125,6 +126,17 @@ Three things worth carrying:
   `crash_triage`. It identified `0xFC` on the ARM64 dump, and `0x13A` with `MessageManager` as the
   third-party driver on the other, which is what
   [`messagemanager-walkthrough.md`](./messagemanager-walkthrough.md) says it is.
+
+A fourth thing showed up when the harness stopped truncating results, and it is the one that costs
+time rather than context: the turn that *consumed* those 53,772 characters took **169s**, because
+~13k new tokens have to be evaluated before the model says anything. Prefix caching pays for the
+surface once; it does nothing for a large answer, which is charged in full the moment it arrives. On
+a local box the practical cap on `modules` and `read_memory` is patience, not the window.
+
+`read_memory` at address 0 is worth running once for a different reason: it fails, and it fails as a
+perfectly good MCP result carrying `isError` rather than as a protocol error. A harness that watches
+only for the latter records a failed call as a successful one — which this one did until review
+caught it.
 
 What this run does **not** cover: a long investigation where the transcript grows past the surface,
 anything behind the allow-list (`execute`, `debug_batch`, `launch`), a smaller box where the served

--- a/docs/local-model.md
+++ b/docs/local-model.md
@@ -73,9 +73,10 @@ Then point a local model at it, either way round:
   ```
 
   Sharing the token is survivable rather than safe, and the script is fenced accordingly: it will
-  only `end_session` a session **this run opened**, refuses one with no `session_id` at all (the
-  server would resolve the client's *current* session, which may not be the driver's), and ends what
-  it opened on the way out — so a run neither strands a worker for the lease grace nor leaves the
+  only `end_session` a session **this run opened** — counting only the handles an *opener* returned,
+  never every handle it has seen, since `session_status` and `server_log` name the whole client's —
+  refuses one with no `session_id` at all (the server would resolve the client's *current* session,
+  which may not be the driver's), and ends what it opened on the way out — so a run neither strands a worker for the lease grace nor leaves the
   next run adopting its leftovers.
 
 ## What this server costs a model, measured

--- a/docs/local-model.md
+++ b/docs/local-model.md
@@ -46,11 +46,11 @@ further down this page was produced.
 
 [`tools/local_model_drive.py`](../tools/local_model_drive.py) speaks MCP over HTTP to the listener,
 hands the whole tool surface to `POST /api/chat`, executes the tool calls that come back and feeds
-the results in. It reads the bearer token from the client's own registration, so nothing has to be
-pasted on a command line:
+the results in. It needs a bearer token **of its own** — an environment variable rather than an
+argument, the same rule the listener's own token follows:
 
 ```console
-python3 tools/local_model_drive.py [tasks.json]     # tasks.json: a JSON list of prompts
+WINDBG_MCP_TOKEN="<the driver's token>" python3 tools/local_model_drive.py [tasks.json]
 ```
 
 It executes only a **read-only allow-list**, and reports anything else back to the model as refused.
@@ -58,34 +58,32 @@ That is deliberate: the surface includes `execute` and `launch`, and a debug hos
 to discover unattended what a model does with them — but a wrong pick is still *measured*, which is
 the point.
 
-**The driver needs a credential of its own before it may open anything.** Falling back to the
-registered client's token puts it in *that client's* namespace — ownership working exactly as
-designed — and no fence inside the script can make that safe: a client over the four-session cap has
-its oldest **idle** session reclaimed by the server, so a dump this run opens can evict the editor's
-target without any tool call naming it. So openers are refused unless `WINDBG_MCP_TOKEN` names a
-credential chosen for this run. Read-only work still runs on the borrowed one.
+**Configure that token as a client of its own**, on the Windows machine, beside the one your editor
+uses:
 
 ```console
-# on the Windows machine, beside the unnamed token — foreground listener only, see below
 setx WINDBG_MCP_LISTEN_TOKEN_DRIVER "<another long random string>"
-# on the client machine
-WINDBG_MCP_TOKEN="<the same string>" python3 tools/local_model_drive.py tasks.json
 ```
 
-**A listener installed as the service can hold only one client**, so that recipe needs the foreground
+That is not a nicety. A shared credential is a shared **namespace**: the driver would see and route
+to the editor's sessions, and — the part no fence in a script can prevent — a client over the
+four-session cap has its oldest *idle* session reclaimed by the server, so a dump the driver opens
+can evict the editor's target without any tool call naming it. The script therefore refuses to run
+without a token rather than borrowing one; it cannot tell one token from another, so supplying a
+credential that really is its own is yours to get right.
+
+**A listener installed as the service can hold only one client**, so driver work wants the foreground
 one. The installer points the service at an ACL'd token file, and a configured file is the *only*
 credential this server will read — it shuts the environment out entirely, named tokens included,
 because the machine environment is readable by unprivileged processes and this endpoint has `launch`
-on it (`Credentials::from_entries`). That precedence is right and the one-client consequence is a
-gap: `FOLLOWUPS.md` item 31. Until it closes, isolating the driver means a foreground listener with
-named tokens; against the service, the driver reads and does not open.
+on it (`Credentials::from_entries`). That precedence is right; the one-client consequence is a gap,
+filed as `FOLLOWUPS.md` item 31. Until it closes, handing the driver the service's own token is
+sharing the namespace knowingly — which is a decision, not a default.
 
-Within one namespace the script is still fenced as far as it can be: it will only `end_session` a
-session **this run opened** — counting only the handles an *opener* returned, never every handle it
-has seen, since `session_status` and `server_log` name the whole client's and an opener refused at
-the cap lists them too — refuses one with no `session_id` at all (the server would resolve the
-client's *current* session, which may not be the driver's), and ends what it opened on the way out,
-so a run neither strands a worker for the lease grace nor leaves the next run adopting its leftovers.
+Within one namespace the script still fences what it can: it ends only sessions **this run opened**,
+counting the handles an *opener* returned rather than every handle it has seen, and leaving alone
+whatever the credential already had when it started — a predecessor that died before its cleanup, or
+a run going on beside it. What it opened, it releases on the way out.
 
 **Each task gets its own targets.** A task list is a list of separate conversations, so sessions are
 released after each one; otherwise a later task's `session_id`-less call routes to an earlier task's

--- a/docs/local-model.md
+++ b/docs/local-model.md
@@ -16,8 +16,8 @@ in the environment rather than on a command line:
 setx WINDBG_MCP_LISTEN_TOKEN "<a long random string>"
 ```
 
-**2 — the link.** One ssh channel that both forwards the port and runs the listener, so the server
-lives exactly as long as the tunnel and nothing is left behind:
+**2 — the link.** For a session you are driving anyway, one ssh channel both forwards the port and
+runs the listener, so the server lives exactly as long as the tunnel and nothing is left behind:
 
 ```console
 ssh -L 8765:127.0.0.1:8765 <vm> 'windbg-mcp.exe --listen 127.0.0.1:8765'
@@ -27,6 +27,12 @@ Starting it through `ssh` and letting that command *finish* does not work, and t
 like a healthy start — see [Do not start it through ssh and then hang
 up](./remote-listener.md#do-not-start-it-through-ssh-and-then-hang-up).
 
+**For anything less throwaway, install it as a service** (`--install-service --listen 127.0.0.1:8765`,
+elevated) and the listener survives a logout, a reboot and a dropped tunnel — the forward is then the
+only thing you restart. That is the whole reason the service role exists; see [Run it as a Windows
+service](./remote-listener.md#run-it-as-a-windows-service), which also covers why the token moves to
+an ACL'd file rather than the machine environment.
+
 **3 — the control plane.** Register the server once, against the forwarded port:
 
 ```console
@@ -34,15 +40,25 @@ claude mcp add windbg-vm --scope local --transport http http://127.0.0.1:8765/ \
   --header "Authorization: Bearer <the same string>"
 ```
 
-Then start the client against a local model. With [ollama](https://ollama.com) 0.32.12 or newer:
+Then point a local model at it, either way round:
 
-```console
-ollama launch claude --model <model-tag>
-```
+- **An interactive harness.** With [ollama](https://ollama.com) 0.32.12 or newer, `ollama launch
+  claude --model <model-tag>` wires a local model into Claude Code (`ollama launch --help` lists the
+  integrations it knows). The MCP registration above is unaffected by which model is driving.
+- **The ollama server API, with no harness at all** — which is what makes the question repeatable.
+  [`tools/local_model_drive.py`](../tools/local_model_drive.py) speaks MCP over HTTP to the listener,
+  hands the whole tool surface to `POST /api/chat`, executes the tool calls that come back and feeds
+  the results in. It reads the bearer token from the client's own registration, so nothing has to be
+  pasted on a command line:
 
-`ollama launch` wires a local model into a coding harness — `ollama launch --help` lists the
-integrations it knows, of which `claude` is Claude Code. The MCP registration above is unaffected by
-which model is driving: the client is the same client.
+  ```console
+  python3 tools/local_model_drive.py [tasks.json]     # tasks.json: a JSON list of prompts
+  ```
+
+  It executes only a **read-only allow-list**, and reports anything else back to the model as
+  refused. That is deliberate: the surface includes `execute` and `launch`, and a debug host is the
+  wrong place to discover unattended what a model does with them — but a wrong pick is still
+  *measured*, which is the point.
 
 ## What this server costs a model, measured
 
@@ -81,10 +97,44 @@ Worked example, measured on the bench this page was written on: `ollama show` re
 17k-token surface is about 6.5% of the window. That is a fact about that machine's memory, not about
 the model: the same tag on a smaller box is served at 4k or 32k by the same default.
 
+## What one run showed
+
+Measured 20 August 2026 with `tools/local_model_drive.py`, against a 27.8B nvfp4 build served at
+262,144 (see above), on the two checked-in kernel dumps. One model, one bench, six tasks — read it
+as a sighting rather than a benchmark.
+
+| | |
+| --- | --- |
+| Tools offered | 51 (68,970 B in ollama's function shape; the same surface `token-budget.md` measures at 67,076 B as MCP reports it) |
+| Prompt tokens, first turn of every task | **17,095–17,127**, by the model's own tokenizer |
+| Share of the window | ~6.5% |
+| Tool picks | 9 calls across 6 tasks, **all correct first try** |
+
+Three things worth carrying:
+
+- **The ≈4 B/token rule of thumb held.** 67,076 B predicted ~16.8k; the tokenizer said ~17.1k. The
+  golden's bytes are a usable proxy for what a model is charged.
+- **The surface costs context every turn but compute only once.** The first turn after a cold load
+  took 86.5s, nearly all of it evaluating those 17k tokens; every later turn started in 0.6–4.7s,
+  because the runtime caches the prefix. A surface that fits is therefore paid for once per model
+  load, not once per question.
+- **Selection was not the problem it was predicted to be.** The plan's section 07 expected a
+  30B-class model to struggle with a surface this size; this one picked `open_dump` with the right
+  path, `modules` and then *refined its own call* with a `filter`, `decode_ioctl`, and
+  `session_status` — and answered the bug check off the opener's summary without needing
+  `crash_triage`. It identified `0xFC` on the ARM64 dump, and `0x13A` with `MessageManager` as the
+  third-party driver on the other, which is what
+  [`messagemanager-walkthrough.md`](./messagemanager-walkthrough.md) says it is.
+
+What this run does **not** cover: a long investigation where the transcript grows past the surface,
+anything behind the allow-list (`execute`, `debug_batch`, `launch`), a smaller box where the served
+context is 4k or 32k, and any model but this one.
+
 ## What to measure
 
 The claims worth testing are about the *client's* budget, not this server's correctness, and the
-smoke tiers cannot reach them:
+smoke tiers cannot reach them — which is why the driver script exists and why the run above is
+written down rather than remembered:
 
 - **Does the surface fit**, at the context the runtime is actually serving.
 - **Does the model pick the right tool out of 51**, which is orthogonal to window size and is the

--- a/docs/local-model.md
+++ b/docs/local-model.md
@@ -40,44 +40,48 @@ claude mcp add windbg-vm --scope local --transport http http://127.0.0.1:8765/ \
   --header "Authorization: Bearer <the same string>"
 ```
 
-Then point a local model at it, either way round:
+Then drive a local model against it **through ollama's server API**. No second harness is involved
+and nothing has to be launched: a session you already have runs the script, which is how every number
+further down this page was produced.
 
-- **An interactive harness.** With [ollama](https://ollama.com) 0.32.12 or newer, `ollama launch
-  claude --model <model-tag>` wires a local model into Claude Code (`ollama launch --help` lists the
-  integrations it knows). The MCP registration above is unaffected by which model is driving.
-- **The ollama server API, with no harness at all** — which is what makes the question repeatable.
-  [`tools/local_model_drive.py`](../tools/local_model_drive.py) speaks MCP over HTTP to the listener,
-  hands the whole tool surface to `POST /api/chat`, executes the tool calls that come back and feeds
-  the results in. It reads the bearer token from the client's own registration, so nothing has to be
-  pasted on a command line:
+[`tools/local_model_drive.py`](../tools/local_model_drive.py) speaks MCP over HTTP to the listener,
+hands the whole tool surface to `POST /api/chat`, executes the tool calls that come back and feeds
+the results in. It reads the bearer token from the client's own registration, so nothing has to be
+pasted on a command line:
 
-  ```console
-  python3 tools/local_model_drive.py [tasks.json]     # tasks.json: a JSON list of prompts
-  ```
+```console
+python3 tools/local_model_drive.py [tasks.json]     # tasks.json: a JSON list of prompts
+```
 
-  It executes only a **read-only allow-list**, and reports anything else back to the model as
-  refused. That is deliberate: the surface includes `execute` and `launch`, and a debug host is the
-  wrong place to discover unattended what a model does with them — but a wrong pick is still
-  *measured*, which is the point.
+It executes only a **read-only allow-list**, and reports anything else back to the model as refused.
+That is deliberate: the surface includes `execute` and `launch`, and a debug host is the wrong place
+to discover unattended what a model does with them — but a wrong pick is still *measured*, which is
+the point.
 
-  **Give the driver its own credential.** Falling back to the registered client's token puts it in
-  *that client's* namespace, which is ownership working exactly as designed — the driver then sees,
-  routes to and could end the sessions your editor has open. A token of its own makes it a separate
-  client with a separate namespace, which is what the per-client work is for:
+**Give the driver its own credential.** Falling back to the registered client's token puts it in
+*that client's* namespace, which is ownership working exactly as designed — the driver then sees,
+routes to and could end the sessions your editor has open. A token of its own makes it a separate
+client with a separate namespace, which is what the per-client work is for:
 
-  ```console
-  # on the Windows machine, beside the unnamed token
-  setx WINDBG_MCP_LISTEN_TOKEN_DRIVER "<another long random string>"
-  # on the client machine
-  WINDBG_MCP_TOKEN="<the same string>" python3 tools/local_model_drive.py tasks.json
-  ```
+```console
+# on the Windows machine, beside the unnamed token
+setx WINDBG_MCP_LISTEN_TOKEN_DRIVER "<another long random string>"
+# on the client machine
+WINDBG_MCP_TOKEN="<the same string>" python3 tools/local_model_drive.py tasks.json
+```
 
-  Sharing the token is survivable rather than safe, and the script is fenced accordingly: it will
-  only `end_session` a session **this run opened** — counting only the handles an *opener* returned,
-  never every handle it has seen, since `session_status` and `server_log` name the whole client's —
-  refuses one with no `session_id` at all (the server would resolve the client's *current* session,
-  which may not be the driver's), and ends what it opened on the way out — so a run neither strands a worker for the lease grace nor leaves the
-  next run adopting its leftovers.
+Sharing the token is survivable rather than safe, and the script is fenced accordingly: it will only
+`end_session` a session **this run opened** — counting only the handles an *opener* returned, never
+every handle it has seen, since `session_status` and `server_log` name the whole client's — refuses
+one with no `session_id` at all (the server would resolve the client's *current* session, which may
+not be the driver's), and ends what it opened on the way out, so a run neither strands a worker for
+the lease grace nor leaves the next run adopting its leftovers.
+
+**A different arrangement, not a prerequisite:** `ollama launch claude --model <tag>` (ollama 0.32.12
+or newer) makes the local model *the agent* — it drives the harness itself, with these tools as its
+tools, rather than being called through the API by something else. That is the end state the
+split-plane plan is aimed at, and it is worth knowing about; it is not how anything on this page was
+measured, and it is not needed to measure it.
 
 ## What this server costs a model, measured
 

--- a/docs/local-model.md
+++ b/docs/local-model.md
@@ -60,6 +60,24 @@ Then point a local model at it, either way round:
   wrong place to discover unattended what a model does with them — but a wrong pick is still
   *measured*, which is the point.
 
+  **Give the driver its own credential.** Falling back to the registered client's token puts it in
+  *that client's* namespace, which is ownership working exactly as designed — the driver then sees,
+  routes to and could end the sessions your editor has open. A token of its own makes it a separate
+  client with a separate namespace, which is what the per-client work is for:
+
+  ```console
+  # on the Windows machine, beside the unnamed token
+  setx WINDBG_MCP_LISTEN_TOKEN_DRIVER "<another long random string>"
+  # on the client machine
+  WINDBG_MCP_TOKEN="<the same string>" python3 tools/local_model_drive.py tasks.json
+  ```
+
+  Sharing the token is survivable rather than safe, and the script is fenced accordingly: it will
+  only `end_session` a session **this run opened**, refuses one with no `session_id` at all (the
+  server would resolve the client's *current* session, which may not be the driver's), and ends what
+  it opened on the way out — so a run neither strands a worker for the lease grace nor leaves the
+  next run adopting its leftovers.
+
 ## What this server costs a model, measured
 
 [`token-budget.md`](./token-budget.md) has the method and the golden; these are the numbers that

--- a/docs/local-model.md
+++ b/docs/local-model.md
@@ -58,24 +58,39 @@ That is deliberate: the surface includes `execute` and `launch`, and a debug hos
 to discover unattended what a model does with them — but a wrong pick is still *measured*, which is
 the point.
 
-**Give the driver its own credential.** Falling back to the registered client's token puts it in
-*that client's* namespace, which is ownership working exactly as designed — the driver then sees,
-routes to and could end the sessions your editor has open. A token of its own makes it a separate
-client with a separate namespace, which is what the per-client work is for:
+**The driver needs a credential of its own before it may open anything.** Falling back to the
+registered client's token puts it in *that client's* namespace — ownership working exactly as
+designed — and no fence inside the script can make that safe: a client over the four-session cap has
+its oldest **idle** session reclaimed by the server, so a dump this run opens can evict the editor's
+target without any tool call naming it. So openers are refused unless `WINDBG_MCP_TOKEN` names a
+credential chosen for this run. Read-only work still runs on the borrowed one.
 
 ```console
-# on the Windows machine, beside the unnamed token
+# on the Windows machine, beside the unnamed token — foreground listener only, see below
 setx WINDBG_MCP_LISTEN_TOKEN_DRIVER "<another long random string>"
 # on the client machine
 WINDBG_MCP_TOKEN="<the same string>" python3 tools/local_model_drive.py tasks.json
 ```
 
-Sharing the token is survivable rather than safe, and the script is fenced accordingly: it will only
-`end_session` a session **this run opened** — counting only the handles an *opener* returned, never
-every handle it has seen, since `session_status` and `server_log` name the whole client's — refuses
-one with no `session_id` at all (the server would resolve the client's *current* session, which may
-not be the driver's), and ends what it opened on the way out, so a run neither strands a worker for
-the lease grace nor leaves the next run adopting its leftovers.
+**A listener installed as the service can hold only one client**, so that recipe needs the foreground
+one. The installer points the service at an ACL'd token file, and a configured file is the *only*
+credential this server will read — it shuts the environment out entirely, named tokens included,
+because the machine environment is readable by unprivileged processes and this endpoint has `launch`
+on it (`Credentials::from_entries`). That precedence is right and the one-client consequence is a
+gap: `FOLLOWUPS.md` item 31. Until it closes, isolating the driver means a foreground listener with
+named tokens; against the service, the driver reads and does not open.
+
+Within one namespace the script is still fenced as far as it can be: it will only `end_session` a
+session **this run opened** — counting only the handles an *opener* returned, never every handle it
+has seen, since `session_status` and `server_log` name the whole client's and an opener refused at
+the cap lists them too — refuses one with no `session_id` at all (the server would resolve the
+client's *current* session, which may not be the driver's), and ends what it opened on the way out,
+so a run neither strands a worker for the lease grace nor leaves the next run adopting its leftovers.
+
+**Each task gets its own targets.** A task list is a list of separate conversations, so sessions are
+released after each one; otherwise a later task's `session_id`-less call routes to an earlier task's
+target and its measurement depends on the prompts before it. A list meant as one continuing
+investigation says so with `WINDBG_MCP_SCENARIO=1`.
 
 **A different arrangement, not a prerequisite:** `ollama launch claude --model <tag>` (ollama 0.32.12
 or newer) makes the local model *the agent* — it drives the harness itself, with these tools as its

--- a/docs/remote-listener.md
+++ b/docs/remote-listener.md
@@ -394,6 +394,14 @@ Three things that surprise people, all of them consequences of running as `Local
   and re-ACL the token file to match — at the cost of local kernel and process attach, which need
   privileges that account does not have.
 
+## Driving it with a local model
+
+Same listener, same registration — what changes is the budget, since the surface and every answer
+now have to fit a window you are paying for in RAM rather than in tokens.
+[`local-model.md`](./local-model.md) is the runbook: the three pieces, the measured cost of this
+server's tool surface, and why the context your runtime *serves* is the number that matters rather
+than the one on the model card.
+
 ## Not there yet
 
 Nothing on this page is known-missing. `FOLLOWUPS.md` is where anything new lands.

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -17,10 +17,12 @@ connected MCP client holds a lock on (see [`CLAUDE.md`](../CLAUDE.md)). The prot
 adding the debugger tier takes it to ~50s, almost all of it two tests waiting out real timers — a
 lease grace, and a call staying silent long enough to have to report that it is still running.
 
-**The pass count is the same either way**, because each gate is inside its own test: 64 passed with
-the tier off, 64 passed with it on. The runtime is what tells them apart, and `--nocapture` is what
-prints the `SKIPPED` reason — a run that reports 64 green having taken a second covered no debugger
-claim at all.
+**The pass count is the same either way**, because each gate is inside its own test: `cargo test
+--test mcp_smoke` reports 64 passed with the tier off and 64 passed with it on. (A plain `cargo test`
+runs the unit tests beside it and prints a result line per binary, so it is this harness's own line
+to read.) The runtime is what tells the two runs apart, and `--nocapture` is what prints the
+`SKIPPED` reason — a run that reports 64 green having taken a second covered no debugger claim at
+all.
 
 ### Tiers
 

--- a/tools/local_model_drive.py
+++ b/tools/local_model_drive.py
@@ -19,7 +19,11 @@ Configuration, all optional:
     WINDBG_MCP_TOKEN    bearer token; falls back to the Claude Code registration
                         in ~/.claude.json for WINDBG_MCP_PROJECT, so the token
                         never has to be pasted on a command line
-    WINDBG_MCP_PROJECT  which registration to read it from (default: this repo)
+    WINDBG_MCP_PROJECT  which project's registrations to read it from (default: this repo)
+    WINDBG_MCP_SERVER   which registration in that project, by name, when the URL
+                        does not identify one on its own
+    RESULT_LIMIT        truncate tool results to this many characters before the
+                        model sees them; `0`, the default, passes them whole
 """
 import json
 import os
@@ -46,20 +50,46 @@ ALLOWED = {
 }
 
 MAX_STEPS = 6
-RESULT_LIMIT = 6000
+# Results reach the model **whole** by default. Truncating them would quietly defeat
+# one of the things this harness exists to measure — whether a single answer fits a
+# local model's window — and would have it reason from JSON cut off mid-structure
+# without being told. A cap is available for a deliberately clamped run, and says so
+# in the transcript when it bites.
+RESULT_LIMIT = int(os.environ.get("RESULT_LIMIT", "0"))
+
+
+def same_endpoint(a, b):
+    """Whether two registration URLs name the same listener, modulo a trailing slash."""
+    return a.rstrip("/") == b.rstrip("/")
 
 
 def bearer():
-    """The token, from the environment or from this client's own registration."""
+    """The token, from the environment or from this client's registration **for this listener**.
+
+    Matched by URL, or by name when `WINDBG_MCP_SERVER` says which. Never "the first
+    registration that has a token": a project can hold several, and handing this
+    listener another server's credential would send that secret to a host it does not
+    belong to — and then fail the handshake, which is the milder half.
+    """
     if os.environ.get("WINDBG_MCP_TOKEN"):
         return "Bearer " + os.environ["WINDBG_MCP_TOKEN"]
     registry = json.load(open(os.path.expanduser("~/.claude.json")))
-    servers = registry["projects"][PROJECT]["mcpServers"]
-    for entry in servers.values():
+    servers = registry.get("projects", {}).get(PROJECT, {}).get("mcpServers", {})
+    wanted = os.environ.get("WINDBG_MCP_SERVER")
+    for name, entry in servers.items():
+        if wanted and name != wanted:
+            continue
+        if not wanted and not same_endpoint(entry.get("url", ""), MCP_URL):
+            continue
         auth = (entry.get("headers") or {}).get("Authorization")
         if auth:
             return auth
-    raise SystemExit("no token: set WINDBG_MCP_TOKEN, or register the server with a bearer header")
+        raise SystemExit(f"registration `{name}` has no Authorization header")
+    raise SystemExit(
+        f"no registration for {MCP_URL} in {PROJECT} "
+        f"(registered: {', '.join(servers) or 'none'}). "
+        "Set WINDBG_MCP_TOKEN, or WINDBG_MCP_SERVER to name one."
+    )
 
 
 AUTH = bearer()
@@ -105,14 +135,35 @@ def handshake():
     return out["result"]["protocolVersion"]
 
 
+def ollama(path, body=None):
+    url = OLLAMA.replace("/api/chat", path)
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(url, data=data, method="POST" if data else "GET")
+    if data:
+        req.add_header("Content-Type", "application/json")
+    with urllib.request.urlopen(req, timeout=60) as response:
+        return json.load(response)
+
+
 def pick_model():
+    """The configured tag, or the first installed one that can actually call tools.
+
+    Asked rather than assumed: an embedding model, or a chat model without tool
+    support, is a perfectly ordinary first entry in `ollama list`, and picking it
+    fails at the first `/api/chat` with an error about the wrong thing.
+    """
     if MODEL:
         return MODEL
-    tags = urllib.request.urlopen(OLLAMA.replace("/api/chat", "/api/tags"), timeout=30)
-    models = json.load(tags).get("models", [])
-    if not models:
+    installed = [m["name"] for m in ollama("/api/tags").get("models", [])]
+    if not installed:
         raise SystemExit("no ollama models pulled; `ollama pull <tag>` first")
-    return models[0]["name"]
+    for tag in installed:
+        if "tools" in (ollama("/api/show", {"model": tag}).get("capabilities") or []):
+            return tag
+    raise SystemExit(
+        "none of the installed models declares the `tools` capability "
+        f"({', '.join(installed)}); set LOCAL_MODEL to one that does"
+    )
 
 
 def as_ollama(tools):
@@ -133,13 +184,24 @@ def chat(messages, tools):
 
 
 def call_tool(name, args):
+    """Run one tool call. Returns (text for the model, ok, full size in characters)."""
     if name not in ALLOWED:
-        return f"refused: `{name}` is not permitted in this harness", None
+        return f"refused: `{name}` is not permitted in this harness", None, 0
     try:
         out = mcp("tools/call", {"name": name, "arguments": args})
     except Exception as e:  # a transport failure is a result the model can react to
-        return f"transport error: {e}", False
-    return json.dumps(out.get("result", out))[:RESULT_LIMIT], "error" not in out
+        return f"transport error: {e}", False, 0
+    result = out.get("result", {})
+    # **Both kinds of failure.** A protocol error arrives as a top-level `error`; an
+    # ordinary tool failure — a bad address, a stale handle — arrives as a perfectly
+    # good result carrying `isError`. Counting only the first reports a failed call as
+    # a successful one, which is exactly the telemetry this harness is for.
+    ok = "error" not in out and not result.get("isError")
+    text = json.dumps(result if result else out)
+    size = len(text)
+    if RESULT_LIMIT and size > RESULT_LIMIT:
+        text = text[:RESULT_LIMIT] + f"\n[truncated by the harness: {size} characters in full]"
+    return text, ok, size
 
 
 def run(task, tools):
@@ -168,8 +230,8 @@ def run(task, tools):
             args = call["function"].get("arguments") or {}
             if isinstance(args, str):
                 args = json.loads(args or "{}")
-            text, ok = call_tool(name, args)
-            print(f"  [{took:>6}s] -> {name}({json.dumps(args)[:120]}) ok={ok}")
+            text, ok, size = call_tool(name, args)
+            print(f"  [{took:>6}s] -> {name}({json.dumps(args)[:120]}) ok={ok} result={size} chars")
             print(f"           {text[:200]}")
             messages.append({"role": "tool", "tool_name": name, "content": text})
     print(f"  gave up after {MAX_STEPS} steps")

--- a/tools/local_model_drive.py
+++ b/tools/local_model_drive.py
@@ -11,17 +11,19 @@ with a repeatable answer rather than an impression from a chat session.
 `tasks.json` is a list of strings, one per task; without it, one default task
 runs. See `docs/local-model.md` for what to make of the numbers it prints.
 
-Configuration, all optional:
+`WINDBG_MCP_TOKEN` is **required, and must be a credential of this run's own** — not
+the one your editor is registered with. A shared credential is a shared namespace:
+this run would see, route to and (at the four-session cap) cause the reclamation of
+the editor's targets, and no fence inside a script can prevent the last of those.
+The script cannot tell one token from another, so this is the operator's to get
+right; `docs/local-model.md` has the listener side of it.
 
+Configuration:
+
+    WINDBG_MCP_TOKEN    bearer token for a client of this run's own — required
     LOCAL_MODEL         ollama model tag       (default: the first tool-capable one)
     OLLAMA_URL          ollama chat endpoint   (default: http://localhost:11434/api/chat)
     WINDBG_MCP_URL      the listener           (default: http://127.0.0.1:8765/)
-    WINDBG_MCP_TOKEN    bearer token; falls back to the Claude Code registration
-                        in ~/.claude.json for WINDBG_MCP_PROJECT, so the token
-                        never has to be pasted on a command line
-    WINDBG_MCP_PROJECT  which project's registrations to read it from (default: this repo)
-    WINDBG_MCP_SERVER   which registration in that project, by name, when the URL
-                        does not identify one on its own
     RESULT_LIMIT        truncate tool results to this many characters before the
                         model sees them; `0`, the default, passes them whole
     WINDBG_MCP_SCENARIO treat the task list as one continuing investigation, keeping
@@ -36,9 +38,6 @@ import urllib.request
 MCP_URL = os.environ.get("WINDBG_MCP_URL", "http://127.0.0.1:8765/")
 OLLAMA = os.environ.get("OLLAMA_URL", "http://localhost:11434/api/chat")
 MODEL = os.environ.get("LOCAL_MODEL", "")
-PROJECT = os.environ.get(
-    "WINDBG_MCP_PROJECT", os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-)
 REVISION = "2025-06-18"
 
 # Tool calls this harness will actually execute. Everything else is reported back
@@ -46,14 +45,9 @@ REVISION = "2025-06-18"
 # the surface includes `launch` and `execute`, and a debug host is the wrong place
 # to find out what a model does with them unattended.
 #
-# `end_session` is in here and is the one destructive member, so it is fenced twice
-# over (see `call_tool`): this run may only end sessions it opened itself. Falling
-# back to the registered client's token puts the driver in **that client's**
-# namespace — which is the ownership model working as designed — so an
-# `end_session` with no `session_id` would resolve whatever session that client has
-# current and close somebody else's target. Give the driver its own credential
-# (`WINDBG_MCP_LISTEN_TOKEN_DRIVER` on the listener, `WINDBG_MCP_TOKEN` here) and it
-# gets a namespace of its own instead.
+# `end_session` is the one destructive member, and it is fenced to sessions this run
+# opened: the rest of the namespace belongs to a run that crashed before its cleanup,
+# or to one running beside this one.
 ALLOWED = {
     "open_dump", "open_trace", "crash_triage", "backtrace", "modules", "registers",
     "threads", "session_status", "end_session", "decode_ioctl", "disassemble",
@@ -100,44 +94,26 @@ def opened_session(result):
 RESULT_LIMIT = int(os.environ.get("RESULT_LIMIT", "0"))
 
 
-def same_endpoint(a, b):
-    """Whether two registration URLs name the same listener, modulo a trailing slash."""
-    return a.rstrip("/") == b.rstrip("/")
-
-
 def bearer():
-    """The token, from the environment or from this client's registration **for this listener**.
+    """The token this run authenticates with, which it does not go looking for.
 
-    Matched by URL, or by name when `WINDBG_MCP_SERVER` says which. Never "the first
-    registration that has a token": a project can hold several, and handing this
-    listener another server's credential would send that secret to a host it does not
-    belong to — and then fail the handshake, which is the milder half.
+    Reading it from whatever the editor is registered with was the earlier
+    behaviour, and it is what six rounds of review were about: it put this run in
+    the editor's namespace, where opening a session can reclaim the editor's idle
+    one and no fence in this file can see it happen. Requiring the operator to name
+    a credential deletes that class rather than defending against it.
     """
-    if os.environ.get("WINDBG_MCP_TOKEN"):
-        return "Bearer " + os.environ["WINDBG_MCP_TOKEN"]
-    registry = json.load(open(os.path.expanduser("~/.claude.json")))
-    servers = registry.get("projects", {}).get(PROJECT, {}).get("mcpServers", {})
-    wanted = os.environ.get("WINDBG_MCP_SERVER")
-    for name, entry in servers.items():
-        if wanted and name != wanted:
-            continue
-        if not wanted and not same_endpoint(entry.get("url", ""), MCP_URL):
-            continue
-        auth = (entry.get("headers") or {}).get("Authorization")
-        if auth:
-            return auth
-        raise SystemExit(f"registration `{name}` has no Authorization header")
-    raise SystemExit(
-        f"no registration for {MCP_URL} in {PROJECT} "
-        f"(registered: {', '.join(servers) or 'none'}). "
-        "Set WINDBG_MCP_TOKEN, or WINDBG_MCP_SERVER to name one."
-    )
+    token = os.environ.get("WINDBG_MCP_TOKEN", "").strip()
+    if not token:
+        raise SystemExit(
+            "set WINDBG_MCP_TOKEN to a bearer token for a client of this run's own — not the one "
+            "your editor uses, since a shared credential is a shared namespace. Configure one with "
+            "WINDBG_MCP_LISTEN_TOKEN_DRIVER on a foreground listener; see docs/local-model.md."
+        )
+    return "Bearer " + token
 
 
 AUTH = bearer()
-# Whether this run has a credential of its own, rather than borrowing the editor's.
-# It decides whether openers may run at all — see `call_tool`.
-DEDICATED = bool(os.environ.get("WINDBG_MCP_TOKEN"))
 SCENARIO = bool(os.environ.get("WINDBG_MCP_SCENARIO"))
 SESSION = None
 
@@ -233,25 +209,12 @@ def call_tool(name, args):
     """Run one tool call. Returns (text for the model, ok, full size in characters)."""
     if name not in ALLOWED:
         return f"refused: `{name}` is not permitted in this harness", None, 0
-    if name in OPENERS and not DEDICATED:
-        # **Opening on a borrowed credential can cost the lender a session**, and no
-        # fence in this script can stop it: a client over `MAX_SESSIONS` has its
-        # oldest *idle* session reclaimed by the server, so the target this run opens
-        # can evict the editor's — without any tool call naming it. The only fix is
-        # not to share the namespace.
-        return ("refused: opening a session needs a credential of this run's own. Set "
-                "WINDBG_MCP_TOKEN to a token configured for a client of its own "
-                "(WINDBG_MCP_LISTEN_TOKEN_DRIVER on a foreground listener); borrowing the "
-                "editor's would put this run in the editor's namespace, where opening can "
-                "reclaim its idle sessions."), None, 0
-    if name == "end_session":
-        wanted = args.get("session_id")
-        if not wanted:
-            return ("refused: name the `session_id` to end. Without one the server ends this "
-                    "client's *current* session, which this harness may not have opened."), None, 0
-        if wanted not in OPENED:
-            return (f"refused: `{wanted}` was not opened by this run, so it is not this "
-                    "harness's to end"), None, 0
+    if name == "end_session" and args.get("session_id") not in OPENED:
+        # One rule, and it covers the call that names nothing: without a `session_id`
+        # the server ends this credential's *current* session, which may be a
+        # predecessor's leftover rather than anything this run opened.
+        return (f"refused: `{args.get('session_id') or 'the current session'}` was not opened by "
+                "this run, so it is not this harness's to end"), None, 0
     try:
         out = mcp("tools/call", {"name": name, "arguments": args})
     except Exception as e:  # a transport failure is a result the model can react to
@@ -346,8 +309,8 @@ def snapshot_existing():
 def reconcile_opened():
     """Adopt sessions that appeared during this run, after an ambiguous opener.
 
-    Sound because openers require a credential of this run's own: on a borrowed one
-    they are refused outright. Bounded by the startup snapshot, so what another
+    Sound because this run authenticates as a client of its own, so the namespace is
+    the driver's rather than the editor's. Bounded by the startup snapshot, so what another
     invocation or a crashed predecessor left behind stays theirs. Two runs sharing
     one credential *concurrently* can still overlap here — the answer to that is the
     same as everywhere else on this page: a credential per run.
@@ -425,11 +388,9 @@ def main():
     offered = as_ollama(tools)
     surface = len(json.dumps(offered, separators=(",", ":")))
     print(f"tools offered: {len(tools)} ({surface} B of minified JSON)")
-    whose = "its own" if DEDICATED else "borrowed from the editor — openers refused"
-    mode = " (scenario: sessions kept between tasks)" if SCENARIO else ""
-    print(f"credential: {whose}{mode}")
-    if DEDICATED:
-        snapshot_existing()
+    if SCENARIO:
+        print("scenario: sessions are kept between tasks")
+    snapshot_existing()
     tasks = json.load(open(sys.argv[1])) if len(sys.argv) > 1 else [
         "What debug sessions do I currently have open on this server?"
     ]

--- a/tools/local_model_drive.py
+++ b/tools/local_model_drive.py
@@ -66,6 +66,13 @@ MAX_STEPS = 6
 # the lease grace and the next run does not adopt it.
 OPENED = []
 SESSION_ID = re.compile(r"sess-[0-9a-f]+-\d+")
+
+# The tools that can *create* a session, and so the only ones whose answers name a
+# handle this run is responsible for. Scanning every successful answer instead would
+# be worse than not tracking at all: `session_status` lists the whole client's
+# sessions and `server_log` names them too, so on a shared credential the cleanup
+# would end the editor's targets — the exact harm the fence above exists to prevent.
+OPENERS = {"open_dump", "open_trace"}
 # Results reach the model **whole** by default. Truncating them would quietly defeat
 # one of the things this harness exists to measure — whether a single answer fits a
 # local model's window — and would have it reason from JSON cut off mid-structure
@@ -223,15 +230,16 @@ def call_tool(name, args):
     ok = "error" not in out and not result.get("isError")
     text = json.dumps(result if result else out)
     size = len(text)
-    if ok:
-        # Whatever this call opened is now this run's to clean up. Read out of the
-        # answer rather than tracked per tool, because every opener names its handle
-        # and none of them names it the same way twice.
+    if name in OPENERS:
+        # **Whatever the call reported.** An opener can register a session and then
+        # fail — a dump that opens and a later step that does not — and the handle is
+        # named in the answer either way. Tracking only the successes would leave that
+        # worker holding its target until the lease grace ran out.
         for found in SESSION_ID.findall(text):
-            if name != "end_session" and found not in OPENED:
+            if found not in OPENED:
                 OPENED.append(found)
-        if name == "end_session":
-            OPENED[:] = [s for s in OPENED if s != args.get("session_id")]
+    elif name == "end_session" and ok:
+        OPENED[:] = [s for s in OPENED if s != args.get("session_id")]
     if RESULT_LIMIT and size > RESULT_LIMIT:
         text = text[:RESULT_LIMIT] + f"\n[truncated by the harness: {size} characters in full]"
     return text, ok, size

--- a/tools/local_model_drive.py
+++ b/tools/local_model_drive.py
@@ -24,6 +24,8 @@ Configuration, all optional:
                         does not identify one on its own
     RESULT_LIMIT        truncate tool results to this many characters before the
                         model sees them; `0`, the default, passes them whole
+    WINDBG_MCP_SCENARIO treat the task list as one continuing investigation, keeping
+                        its sessions open between tasks instead of releasing each
 """
 import json
 import os
@@ -128,6 +130,10 @@ def bearer():
 
 
 AUTH = bearer()
+# Whether this run has a credential of its own, rather than borrowing the editor's.
+# It decides whether openers may run at all — see `call_tool`.
+DEDICATED = bool(os.environ.get("WINDBG_MCP_TOKEN"))
+SCENARIO = bool(os.environ.get("WINDBG_MCP_SCENARIO"))
 SESSION = None
 
 
@@ -222,6 +228,17 @@ def call_tool(name, args):
     """Run one tool call. Returns (text for the model, ok, full size in characters)."""
     if name not in ALLOWED:
         return f"refused: `{name}` is not permitted in this harness", None, 0
+    if name in OPENERS and not DEDICATED:
+        # **Opening on a borrowed credential can cost the lender a session**, and no
+        # fence in this script can stop it: a client over `MAX_SESSIONS` has its
+        # oldest *idle* session reclaimed by the server, so the target this run opens
+        # can evict the editor's — without any tool call naming it. The only fix is
+        # not to share the namespace.
+        return ("refused: opening a session needs a credential of this run's own. Set "
+                "WINDBG_MCP_TOKEN to a token configured for a client of its own "
+                "(WINDBG_MCP_LISTEN_TOKEN_DRIVER on a foreground listener); borrowing the "
+                "editor's would put this run in the editor's namespace, where opening can "
+                "reclaim its idle sessions."), None, 0
     if name == "end_session":
         wanted = args.get("session_id")
         if not wanted:
@@ -338,6 +355,9 @@ def main():
     offered = as_ollama(tools)
     surface = len(json.dumps(offered, separators=(",", ":")))
     print(f"tools offered: {len(tools)} ({surface} B of minified JSON)")
+    whose = "its own" if DEDICATED else "borrowed from the editor — openers refused"
+    mode = " (scenario: sessions kept between tasks)" if SCENARIO else ""
+    print(f"credential: {whose}{mode}")
     tasks = json.load(open(sys.argv[1])) if len(sys.argv) > 1 else [
         "What debug sessions do I currently have open on this server?"
     ]
@@ -345,6 +365,12 @@ def main():
         for i, task in enumerate(tasks, 1):
             print(f"\n=== task {i}: {task[:110]}")
             run(task, offered)
+            # Each task is its own conversation, so it gets its own targets: a session
+            # left open would be routed to by the next task's `session_id`-less call,
+            # which makes that task's measurement depend on the one before it. A task
+            # list meant as one continuing investigation says so with WINDBG_MCP_SCENARIO.
+            if not SCENARIO:
+                release_what_this_run_opened()
     finally:
         release_what_this_run_opened()
         close_transport_session()

--- a/tools/local_model_drive.py
+++ b/tools/local_model_drive.py
@@ -27,7 +27,6 @@ Configuration, all optional:
 """
 import json
 import os
-import re
 import sys
 import time
 import urllib.request
@@ -65,14 +64,27 @@ MAX_STEPS = 6
 # ones it ends on the way out, so a run does not leave a worker holding a target for
 # the lease grace and the next run does not adopt it.
 OPENED = []
-SESSION_ID = re.compile(r"sess-[0-9a-f]+-\d+")
 
 # The tools that can *create* a session, and so the only ones whose answers name a
-# handle this run is responsible for. Scanning every successful answer instead would
-# be worse than not tracking at all: `session_status` lists the whole client's
-# sessions and `server_log` names them too, so on a shared credential the cleanup
-# would end the editor's targets — the exact harm the fence above exists to prevent.
+# handle this run is responsible for.
 OPENERS = {"open_dump", "open_trace"}
+
+
+def opened_session(result):
+    """The handle an opener created, from the answer's own field — never from its prose.
+
+    `structuredContent.session_id` on success, `structuredContent.error.session_id`
+    on a failure, which is where an opener that created a target and *then* failed
+    reports the only handle that can reach it.
+
+    Reading the text instead is wrong twice over, and both ways end with this run
+    terminating sessions it does not own: `session_status` and `server_log` name the
+    whole client's sessions, and an opener refused at the four-session cap lists every
+    live handle in its own error message (`Sessions::take_slot`). The structured field
+    is the server's answer to "which session is this about"; the prose is not.
+    """
+    structured = result.get("structuredContent") or {}
+    return structured.get("session_id") or (structured.get("error") or {}).get("session_id")
 # Results reach the model **whole** by default. Truncating them would quietly defeat
 # one of the things this harness exists to measure — whether a single answer fits a
 # local model's window — and would have it reason from JSON cut off mid-structure
@@ -232,12 +244,12 @@ def call_tool(name, args):
     size = len(text)
     if name in OPENERS:
         # **Whatever the call reported.** An opener can register a session and then
-        # fail — a dump that opens and a later step that does not — and the handle is
-        # named in the answer either way. Tracking only the successes would leave that
+        # fail — a dump that opens and a later step that does not — and the answer
+        # carries the handle either way. Tracking only the successes would leave that
         # worker holding its target until the lease grace ran out.
-        for found in SESSION_ID.findall(text):
-            if found not in OPENED:
-                OPENED.append(found)
+        found = opened_session(result)
+        if found and found not in OPENED:
+            OPENED.append(found)
     elif name == "end_session" and ok:
         OPENED[:] = [s for s in OPENED if s != args.get("session_id")]
     if RESULT_LIMIT and size > RESULT_LIMIT:
@@ -278,6 +290,28 @@ def run(task, tools):
     print(f"  gave up after {MAX_STEPS} steps")
 
 
+def close_transport_session():
+    """Say goodbye to the MCP session as well as to the debug sessions.
+
+    The revision this speaks mints an `Mcp-Session-Id`, and a run that simply stops
+    leaves it resident in the server until a whole grace passes with no traffic at
+    all — so repeated runs on one credential pile them up, each new request renewing
+    the lease that would have swept them. A `DELETE` is what the protocol provides.
+    """
+    global SESSION
+    if not SESSION:
+        return
+    req = urllib.request.Request(MCP_URL, method="DELETE")
+    req.add_header("Authorization", AUTH)
+    req.add_header("Mcp-Session-Id", SESSION)
+    try:
+        with urllib.request.urlopen(req, timeout=60) as response:
+            print(f"  closed the MCP session ({response.status})")
+    except Exception as e:
+        print(f"  could not close the MCP session: {e}")
+    SESSION = None
+
+
 def release_what_this_run_opened():
     """End the run's own sessions, so the next one starts from nothing.
 
@@ -313,6 +347,7 @@ def main():
             run(task, offered)
     finally:
         release_what_this_run_opened()
+        close_transport_session()
 
 
 if __name__ == "__main__":

--- a/tools/local_model_drive.py
+++ b/tools/local_model_drive.py
@@ -250,6 +250,12 @@ def call_tool(name, args):
     try:
         out = mcp("tools/call", {"name": name, "arguments": args})
     except Exception as e:  # a transport failure is a result the model can react to
+        if name in OPENERS:
+            # **Ambiguous, not failed.** The call may have reached the server and
+            # opened a target before the answer went missing, and nothing else will
+            # ever name that handle: the model retries and gets a second target, and
+            # the cleanup has nothing to release. Ask what exists instead of assuming.
+            reconcile_opened()
         return f"transport error: {e}", False, 0
     result = out.get("result", {})
     # **Both kinds of failure.** A protocol error arrives as a top-level `error`; an
@@ -307,6 +313,26 @@ def run(task, tools):
     print(f"  gave up after {MAX_STEPS} steps")
 
 
+def reconcile_opened():
+    """Adopt every session in this credential's namespace, after an ambiguous opener.
+
+    Sound because openers require a credential of this run's own: on a borrowed one
+    they are refused outright, so anything here is this run's to account for. Read
+    from `structuredContent.sessions`, like every other handle in this script.
+    """
+    try:
+        out = mcp("tools/call", {"name": "session_status", "arguments": {}})
+    except Exception as e:
+        print(f"  could not reconcile after an ambiguous open: {e}")
+        return
+    structured = (out.get("result") or {}).get("structuredContent") or {}
+    for entry in structured.get("sessions") or []:
+        found = entry.get("session_id")
+        if found and found not in OPENED:
+            OPENED.append(found)
+            print(f"  adopted {found} after an ambiguous open")
+
+
 def close_transport_session():
     """Say goodbye to the MCP session as well as to the debug sessions.
 
@@ -337,13 +363,27 @@ def release_what_this_run_opened():
     that was supposed to start clean starts with somebody's leftovers — or trips the
     four-session cap and reclaims one.
     """
+    # **What could not be released stays on the list.** Clearing it regardless would
+    # leave the final pass with nothing to retry, and the next task routing its
+    # session-less calls to a target this one was supposed to have let go.
+    kept = []
     for session in list(OPENED):
         try:
-            mcp("tools/call", {"name": "end_session", "arguments": {"session_id": session}})
-            print(f"  released {session}")
+            out = mcp("tools/call", {"name": "end_session", "arguments": {"session_id": session}})
+            error = ((out.get("result") or {}).get("structuredContent") or {}).get("error") or {}
+            category = error.get("category")
+            if not error:
+                print(f"  released {session}")
+            elif category in ("stale_session", "worker_lost"):
+                # Gone either way, so there is nothing left to retry.
+                print(f"  {session} was already gone ({category})")
+            else:
+                kept.append(session)
+                print(f"  could not release {session}: {error.get('message', category)}")
         except Exception as e:
+            kept.append(session)
             print(f"  could not release {session}: {e}")
-    OPENED.clear()
+    OPENED[:] = kept
 
 
 def main():

--- a/tools/local_model_drive.py
+++ b/tools/local_model_drive.py
@@ -27,6 +27,7 @@ Configuration, all optional:
 """
 import json
 import os
+import re
 import sys
 import time
 import urllib.request
@@ -43,6 +44,15 @@ REVISION = "2025-06-18"
 # to the model as refused, so a wrong pick is *measured* rather than performed —
 # the surface includes `launch` and `execute`, and a debug host is the wrong place
 # to find out what a model does with them unattended.
+#
+# `end_session` is in here and is the one destructive member, so it is fenced twice
+# over (see `call_tool`): this run may only end sessions it opened itself. Falling
+# back to the registered client's token puts the driver in **that client's**
+# namespace — which is the ownership model working as designed — so an
+# `end_session` with no `session_id` would resolve whatever session that client has
+# current and close somebody else's target. Give the driver its own credential
+# (`WINDBG_MCP_LISTEN_TOKEN_DRIVER` on the listener, `WINDBG_MCP_TOKEN` here) and it
+# gets a namespace of its own instead.
 ALLOWED = {
     "open_dump", "open_trace", "crash_triage", "backtrace", "modules", "registers",
     "threads", "session_status", "end_session", "decode_ioctl", "disassemble",
@@ -50,6 +60,12 @@ ALLOWED = {
 }
 
 MAX_STEPS = 6
+
+# The debug sessions this run opened, which are the only ones it may end — and the
+# ones it ends on the way out, so a run does not leave a worker holding a target for
+# the lease grace and the next run does not adopt it.
+OPENED = []
+SESSION_ID = re.compile(r"sess-[0-9a-f]+-\d+")
 # Results reach the model **whole** by default. Truncating them would quietly defeat
 # one of the things this harness exists to measure — whether a single answer fits a
 # local model's window — and would have it reason from JSON cut off mid-structure
@@ -187,6 +203,14 @@ def call_tool(name, args):
     """Run one tool call. Returns (text for the model, ok, full size in characters)."""
     if name not in ALLOWED:
         return f"refused: `{name}` is not permitted in this harness", None, 0
+    if name == "end_session":
+        wanted = args.get("session_id")
+        if not wanted:
+            return ("refused: name the `session_id` to end. Without one the server ends this "
+                    "client's *current* session, which this harness may not have opened."), None, 0
+        if wanted not in OPENED:
+            return (f"refused: `{wanted}` was not opened by this run, so it is not this "
+                    "harness's to end"), None, 0
     try:
         out = mcp("tools/call", {"name": name, "arguments": args})
     except Exception as e:  # a transport failure is a result the model can react to
@@ -199,6 +223,15 @@ def call_tool(name, args):
     ok = "error" not in out and not result.get("isError")
     text = json.dumps(result if result else out)
     size = len(text)
+    if ok:
+        # Whatever this call opened is now this run's to clean up. Read out of the
+        # answer rather than tracked per tool, because every opener names its handle
+        # and none of them names it the same way twice.
+        for found in SESSION_ID.findall(text):
+            if name != "end_session" and found not in OPENED:
+                OPENED.append(found)
+        if name == "end_session":
+            OPENED[:] = [s for s in OPENED if s != args.get("session_id")]
     if RESULT_LIMIT and size > RESULT_LIMIT:
         text = text[:RESULT_LIMIT] + f"\n[truncated by the harness: {size} characters in full]"
     return text, ok, size
@@ -237,6 +270,23 @@ def run(task, tools):
     print(f"  gave up after {MAX_STEPS} steps")
 
 
+def release_what_this_run_opened():
+    """End the run's own sessions, so the next one starts from nothing.
+
+    Without this a task that opens a dump and never says goodbye leaves a worker
+    holding it for the whole lease grace, the next run adopts it, and a measurement
+    that was supposed to start clean starts with somebody's leftovers — or trips the
+    four-session cap and reclaims one.
+    """
+    for session in list(OPENED):
+        try:
+            mcp("tools/call", {"name": "end_session", "arguments": {"session_id": session}})
+            print(f"  released {session}")
+        except Exception as e:
+            print(f"  could not release {session}: {e}")
+    OPENED.clear()
+
+
 def main():
     global MODEL
     MODEL = pick_model()
@@ -249,9 +299,12 @@ def main():
     tasks = json.load(open(sys.argv[1])) if len(sys.argv) > 1 else [
         "What debug sessions do I currently have open on this server?"
     ]
-    for i, task in enumerate(tasks, 1):
-        print(f"\n=== task {i}: {task[:110]}")
-        run(task, offered)
+    try:
+        for i, task in enumerate(tasks, 1):
+            print(f"\n=== task {i}: {task[:110]}")
+            run(task, offered)
+    finally:
+        release_what_this_run_opened()
 
 
 if __name__ == "__main__":

--- a/tools/local_model_drive.py
+++ b/tools/local_model_drive.py
@@ -67,6 +67,11 @@ MAX_STEPS = 6
 # the lease grace and the next run does not adopt it.
 OPENED = []
 
+# Sessions this credential already had when the run started — a prior run that
+# crashed before its cleanup, or another invocation sharing the token. They are not
+# this run's to adopt and not its to release, so reconciliation skips them.
+PRE_EXISTING = set()
+
 # The tools that can *create* a session, and so the only ones whose answers name a
 # handle this run is responsible for.
 OPENERS = {"open_dump", "open_trace"}
@@ -313,22 +318,47 @@ def run(task, tools):
     print(f"  gave up after {MAX_STEPS} steps")
 
 
-def reconcile_opened():
-    """Adopt every session in this credential's namespace, after an ambiguous opener.
+def live_sessions():
+    """Every session id this credential can see, from the structured answer."""
+    out = mcp("tools/call", {"name": "session_status", "arguments": {}})
+    structured = (out.get("result") or {}).get("structuredContent") or {}
+    return [s["session_id"] for s in structured.get("sessions") or [] if s.get("session_id")]
 
-    Sound because openers require a credential of this run's own: on a borrowed one
-    they are refused outright, so anything here is this run's to account for. Read
-    from `structuredContent.sessions`, like every other handle in this script.
+
+def snapshot_existing():
+    """Record what was already open, before this run opens anything.
+
+    Without this, the reconciliation below adopts the whole namespace — including a
+    session a crashed run left behind or a second invocation sharing the credential —
+    and the cleanup then ends somebody else's target. The fence is per *run*, so the
+    baseline has to be per run too.
     """
     try:
-        out = mcp("tools/call", {"name": "session_status", "arguments": {}})
+        PRE_EXISTING.update(live_sessions())
+    except Exception as e:
+        print(f"  could not read the credential's existing sessions: {e}")
+        return
+    if PRE_EXISTING:
+        print(f"  {len(PRE_EXISTING)} session(s) already open on this credential; "
+              "this run will neither adopt nor release them")
+
+
+def reconcile_opened():
+    """Adopt sessions that appeared during this run, after an ambiguous opener.
+
+    Sound because openers require a credential of this run's own: on a borrowed one
+    they are refused outright. Bounded by the startup snapshot, so what another
+    invocation or a crashed predecessor left behind stays theirs. Two runs sharing
+    one credential *concurrently* can still overlap here — the answer to that is the
+    same as everywhere else on this page: a credential per run.
+    """
+    try:
+        sessions = live_sessions()
     except Exception as e:
         print(f"  could not reconcile after an ambiguous open: {e}")
         return
-    structured = (out.get("result") or {}).get("structuredContent") or {}
-    for entry in structured.get("sessions") or []:
-        found = entry.get("session_id")
-        if found and found not in OPENED:
+    for found in sessions:
+        if found not in OPENED and found not in PRE_EXISTING:
             OPENED.append(found)
             print(f"  adopted {found} after an ambiguous open")
 
@@ -398,6 +428,8 @@ def main():
     whose = "its own" if DEDICATED else "borrowed from the editor — openers refused"
     mode = " (scenario: sessions kept between tasks)" if SCENARIO else ""
     print(f"credential: {whose}{mode}")
+    if DEDICATED:
+        snapshot_existing()
     tasks = json.load(open(sys.argv[1])) if len(sys.argv) > 1 else [
         "What debug sessions do I currently have open on this server?"
     ]

--- a/tools/local_model_drive.py
+++ b/tools/local_model_drive.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""Drive windbg-mcp from a local model through the ollama server API.
+
+The point of this script is that the local-model plane needs no interactive
+harness: it speaks MCP over HTTP to a `--listen` server and hands the whole tool
+surface to `POST /api/chat`, so "can a local model drive this?" is a question
+with a repeatable answer rather than an impression from a chat session.
+
+    python3 tools/local_model_drive.py [tasks.json]
+
+`tasks.json` is a list of strings, one per task; without it, one default task
+runs. See `docs/local-model.md` for what to make of the numbers it prints.
+
+Configuration, all optional:
+
+    LOCAL_MODEL         ollama model tag       (default: the first tool-capable one)
+    OLLAMA_URL          ollama chat endpoint   (default: http://localhost:11434/api/chat)
+    WINDBG_MCP_URL      the listener           (default: http://127.0.0.1:8765/)
+    WINDBG_MCP_TOKEN    bearer token; falls back to the Claude Code registration
+                        in ~/.claude.json for WINDBG_MCP_PROJECT, so the token
+                        never has to be pasted on a command line
+    WINDBG_MCP_PROJECT  which registration to read it from (default: this repo)
+"""
+import json
+import os
+import sys
+import time
+import urllib.request
+
+MCP_URL = os.environ.get("WINDBG_MCP_URL", "http://127.0.0.1:8765/")
+OLLAMA = os.environ.get("OLLAMA_URL", "http://localhost:11434/api/chat")
+MODEL = os.environ.get("LOCAL_MODEL", "")
+PROJECT = os.environ.get(
+    "WINDBG_MCP_PROJECT", os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+)
+REVISION = "2025-06-18"
+
+# Tool calls this harness will actually execute. Everything else is reported back
+# to the model as refused, so a wrong pick is *measured* rather than performed —
+# the surface includes `launch` and `execute`, and a debug host is the wrong place
+# to find out what a model does with them unattended.
+ALLOWED = {
+    "open_dump", "open_trace", "crash_triage", "backtrace", "modules", "registers",
+    "threads", "session_status", "end_session", "decode_ioctl", "disassemble",
+    "read_memory", "server_log",
+}
+
+MAX_STEPS = 6
+RESULT_LIMIT = 6000
+
+
+def bearer():
+    """The token, from the environment or from this client's own registration."""
+    if os.environ.get("WINDBG_MCP_TOKEN"):
+        return "Bearer " + os.environ["WINDBG_MCP_TOKEN"]
+    registry = json.load(open(os.path.expanduser("~/.claude.json")))
+    servers = registry["projects"][PROJECT]["mcpServers"]
+    for entry in servers.values():
+        auth = (entry.get("headers") or {}).get("Authorization")
+        if auth:
+            return auth
+    raise SystemExit("no token: set WINDBG_MCP_TOKEN, or register the server with a bearer header")
+
+
+AUTH = bearer()
+SESSION = None
+
+
+def parse(body, ctype):
+    if "text/event-stream" in (ctype or ""):
+        # The stream opens with an empty `data:` keep-alive before the payload.
+        for line in body.splitlines():
+            if line.startswith("data:") and line[5:].strip():
+                return json.loads(line[5:].strip())
+        return None
+    return json.loads(body) if body.strip() else None
+
+
+def mcp(method, params=None, notify=False):
+    global SESSION
+    payload = {"jsonrpc": "2.0", "method": method}
+    if not notify:
+        payload["id"] = int(time.time() * 1000) % 100000
+    if params is not None:
+        payload["params"] = params
+    req = urllib.request.Request(MCP_URL, data=json.dumps(payload).encode(), method="POST")
+    req.add_header("Authorization", AUTH)
+    req.add_header("Content-Type", "application/json")
+    req.add_header("Accept", "application/json, text/event-stream")
+    if SESSION:
+        req.add_header("Mcp-Session-Id", SESSION)
+    with urllib.request.urlopen(req, timeout=600) as response:
+        if response.headers.get("Mcp-Session-Id"):
+            SESSION = response.headers["Mcp-Session-Id"]
+        return parse(response.read().decode("utf-8", "replace"), response.headers.get("Content-Type"))
+
+
+def handshake():
+    out = mcp("initialize", {
+        "protocolVersion": REVISION,
+        "capabilities": {},
+        "clientInfo": {"name": "local-model-drive", "version": "1"},
+    })
+    mcp("notifications/initialized", notify=True)
+    return out["result"]["protocolVersion"]
+
+
+def pick_model():
+    if MODEL:
+        return MODEL
+    tags = urllib.request.urlopen(OLLAMA.replace("/api/chat", "/api/tags"), timeout=30)
+    models = json.load(tags).get("models", [])
+    if not models:
+        raise SystemExit("no ollama models pulled; `ollama pull <tag>` first")
+    return models[0]["name"]
+
+
+def as_ollama(tools):
+    """MCP tool definitions in the function-calling shape ollama takes."""
+    return [{"type": "function", "function": {
+        "name": tool["name"],
+        "description": tool.get("description", ""),
+        "parameters": tool.get("inputSchema", {"type": "object", "properties": {}}),
+    }} for tool in tools]
+
+
+def chat(messages, tools):
+    body = {"model": MODEL, "messages": messages, "tools": tools, "stream": False, "think": False}
+    req = urllib.request.Request(OLLAMA, data=json.dumps(body).encode(), method="POST")
+    req.add_header("Content-Type", "application/json")
+    with urllib.request.urlopen(req, timeout=1800) as response:
+        return json.load(response)
+
+
+def call_tool(name, args):
+    if name not in ALLOWED:
+        return f"refused: `{name}` is not permitted in this harness", None
+    try:
+        out = mcp("tools/call", {"name": name, "arguments": args})
+    except Exception as e:  # a transport failure is a result the model can react to
+        return f"transport error: {e}", False
+    return json.dumps(out.get("result", out))[:RESULT_LIMIT], "error" not in out
+
+
+def run(task, tools):
+    messages = [
+        {"role": "system", "content":
+         "You are a Windows kernel debugging assistant. Use the provided tools to answer. "
+         "Call one tool at a time and use its result. Be concise."},
+        {"role": "user", "content": task},
+    ]
+    first_prompt_tokens = None
+    for step in range(MAX_STEPS):
+        started = time.time()
+        out = chat(messages, tools)
+        took = round(time.time() - started, 1)
+        message = out.get("message", {})
+        if first_prompt_tokens is None:
+            first_prompt_tokens = out.get("prompt_eval_count")
+            print(f"  prompt tokens: {first_prompt_tokens}")
+        messages.append(message)
+        calls = message.get("tool_calls") or []
+        if not calls:
+            print(f"  [{took:>6}s] answer: {(message.get('content') or '')[:400]}")
+            return
+        for call in calls:
+            name = call["function"]["name"]
+            args = call["function"].get("arguments") or {}
+            if isinstance(args, str):
+                args = json.loads(args or "{}")
+            text, ok = call_tool(name, args)
+            print(f"  [{took:>6}s] -> {name}({json.dumps(args)[:120]}) ok={ok}")
+            print(f"           {text[:200]}")
+            messages.append({"role": "tool", "tool_name": name, "content": text})
+    print(f"  gave up after {MAX_STEPS} steps")
+
+
+def main():
+    global MODEL
+    MODEL = pick_model()
+    print(f"model: {MODEL}")
+    print("MCP revision negotiated:", handshake())
+    tools = mcp("tools/list")["result"]["tools"]
+    offered = as_ollama(tools)
+    surface = len(json.dumps(offered, separators=(",", ":")))
+    print(f"tools offered: {len(tools)} ({surface} B of minified JSON)")
+    tasks = json.load(open(sys.argv[1])) if len(sys.argv) > 1 else [
+        "What debug sessions do I currently have open on this server?"
+    ]
+    for i, task in enumerate(tasks, 1):
+        print(f"\n=== task {i}: {task[:110]}")
+        run(task, offered)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
The last plane of the split-plane arrangement had no runbook. The listener, the tunnel and the
registration are documented; the one thing that is *different* when the model is local — the
budget — was spread across `docs/token-budget.md`, an architecture note and nobody's memory, which
means a session that resets loses it. `docs/local-model.md` is that page.

**The three pieces**, in the order they fail: the listener with its token in the environment, one
ssh channel that both forwards the port and runs it (starting it through ssh and hanging up is
already documented as the trap it is), and a client pointed at a local model —
`ollama launch claude --model <tag>` wires one into this harness, and the MCP registration does not
care which model is driving.

**The number that decides the question is not the one on the model card.** ollama serves
`OLLAMA_CONTEXT_LENGTH`, whose default its own help gives as *"4k/32k/256k based on VRAM"* — so a
model advertising 262,144 can be served at 4k, and this server's 51-tool surface (67,076 B, ~17k
tokens) does not fit in 4k. `ollama show` gives the model's maximum; `ollama ps` gives what the
loaded instance is serving. Only the second is an answer, and it prints nothing until something has
loaded the model.

Measured on the bench this was written on: the default landed on `262144` with the model wholly on
the GPU, putting the surface at ~6.5% of the window. Recorded as a fact about that machine's memory
rather than about the model, because the same tag on a smaller box gets 4k from the same default.

**What to measure**, since none of it is reachable from the smoke tiers: whether the surface fits at
the served context; whether the model picks the right tool out of 51, which is orthogonal to window
size and is the part a bigger context does not fix; and whether a single answer can blow the window —
two can, since `modules` has no `limit` and `read_memory` returns up to ~4 MiB by design. Those are
`FOLLOWUPS.md` item 24's last bullets, which now point here: the three knobs the plan proposed for a
small model (tool-surface profile, per-call response budget, text-or-data switch) are all
client-side, and this server has none of them.

Docs only. `README.md` and `docs/remote-listener.md` link the new page; `FOLLOWUPS.md` item 24 gains
the pointer. Markdown lint run locally: 0 issues. No machine-specific wiring is committed — hostname,
model tag and token stay out, per `AGENTS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
