### PR TITLE
Name the `limit` that returns everything, and keep a slow client's lease

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **A `modules` page names the `limit` that would return everything.** Driving the capped tool with
+  a local model found the trap the cap had introduced: the obvious value to raise `limit` to is the
+  count the note above the rows just gave (`227 module(s) loaded`), and that one is *guaranteed* to
+  fall short, because the budget is shared with the unloaded half - the model asked for 227, got 177
+  loaded rows and 50 unloaded ones, and had to fetch the table a second time. The note now reads
+  ``Showing the first 64 loaded row(s) - `limit: 277` returns all of them, or narrow with `filter`
+  to ask about one driver.`` Both halves' match counts are known where the note is built, so the sum
+  is too. Above the 2000-row ceiling there is no such value and the note says so rather than naming
+  one that would still be short. A re-run halved that task's cost, 146,359 characters to 70,929.
+
+- **`tools/local_model_drive.py` keeps its lease alive while the model thinks.** The same run found
+  something that is not about tokens at all: a lease is renewed by requests and its grace is derived
+  from how long a *call* may take, so it assumes the server is the slow party. A local model
+  inverts that - one turn took 440s against a 390s grace - and the sweep released the client's
+  sessions mid-investigation, after which every call returned `404 Session not found`, which reads
+  exactly like a broken server. The script now pings after 120s of silence
+  (`WINDBG_MCP_KEEPALIVE`, `0` disables). Whether the listener should also be more patient with a
+  still-connected client is [`FOLLOWUPS.md`](./FOLLOWUPS.md) item 33.
+
 - **`modules` answers with a page of the table rather than all of it** ([`FOLLOWUPS.md`](./FOLLOWUPS.md)
   item 24). It was the largest single answer this server gives - 53,933 B of model-visible JSON for
   227 modules, a fifth of a whole tool surface for one question, and on a local model a turn of

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -1,6 +1,6 @@
 # Follow-ups
 
