### PR TITLE
Say how a service-hosted listener gets a second client, and file the gap

### DIFF
--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -1228,16 +1228,40 @@ the documented one, is a second *foreground* listener on another port with its o
 ([`docs/local-model.md`](./docs/local-model.md)); this item is about the case where the service is
 the listener you have.
 
-- **What to build:** `--add-listen-client <name>` and `--rotate-listen-client <name>`, writing the
-  file the way `finish_install` does — remove, `create_new`, re-apply the ACL — and **generating the
-  token itself**, printing only a fingerprint (`sha256:701E4CF3…`). Three things fall out of that:
-  no reinstall, no secret through a shell history or an agent's transcript, and an operation narrow
-  enough to allow-list in a permission rule, where "let this write `%ProgramData%` over ssh" is not.
-- **The awkward part, and the reason this is not trivial:** `Credentials` is built once at startup
-  (`client::Credentials::from_entries`), so a client added while the service runs would not be
-  admitted until the next start. Either the command says so plainly, or the service grows a control
-  code that re-reads the file — and *that* wants care, because re-reading a credential store at
-  runtime is a way to lose the property that the file was created by the installer and never reused.
+**The reinstall is not a decision anyone made** — it is what falls out of there being no writer but
+the installer. Two properties *were* chosen deliberately, and neither of them requires it: "only the
+installer writes this file" becomes "only **this program**, running elevated, writes it", since the
+command below is the same binary; and "never write through a file it did not create" survives a
+fresh temp created with `create_new` in the same protected directory and renamed over the old one.
+So the hardening and the fix are compatible, which is the reason to build the fix rather than
+document the dance.
+
+- **What to build, and it is three commands rather than one:** `--add-listen-client <name>`,
+  `--remove-listen-client <name>` and `--rotate-listen-client <name>`. Rotation is the one with a
+  schedule attached — rotating the *only* credential is today's same uninstall/reinstall — and
+  removal is what keeps a bench credential from outliving the bench. Each writes the file the way
+  `finish_install` does (a fresh file, `create_new`, the same ACL re-applied), **generates the token
+  itself**, and prints only a fingerprint (`sha256:701E4CF3…`). Three things fall out: no reinstall,
+  no secret through a shell history or an agent's transcript, and an operation narrow enough to
+  allow-list in a permission rule, where "let this write `%ProgramData%` over ssh" is not.
+- **The reload is the other half, not a footnote.** `Credentials` is built once at startup
+  (`client::Credentials::from_entries`), so a client added under a running service is not admitted
+  until the next start — and a *restart* still drops every session, which is most of what makes the
+  reinstall unfriendly in the first place. Without a live reload this item is an improvement in
+  ergonomics and not in outcome. Preferred mechanism: a **user-defined service control code** the
+  command sends after writing, which is explicit, needs no background watcher, and fits the plumbing
+  that already handles Stop and Preshutdown. A file watcher is the alternative and costs more: it
+  needs the writes to be atomic to be safe, and it mainly serves hand-editing, which the ACL is
+  there to discourage. Removing a client that still holds sessions is its own decision — refuse, or
+  release them down the path the lease sweep already uses.
 - **What not to do:** relax the ACL, or teach the installer to update in place. The refusal to write
   through a file it did not create is what stops an unprivileged user pre-creating the path and
   ending up owning the credential.
