### PR TITLE
Let the token file name its own clients, since a service reads nothing else

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     rather than one rule and an exception.
   - **Every credential variable is stripped from the processes this server creates** — by prefix,
     so a token added later cannot quietly reach a debuggee — and a configured token *file* shuts the
-    environment out entirely, which is the precedence a LocalSystem service depends on.
+    environment out entirely, which is the precedence a LocalSystem service depends on. That file
+    names its own clients (below), because a service reads nothing else.
 
   **Why authentication is the identity.** `2026-07-28` removed the protocol-level MCP session, so
   there is no session id to key on; requests arrive on whatever socket a client's pool hands them,
@@ -66,6 +67,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   This separates clients; it does not rank them. Everyone who can authenticate still has the whole
   tool surface.
+
+- **The token file can name more than one client, so a service-hosted listener can hold more than
+  one.** A configured `WINDBG_MCP_LISTEN_TOKEN_FILE` is the *only* credential — deliberately, since
+  the service installer ACLs it to SYSTEM and Administrators precisely because the machine
+  environment is readable by unprivileged processes. The consequence was that the per-client work
+  above could not be had in the deployment `docs/remote-listener.md` recommends: a foreground
+  listener could hold `local`, `ci` and `laptop`; the service could hold one, so two agents on one
+  host shared a namespace, and one of them going over the four-session cap could evict the other's
+  target with nothing naming it.
+
+  The file now takes either shape: a **bare token**, which names `local` and is what it has always
+  held, or a **JSON object of client name to token** — the shape `WINDBG_MCP_PROFILES` already uses
+  for kernel profiles. A leading `{` is what tells them apart, so a bare token may not begin with
+  one; a file that does is refused at startup by name rather than read as the other thing. The ACL
+  story is unchanged, since it is one file either way.
+
+  `--install-service` copies **every** `WINDBG_MCP_LISTEN_TOKEN*` variable in the installing shell
+  rather than the unnamed one alone, and writes the shape that fits — a bare token for a single
+  `local`, the object otherwise — so an existing single-client install keeps a file nobody has to
+  rewrite. It validates them the way the listener would, because the SCM registers a service once
+  and a credential it refuses then fails it at every start.
+
+  Its refusals name the file and the key and never a value, for the same reason the environment's
+  name the variable: they are printed at startup, and under the service into a log file. One thing
+  they cannot catch is an entry written back to front — a token is a valid client name — so the
+  documentation says which way round it goes.
 
 - **`server_log` — the server's own log, readable from wherever the client is.** The supervisor
   keeps a bounded ring of the most recent records, its own and every engine worker's, and serves

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,8 +90,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and a credential it refuses then fails it at every start.
 
   Its refusals name the file and the key and never a value, for the same reason the environment's
-  name the variable: they are printed at startup, and under the service into a log file. One thing
-  they cannot catch is an entry written back to front — a token is a valid client name — so the
+  name the variable: they are printed at startup, and under the service into a log file. A client
+  name is now held to one rule wherever it was configured — a variable whose suffix is not a name is
+  refused rather than skipped, since an install copies those names into the file — and a name
+  written twice in the file is refused rather than collapsed to the last of them. One thing none of
+  it can catch is an entry written back to front, since a token is a valid client name, so the
   documentation says which way round it goes.
 
 - **`server_log` — the server's own log, readable from wherever the client is.** The supervisor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   rewrite. It validates them the way the listener would, because the SCM registers a service once
   and a credential it refuses then fails it at every start.
 
+  **Upgrading with a token that begins with `{`:** an install predating this wrote whatever the
+  shell held, so such a file is now read as the JSON shape and the service refuses to start rather
+  than authenticating. Write it as `{"local": "<that token>"}` — the refusal in the service log says
+  so too — and it works exactly as it did. Any other token is unaffected. The rule is not softened
+  to a fallback on purpose: reading a file whose JSON does not parse as one long token would turn a
+  hand-written object with a typo in it into a credential that authenticates nobody and explains
+  nothing, which is the likelier file by far.
+
   Its refusals name the file and the key and never a value, for the same reason the environment's
   name the variable: they are printed at startup, and under the service into a log file. A client
   name is now held to one rule wherever it was configured — a variable whose suffix is not a name is

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -379,7 +379,10 @@ as the parser having made things worse.
 
 A `--listen` server holds **one bearer token per client**: `WINDBG_MCP_LISTEN_TOKEN_<NAME>` names
 one, the unnamed variable names `local`, and a configured `WINDBG_MCP_LISTEN_TOKEN_FILE` shuts the
-environment out entirely rather than merely outranking it. Under stdio everything runs as `local`,
+environment out entirely rather than merely outranking it — so that file names its own clients (a
+bare token is `local`; a JSON object of name to token is as many as it lists), which is the only way
+a service-hosted listener holds more than one, and `--install-service` copies every credential
+variable in the shell rather than the unnamed one alone. Under stdio everything runs as `local`,
 so there is one set of rules and no transport exception. `docs/remote-listener.md` is the operator's
 half; what follows is what bites while editing.
 

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -1023,7 +1023,10 @@ deserialized through a visitor that keeps every pair, and a name written twice i
 names the file. The third finding was the same shape from the writer's side — a token that happens
 to begin with `{` cannot go in the file bare, because the reader takes a leading brace as the JSON
 shape — and the fix is the general one: the installer asks the reader whether the bare form reads
-back as what it meant, rather than restating the rule in a second place.
+back as what it meant, rather than restating the rule in a second place. Worth knowing that the
+first version of *that* asked the wrong question — it checked the client's name, which a token that
+is itself a one-entry object satisfies while carrying a different token — so the round trip is on
+the whole credential: exactly one, and it is this token naming `local`.
 
 The end-to-end half is one protocol-tier smoke assertion
 (`a_token_file_names_its_own_clients_and_shuts_the_environment_out`): a real listener, a real file

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -1020,7 +1020,10 @@ one name rule now, wherever the credential was configured, and the environment i
 all when a file is present. And a repeated key in the file was collapsed by `serde_json::Map` to the
 last of the two, silently, which is the shape this module refuses everywhere else — so the object is
 deserialized through a visitor that keeps every pair, and a name written twice is a refusal that
-names the file.
+names the file. The third finding was the same shape from the writer's side — a token that happens
+to begin with `{` cannot go in the file bare, because the reader takes a leading brace as the JSON
+shape — and the fix is the general one: the installer asks the reader whether the bare form reads
+back as what it meant, rather than restating the rule in a second place.
 
 The end-to-end half is one protocol-tier smoke assertion
 (`a_token_file_names_its_own_clients_and_shuts_the_environment_out`): a real listener, a real file

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -1026,7 +1026,11 @@ shape — and the fix is the general one: the installer asks the reader whether 
 back as what it meant, rather than restating the rule in a second place. Worth knowing that the
 first version of *that* asked the wrong question — it checked the client's name, which a token that
 is itself a one-entry object satisfies while carrying a different token — so the round trip is on
-the whole credential: exactly one, and it is this token naming `local`.
+the whole credential: exactly one, and it is this token naming `local`. The last one was a *document*
+— a JSON example with the file's path commented above it, which does not begin with `{` and is
+therefore read as one token spanning four lines. The example lost its comment, and the parse now
+refuses a bare token carrying a line break at all: nothing could present one in an `Authorization`
+header, so a listener that accepts it is a listener that accepts nobody.
 
 The end-to-end half is one protocol-tier smoke assertion
 (`a_token_file_names_its_own_clients_and_shuts_the_environment_out`): a real listener, a real file

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -1029,8 +1029,9 @@ is itself a one-entry object satisfies while carrying a different token — so t
 the whole credential: exactly one, and it is this token naming `local`. The last one was a *document*
 — a JSON example with the file's path commented above it, which does not begin with `{` and is
 therefore read as one token spanning four lines. The example lost its comment, and the parse now
-refuses a bare token carrying a line break at all: nothing could present one in an `Authorization`
-header, so a listener that accepts it is a listener that accepts nobody.
+refuses a token carrying a line break at all — from any source, since it is a fact about the
+transport rather than about where the token was written: nothing can present one in an
+`Authorization` header, so a listener that accepts it is a listener that accepts nobody.
 
 The end-to-end half is one protocol-tier smoke assertion
 (`a_token_file_names_its_own_clients_and_shuts_the_environment_out`): a real listener, a real file

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -1029,9 +1029,15 @@ is itself a one-entry object satisfies while carrying a different token — so t
 the whole credential: exactly one, and it is this token naming `local`. The last one was a *document*
 — a JSON example with the file's path commented above it, which does not begin with `{` and is
 therefore read as one token spanning four lines. The example lost its comment, and the parse now
-refuses a token carrying a line break at all — from any source, since it is a fact about the
-transport rather than about where the token was written: nothing can present one in an
-`Authorization` header, so a listener that accepts it is a listener that accepts nobody.
+refuses, from any source, a token that cannot travel in an `Authorization` header at all — a
+listener that accepts one is a listener that accepts nobody.
+
+**The lesson of the review rounds is one thing said three times.** A rule about a value was
+*described* in the code — a name charset, then a line-break test — and each round found the next
+character class it had not thought of. The two checks that stopped generating findings are the two
+that ask the thing that will actually do the work: the installer asks the reader whether the file
+shape round-trips, and `is_presentable` builds the header a client would send and reads it back the
+way `authorised` does. Where a rule belongs to something else, deriving it beats restating it.
 
 The end-to-end half is one protocol-tier smoke assertion
 (`a_token_file_names_its_own_clients_and_shuts_the_environment_out`): a real listener, a real file

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -1006,12 +1006,21 @@ Two things worth carrying:
   quote the value they rejected — and every value in this file is a credential. `Credentials` and
   `TokenFile` grew hand-written `Debug`s that print names only, for the same reason `Connection`
   has one.
-- **A name-shaped token is a name.** A charset check on the keys catches a connection string or
+- **A name-shaped token is a name.** A charset check on client names catches a connection string or
   anything carrying a line break, but it cannot catch an entry written back to front, since a
   bearer token is a perfectly good client name — and that entry configures a client named after
   your token, which the startup line prints. That is not fixable in code; it is why the refusal
   that *is* detectable quotes nothing, and why `docs/remote-listener.md` says which way round the
   file goes.
+
+Review found the two gaps that came of writing the file's rules as *the file's*. A name from the
+environment was not held to the charset check, which an install then copies into the file — so a
+variable the listener accepted could install cleanly and fail the service at every start; there is
+one name rule now, wherever the credential was configured, and the environment is still not read at
+all when a file is present. And a repeated key in the file was collapsed by `serde_json::Map` to the
+last of the two, silently, which is the shape this module refuses everywhere else — so the object is
+deserialized through a visitor that keeps every pair, and a name written twice is a refusal that
+names the file.
 
 The end-to-end half is one protocol-tier smoke assertion
 (`a_token_file_names_its_own_clients_and_shuts_the_environment_out`): a real listener, a real file

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -959,26 +959,26 @@ mechanism to catch, so it is worth doing only if the arming rule ever grows a se
 handled. Picks up at the listener helpers in `tests/mcp_smoke.rs`, beside
 `the_listener_serves_the_stateless_revision_it_negotiates`.
 
-## 31. [windbg-mcp] A service-hosted listener can hold only one client
+## 31. [windbg-mcp] A service-hosted listener can hold only one client — **done** (2026-08-20)
 
-`Credentials::from_entries` treats a configured `WINDBG_MCP_LISTEN_TOKEN_FILE` as the **only**
-credential: it loads that token as `local` and returns, ignoring every environment token including
-named ones. That precedence is deliberate and load-bearing — the service installer ACLs the file to
+`Credentials::from_entries` treated a configured `WINDBG_MCP_LISTEN_TOKEN_FILE` as the **only**
+credential, and read one token out of it: it loaded that token as `local` and returned, ignoring
+every environment token including named ones. That precedence is deliberate and load-bearing — the service installer ACLs the file to
 SYSTEM and Administrators precisely because the machine environment is readable by unprivileged
 processes, and a variable standing beside it would let a stale or planted one authenticate to a
 LocalSystem listener that has `launch` on it.
 
