### PR TITLE
Hand the token-budget work over: the traps, not just the result

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,6 +93,13 @@ win-kexp = { path = "../win-kexp" }
 ```
 `git checkout -- Cargo.toml Cargo.lock` afterwards.
 
+**A green win-kexp PR says nothing about Miri**, since 2026-08-22: it is by far the longest job
+there (9 minutes median against `ci.yml`'s 1) and had never failed in a hundred runs, so it runs on
+the merge to `main`, weekly for nightly-toolchain drift, and on `workflow_dispatch` — **not** on
+pull requests. Dispatch it against the branch when a change touches unsafe code; the alternative is
+`main` going red after your merge. A path filter was measured and rejected there, and the workflow's
+own header says why, so it is not worth re-proposing.
+
 **Both repos require an approving review**, and a solo maintainer cannot self-approve, so a green
 PR still needs `gh pr merge --admin`. In this harness that call is refused by the permission
 classifier — so **the human merges**, and an agent's job ends at "green and waiting". Plan the two
@@ -559,6 +566,14 @@ Two things worth knowing when using it here:
   exists only inside a worker reaches the transcript only if it crosses the pipe as a value — which
   is the same rule as everything else in `src/structured.rs`, and the reason `debug_batch` grew a
   typed report.
+- **It is also how you measure what an answer is *made of*.** With
+  `WINDBG_MCP_TRANSCRIPT_MAX_FIELD=0` the whole structured payload is kept, so one debugger-tier run
+  leaves every tool's `data` on disk to be counted field by field — no probe to write, no code to
+  add. Do that before optimising a result, because reading the source predicts the wrong half:
+  `registers` was blamed in `docs/token-budget.md` for `"kind":"int"` and `"subregister":false`
+  scaffolding, which is real and is 41% of it, while the actual bulk was 64 rows of the vector bank
+  that the default filter was written to exclude and did not (2026-08-22). One run of the tier
+  answered both questions in a form nothing else in this repo can produce.
 - **`windbg-mcp --render-cast <transcript.jsonl>`** turns one into an asciicast. That is the
   supported way to produce the recordings under `examples/` and `docs/` — the older ones are
   hand-reconstructed and say so, and a new walkthrough should not add another.

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -9,17 +9,16 @@ from transactional batches (#82, 2026-08-09/10 — item 17 is what validating th
 session's own transcript turned up, and item 18 what reviewing it did), item 19 from
 `walk_memory` (#103, 2026-08-13), items 20–22 from standing the server up on an ARM64 guest
 (#131, #132, #134, 2026-08-16), item 23 from making the listener usable rather than merely
-working (2026-08-17), item 24 from first measuring what this server costs the model driving it
-(2026-08-17), items 25–26 from giving the debugger tier an ARM64 *target* (#143, #152,
+working (2026-08-17), items 24 and 35 from measuring what this server costs the model driving it —
+the surface and the results first (2026-08-17), and then what a `registers` answer is actually made
+of (2026-08-22) — items 25–26 from giving the debugger tier an ARM64 *target* (#143, #152,
 2026-08-18), item 27 from completing the coordinate work (#156–#158, 2026-08-18), items 28–29
 from giving each client its own sessions (#162, #164–#166, 2026-08-19), item 30 from serving
 the stateless revision concurrently (#168 / #169, 2026-08-19), item 31 from giving a service-hosted
 listener more than one client (2026-08-20), item 32 from running the debugger tier on the
-ARM64 runner image that replaces `windows-11-arm` in September 2026, and item 33 from driving the
-server with a **local model** and finding the lease grace measured against the wrong slow party,
-item 34 from the same run finding a service's clients fixed at install time, and item 35 from
-measuring what a `registers` answer is actually made of and finding the engine could not say (all
-2026-08-22). Each item notes its repo,
+ARM64 runner image that replaces `windows-11-arm` in September 2026, and items 33–34 from driving
+the server with a **local model** — the lease grace measured against the wrong slow party, and a
+service's clients fixed at install time (both 2026-08-22). Each item notes its repo,
 why it was deferred, and where it picks up. See [`DECISIONS.md`](./DECISIONS.md) for the design rationale (D1–D5) items 1–6 extend,
 and the 2026-08-02 entries that items 13–14 and item 10 extend.
 

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -112,7 +112,7 @@ The worry that a symbol condition silences assertions passing today is settled r
 the x64 entry reads `mm_exploit_v5.exe` out of `SeAuditProcessCreationInfo`, a walk through `nt`'s
 types that cannot happen without its PDB, and its run shows all four *running* rather than skipping.
 
-**The sample they open follows the host.** Three dumps are checked in (below), and the two crashes
+**The sample they open follows the host.** Four dumps are checked in (below), and the two crashes
 a *memory* read is asserted against are paired with the architecture the tests are running on — so
 an ARM64 run reads an ARM64 target, which is coverage this suite has nowhere else
 ([#143](https://github.com/glslang/windbg-mcp/issues/143)). That pairing is a choice about what to
@@ -252,6 +252,22 @@ figures under `--nocapture`, which on this sample reads `12268 B model / 16871 B
 default page, against 53933 B / 74052 B for all 227 modules` — the same dump
 [`token-budget.md`](./token-budget.md) records its baseline against, so the two can be read
 together.
+
+**`registers` gets the same treatment, and its test runs against this host's own architecture.** A
+default answer is documented as the integer registers, excluding the x87 and vector ones — and it
+carried 64 of them, because DbgEng exposes `xmm0` twice and leaves the subregister flag clear on the
+four 32-bit lanes it calls `xmm0/0` … `xmm0/3`. The tier asserts no default row's name carries the
+`/` that names a lane, that no row spends bytes on `"subregister":false`, and that the default is a
+**subset of `all`** — the last because a rule that dropped a register from both answers would
+satisfy every size check here while losing a caller the register they asked for.
+
+It opens the crash paired with this host's architecture — *The sample they open follows the host*,
+above — rather than the shared x64 dump, on purpose: the rule is a naming
+convention, and a convention that held on one architecture and not the other would cost the saving
+silently on half the runners. That is not hypothetical — running it that way is what found ARM64
+carrying `w0`–`w30` for the same reason and under a different name, which is
+[`FOLLOWUPS.md`](../FOLLOWUPS.md) item 35, measured and declined. The test deliberately asserts
+nothing about the ARM64 shape: it is a measured cost, not a settled contract.
 
 It also triages the dump's bug check (`crash_triage`), which is the one place the tier depends on
 the sample being a *crash* dump rather than any dump: the `0x9F` code and its four parameters read

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -258,8 +258,11 @@ default answer is documented as the integer registers, excluding the x87 and vec
 carried 64 of them, because DbgEng exposes `xmm0` twice and leaves the subregister flag clear on the
 four 32-bit lanes it calls `xmm0/0` … `xmm0/3`. The tier asserts no default row's name carries the
 `/` that names a lane, that no row spends bytes on `"subregister":false`, and that the default is a
-**subset of `all`** — the last because a rule that dropped a register from both answers would
-satisfy every size check here while losing a caller the register they asked for.
+**subset of `all`** — the last catching the two answers being computed by rules that have drifted
+apart, a row the default has and `all` does not. It does **not** catch a register dropped from
+both, which leaves the subset relation intact; that needs an oracle from outside the pair, and it
+is a separate assertion that the instruction and stack pointers are still there under whichever
+names this architecture gives them.
 
 It opens the crash paired with this host's architecture — *The sample they open follows the host*,
 above — rather than the shared x64 dump, on purpose: the rule is a naming

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -4862,13 +4862,29 @@ fn a_default_register_set_leaves_out_the_vector_bank_on_this_architecture() {
         plain.len()
     );
     // The property that makes the default a *narrowing* rather than a different answer: everything
-    // in it is in `all` too. A rule that excluded a register from both would satisfy every size
-    // check here and quietly lose a caller the register they asked for by name.
+    // in it is in `all` too. This catches the two answers being computed by rules that have drifted
+    // apart — a row the default has and `all` does not — and **not** a register dropped from both,
+    // which leaves the subset relation intact. That case needs an oracle from outside the pair, and
+    // it is the assertion below (reported by chatgpt-codex-connector on #188).
     let missing: Vec<_> = plain.iter().filter(|name| !all.contains(name)).collect();
     assert!(
         missing.is_empty(),
         "the default has to be a subset of `all`; these are in one and not the other: {missing:?}"
     );
+
+    // The oracle: whatever else a filter drops, it may not drop the two registers every caller of
+    // this tool came for. Named per architecture rather than derived, because deriving them from
+    // the answer is what a broken filter would break — and both names are checked so this test
+    // stays honest on whichever host runs it.
+    for wanted in [["rip", "pc"], ["rsp", "sp"]] {
+        assert!(
+            wanted
+                .iter()
+                .any(|name| plain.iter().any(|got| got == name)),
+            "a default register set that has lost {wanted:?} is not a narrowing, it is a hole — \
+             and `all` would still be a superset of it. Got: {plain:?}"
+        );
+    }
 }
 
 /// **What one `modules` call costs the caller, and what a cut listing still tells them.**


### PR DESCRIPTION
The handoff pass for #183–#187, audited against the code rather than against the previous draft of
each sentence. Docs only.

## `FOLLOWUPS.md`

The header attributed item 35 to the local-model cluster it did not come from — it came from
measuring a `registers` answer, which is item 24's — and the sentence had lost its grammar to two
rounds of appending. Clusters re-counted after the edit: still seventeen, and all 35 items have
headings.

## `docs/smoke-test.md`

- **The debugger tier gained a `registers` test in #186 and this file never heard about it.** It now
  says what the test claims: no `/` lane in a default answer, no bytes spent on
  `"subregister":false`, and the default a **subset** of `all` — that last because a rule dropping a
  register from *both* answers would satisfy every size check here while losing a caller the
  register they asked for.
- Why it opens the architecture-paired dump rather than the shared x64 one: the rule is a naming
  convention, and running it that way is exactly what found ARM64 carrying `w0`–`w30` for the same
  reason under a different name.
- **"Three dumps are checked in" was four**, and had been since the ARM64 driver crash landed in
  #154.
- A `[NATIVE_SAMPLE](#tiers)` link I had written an hour earlier pointed at a table that does not
  define it. It names the paragraph that does.

## `CLAUDE.md`

- **The transcript measures what an answer is made of** — the most transferable thing this work
  produced, and it was nowhere. `WINDBG_MCP_TRANSCRIPT_MAX_FIELD=0` keeps whole payloads, so one
  debugger-tier run leaves every result on disk to be counted field by field, with no probe to write.
  It is worth doing *before* optimising a result, because reading the source predicts the wrong half:
  `registers`' bulk was not the scaffolding `token-budget.md` blamed (41%) but 64 rows of the vector
  bank its own filter was written to exclude (44%).
- **A green win-kexp PR now says nothing about Miri.** Since glslang/win-kexp#116 it runs on merge,
  weekly, and on dispatch — so an agent reading green as "fully checked" is wrong there, and the fix
  is to dispatch it against the branch when the change touches unsafe code.

## Outside the repo

The split-plane plan artifact is updated to match: phase 4 moves from *measured, not built* to
*under way*, section 00 records that the first response budget landed **in the tool rather than in
the proxy**, and section 07 gains what came of its own prediction — the two figures, and the two
lessons a real local model taught (a cap the caller has to negotiate is worse than no cap; a lease
grace measures the wrong slow party).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
