### PR TITLE
Run the debugger tier on the new ARM64 runner image too

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,9 +96,10 @@ jobs:
     # separately because they fail apart — this entry is where that was learned, by reading a
     # module base and then failing a stack walk. That, and not the architecture pairing it was
     # first read as, is issue #142. What decides whether a runner resolves anything is
-    # `symsrv.dll`, and the two images differ in whether they have one: that is what the copy step
-    # below is for, and why it runs on one entry only (issue #153). Those four print `SKIPPED`
-    # with the reason where it happens, so a green run here never claims more than it checked.
+    # `symsrv.dll`, and the images differ in whether they have one: that is what the copy step
+    # below is for, and why it runs on the ARM64 entries only (issue #153). Those four print
+    # `SKIPPED` with the reason where it happens, so a green run here never claims more than it
+    # checked.
     #
     # Only this tier is matrixed. The crate is architecture-independent Rust, so `fmt`, clippy and
     # the unit tests in `build` have no reason to differ and a second entry there would buy runtime
@@ -107,6 +108,8 @@ jobs:
     strategy:
       # An ARM64 failure must not cancel the x64 run: x64 is the result this repo has trusted for
       # every release, and a new runner label is exactly the thing most likely to be flaky first.
+      # For the same reason neither ARM64 entry may cancel the other — the whole point of running
+      # both images is to see which of them a failure belongs to.
       fail-fast: false
       matrix:
         include:
@@ -122,6 +125,23 @@ jobs:
           - arch: arm64
             runner: windows-11-arm
             suffix: ", arm64"
+          # The image behind `windows-11-arm` is being replaced under it. The Visual Studio 2026
+          # ARM64 image went generally available on 2026-08-20 as `windows-11-vs2026-arm`, and
+          # GitHub migrates the `windows-11-arm` label onto it between 21 and 30 September 2026.
+          # What that changes for this job is not the compiler — the crate is Rust, and the x64
+          # entry has been building against a VS2026 image ever since `windows-latest` migrated —
+          # but the **OS build**, and with it the inbox `dbgeng.dll` that this entry exists to
+          # load: 10.0.26200.9168 against .8875 when this was written. So run the new label now,
+          # while the old one is still beside it to compare against. A break that only the new
+          # image has is one this repo would otherwise meet on the migration date, on every PR at
+          # once, with nothing green next to it to say which half moved.
+          #
+          # This entry has an expiry: once the migration completes, the two labels name the same
+          # image and the pair buys a second run of the same thing. Drop the older entry then
+          # (`FOLLOWUPS.md` item 32).
+          - arch: arm64
+            runner: windows-11-vs2026-arm
+            suffix: ", arm64 vs2026"
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 20
     steps:
@@ -138,9 +158,11 @@ jobs:
       - name: Cache cargo registry and build
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
         with:
-          # Keyed by architecture, or the two entries share one cache and each restores the
-          # other's target directory — objects for the wrong triple, rebuilt every run at best.
-          key: ${{ matrix.arch }}
+          # Keyed by runner label rather than by architecture, or entries share one cache and
+          # each restores another's target directory — objects for the wrong triple across the two
+          # architectures, and a target directory linked by a different MSVC across the two ARM64
+          # images. Rebuilt every run at best.
+          key: ${{ matrix.runner }}
 
       # `cargo test` builds this itself; doing it as its own step is what gives the copy below
       # somewhere to copy *to*.
@@ -154,6 +176,12 @@ jobs:
       # of the four stands down. Both images do carry the Debugging Tools, so the half that is
       # missing is already on the runner's disk.
       #
+      # It runs on **both** ARM64 entries, and what `windows-11-vs2026-arm`'s System32 holds was
+      # never measured — deliberately. Copying makes the entry not depend on the answer, which is
+      # the property worth having across an image migration: the one thing that must stay the
+      # runner's own is `dbgeng.dll`, and that is what the next paragraph is about. If the new
+      # image turns out to ship a `symsrv.dll` of its own, this step costs it two file copies.
+      #
       # `dbgeng.dll` is deliberately **not** copied. The entry goes on loading the image's own
       # engine, which is the claim it was matrixed for (issue #134) and the one this repo wants to
       # hear about breaking; what it gains is the symbol half, which was measured on this