-The consequence is that **the per-client work of [#162](https://github.com/glslang/windbg-mcp/issues/162)
-is unreachable in the deployment `docs/remote-listener.md` recommends.** A foreground listener can
-hold `local`, `ci` and `laptop`; the service can hold one client, so two agents on one service-hosted
-host share a namespace — which is exactly what ownership was built to stop.
+The consequence was that **the per-client work of [#162](https://github.com/glslang/windbg-mcp/issues/162)
+was unreachable in the deployment `docs/remote-listener.md` recommends.** A foreground listener could
+hold `local`, `ci` and `laptop`; the service could hold one client, so two agents on one
+service-hosted host shared a namespace — which is exactly what ownership was built to stop.
 
 It surfaced from the other end, in review of [#173](https://github.com/glslang/windbg-mcp/pull/173):
 a local-model driver must not share a credential with the editor, because a client over the
 four-session cap has its oldest idle session reclaimed, so the driver's `open_dump` can evict the
 editor's target with nothing naming it. That driver now **requires** a credential of its own rather
-than defending against sharing one — which is the right shape and makes this item the only thing
-standing between it and the recommended deployment: under the service there is no second credential
+than defending against sharing one — which is the right shape, and made this item the only thing
+standing between it and the recommended deployment: under the service there was no second credential
 to give it.
 
 **What would close it:** a token file that can name more than one client. The obvious shape is the
@@ -986,6 +986,34 @@ same one `WINDBG_MCP_PROFILES` already uses for kernel profiles — a JSON objec
 with a bare string still read as `local` so every existing install keeps working. The ACL story is
 unchanged, since it is one file either way.
 
-**Why deferred:** it is a file-format change to the one file that holds credentials, and it wants to
-land on its own rather than inside a runbook PR. Picks up at `Credentials::from_entries`
-(`src/client.rs`) and `service::install`, which writes the file.
+**Why it was deferred:** it is a file-format change to the one file that holds credentials, and it
+wanted to land on its own rather than inside a runbook PR.
+
+**What landed.** The obvious shape, as predicted: `client::TokenFile` reads either a **bare token**
+— which names `local`, so every file written before this keeps working untouched — or a **JSON
+object of client name to token**, the shape `WINDBG_MCP_PROFILES` already uses. A leading `{` is
+what tells them apart, which makes "a bare token may not begin with `{`" a rule rather than a guess:
+a file that does is refused at startup by name. The precedence is untouched — a configured file is
+still the only credential — and `service::install` now copies **every** `WINDBG_MCP_LISTEN_TOKEN*`
+variable in the installing shell, writing a bare token for a lone `local` and the object otherwise,
+validated through the same `Credentials` the listener builds so a shell that could not start a
+foreground listener cannot register a service.
+
+Two things worth carrying:
+
+- **The parse is the same problem `kdconn` solved for profiles, and gets the same answer**: values
+  are walked as generic JSON rather than deserialized into a typed map, because serde's type errors
+  quote the value they rejected — and every value in this file is a credential. `Credentials` and
+  `TokenFile` grew hand-written `Debug`s that print names only, for the same reason `Connection`
+  has one.
+- **A name-shaped token is a name.** A charset check on the keys catches a connection string or
+  anything carrying a line break, but it cannot catch an entry written back to front, since a
+  bearer token is a perfectly good client name — and that entry configures a client named after
+  your token, which the startup line prints. That is not fixable in code; it is why the refusal
+  that *is* detectable quotes nothing, and why `docs/remote-listener.md` says which way round the
+  file goes.
+
+The end-to-end half is one protocol-tier smoke assertion
+(`a_token_file_names_its_own_clients_and_shuts_the_environment_out`): a real listener, a real file
+naming two clients, the environment token refused `401`, and both file clients served through a full
+handshake.

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -1032,6 +1032,16 @@ therefore read as one token spanning four lines. The example lost its comment, a
 refuses, from any source, a token that cannot travel in an `Authorization` header at all — a
 listener that accepts one is a listener that accepts nobody.
 
+One finding was taken as a fact rather than as its proposed remedy: a token file written by an
+earlier install whose token *begins* with `{` — a braced GUID is the plausible way to have one —
+now reads as the JSON shape and stops the service at its next start. The remedy offered was a
+format marker or a fallback to the bare reading when the JSON does not parse; both are worse than
+the problem. A marker is not unambiguous either, since a token can carry whatever marks the object,
+and the fallback rescues that rare file by turning the likely one — a hand-written object with a
+typo in it — into one long token that authenticates nobody and explains nothing. So the rule stands
+and the refusal carries the way out (`{"local": "<that token>"}`), with the same note in the
+changelog and a test pinning it.
+
 **The lesson of the review rounds is one thing said three times.** A rule about a value was
 *described* in the code — a name charset, then a line-break test — and each round found the next
 character class it had not thought of. The two checks that stopped generating findings are the two

--- a/docs/local-model.md
+++ b/docs/local-model.md
@@ -77,10 +77,10 @@ at an ACL'd token file, and a configured file is the *only* credential this serv
 shuts the environment out entirely, named tokens included, because the machine environment is
 readable by unprivileged processes and this endpoint has `launch` on it
 (`Credentials::from_entries`). So the driver's credential goes **in the file**, which names its own
-clients:
+clients — `%ProgramData%\windbg-mcp\token`, as strict JSON (no comments; a file that does not begin
+with `{` is read as a single bare token):
 
-```jsonc
-// %ProgramData%\windbg-mcp\token
+```json
 {
   "local":  "<what your editor presents>",
   "driver": "<another long random string>"

--- a/docs/local-model.md
+++ b/docs/local-model.md
@@ -72,16 +72,30 @@ can evict the editor's target without any tool call naming it. The script theref
 without a token rather than borrowing one; it cannot tell one token from another, so supplying a
 credential that really is its own is yours to get right.
 
-**A listener installed as the service can hold only one client**, so driver work wants the foreground
-one. The installer points the service at an ACL'd token file, and a configured file is the *only*
-credential this server will read — it shuts the environment out entirely, named tokens included,
-because the machine environment is readable by unprivileged processes and this endpoint has `launch`
-on it (`Credentials::from_entries`). That precedence is right; the one-client consequence is a gap,
-filed as `FOLLOWUPS.md` item 31. Until it closes, handing the driver the service's own token is
-sharing the namespace knowingly — which is a decision, not a default.
+**Under the service, that variable is not where the token goes.** The installer points the service
+at an ACL'd token file, and a configured file is the *only* credential this server will read — it
+shuts the environment out entirely, named tokens included, because the machine environment is
+readable by unprivileged processes and this endpoint has `launch` on it
+(`Credentials::from_entries`). So the driver's credential goes **in the file**, which names its own
+clients:
 
-Within one namespace the script still fences what it can: it ends only sessions **this run opened**,
-counting the handles an *opener* returned rather than every handle it has seen, and leaving alone
+```jsonc
+// %ProgramData%\windbg-mcp\token
+{
+  "local":  "<what your editor presents>",
+  "driver": "<another long random string>"
+}
+```
+
+`--install-service` writes that for you from the credential variables in the installing shell, so
+setting `WINDBG_MCP_LISTEN_TOKEN_DRIVER` beside the unnamed one before installing is enough. Editing
+the file afterwards works too — it is read at startup, so restart the service. Handing the driver
+the *editor's* token is still possible and is sharing the namespace knowingly, which is a decision
+rather than a default.
+
+Should you share one anyway, the script still fences what it can within that namespace: it ends only
+sessions **this run opened**, counting the handles an *opener* returned rather than every handle it
+has seen, and leaving alone
 whatever the credential already had when it started — a predecessor that died before its cleanup, or
 a run going on beside it. What it opened, it releases on the way out.
 

--- a/docs/remote-listener.md
+++ b/docs/remote-listener.md
@@ -270,11 +270,40 @@ what the oldest record is — is over that client's own stream. Numbering per cl
 last of it and cost the cursor its stability, which is a bad trade for a shared debug host and a
 worse one for a hostile tenant, who should not be sharing a listener at all.
 
-**A token file is the only credential when one is configured.** `WINDBG_MCP_LISTEN_TOKEN_FILE` shuts
-the environment out entirely — named tokens included — rather than merely outranking the unnamed
-variable. That precedence is load-bearing: the service installer ACLs that file to SYSTEM and
-Administrators *because* the machine environment is readable by unprivileged processes, so a
-variable standing beside it would reintroduce exactly what the file was written to avoid.
+**A token file is the only credential when one is configured, so it names its own clients.**
+`WINDBG_MCP_LISTEN_TOKEN_FILE` shuts the environment out entirely — named tokens included — rather
+than merely outranking the unnamed variable. That precedence is load-bearing: the service installer
+ACLs that file to SYSTEM and Administrators *because* the machine environment is readable by
+unprivileged processes, so a variable standing beside it would reintroduce exactly what the file was
+written to avoid.
+
+Which is why the file takes either shape. A **bare token**, which names `local` and is what this
+file has always held:
+
+```text
+<a long random string>
+```
+
+Or a **JSON object of client name to token**, the same shape `WINDBG_MCP_PROFILES` uses for kernel
+profiles:
+
+```json
+{
+  "local":  "<a long random string>",
+  "ci":     "<another>",
+  "laptop": "<another>"
+}
+```
+
+A leading `{` is what tells them apart, so a bare token may not begin with one — a file that does is
+refused at startup, by name, rather than read as the other thing. Keys are client names, values are
+their tokens: **written the other way round it configures a client named after your token**, and the
+line this server logs at startup says who may connect. Nothing can detect that for you, since a
+token is a valid name.
+
+Everything else about the file is unchanged: one file, one ACL, and every rule above about what
+owning a session means applies to the clients it names exactly as it does to tokens from the
+environment.
 
 **Every credential variable is stripped from the processes this server creates** — engine workers
 and the TTD recorder — by prefix rather than by name, so a token added later cannot quietly reach a
@@ -368,6 +397,14 @@ machine environment is readable by every local process, the listener is reachabl
 same, and `launch` takes an arbitrary command line and runs it from a worker this service spawned —
 as `LocalSystem`. The token is the only thing in the way, so it has to stay unreadable by an
 unprivileged process, which is the one property the foreground listener gets for free.
+
+**Every credential in the installing shell is copied, not just the unnamed one.** A service reads
+its file and nothing else, so this is the only way it can hold more than one client — set
+`WINDBG_MCP_LISTEN_TOKEN_CI` beside `WINDBG_MCP_LISTEN_TOKEN` before installing and the file it
+writes names both. One client called `local` is written as a bare token, as it always was; anything
+else is the JSON object above. The install validates them the way the listener would, so a shell
+that could not start a foreground listener cannot register a service either — which matters here,
+because the SCM registers a service once and a bad credential then fails it at every start.
 
 `windbg-mcp.exe --uninstall-service` removes it, stopping it first and waiting for it — a delete
 issued against a running service only marks it, and this one has debug targets to let go of.

--- a/src/client.rs
+++ b/src/client.rs
@@ -297,6 +297,18 @@ pub fn env_credentials(
 /// **A leading `{` is what tells them apart**, so a bare token may not begin with one. That is a
 /// rule rather than a guess: a token that did would be refused at startup, by name, rather than
 /// quietly read as something else.
+///
+/// **Which is a change of meaning for one pre-existing file**, and review was right to name it: an
+/// install predating this wrote whatever the shell held, so a token that begins with `{` — a
+/// braced GUID is the plausible way to get one — stops the service at its next start rather than
+/// authenticating. That refusal says how to fix it (put the token in a one-entry object), and the
+/// changelog carries the same note, because the alternative is worse. Falling back to the bare
+/// reading when the JSON does not parse would rescue that file at the cost of the failure this
+/// shape exists to prevent: a hand-written object with a typo in it, read as one long token that
+/// authenticates nobody and says nothing. A loud refusal on the rare file beats a silent one on
+/// the file people will actually hand-edit. No marker helps here either — whatever marks the
+/// object, a token could carry it — and only a signal outside the file could be unambiguous, which
+/// is a heavier format than a credential file wants.
 pub struct TokenFile {
     entries: Vec<Configured>,
 }
@@ -361,8 +373,9 @@ impl TokenFile {
         let Entries(object) = serde_json::from_str(text).map_err(|e| {
             anyhow!(
                 "{} begins with `{{`, so it is read as a JSON object of client name to token — and \
-                 it is not valid JSON ({e}). A file holding one token is still a token file; it \
-                 just may not start with `{{`.",
+                 it is not valid JSON ({e}). If this file holds a single bearer token that happens \
+                 to begin with `{{` — one written before this file could name clients — write it \
+                 as `{{\"local\": \"<that token>\"}}` and it will authenticate exactly as it did.",
                 path.display()
             )
         })?;
@@ -748,6 +761,33 @@ mod tests {
         assert_eq!(creds.len(), 1, "the environment must not add credentials");
         assert_eq!(creds.client_for("from-the-environment"), None);
         assert_eq!(creds.client_for("also-from-the-environment"), None);
+    }
+
+    /// The one file whose meaning this changed, and the way out, which the refusal has to carry:
+    /// a token written before the file could name clients that happens to begin with `{`. It is
+    /// read as the JSON shape now, so the listener refuses to start — and the same token in a
+    /// one-entry object authenticates exactly as it did.
+    ///
+    /// Not softened to "fall back to the bare reading when the JSON does not parse": that would
+    /// rescue this file at the cost of turning a hand-written object with a typo in it into one
+    /// long token that authenticates nobody and says nothing.
+    #[test]
+    fn a_legacy_token_beginning_with_a_brace_is_refused_and_told_how_to_survive() {
+        let legacy = "{6F9619FF-8B86-D011-B42D-00CF4FC964FF}";
+        let why = TokenFile::parse(legacy, Path::new(FILE))
+            .expect_err("a file beginning with `{` is the JSON shape")
+            .to_string();
+        assert!(why.contains(FILE), "{why}");
+        assert!(
+            why.contains(r#"`{"local": "<that token>"}`"#),
+            "the refusal has to carry the way out, since it is all the operator sees: {why}"
+        );
+        let creds = Credentials::from_entries(
+            vars(&[]),
+            Some(file(&format!(r#"{{"local": "{legacy}"}}"#))),
+        )
+        .expect("the same token, in the shape this file now takes");
+        assert_eq!(creds.client_for(legacy).map(Client::name), Some("local"));
     }
 
     /// **And because it is the only credential, it has to be able to name more than one.** A

--- a/src/client.rs
+++ b/src/client.rs
@@ -34,19 +34,24 @@
 //! has.
 
 use std::collections::HashMap;
+use std::path::Path;
 use std::sync::Arc;
 
-use anyhow::{Result, bail};
+use anyhow::{Result, anyhow, bail};
 
 /// The unnamed token, and the prefix of a named one.
 const TOKEN_ENV: &str = "WINDBG_MCP_LISTEN_TOKEN";
 
-/// The variable naming a *file* to read a token from, which shares that prefix and is not one.
+/// The variable naming a *file* to read credentials from, which shares that prefix and is not one.
 ///
 /// Excluded by name rather than by shape: its value is a path, so without this it would configure
 /// a client called `file` whose credential is `C:\...\token` — a token nobody holds, under a name
 /// nobody chose, and the real token silently absent.
 const TOKEN_FILE_ENV: &str = "WINDBG_MCP_LISTEN_TOKEN_FILE";
+
+/// How long a client's name may be — the same bound a kernel profile's name has, and for the same
+/// reason: a name is rendered in log lines and in refusals, so it has to be a name.
+const NAME_LIMIT: usize = 64;
 
 /// Who a call belongs to.
 ///
@@ -84,9 +89,20 @@ impl std::fmt::Display for Client {
 }
 
 /// The tokens this listener accepts, and the client each one names.
-#[derive(Debug, Clone, Default)]
+#[derive(Clone, Default)]
 pub struct Credentials {
     by_token: HashMap<String, Client>,
+}
+
+/// **The names, never the tokens** — the same reason [`crate::kdconn::Connection`]'s is redacted.
+/// A derived one would put every credential this listener accepts into whatever formatted it, and
+/// the things that format a value like this are a log line and a test's panic message.
+impl std::fmt::Debug for Credentials {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Credentials")
+            .field("clients", &self.names())
+            .finish()
+    }
 }
 
 impl Credentials {
@@ -106,36 +122,54 @@ impl Credentials {
         names
     }
 
-    /// Builds the set from `(variable, value)` pairs and the file token, if there is one.
+    /// Builds the set from `(variable, value)` pairs, or from the token file if there is one.
     ///
     /// Takes the variables rather than reading the environment for the reason
     /// [`crate::kdconn::env_entries`] does: `set_var` is `unsafe` in edition 2024 and mutates state
     /// the whole test binary shares, so the only way to assert that
     /// `WINDBG_MCP_LISTEN_TOKEN_CI` names the client `ci` is to hand the scan its variables.
     ///
+    /// **A configured file is the *only* credential.** That precedence predates named tokens and
+    /// is load-bearing: the service installer writes the file to `%ProgramData%` with an ACL of
+    /// SYSTEM and Administrators precisely because the machine environment is readable by
+    /// unprivileged processes. Letting an environment token stand beside it would mean a stale or
+    /// planted variable authenticating to a LocalSystem listener — which has `launch` on it. So a
+    /// file shuts the environment out entirely rather than merely outranking the unnamed variable,
+    /// and names its own clients ([`TokenFile`]) rather than leaving the deployment that needs it
+    /// most with room for one.
+    pub fn from_entries(
+        vars: impl Iterator<Item = (String, String)>,
+        file: Option<TokenFile>,
+    ) -> Result<Self> {
+        match file {
+            Some(file) => Self::build(&file.entries),
+            None => Self::build(&from_env(vars)),
+        }
+    }
+
+    /// The two refusals every source of credentials is held to, wherever it was configured.
+    ///
     /// A token appearing twice is refused rather than resolved. Two names for one credential means
     /// a caller's sessions land under whichever name won a `HashMap` insertion, which is a rule
     /// nobody could predict and a boundary that would move.
-    pub fn from_entries(
-        vars: impl Iterator<Item = (String, String)>,
-        file_token: Option<String>,
-    ) -> Result<Self> {
+    fn build(configured: &[Configured]) -> Result<Self> {
         let mut by_token: HashMap<String, Client> = HashMap::new();
-        // Client name to the *variable* that configured it — never to the token. Both refusals
-        // below are printed at startup, to stderr in the foreground and to the service log under
-        // the SCM, so a message quoting the credential it is complaining about would write a
-        // working listener token into whatever collects those. The variable is also the more useful
-        // half: it is what the operator has to go and change.
-        let mut named: HashMap<String, String> = HashMap::new();
-        let mut insert = |token: String, name: &str, from: &str| -> Result<()> {
-            if let Some(existing) = by_token.get(&token) {
-                // One client is one credential (the check below), so the variable that configured
-                // this token is the one that configured that client.
+        // Client name to *what configured it* — never to the token. Both refusals below are
+        // printed at startup, to stderr in the foreground and to the service log under the SCM, so
+        // a message quoting the credential it is complaining about would write a working listener
+        // token into whatever collects those. The source is also the more useful half: it is what
+        // the operator has to go and change.
+        let mut named: HashMap<&str, &str> = HashMap::new();
+        for Configured { name, token, from } in configured {
+            if let Some(existing) = by_token.get(token) {
+                // One client is one credential (the check below), so whatever configured this
+                // token is what configured that client.
                 let first = named
                     .get(existing.name())
-                    .map_or("another variable", String::as_str);
+                    .copied()
+                    .unwrap_or("another entry");
                 bail!(
-                    "`{from}` and `{first}` are the same token, configured for `{name}` and \
+                    "{from} and {first} are the same token, configured for `{name}` and \
                      `{existing}`. One credential cannot name two clients: sessions opened with it \
                      would belong to whichever name happened to win."
                 );
@@ -144,56 +178,213 @@ impl Credentials {
             // insidious half: nothing looks wrong, both callers authenticate, and they silently
             // share a namespace — routing, listing, capacity, teardown rights, the lot. Names are
             // folded before comparison, so `WINDBG_MCP_LISTEN_TOKEN` and `…_TOKEN_LOCAL` collide
-            // (both `local`), as do `…_CI` and `…__CI`. A boundary two credentials can stand on is
-            // not a boundary, so this is a configuration error rather than a merge.
-            if let Some(other) = named.get(name) {
+            // (both `local`), as do `…_CI` and `…__CI`, and so do two spellings of one key in the
+            // token file. A boundary two credentials can stand on is not a boundary, so this is a
+            // configuration error rather than a merge.
+            if let Some(other) = named.get(name.as_str()) {
                 bail!(
-                    "two different tokens are configured for the client `{name}` (`{other}` and \
-                     `{from}`). Each client is one credential: two would share every session, \
-                     which is the isolation this is for, silently absent."
+                    "two different tokens are configured for the client `{name}` ({other} and \
+                     {from}). Each client is one credential: two would share every session, which \
+                     is the isolation this is for, silently absent."
                 );
             }
-            named.insert(name.to_string(), from.to_string());
-            by_token.insert(token, Client::new(name));
-            Ok(())
-        };
-
-        // **A configured file is the *only* credential.** That precedence predates named tokens
-        // and is load-bearing: the service installer writes the token to `%ProgramData%` with an
-        // ACL of SYSTEM and Administrators precisely because the machine environment is readable by
-        // unprivileged processes. Letting an environment token stand beside it would mean a stale
-        // or planted variable authenticating to a LocalSystem listener — which has `launch` on it.
-        // So a file shuts the environment out entirely rather than merely outranking the unnamed
-        // variable.
-        if let Some(token) = file_token {
-            insert(token, Client::LOCAL, TOKEN_FILE_ENV)?;
-            return Ok(Self { by_token });
-        }
-        for (key, value) in vars {
-            let token = value.trim().to_string();
-            if token.is_empty() {
-                continue;
-            }
-            if is_token_file(&key) {
-                continue;
-            }
-            match credential_suffix(&key) {
-                // The unnamed variable, which is what every existing setup uses.
-                Some("") => insert(token, Client::LOCAL, &key)?,
-                // `WINDBG_MCP_LISTEN_TOKEN_CI` names the client `ci`, the same lowercasing a
-                // kernel profile's variable gets.
-                Some(suffix) => {
-                    let name = suffix.trim_start_matches('_').to_ascii_lowercase();
-                    if name.is_empty() {
-                        continue;
-                    }
-                    insert(token, &name, &key)?;
-                }
-                None => {}
-            }
+            named.insert(name.as_str(), from.as_str());
+            by_token.insert(token.clone(), Client::new(name));
         }
         Ok(Self { by_token })
     }
+}
+
+/// One configured credential: the client it names, the token, and where it came from.
+///
+/// The third field is what a refusal quotes, and it is deliberately never the token — a variable
+/// name, or a key and the file holding it. It arrives already quoted, because how a source is
+/// referred to is the source's business: `` `WINDBG_MCP_LISTEN_TOKEN_CI` `` reads as a variable and
+/// `` `ci` in C:\ProgramData\windbg-mcp\token `` reads as an entry, and one template cannot
+/// render both.
+struct Configured {
+    name: String,
+    token: String,
+    from: String,
+}
+
+/// The credentials a set of environment variables configures — names derived, nothing validated.
+///
+/// Validation is [`Credentials::build`]'s, so that the listener and [`env_credentials`] hold a
+/// configuration to exactly one standard.
+fn from_env(vars: impl Iterator<Item = (String, String)>) -> Vec<Configured> {
+    let mut configured = Vec::new();
+    for (key, value) in vars {
+        let token = value.trim().to_string();
+        // An empty value is not a token — it is a variable somebody exported and never set.
+        if token.is_empty() || is_token_file(&key) {
+            continue;
+        }
+        let name = match credential_suffix(&key) {
+            // The unnamed variable, which is what every existing setup uses.
+            Some("") => Client::LOCAL.to_string(),
+            // `WINDBG_MCP_LISTEN_TOKEN_CI` names the client `ci`, the same lowercasing a kernel
+            // profile's variable gets.
+            Some(suffix) => suffix.trim_start_matches('_').to_ascii_lowercase(),
+            None => continue,
+        };
+        if name.is_empty() {
+            continue;
+        }
+        configured.push(Configured {
+            from: format!("`{key}`"),
+            name,
+            token,
+        });
+    }
+    configured
+}
+
+/// What this process's environment configures, as `(client, token)` pairs.
+///
+/// For [`crate::service::install`], which copies the installing shell's credentials into the file
+/// the service reads. It validates by building the same [`Credentials`] the listener would, so an
+/// install cannot write a file the service then refuses to start on — which is the worst shape
+/// this can take, since the SCM registers a service once and it fails at every start afterwards.
+pub fn env_credentials(
+    vars: impl Iterator<Item = (String, String)>,
+) -> Result<Vec<(String, String)>> {
+    let configured = from_env(vars);
+    Credentials::build(&configured)?;
+    Ok(configured.into_iter().map(|c| (c.name, c.token)).collect())
+}
+
+/// The credentials a token file holds.
+///
+/// **Two shapes, because the file has two jobs.** A **bare token** names [`Client::LOCAL`]: that is
+/// what a hand-written file has always been, and what [`crate::service::install`] writes for a
+/// single-client host, so an install predating this keeps working with a file nobody has to touch.
+/// A **JSON object of name to token** names several — the shape `WINDBG_MCP_PROFILES` already uses
+/// for kernel profiles, so it is one an operator of this server has met before.
+///
+/// The second shape exists because of the precedence in [`Credentials::from_entries`]: a configured
+/// file is the *only* credential, so until it a service-hosted listener could hold exactly one
+/// client — and the per-client boundary was unreachable in precisely the deployment
+/// `docs/remote-listener.md` recommends (`FOLLOWUPS.md` item 31). It is one file either way, so
+/// the ACL that makes the file worth having is unchanged.
+///
+/// **A leading `{` is what tells them apart**, so a bare token may not begin with one. That is a
+/// rule rather than a guess: a token that did would be refused at startup, by name, rather than
+/// quietly read as something else.
+pub struct TokenFile {
+    entries: Vec<Configured>,
+}
+
+/// The names, never the tokens — as [`Credentials`]'s is, and for the same reason. [`Configured`]
+/// has no `Debug` at all, so a container that grows a derived one fails to compile rather than
+/// quietly starting to print credentials.
+impl std::fmt::Debug for TokenFile {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TokenFile")
+            .field(
+                "clients",
+                &self.entries.iter().map(|c| &c.name).collect::<Vec<_>>(),
+            )
+            .finish()
+    }
+}
+
+impl TokenFile {
+    /// Parses a token file's text. `path` is here only to name the file in a refusal.
+    ///
+    /// **No message this can produce quotes a value from the file**, because every value in it is a
+    /// credential and every one of these refusals is printed at startup — to stderr in the
+    /// foreground, to the service log under the SCM. That is also why the JSON is walked as generic
+    /// values rather than deserialized into a typed map, exactly as [`crate::kdconn`] walks the
+    /// profile file: serde's type errors quote the value they rejected (`invalid type: integer 5`),
+    /// while a syntax error carries a position and nothing else.
+    pub fn parse(text: &str, path: &Path) -> Result<Self> {
+        // **A leading UTF-8 BOM is not a broken file.** Windows PowerShell 5.1's `Set-Content
+        // -Encoding utf8` — an obvious way to write this file — puts one in front, and U+FEFF is
+        // not whitespace, so it survives a trim and lands *inside* the token. That is a file which
+        // looks exactly right and authenticates nobody.
+        let text = text.strip_prefix('\u{feff}').unwrap_or(text).trim();
+        if text.is_empty() {
+            bail!("{} is empty; that is not a token.", path.display());
+        }
+        if !text.starts_with('{') {
+            return Ok(Self {
+                entries: vec![Configured {
+                    name: Client::LOCAL.to_string(),
+                    token: text.to_string(),
+                    from: path.display().to_string(),
+                }],
+            });
+        }
+        let object: serde_json::Map<String, serde_json::Value> = serde_json::from_str(text)
+            .map_err(|e| {
+                anyhow!(
+                    "{} begins with `{{`, so it is read as a JSON object of client name to token — \
+                     and it is not valid JSON ({e}). A file holding one token is still a token \
+                     file; it just may not start with `{{`.",
+                    path.display()
+                )
+            })?;
+        let mut entries = Vec::new();
+        for (key, value) in object {
+            let name = key.trim().to_ascii_lowercase();
+            if !is_client_name(&name) {
+                bail!(
+                    "an entry in {} is named something that is not a client name (letters, digits, \
+                     `-`, `_` or `.`, up to {NAME_LIMIT} characters). It is not quoted here on \
+                     purpose: the likeliest way to write this file wrong is back to front, which \
+                     would make that name a bearer token — and this refusal is printed at startup.",
+                    path.display()
+                );
+            }
+            let Some(token) = value.as_str() else {
+                bail!(
+                    "`{name}` in {} must be a string: the bearer token that client presents.",
+                    path.display()
+                );
+            };
+            let token = token.trim();
+            if token.is_empty() {
+                bail!(
+                    "`{name}` in {} has no token. Give it one or remove the entry: a name nothing \
+                     can present is a client that cannot connect.",
+                    path.display()
+                );
+            }
+            entries.push(Configured {
+                from: format!("`{name}` in {}", path.display()),
+                name,
+                token: token.to_string(),
+            });
+        }
+        if entries.is_empty() {
+            bail!(
+                "{} names no clients. It is a JSON object, so it has to map at least one client \
+                 name to that client's token — `{{\"local\": \"<token>\"}}`.",
+                path.display()
+            );
+        }
+        Ok(Self { entries })
+    }
+}
+
+/// Whether this is a client name rather than something else that got put where one belongs.
+///
+/// The charset is what makes a name safe to *render*: no line breaks, so nothing configured here
+/// can inject a line into the service log, and no `"`, `{` or `=`, so a connection string or a
+/// token carrying one cannot pass for a name. The same rule a kernel profile's name follows.
+///
+/// **What it cannot do is tell a token from a name**, because a name-shaped token is a name: a file
+/// written back to front — `{"<token>": "ci"}` — configures a client called after your token, and
+/// the line that says who may connect prints client names. Nothing here can catch that, which is
+/// why the refusal it *can* catch does not quote what it rejected, and why the operator-facing
+/// documentation says which way round the file goes.
+fn is_client_name(name: &str) -> bool {
+    !name.is_empty()
+        && name.len() <= NAME_LIMIT
+        && name
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.'))
 }
 
 /// The part of a credential variable's name after the prefix, if it is one.
@@ -289,6 +480,14 @@ mod tests {
             .into_iter()
     }
 
+    /// Where a token file lives on the host this is all written for. Never read: [`TokenFile`]
+    /// parses text, so these tests need no filesystem and the path is only what a refusal names.
+    const FILE: &str = r"C:\ProgramData\windbg-mcp\token";
+
+    fn file(text: &str) -> TokenFile {
+        TokenFile::parse(text, Path::new(FILE)).expect("a token file these tests can use")
+    }
+
     /// The unnamed variable is what every existing listener uses, so it keeps working and names the
     /// same client stdio calls run as.
     #[test]
@@ -367,6 +566,27 @@ mod tests {
                 );
             }
         }
+        // And the same for the file, whose every *value* is a credential — and whose *key* is one
+        // too when the entry was written back to front.
+        for text in [
+            format!(r#"{{"a": "{}", "b": "{}"}}"#, secrets[0], secrets[0]),
+            format!(r#"{{"ci": "{} "#, secrets[0]),
+            format!(r#"{{"ci": ["{}"]}}"#, secrets[0]),
+            // Back to front, with a key no name could be — which is the shape this refuses, and
+            // the shape most likely to be holding a credential.
+            format!(r#"{{"{}=x": "ci"}}"#, secrets[0]),
+        ] {
+            let why = TokenFile::parse(&text, Path::new(FILE))
+                .and_then(|f| Credentials::from_entries(vars(&[]), Some(f)))
+                .expect_err("a configuration error")
+                .to_string();
+            for secret in secrets {
+                assert!(
+                    !why.contains(secret),
+                    "a startup refusal wrote a bearer token into the log: {why}"
+                );
+            }
+        }
     }
 
     /// Windows environment names are case-insensitive, and `std::env::var` honours that — so a host
@@ -402,7 +622,7 @@ mod tests {
                 (TOKEN_ENV, "from-the-environment"),
                 ("WINDBG_MCP_LISTEN_TOKEN_CI", "also-from-the-environment"),
             ]),
-            Some("from-the-file".to_string()),
+            Some(file("from-the-file")),
         )
         .expect("valid");
         assert_eq!(
@@ -412,6 +632,92 @@ mod tests {
         assert_eq!(creds.len(), 1, "the environment must not add credentials");
         assert_eq!(creds.client_for("from-the-environment"), None);
         assert_eq!(creds.client_for("also-from-the-environment"), None);
+    }
+
+    /// **And because it is the only credential, it has to be able to name more than one.** A
+    /// service-hosted listener reads nothing else, so before this the deployment
+    /// `docs/remote-listener.md` recommends could hold exactly one client — with the per-client
+    /// boundary that #162 built unreachable on the host that most needs it (`FOLLOWUPS.md` 31).
+    #[test]
+    fn a_token_file_may_name_several_clients() {
+        let creds = Credentials::from_entries(
+            vars(&[(TOKEN_ENV, "from-the-environment")]),
+            Some(file(
+                r#"{ "local": "for-local", "ci": "for-ci", "laptop": "for-laptop" }"#,
+            )),
+        )
+        .expect("valid");
+        assert_eq!(creds.names(), vec!["ci", "laptop", "local"]);
+        assert_eq!(creds.client_for("for-ci").map(Client::name), Some("ci"));
+        assert_eq!(
+            creds.client_for("for-laptop").map(Client::name),
+            Some("laptop")
+        );
+        // Still the only credential: naming several clients does not let the environment back in.
+        assert_eq!(creds.client_for("from-the-environment"), None);
+    }
+
+    /// The shape is chosen by the file's first character, so a token stays a token.
+    ///
+    /// Every file written before this one is a bare token, and the installer still writes one for a
+    /// single-client host — so the common file must not need re-writing to keep working.
+    #[test]
+    fn a_bare_token_file_is_a_token_and_a_json_one_is_a_map() {
+        for (text, whose) in [
+            ("plain-token", "local"),
+            (r#"{"ci": "plain-token"}"#, "ci"),
+            // Whitespace and a trailing newline are how a file arrives from an editor, and a BOM is
+            // how it arrives from Windows PowerShell 5.1's `Set-Content -Encoding utf8`. U+FEFF is
+            // not whitespace, so without the strip it lands inside the token: a file that looks
+            // right and authenticates nobody.
+            ("\u{feff}  plain-token\r\n", "local"),
+            ("\u{feff}{\"ci\": \"plain-token\"}\n", "ci"),
+        ] {
+            let creds = Credentials::from_entries(vars(&[]), Some(file(text)))
+                .unwrap_or_else(|e| panic!("{text:?} is a token file: {e}"));
+            assert_eq!(
+                creds.client_for("plain-token").map(Client::name),
+                Some(whose),
+                "{text:?}"
+            );
+        }
+    }
+
+    /// The refusals a badly written token file earns, and every one of them at startup rather than
+    /// as a client that cannot connect for reasons nobody can see.
+    #[test]
+    fn a_token_file_that_names_nothing_usable_is_refused() {
+        for (text, expected) in [
+            ("", "is empty"),
+            ("   \n", "is empty"),
+            ("{}", "names no clients"),
+            (r#"{"ci": }"#, "not valid JSON"),
+            (r#"{"ci": 5}"#, "must be a string"),
+            (r#"{"ci": "  "}"#, "has no token"),
+            // Written back to front, with a token no name could be — the detectable half of that
+            // mistake. The other half is not: see `is_client_name`.
+            (
+                r#"{"net:port=50000,key=1.2.3.4": "ci"}"#,
+                "not a client name",
+            ),
+            // Two spellings of one name are two tokens for one client, the same as the environment.
+            (r#"{"ci": "one", "CI ": "two"}"#, "two different tokens"),
+            // And one token under two names is the other half of it.
+            (
+                r#"{"ci": "same", "laptop": "same"}"#,
+                "cannot name two clients",
+            ),
+        ] {
+            let why = TokenFile::parse(text, Path::new(FILE))
+                .and_then(|f| Credentials::from_entries(vars(&[]), Some(f)))
+                .expect_err(&format!("{text:?} is not a usable token file"))
+                .to_string();
+            assert!(why.contains(expected), "{text:?} was refused with: {why}");
+            assert!(
+                why.contains(FILE),
+                "a refusal has to name the file it is about: {why}"
+            );
+        }
     }
 
     /// Two credentials normalising to one name is refused, and it is the quieter half of the same
@@ -456,7 +762,7 @@ mod tests {
                 ("WINDBG_MCP_LISTEN_TOKEN_FILE", r"C:\somewhere\token"),
                 ("PATH", "/usr/bin"),
             ]),
-            Some("from-the-file".to_string()),
+            Some(file("from-the-file")),
         )
         .expect("valid");
         assert_eq!(

--- a/src/client.rs
+++ b/src/client.rs
@@ -165,6 +165,15 @@ impl Credentials {
         // the operator has to go and change.
         let mut named: HashMap<&str, &str> = HashMap::new();
         for Configured { name, token, from } in configured {
+            if !is_presentable(token) {
+                bail!(
+                    "the token in {from} carries a line break, so nothing can present it: a bearer \
+                     token travels in an `Authorization` header, and a header value cannot span \
+                     lines. It is not quoted here — it is printed at startup — and it is not \
+                     repaired either, since a credential that is quietly not the one you wrote is \
+                     what this refuses."
+                );
+            }
             if let Some(existing) = by_token.get(token) {
                 // One client is one credential (the check below), so whatever configured this
                 // token is what configured that client.
@@ -324,14 +333,13 @@ impl TokenFile {
             bail!("{} is empty; that is not a token.", path.display());
         }
         if !text.starts_with('{') {
-            // **A bearer token is one line, and this is the copy-paste trap made loud.** Anything
-            // that does not begin with `{` is the bare shape, so a JSON object with a comment
-            // above it — which is what an operator copies out of a document — is read as one token
-            // that happens to span the file. It could never authenticate anyone either way: a line
-            // break cannot travel in an `Authorization` header, so nothing can present it. A
-            // listener that starts and accepts nobody is the worst answer available here, and this
-            // is the one place that can tell.
-            if text.contains(['\n', '\r']) {
+            // **The copy-paste trap, made loud.** Anything not beginning with `{` is the bare
+            // shape, so a JSON object with a comment above it — which is what an operator copies
+            // out of a document — is read as one token that happens to span the file.
+            // [`Credentials::build`] would refuse it anyway, since nothing can present a token
+            // carrying a line break; this says the more useful thing first, because here the
+            // diagnosis is available: what is wrong is the file's *shape*, not its credential.
+            if !is_presentable(text) {
                 bail!(
                     "{} is not a token: it runs over more than one line, and a bearer token cannot \
                      contain a line break — nothing could present it. If this was meant to name \
@@ -409,6 +417,20 @@ impl TokenFile {
         }
         Ok(Self { entries })
     }
+}
+
+/// Whether a token could be presented at all.
+///
+/// A bearer token travels in an `Authorization` header, and a header value cannot span lines — so a
+/// credential carrying a line break authenticates nobody, whatever else is right about it. Every
+/// source of credentials is held to this in [`Credentials::build`], because it is a fact about the
+/// transport rather than about where the token was written down: a variable can hold one as easily
+/// as a JSON string can, and the installer would copy it into the file and report success.
+///
+/// Refused rather than repaired. What the operator wrote is not what would work, and this module's
+/// whole job is that a credential is either configured or said to be absent.
+fn is_presentable(token: &str) -> bool {
+    !token.contains(['\n', '\r'])
 }
 
 /// A JSON object's entries **in the order they were written, duplicates and all**.
@@ -838,6 +860,31 @@ mod tests {
             assert!(
                 why.to_string().contains("two different tokens"),
                 "{why} (from {pairs:?})"
+            );
+        }
+    }
+
+    /// A token carrying a line break is refused wherever it was configured, because nothing could
+    /// present it: a bearer token travels in an `Authorization` header, and a header value cannot
+    /// span lines. Accepting one is a listener that starts and authenticates nobody.
+    #[test]
+    fn a_token_that_cannot_be_presented_is_refused() {
+        let secret = "s3cret\nalpha";
+        let refusals = [
+            // From the environment, which the installer would then copy into the file.
+            Credentials::from_entries(vars(&[(TOKEN_ENV, secret)]), None),
+            // And from the file, where a JSON string can carry an escaped one.
+            TokenFile::parse(r#"{"ci": "s3cret\nalpha"}"#, Path::new(FILE))
+                .and_then(|f| Credentials::from_entries(vars(&[]), Some(f))),
+        ];
+        for refusal in refusals {
+            let why = refusal
+                .expect_err("a token nothing can present is a configuration error")
+                .to_string();
+            assert!(why.contains("line break"), "{why}");
+            assert!(
+                !why.contains("s3cret"),
+                "a startup refusal wrote a bearer token into the log: {why}"
             );
         }
     }

--- a/src/client.rs
+++ b/src/client.rs
@@ -167,10 +167,11 @@ impl Credentials {
         for Configured { name, token, from } in configured {
             if !is_presentable(token) {
                 bail!(
-                    "the token in {from} carries a line break, so nothing can present it: a bearer \
-                     token travels in an `Authorization` header, and a header value cannot span \
-                     lines. It is not quoted here — it is printed at startup — and it is not \
-                     repaired either, since a credential that is quietly not the one you wrote is \
+                    "the token in {from} cannot travel in an `Authorization` header, so nothing \
+                     could ever authenticate with it: this server reads that header back as \
+                     visible ASCII, which rules out a line break and anything outside it. It is \
+                     not quoted here — this is printed at startup — and it is not repaired \
+                     either, since a credential that is quietly not the one you wrote is exactly \
                      what this refuses."
                 );
             }
@@ -336,10 +337,11 @@ impl TokenFile {
             // **The copy-paste trap, made loud.** Anything not beginning with `{` is the bare
             // shape, so a JSON object with a comment above it — which is what an operator copies
             // out of a document — is read as one token that happens to span the file.
-            // [`Credentials::build`] would refuse it anyway, since nothing can present a token
-            // carrying a line break; this says the more useful thing first, because here the
-            // diagnosis is available: what is wrong is the file's *shape*, not its credential.
-            if !is_presentable(text) {
+            // [`Credentials::build`] refuses that anyway, since nothing can present it; this says
+            // the more useful thing first. A line break is tested for here rather than
+            // presentability at large because it is being read as *evidence about the shape* —
+            // what is wrong is that this is not a token file, not that its credential is unusable.
+            if text.contains(['\n', '\r']) {
                 bail!(
                     "{} is not a token: it runs over more than one line, and a bearer token cannot \
                      contain a line break — nothing could present it. If this was meant to name \
@@ -421,16 +423,23 @@ impl TokenFile {
 
 /// Whether a token could be presented at all.
 ///
-/// A bearer token travels in an `Authorization` header, and a header value cannot span lines — so a
-/// credential carrying a line break authenticates nobody, whatever else is right about it. Every
-/// source of credentials is held to this in [`Credentials::build`], because it is a fact about the
-/// transport rather than about where the token was written down: a variable can hold one as easily
-/// as a JSON string can, and the installer would copy it into the file and report success.
+/// **Asked of the transport rather than described**, the same way the installer asks the reader
+/// which file shape round-trips. A bearer token gets here as `Authorization: Bearer <token>`, and
+/// `authorised` reads it back with `HeaderValue::to_str` — which yields only visible ASCII. So the
+/// question is exactly whether this string survives that round trip: build the header value a
+/// client would send, and read it back out the way the listener does. A token that does not
+/// survive it authenticates nobody, however right everything else about it is.
+///
+/// Two rounds of review arrived here one case at a time — a line break first, then non-ASCII text
+/// — which is what a hand-written charset would have kept doing. Every source of credentials is
+/// held to it in [`Credentials::build`], because it is a fact about the header rather than about
+/// where the token was written down: a variable can hold such a token as easily as a JSON string
+/// can, and the installer would copy it into the file and report success.
 ///
 /// Refused rather than repaired. What the operator wrote is not what would work, and this module's
 /// whole job is that a credential is either configured or said to be absent.
 fn is_presentable(token: &str) -> bool {
-    !token.contains(['\n', '\r'])
+    hyper::header::HeaderValue::from_str(token).is_ok_and(|value| value.to_str().is_ok())
 }
 
 /// A JSON object's entries **in the order they were written, duplicates and all**.
@@ -864,24 +873,29 @@ mod tests {
         }
     }
 
-    /// A token carrying a line break is refused wherever it was configured, because nothing could
-    /// present it: a bearer token travels in an `Authorization` header, and a header value cannot
-    /// span lines. Accepting one is a listener that starts and authenticates nobody.
+    /// A token that cannot travel in an `Authorization` header is refused wherever it was
+    /// configured — a line break, non-ASCII text, anything `HeaderValue::to_str` will not yield —
+    /// because `authorised` reads the header back that way and could never match it. Accepting one
+    /// is a listener that starts and authenticates nobody.
     #[test]
     fn a_token_that_cannot_be_presented_is_refused() {
-        let secret = "s3cret\nalpha";
         let refusals = [
-            // From the environment, which the installer would then copy into the file.
-            Credentials::from_entries(vars(&[(TOKEN_ENV, secret)]), None),
+            // A line break, from the environment — which the installer would copy into the file.
+            Credentials::from_entries(vars(&[(TOKEN_ENV, "s3cret\nalpha")]), None),
             // And from the file, where a JSON string can carry an escaped one.
             TokenFile::parse(r#"{"ci": "s3cret\nalpha"}"#, Path::new(FILE))
+                .and_then(|f| Credentials::from_entries(vars(&[]), Some(f))),
+            // Non-ASCII, which `HeaderValue::to_str` will not yield either — so `authorised` can
+            // never match it, and every request from that client would be a 401.
+            Credentials::from_entries(vars(&[(TOKEN_ENV, "s3cret-café")]), None),
+            TokenFile::parse(r#"{"ci": "s3cret-café"}"#, Path::new(FILE))
                 .and_then(|f| Credentials::from_entries(vars(&[]), Some(f))),
         ];
         for refusal in refusals {
             let why = refusal
                 .expect_err("a token nothing can present is a configuration error")
                 .to_string();
-            assert!(why.contains("line break"), "{why}");
+            assert!(why.contains("`Authorization` header"), "{why}");
             assert!(
                 !why.contains("s3cret"),
                 "a startup refusal wrote a bearer token into the log: {why}"

--- a/src/client.rs
+++ b/src/client.rs
@@ -142,8 +142,12 @@ impl Credentials {
         file: Option<TokenFile>,
     ) -> Result<Self> {
         match file {
+            // The environment is not read at all when a file is configured — not even to complain
+            // about it, which is the precedence stated as code: a host with a file is a host whose
+            // environment is not trusted, so a variable there cannot stop this server starting any
+            // more than it can authenticate to it.
             Some(file) => Self::build(&file.entries),
-            None => Self::build(&from_env(vars)),
+            None => Self::build(&from_env(vars)?),
         }
     }
 
@@ -178,9 +182,10 @@ impl Credentials {
             // insidious half: nothing looks wrong, both callers authenticate, and they silently
             // share a namespace — routing, listing, capacity, teardown rights, the lot. Names are
             // folded before comparison, so `WINDBG_MCP_LISTEN_TOKEN` and `…_TOKEN_LOCAL` collide
-            // (both `local`), as do `…_CI` and `…__CI`, and so do two spellings of one key in the
-            // token file. A boundary two credentials can stand on is not a boundary, so this is a
-            // configuration error rather than a merge.
+            // (both `local`), as do `…_CI` and `…__CI`. (Two spellings of one *key* never reach
+            // here: `TokenFile::parse` refuses a repeated name against the file itself, which can
+            // say which file and which name.) A boundary two credentials can stand on is not a
+            // boundary, so this is a configuration error rather than a merge.
             if let Some(other) = named.get(name.as_str()) {
                 bail!(
                     "two different tokens are configured for the client `{name}` ({other} and \
@@ -212,7 +217,7 @@ struct Configured {
 ///
 /// Validation is [`Credentials::build`]'s, so that the listener and [`env_credentials`] hold a
 /// configuration to exactly one standard.
-fn from_env(vars: impl Iterator<Item = (String, String)>) -> Vec<Configured> {
+fn from_env(vars: impl Iterator<Item = (String, String)>) -> Result<Vec<Configured>> {
     let mut configured = Vec::new();
     for (key, value) in vars {
         let token = value.trim().to_string();
@@ -228,8 +233,19 @@ fn from_env(vars: impl Iterator<Item = (String, String)>) -> Vec<Configured> {
             Some(suffix) => suffix.trim_start_matches('_').to_ascii_lowercase(),
             None => continue,
         };
-        if name.is_empty() {
-            continue;
+        // **Held to the same rule as a key in the file**, rather than skipped as it used to be.
+        // Skipping is the shape this module refuses everywhere else: a credential the operator
+        // configured, silently not configured, and a client that cannot authenticate for a reason
+        // nothing says out loud. It also has to be *this* rule and not a laxer one, because
+        // `env_credentials` writes these names into the token file — a name only the environment
+        // would take is an install that succeeds and a service that then fails at every start.
+        if !is_client_name(&name) {
+            bail!(
+                "`{key}` does not name a client. What follows `{TOKEN_ENV}_` is the name, and a \
+                 name is letters, digits, `-`, `_` or `.`, up to {NAME_LIMIT} characters — \
+                 `{TOKEN_ENV}_CI` names `ci`. The token it carries is not quoted here and is not \
+                 the problem."
+            );
         }
         configured.push(Configured {
             from: format!("`{key}`"),
@@ -237,7 +253,7 @@ fn from_env(vars: impl Iterator<Item = (String, String)>) -> Vec<Configured> {
             token,
         });
     }
-    configured
+    Ok(configured)
 }
 
 /// What this process's environment configures, as `(client, token)` pairs.
@@ -249,7 +265,7 @@ fn from_env(vars: impl Iterator<Item = (String, String)>) -> Vec<Configured> {
 pub fn env_credentials(
     vars: impl Iterator<Item = (String, String)>,
 ) -> Result<Vec<(String, String)>> {
-    let configured = from_env(vars);
+    let configured = from_env(vars)?;
     Credentials::build(&configured)?;
     Ok(configured.into_iter().map(|c| (c.name, c.token)).collect())
 }
@@ -316,16 +332,15 @@ impl TokenFile {
                 }],
             });
         }
-        let object: serde_json::Map<String, serde_json::Value> = serde_json::from_str(text)
-            .map_err(|e| {
-                anyhow!(
-                    "{} begins with `{{`, so it is read as a JSON object of client name to token — \
-                     and it is not valid JSON ({e}). A file holding one token is still a token \
-                     file; it just may not start with `{{`.",
-                    path.display()
-                )
-            })?;
-        let mut entries = Vec::new();
+        let Entries(object) = serde_json::from_str(text).map_err(|e| {
+            anyhow!(
+                "{} begins with `{{`, so it is read as a JSON object of client name to token — and \
+                 it is not valid JSON ({e}). A file holding one token is still a token file; it \
+                 just may not start with `{{`.",
+                path.display()
+            )
+        })?;
+        let mut entries: Vec<Configured> = Vec::new();
         for (key, value) in object {
             let name = key.trim().to_ascii_lowercase();
             if !is_client_name(&name) {
@@ -351,6 +366,18 @@ impl TokenFile {
                     path.display()
                 );
             }
+            // **A repeated key is refused, not resolved**, which is why [`Entries`] keeps every
+            // pair a `serde_json::Map` would have collapsed. Which of two entries wins is a
+            // parser's business, not a boundary's: the operator sees both tokens written down and
+            // one of them silently authenticates nobody.
+            if entries.iter().any(|e| e.name == name) {
+                bail!(
+                    "`{name}` appears more than once in {}. Give each client one entry: which of \
+                     the two would be accepted is whichever the parser kept, so the other is a \
+                     credential you can read in the file and nobody can present.",
+                    path.display()
+                );
+            }
             entries.push(Configured {
                 from: format!("`{name}` in {}", path.display()),
                 name,
@@ -368,11 +395,53 @@ impl TokenFile {
     }
 }
 
+/// A JSON object's entries **in the order they were written, duplicates and all**.
+///
+/// `serde_json::Map` is the obvious target and the wrong one: it keeps the last of two entries
+/// under one key and says nothing, so a file naming `ci` twice would configure one client, and the
+/// token that lost is one the operator can read in the file and no client can present. Collecting
+/// the pairs is what lets [`TokenFile::parse`] refuse that.
+///
+/// It quotes nothing either: keys arrive as `String` and values as `serde_json::Value`, so no
+/// serde type error can be raised about a value here — the check that a value is a string is
+/// [`TokenFile::parse`]'s, which names the key instead.
+struct Entries(Vec<(String, serde_json::Value)>);
+
+impl<'de> serde::Deserialize<'de> for Entries {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct EveryPair;
+        impl<'de> serde::de::Visitor<'de> for EveryPair {
+            type Value = Entries;
+
+            fn expecting(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.write_str("a JSON object of client name to token")
+            }
+
+            fn visit_map<M: serde::de::MapAccess<'de>>(
+                self,
+                mut map: M,
+            ) -> Result<Entries, M::Error> {
+                let mut pairs = Vec::new();
+                while let Some(pair) = map.next_entry::<String, serde_json::Value>()? {
+                    pairs.push(pair);
+                }
+                Ok(Entries(pairs))
+            }
+        }
+        deserializer.deserialize_map(EveryPair)
+    }
+}
+
 /// Whether this is a client name rather than something else that got put where one belongs.
 ///
 /// The charset is what makes a name safe to *render*: no line breaks, so nothing configured here
 /// can inject a line into the service log, and no `"`, `{` or `=`, so a connection string or a
 /// token carrying one cannot pass for a name. The same rule a kernel profile's name follows.
+///
+/// **One rule, wherever the credential was configured** — a key in the token file and the suffix of
+/// a variable are both held to it. The asymmetry that is not there any more is what review found
+/// first: an install copies the environment's names *into* the file, so a name only the environment
+/// would take is an install that succeeds and a service that then fails at every start.
 ///
 /// **What it cannot do is tell a token from a name**, because a name-shaped token is a name: a file
 /// written back to front — `{"<token>": "ci"}` — configures a client called after your token, and
@@ -700,8 +769,13 @@ mod tests {
                 r#"{"net:port=50000,key=1.2.3.4": "ci"}"#,
                 "not a client name",
             ),
-            // Two spellings of one name are two tokens for one client, the same as the environment.
-            (r#"{"ci": "one", "CI ": "two"}"#, "two different tokens"),
+            // One name written twice, which a `serde_json::Map` would have collapsed to the last
+            // of them — leaving a token written in the file that authenticates nobody.
+            (r#"{"ci": "one", "ci": "two"}"#, "appears more than once"),
+            (r#"{"ci": "one", "ci": "one"}"#, "appears more than once"),
+            // Two *spellings* of one name are the same thing, since names are folded before they
+            // are compared — which is what makes this a name collision rather than two clients.
+            (r#"{"ci": "one", "CI ": "two"}"#, "appears more than once"),
             // And one token under two names is the other half of it.
             (
                 r#"{"ci": "same", "laptop": "same"}"#,
@@ -743,6 +817,44 @@ mod tests {
                 "{why} (from {pairs:?})"
             );
         }
+    }
+
+    /// A variable whose suffix is not a client name is refused, and the refusal names the variable
+    /// rather than what it carries.
+    ///
+    /// It used to be skipped, which is the failure this module refuses everywhere else: a
+    /// credential the operator configured, silently not configured. And it has to be the *same*
+    /// rule the file is held to, because `env_credentials` copies these names into the file — a
+    /// name only the environment would take is an install that reports success and a service that
+    /// fails at every start, which is precisely what validating at install time is for.
+    #[test]
+    fn a_variable_that_does_not_name_a_client_is_refused() {
+        let secret = "s3cret-alpha";
+        for key in [
+            "WINDBG_MCP_LISTEN_TOKEN_MY CLIENT",
+            "WINDBG_MCP_LISTEN_TOKEN_ci=laptop",
+            &format!("WINDBG_MCP_LISTEN_TOKEN_{}", "x".repeat(NAME_LIMIT + 1)),
+            // The prefix with nothing after it but a separator: a typo, not the unnamed variable.
+            "WINDBG_MCP_LISTEN_TOKEN_",
+        ] {
+            let why = Credentials::from_entries(vars(&[(key, secret)]), None)
+                .expect_err(&format!("`{key}` does not name a client"))
+                .to_string();
+            assert!(why.contains("does not name a client"), "{key}: {why}");
+            assert!(
+                !why.contains(secret),
+                "a startup refusal wrote a bearer token into the log: {why}"
+            );
+        }
+        // And the same variable is *ignored* when a file is configured, rather than refusing the
+        // start: a file shuts the environment out entirely, so nothing there can stop this server
+        // any more than it can authenticate to it.
+        let creds = Credentials::from_entries(
+            vars(&[("WINDBG_MCP_LISTEN_TOKEN_MY CLIENT", secret)]),
+            Some(file("from-the-file")),
+        )
+        .expect("a file is read instead of the environment, not beside it");
+        assert_eq!(creds.names(), vec!["local"]);
     }
 
     /// An empty value is not a token — it is a variable somebody exported and never set.

--- a/src/client.rs
+++ b/src/client.rs
@@ -324,6 +324,22 @@ impl TokenFile {
             bail!("{} is empty; that is not a token.", path.display());
         }
         if !text.starts_with('{') {
+            // **A bearer token is one line, and this is the copy-paste trap made loud.** Anything
+            // that does not begin with `{` is the bare shape, so a JSON object with a comment
+            // above it — which is what an operator copies out of a document — is read as one token
+            // that happens to span the file. It could never authenticate anyone either way: a line
+            // break cannot travel in an `Authorization` header, so nothing can present it. A
+            // listener that starts and accepts nobody is the worst answer available here, and this
+            // is the one place that can tell.
+            if text.contains(['\n', '\r']) {
+                bail!(
+                    "{} is not a token: it runs over more than one line, and a bearer token cannot \
+                     contain a line break — nothing could present it. If this was meant to name \
+                     clients, it has to be a JSON object and start with `{{`: no comment above it, \
+                     since a file that does not begin with `{{` is read as one token.",
+                    path.display()
+                );
+            }
             return Ok(Self {
                 entries: vec![Configured {
                     name: Client::LOCAL.to_string(),
@@ -759,6 +775,13 @@ mod tests {
         for (text, expected) in [
             ("", "is empty"),
             ("   \n", "is empty"),
+            // The copy-paste trap: a JSON object with the file's path commented above it. It does
+            // not begin with `{`, so it is the bare shape — a "token" spanning four lines, which
+            // no `Authorization` header could ever carry.
+            (
+                "// C:\\ProgramData\\windbg-mcp\\token\n{\"ci\": \"one\"}",
+                "more than one line",
+            ),
             ("{}", "names no clients"),
             (r#"{"ci": }"#, "not valid JSON"),
             (r#"{"ci": 5}"#, "must be a string"),

--- a/src/listen.rs
+++ b/src/listen.rs
@@ -87,7 +87,7 @@ pub const LISTEN_FLAG: &str = "--listen";
 /// command line is readable by every process on the machine — including a `launch`ed debuggee.
 pub const TOKEN_ENV: &str = "WINDBG_MCP_LISTEN_TOKEN";
 
-/// A file to read the bearer token from instead, for when an environment variable is not private
+/// A file to read credentials from instead, for when an environment variable is not private
 /// enough.
 ///
 /// It is not, for a **service**: a service reads the *machine* environment, and that is readable by
@@ -96,7 +96,10 @@ pub const TOKEN_ENV: &str = "WINDBG_MCP_LISTEN_TOKEN";
 /// local privilege escalation rather than an inconvenience — see [`crate::service`], which writes
 /// this file with an ACL that excludes ordinary users and points the service at it.
 ///
-/// Read *before* [`TOKEN_ENV`], so a host that has both is using the private one.
+/// Read *instead of* [`TOKEN_ENV`] and every named token, not merely before them: a host that has
+/// a file is a host whose environment is not trusted. Which is why the file names its own clients —
+/// a bare token is `local`, a JSON object of name to token is as many as it lists
+/// ([`crate::client::TokenFile`]).
 pub const TOKEN_FILE_ENV: &str = "WINDBG_MCP_LISTEN_TOKEN_FILE";
 
 /// How long a session may go unused before it is released, from [`IDLE_ENV`] or [`IDLE_RELEASE`].
@@ -573,10 +576,8 @@ async fn bind_when_ready(addr: SocketAddr) -> Result<TcpListener> {
     }
 }
 
-/// The bearer token, from a file if one is named and from the environment otherwise.
-///
-/// Trimmed, because a token in a file arrives with whatever line ending wrote it, and a token that
-/// works from an editor but not from `Set-Content` would be an unpleasant afternoon.
+/// The credentials this listener accepts, from a file if one is named and from the environment
+/// otherwise.
 fn credentials() -> Result<crate::client::Credentials> {
     let creds = crate::client::Credentials::from_entries(std::env::vars(), token_file()?)?;
     if creds.len() == 0 {
@@ -589,22 +590,23 @@ fn credentials() -> Result<crate::client::Credentials> {
     Ok(creds)
 }
 
-/// The token in the file [`TOKEN_FILE_ENV`] names, if it names one.
-fn token_file() -> Result<Option<String>> {
-    if let Some(path) = std::env::var_os(TOKEN_FILE_ENV) {
-        let path = std::path::PathBuf::from(path);
-        let token = std::fs::read_to_string(&path).with_context(|| {
-            format!(
-                "{TOKEN_FILE_ENV} names {}, which cannot be read",
-                path.display()
-            )
-        })?;
-        if token.trim().is_empty() {
-            bail!("{} is empty; that is not a token.", path.display());
-        }
-        return Ok(Some(token.trim().to_string()));
-    }
-    Ok(None)
+/// The credentials in the file [`TOKEN_FILE_ENV`] names, if it names one.
+///
+/// The read is here and the parse is in [`crate::client`], which is the same split every other
+/// rule about who may connect follows — and it lets the file's two shapes be asserted without a
+/// filesystem.
+fn token_file() -> Result<Option<crate::client::TokenFile>> {
+    let Some(path) = std::env::var_os(TOKEN_FILE_ENV) else {
+        return Ok(None);
+    };
+    let path = std::path::PathBuf::from(path);
+    let text = std::fs::read_to_string(&path).with_context(|| {
+        format!(
+            "{TOKEN_FILE_ENV} names {}, which cannot be read",
+            path.display()
+        )
+    })?;
+    crate::client::TokenFile::parse(&text, &path).map(Some)
 }
 
 pub async fn serve(

--- a/src/service.rs
+++ b/src/service.rs
@@ -40,11 +40,19 @@
 //! a worker this service spawned. So any local user who can read that variable can have
 //! `LocalSystem`, and the token is the only thing in the way.
 //!
-//! So [`install`] takes the token out of the installing shell's *user* environment, writes it to
-//! [`token_file`], strips inheritance and grants read to `SYSTEM` and `Administrators` only, and
-//! points the service at it with [`crate::listen::TOKEN_FILE_ENV`]. The property that makes the
-//! foreground listener safe — the token is not readable by an unprivileged process — is the one
-//! being preserved, by the only mechanism that preserves it once the reader is a service.
+//! So [`install`] takes the credentials out of the installing shell's *user* environment, writes
+//! them to [`token_file`], strips inheritance and grants read to `SYSTEM` and `Administrators`
+//! only, and points the service at it with [`crate::listen::TOKEN_FILE_ENV`]. The property that
+//! makes the foreground listener safe — the token is not readable by an unprivileged process — is
+//! the one being preserved, by the only mechanism that preserves it once the reader is a service.
+//!
+//! **Credentials, plural, because a service reads nothing else.** A file shuts the environment out
+//! entirely (that is the point of it), so a service-hosted listener holds exactly the clients its
+//! file names — and until it could name more than one, the per-client boundary this server has
+//! could not be had in the deployment it recommends. The install copies every
+//! `WINDBG_MCP_LISTEN_TOKEN*` variable in the shell, and writes the shape that fits: one client
+//! named `local` is a bare token, as it always was, and anything else is a JSON object of name to
+//! token. Same file, same ACL, same reasoning.
 //!
 //! The same applies to **kernel connection profiles**, and less obviously, because they are a file
 //! rather than a variable: `LocalSystem`'s `%USERPROFILE%` is
@@ -181,6 +189,36 @@ pub fn token_file() -> PathBuf {
     state_dir().join("token")
 }
 
+/// What goes in [`token_file`]: the credentials from the installing shell, in the shape that fits.
+///
+/// **One client called `local` is written as a bare token**, which is what this file has always
+/// held and what a hand-written one still is — so an upgrade does not rewrite the file of the
+/// install everybody has, and an operator comparing it against `$env:WINDBG_MCP_LISTEN_TOKEN` sees
+/// the same thing they always did. Anything else is a JSON object of name to token, which is the
+/// only shape that can carry more than one and the same one `WINDBG_MCP_PROFILES` uses.
+///
+/// Both are read back by [`crate::client::TokenFile`], which is where the shapes are defined; this
+/// only has to pick between them.
+fn token_file_contents(credentials: &[(String, String)]) -> String {
+    if let [(name, token)] = credentials
+        && name == crate::client::Client::LOCAL
+    {
+        return token.clone();
+    }
+    let named: std::collections::BTreeMap<&str, &str> = credentials
+        .iter()
+        .map(|(name, token)| (name.as_str(), token.as_str()))
+        .collect();
+    // Pretty, and a trailing newline: this is a file an operator will open when something is wrong,
+    // and `Get-Content` on a single long line is not a way to read one.
+    //
+    // `expect` rather than a fallback, on a map of strings that cannot fail to serialize: the
+    // fallback would be an empty credential file written by an install that reported success, and
+    // a service that then refuses every caller — which is the exact outcome this path exists to
+    // prevent.
+    serde_json::to_string_pretty(&named).expect("a map of strings serializes") + "\n"
+}
+
 /// `SYSTEM` and `Administrators`, by SID so a localised Windows is not a special case.
 const SYSTEM_SID: &str = "*S-1-5-18";
 const ADMINISTRATORS_SID: &str = "*S-1-5-32-544";
@@ -289,7 +327,10 @@ fn under_protected_root(exe: &std::path::Path) -> bool {
 /// replaced the *running* service's token, which would keep serving on the one in its memory and
 /// switch to a different one at its next restart, having reported a failure. Nothing is started
 /// here, so there is no window in which the file exists and something is serving with it.
-fn finish_install(service: &windows_service::service::Service, token: &str) -> Result<()> {
+fn finish_install(
+    service: &windows_service::service::Service,
+    credentials: &[(String, String)],
+) -> Result<()> {
     service
         .set_description(DESCRIPTION)
         .context("the service's description could not be set")?;
@@ -320,7 +361,7 @@ fn finish_install(service: &windows_service::service::Service, token: &str) -> R
                     token_at.display()
                 )
             })?;
-        file.write_all(token.trim().as_bytes())
+        file.write_all(token_file_contents(credentials).as_bytes())
             .with_context(|| format!("cannot write {}", token_at.display()))?;
     }
     restrict_to_administrators(&token_at, "R")
@@ -329,22 +370,25 @@ fn finish_install(service: &windows_service::service::Service, token: &str) -> R
 /// Registers the service to run this exe with `--service --listen <addr>`.
 pub fn install(addr: SocketAddr, allow_unprotected: bool) -> Result<()> {
     // Refused rather than warned about, and this changed once the token moved into a file: an
-    // install has to *have* the token to write it down, and a service registered without one is a
-    // service that fails at every start.
-    let token = std::env::var(crate::listen::TOKEN_ENV)
-        .ok()
-        .filter(|t| !t.trim().is_empty())
-        .with_context(|| {
-            format!(
-                "set {} in this shell first — the install copies it into a file only SYSTEM and \
-                 Administrators can read, which is how the service gets it. A *machine-scope* \
-                 environment variable would work and must not be used: it is readable by every \
-                 local process, and this endpoint's `launch` runs arbitrary commands as \
-                 LocalSystem.\n    $env:{} = \"<a long random string>\"",
-                crate::listen::TOKEN_ENV,
-                crate::listen::TOKEN_ENV
-            )
-        })?;
+    // install has to *have* a credential to write it down, and a service registered without one is
+    // a service that fails at every start. Validated here too, by the listener's own rules, so a
+    // shell that could not start a foreground listener cannot register a service either.
+    let credentials = crate::client::env_credentials(std::env::vars())?;
+    if credentials.is_empty() {
+        bail!(
+            "set {} in this shell first — the install copies it into a file only SYSTEM and \
+             Administrators can read, which is how the service gets it. A *machine-scope* \
+             environment variable would work and must not be used: it is readable by every local \
+             process, and this endpoint's `launch` runs arbitrary commands as \
+             LocalSystem.\n    $env:{} = \"<a long random string>\"\n\nEvery {}_<NAME> in this \
+             shell is copied too, each naming a client of its own — which under a service is the \
+             only way to have more than one, since the file it reads is the whole of what it \
+             accepts.",
+            crate::listen::TOKEN_ENV,
+            crate::listen::TOKEN_ENV,
+            crate::listen::TOKEN_ENV
+        );
+    }
 
     let exe = std::env::current_exe().context("cannot find this executable's own path")?;
     if !under_protected_root(&exe) && !allow_unprotected {
@@ -396,7 +440,7 @@ pub fn install(addr: SocketAddr, allow_unprotected: bool) -> Result<()> {
     // after the SCM work fixed one half-done install (a failed create no longer replaces a running
     // service's token) and would otherwise create another: a registration left behind by a token
     // step that refused. An install either happened or it did not.
-    if let Err(e) = finish_install(&service, &token) {
+    if let Err(e) = finish_install(&service, &credentials) {
         let undone = service.delete().is_ok();
         // Waited out, not merely asked for. A delete marks a service and completes when the last
         // handle to it closes, so returning here without waiting makes "nothing was installed"
@@ -751,6 +795,62 @@ mod tests {
         // And the flag the SCM passes is the one `requested` answers `Run` to, which is the join
         // between installing and starting that nothing else checks.
         assert_eq!(requested(&rendered), Some(Role::Run));
+    }
+
+    /// The file the installer writes is the file the listener reads — asserted end to end, because
+    /// the two halves are in different modules and nothing else joins them. A service that starts
+    /// and accepts nobody is the failure shape, and it costs a reinstall to find out.
+    #[test]
+    fn what_the_install_writes_is_what_the_listener_reads_back() {
+        // Never opened — `TokenFile` parses text — but it is the real path, so the refusals
+        // this exercises name what an operator would actually go and look at.
+        let at = token_file();
+        let read_back = |written: &str| {
+            crate::client::Credentials::from_entries(
+                std::iter::empty(),
+                Some(
+                    crate::client::TokenFile::parse(written, &at)
+                        .unwrap_or_else(|e| panic!("the installer wrote {written:?}: {e}")),
+                ),
+            )
+            .unwrap_or_else(|e| panic!("the installer wrote {written:?}: {e}"))
+        };
+
+        // One client called `local` keeps the shape every existing install has: the token, and
+        // nothing around it.
+        let one = [(
+            crate::client::Client::LOCAL.to_string(),
+            "s3cret".to_string(),
+        )];
+        let written = token_file_contents(&one);
+        assert_eq!(written, "s3cret", "a single local token is written bare");
+        assert_eq!(
+            read_back(&written).client_for("s3cret").map(|c| c.name()),
+            Some("local")
+        );
+
+        // Anything else is the JSON object, which is the only shape that can carry more than one —
+        // and under a service the only way to have a second client at all.
+        for credentials in [
+            vec![
+                ("local".to_string(), "for-local".to_string()),
+                ("ci".to_string(), "for-ci".to_string()),
+            ],
+            // A shell with only a named token configures no `local`, and that is not a special
+            // case: it is one client, which happens not to be that one.
+            vec![("ci".to_string(), "for-ci".to_string())],
+        ] {
+            let written = token_file_contents(&credentials);
+            let creds = read_back(&written);
+            assert_eq!(creds.len(), credentials.len());
+            for (name, token) in &credentials {
+                assert_eq!(
+                    creds.client_for(token).map(|c| c.name()),
+                    Some(name.as_str()),
+                    "{written}"
+                );
+            }
+        }
     }
 
     /// The log has to land somewhere a service account can write and an operator will look, and it

--- a/src/service.rs
+++ b/src/service.rs
@@ -230,12 +230,23 @@ fn token_file_contents(credentials: &[(String, String)]) -> String {
 /// object instead — the token is not the operator's mistake — and a writer that asks cannot drift
 /// from a reader that changes.
 ///
+/// **The question is about the credential, not the name**, and getting that wrong was the second
+/// finding: a token that is itself a one-entry object — `{"local":"replacement"}` — parses to a
+/// client called `local`, so a check on the name alone said yes and the service would then have
+/// accepted `replacement` instead of what the operator set. So: exactly one credential, and it is
+/// *this* token naming `local`.
+///
 /// No filesystem is touched: [`crate::client::TokenFile::parse`] takes the text, and the path is
 /// only what its refusals would name.
 fn reads_back_bare(token: &str) -> bool {
     crate::client::TokenFile::parse(token, &token_file())
         .and_then(|file| crate::client::Credentials::from_entries(std::iter::empty(), Some(file)))
-        .is_ok_and(|creds| creds.names() == [crate::client::Client::LOCAL])
+        .is_ok_and(|creds| {
+            creds.len() == 1
+                && creds
+                    .client_for(token)
+                    .is_some_and(|client| client.name() == crate::client::Client::LOCAL)
+        })
 }
 
 /// `SYSTEM` and `Administrators`, by SID so a localised Windows is not a special case.
@@ -862,6 +873,13 @@ mod tests {
             // the reader would take it for the JSON one. Nothing is wrong with the token, so it
             // goes in the object rather than being refused.
             vec![("local".to_string(), "{not-json-just-a-token".to_string())],
+            // The nastier one: a token that *is* a one-entry object naming `local`. Written bare
+            // it parses — to a different token — so this asserts the whole credential survives,
+            // not just the client's name.
+            vec![(
+                "local".to_string(),
+                r#"{"local":"replacement"}"#.to_string(),
+            )],
         ] {
             let written = token_file_contents(&credentials);
             let creds = read_back(&written);

--- a/src/service.rs
+++ b/src/service.rs
@@ -198,10 +198,12 @@ pub fn token_file() -> PathBuf {
 /// only shape that can carry more than one and the same one `WINDBG_MCP_PROFILES` uses.
 ///
 /// Both are read back by [`crate::client::TokenFile`], which is where the shapes are defined; this
-/// only has to pick between them.
+/// only has to pick between them — and picks by [asking it](reads_back_bare) rather than by
+/// restating its rule.
 fn token_file_contents(credentials: &[(String, String)]) -> String {
     if let [(name, token)] = credentials
         && name == crate::client::Client::LOCAL
+        && reads_back_bare(token)
     {
         return token.clone();
     }
@@ -217,6 +219,23 @@ fn token_file_contents(credentials: &[(String, String)]) -> String {
     // a service that then refuses every caller — which is the exact outcome this path exists to
     // prevent.
     serde_json::to_string_pretty(&named).expect("a map of strings serializes") + "\n"
+}
+
+/// Whether `token`, written on its own, reads back as the one `local` credential it is meant to be.
+///
+/// **Asked of the reader rather than restated here**, because the bare shape is the reader's to
+/// define and this is the second place that would have to know its rules. Review caught the first
+/// thing that costs: a random token beginning with `{` is read as the JSON shape, so writing it
+/// bare is an install that reports success and a service that fails at every start. It goes in the
+/// object instead — the token is not the operator's mistake — and a writer that asks cannot drift
+/// from a reader that changes.
+///
+/// No filesystem is touched: [`crate::client::TokenFile::parse`] takes the text, and the path is
+/// only what its refusals would name.
+fn reads_back_bare(token: &str) -> bool {
+    crate::client::TokenFile::parse(token, &token_file())
+        .and_then(|file| crate::client::Credentials::from_entries(std::iter::empty(), Some(file)))
+        .is_ok_and(|creds| creds.names() == [crate::client::Client::LOCAL])
 }
 
 /// `SYSTEM` and `Administrators`, by SID so a localised Windows is not a special case.
@@ -839,6 +858,10 @@ mod tests {
             // A shell with only a named token configures no `local`, and that is not a special
             // case: it is one client, which happens not to be that one.
             vec![("ci".to_string(), "for-ci".to_string())],
+            // And a lone `local` whose token begins with `{`, which the bare shape cannot carry:
+            // the reader would take it for the JSON one. Nothing is wrong with the token, so it
+            // goes in the object rather than being refused.
+            vec![("local".to_string(), "{not-json-just-a-token".to_string())],
         ] {
             let written = token_file_contents(&credentials);
             let creds = read_back(&written);

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -2952,6 +2952,67 @@ fn an_unauthenticated_request_is_refused_and_costs_the_server_nothing() {
     );
 }
 
+/// A token file may name **more than one client**, and it is still the only credential there is.
+///
+/// Both halves matter, and they pull against each other. The precedence is load-bearing: the
+/// service installer ACLs that file to SYSTEM and Administrators *because* the machine environment
+/// is readable by unprivileged processes, so an environment token standing beside it would
+/// reintroduce exactly what the file was written to avoid. But a file that could only ever name one
+/// client made the per-client boundary of
+/// [#162](https://github.com/glslang/windbg-mcp/issues/162) unreachable in the deployment
+/// `docs/remote-listener.md` recommends — a service reads nothing else, so two agents on one host
+/// shared a namespace (`FOLLOWUPS.md` item 31).
+///
+/// Protocol tier: no target, no worker. What is exercised here is the call site — a real listener
+/// reading a real file — over the parse and precedence rules unit-tested in `src/client.rs`.
+#[test]
+fn a_token_file_names_its_own_clients_and_shuts_the_environment_out() {
+    let at = marker_path("token-file");
+    let for_local = "smoke-file-token-local";
+    let for_ci = "smoke-file-token-ci";
+    std::fs::write(
+        &at,
+        format!(r#"{{ "local": "{for_local}", "ci": "{for_ci}" }}"#),
+    )
+    .unwrap_or_else(|e| panic!("cannot write {}: {e}", at.display()));
+
+    // The helper sets `WINDBG_MCP_LISTEN_TOKEN` on every listener it starts, which is the variable
+    // this file has to shut out — so the environment half needs no arranging.
+    let mut server = Listener::start(&[("WINDBG_MCP_LISTEN_TOKEN_FILE", &at.to_string_lossy())]);
+    assert!(
+        server.wait_for_stderr("clients: ci, local", Duration::from_secs(30)),
+        "the startup line should name both clients the file configures:\n{}",
+        server.stderr()
+    );
+
+    let from_the_environment = server.token.clone();
+    let refused = server.send(
+        "POST",
+        Some(&from_the_environment),
+        None,
+        Some(&json!({ "jsonrpc": "2.0", "id": 1, "method": "tools/list", "params": {} })),
+    );
+    assert_eq!(
+        refused.status, 401,
+        "a file was configured, so the environment token must authenticate nobody: {}",
+        refused.body
+    );
+
+    // And each client the file names is served, through the whole handshake.
+    for (whose, token) in [("local", for_local), ("ci", for_ci)] {
+        server.token = token.to_string();
+        let session = server.initialize();
+        let status = server.tool(&session, "session_status", json!({}));
+        assert_eq!(
+            status["status"], "ok",
+            "the client `{whose}`, which the token file names, was not served: {status}"
+        );
+    }
+
+    drop(server);
+    let _ = std::fs::remove_file(&at);
+}
+
 /// A credential's second MCP session is **served alongside** the first, not refused.
 ///
 /// This was a `409` until the gate was retired, and it was once the whole boundary: handles were


### PR DESCRIPTION
Closes `FOLLOWUPS.md` item 31.

A configured `WINDBG_MCP_LISTEN_TOKEN_FILE` is the **only** credential this server reads — deliberately, and load-bearing: the installer ACLs that file to SYSTEM and Administrators precisely because the machine environment is readable by unprivileged processes, so a variable standing beside it would reintroduce what the file was written to avoid.

The consequence was that the per-client work of #162 could not be had in the deployment `docs/remote-listener.md` recommends. A foreground listener could hold `local`, `ci` and `laptop`; the service could hold one, so two agents on one host shared a namespace — and a client over the four-session cap has its oldest idle session reclaimed, so one could evict the other's target with nothing naming it. It surfaced from the other end in review of #173: the local-model driver now *requires* a credential of its own, and under the service there was none to give it.

## What changed

- **`src/client.rs`** — `TokenFile` reads either a **bare token** (names `local`; what every existing file holds) or a **JSON object of client name to token**, the shape `WINDBG_MCP_PROFILES` already uses for kernel profiles. A leading `{` tells them apart, which makes "a bare token may not begin with `{`" a rule rather than a guess: a file that does is refused at startup by name. `from_entries` now routes both the environment and the file through one `build`, so the two collision refusals cover the file for free. The precedence is untouched.
- **`src/service.rs`** — `install` copies **every** `WINDBG_MCP_LISTEN_TOKEN*` variable in the installing shell rather than the unnamed one alone, and writes the shape that fits: a bare token for a lone `local` (so a single-client install's file is byte-identical to today's), the object otherwise. It validates them by building the same `Credentials` the listener would, because the SCM registers a service once and a credential it refuses fails it at every start.
- **`src/listen.rs`** — reads the file, parses in `client`, which is the split every other rule about who may connect follows.

## Two things it settled that the item did not anticipate

- **The parse is the problem `kdconn` already solved for profiles, and gets the same answer.** Values are walked as generic JSON rather than deserialized into a typed map, because serde's type errors quote the value they rejected — and every value in this file is a credential. `Credentials` and `TokenFile` also grew hand-written `Debug`s that print names only, for the same reason `Connection` has one; the derived one on `Credentials` would have put every accepted token into any log line or panic message that formatted it, which a test caught by doing exactly that.
- **A name-shaped token is a name.** The charset check on keys catches a connection string or anything carrying a line break into the service log, but it cannot catch an entry written back to front, since a bearer token is a perfectly good client name — and that entry configures a client *named after your token*, which the startup line prints. Not fixable in code, so the refusal that *is* detectable quotes nothing, and `docs/remote-listener.md` says which way round the file goes. (The same exposure `kdconn` has for profile keys.)

## Verification

On the ARM64 bench, on bytes confirmed identical to the tree here: `cargo clippy --all-targets -- -D warnings` clean, 472 unit tests, 65 smoke tests, and the debugger tier with `WINDBG_MCP_SMOKE_DUMP=1` (58.6s, no `SKIPPED` lines).

New coverage: a round-trip test that what `install` writes is what the listener reads back, and a protocol-tier smoke assertion (`a_token_file_names_its_own_clients_and_shuts_the_environment_out`) — a real listener, a real file naming two clients, the environment token refused `401`, and both file clients served through a full handshake.

The bare-token path was also run against that host's real installed token file: the new binary reports `clients: local` and the running service was left untouched.

Docs: `CHANGELOG.md`, `docs/remote-listener.md`, `docs/local-model.md` (its "the service can hold only one client, so driver work wants the foreground one" workaround is now just "put the driver's credential in the file"), and the `CLAUDE.md` listener paragraph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)