### PR TITLE
Release 0.10.0: introduce the features the notes never mentioned

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -3,7 +3,7 @@
   "name": "windbg-mcp",
   "displayName": "WinDbg MCP",
   "description": "WinDbg/DbgEng debugging: crash dumps, live user-mode and kernel, and Time Travel Debugging (TTD) — MCP server plus a skill that drives it.",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "author": { "name": "glslang", "email": "glslang@gmail.com" },
   "homepage": "https://github.com/glslang/windbg-mcp",
   "repository": "https://github.com/glslang/windbg-mcp",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,15 +24,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     every start when that is not loopback, because the argument for skipping a tunnel — a
     hypervisor network that does not route off the host — is exactly wrong on a debugger host: the
     guest being debugged is on that network, and is a sandbox by design.
-  - **A session lease replaces "stdio closed".** Under stdio the disconnect *is* the teardown
-    signal, and it drives a real `EndSession` through every worker rather than killing it, because
-    a live kernel that is merely killed is left frozen. HTTP has no such event, so each credential
-    holds a deadline that every admitted request renews, and a sweep releases what an absent client
-    left — the same clean release, on a timer instead of an EOF.
-  - **Silence is not departure and a goodbye is.** Every request is its own connection, so quiet is
-    the resting state; a `DELETE` is the client saying it is done. One that comes back inside the
-    grace **adopts what it left**, which is what makes a client restart cost nothing where under
-    stdio it costs a KDNET attach — and a KDNET attach costs a reboot of the target.
+  - **A session lease stands in for "stdio closed" — for the clients that can have one.** Under
+    stdio the disconnect *is* the teardown signal, and it drives a real `EndSession` through every
+    worker rather than killing it, because a live kernel that is merely killed is left frozen. HTTP
+    has no such event, so a credential that holds a settled MCP session holds a deadline with it,
+    renewed by every admitted request, and a sweep releases what an absent client left. **A
+    `2026-07-28` client has no such session and is therefore never given a clock** — SEP-2567
+    removed the id a lease is armed by — so what covers an abandoned target there is the per-session
+    idle release under **Changed** below, which is a different question deliberately answered
+    differently: it is far longer, it is per session rather than per credential, and it spares a
+    session with a call still outstanding. A parked `attach_kernel` is exactly that, so it is held
+    until somebody ends it rather than until a timer notices.
+  - **Silence is not departure and a goodbye is** — both of them session-id behaviours, so both
+    belong to the client above that has one. Every request is its own connection, so quiet is the
+    resting state; a `DELETE` is the client saying it is done. One that comes back inside the grace
+    **adopts what it left**, which is what makes a client restart cost nothing where under stdio it
+    costs a KDNET attach — and a KDNET attach costs a reboot of the target.
   - **The grace has a floor and the floor is derived, not chosen**: the longest a single call can
     keep a client quiet is `WORKER_READY_TIMEOUT` plus the call timeout, since an opener spends up
     to 30s bringing a worker up before its budget starts. A shorter grace would release a session
@@ -176,8 +183,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   documentation says which way round it goes.
 
 - **`server_log` — the server's own log, readable from wherever the client is.** The supervisor
-  keeps a bounded ring of the most recent records, its own and every engine worker's, and serves
-  them as a tool: filterable by session and level, paged with a `since` cursor, answered without
+  keeps a bounded ring of the most recent records, its own and every engine worker's, and serves a
+  caller its own share of them — the supervisor's, which name no session, plus those of the sessions
+  that caller opened (under stdio, one client by construction, that is all of them): filterable by session and level, paged with a `since` cursor, answered without
   ever touching a session's engine — so it still answers while the session it is about is wedged,
   like `session_status`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-08-20
+
 ### Added
 
 - **`--listen`: the same tool surface over HTTP, so the client and the model need not be on the
@@ -1891,7 +1893,8 @@ Initial release, packaged as a single-plugin Claude Code marketplace.
 - Crash-dump `!analyze` support via automatic WinDbg extension DLL loading.
 - Windows CI (format, clippy, build, test) and walkthrough docs with sample dumps.
 
