### PR TITLE
Carry the transcript through a scenario, since that is what the flag promises

### DIFF
--- a/docs/local-model.md
+++ b/docs/local-model.md
@@ -85,10 +85,15 @@ counting the handles an *opener* returned rather than every handle it has seen, 
 whatever the credential already had when it started — a predecessor that died before its cleanup, or
 a run going on beside it. What it opened, it releases on the way out.
 
-**Each task gets its own targets.** A task list is a list of separate conversations, so sessions are
-released after each one; otherwise a later task's `session_id`-less call routes to an earlier task's
-target and its measurement depends on the prompts before it. A list meant as one continuing
-investigation says so with `WINDBG_MCP_SCENARIO=1`.
+**Each task gets its own conversation and its own targets.** A task list is a list of separate
+questions, so the transcript is fresh and the sessions are released after each one; otherwise a later
+task's `session_id`-less call routes to an earlier task's target, and its measurement depends on the
+prompts before it.
+
+`WINDBG_MCP_SCENARIO=1` says the list is one continuing investigation instead — **one transcript and
+one set of sessions across every task**, so "disassemble the address you just found" means something.
+It is also how you would measure the case the run below does not cover: the prompt-token count
+printed for each task is the transcript growing, and scenario mode is what makes it grow.
 
 **A different arrangement, not a prerequisite:** `ollama launch claude --model <tag>` (ollama 0.32.12
 or newer) makes the local model *the agent* — it drives the harness itself, with these tools as its

--- a/tools/local_model_drive.py
+++ b/tools/local_model_drive.py
@@ -26,8 +26,9 @@ Configuration:
     WINDBG_MCP_URL      the listener           (default: http://127.0.0.1:8765/)
     RESULT_LIMIT        truncate tool results to this many characters before the
                         model sees them; `0`, the default, passes them whole
-    WINDBG_MCP_SCENARIO treat the task list as one continuing investigation, keeping
-                        its sessions open between tasks instead of releasing each
+    WINDBG_MCP_SCENARIO treat the task list as one continuing investigation: one
+                        transcript and one set of sessions across every task, rather
+                        than a conversation and a target apiece
 """
 import json
 import os
@@ -248,13 +249,21 @@ def call_tool(name, args):
     return text, ok, size
 
 
-def run(task, tools):
-    messages = [
+def run(task, tools, transcript=None):
+    """Work one task, and hand back the transcript it leaves behind.
+
+    A task is its own conversation unless `transcript` says otherwise: in scenario
+    mode the same one carries across tasks, so "disassemble the address you found"
+    means something. Keeping the *session* and dropping the *messages* would be a
+    continuing investigation the model cannot remember — target reuse dressed up as
+    one, which is what the flag would then be lying about.
+    """
+    messages = transcript or [
         {"role": "system", "content":
          "You are a Windows kernel debugging assistant. Use the provided tools to answer. "
          "Call one tool at a time and use its result. Be concise."},
-        {"role": "user", "content": task},
     ]
+    messages.append({"role": "user", "content": task})
     first_prompt_tokens = None
     for step in range(MAX_STEPS):
         started = time.time()
@@ -268,7 +277,7 @@ def run(task, tools):
         calls = message.get("tool_calls") or []
         if not calls:
             print(f"  [{took:>6}s] answer: {(message.get('content') or '')[:400]}")
-            return
+            return messages
         for call in calls:
             name = call["function"]["name"]
             args = call["function"].get("arguments") or {}
@@ -279,6 +288,7 @@ def run(task, tools):
             print(f"           {text[:200]}")
             messages.append({"role": "tool", "tool_name": name, "content": text})
     print(f"  gave up after {MAX_STEPS} steps")
+    return messages
 
 
 def live_sessions():
@@ -394,15 +404,17 @@ def main():
     tasks = json.load(open(sys.argv[1])) if len(sys.argv) > 1 else [
         "What debug sessions do I currently have open on this server?"
     ]
+    transcript = None
     try:
         for i, task in enumerate(tasks, 1):
             print(f"\n=== task {i}: {task[:110]}")
-            run(task, offered)
+            transcript = run(task, offered, transcript)
             # Each task is its own conversation, so it gets its own targets: a session
             # left open would be routed to by the next task's `session_id`-less call,
             # which makes that task's measurement depend on the one before it. A task
             # list meant as one continuing investigation says so with WINDBG_MCP_SCENARIO.
             if not SCENARIO:
+                transcript = None
                 release_what_this_run_opened()
     finally:
         release_what_this_run_opened()


### PR DESCRIPTION
A late review comment landed on #173 after it had merged, and it is right.

`WINDBG_MCP_SCENARIO=1` says a task list is one continuing investigation. It kept the **debug
sessions** across tasks — and started a fresh `messages` list for every one of them, so the model
remembered nothing. "Disassemble the address you just found" could not work: the target survived and
the conversation did not. That is target reuse, and the flag was advertising something else.

The transcript now carries across tasks in scenario mode, alongside the sessions, so both halves of
the option mean the same thing. Ordinary mode is untouched: a conversation and a target apiece,
released and forgotten, so no task's measurement depends on the prompts before it.

**It also makes reachable the one case `docs/local-model.md` lists as uncovered** — a long
investigation whose transcript outgrows the tool surface. The prompt-token count printed for each
task *is* that growth, and scenario mode is what makes it grow:

```
=== task 1 …                          prompt tokens: 17,095
=== task 2 (told to call no tools)    prompt tokens: 18,823
  answer: Based on what I told you in the previous message:
  - Bug check code: 0xFC — ATTEMPTED_EXECUTE_OF_NOEXECUTE_MEMORY
  - Dump file: C:\workspace\windbg-mcp\docs\samples\121524-4703-01.dmp
```

That is the verification, not an illustration: the second task was instructed to call no tool, and
answered the first task's bug check and dump path from memory.

Docs updated to describe the flag as one transcript and one set of sessions, and to point at it as
the way to measure transcript growth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
