### PR TITLE
Give the ARM64 CI entry the symbol half its image is missing (#153)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,6 +149,63 @@ jobs:
           WINDBG_MCP_SMOKE_DUMP: "1"
         run: cargo test --test mcp_smoke -- --nocapture
 
+  # TEMPORARY (issue #153): answers the two probes that decide whether the ARM64 entry's
+  # symbol-less engine is an image difference or something this repo can fix in the workflow.
+  # Delete once #153 is settled.
+  probe-symbols:
+    name: Probe symbols (${{ matrix.arch }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x64
+            runner: windows-latest
+          - arch: arm64
+            runner: windows-11-arm
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 10
+    steps:
+      - name: Where the engine and its symbol halves come from
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Continue'
+          Write-Host "=== PROCESSOR_ARCHITECTURE: $env:PROCESSOR_ARCHITECTURE"
+          Write-Host "=== _NT_SYMBOL_PATH: '$env:_NT_SYMBOL_PATH'"
+
+          Write-Host "`n=== Windows Kits Debuggers directory"
+          $kits = 'C:\Program Files (x86)\Windows Kits\10\Debuggers'
+          if (Test-Path $kits) {
+            Get-ChildItem $kits | Select-Object -ExpandProperty Name
+            foreach ($d in Get-ChildItem $kits -Directory) {
+              Write-Host "--- $($d.FullName)"
+              Get-ChildItem $d.FullName -Filter '*.dll' |
+                Select-Object Name, Length | Format-Table -AutoSize | Out-String | Write-Host
+            }
+          } else {
+            Write-Host "ABSENT: $kits"
+          }
+
+          Write-Host "`n=== where.exe"
+          foreach ($dll in 'symsrv.dll', 'dbghelp.dll', 'dbgeng.dll', 'dbgcore.dll', 'dbgmodel.dll', 'msdia140.dll') {
+            $found = & where.exe $dll 2>&1
+            if ($LASTEXITCODE -eq 0) { Write-Host "$dll ->"; $found | ForEach-Object { Write-Host "    $_" } }
+            else { Write-Host "$dll -> NOT ON PATH" }
+          }
+
+          Write-Host "`n=== every symsrv.dll / dbgeng.dll under the roots that could hold one"
+          $roots = 'C:\Windows\System32', 'C:\Windows\SysWOW64', 'C:\Program Files', 'C:\Program Files (x86)'
+          foreach ($dll in 'symsrv.dll', 'dbgeng.dll', 'msdia140.dll') {
+            foreach ($root in $roots) {
+              if (-not (Test-Path $root)) { continue }
+              Get-ChildItem -Path $root -Filter $dll -Recurse -File -ErrorAction SilentlyContinue |
+                Select-Object -First 20 |
+                ForEach-Object { Write-Host ("{0,10}  {1}  {2}" -f $_.Length, $_.VersionInfo.FileVersion, $_.FullName) }
+            }
+          }
+
+          Write-Host "`n=== PATH entries naming a kit or a debugger"
+          $env:PATH -split ';' | Where-Object { $_ -match 'Windows Kits|Debugg' } | ForEach-Object { Write-Host "    $_" }
+
   docs:
     name: Documentation lint
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,6 +187,13 @@ jobs:
       - name: The target-reading assertions must have run
         shell: pwsh
         run: |
+          # Prove the log is the log before reading anything out of it. A stand-down is printed by
+          # `eprintln!`, so it is only in this file because of the `2>&1` above - and if that ever
+          # stopped capturing, every check below would pass by finding nothing, which is the same
+          # false green this step exists to prevent.
+          if (-not (Select-String -Path smoke.log -SimpleMatch -Pattern 'test result:' -Quiet)) {
+            throw 'smoke.log does not hold the test output; the checks below would pass vacuously'
+          }
           $skips = Select-String -Path smoke.log -SimpleMatch -Pattern @(
             "could not read ``nt``'s own base",
             "``nt`` resolved no PDB on this host"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,12 +95,10 @@ jobs:
     # reads the dump's own structure and nothing behind it. The two conditions are asked
     # separately because they fail apart — this entry is where that was learned, by reading a
     # module base and then failing a stack walk. That, and not the architecture pairing it was
-    # first read as, is issue #142:
-    # Windows ships `dbghelp.dll` in System32 and no `symsrv.dll` anywhere outside the Debugging
-    # Tools, so a runner without them resolves nothing over a `srv*` path — and running that
-    # configuration by hand reproduces the reported failure address for address. Those
-    # four print `SKIPPED` with the reason where it happens, so a green run here never claims more
-    # than it checked.
+    # first read as, is issue #142. What decides whether a runner resolves anything is
+    # `symsrv.dll`, and the two images differ in whether they have one: that is what the copy step
+    # below is for, and why it runs on one entry only (issue #153). Those four print `SKIPPED`
+    # with the reason where it happens, so a green run here never claims more than it checked.
     #
     # Only this tier is matrixed. The crate is architecture-independent Rust, so `fmt`, clippy and
     # the unit tests in `build` have no reason to differ and a second entry there would buy runtime
@@ -144,67 +142,60 @@ jobs:
           # other's target directory — objects for the wrong triple, rebuilt every run at best.
           key: ${{ matrix.arch }}
 
+      # `cargo test` builds this itself; doing it as its own step is what gives the copy below
+      # somewhere to copy *to*.
+      - name: Build the binary under test
+        run: cargo build
+
+      # Measured, not assumed (issue #153): `windows-latest` carries `symsrv.dll` in System32
+      # beside the `dbghelp.dll` that ships there, so its stock engine reaches the symbol server
+      # and all four target-reading assertions run. `windows-11-arm` has no `symsrv.dll` in
+      # System32 at all, so a `srv*` path downloads nothing, `nt` resolves no PDB, and every one
+      # of the four stands down. Both images do carry the Debugging Tools, so the half that is
+      # missing is already on the runner's disk.
+      #
+      # `dbgeng.dll` is deliberately **not** copied. The entry goes on loading the image's own
+      # engine, which is the claim it was matrixed for (issue #134) and the one this repo wants to
+      # hear about breaking; what it gains is the symbol half, which was measured on this
+      # project's own ARM64 bench to be all an inbox engine needs (`docs/smoke-test.md`). It is
+      # also exactly what `skills/windbg-debugging/setup.md` tells a user to do, so the entry moves
+      # from what a bare machine gets to what a reader of this repo's setup gets.
+      - name: Give the ARM64 engine its symbol half (issue #153)
+        if: matrix.arch == 'arm64'
+        shell: pwsh
+        run: |
+          $kit = 'C:\Program Files (x86)\Windows Kits\10\Debuggers\arm64'
+          foreach ($dll in 'dbghelp.dll', 'symsrv.dll') {
+            $from = Join-Path $kit $dll
+            if (-not (Test-Path $from)) {
+              # A red build is the point: the runner image stopped shipping the Debugging Tools,
+              # and this entry is back to asserting nothing about reading a target.
+              throw "$from is missing - the ARM64 image no longer carries the Debugging Tools"
+            }
+            Copy-Item $from 'target\debug' -Force
+            Write-Host "copied $dll beside the binary under test"
+          }
+
       - name: Smoke test against the sample dump
         env:
           WINDBG_MCP_SMOKE_DUMP: "1"
-        run: cargo test --test mcp_smoke -- --nocapture
+        run: cargo test --test mcp_smoke -- --nocapture 2>&1 | Tee-Object -FilePath smoke.log
+        shell: pwsh
 
-  # TEMPORARY (issue #153): answers the two probes that decide whether the ARM64 entry's
-  # symbol-less engine is an image difference or something this repo can fix in the workflow.
-  # Delete once #153 is settled.
-  probe-symbols:
-    name: Probe symbols (${{ matrix.arch }})
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - arch: x64
-            runner: windows-latest
-          - arch: arm64
-            runner: windows-11-arm
-    runs-on: ${{ matrix.runner }}
-    timeout-minutes: 10
-    steps:
-      - name: Where the engine and its symbol halves come from
+      # The copy above is the only thing standing between this entry and four silent `SKIPPED`s,
+      # and a skip passes. Without this check a broken copy reads exactly like a green run.
+      - name: The target-reading assertions must have run
         shell: pwsh
         run: |
-          $ErrorActionPreference = 'Continue'
-          Write-Host "=== PROCESSOR_ARCHITECTURE: $env:PROCESSOR_ARCHITECTURE"
-          Write-Host "=== _NT_SYMBOL_PATH: '$env:_NT_SYMBOL_PATH'"
-
-          Write-Host "`n=== Windows Kits Debuggers directory"
-          $kits = 'C:\Program Files (x86)\Windows Kits\10\Debuggers'
-          if (Test-Path $kits) {
-            Get-ChildItem $kits | Select-Object -ExpandProperty Name
-            foreach ($d in Get-ChildItem $kits -Directory) {
-              Write-Host "--- $($d.FullName)"
-              Get-ChildItem $d.FullName -Filter '*.dll' |
-                Select-Object Name, Length | Format-Table -AutoSize | Out-String | Write-Host
-            }
-          } else {
-            Write-Host "ABSENT: $kits"
+          $skips = Select-String -Path smoke.log -SimpleMatch -Pattern @(
+            "could not read ``nt``'s own base",
+            "``nt`` resolved no PDB on this host"
+          )
+          if ($skips) {
+            $skips | ForEach-Object { Write-Host $_.Line }
+            throw 'this runner stood down from reading a target; see the SKIPPED lines above'
           }
-
-          Write-Host "`n=== where.exe"
-          foreach ($dll in 'symsrv.dll', 'dbghelp.dll', 'dbgeng.dll', 'dbgcore.dll', 'dbgmodel.dll', 'msdia140.dll') {
-            $found = & where.exe $dll 2>&1
-            if ($LASTEXITCODE -eq 0) { Write-Host "$dll ->"; $found | ForEach-Object { Write-Host "    $_" } }
-            else { Write-Host "$dll -> NOT ON PATH" }
-          }
-
-          Write-Host "`n=== every symsrv.dll / dbgeng.dll under the roots that could hold one"
-          $roots = 'C:\Windows\System32', 'C:\Windows\SysWOW64', 'C:\Program Files', 'C:\Program Files (x86)'
-          foreach ($dll in 'symsrv.dll', 'dbgeng.dll', 'msdia140.dll') {
-            foreach ($root in $roots) {
-              if (-not (Test-Path $root)) { continue }
-              Get-ChildItem -Path $root -Filter $dll -Recurse -File -ErrorAction SilentlyContinue |
-                Select-Object -First 20 |
-                ForEach-Object { Write-Host ("{0,10}  {1}  {2}" -f $_.Length, $_.VersionInfo.FileVersion, $_.FullName) }
-            }
-          }
-
-          Write-Host "`n=== PATH entries naming a kit or a debugger"
-          $env:PATH -split ';' | Where-Object { $_ -match 'Windows Kits|Debugg' } | ForEach-Object { Write-Host "    $_" }
+          Write-Host 'no target-read skips: the four assertions ran'
 
   docs:
     name: Documentation lint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **The ARM64 CI entry resolves symbols, so its target-reading assertions run**
+  ([#153](https://github.com/glslang/windbg-mcp/issues/153)). Both runner images carry the
+  Debugging Tools; what differs is System32. `windows-latest` ships a `symsrv.dll` there beside
+  the `dbghelp.dll` that is always present, so its stock engine reaches the symbol server;
+  `windows-11-arm` has none, so a `srv*` path downloaded nothing, `nt` resolved no PDB, and all
+  four assertions that read a *target* stood down. That entry now copies the kit's `dbghelp.dll`
+  and `symsrv.dll` beside the binary under test - `dbgeng.dll` is deliberately left alone, so it
+  goes on loading the image's own engine - and the job fails if either stand-down appears in the
+  output, since a skip otherwise reads exactly like a green run.
+
+  This also retires the claim that Windows ships no `symsrv.dll` outside the Debugging Tools. It
+  holds on ARM64 and does not hold on the x64 runner image.
+
 ## [0.10.0] - 2026-08-20
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -364,7 +364,10 @@ Issue `.sympath` alone, or use the **`set_symbol_path`** tool (goes through the 
 **Nothing resolves at all without `msdia140.dll` beside the engine** — `symsrv.dll` finds a PDB and
 that one *parses* it, so without it every module reports `Symbol Type: EXPORT - PDB not found` even
 when the identity was known and the file was downloaded. **`symsrv.dll` is the other half, and
-System32 does not ship it**: on a machine with neither, a `srv*` path downloads nothing. Worth
+System32 usually does not ship it**: on a machine with neither, a `srv*` path downloads nothing.
+*Usually*, because it is not a constant and this repo believed it was — probing both CI runners for
+#153 found one in `windows-latest`'s System32 and none in `windows-11-arm`'s, so check the host in
+front of you (`where.exe symsrv.dll`) rather than assuming either way. Worth
 knowing because of how that presents on a *dump* — not as missing symbols but as a **memory read
 failing** (`0x8007001E`), since a kernel dump's virtual addresses are translated through structures
 the engine locates with `nt`'s symbols. That symptom was read as an ARM64 engine limitation for a

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -23,7 +23,10 @@ landed** (process-per-session, 2026-08-02); it is kept here rather than deleted 
 **Items 16, 17 and 18 have landed** (2026-08-10) and are kept for the opposite reason: each turned
 out to need something its entry did not anticipate — item 18 needed much less of item 7 than it
 claimed to, item 17 needed a walk deadline nothing had asked for, and item 16 needed a probe before
-it could measure anything at all. **Items 20 and 22 have landed** (2026-08-16, #131 and #134) and are kept because each needed
+it could measure anything at all. **Items 25 and 26 have landed** (2026-08-21, #153 and #154), and both are kept because each turned
+out to rest on something that was not so: item 25's premise about what Windows ships was only true
+on one of the two runner images, and item 26's "one decision first" was the wrong decision to be
+weighing. **Items 20 and 22 have landed** (2026-08-16, #131 and #134) and are kept because each needed
 something its entry did not see — item 22's job rename silently removed a required status check.
 Item 20's fix needed something the entry did not see: the two installers spell x64 differently, so the reordering it proposed would have
 picked the wrong architecture by another route. **Item 7 has landed** too (2026-08-10, the
@@ -779,26 +782,36 @@ say what it means for the other.
 Picks up at [`docs/token-budget.md`](./docs/token-budget.md) and the two budget tests in
 `tests/mcp_smoke.rs`.
 
-## 25. [windbg-mcp] The ARM64 CI runner resolves no symbols, so its target reads never run
+## 25. [windbg-mcp] The ARM64 CI runner resolves no symbols, so its target reads never run — **done** (2026-08-21, #153)
 
 Since #152 the debugger tier's target-reading assertions decide for themselves whether the host can
-support them, and the two CI entries decide differently: on `windows-latest` all four run and pass,
-on `windows-11-arm` all four print `SKIPPED`. Same code, same dumps. Windows ships `dbghelp.dll` in
-System32 and **no `symsrv.dll`** outside the Debugging Tools, so a runner without them downloads no
-PDB — and without `nt`'s symbols a kernel dump's pointers cannot be followed at all
-([#142](https://github.com/glslang/windbg-mcp/issues/142)).
+support them, and the two CI entries decided differently: on `windows-latest` all four ran and
+passed, on `windows-11-arm` all four printed `SKIPPED`. Same code, same dumps.
 
-- **Why deferred:** the job's stated position is that it runs the runner's *stock* engine, on the
-  reasoning that "a runner whose DbgEng cannot open a checked-in dump is something this repo wants
-  to hear about". Provisioning symbols moves it away from what a bare machine gets — and toward
-  what a user following this repo's own setup gets, since that setup copies the engine bundle
-  beside the exe. That is a decision about what the job is *for*, not a fix.
-- **What it costs today:** `docs/samples/121524-4703-01.dmp`, added so an ARM64 run reads an ARM64
-  target, is exercised only on a bench with the engine bundle. CI proves the protocol and the
-  session machinery there and nothing about reading.
-- **Picks up at** [#153](https://github.com/glslang/windbg-mcp/issues/153), which lists the two
-  probes (`dir` of the arm64 Debuggers directory, `where.exe symsrv.dll`) that would confirm this
-  is an image difference rather than something this repo can fix in the workflow.
+**The probe the entry asked for answered it, and not the way either the entry or the issue
+guessed.** The reasoning here was that Windows ships `dbghelp.dll` in System32 and no `symsrv.dll`
+outside the Debugging Tools, so a runner with neither downloads no PDB. Measured on both runners:
+
+- `windows-latest` **has** a `symsrv.dll` in System32, servicing-versioned like an inbox component.
+  That, not the kit, is where its stock engine gets its symbol store — which is why it resolves
+  symbols with `_NT_SYMBOL_PATH` unset;
+- `windows-11-arm` has none anywhere in System32, matching this project's own ARM64 bench;
+- **both** images carry the Debugging Tools, `symsrv.dll` and a full `dbgeng.dll` included.
+
+So the deferral rested on a premise that was only half true, and the thing that was supposedly
+unavailable was already on the runner's disk. The fix is the issue's option 1, one entry only: copy
+the kit's `dbghelp.dll` and `symsrv.dll` beside the binary under test on the ARM64 entry.
+
+**What the entry called a decision about what the job is for turned out to be smaller than that.**
+The job's position is that it runs the runner's *stock* engine. `dbgeng.dll` is deliberately not
+copied, so it still does — the entry goes on loading the image's own engine, which is the claim it
+was matrixed for (#134). What it gains is the symbol *half*, which this repo had already measured
+to be all an inbox engine needs. "Stock" was never a single thing anyway: the two images' System32
+differ, and that difference alone produced the asymmetry.
+
+**A skip passes, so the fix needed a guard of its own.** The job now fails if either target-read
+stand-down appears in the output; without that, a copy that stopped working would read exactly like
+a green run — which is the shape of failure this whole item is about.
 
 ## 26. [windbg-mcp] No ARM64 driver crash, so frame attribution is asserted only on x64 stacks
 

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -57,15 +57,26 @@ it is not one. Measured on one ARM64 host:
 - with the SDK's `dbghelp.dll` and `symsrv.dll` beside the binary, one engine reads **both** x64
   samples and the ARM64 one completely — private symbols, the `EPROCESS`, the driver frame at its
   literal RVA. The whole tier passes there, 60 of 60;
-- with nothing beside the binary — System32 ships `dbghelp.dll` and **no** `symsrv.dll`, so a
-  `srv*` path downloads nothing — it reproduces the CI failure exactly, down to the address and
-  `0x8007001E`;
+- with nothing beside the binary — that host's System32 ships `dbghelp.dll` and **no**
+  `symsrv.dll`, so a `srv*` path downloads nothing — it reproduces the CI failure exactly, down to
+  the address and `0x8007001E`;
 - and with the full bundle but `_NT_SYMBOL_PATH` pointed at an empty directory it fails again, and
   fails *differently per dump*: the ARM64 sample reads nothing at all, while the x64 sample gives
   up a module base and then walks a stack of the bug check's own parameters. Neither is an answer,
   and only one of them looks like a failure.
 
 Same engine, same dumps: symbols are the variable, and the engine's architecture is not.
+
+**Whether System32 has a `symsrv.dll` is not a constant, which is what
+[#153](https://github.com/glslang/windbg-mcp/issues/153) turned on.** Probing both CI runners
+directly: `windows-latest` has one at `C:\Windows\System32\symsrv.dll`, servicing-versioned like
+an inbox component, which is why its stock engine resolves symbols with `_NT_SYMBOL_PATH` unset.
+`windows-11-arm` has none anywhere in System32, matching this project's own ARM64 bench. Both
+images do carry the Debugging Tools, `symsrv.dll` included, so on the ARM64 entry the missing half
+was already on disk — the job copies the kit's `dbghelp.dll` and `symsrv.dll` beside the binary
+under test and leaves `dbgeng.dll` stock, so what that entry exercises is still the image's own
+engine. Read any blanket statement about what "Windows ships" in this repo with that measurement
+in mind.
 
 So they **ask the host** instead of guessing from `cfg!(target_arch)`, and each asks for the
 premise it actually has. `walk_memory` and the batch work on numeric addresses, so they need only

--- a/skills/windbg-debugging/setup.md
+++ b/skills/windbg-debugging/setup.md
@@ -27,9 +27,11 @@ structures it locates with `nt`'s symbols. That is what
 architecture limitation, which it is not: the same host reads x64 and ARM64 dumps alike once
 symbols resolve, and reads neither when they do not.
 
-`symsrv.dll` is the file this usually comes down to. System32 ships `dbghelp.dll` and **no**
-`symsrv.dll`, so a machine with nothing beside the binary cannot download a PDB over a `srv*` path
-at all — and the symptom is not "no symbols", it is a memory read failing.
+`symsrv.dll` is the file this usually comes down to. System32 always ships `dbghelp.dll` and
+**often has no `symsrv.dll` beside it**, and a machine without one cannot download a PDB over a
+`srv*` path at all — the symptom being not "no symbols" but a memory read failing. Whether it is
+there is worth checking rather than assuming: `where.exe symsrv.dll`. Of the two GitHub Actions
+Windows images, the x64 one has a System32 `symsrv.dll` and the ARM64 one does not.
 
 Live user-mode and live kernel are untested on ARM64, and the bitness rule above still applies to
 those.


### PR DESCRIPTION
Closes #153. `FOLLOWUPS.md` item 25.

Since #152 the debugger tier's four target-reading assertions decide for themselves whether the host can support them, and the two CI entries decided differently — `windows-latest` ran all four, `windows-11-arm` printed `SKIPPED` for all four.

## The probe first, because the premise was wrong

The recorded reasoning (#142, `CLAUDE.md`, `docs/smoke-test.md`) was that Windows ships `dbghelp.dll` in System32 and **no** `symsrv.dll` outside the Debugging Tools. The first commit here probes both runners instead of assuming. What they actually hold:

| | `windows-latest` | `windows-11-arm` |
| --- | --- | --- |
| `where.exe symsrv.dll` | **`C:\Windows\System32\symsrv.dll`** (10.0.26100.7309) | **not on PATH, none in System32** |
| `System32\dbghelp.dll` | present | present |
| `System32\dbgeng.dll` | present | present |
| Debugging Tools installed | yes, `Debuggers\{arm,arm64,x64,x86}` | **yes**, `Debuggers\arm64` incl. `symsrv.dll` |

So the x64 image has a `symsrv.dll` in System32 — servicing-versioned, like an inbox component — and that, not the kit, is why its stock engine resolves symbols with `_NT_SYMBOL_PATH` unset. The ARM64 image has none, which matches this project's own ARM64 bench. And **both** images carry the kit, so the half the ARM64 entry was missing was already on its disk.

## The fix

The issue's option 1, on one entry only: copy the kit's `dbghelp.dll` and `symsrv.dll` beside the binary under test on the ARM64 entry — which is what `skills/windbg-debugging/setup.md` already tells users to do.

`dbgeng.dll` is deliberately **not** copied. That entry goes on loading the image's own engine, which is the claim it was matrixed for (#134) and the one this repo wants to hear about breaking. What it gains is the symbol half, measured on this project's bench to be all an inbox engine needs.

The entry's stated position — that it runs the runner's *stock* engine — survives this. "Stock" was never one thing anyway: the two images' System32 differ, and that difference alone produced the asymmetry the issue was filed about.

## A skip passes, so the fix needed a guard

Without one, a copy that stopped working would read exactly like a green run — the same shape of failure this item is about. The job now fails if either target-read stand-down appears in the output, and the copy step throws if the kit is gone.

## Verification

Green run on this branch (32455307825):

- **`Smoke test (debugger tier, arm64)`**: `copied dbghelp.dll` / `copied symsrv.dll`, `67 passed; 0 failed`, and `no target-read skips: the four assertions ran`. Zero `SKIPPED` lines in the log.
- **`Smoke test (debugger tier)`** (x64): unchanged, same guard passes.

The probe job is removed in the second commit; only its findings remain, in the job comment and `docs/smoke-test.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)