+- **The second listener is a development workflow, and stays one.** The recipe in
+  [`docs/local-model.md`](./docs/local-model.md) is right for a bench — a borrowed box with no
+  administrator, a credential that should vanish with the process, a run that must not share a
+  process with the listener an editor depends on, a build that is not the installed one — and every
+  one of those is a *developer's* problem. It is not an operator's answer and must not become one:
+  **if someone running a deployed listener ever has to start a second one to add a client, these
+  commands are incomplete.** That is the bar to build against, and the reason the reload above is
+  not optional.

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -16,8 +16,8 @@ from giving each client its own sessions (#162, #164–#166, 2026-08-19), item 3
 the stateless revision concurrently (#168 / #169, 2026-08-19), item 31 from giving a service-hosted
 listener more than one client (2026-08-20), item 32 from running the debugger tier on the
 ARM64 runner image that replaces `windows-11-arm` in September 2026, and item 33 from driving the
-server with a **local model** and finding the lease grace measured against the wrong slow party
-(2026-08-22). Each item notes its repo,
+server with a **local model** and finding the lease grace measured against the wrong slow party,
+and item 34 from the same run finding a service's clients fixed at install time (both 2026-08-22). Each item notes its repo,
 why it was deferred, and where it picks up. See [`DECISIONS.md`](./DECISIONS.md) for the design rationale (D1–D5) items 1–6 extend,
 and the 2026-08-02 entries that items 13–14 and item 10 extend.
 
@@ -1212,3 +1212,32 @@ does not know to ping is exactly the client this bites.
 - **What it is not:** a reason to raise the default grace. 390s is derived from the call timeout for
   a reason, and a client that thinks for seven minutes is a fact about local models rather than
   about this server.
+
+## 34. [windbg-mcp] A service-hosted listener's clients are fixed at install time
+
+`--install-service` is the **only** writer of `%ProgramData%\windbg-mcp\token`, and it leaves the
+file granting `SYSTEM` and `Administrators` *read* — deliberately, since the token is the one thing
+between an unprivileged local process and `launch` running its command line as `LocalSystem`. The
+SCM then refuses a second registration under the same name. So adding or rotating a client means
+`--uninstall-service`, set every credential variable again, `--install-service`, `Start-Service` —
+which **drops every session the service holds**, a parked kernel attach included.
+
+Found the hard way (2026-08-22): giving a local-model bench a credential of its own turned into an
+attempt to edit that file, which failed on the ACL — correctly. The fallback that worked, and is now
+the documented one, is a second *foreground* listener on another port with its own token
+([`docs/local-model.md`](./docs/local-model.md)); this item is about the case where the service is
+the listener you have.
+
+- **What to build:** `--add-listen-client <name>` and `--rotate-listen-client <name>`, writing the
+  file the way `finish_install` does — remove, `create_new`, re-apply the ACL — and **generating the
+  token itself**, printing only a fingerprint (`sha256:701E4CF3…`). Three things fall out of that:
+  no reinstall, no secret through a shell history or an agent's transcript, and an operation narrow
+  enough to allow-list in a permission rule, where "let this write `%ProgramData%` over ssh" is not.
+- **The awkward part, and the reason this is not trivial:** `Credentials` is built once at startup
+  (`client::Credentials::from_entries`), so a client added while the service runs would not be
+  admitted until the next start. Either the command says so plainly, or the service grows a control
+  code that re-reads the file — and *that* wants care, because re-reading a credential store at
+  runtime is a way to lose the property that the file was created by the installer and never reused.
+- **What not to do:** relax the ACL, or teach the installer to update in place. The refusal to write
+  through a file it did not create is what stops an unprivileged user pre-creating the path and
+  ending up owning the credential.

--- a/docs/local-model.md
+++ b/docs/local-model.md
@@ -53,6 +53,40 @@ argument, the same rule the listener's own token follows:
 WINDBG_MCP_TOKEN="<the driver's token>" python3 tools/local_model_drive.py [tasks.json]
 ```
 
+### Give the run its own listener, not a share of yours
+
+**A credential of its own is the requirement; a listener of its own is how to get one.** The script
+refuses to run on the token your editor is registered with, because a shared credential is a shared
+namespace: the run would see, route to, and at the four-session cap cause the reclamation of your
+targets. And a *service*-hosted listener cannot be given a second client without an uninstall and a
+reinstall, which drops every session it is holding ([`remote-listener.md`](./remote-listener.md#adding-or-rotating-a-client-afterwards-costs-a-reinstall)).
+Neither of those is a thing to do for a measurement.
+
+A foreground listener on a second port costs nothing and disappears when you close it. Generate the
+token on the machine that will *use* it, and pass it over **stdin** — never on a command line, where
+every process on the box can read it:
+
+```pwsh
+# on the debug host, from a script run over ssh with the token on stdin:
+$token = [Console]::In.ReadToEnd().Trim()
+Remove-Item Env:WINDBG_MCP_LISTEN_TOKEN -ErrorAction SilentlyContinue  # no second `local`
+$env:WINDBG_MCP_LISTEN_TOKEN_DRIVER = $token
+& <path>\windbg-mcp.exe --listen 127.0.0.1:8766
+```
+
+```console
+# on your machine
+python3 -c "import secrets;print(secrets.token_urlsafe(32))" > driver.token   # mode 600
+cat driver.token | ssh <vm> 'powershell -NoProfile -File C:\path\start-driver-listener.ps1' &
+ssh -N -L 8766:127.0.0.1:8766 <vm> &
+WINDBG_MCP_URL=http://127.0.0.1:8766/ WINDBG_MCP_TOKEN="$(cat driver.token)" \
+  python3 tools/local_model_drive.py tasks.json
+```
+
+The listener's startup line names the clients it holds — `clients: driver` and nothing else is the
+check that the recipe worked. Sessions belong to the listener process that opened them, so this run
+and your editor's cannot reach each other's even by accident.
+
 It executes only a **read-only allow-list**, and reports anything else back to the model as refused.
 That is deliberate: the surface includes `execute` and `launch`, and a debug host is the wrong place
 to discover unattended what a model does with them — but a wrong pick is still *measured*, which is

--- a/docs/remote-listener.md
+++ b/docs/remote-listener.md
@@ -409,6 +409,35 @@ because the SCM registers a service once and a bad credential then fails it at e
 `windbg-mcp.exe --uninstall-service` removes it, stopping it first and waiting for it — a delete
 issued against a running service only marks it, and this one has debug targets to let go of.
 
+### Adding or rotating a client afterwards costs a reinstall
+
+**There is no command for it, and the file is not yours to edit.** The install is the only writer of
+`%ProgramData%\windbg-mcp\token`, and it leaves the file granting `SYSTEM` and `Administrators`
+**read** — so an administrator who tries to add a client by editing it is told `Access to the path
+is denied`, which is the ACL working rather than something to route around. Taking ownership to
+write it anyway leaves a credential owned by whoever did that, which is the reason the installer
+refuses to reuse a file it did not create.
+
+The SCM refuses a second registration under the same name, so the whole procedure is:
+
+```pwsh
+windbg-mcp.exe --uninstall-service                        # stops it; every session goes
+$env:WINDBG_MCP_LISTEN_TOKEN = "<the existing one>"       # keep it, or clients stop working
+$env:WINDBG_MCP_LISTEN_TOKEN_CI = "<the new one>"
+windbg-mcp.exe --install-service --listen 127.0.0.1:8765
+Start-Service windbg-mcp
+```
+
+**That drops every session the service holds** — a parked kernel attach included — so it is a
+planned outage rather than an incremental change, and it is worth knowing before the moment you
+need a second client. [`FOLLOWUPS.md`](../FOLLOWUPS.md) item 34 is the CLI that would make it one.
+
+**For a short-lived credential, do not touch the service at all.** A bench, a driver script, a
+one-off measurement: run a *second, foreground* listener on another port with its own token, which
+needs no privileged write and disappears when you close it — [Driving it with a local model](#driving-it-with-a-local-model)
+has the recipe. Two listeners on one host is a normal arrangement; sessions belong to a listener's
+own process, so the two cannot see each other's.
+
 **Stopping is graceful, and that is the point.** `Stop-Service` takes the same path a client
 disconnect takes: every session is asked to release its target before the process exits, and the SCM
 is given a wait hint that covers it rather than being left to assume the default and kill us

--- a/docs/remote-listener.md
+++ b/docs/remote-listener.md
@@ -430,11 +430,15 @@ Start-Service windbg-mcp
 
 **That drops every session the service holds** — a parked kernel attach included — so it is a
 planned outage rather than an incremental change, and it is worth knowing before the moment you
-need a second client. [`FOLLOWUPS.md`](../FOLLOWUPS.md) item 34 is the CLI that would make it one.
+need a second client. It is also not a design decision: the installer is simply the only thing that
+writes that file, and [`FOLLOWUPS.md`](../FOLLOWUPS.md) item 34 is the `--add-listen-client` /
+`--remove-listen-client` / `--rotate-listen-client` that would make this incremental — together with
+the live reload that has to come with them, since a *restart* would still cost you the sessions.
 
-**For a short-lived credential, do not touch the service at all.** A bench, a driver script, a
-one-off measurement: run a *second, foreground* listener on another port with its own token, which
-needs no privileged write and disappears when you close it — [Driving it with a local model](#driving-it-with-a-local-model)
+**For a short-lived credential, do not touch the service at all** — though this is a *development*
+workflow rather than something to operate a deployment with. A bench, a driver script, a one-off
+measurement: run a *second, foreground* listener on another port with its own token, which needs no
+privileged write and disappears when you close it — [Driving it with a local model](#driving-it-with-a-local-model)
 has the recipe. Two listeners on one host is a normal arrangement; sessions belong to a listener's
 own process, so the two cannot see each other's.
 


### PR DESCRIPTION
Stacked on #184 (base is `modules-limit-note`; GitHub retargets it to `main` when that merges).
Docs and one follow-up item — no code.

## What this is about

Giving the local-model bench a credential of its own, during #184's work, turned into an attempt to
edit `%ProgramData%\windbg-mcp\token`. It failed with `Access to the path is denied`, which is the
ACL working exactly as designed: `finish_install` grants `SYSTEM` and `Administrators` **read**, and
that token is the only thing between an unprivileged local process and `launch` running its command
line as `LocalSystem`. Nothing in the docs said so, and nothing said what to do instead.

## `docs/remote-listener.md` — the procedure that actually exists

A new section under the service instructions: the install is the only writer of that file, the SCM
refuses a second registration under the same name, so adding or rotating a client is

```
--uninstall-service  →  set every credential variable again  →  --install-service  →  Start-Service
```

and **that drops every session the service holds**, a parked kernel attach included. It also says
plainly that taking ownership to write the file anyway leaves a credential owned by whoever did
that — which is the reason the installer refuses to reuse a file it did not create.

## `docs/local-model.md` — a listener of its own for bench work

The page showed registration against the service and mentioned the driver credential only in
passing. It now leads with the arrangement every measurement on it actually used: a **foreground
listener on a second port**, its token generated on the machine that will use it and passed over
**stdin** rather than a command line, with `clients: driver` in the startup line as the check that
it worked. No privileged write, and it disappears when you close it.

## `FOLLOWUPS.md` item 34

`--add-listen-client <name>` / `--rotate-listen-client <name>`: write the file the way
`finish_install` does (remove, `create_new`, re-apply the ACL), generate the token in place, print
only a fingerprint. That makes the operation incremental, keeps the secret out of a shell history or
an agent transcript, and is narrow enough to allow-list in a permission rule where "write
`%ProgramData%` over ssh" never could be.

The item also carries the part that makes it non-trivial rather than pretending it is a small
change: `Credentials` is built once at startup, so a client added under a running service is not
admitted until the next start — either the command says that, or the service grows a control code to
re-read, and re-reading a credential store at runtime risks the property that the file was created
by the installer and never reused. And it names what *not* to do: relax the ACL, or teach the
installer to write in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