@@ -163,6 +191,11 @@ jobs:
       - name: Give the ARM64 engine its symbol half (issue #153)
         if: matrix.arch == 'arm64'
         shell: pwsh
+        env:
+          # Through the environment rather than interpolated into the script: the value is a
+          # literal from the matrix above, but a step that reads workflow expressions as PowerShell
+          # source is a habit worth not having.
+          RUNNER_IMAGE: ${{ matrix.runner }}
         run: |
           $kit = 'C:\Program Files (x86)\Windows Kits\10\Debuggers\arm64'
           foreach ($dll in 'dbghelp.dll', 'symsrv.dll') {
@@ -170,7 +203,7 @@ jobs:
             if (-not (Test-Path $from)) {
               # A red build is the point: the runner image stopped shipping the Debugging Tools,
               # and this entry is back to asserting nothing about reading a target.
-              throw "$from is missing - the ARM64 image no longer carries the Debugging Tools"
+              throw "$from is missing - the $env:RUNNER_IMAGE image no longer carries the Debugging Tools"
             }
             Copy-Item $from 'target\debug' -Force
             Write-Host "copied $dll beside the binary under test"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **CI runs the debugger tier on the new ARM64 runner image as well.** GitHub's Visual Studio 2026
+  ARM64 image went generally available on 2026-08-20 as `windows-11-vs2026-arm`, and the
+  `windows-11-arm` label migrates onto it between 21 and 30 September 2026. The tier's ARM64 half
+  is now a pair of entries, one per label, because what this job exercises that nothing else does
+  is a real inbox `dbgeng.dll` and the two labels are - until the migration completes - two
+  different OS builds carrying two different ones. Running both is what makes a break attributable
+  to the image rather than to the change under review; the older entry is meant to be dropped once
+  the labels converge ([`FOLLOWUPS.md`](./FOLLOWUPS.md) item 32). The cargo cache is now keyed by
+  runner label rather than by architecture, or the two ARM64 entries would share one. The x64 entry
+  needs no pairing: `windows-latest` has been the Visual Studio 2026 image since its own migration.
+
 - **The ARM64 CI entry resolves symbols, so its target-reading assertions run**
   ([#153](https://github.com/glslang/windbg-mcp/issues/153)). Both runner images carry the
   Debugging Tools; what differs is System32. `windows-latest` ships a `symsrv.dll` there beside

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -1128,3 +1128,27 @@ The end-to-end half is one protocol-tier smoke assertion
 (`a_token_file_names_its_own_clients_and_shuts_the_environment_out`): a real listener, a real file
 naming two clients, the environment token refused `401`, and both file clients served through a full
 handshake.
+
+## 32. [windbg-mcp] Two ARM64 CI entries, one of which expires
+
+The debugger tier's ARM64 half is a **pair**: `windows-11-arm` and `windows-11-vs2026-arm`. That is
+deliberate and temporary. GitHub's Visual Studio 2026 ARM64 image went generally available on
+2026-08-20 under the new label, and the `windows-11-arm` label is migrated onto it between 21 and
+30 September 2026 — so today the two labels are two *OS builds* (10.0.26200.9168 against .8875 when
+this was written) and therefore two inbox `dbgeng.dll`s, which is the one thing this job exists to
+load. Running both is what makes a break during that window attributable to the image rather than
+to the change under review, and what gives the repo notice before every PR meets it at once.
+
+- **What to do, and when:** after the migration completes, the two labels name the same image and
+  the pair buys a second run of the same tier. Drop the `windows-11-arm` entry — not the new one:
+  the new label is the stable name for that image, and `windows-11-arm` is the one whose meaning
+  moved. The x64 entry is untouched either way; `windows-latest` migrated to the Visual Studio 2026
+  Windows Server 2025 image before this.
+- **How you will know it converged:** the two entries stop differing in the OS build they report,
+  and `actions/runner-images`' `Windows11-Arm64-Readme.md` stops naming a separate VS2022 image.
+  Until then, an entry that fails alone is the interesting one — read which label it is before
+  reading the diff.
+- **What it could still turn up in the meantime:** the copy step assumes the kit at
+  `C:\Program Files (x86)\Windows Kits\10\Debuggers\arm64`, which both images carry today (the
+  same WDK build, 10.1.26100.6584). It throws by name if that stops being true, which is the
+  failure this pair is here to catch early rather than on the migration date.

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -38,10 +38,20 @@ all.
 The protocol tier rides `cargo test`, so CI already runs it. The debugger tier is opt-in
 *locally* but runs on every push and PR in CI, as the **Smoke test (debugger tier)** job — it is
 the only automated check of the properties process-per-session exists for, and it needs no symbols
-and no network. It runs **twice, on x64 and on ARM64** (`windows-11-arm`), because the thing it
+and no network. It runs **three times: on x64 and on both ARM64 images**, because the thing it
 exercises that nothing else does is a real `dbgeng.dll`, and there is a different one on each
-([#134](https://github.com/glslang/windbg-mcp/issues/134)). The two entries do not share a cargo
-cache, and an ARM64 failure does not cancel the x64 run.
+([#134](https://github.com/glslang/windbg-mcp/issues/134)). No two entries share a cargo
+cache — the key is the runner label, not the architecture — and no entry's failure cancels
+another's.
+
+The two ARM64 entries are `windows-11-arm` and `windows-11-vs2026-arm`, and the pair is temporary.
+The Visual Studio 2026 ARM64 image went generally available on 2026-08-20, and GitHub migrates the
+`windows-11-arm` label onto it between 21 and 30 September 2026 — so for now the two labels are two
+*OS builds*, which for this job means two inbox `dbgeng.dll`s, and running both is what makes a
+break attributable to the image rather than to the change under review. Once the migration
+completes they are one image and the older entry should go (`FOLLOWUPS.md` item 32). The x64 entry
+needs no such pairing: `windows-latest` has been the Visual Studio 2026 Windows Server 2025 image
+since its own migration.
 
 **Four of its assertions read the target's memory rather than the dump's structure, and they stand
 down on a host whose engine cannot.** A kernel dump's virtual addresses are translated through
@@ -75,8 +85,10 @@ an inbox component, which is why its stock engine resolves symbols with `_NT_SYM
 images do carry the Debugging Tools, `symsrv.dll` included, so on the ARM64 entry the missing half
 was already on disk — the job copies the kit's `dbghelp.dll` and `symsrv.dll` beside the binary
 under test and leaves `dbgeng.dll` stock, so what that entry exercises is still the image's own
-engine. Read any blanket statement about what "Windows ships" in this repo with that measurement
-in mind.
+engine. The copy runs on the `windows-11-vs2026-arm` entry too, without that image's System32
+having been probed: copying is what makes the entry independent of the answer, which is worth more
+across an image migration than a measurement a migration can invalidate. Read any blanket statement
+about what "Windows ships" in this repo with that measurement in mind.
 
 So they **ask the host** instead of guessing from `cfg!(target_arch)`, and each asks for the
 premise it actually has. `walk_memory` and the batch work on numeric addresses, so they need only


### PR DESCRIPTION
GitHub's Visual Studio 2026 ARM64 image went [generally available on 2026-08-20](https://github.blog/changelog/2026-08-20-windows-11-arm64-vs2026-image-generally-available/) as `windows-11-vs2026-arm`, and the `windows-11-arm` label is migrated onto it between **21 and 30 September 2026**. This adds a third `smoke-debugger` entry on the new label.

## Why a pair rather than a swap

What the migration changes for this job is not the compiler — the crate is Rust, and the x64 entry has been building against a VS2026 image ever since `windows-latest` migrated — but the **OS build**, and with it the inbox `dbgeng.dll` this tier exists to load: `10.0.26200.9168` on the new image against `.8875` on the old one, per the `actions/runner-images` readmes today.

So for as long as the two labels are two images, running both is what makes a break *attributable*: an entry that fails alone says the image moved, not the diff. The alternative is meeting that break on the migration date, on every PR at once, with nothing green beside it.

The entry has an expiry, and it is written down rather than left to memory: once the labels converge the pair buys a second run of the same tier, and the `windows-11-arm` entry should go (`FOLLOWUPS.md` item 32 — it is the older label whose meaning moved; the new one is the stable name for that image).

## What else the third entry forced

- **The cargo cache is keyed by `matrix.runner`, not `matrix.arch`.** Two ARM64 entries share an architecture, so the old key would have had them share one cache and restore each other's `target` directory — linked by a different MSVC.
- **The symbol copy (#153) runs on both ARM64 entries**, and what `windows-11-vs2026-arm`'s System32 holds is deliberately *not* measured: copying is what makes the entry independent of the answer, which is the property worth having across an image migration. `dbgeng.dll` is still left stock on both, so each entry goes on loading its own image's engine — the claim the matrix exists for (#134). The missing-kit `throw` now names the image it failed on, passed through the environment rather than interpolated into the script.
- **`fail-fast: false` now has a second reason on the record**: neither ARM64 entry may cancel the other, or the comparison the pair exists for is gone.
- Both images carry the same WDK build (`10.1.26100.6584`), so the kit path the copy step assumes holds on the new one too; if it stops holding, the step fails by name, which is what this pair is here to catch early.

The x64 entry keeps its exact check name `Smoke test (debugger tier)` — it is a required status check, and adding matrix entries is not a rename.

## Testing

Workflow and documentation only; no Rust changed. YAML parsed and the matrix confirmed to expand to `windows-latest`, `windows-11-arm`, `windows-11-vs2026-arm`; `markdownlint-cli2` clean over the linted globs. The real verification is this PR's own CI — the new entry reports here for the first time, and a green `Smoke test (debugger tier, arm64 vs2026)` is the result to read.

Docs updated: `CHANGELOG.md` (Unreleased), `docs/smoke-test.md` (the tier now runs three times), `FOLLOWUPS.md` item 32 (when and how to retire the pair).

---
_Generated by [Claude Code](https://claude.ai/code/session_01UgvNakcKUbmvhpuZh4ha29)_