-[Unreleased]: https://github.com/glslang/windbg-mcp/compare/v0.9.0...HEAD
+[Unreleased]: https://github.com/glslang/windbg-mcp/compare/v0.10.0...HEAD
+[0.10.0]: https://github.com/glslang/windbg-mcp/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/glslang/windbg-mcp/compare/v0.8.1...v0.9.0
 [0.8.1]: https://github.com/glslang/windbg-mcp/compare/v0.8.0...v0.8.1
 [0.8.0]: https://github.com/glslang/windbg-mcp/compare/v0.7.0...v0.8.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,74 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`--listen`: the same tool surface over HTTP, so the client and the model need not be on the
+  debugger host** ([#135](https://github.com/glslang/windbg-mcp/pull/135)). DbgEng is Windows-only
+  and holds one debuggee per process; nothing about the *client* has to be. `windbg-mcp.exe --listen
+  127.0.0.1:8765` serves every tool over streamable HTTP, with the process tree below it unchanged —
+  same supervisor, same private pipes to each engine worker, same teardown.
+
+  - **A bearer token is required, and the server refuses to start without one.** The surface
+    includes `execute` and `launch`, so a port with no lock on it is arbitrary code on the machine
+    holding your kernel debugger. `WINDBG_MCP_LISTEN_TOKEN` names it.
+  - **Bind loopback and forward with `ssh -L`.** The listener binds what it is told and *warns* on
+    every start when that is not loopback, because the argument for skipping a tunnel — a
+    hypervisor network that does not route off the host — is exactly wrong on a debugger host: the
+    guest being debugged is on that network, and is a sandbox by design.
+  - **A session lease replaces "stdio closed".** Under stdio the disconnect *is* the teardown
+    signal, and it drives a real `EndSession` through every worker rather than killing it, because
+    a live kernel that is merely killed is left frozen. HTTP has no such event, so each credential
+    holds a deadline that every admitted request renews, and a sweep releases what an absent client
+    left — the same clean release, on a timer instead of an EOF.
+  - **Silence is not departure and a goodbye is.** Every request is its own connection, so quiet is
+    the resting state; a `DELETE` is the client saying it is done. One that comes back inside the
+    grace **adopts what it left**, which is what makes a client restart cost nothing where under
+    stdio it costs a KDNET attach — and a KDNET attach costs a reboot of the target.
+  - **The grace has a floor and the floor is derived, not chosen**: the longest a single call can
+    keep a client quiet is `WORKER_READY_TIMEOUT` plus the call timeout, since an opener spends up
+    to 30s bringing a worker up before its budget starts. A shorter grace would release a session
+    underneath the request that opened it, so it is refused at startup rather than truncated.
+    `WINDBG_MCP_LEASE_GRACE_SECS` overrides it.
+
+  [`docs/remote-listener.md`](./docs/remote-listener.md) is the operator's half.
+
+- **The listener installs as a Windows service** ([#151](https://github.com/glslang/windbg-mcp/pull/151)).
+  `--install-service --listen <addr>`, elevated, registers it with the SCM as `windbg-mcp`,
+  auto-start, `LocalSystem`; `--uninstall-service` stops and removes it. That is what gives it
+  `PATH`, boot start and a life independent of a login shell. Elevation is *not* among the reasons:
+  Windows OpenSSH already hands an Administrators member a full token.
+
+  - **The stop is the whole of the difficulty.** A service killed rather than asked leaves a
+    detached-but-halted kernel frozen, so `listen::serve` grew a shutdown future for this one case —
+    nothing else in this server needs one — and the SCM is told a preshutdown wait sized from what
+    releasing every worker can actually take, refreshed at every start rather than left on the
+    default.
+  - **The token moves out of the environment**, because `launch` under `LocalSystem` would make a
+    machine-scope variable a local privilege escalation. `install` writes it to
+    `%ProgramData%\windbg-mcp\token`, ACL'd to SYSTEM and Administrators, and refuses to install
+    from a user-writable directory unless `--allow-unprotected-path` says the machine is yours.
+  - **`LocalSystem` does not read your `profiles.json`** — its `%USERPROFILE%` is the system
+    profile — so kernel profiles have to be configured machine-wide or the service sees none.
+    Verified rather than assumed, and `install` says so where an operator will read it.
+  - A service has no console, so the role also writes to `%ProgramData%\windbg-mcp\service.log`.
+    `server_log` is the better channel and is only reachable once the listener is up, which is
+    exactly the case that file is for.
+
+- **A long call says how it is going** ([#147](https://github.com/glslang/windbg-mcp/pull/147),
+  `src/progress.rs`). A caller that puts a `progressToken` in a call's `_meta` gets
+  `notifications/progress` while the call runs. The worker already emitted the milestones; what was
+  missing was a route out to the client — and two decisions that are the difference between a
+  progress bar and a liveness signal.
+
+  - **Seconds elapsed, with no `total`.** A denominator would have to be a per-tool budget, and in
+    an opener's case that budget does not even cover the 30s worker handshake before it starts.
+  - **Ten seconds without a word is itself reported.** The milestones alone would have left the two
+    longest silences exactly as they were: a parked kernel attach reports once in the first second
+    and may never report again, and a pool walk or a `crash_triage` has no milestones at all.
+    Incidentally this makes progress something a client can extend its own request timeout on.
+
+  It matters most over `--listen`, where a quiet five-minute call and a dead link look identical
+  from the other machine.
+
 - **Per-client session namespaces, so two clients on one listener cannot reach each other's
   targets** ([#162](https://github.com/glslang/windbg-mcp/issues/162), slices 2 and 3). A listener
   may now hold several bearer tokens — `WINDBG_MCP_LISTEN_TOKEN_<NAME>` names a client, the unnamed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1091,7 +1091,7 @@ dependencies = [
 
 [[package]]
 name = "windbg-mcp"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "windbg-mcp"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2024"
 
 [dependencies]

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -823,7 +823,7 @@ run against an **ARM64** stack. #143 closed the other three assertions this way 
   assert the symbolized form and let the pair cover both.
 - **Picks up at** [#154](https://github.com/glslang/windbg-mcp/issues/154).
 
-## 27. [windbg-mcp + win-kexp] A deferred module reports no PDB identity
+## 27. [windbg-mcp + win-kexp] A deferred module reports no PDB identity — **measured and declined** (2026-08-20)
 
 `modules` carries `pdb` — the GUID, age and symbol-server `key` — only for a module whose symbols
 the engine has **already resolved** (`symbols: pdb` or `dia`). On a freshly opened dump that is one
@@ -850,6 +850,38 @@ symbol load to populate it would be strictly worse: that is a `.reload` per modu
 
 **Depends on nothing.** Picks up at `worker::with_pdb_identity` and
 `win_kexp::DebugEngine::module_pdb`.
+
+**Built and measured, 2026-08-20 — and declined.** The parse is small and was not the problem: ~60
+lines reading the DOS stub, the optional header's data directories, the debug directory and the
+`RSDS` record, unit-testable against a synthetic image without a debugger. Wired in as a fallback
+for every module the engine has no PDB for, on the ARM64 kernel sample:
+
+| | baseline | with the image fallback |
+| --- | --- | --- |
+| `modules`, model-visible | 53,897 B | **73,597 B** (+37%, over its 73,000 B budget) |
+| `tool_results_stay_within_their_budget` | 1.31 s | **179.6 s** cold, **10.6 s** warm |
+
+**The cold number is the finding.** Reading a header the dump did not capture makes the engine go
+and *get the image* — from the image path, which on this host is a symbol server — so a listing of
+two hundred modules becomes two hundred image downloads. Which means the field cannot save the
+download it exists to save: on a minidump the answer is paid for with the very fetch a client would
+otherwise do itself, only on the debugger host and with 60 bytes to show for it. Warm, it is still
+8× the baseline, because each row is a symsrv cache hit.
+
+Where it would be cheap is a target whose headers are already in memory — a live target, or a
+full-memory dump — and that is also the case where the caller can just load symbols for the one
+module they care about and read the engine's own answer.
+
+So: not always-on (the numbers), not behind a `pdb: true` argument either (a knob whose honest
+description is "this may download two hundred images" is a knob nobody can use safely), and not
+behind a match-count threshold (an answer whose *content* varies with how many rows matched). The
+contract in [`docs/coordinates.md`](./docs/coordinates.md) stands as written: this field reports the
+PDB the engine **has**.
+
+**What would change the answer** is a way to read a header without the engine paging the image in —
+`SYMOPT_NO_IMAGE_SEARCH` would do it, but it is a global symbol option and setting it for one field
+would change how every symbol on the target resolves. Worth revisiting only with a per-read way to
+say "from the dump only".
 
 ## 28. [windbg-mcp] The tenancy gate no longer earned its place — **done** (2026-08-20)
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/glslang/windbg-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/glslang/windbg-mcp/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![CodeRabbit Pull Request Reviews](https://img.shields.io/coderabbit/prs/github/glslang/windbg-mcp?utm_source=oss&utm_medium=github&utm_campaign=glslang%2Fwindbg-mcp&labelColor=171717&color=FF570A&label=CodeRabbit+Reviews)](https://coderabbit.ai)
-[![Latest release](https://img.shields.io/badge/release-v0.9.0-blue)](https://github.com/glslang/windbg-mcp/releases/latest)
+[![Latest release](https://img.shields.io/badge/release-v0.10.0-blue)](https://github.com/glslang/windbg-mcp/releases/latest)
 [![Platform: Windows x64](https://img.shields.io/badge/platform-Windows%20x64-0078D6)](https://github.com/glslang/windbg-mcp#requirements)
 
 An [MCP](https://modelcontextprotocol.io) server that exposes **WinDbg/DbgEng** to AI agents

--- a/README.md
+++ b/README.md
@@ -217,12 +217,13 @@ The server has to run where DbgEng does, but the client and the model do not. `-
 serves the same tools over HTTP instead of stdio, so a Mac can drive a Windows VM:
 
 ```console
-# Windows, with WINDBG_MCP_LISTEN_TOKEN set
+# Windows, with WINDBG_MCP_LISTEN_TOKEN set to a long random string
 windbg-mcp.exe --listen 127.0.0.1:8765
-# client machine
+# client machine — the same string, spelled out: the variable lives on the Windows
+# host, and a shell without it sends an empty bearer and gets a 401 on every call
 ssh -N -L 8765:127.0.0.1:8765 windbg-vm
 claude mcp add windbg-vm --transport http http://127.0.0.1:8765/ \
-  --header "Authorization: Bearer $WINDBG_MCP_LISTEN_TOKEN"
+  --header "Authorization: Bearer <the same string>"
 ```
 
 Install it as a **Windows service** (`--install-service --listen <addr>`, elevated) and it survives

--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ gh attestation verify <zip> --repo glslang/windbg-mcp `
 | Group | Tools |
 |-------|-------|
 | Session | `open_dump`, `open_trace`, `attach_kernel_local`, `attach_kernel`, `attach_process`, `launch`, `interrupt`, `end_session`, `session_status` |
-| Server   | `server_log` — the server's own log, the supervisor's and every engine worker's, tagged with the session each record belongs to |
+| Server   | `server_log` — the server's own log: the supervisor's records, plus those of the sessions you opened, tagged with the session each belongs to |
 | State   | `registers`, `read_memory`, `walk_memory`, `backtrace` (the stack as typed frames, each carrying `module`+`RVA` where the engine can place it, as well as its symbol), `modules`, `threads`, `disassemble` (instructions as records, each with its encoding and, where the engine can place it, its `RVA`), `dx` |
 | Crash   | `crash_triage` — a bug check as fields: code and parameters, crashing process, the stack as `module+RVA`, and the faulting driver frame |
 | Control | `go`, `step_over`, `step_into`, `set_breakpoint`, `run_to_address` |

--- a/docs/remote-listener.md
+++ b/docs/remote-listener.md
@@ -171,7 +171,7 @@ hour.
 
 | | |
 | --- | --- |
-| Default | **30 minutes** since the last call naming that session |
+| Default | **30 minutes** since the last call that reached that session's engine. `session_status` and `server_log` are answered by the supervisor and never routed, so they name a session without touching its clock |
 | Override | `WINDBG_MCP_SESSION_IDLE_SECS`, whole seconds; `0` disables it |
 | Floor | must exceed the longest a single call can run, or the server refuses to start |
 

--- a/skills/windbg-debugging/SKILL.md
+++ b/skills/windbg-debugging/SKILL.md
@@ -39,6 +39,7 @@ already does the job.
 | TTD analysis | `ttd_calls`, `ttd_memory`, `ttd_events`, `index_trace`, `record_trace` |
 | Kernel pool | `pool_find_tag`, `pool_chunk`, `pool_census`, `pool_diagnostics` |
 | User Segment Heap | `heap_list`, `heap_allocations`, `heap_chunk`, `heap_census`, `heap_diagnostics` |
+| Server | `server_log` — the server's own records, the supervisor's and every engine worker's, tagged by session |
 | Raw | `execute` — run any debugger command, returns full text output |
 
 The forward control tools (`go`/`step_over`/`step_into`) and the reverse ones
@@ -65,6 +66,14 @@ teardown while the batch runs — `end_session`, or a client disconnect — stop
 step and rolls it back first, reported as `BATCH: ABANDONED`; it cannot cut short a step already
 inside the debugger, so a batch built from long steps waits out the one it is in before it unwinds
 (the teardown waits with it).
+
+**`server_log` answers "why did that fail?" when the result did not.** It serves both processes'
+records — the supervisor's, and every engine worker's tagged with its session — so it reaches the
+run-up to a session that failed to *open*, which has no handle to ask anything else about. Reach
+for it after an opener that errored, a worker that died, or a call that timed out with nothing to
+show for it; `session_status` says what state a session is in, and this says what it did to get
+there. It is also the only route to a worker's own output when the server is on another machine,
+where its stderr is not on your screen.
 
 ## Cross-cutting gotchas (apply to every workflow)
 

--- a/skills/windbg-debugging/SKILL.md
+++ b/skills/windbg-debugging/SKILL.md
@@ -39,7 +39,7 @@ already does the job.
 | TTD analysis | `ttd_calls`, `ttd_memory`, `ttd_events`, `index_trace`, `record_trace` |
 | Kernel pool | `pool_find_tag`, `pool_chunk`, `pool_census`, `pool_diagnostics` |
 | User Segment Heap | `heap_list`, `heap_allocations`, `heap_chunk`, `heap_census`, `heap_diagnostics` |
-| Server | `server_log` — the server's own records, the supervisor's and every engine worker's, tagged by session |
+| Server | `server_log` — the server's own records: the supervisor's, plus your own sessions' workers, tagged by session |
 | Raw | `execute` — run any debugger command, returns full text output |
 
 The forward control tools (`go`/`step_over`/`step_into`) and the reverse ones
@@ -68,7 +68,9 @@ inside the debugger, so a batch built from long steps waits out the one it is in
 (the teardown waits with it).
 
 **`server_log` answers "why did that fail?" when the result did not.** It serves both processes'
-records — the supervisor's, and every engine worker's tagged with its session — so it reaches the
+records — the supervisor's, and those of the sessions **you** opened, each tagged with its session.
+(A listener may hold several clients, and another client's worker records are no more readable than
+its sessions are; under stdio there is one client, so this is everything.) That reaches the
 run-up to a session that failed to *open*, which has no handle to ask anything else about. Reach
 for it after an opener that errored, a worker that died, or a call that timed out with nothing to
 show for it; `session_status` says what state a session is in, and this says what it did to get

--- a/skills/windbg-debugging/setup.md
+++ b/skills/windbg-debugging/setup.md
@@ -416,12 +416,14 @@ host's* problem, and the setup question that changes when the client is elsewher
 gets there.
 
 ```console
-# on the debugger host, with WINDBG_MCP_LISTEN_TOKEN already set
+# on the debugger host, with WINDBG_MCP_LISTEN_TOKEN set to a long random string
 windbg-mcp.exe --listen 127.0.0.1:8765
-# on the client machine
+# on the client machine — the same string, spelled out: the variable is set on the
+# debugger host, and a shell that does not have it expands it to nothing, which is
+# an `Authorization: Bearer ` header and a `401` on every call
 ssh -N -L 8765:127.0.0.1:8765 <debugger-host>
 claude mcp add windbg-vm --transport http http://127.0.0.1:8765/ \
-  --header "Authorization: Bearer $WINDBG_MCP_LISTEN_TOKEN"
+  --header "Authorization: Bearer <the same string>"
 ```
 
 Four things decide whether that works, and each fails in a way that reads as something else:
@@ -441,12 +443,29 @@ Four things decide whether that works, and each fails in a way that reads as som
   Note `LocalSystem` does not read *your* `%USERPROFILE%`, so kernel profiles have to be configured
   machine-wide for a service to see them.
 
-Two behaviours differ from stdio and are worth knowing before they surprise you. A client that
-disconnects does not immediately release its targets: a **lease** does that after a grace period,
-so a client restart inside the grace comes back to the sessions it left — which is what keeps a
-client restart from costing a KDNET attach. And every client authenticates as itself: two tokens
-are two namespaces, so a session opened under one is *unknown* to the other rather than refused.
-If a handle has "vanished", check which token the request carried.
+Two behaviours differ from stdio and are worth knowing before they surprise you.
+
+**A disconnect is not a teardown, and what reclaims an abandoned target depends on the revision the
+client negotiated.** Under stdio, closing the connection releases every session. Over HTTP there is
+no such event, and two different mechanisms cover it:
+
+- A client whose revision still mints an `Mcp-Session-Id` holds a **lease**: silence past the grace
+  releases everything that credential has open, and coming back *inside* the grace adopts what it
+  left — which is what keeps a client restart from costing a KDNET attach.
+- On **`2026-07-28`** — which is what most clients now negotiate — there is no session id, so no
+  lease is ever armed. What reclaims a target there is the per-session **idle release**: 30 minutes
+  since the last call naming that session. It is deliberately not the lease: a stateless client is
+  legitimately silent for a long time (a model thinking between calls), and releasing a live kernel
+  from under someone who is merely thinking is worse than holding an abandoned one for half an hour.
+
+That second mechanism **spares a session with a call still outstanding**, and a parked
+`attach_kernel` is exactly that — so a kernel attach whose target never dialled in is held until
+somebody ends it, not until a timer notices. `session_status` says how long it has been waiting;
+`end_session` reclaims it and terminates the worker.
+
+**Every client authenticates as itself.** Two tokens are two namespaces, so a session opened under
+one is *unknown* to the other rather than refused. If a handle has "vanished", check which token the
+request carried.
 
 `docs/remote-listener.md` in the repository is the operator's reference for the rest — the grace
 and how to change it, what a `409` means, and running behind a service.

--- a/skills/windbg-debugging/setup.md
+++ b/skills/windbg-debugging/setup.md
@@ -454,9 +454,14 @@ no such event, and two different mechanisms cover it:
   left — which is what keeps a client restart from costing a KDNET attach.
 - On **`2026-07-28`** — which is what most clients now negotiate — there is no session id, so no
   lease is ever armed. What reclaims a target there is the per-session **idle release**: 30 minutes
-  since the last call naming that session. It is deliberately not the lease: a stateless client is
-  legitimately silent for a long time (a model thinking between calls), and releasing a live kernel
-  from under someone who is merely thinking is worse than holding an abandoned one for half an hour.
+  since the last call that *reached that session's engine*. It is deliberately not the lease: a
+  stateless client is legitimately silent for a long time (a model thinking between calls), and
+  releasing a live kernel from under someone who is merely thinking is worse than holding an
+  abandoned one for half an hour.
+  - **Polling does not count as using it.** `session_status` and `server_log` name a session but are
+    answered by the supervisor and never routed to its worker — which is what keeps them working
+    while that session is wedged — so neither touches the idle clock. A loop that watches a session
+    without asking it anything will watch it be released.
 
 That second mechanism **spares a session with a call still outstanding**, and a parked
 `attach_kernel` is exactly that — so a kernel attach whose target never dialled in is held until

--- a/skills/windbg-debugging/setup.md
+++ b/skills/windbg-debugging/setup.md
@@ -406,3 +406,47 @@ tell two kernel targets apart. `attach_kernel` with no arguments lists the profi
 `record_trace` captures the recorder's startup output to `<out_dir>\ttd_record.log` and
 watches it briefly, so a fast failure (e.g. un-elevated → `0x80070005 Access is denied`)
 is reported as an error rather than a false "recording started".
+
+## The server on another machine
+
+Everything above is about the machine the **server** runs on, which need not be the machine the
+client and the model run on. DbgEng is Windows-only and holds one debuggee per process; nothing
+about the client is. So the engine bundle, the symbols and the elevation table are the *debugger
+host's* problem, and the setup question that changes when the client is elsewhere is only how it
+gets there.
+
+```console
+# on the debugger host, with WINDBG_MCP_LISTEN_TOKEN already set
+windbg-mcp.exe --listen 127.0.0.1:8765
+# on the client machine
+ssh -N -L 8765:127.0.0.1:8765 <debugger-host>
+claude mcp add windbg-vm --transport http http://127.0.0.1:8765/ \
+  --header "Authorization: Bearer $WINDBG_MCP_LISTEN_TOKEN"
+```
+
+Four things decide whether that works, and each fails in a way that reads as something else:
+
+- **A token is required and the server refuses to start without one.** This endpoint runs
+  `execute`, `debug_batch` and `launch`, so an unauthenticated port is arbitrary code on the host
+  holding your kernel debugger. A start that exits immediately, having said so on stderr, is this.
+- **Bind loopback and forward over ssh.** The token is sent in clear, and a hypervisor's guest
+  network is not private when the machine being debugged is on it. A non-loopback bind warns on
+  every start rather than refusing, because sometimes you mean it.
+- **Symbols are still fetched by the server**, from the debugger host's `_NT_SYMBOL_PATH` — never
+  over the link from the client, and never over the KD wire from the target. A client with symbols
+  configured and a server without resolves nothing.
+- **For anything longer than one session, install it as a service** (`--install-service --listen
+  <addr>`, elevated). It survives logout and starts at boot, and it gets a defined working
+  directory — which is what decides whether the engine DLLs beside the exe are the ones that load.
+  Note `LocalSystem` does not read *your* `%USERPROFILE%`, so kernel profiles have to be configured
+  machine-wide for a service to see them.
+
+Two behaviours differ from stdio and are worth knowing before they surprise you. A client that
+disconnects does not immediately release its targets: a **lease** does that after a grace period,
+so a client restart inside the grace comes back to the sessions it left — which is what keeps a
+client restart from costing a KDNET attach. And every client authenticates as itself: two tokens
+are two namespaces, so a session opened under one is *unknown* to the other rather than refused.
+If a handle has "vanished", check which token the request carried.
+
+`docs/remote-listener.md` in the repository is the operator's reference for the rest — the grace
+and how to change it, what a `409` means, and running behind a service.

--- a/skills/windbg-debugging/setup.md
+++ b/skills/windbg-debugging/setup.md
@@ -438,10 +438,13 @@ Four things decide whether that works, and each fails in a way that reads as som
   over the link from the client, and never over the KD wire from the target. A client with symbols
   configured and a server without resolves nothing.
 - **For anything longer than one session, install it as a service** (`--install-service --listen
-  <addr>`, elevated). It survives logout and starts at boot, and it gets a defined working
-  directory — which is what decides whether the engine DLLs beside the exe are the ones that load.
-  Note `LocalSystem` does not read *your* `%USERPROFILE%`, so kernel profiles have to be configured
-  machine-wide for a service to see them.
+  <addr>`, elevated) — and then **start it**. Installing only *registers* it; "starts
+  automatically" means from the next boot, so `Start-Service windbg-mcp` is what gets you an
+  endpoint in this one. Skip that and everything keeps working until the foreground listener stops,
+  and there is nothing listening after it. Once running it survives logout, comes back at boot, and
+  has a defined working directory — which is what decides whether the engine DLLs beside the exe
+  are the ones that load. Note `LocalSystem` does not read *your* `%USERPROFILE%`, so kernel
+  profiles have to be configured machine-wide for a service to see them.
 
 Two behaviours differ from stdio and are worth knowing before they surprise you.
 


### PR DESCRIPTION
Documentation and the version bump. No behaviour changes.

## Why this is not just a bump

The release body is generated from this version's CHANGELOG section, and that section never introduced **`--listen`**, the **Windows service**, or **progress notifications**. They appeared only as background inside entries about other things — per-client namespaces, `server_log`, the lease smoke tier, a progress *bug fix* — so someone reading the 0.10.0 notes would not have learned the server can be driven from another machine at all, which is the largest thing to land since 0.9.0.

Each new entry says what the feature is for and what it cost to get right: why the listener refuses to start without a token and warns on a non-loopback bind; why a lease replaces "stdio closed" and why its floor is *derived* from the call budget rather than chosen; why the **stop** is the whole difficulty of the service and why its token cannot live in the machine environment; and why progress counts seconds with no `total` and reports its own silence.

## The skill, which ships as a snapshot

The plugin carries the last *published* release, so whatever the skill does not know at tag time is what its users get until the release after — and it did not know the server can run anywhere but locally.

- **`setup.md`** gains a closing section, placed there because everything above it turns out to be about the *debugger host* rather than the client: the engine bundle, the symbols and the elevation table do not move. What changes is the four things that decide whether the link works, each of which fails looking like something else — the mandatory token, the loopback bind, symbols still being fetched by the server (never over the link, never over the KD wire), and the service for anything longer than one session. Plus the two behaviours that differ from stdio: a disconnect releases nothing until the lease does, and two tokens are two namespaces.
- **`SKILL.md`** gains `server_log` in the tool map, which it has never had. It is the tool that reaches the run-up to a session that failed to *open* — the case with no handle to ask anything else about — and the only route to a worker's records when the server is elsewhere.

## FOLLOWUPS item 27, measured and declined

The entry deferred the image-header PDB fallback on a cost nobody had measured. I built it and measured it on the ARM64 kernel sample: `modules` grows **53,897 B → 73,597 B** of model context, and the budget test goes from **1.31 s → 179.6 s cold, 10.6 s warm**.

The cold figure is the finding. A header a minidump did not capture makes the engine fetch the *image* to satisfy the read, so a two-hundred-row listing becomes two hundred image downloads — precisely the download the field exists to save the caller, moved onto the debugger host and answered with sixty bytes. The item now records that, and why the two obvious mitigations are worse than the gap. The code is not in this PR.

## Verification

Ran the release workflow's own guards here rather than discovering them on a tag: `Cargo.toml`, `Cargo.lock`, `.claude-plugin/plugin.json` and the README badge all read `0.10.0`, the CHANGELOG has a matching `## [0.10.0]` section, and the notes extraction yields 23 entries across Added, Fixed and Changed. `cargo metadata` resolves against the edited lockfile; `markdownlint-cli2` is clean over `skills/**/*.md`, `README.md` and `CHANGELOG.md`. `packaging/mcpb/manifest.json` and `server.json` keep their template versions, which CI rewrites from the tag — as the 0.9.0 release also left them.

After this merges, the tag is what does the rest: `git tag v0.10.0 && git push origin v0.10.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