-Deferred work, in sixteen clusters: items 1–6 come from the reachability-confirmation effort (path
+Deferred work, in seventeen clusters: items 1–6 come from the reachability-confirmation effort (path
 recipe + `run_to_address`, merged 2026-07-04), items 7–11 from surveying this server against the
 MCP `2026-07-28` extensions (tasks, apps), item 12 from the opener split
 (glslang/win-kexp#71, 2026-08-01), items 13–14 from the bounded-command coverage review
@@ -14,8 +14,10 @@ working (2026-08-17), item 24 from first measuring what this server costs the mo
 2026-08-18), item 27 from completing the coordinate work (#156–#158, 2026-08-18), items 28–29
 from giving each client its own sessions (#162, #164–#166, 2026-08-19), item 30 from serving
 the stateless revision concurrently (#168 / #169, 2026-08-19), item 31 from giving a service-hosted
-listener more than one client (2026-08-20), and item 32 from running the debugger tier on the
-ARM64 runner image that replaces `windows-11-arm` in September 2026. Each item notes its repo,
+listener more than one client (2026-08-20), item 32 from running the debugger tier on the
+ARM64 runner image that replaces `windows-11-arm` in September 2026, and item 33 from driving the
+server with a **local model** and finding the lease grace measured against the wrong slow party
+(2026-08-22). Each item notes its repo,
 why it was deferred, and where it picks up. See [`DECISIONS.md`](./DECISIONS.md) for the design rationale (D1–D5) items 1–6 extend,
 and the 2026-08-02 entries that items 13–14 and item 10 extend.
 
@@ -1180,3 +1182,33 @@ to the change under review, and what gives the repo notice before every PR meets
   `C:\Program Files (x86)\Windows Kits\10\Debuggers\arm64`, which both images carry today (the
   same WDK build, 10.1.26100.6584). It throws by name if that stops being true, which is the
   failure this pair is here to catch early rather than on the migration date.
+
+## 33. [windbg-mcp] The lease grace assumes the server is the slow party
+
+A client's lease is renewed by its requests, and the grace is derived from how long a *call* may
+take — which is the right bound when the thing that goes quiet is the server working. Driving a
+**local model** inverts it: a turn is the model thinking, with no request in flight, and one
+measured on this repo's own bench took **440s against a 390s grace** (2026-08-22,
+[`docs/local-model.md`](./docs/local-model.md)). The sweep released the client's sessions
+mid-investigation, and every later call came back `404 Session not found` — indistinguishable, from
+the caller's side, from a server that had fallen over.
+
+The client half is fixed: `tools/local_model_drive.py` pings after 120s of silence. That is the
+right layer for a *known* slow client, and it is not an answer for any other one — a client that
+does not know to ping is exactly the client this bites.
+
+- **The question:** should a lease be renewed by something other than a request — an MCP session
+  that is still connected, say? The pieces are already there: rmcp knows whether a session's stream
+  is live, and `Lease::admit` already refuses on two grounds before renewing. The risk is the
+  reason the lease exists at all: a client that vanished with a live kernel target open must not
+  hold it for ever, and "still connected" is exactly what a half-open TCP connection claims to be
+  ([`split-plane` phase 1's own argument](./docs/remote-listener.md)). So a connection is evidence,
+  not proof, and the shape that survives that is probably *a longer grace for a connected client*
+  rather than an exemption.
+- **Where it picks up:** `Lease` in `src/listen.rs`, and the startup floor in `Lease::new` that
+  makes "no request of that credential's can still be in flight when its lease expires" true. Any
+  change here has to keep that property — it is what lets the sweep zero nothing and wait for
+  nothing.
+- **What it is not:** a reason to raise the default grace. 390s is derived from the call timeout for
+  a reason, and a client that thinks for seven minutes is a fact about local models rather than
+  about this server.

--- a/docs/local-model.md
+++ b/docs/local-model.md
@@ -197,6 +197,56 @@ What this run does **not** cover: a long investigation where the transcript grow
 anything behind the allow-list (`execute`, `debug_batch`, `launch`), a smaller box where the served
 context is 4k or 32k, and any model but this one.
 
+## What the second run showed, after `modules` was capped
+
+Measured 22 August 2026, same model and bench, six tasks aimed at the row cap rather than at the
+surface: three about the module table and three of the first run's questions for comparison. Read
+the two runs' figures side by side with care — the first run's 53,772-character `modules` answer was
+a **different dump** (the ARM64 one, 177 modules) from this run's x64 sample (227 loaded, 50
+unloaded), so the honest like-for-like page-against-table pair is the smoke tier's, in
+[`token-budget.md`](./token-budget.md).
+
+| | |
+| --- | --- |
+| Prompt tokens, first turn of every task | 17,254–17,294 (surface now 69,552 B, the `limit` argument included) |
+| Tool picks | **10 calls across 6 tasks, all correct first try**, nothing refused |
+| Tool results, whole run | **94,758 characters** (~23.7k tokens), of which one module page is 68,571 |
+| "How many modules are loaded?" | answered **227**, from the opener's summary, with **no `modules` call at all** — 2,358 characters, 8.1s |
+| "Is `nvhda64v` present, and where?" | `modules { "filter": "nvhda64v" }` — **7,597 characters**, and the right answer: not loaded, 26 unload records |
+
+**The model never mistook a page for the inventory**, which was the risk the cap introduced. Asked
+for the whole table it called its own answer "the first page of loaded modules" and reported
+`227 loaded / 50 unloaded` from the counts; asked for a total it read the opener's summary and did
+not list anything at all.
+
+**But a guessed `limit` is still short, and that is the cap's own doing.** The model asked for
+`limit: 240` — a round number above the 227 it had been told — and got 190 loaded rows and 50
+unloaded ones, because the budget is shared between the halves. It did not need to ask again here,
+having the counts; a caller that did would have paid a third call. That is what the note's
+`` `limit: 277` returns all of them `` sentence is for, added the same day: **the number a reader
+takes from the line above the rows is guaranteed to fall short, so the note names the one that is
+not**.
+
+**The pre-fix run of the same tasks cost 146,359 characters on task 1 alone**, against 70,929 here,
+because the model fetched the table twice — once at a guessed limit and once with
+`filter: "*", limit: 2000`. A cap the caller has to negotiate is worse than no cap; a cap that says
+what to ask for next is not.
+
+### The failure that run found first, which was not about tokens at all
+
+The first attempt never reached task 2. The model spent **440.6s** composing an answer, the
+listener's lease grace is **390s**, and a lease is renewed by *requests* — so with nothing in
+flight the sweep released the client's sessions, and every later call came back
+`404 Session not found`, which reads exactly like a broken server.
+
+The grace is derived from how long a *call* may take: it assumes the **server** is the slow party.
+Driving a local model inverts that assumption, and nothing before this had met a client that goes
+quiet for seven minutes while still working. `tools/local_model_drive.py` now pings the listener
+after 120 seconds of silence (`WINDBG_MCP_KEEPALIVE`, `0` disables) — two pings carried that turn in
+the re-run, and every session was released cleanly at the end. Whether the *listener* should also
+be more patient with a client whose MCP session is still connected is
+[`FOLLOWUPS.md`](../FOLLOWUPS.md) item 33.
+
 ## What to measure
 
 The claims worth testing are about the *client's* budget, not this server's correctness, and the
@@ -210,8 +260,10 @@ written down rather than remembered:
   reachable in one careless call. `modules` was the other half of that and is **fixed** since
   2026-08-21: it answers with 64 rows unless a `limit` says otherwise, which on the checked-in
   kernel sample is 12,268 B of model context rather than 53,933 B, with `loaded` / `matched` still
-  reporting the whole inventory. The 169-second turn above was that call, and it should now cost
-  roughly a quarter of it — a measurement this page wants and does not have yet.
+  reporting the whole inventory. What that is worth in practice is the second run above, and it is
+  not the flat saving this bullet first predicted: a model asked for one driver pays 7,597
+  characters, a model asked for a total pays none at all, and a model asked for the whole table
+  still asks for the whole table.
 
 If a model does not cope, the remaining knobs are all **client-side** — a tool-surface profile, a
 per-call response budget, a text-or-data content switch. This server has none of them: every caller

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -1689,6 +1689,14 @@ fn listing_note(list: &structured::ModuleList) -> String {
 /// `filter`. It names `limit` rather than saying rows are missing, for the same reason
 /// `backtrace`'s truncation line names `frames` — an answer that stops short has to name the
 /// argument that undoes it.
+///
+/// **And it names the number**, which is the difference between one more call and two. The obvious
+/// value to reach for is the count the note above just gave — `227 module(s) loaded` — and that one
+/// is *guaranteed* to fall short, because the budget it goes into is shared with the unloaded half:
+/// a local model measured driving this asked for `limit: 227`, was given 177 loaded rows and 50
+/// unloaded ones, and had to ask a third time for the rest. Both halves are known here, so their
+/// sum is known here, and a caller who wants all of it should have to read it rather than derive
+/// it.
 fn truncation_note(list: &structured::ModuleList) -> Option<String> {
     let cut = (
         list.modules.len() < list.matched,
@@ -1696,7 +1704,7 @@ fn truncation_note(list: &structured::ModuleList) -> Option<String> {
     );
     let rows = match cut {
         (false, false) => return None,
-        (true, false) => format!("the first {} row(s)", list.modules.len()),
+        (true, false) => format!("the first {} loaded row(s)", list.modules.len()),
         (false, true) => format!("the first {} unloaded row(s)", list.unloaded.len()),
         (true, true) => format!(
             "the first {} loaded and {} unloaded row(s)",
@@ -1704,10 +1712,20 @@ fn truncation_note(list: &structured::ModuleList) -> Option<String> {
             list.unloaded.len()
         ),
     };
-    Some(format!(
-        "Showing {rows} — raise `limit` (up to {MAX_MODULE_ROWS}) to see the rest, or narrow with \
-         `filter`."
-    ))
+    // What it would take to see everything that matched. Past the ceiling there is no such value,
+    // and saying one would be worse than saying none: `filter` is the only way through from there.
+    let all = list.matched + list.unloaded_matched;
+    let rest = if all <= MAX_MODULE_ROWS as usize {
+        format!(
+            "`limit: {all}` returns all of them, or narrow with `filter` to ask about one driver"
+        )
+    } else {
+        format!(
+            "`limit` stops at {MAX_MODULE_ROWS}, short of the {all} that matched — narrow with \
+             `filter` to ask about one driver"
+        )
+    };
+    Some(format!("Showing {rows} — {rest}."))
 }
 
 /// Where the unloaded rows are, said wherever any of them are in the answer: above under their own
@@ -6079,12 +6097,14 @@ mod tests {
             "the inventory is what it always was:\n{text}"
         );
         assert!(
-            text.contains("Showing the first 2 row(s)"),
-            "and the listing says it is a part of it:\n{text}"
+            text.contains("Showing the first 2 loaded row(s)"),
+            "and the listing says it is a part of it, naming the half it counted — the unloaded \
+             row beside them is in the listing too:\n{text}"
         );
         assert!(
-            text.contains("raise `limit`"),
-            "an answer that stops short names the argument that undoes it:\n{text}"
+            text.contains("`limit: 4` returns all of them"),
+            "…and names the value that would: three loaded rows and one unloaded, so four — not \
+             the `3` a reader would take from the count above it:\n{text}"
         );
 
         // Nothing was cut, so nothing is said about a cut: the note a caller reads on every
@@ -6147,6 +6167,65 @@ mod tests {
         assert!(
             text.contains("Showing the first 1 loaded and 1 unloaded row(s)"),
             "both halves cut is one sentence naming both:\n{text}"
+        );
+        assert!(
+            text.contains("`limit: 253` returns all of them"),
+            "and the value that returns everything is both halves' matches, not either one's:\n{text}"
+        );
+    }
+
+    /// **The number a caller reaches for is the one that falls short**, which is why the note names
+    /// the other one. `227 module(s) loaded` is what the line above says, so `limit: 227` is what
+    /// gets asked for — and it buys 177 loaded rows and 50 unloaded ones, because the budget is
+    /// shared. A local model driving this server did exactly that and had to ask a third time
+    /// (`docs/local-model.md`).
+    #[test]
+    fn the_note_names_the_limit_that_returns_everything_not_the_one_that_falls_short() {
+        let listing = |limit: usize| {
+            let (for_loaded, for_unloaded) = split_row_budget(limit, 227, 50);
+            structured::ModuleList {
+                loaded: 227,
+                matched: 227,
+                unloaded_matched: 50,
+                filter: None,
+                modules: (0..for_loaded)
+                    .map(|i| structured::ModuleInfo::from(&module("drv", 0x1000 + i as u64 * 0x10)))
+                    .collect(),
+                unloaded: (0..for_unloaded)
+                    .map(|i| {
+                        structured::ModuleInfo::from(&unloaded_module(
+                            "gone.sys",
+                            0x9000 + i as u64 * 0x10,
+                        ))
+                    })
+                    .collect(),
+            }
+        };
+
+        // The default page, and the guess it invites.
+        let text = render_modules(&listing(64));
+        assert!(text.contains("227 module(s) loaded"), "{text}");
+        assert!(
+            text.contains("`limit: 277` returns all of them"),
+            "the whole listing is both halves, so the value is 227 + 50:\n{text}"
+        );
+
+        // The guess itself: still short, and still told what would not be.
+        let text = render_modules(&listing(227));
+        assert!(
+            text.contains("Showing the first 177 loaded row(s)"),
+            "the count from the line above does not buy the whole table — it buys 177 of the 227 \
+             loaded rows, the other 50 of the budget having gone to the unloaded half:\n{text}"
+        );
+        assert!(text.contains("`limit: 277` returns all of them"), "{text}");
+
+        // And that value does.
+        let whole = listing(277);
+        assert_eq!(whole.modules.len(), 227);
+        assert_eq!(whole.unloaded.len(), 50);
+        assert!(
+            truncation_note(&whole).is_none(),
+            "nothing was cut, so nothing is said about a cut"
         );
     }
 

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -4865,8 +4865,12 @@ fn a_module_listing_is_a_page_of_the_table_and_says_so() {
         text.contains(&format!(
             "Showing the first {}",
             first["modules"].as_array().map_or(0, Vec::len)
-        )) && text.contains("raise `limit`"),
-        "a listing that stops short says so, and says how to get the rest:\n{text}"
+        )) && text.contains(&format!(
+            "`limit: {}` returns all of them",
+            loaded + table["unloaded_matched"].as_u64().unwrap_or_default()
+        )),
+        "a listing that stops short says so, and names the value that returns everything — the \
+         count above it is the one that would fall short:\n{text}"
     );
     assert_eq!(
         listed_rows(&text),

--- a/tools/local_model_drive.py
+++ b/tools/local_model_drive.py
@@ -134,6 +134,9 @@ SESSION = None
 WIRE = threading.Lock()
 LAST_REQUEST = time.monotonic()
 KEEPALIVE_AFTER = float(os.environ.get("WINDBG_MCP_KEEPALIVE", "120"))
+# Set before the MCP session is deleted. Read *inside* `WIRE`, which is what makes the
+# ping and the `DELETE` a total order rather than two racing requests on one id.
+STOP = threading.Event()
 
 
 def parse(body, ctype):
@@ -147,7 +150,15 @@ def parse(body, ctype):
 
 
 def mcp(method, params=None, notify=False):
-    global SESSION
+    """One request, with the wire to itself."""
+    with WIRE:
+        return request(method, params, notify)
+
+
+def request(method, params=None, notify=False):
+    """The request itself. **The caller holds [`WIRE`]** — which the keepalive needs, because
+    its decision to ping and the ping itself have to be one atomic thing against teardown."""
+    global SESSION, LAST_REQUEST
     payload = {"jsonrpc": "2.0", "method": method}
     if not notify:
         payload["id"] = int(time.time() * 1000) % 100000
@@ -159,16 +170,14 @@ def mcp(method, params=None, notify=False):
     req.add_header("Accept", "application/json, text/event-stream")
     if SESSION:
         req.add_header("Mcp-Session-Id", SESSION)
-    global LAST_REQUEST
-    with WIRE:
-        with urllib.request.urlopen(req, timeout=600) as response:
-            if response.headers.get("Mcp-Session-Id"):
-                SESSION = response.headers["Mcp-Session-Id"]
-            body = parse(
-                response.read().decode("utf-8", "replace"), response.headers.get("Content-Type")
-            )
-        LAST_REQUEST = time.monotonic()
-        return body
+    with urllib.request.urlopen(req, timeout=600) as response:
+        if response.headers.get("Mcp-Session-Id"):
+            SESSION = response.headers["Mcp-Session-Id"]
+        body = parse(
+            response.read().decode("utf-8", "replace"), response.headers.get("Content-Type")
+        )
+    LAST_REQUEST = time.monotonic()
+    return body
 
 
 def keepalive():
@@ -179,15 +188,29 @@ def keepalive():
     renewed the lease all the same. It reports the first failure and then stays quiet:
     the run's own calls are what matter, and a keepalive that spammed the transcript
     would be worse than one that stopped.
+
+    **It must not outlive the session it is keeping alive.** A ping that is decided while
+    `close_transport_session` is deleting the id lands *after* the `DELETE`, and an id the
+    server has stopped recording is one any credential may present — so the listener takes
+    it back into this client's set and renews the lease around a session that no longer
+    exists, which is the pile-up the `DELETE` is there to prevent. Reading [`STOP`] and
+    [`SESSION`] inside [`WIRE`], and sending inside the same lock, is what stops that: the
+    ping either finished before teardown took the lock, or it never starts. Joining this
+    thread would do the same job and block on a request that may take as long as the call
+    timeout, for no more safety.
+
+    Reported by chatgpt-codex-connector on #184.
     """
     complained = False
-    while KEEPALIVE_AFTER > 0:
-        time.sleep(min(30.0, KEEPALIVE_AFTER / 2))
-        idle = time.monotonic() - LAST_REQUEST
-        if idle < KEEPALIVE_AFTER or SESSION is None:
-            continue
+    while KEEPALIVE_AFTER > 0 and not STOP.is_set():
+        if STOP.wait(min(30.0, KEEPALIVE_AFTER / 2)):
+            return
         try:
-            mcp("ping")
+            with WIRE:
+                idle = time.monotonic() - LAST_REQUEST
+                if STOP.is_set() or SESSION is None or idle < KEEPALIVE_AFTER:
+                    continue
+                request("ping")
             print(f"  keepalive: pinged the listener after {idle:.0f}s of thinking")
         except Exception as e:  # noqa: BLE001 - a keepalive must not end the run
             if not complained:
@@ -392,17 +415,21 @@ def close_transport_session():
     the lease that would have swept them. A `DELETE` is what the protocol provides.
     """
     global SESSION
-    if not SESSION:
-        return
-    req = urllib.request.Request(MCP_URL, method="DELETE")
-    req.add_header("Authorization", AUTH)
-    req.add_header("Mcp-Session-Id", SESSION)
-    try:
-        with urllib.request.urlopen(req, timeout=60) as response:
-            print(f"  closed the MCP session ({response.status})")
-    except Exception as e:
-        print(f"  could not close the MCP session: {e}")
-    SESSION = None
+    # Told before the lock is taken, so a keepalive already waiting for it re-reads this and
+    # stands down rather than pinging an id that is about to stop existing.
+    STOP.set()
+    with WIRE:
+        if not SESSION:
+            return
+        req = urllib.request.Request(MCP_URL, method="DELETE")
+        req.add_header("Authorization", AUTH)
+        req.add_header("Mcp-Session-Id", SESSION)
+        try:
+            with urllib.request.urlopen(req, timeout=60) as response:
+                print(f"  closed the MCP session ({response.status})")
+        except Exception as e:
+            print(f"  could not close the MCP session: {e}")
+        SESSION = None
 
 
 def release_what_this_run_opened():

--- a/tools/local_model_drive.py
+++ b/tools/local_model_drive.py
@@ -29,10 +29,21 @@ Configuration:
     WINDBG_MCP_SCENARIO treat the task list as one continuing investigation: one
                         transcript and one set of sessions across every task, rather
                         than a conversation and a target apiece
+    WINDBG_MCP_KEEPALIVE  seconds of silence after which this run pings the listener to
+                        keep its lease alive (default 120; `0` disables) — see below
+
+**Why the keepalive exists.** The listener releases a client's sessions when its lease
+runs out, and the grace is derived from how long a *call* may take, on the assumption
+that the server is the slow party. Driving a local model inverts that: a turn is the
+model thinking, with no request in flight, and one measured here took **440s against a
+390s grace** — so the sweep released the session mid-investigation and every later call
+came back `404 Session not found`, which reads exactly like a broken server. A ping
+during a long turn costs nothing and removes the whole class.
 """
 import json
 import os
 import sys
+import threading
 import time
 import urllib.request
 
@@ -118,6 +129,12 @@ AUTH = bearer()
 SCENARIO = bool(os.environ.get("WINDBG_MCP_SCENARIO"))
 SESSION = None
 
+# One request at a time on this MCP session: the keepalive below runs on its own thread,
+# and two requests sharing `SESSION` would race over the header it may hand back.
+WIRE = threading.Lock()
+LAST_REQUEST = time.monotonic()
+KEEPALIVE_AFTER = float(os.environ.get("WINDBG_MCP_KEEPALIVE", "120"))
+
 
 def parse(body, ctype):
     if "text/event-stream" in (ctype or ""):
@@ -142,10 +159,40 @@ def mcp(method, params=None, notify=False):
     req.add_header("Accept", "application/json, text/event-stream")
     if SESSION:
         req.add_header("Mcp-Session-Id", SESSION)
-    with urllib.request.urlopen(req, timeout=600) as response:
-        if response.headers.get("Mcp-Session-Id"):
-            SESSION = response.headers["Mcp-Session-Id"]
-        return parse(response.read().decode("utf-8", "replace"), response.headers.get("Content-Type"))
+    global LAST_REQUEST
+    with WIRE:
+        with urllib.request.urlopen(req, timeout=600) as response:
+            if response.headers.get("Mcp-Session-Id"):
+                SESSION = response.headers["Mcp-Session-Id"]
+            body = parse(
+                response.read().decode("utf-8", "replace"), response.headers.get("Content-Type")
+            )
+        LAST_REQUEST = time.monotonic()
+        return body
+
+
+def keepalive():
+    """Renews this client's lease while the model is thinking.
+
+    An **admitted** request is what renews a lease, and the JSON-RPC body does not enter
+    into it — so this pings, and a server that answered the ping with an error would have
+    renewed the lease all the same. It reports the first failure and then stays quiet:
+    the run's own calls are what matter, and a keepalive that spammed the transcript
+    would be worse than one that stopped.
+    """
+    complained = False
+    while KEEPALIVE_AFTER > 0:
+        time.sleep(min(30.0, KEEPALIVE_AFTER / 2))
+        idle = time.monotonic() - LAST_REQUEST
+        if idle < KEEPALIVE_AFTER or SESSION is None:
+            continue
+        try:
+            mcp("ping")
+            print(f"  keepalive: pinged the listener after {idle:.0f}s of thinking")
+        except Exception as e:  # noqa: BLE001 - a keepalive must not end the run
+            if not complained:
+                complained = True
+                print(f"  keepalive: could not ping ({e}); the lease is on its own now")
 
 
 def handshake():
@@ -394,6 +441,7 @@ def main():
     MODEL = pick_model()
     print(f"model: {MODEL}")
     print("MCP revision negotiated:", handshake())
+    threading.Thread(target=keepalive, daemon=True).start()
     tools = mcp("tools/list")["result"]["tools"]
     offered = as_ollama(tools)
     surface = len(json.dumps(offered, separators=(",", ":")))


### PR DESCRIPTION
Follow-up to #183, and both halves come from driving the newly-capped `modules` with a **local
model** (`tools/local_model_drive.py`, a 27.8B build served at 262k) rather than from a test. Each
is a defect that a smoke tier cannot see, because both need a caller that reasons about the answer
and then goes quiet.

## 1. The note names the number now

The cap gave a caller two ways forward — raise `limit`, or narrow with `filter` — and the obvious
value to raise it *to* is the count the note above the rows just gave. That value is **guaranteed
to fall short**, because the budget is shared with the unloaded half. Measured:

```
modules { limit: 227 }   -> 177 loaded + 50 unloaded rows   (64,823 chars)
modules { filter: "*", limit: 2000 } -> the whole table     (79,178 chars)
```

**146,359 characters for one question**, where the uncapped server would have cost ~79,000. A cap
the caller has to negotiate is worse than no cap. Both halves' match counts are known where the
note is built, so their sum is too:

> Showing the first 64 loaded row(s) — `limit: 277` returns all of them, or narrow with `filter` to
> ask about one driver.

Above the 2000-row ceiling no such value exists, and the note says that rather than naming one that
would still be short. The single-half sentence also names **which** half it counted: "the first 177
row(s)" under a listing that had printed 227 of them was ambiguous, and my own test caught it by
asserting the wrong branch.

Re-run of the same task: **70,929 characters, one call instead of two.**

## 2. The bench keeps its lease alive

The first attempt never reached task 2. A lease is renewed by *requests*, and its grace is derived
from how long a **call** may take — so it assumes the server is the slow party. A local model
inverts that:

```
06:04:35  modules(filter:"*", limit:2000) — the last request
06:11:09  the lease of client `driver` ran out; releasing the sessions it left open
06:11:55  next request -> 404 Session not found
```

440.6s of thinking against a 390s grace. The sessions were swept mid-investigation and every later
call `404`'d, which from the caller's side is indistinguishable from a server that fell over — the
model's own answer for the remaining tasks was "the debugger backend is unreachable".

`tools/local_model_drive.py` now pings after 120s of silence (`WINDBG_MCP_KEEPALIVE`, `0` disables),
on its own thread behind a lock so it cannot race a real request over the `Mcp-Session-Id`. Any
*admitted* request renews a lease whatever its JSON-RPC body says, so even a ping an older server
refused would still do the job.

Whether the **listener** should also be more patient with a still-connected client is
`FOLLOWUPS.md` item 33, filed as a question rather than a fix: "still connected" is also what a
half-open TCP connection claims, and holding a live kernel target on that basis is the failure the
lease exists to prevent.

## What the re-run showed

| | before | after |
| --- | ---: | ---: |
| tasks completed | 1 of 6 | **6 of 6** |
| tool calls, all correct first try | 3, then `404`s | **10** |
| task 1 ("which modules are loaded") | 146,359 chars | **70,929** |
| whole run's tool results | — | 94,758 chars (~23.7k tokens) |

The risk the cap introduced — a model mistaking a page for the inventory — did not materialise:

- *"How many modules are loaded in total?"* → **227, off the opener's summary, with no `modules`
  call at all** (2,358 chars, 8.1s).
- *"Is `nvhda64v` present, and where?"* → `modules { filter: "nvhda64v" }`, 7,597 chars, correct:
  not loaded, 26 unload records.
- Asked for the whole table it called its own output "the first page of loaded modules" and
  reported `227 loaded / 50 unloaded` from the counts.

`docs/local-model.md` records the run, and corrects a comparison I had invited: the first run's
53,772-character `modules` figure was a **different dump** (the ARM64 one, 177 modules), so the two
runs' headline numbers are not a like-for-like pair. The tier's page-against-table measurement is.

## Verification

On the ARM64 bench: `cargo clippy --all-targets -- -D warnings` clean, `cargo fmt --all --check`
clean, **482 unit tests**, **68 smoke tests** with `WINDBG_MCP_SMOKE_DUMP=1` and no `SKIPPED` lines.
A new unit test walks the exact trap: `limit: 64` names 277, `limit: 227` gives 177 loaded rows and
names 277 again, `limit: 277` truncates nothing. No tool-surface change — the note is result text,
and the tier's `modules` wire figure moved 16,871 → 16,885 B for the longer sentence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
