### PR TITLE
Change a service listener's clients without stopping it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,9 +40,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   client is refused: a listener with no credentials will not start, and `--uninstall-service` is the
   command that means "stop serving".
 
-  A reload that cannot read the file **changes nothing** — the set is only ever replaced by one that
-  would have started this listener from cold, so a typo is a loud log line and a service still
-  serving, rather than every client locked out of a live kernel target.
+  The command **waits for the reload**, so the set in force when it returns is the set it wrote — the
+  control handler blocks on the reload task's answer and reports a failed re-read as a failed
+  control code. A reload that cannot read the file **changes nothing**: the set is only ever
+  replaced by one that would have started this listener from cold, so a typo is a loud log line and
+  a service still serving, rather than every client locked out of a live kernel target. That failure
+  is reported as an **error** for a `--remove` or `--rotate`, whose whole point is that a credential
+  stops being accepted, and as a warning for an `--add`.
+
+  Two of these commands cannot run at once (a `token.lock` in the state directory, opened with no
+  sharing): both would compute a whole file from their own snapshot and the later write would
+  silently discard the earlier.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   sharing): both would compute a whole file from their own snapshot and the later write would
   silently discard the earlier.
 
+  A removal also **deletes that client's token copy** if it is still sitting there: the credential
+  file is written by then, so the file authenticates nothing from the moment the command returns.
+
   A revocation **closes the gate before it walks anything** (`Sessions::revoke`). A lease expiry does
   not need to — it only fires after the client has been silent for longer than any call can keep it
   quiet, so nothing of that credential's can still be in flight — but a revocation has no quiet

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   out and the sweep that was to run on its next pass would not. Changing a token *without* losing
   the sessions is what `--rotate-listen-client` is for.
 
+  The registry gate a revocation closes is lifted **when the name is configured again**, not when
+  the teardown finishes. That release is one pass over the sessions that exist, so an opener which
+  authenticated before the revocation and has not registered yet — an `attach_kernel` is a worker
+  spawn away — is invisible to it, and lifting on "nothing left to release" let that opener register
+  a target owned by a credential nothing can authenticate as. A name revoked and never given back
+  keeps its gate for the life of the process, which is the answer wanted.
+
 ### Changed
 
 - **A default `registers` answer stopped carrying the vector bank** (`FOLLOWUPS.md` item 24's

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **A service-hosted listener's clients can be changed without a reinstall**
+  (`FOLLOWUPS.md` item 34). `--add-listen-client <name>`, `--remove-listen-client <name>` and
+  `--rotate-listen-client <name>`, from an elevated shell, edit the credential file the service
+  reads and then tell the running service to re-read it — so a client is added, revoked or rotated
+  **without stopping anything**. Before this, `--install-service` was the file's only writer and the
+  SCM refuses a second registration, so adding a client meant uninstall, set every credential
+  variable again, install, start — which drops every session the service holds, a parked kernel
+  attach included.
+
+  Each command **generates the token itself** and never prints one: standard output carries a
+  fingerprint (`sha256:701E4CF334890225`) and the token goes to the file `--token-out <path>` names,
+  created fresh and given the same SYSTEM-and-Administrators ACL as the credential file it came
+  from. That keeps a working credential out of a shell history and out of an agent's transcript, and
+  it is what makes these commands narrow enough to allow-list in a permission rule where "let this
+  write `%ProgramData%`" would not be.
+
+  The two properties the installer was hardened for are unchanged: only *this program*, running
+  elevated, writes that file, and it still never writes through a file it did not create — the
+  content goes to a fresh sibling created with `create_new` in the protected directory, is ACL'd
+  there, and is renamed over the old name, which also makes the replacement atomic for a service
+  reading it concurrently. `--install-service` now shares that writer, so an install and an
+  `--add-listen-client` leave the file to one standard.
+
+  A **rotation keeps the client's name**, and so keeps the debug sessions it has open — only the
+  token moves. A **removal releases** what that client still held, down the path a lease expiry
+  already uses (an orderly release, not a worker killed and a live kernel left frozen); the command
+  could not have refused on their account, since it runs in another process and cannot see them, and
+  blocking a revocation on the sessions it is revoking is the wrong way round. Removing the *last*
+  client is refused: a listener with no credentials will not start, and `--uninstall-service` is the
+  command that means "stop serving".
+
+  A reload that cannot read the file **changes nothing** — the set is only ever replaced by one that
+  would have started this listener from cold, so a typo is a loud log line and a service still
+  serving, rather than every client locked out of a live kernel target.
+
 ### Changed
 
 - **A default `registers` answer stopped carrying the vector bank** (`FOLLOWUPS.md` item 24's

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,12 +57,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   A removal also **deletes that client's token copy** if it is still sitting there: the credential
   file is written by then, so the file authenticates nothing from the moment the command returns.
 
-  A revocation **closes the gate before it walks anything** (`Sessions::revoke`). A lease expiry does
-  not need to — it only fires after the client has been silent for longer than any call can keep it
-  quiet, so nothing of that credential's can still be in flight — but a revocation has no quiet
-  period: an opener that authenticated a moment earlier can be seconds from registering, and a
-  session admitted behind a one-pass release would belong to a client nothing can authenticate as
-  and nothing will ever come back for.
+  **A revocation is an expiry that does not wait.** It sets that client's lease clock to now and
+  closes an admission gate (`Sessions::revoke`); the sweeper — which already releases an expired
+  client's debug sessions, closes the MCP sessions it left resident and clears its state — does the
+  teardown on its next pass, and lifts the gate when it is done. So nothing an operator waits on is
+  behind a live kernel letting go, and there is no second teardown path to keep in step with the
+  first. The gate is what a lease expiry does not need: an expiry fires only after the client has
+  been silent for longer than any call can keep it quiet, so nothing of that credential's can still
+  be in flight, whereas here an opener that authenticated a moment earlier can be seconds from
+  registering — and a session admitted behind the sweep would belong to a client nothing can
+  authenticate as and nothing will ever come back for.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   registering — and a session admitted behind the sweep would belong to a client nothing can
   authenticate as and nothing will ever come back for.
 
+  **A name is not reusable until the sweep has forgotten it.** A client is identified by its name,
+  so `--remove-listen-client ci` followed by `--add-listen-client ci` makes two credentials that
+  nothing keyed on identity can tell apart; in between, the lease entry still holds the previous
+  holder's sessions. Requests on a revoked name are refused with a `409` ("ask again in a moment")
+  rather than served, and a request already inside the MCP service when the set was swapped records
+  its MCP session but does not renew the clock — a renewal would push the revocation a whole grace
+  out and the sweep that was to run on its next pass would not. Changing a token *without* losing
+  the sessions is what `--rotate-listen-client` is for.
+
 ### Changed
 
 - **A default `registers` answer stopped carrying the vector bank** (`FOLLOWUPS.md` item 24's

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,10 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   attach included.
 
   Each command **generates the token itself** and never prints one: standard output carries a
-  fingerprint (`sha256:701E4CF334890225`) and the token goes to the file `--token-out <path>` names,
-  created fresh and given the same SYSTEM-and-Administrators ACL as the credential file it came
-  from. That keeps a working credential out of a shell history and out of an agent's transcript, and
-  it is what makes these commands narrow enough to allow-list in a permission rule where "let this
+  fingerprint (`sha256:701E4CF334890225`) and the token goes to `<name>.token` beside the credential
+  file, in the same SYSTEM-and-Administrators directory — not to a path the operator names, because
+  writing a live credential into a directory this program does not control the protection of means
+  creating, ACL'ing and reopening it by name, which is a window to substitute a file and keep a read
+  handle to it. Keeping a working credential out of a shell history and out of an agent's transcript
+  is what makes these commands narrow enough to allow-list in a permission rule where "let this
   write `%ProgramData%`" would not be.
 
   The two properties the installer was hardened for are unchanged: only *this program*, running
@@ -51,6 +53,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Two of these commands cannot run at once (a `token.lock` in the state directory, opened with no
   sharing): both would compute a whole file from their own snapshot and the later write would
   silently discard the earlier.
+
+  A revocation **closes the gate before it walks anything** (`Sessions::revoke`). A lease expiry does
+  not need to — it only fires after the client has been silent for longer than any call can keep it
+  quiet, so nothing of that credential's can still be in flight — but a revocation has no quiet
+  period: an opener that authenticated a moment earlier can be seconds from registering, and a
+  session admitted behind a one-pass release would belong to a client nothing can authenticate as
+  and nothing will ever come back for.
 
 ### Changed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,9 +35,15 @@ schemars = "1"
 anyhow = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-# Only for the handle plumbing behind the supervisor↔worker channel (see `engine::spawn_worker`):
-# marking a pipe end inheritable is the one thing std cannot express.
-windows-sys = { version = "0.61", features = ["Win32_Foundation"] }
+# Two things std cannot express. The handle plumbing behind the supervisor↔worker channel (see
+# `engine::spawn_worker`): marking a pipe end inheritable. And CNG (`Win32_Security_Cryptography`),
+# for the two credential primitives in `src/client.rs` — a token generated from the system RNG, and
+# the SHA-256 fingerprint that is the only thing a client command may print about one. Both are
+# one-shot calls against pseudo-handles, which is why this pulls in no crypto crate.
+windows-sys = { version = "0.61", features = [
+    "Win32_Foundation",
+    "Win32_Security_Cryptography",
+] }
 # The Windows service role (`src/service.rs`). A wrapper rather than hand-rolled SCM FFI because
 # that lifecycle is the one part of this which must not be subtly wrong: a service that mishandles
 # its stop is a service that cannot be stopped, and for this server that means a live kernel target

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -1293,6 +1293,18 @@ bench` → `401` again, and the credential file back **byte-for-byte** to its pr
 token untouched and the file returned from the JSON shape to the bare one. Removing `local` (the
 only remaining client) was refused.
 
+**What review then corrected** (both bots, on the first commit). The reload was asynchronous while
+the command said it was not, so the printed claim is now backed by an acknowledgement the control
+handler blocks on — and a re-read that failed comes back as a failed control code, which is an
+*error* for the two commands that revoke a credential. A revoked client kept half its state:
+`reloaded` released the debug sessions where the sweep does three things, so its MCP sessions stayed
+resident and — lease state being keyed by name — a re-added name inherited the ids of whoever held
+it before (`Lease::revoked_for` and `Lease::forget`). The `--token-out` ACL went on *after* the
+secret, and a DACL change does not revoke access through an already-open handle. Two elevated shells
+could each write a whole file from its own snapshot (`token.lock`, `share_mode(0)`). And
+`--add-listen-client --token-out C:\x` took `--token-out` as the client *name*, which passes the
+name rule since a name may contain `-`.
+
 **What was left alone deliberately.** The ACL, and the refusal to write through a file it did not
 create. The environment is still read only by `--install-service`. And the second foreground
 listener stays a development workflow — the bar in this item ("if someone running a deployed

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -1305,7 +1305,18 @@ is written into the state directory, which is already `SYSTEM`-and-`Administrato
 traverse for anyone else, and the choice that generated both findings is deleted rather than patched
 a third time. A revocation also had a window a lease expiry does not (`Sessions::revoke`): the token
 stops being accepted at the swap, but an opener that authenticated a moment earlier can be seconds
-from registering, and a one-pass release cannot see it. Two elevated shells
+from registering, and a one-pass release cannot see it.
+
+**And then the shape changed rather than growing again.** Three rounds of findings had clustered on
+two things — how the secret reaches the operator, which the `--token-out` deletion settled, and
+revocation, which by then had four mechanisms of its own and a task with an ordering rule. The
+second cluster is gone the same way: a revocation is now **an expiry that does not wait**, so it
+sets the lease clock to now and the sweeper does the teardown it was already doing for expired
+clients. Deleted with it: the teardown task, its channel, the ordering rule between `forget` and
+`unrevoke`, and `Lease::revoked_for`. What is left is a flag on `Presence`, a branch in the sweep,
+and the admission gate — which stays, because it is the one thing an expiry genuinely does not need.
+A grace is there so a client that went *quiet* can come back to what it left; a revoked credential
+is never coming back, so skipping it costs nothing. Two elevated shells
 could each write a whole file from its own snapshot (`token.lock`, `share_mode(0)`). And
 `--add-listen-client --token-out C:\x` took `--token-out` as the client *name*, which passes the
 name rule since a name may contain `-`.

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -1300,7 +1300,12 @@ handler blocks on — and a re-read that failed comes back as a failed control c
 `reloaded` released the debug sessions where the sweep does three things, so its MCP sessions stayed
 resident and — lease state being keyed by name — a re-added name inherited the ids of whoever held
 it before (`Lease::revoked_for` and `Lease::forget`). The `--token-out` ACL went on *after* the
-secret, and a DACL change does not revoke access through an already-open handle. Two elevated shells
+secret; moving it earlier then exposed a close-and-reopen race, so the flag is **gone** — the token
+is written into the state directory, which is already `SYSTEM`-and-`Administrators`-only with no
+traverse for anyone else, and the choice that generated both findings is deleted rather than patched
+a third time. A revocation also had a window a lease expiry does not (`Sessions::revoke`): the token
+stops being accepted at the swap, but an opener that authenticated a moment earlier can be seconds
+from registering, and a one-pass release cannot see it. Two elevated shells
 could each write a whole file from its own snapshot (`token.lock`, `share_mode(0)`). And
 `--add-listen-client --token-out C:\x` took `--token-out` as the client *name*, which passes the
 name rule since a name may contain `-`.

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -1316,7 +1316,18 @@ clients. Deleted with it: the teardown task, its channel, the ordering rule betw
 `unrevoke`, and `Lease::revoked_for`. What is left is a flag on `Presence`, a branch in the sweep,
 and the admission gate — which stays, because it is the one thing an expiry genuinely does not need.
 A grace is there so a client that went *quiet* can come back to what it left; a revoked credential
-is never coming back, so skipping it costs nothing. Two elevated shells
+is never coming back, so skipping it costs nothing.
+
+**What it did not settle, and is now [#190](https://github.com/glslang/windbg-mcp/issues/190).** A
+`Client` is a name, so `--remove-listen-client ci` then `--add-listen-client ci` makes two
+credentials that everything keyed on identity — session ownership, routing, lease state, the
+revocation gate — treats as one. Four of #189's findings were different consumers of that one
+ambiguity, and the four fixes that shipped (a `409` on a revoked presence, a lease that does not
+renew for one, an admission gate on the owner name, and lifting that gate on re-add rather than on
+an empty release) each narrow the window without closing it: at the moment a session registers there
+is nothing in it that says *which* `ci` opened it. Giving `Client` an incarnation would delete all
+four rather than add a fifth. Not urgent — the residual needs two elevated commands issued during
+one open, and nothing a client can do reaches it. Two elevated shells
 could each write a whole file from its own snapshot (`token.lock`, `share_mode(0)`). And
 `--add-listen-client --token-out C:\x` took `--token-out` as the client *name*, which passes the
 name rule since a name may contain `-`.

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -1219,7 +1219,7 @@ does not know to ping is exactly the client this bites.
   a reason, and a client that thinks for seven minutes is a fact about local models rather than
   about this server.
 
-## 34. [windbg-mcp] A service-hosted listener's clients are fixed at install time
+## 34. [windbg-mcp] A service-hosted listener's clients are fixed at install time — **done** (2026-08-22)
 
 `--install-service` is the **only** writer of `%ProgramData%\windbg-mcp\token`, and it leaves the
 file granting `SYSTEM` and `Administrators` *read* — deliberately, since the token is the one thing
@@ -1271,6 +1271,34 @@ document the dance.
   **if someone running a deployed listener ever has to start a second one to add a client, these
   commands are incomplete.** That is the bar to build against, and the reason the reload above is
   not optional.
+
+**Built as described.** `--add-listen-client <name>`, `--remove-listen-client <name>` and
+`--rotate-listen-client <name>` (`src/service.rs`), each generating the token, writing it to the
+`--token-out <path>` it requires, and printing only a fingerprint. The write is
+`service::write_credentials` — a fresh sibling created with `create_new` in the protected
+directory, ACL'd there, renamed over the old name — and `finish_install` now shares it, so the
+installer and the commands write that file to one standard and the replacement is atomic for a
+service reading it. The reload is user-defined control code **128**, sent by the command and
+answered in `serve_as_service`'s handler; it reaches `listen::reloaded`, which re-reads through the
+same `credentials()` that decides whether the listener may start at all — so a set that would not
+have started it cannot replace the one that did — swaps it into `client::Accepted`, and releases a
+departed client's sessions down the lease-sweep path. A removal of the *last* client is refused,
+since a listener with no credentials will not start.
+
+**Verified on the ARM64 bench against the installed service** (2026-08-22), one process throughout
+(pid 9108, never restarted): `--add-listen-client bench` → the log says `re-read the clients: added
+[bench], removed []` and that token completes an MCP `initialize` (`200`, `mcp-session-id`);
+`--rotate-listen-client bench` → the old token `401`, the new one `200`; `--remove-listen-client
+bench` → `401` again, and the credential file back **byte-for-byte** to its pre-test hash, `local`'s
+token untouched and the file returned from the JSON shape to the bare one. Removing `local` (the
+only remaining client) was refused.
+
+**What was left alone deliberately.** The ACL, and the refusal to write through a file it did not
+create. The environment is still read only by `--install-service`. And the second foreground
+listener stays a development workflow — the bar in this item ("if someone running a deployed
+listener ever has to start a second one to add a client, these commands are incomplete") is met:
+add, revoke and rotate are all in place, and all three take effect without stopping anything.
+
 
 ## 35. [windbg-mcp + win-kexp] The engine's subregister flag misses the views that matter — **measured and declined** (2026-08-22)
 

--- a/README.md
+++ b/README.md
@@ -231,8 +231,8 @@ logout, starts at boot, and gets a defined `PATH` and working directory — whic
 whether the engine DLLs beside the exe are the ones that load. `Stop-Service` releases every debug
 target before exiting, because a live kernel that is merely killed is left frozen. Its clients are
 changed in place — `--add-listen-client`, `--remove-listen-client`, `--rotate-listen-client`, each
-generating the token itself and printing only a fingerprint — so adding or revoking one costs
-neither a reinstall nor the sessions the service is holding.
+generating the token itself, writing it beside the credential file and printing only a fingerprint —
+so adding or revoking one costs neither a reinstall nor the sessions the service is holding.
 
 **Bind loopback and forward over SSH.** This endpoint runs `execute`, `debug_batch` and `launch`
 against a live kernel, and the token is sent in clear — a hypervisor's guest network is not private

--- a/README.md
+++ b/README.md
@@ -229,7 +229,10 @@ claude mcp add windbg-vm --transport http http://127.0.0.1:8765/ \
 Install it as a **Windows service** (`--install-service --listen <addr>`, elevated) and it survives
 logout, starts at boot, and gets a defined `PATH` and working directory — which is what decides
 whether the engine DLLs beside the exe are the ones that load. `Stop-Service` releases every debug
-target before exiting, because a live kernel that is merely killed is left frozen.
+target before exiting, because a live kernel that is merely killed is left frozen. Its clients are
+changed in place — `--add-listen-client`, `--remove-listen-client`, `--rotate-listen-client`, each
+generating the token itself and printing only a fingerprint — so adding or revoking one costs
+neither a reinstall nor the sessions the service is holding.
 
 **Bind loopback and forward over SSH.** This endpoint runs `execute`, `debug_batch` and `launch`
 against a live kernel, and the token is sent in clear — a hypervisor's guest network is not private

--- a/docs/remote-listener.md
+++ b/docs/remote-listener.md
@@ -462,7 +462,8 @@ who could write that directory had a window to substitute a file of their own an
 to it (a DACL change does not revoke access through a handle already open). The state directory is
 already SYSTEM and Administrators only, with no traverse for anyone else, so there is no window to
 race and nothing to substitute. An existing `<name>.token` there is never overwritten: it is a
-credential an earlier command wrote and nobody has moved yet.
+credential an earlier command wrote and nobody has moved yet, and the fix is to move it — or, if it
+belongs to a client you are done with, to remove that client, which deletes it.
 
 Four behaviours worth knowing before you need them:
 
@@ -472,7 +473,8 @@ Four behaviours worth knowing before you need them:
 - **A removal releases what that client still held**, down the path a lease expiry already uses, so
   a live kernel is let go rather than left frozen. It is not refused on their account: the command
   runs in another process and cannot see them, and blocking a revocation on the sessions it is
-  revoking would be exactly backwards.
+  revoking would be exactly backwards. It also deletes that client's `<name>.token` if the copy is
+  still sitting there — from the moment the command returns, that file authenticates nothing.
 - **Removing the last client is refused.** A listener with no credentials will not start, so that is
   not an incremental change but a decision to stop serving — which is `--uninstall-service`, and it
   takes the file with it rather than leaving a service that fails at every start.

--- a/docs/remote-listener.md
+++ b/docs/remote-listener.md
@@ -415,8 +415,8 @@ issued against a running service only marks it, and this one has debug targets t
 Three commands, from an **elevated** shell, and none of them costs you a session:
 
 ```pwsh
-windbg-mcp.exe --add-listen-client    ci --token-out C:\Users\you\ci.token
-windbg-mcp.exe --rotate-listen-client ci --token-out C:\Users\you\ci-new.token
+windbg-mcp.exe --add-listen-client    ci
+windbg-mcp.exe --rotate-listen-client ci
 windbg-mcp.exe --remove-listen-client ci
 ```
 
@@ -444,17 +444,25 @@ added the client `ci` (sha256:076C14953E1DE5EF) — it gets the whole tool surfa
 here does — a token separates clients from each other, it does not limit one.
 `windbg-mcp` now holds: `ci` (sha256:076C14953E1DE5EF), `local` (sha256:701E4CF334890225).
 
-Its token is in C:\Users\you\ci.token — readable by SYSTEM and Administrators only, like the
-credential file it came from. …
+Its token is in C:\ProgramData\windbg-mcp\ci.token — the same SYSTEM-and-Administrators
+directory the credential file is in, which is why it goes there and not somewhere you name. …
 
 `windbg-mcp` re-read its clients; nothing was stopped.
 ```
 
-`--token-out` is required for the two that mint a token, and the file it names is created fresh
-(never overwritten) and locked down the same way. Move it to the client machine, set it there as
-`WINDBG_MCP_LISTEN_TOKEN`, and delete this copy. The reason for all of that is one property: a token
-you typed has been through a shell history, and on a machine being driven by an agent, through a
-transcript. One this server generated has been through neither.
+Move that file to the client machine, set it there as `WINDBG_MCP_LISTEN_TOKEN`, and delete this
+copy. The reason for all of it is one property: a token you typed has been through a shell history,
+and on a machine being driven by an agent, through a transcript. One this server generated has been
+through neither.
+
+**You do not choose where it lands, and that is deliberate.** An earlier draft took a
+`--token-out <path>`, which meant writing a live credential into a directory this program does not
+control the protection of — so the file had to be created, ACL'd and reopened by name, and anyone
+who could write that directory had a window to substitute a file of their own and keep a read handle
+to it (a DACL change does not revoke access through a handle already open). The state directory is
+already SYSTEM and Administrators only, with no traverse for anyone else, so there is no window to
+race and nothing to substitute. An existing `<name>.token` there is never overwritten: it is a
+credential an earlier command wrote and nobody has moved yet.
 
 Four behaviours worth knowing before you need them:
 

--- a/docs/remote-listener.md
+++ b/docs/remote-listener.md
@@ -421,9 +421,13 @@ windbg-mcp.exe --remove-listen-client ci
 ```
 
 Each one rewrites `%ProgramData%\windbg-mcp\token` and then tells the running service to re-read
-it, so the change is in force before the command returns. Nothing is stopped and nothing is
-restarted — which is the whole point, since a restart drops every session the service holds, a
-parked kernel attach included.
+it — **waiting for it to have done so**, so the set in force when the command returns is the set it
+wrote. Nothing is stopped and nothing is restarted, which is the whole point: a restart drops every
+session the service holds, a parked kernel attach included.
+
+Two commands cannot run at once. The second is refused rather than queued, because both would
+compute a whole file from their own snapshot of it and the later write would silently discard the
+earlier — an add and a revocation run together, both reporting success, and the revocation gone.
 
 **The file is still not yours to edit.** It grants `SYSTEM` and `Administrators` *read*, so an
 administrator who opens it in an editor is told `Access to the path is denied` — that is the ACL
@@ -466,7 +470,11 @@ Four behaviours worth knowing before you need them:
   takes the file with it rather than leaving a service that fails at every start.
 - **A reload that cannot read the file changes nothing.** The set is only ever replaced by one that
   would have started this listener from cold, so a mangled file is a loud line in the service log
-  and a service still serving the clients it had.
+  and a service still serving the clients it had. The command that asked is told, and for a
+  **revocation** it is told as a *failure*: a `--remove` or `--rotate` whose reload did not land
+  means the credential you were taking out of service is still being accepted, which is not
+  something to mention in passing. An `--add` in the same position is a warning — the new client
+  simply cannot connect until the next start, and nothing that worked has stopped working.
 
 If the service is not running, the file is written anyway and the command says it will be read at
 the next start. If it is not *installed*, the commands refuse — a foreground listener takes its

--- a/docs/remote-listener.md
+++ b/docs/remote-listener.md
@@ -399,9 +399,10 @@ as `LocalSystem`. The token is the only thing in the way, so it has to stay unre
 unprivileged process, which is the one property the foreground listener gets for free.
 
 **Every credential in the installing shell is copied, not just the unnamed one.** A service reads
-its file and nothing else, so this is the only way it can hold more than one client — set
+its file and nothing else, so the environment is only ever consulted *here*, at install — set
 `WINDBG_MCP_LISTEN_TOKEN_CI` beside `WINDBG_MCP_LISTEN_TOKEN` before installing and the file it
-writes names both. One client called `local` is written as a bare token, as it always was; anything
+writes names both. Afterwards the [client commands](#adding-revoking-and-rotating-a-client-without-stopping-anything)
+are how that set changes, and they neither read the environment nor need a reinstall. One client called `local` is written as a bare token, as it always was; anything
 else is the JSON object above. The install validates them the way the listener would, so a shell
 that could not start a foreground listener cannot register a service either — which matters here,
 because the SCM registers a service once and a bad credential then fails it at every start.
@@ -409,35 +410,74 @@ because the SCM registers a service once and a bad credential then fails it at e
 `windbg-mcp.exe --uninstall-service` removes it, stopping it first and waiting for it — a delete
 issued against a running service only marks it, and this one has debug targets to let go of.
 
-### Adding or rotating a client afterwards costs a reinstall
+### Adding, revoking and rotating a client, without stopping anything
 
-**There is no command for it, and the file is not yours to edit.** The install is the only writer of
-`%ProgramData%\windbg-mcp\token`, and it leaves the file granting `SYSTEM` and `Administrators`
-**read** — so an administrator who tries to add a client by editing it is told `Access to the path
-is denied`, which is the ACL working rather than something to route around. Taking ownership to
-write it anyway leaves a credential owned by whoever did that, which is the reason the installer
-refuses to reuse a file it did not create.
-
-The SCM refuses a second registration under the same name, so the whole procedure is:
+Three commands, from an **elevated** shell, and none of them costs you a session:
 
 ```pwsh
-windbg-mcp.exe --uninstall-service                        # stops it; every session goes
-$env:WINDBG_MCP_LISTEN_TOKEN = "<the existing one>"       # keep it, or clients stop working
-$env:WINDBG_MCP_LISTEN_TOKEN_CI = "<the new one>"
-windbg-mcp.exe --install-service --listen 127.0.0.1:8765
-Start-Service windbg-mcp
+windbg-mcp.exe --add-listen-client    ci --token-out C:\Users\you\ci.token
+windbg-mcp.exe --rotate-listen-client ci --token-out C:\Users\you\ci-new.token
+windbg-mcp.exe --remove-listen-client ci
 ```
 
-**That drops every session the service holds** — a parked kernel attach included — so it is a
-planned outage rather than an incremental change, and it is worth knowing before the moment you
-need a second client. It is also not a design decision: the installer is simply the only thing that
-writes that file, and [`FOLLOWUPS.md`](../FOLLOWUPS.md) item 34 is the `--add-listen-client` /
-`--remove-listen-client` / `--rotate-listen-client` that would make this incremental — together with
-the live reload that has to come with them, since a *restart* would still cost you the sessions.
+Each one rewrites `%ProgramData%\windbg-mcp\token` and then tells the running service to re-read
+it, so the change is in force before the command returns. Nothing is stopped and nothing is
+restarted — which is the whole point, since a restart drops every session the service holds, a
+parked kernel attach included.
 
-**For a short-lived credential, do not touch the service at all** — though this is a *development*
-workflow rather than something to operate a deployment with. A bench, a driver script, a one-off
-measurement: run a *second, foreground* listener on another port with its own token, which needs no
+**The file is still not yours to edit.** It grants `SYSTEM` and `Administrators` *read*, so an
+administrator who opens it in an editor is told `Access to the path is denied` — that is the ACL
+working rather than something to route around, and taking ownership to write it anyway leaves a
+credential owned by whoever did that. These commands are the writer instead: the same program,
+running elevated, writing a fresh file with `create_new` in that protected directory, ACL'ing it
+there, and renaming it over the old name. Never through a file it did not create, and atomic for a
+service reading it at the same moment.
+
+**They generate the token, and they will not print it.** What reaches your console is a fingerprint:
+
+```text
+added the client `ci` (sha256:076C14953E1DE5EF) — it gets the whole tool surface, as every client
+here does — a token separates clients from each other, it does not limit one.
+`windbg-mcp` now holds: `ci` (sha256:076C14953E1DE5EF), `local` (sha256:701E4CF334890225).
+
+Its token is in C:\Users\you\ci.token — readable by SYSTEM and Administrators only, like the
+credential file it came from. …
+
+`windbg-mcp` re-read its clients; nothing was stopped.
+```
+
+`--token-out` is required for the two that mint a token, and the file it names is created fresh
+(never overwritten) and locked down the same way. Move it to the client machine, set it there as
+`WINDBG_MCP_LISTEN_TOKEN`, and delete this copy. The reason for all of that is one property: a token
+you typed has been through a shell history, and on a machine being driven by an agent, through a
+transcript. One this server generated has been through neither.
+
+Four behaviours worth knowing before you need them:
+
+- **A rotation keeps the client's name, and so keeps its sessions.** Only the token moves: the old
+  one starts answering `401` and the new one reaches the same debug sessions, because it is the same
+  client. Rotating is the cheap operation — a lost token costs a rotation and nothing else.
+- **A removal releases what that client still held**, down the path a lease expiry already uses, so
+  a live kernel is let go rather than left frozen. It is not refused on their account: the command
+  runs in another process and cannot see them, and blocking a revocation on the sessions it is
+  revoking would be exactly backwards.
+- **Removing the last client is refused.** A listener with no credentials will not start, so that is
+  not an incremental change but a decision to stop serving — which is `--uninstall-service`, and it
+  takes the file with it rather than leaving a service that fails at every start.
+- **A reload that cannot read the file changes nothing.** The set is only ever replaced by one that
+  would have started this listener from cold, so a mangled file is a loud line in the service log
+  and a service still serving the clients it had.
+
+If the service is not running, the file is written anyway and the command says it will be read at
+the next start. If it is not *installed*, the commands refuse — a foreground listener takes its
+clients from the environment it was started with, which is a set that cannot change without the
+process changing too.
+
+**A second foreground listener is still the right answer for a bench**, and it is a *development*
+workflow rather than a way to operate a deployment — the commands above are what an operator uses.
+A borrowed box with no administrator, a credential that should vanish with the process, a run that
+must not share a process with the listener an editor depends on, a build that is not the installed
+one: run a *second, foreground* listener on another port with its own token, which needs no
 privileged write and disappears when you close it — [Driving it with a local model](#driving-it-with-a-local-model)
 has the recipe. Two listeners on one host is a normal arrangement; sessions belong to a listener's
 own process, so the two cannot see each other's.

--- a/skills/windbg-debugging/setup.md
+++ b/skills/windbg-debugging/setup.md
@@ -448,8 +448,8 @@ Four things decide whether that works, and each fails in a way that reads as som
   are the ones that load. Note `LocalSystem` does not read *your* `%USERPROFILE%`, so kernel
   profiles have to be configured machine-wide for a service to see them. Giving it a **second
   client** later costs neither a reinstall nor the sessions it is holding —
-  `--add-listen-client <name> --token-out <path>`, elevated, which generates the token and prints
-  only a fingerprint.
+  `--add-listen-client <name>`, elevated, which generates the token, leaves it beside the
+  credential file and prints only a fingerprint.
 
 Two behaviours differ from stdio and are worth knowing before they surprise you.
 

--- a/skills/windbg-debugging/setup.md
+++ b/skills/windbg-debugging/setup.md
@@ -446,7 +446,10 @@ Four things decide whether that works, and each fails in a way that reads as som
   and there is nothing listening after it. Once running it survives logout, comes back at boot, and
   has a defined working directory — which is what decides whether the engine DLLs beside the exe
   are the ones that load. Note `LocalSystem` does not read *your* `%USERPROFILE%`, so kernel
-  profiles have to be configured machine-wide for a service to see them.
+  profiles have to be configured machine-wide for a service to see them. Giving it a **second
+  client** later costs neither a reinstall nor the sessions it is holding —
+  `--add-listen-client <name> --token-out <path>`, elevated, which generates the token and prints
+  only a fingerprint.
 
 Two behaviours differ from stdio and are worth knowing before they surprise you.
 
@@ -478,4 +481,5 @@ one is *unknown* to the other rather than refused. If a handle has "vanished", c
 request carried.
 
 `docs/remote-listener.md` in the repository is the operator's reference for the rest — the grace
-and how to change it, what a `409` means, and running behind a service.
+and how to change it, what a `409` means, running behind a service, and adding, revoking or
+rotating a client while it runs.

--- a/src/client.rs
+++ b/src/client.rs
@@ -210,6 +210,102 @@ impl Credentials {
     }
 }
 
+/// The credentials a listener is serving *right now*, replaceable while it runs.
+///
+/// [`Credentials`] is what a configuration says; this is what the running listener accepts, and
+/// the difference is a whole feature. Built once at startup, a service-hosted listener's client
+/// list is fixed until the next start — and a restart drops every session it holds, which for a
+/// parked kernel attach is the outage that made adding a client a planned one (`FOLLOWUPS.md`
+/// item 34). So the set lives behind a lock that [`crate::service::reload`] can swap under the
+/// accept loop, and a client added to the token file is admitted without anything being stopped.
+///
+/// **A read lock on the authentication path**, which is the cheapest thing that is also correct: a
+/// request takes it uncontended, and the one writer runs once per administrative command. And it
+/// is [recovered from poisoning](Self::current) rather than unwrapped — a panic anywhere near the
+/// swap must not turn into a listener that refuses every caller for the rest of its life.
+pub struct Accepted {
+    current: std::sync::RwLock<Arc<Credentials>>,
+}
+
+/// What a [reload](Accepted::replace) changed, by name.
+///
+/// **Names, not tokens**, so the caller can log it: this is what the listener says out loud when a
+/// client appears or goes. A rotation shows up as neither — the name is unchanged, so nothing this
+/// describes moved, and the sessions that client holds are untouched by design.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct Change {
+    pub added: Vec<String>,
+    pub removed: Vec<String>,
+}
+
+impl Change {
+    pub fn is_empty(&self) -> bool {
+        self.added.is_empty() && self.removed.is_empty()
+    }
+}
+
+impl Accepted {
+    pub fn new(credentials: Credentials) -> Self {
+        Self {
+            current: std::sync::RwLock::new(Arc::new(credentials)),
+        }
+    }
+
+    /// The set in force, past a poisoned lock.
+    ///
+    /// `into_inner` rather than `unwrap`, because of what the two do on the request path. The lock
+    /// guards an `Arc` that is only ever read or replaced wholesale, so a panic while it was held
+    /// cannot have left a half-written set behind — there is no invariant to protect. Propagating
+    /// the poison would instead take a listener holding live kernel targets and have it refuse
+    /// every caller, its own operator included, until someone restarted it.
+    fn current(&self) -> Arc<Credentials> {
+        match self.current.read() {
+            Ok(guard) => Arc::clone(&guard),
+            Err(poisoned) => Arc::clone(&poisoned.into_inner()),
+        }
+    }
+
+    /// The client presenting `token`, or `None` if nothing here accepts it.
+    pub fn client_for(&self, token: &str) -> Option<Client> {
+        self.current().client_for(token).cloned()
+    }
+
+    /// Every configured name, sorted — for the lines that say who may connect.
+    pub fn names(&self) -> Vec<String> {
+        self.current()
+            .names()
+            .into_iter()
+            .map(str::to_owned)
+            .collect()
+    }
+
+    /// Swaps in a freshly read set, and says which clients appeared and which went.
+    ///
+    /// The *caller* acts on the removals, because what to do about them is not this type's
+    /// business: a client whose credential is gone cannot reach the sessions it opened, so the
+    /// listener releases them down the path the lease sweep already uses. See
+    /// [`crate::listen::reloaded`].
+    pub fn replace(&self, credentials: Credentials) -> Change {
+        let before = self.names();
+        let after: Vec<String> = credentials.names().into_iter().map(str::to_owned).collect();
+        match self.current.write() {
+            Ok(mut guard) => *guard = Arc::new(credentials),
+            Err(poisoned) => *poisoned.into_inner() = Arc::new(credentials),
+        }
+        Change {
+            added: after
+                .iter()
+                .filter(|name| !before.contains(name))
+                .cloned()
+                .collect(),
+            removed: before
+                .into_iter()
+                .filter(|name| !after.contains(name))
+                .collect(),
+        }
+    }
+}
+
 /// One configured credential: the client it names, the token, and where it came from.
 ///
 /// The third field is what a refusal quotes, and it is deliberately never the token — a variable
@@ -432,6 +528,119 @@ impl TokenFile {
         }
         Ok(Self { entries })
     }
+
+    /// The clients this file names, as `(name, token)` pairs, validated the way the listener
+    /// validates them.
+    ///
+    /// For the [client commands](crate::service), which read the file to change one entry and
+    /// write the rest back. It validates rather than merely handing over what parsed, for the
+    /// same reason [`env_credentials`] does: what comes out of here is written straight back to
+    /// the file the service reads, and a set that would not start a listener must not be written
+    /// down as if it would.
+    ///
+    /// **Sorted by name**, so the file a command writes does not depend on the order the previous
+    /// one happened to be in — an operator diffing two of these should see only what changed.
+    pub fn credentials(self) -> Result<Vec<(String, String)>> {
+        Credentials::build(&self.entries)?;
+        let mut pairs: Vec<(String, String)> = self
+            .entries
+            .into_iter()
+            .map(|c| (c.name, c.token))
+            .collect();
+        pairs.sort_by(|a, b| a.0.cmp(&b.0));
+        Ok(pairs)
+    }
+}
+
+/// How many random bytes a generated token carries.
+///
+/// 256 bits, hex-encoded to 64 characters. Hex rather than base64 because the only thing this
+/// string has to survive is an `Authorization` header and a JSON string, and the encoding that is
+/// obviously safe in both without a moment's thought is the one to pick for a credential.
+const TOKEN_BYTES: usize = 32;
+
+/// A token nobody has typed, from the system's own generator.
+///
+/// **The point of generating rather than accepting one** is where the secret is *not*: a token the
+/// operator supplies has been through a shell (and its history), and on this host frequently
+/// through an agent's transcript as well. One made here reaches the token file directly, and what
+/// the command prints is a [fingerprint](fingerprint).
+///
+/// `BCryptGenRandom` with the system-preferred RNG, which is Windows' answer for exactly this and
+/// needs no algorithm handle to be opened or closed. A failure is returned rather than fallen back
+/// from: the fallback for a credential's randomness is a credential that is not random.
+pub fn generate_token() -> Result<String> {
+    use windows_sys::Win32::Security::Cryptography::{
+        BCRYPT_USE_SYSTEM_PREFERRED_RNG, BCryptGenRandom,
+    };
+
+    let mut bytes = [0u8; TOKEN_BYTES];
+    // SAFETY: a null algorithm handle is what `BCRYPT_USE_SYSTEM_PREFERRED_RNG` requires, and the
+    // buffer and its length describe the same local array.
+    let status = unsafe {
+        BCryptGenRandom(
+            std::ptr::null_mut(),
+            bytes.as_mut_ptr(),
+            bytes.len() as u32,
+            BCRYPT_USE_SYSTEM_PREFERRED_RNG,
+        )
+    };
+    if status < 0 {
+        bail!("the system random number generator refused (NTSTATUS {status:#010x})");
+    }
+    Ok(hex(&bytes, false))
+}
+
+/// What may be said about a token out loud: `sha256:` and the first eight bytes of its digest.
+///
+/// A credential-shaped value that a command can print, a log line can carry and an operator can
+/// compare against what they installed on the client — without any of those becoming somewhere a
+/// working token is written down. Truncated because its job is comparison by eye; it is not a
+/// security boundary, and nothing here is ever checked against it.
+pub fn fingerprint(token: &str) -> String {
+    format!("sha256:{}", hex(&sha256(token.as_bytes())[..8], true))
+}
+
+/// SHA-256, via CNG's one-shot hash — no handle to open, nothing to free.
+///
+/// A `panic` on failure rather than a `Result`, which is the one place in this module that is not
+/// a refusal: `BCryptHash` against the SHA-256 pseudo-handle with a correctly sized output buffer
+/// has no failure that is not a bug here, and threading an error out of it would spread a
+/// `Result` through every line that prints a fingerprint.
+fn sha256(data: &[u8]) -> [u8; 32] {
+    use windows_sys::Win32::Security::Cryptography::{BCRYPT_SHA256_ALG_HANDLE, BCryptHash};
+
+    let mut digest = [0u8; 32];
+    // SAFETY: `BCRYPT_SHA256_ALG_HANDLE` is a pseudo-handle the API takes in place of an opened
+    // algorithm; the two pointer/length pairs each describe one slice, and no secret is passed.
+    let status = unsafe {
+        BCryptHash(
+            BCRYPT_SHA256_ALG_HANDLE,
+            std::ptr::null(),
+            0,
+            data.as_ptr(),
+            data.len() as u32,
+            digest.as_mut_ptr(),
+            digest.len() as u32,
+        )
+    };
+    assert!(status >= 0, "BCryptHash(SHA-256) failed: {status:#010x}");
+    digest
+}
+
+/// Bytes as hex — lower case for a token, upper for a fingerprint, which is the difference between
+/// a thing to paste and a thing to compare by eye.
+fn hex(bytes: &[u8], upper: bool) -> String {
+    bytes
+        .iter()
+        .map(|b| {
+            if upper {
+                format!("{b:02X}")
+            } else {
+                format!("{b:02x}")
+            }
+        })
+        .collect()
 }
 
 /// Whether a token could be presented at all.
@@ -514,6 +723,25 @@ fn is_client_name(name: &str) -> bool {
         && name
             .chars()
             .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.'))
+}
+
+/// A client name an operator typed, normalised and held to the same rule as a configured one.
+///
+/// For the [client commands](crate::service::edit_client), which take a name on a command line and
+/// write it into the token file. Lowercased, because that is what both configured sources do — a
+/// `WINDBG_MCP_LISTEN_TOKEN_CI` names `ci`, and a key in the file is folded on the way in — so
+/// `--add-listen-client CI` has to mean the same client `CI` would have named, or the command
+/// could add a second entry the listener then refuses to start on.
+pub fn client_name(raw: &str) -> Result<String> {
+    let name = raw.trim().to_ascii_lowercase();
+    if !is_client_name(&name) {
+        bail!(
+            "`{raw}` is not a client name. A name is letters, digits, `-`, `_` or `.`, up to \
+             {NAME_LIMIT} characters — it is what the listener logs as who may connect, and what \
+             a refusal names."
+        );
+    }
+    Ok(name)
 }
 
 /// The part of a credential variable's name after the prefix, if it is one.
@@ -1006,5 +1234,186 @@ mod tests {
             Some("local")
         );
         assert_eq!(creds.client_for(r"C:\somewhere\token"), None);
+    }
+
+    /// A generated token is one a client could actually present, and is not the same twice.
+    ///
+    /// The first half is the check every configured credential is held to, asked of the one source
+    /// nobody proof-reads: a token this server minted and wrote into its own file must not be one
+    /// [`Credentials::build`] would then refuse at startup. The second is a sanity check on the
+    /// generator being wired to the system RNG rather than to a constant.
+    #[test]
+    fn a_generated_token_is_one_that_could_be_presented() {
+        let first = generate_token().expect("the system RNG answers");
+        let second = generate_token().expect("the system RNG answers");
+        assert_ne!(first, second, "two tokens in a row were identical");
+        assert!(
+            is_presentable(&first),
+            "`{first}` cannot travel in a header"
+        );
+        let creds = Credentials::from_entries(vars(&[(TOKEN_ENV, &first)]), None).expect("valid");
+        assert_eq!(creds.client_for(&first).map(Client::name), Some("local"));
+    }
+
+    /// A fingerprint is stable, distinguishing, and says nothing about the token it describes.
+    ///
+    /// The last clause is the one with a cost attached: this string is printed to a console and
+    /// written into log lines precisely so a *token* never has to be, so a fingerprint that
+    /// carried any of one would defeat the whole arrangement.
+    #[test]
+    fn a_fingerprint_identifies_a_token_without_carrying_it() {
+        let token = "a-long-random-string";
+        let print = fingerprint(token);
+        assert_eq!(
+            print,
+            fingerprint(token),
+            "the same token printed differently"
+        );
+        assert_ne!(print, fingerprint("a-long-random-strinh"));
+        assert!(print.starts_with("sha256:"), "{print}");
+        assert!(
+            !print.contains(token) && !print.contains("random"),
+            "the fingerprint quotes the token it is standing in for: {print}"
+        );
+    }
+
+    /// The known-answer test for the digest behind it, since nothing else here would catch a
+    /// fingerprint that was consistently and wrongly computed.
+    #[test]
+    fn the_digest_is_sha256() {
+        assert_eq!(
+            hex(&sha256(b"abc"), false),
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+        );
+    }
+
+    /// A name typed on a command line means the same client a configured one would.
+    ///
+    /// Both configured sources fold case — `WINDBG_MCP_LISTEN_TOKEN_CI` names `ci`, and a key in
+    /// the token file is lowercased on the way in — so a command that did not would happily add a
+    /// second entry for a client that already exists, and the listener would then refuse to start
+    /// on the two-tokens-one-name rule.
+    #[test]
+    fn a_typed_client_name_is_folded_like_a_configured_one() {
+        assert_eq!(client_name("  CI  ").expect("a name"), "ci");
+        assert_eq!(client_name("bench.1").expect("a name"), "bench.1");
+        for not_a_name in [
+            "",
+            "   ",
+            "two words",
+            "a\"quote",
+            &"x".repeat(NAME_LIMIT + 1),
+        ] {
+            assert!(
+                client_name(not_a_name).is_err(),
+                "`{not_a_name}` was accepted as a client name"
+            );
+        }
+    }
+
+    /// A token file's credentials come back validated and in a stable order.
+    ///
+    /// The order matters because a client command writes them straight back: without it, adding
+    /// one client would reshuffle the file, and an operator diffing two of them could not see what
+    /// changed.
+    #[test]
+    fn a_files_credentials_come_back_sorted() {
+        let parsed = file(r#"{"laptop": "l", "ci": "c", "local": "s"}"#)
+            .credentials()
+            .expect("a valid file");
+        assert_eq!(
+            parsed,
+            vec![
+                ("ci".to_string(), "c".to_string()),
+                ("laptop".to_string(), "l".to_string()),
+                ("local".to_string(), "s".to_string()),
+            ]
+        );
+    }
+
+    /// A set that would not start a listener is refused on the way out, not just on the way in.
+    ///
+    /// [`TokenFile::parse`] catches what one *file* can say twice; this is the other refusal —
+    /// two names sharing a token — which is [`Credentials::build`]'s and would otherwise be
+    /// discovered by the service failing to start after a command reported success.
+    #[test]
+    fn a_files_credentials_are_held_to_the_startup_rules() {
+        let shared = file(r#"{"ci": "same", "laptop": "same"}"#).credentials();
+        assert!(
+            shared.is_err(),
+            "one token naming two clients came back as a usable set"
+        );
+    }
+
+    /// Swapping the set in says which clients appeared and which went, and takes effect at once.
+    #[test]
+    fn replacing_the_set_reports_what_moved() {
+        let accepted = Accepted::new(
+            Credentials::from_entries(
+                vars(&[
+                    ("WINDBG_MCP_LISTEN_TOKEN", "s"),
+                    ("WINDBG_MCP_LISTEN_TOKEN_CI", "c"),
+                ]),
+                None,
+            )
+            .expect("valid"),
+        );
+        assert_eq!(
+            accepted.client_for("c").map(|c| c.name().to_string()),
+            Some("ci".into())
+        );
+
+        let change = accepted.replace(
+            Credentials::from_entries(
+                vars(&[
+                    ("WINDBG_MCP_LISTEN_TOKEN", "s"),
+                    ("WINDBG_MCP_LISTEN_TOKEN_BENCH", "b"),
+                ]),
+                None,
+            )
+            .expect("valid"),
+        );
+        assert_eq!(change.added, vec!["bench"]);
+        assert_eq!(change.removed, vec!["ci"]);
+        assert_eq!(accepted.names(), vec!["bench", "local"]);
+        assert_eq!(
+            accepted.client_for("c"),
+            None,
+            "a removed client's token still authenticated"
+        );
+        assert_eq!(
+            accepted.client_for("b").map(|c| c.name().to_string()),
+            Some("bench".into())
+        );
+    }
+
+    /// A rotation moves a token and no names — which is what lets the client keep its sessions.
+    ///
+    /// The reload acts on [`Change`] to release a departed client's targets, so a rotation
+    /// reporting a removal and an addition of the same name would tear down exactly the sessions
+    /// rotation exists to preserve.
+    #[test]
+    fn rotating_a_token_moves_no_names() {
+        let accepted = Accepted::new(
+            Credentials::from_entries(vars(&[("WINDBG_MCP_LISTEN_TOKEN_CI", "old")]), None)
+                .expect("valid"),
+        );
+        let change = accepted.replace(
+            Credentials::from_entries(vars(&[("WINDBG_MCP_LISTEN_TOKEN_CI", "new")]), None)
+                .expect("valid"),
+        );
+        assert!(
+            change.is_empty(),
+            "a rotation was reported as a client coming or going: {change:?}"
+        );
+        assert_eq!(
+            accepted.client_for("old"),
+            None,
+            "the old token still worked"
+        );
+        assert_eq!(
+            accepted.client_for("new").map(|c| c.name().to_string()),
+            Some("ci".into())
+        );
     }
 }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -3414,8 +3414,13 @@ mod tests {
     /// admitted behind it belongs to a client nothing can authenticate as and nothing will ever
     /// come back for: a live kernel target held by nobody.
     ///
-    /// The lifting is the sweeper's, once that client's sessions are gone, which is what makes a
-    /// name re-added mid-teardown safe without anything sequencing the two.
+    /// **What lifts it is the name being configured again**, and nothing else. Hanging it on the
+    /// teardown finishing lifts it on a timing coincidence: that release is one pass over a
+    /// snapshot, so an opener which authenticated before the revocation but has not registered yet
+    /// — an `attach_kernel` is seconds of worker spawn and link wait away from doing so — is
+    /// invisible to it, and would then register a target owned by a credential nothing can
+    /// authenticate as. A name revoked and never given back keeps its gate for the life of the
+    /// process, which is the answer wanted rather than a leak to tidy.
     #[test]
     fn a_revoked_credential_cannot_register_a_session_until_the_sweep_lifts_it() {
         let sessions = Sessions::new(Duration::from_secs(300));

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -875,6 +875,9 @@ struct Registry {
     /// Set once the client has disconnected. Refuses new opens, so the set of workers to release
     /// stops growing while shutdown is walking it.
     closing: bool,
+    /// Credentials that have been **revoked**, whose sessions must stop growing for the same
+    /// reason `closing` exists — see [`Sessions::revoke`].
+    revoked: std::collections::HashSet<crate::client::Client>,
 }
 
 impl Registry {
@@ -1081,6 +1084,36 @@ impl Sessions {
     /// caller of this method is the only thing that still knows.
     pub fn live_count_for(&self, owner: &crate::client::Client) -> usize {
         self.registry().live_for(owner).len()
+    }
+
+    /// A credential is gone: refuse it any *new* session from here.
+    ///
+    /// The counterpart of `closing`, for one client rather than the server, and it exists for the
+    /// window a revocation has and a lease expiry does not. An expiry only fires after the client
+    /// has been silent for a whole grace, and the grace is longer than the longest a call can keep
+    /// it quiet — so no request of that credential's can still be in flight when its sessions are
+    /// released. A revocation has no such quiet period: the token stops being accepted the moment
+    /// the set is swapped, but a call that got past authentication a moment earlier is still
+    /// running, and an opener may be seconds from registering.
+    ///
+    /// So the release cannot be a single pass over a snapshot. This closes the gate first, under
+    /// the registry lock, and the release then walks a set that cannot grow — the same shape
+    /// `closing` gives shutdown. The in-flight call fails, which is the right answer: its
+    /// credential was revoked while it ran.
+    ///
+    /// Marked rather than cleared on its own, because a name may be configured again later —
+    /// [`Self::unrevoke`] is what a re-added client gets, and it is a different client with the
+    /// same name.
+    pub fn revoke(&self, owner: &crate::client::Client) {
+        self.registry().revoked.insert(owner.clone());
+    }
+
+    /// A name is configured again: it may open sessions.
+    ///
+    /// Not the same client — the credential is new — but the registry keys on the name, so the
+    /// mark has to be lifted or a re-added client could never open anything.
+    pub fn unrevoke(&self, owner: &crate::client::Client) {
+        self.registry().revoked.remove(owner);
     }
 
     pub fn snapshot(&self) -> Vec<SessionSnapshot> {
@@ -1935,6 +1968,15 @@ impl Sessions {
         if registry.closing {
             return Err(shutting_down());
         }
+        // **The credential was revoked while this open was in flight.** Refused here rather than
+        // released afterwards, because "afterwards" has no end: an opener that authenticated a
+        // moment before the revocation can be seconds from registering — an `attach_kernel` is —
+        // so a one-pass release cannot see it, and the session it registers behind that pass is
+        // owned by a client nothing can authenticate as and nothing will ever come back for. See
+        // [`Self::revoke`].
+        if registry.revoked.contains(&session.owner) {
+            return Err(revoked(&session.owner));
+        }
         registry.all.push_back(Arc::clone(session));
         registry.trim();
         Ok(())
@@ -2265,6 +2307,19 @@ fn shutdown_note(outcome: &Release, released: bool) -> ShutdownNote<'_> {
 ///
 /// Shared by the two gates that refuse it — before a worker is spawned, and again after it comes
 /// up — so the answer cannot drift depending on which one the caller raced.
+/// What an opener is told when the credential it authenticated with was revoked while it ran.
+///
+/// Names the cause rather than reporting a generic refusal, because the caller's own token is
+/// about to stop working for a *different* reason (a `401` on its next request) and one message
+/// that explains both saves an operator guessing which of the two they are looking at.
+fn revoked(owner: &crate::client::Client) -> String {
+    format!(
+        "the credential for client `{owner}` was revoked while this was opening, so the session \
+         was not registered — nothing was left running. Whoever administers this listener removed \
+         or rotated that client; the next request with the old token is refused outright."
+    )
+}
+
 fn shutting_down() -> String {
     "this server is shutting down — the client disconnected, and every session is being released. \
      Nothing more can be opened on this connection."

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -3403,6 +3403,61 @@ mod tests {
 
     // ---- the registry (no workers involved) ---------------------------------------
 
+    /// A revoked credential cannot register a session, and a name given back can again.
+    ///
+    /// **The window this closes is the one a lease expiry does not have.** An expiry fires only
+    /// after the client has been silent for longer than any call can keep it quiet, so nothing of
+    /// that credential's can still be in flight. A revocation has no quiet period: the token stops
+    /// being accepted the moment the set is swapped, but a call that got past authentication an
+    /// instant earlier is still running, and an opener can be *seconds* from registering — an
+    /// `attach_kernel` is. Without this gate the sweep is one pass over a snapshot, and a session
+    /// admitted behind it belongs to a client nothing can authenticate as and nothing will ever
+    /// come back for: a live kernel target held by nobody.
+    ///
+    /// The lifting is the sweeper's, once that client's sessions are gone, which is what makes a
+    /// name re-added mid-teardown safe without anything sequencing the two.
+    #[test]
+    fn a_revoked_credential_cannot_register_a_session_until_the_sweep_lifts_it() {
+        let sessions = Sessions::new(Duration::from_secs(300));
+        let gone = crate::client::Client::new("ci");
+        let mine = |id: &str| {
+            let session = dormant(id, SessionState::Open);
+            // `dormant` takes the ambient client, which in a test is `local`; these have to be
+            // owned by the client being revoked for the gate to be about anything.
+            Arc::new(Session {
+                owner: gone.clone(),
+                ..Arc::into_inner(session).expect("`dormant` hands back the only reference")
+            })
+        };
+
+        assert!(
+            sessions.admit(&mine("sess-before")).is_ok(),
+            "nothing is revoked yet"
+        );
+
+        sessions.revoke(&gone);
+        let refused = sessions
+            .admit(&mine("sess-behind-the-sweep"))
+            .expect_err("a revoked credential registered a session");
+        assert!(
+            refused.contains("revoked"),
+            "the refusal has to say why, or it reads as a capacity problem: {refused}"
+        );
+        // Another client is untouched: a revocation is about one credential, not the registry.
+        assert!(
+            sessions
+                .admit(&dormant("sess-someone-else", SessionState::Open))
+                .is_ok(),
+            "revoking one client refused another one's session"
+        );
+
+        sessions.unrevoke(&gone);
+        assert!(
+            sessions.admit(&mine("sess-after")).is_ok(),
+            "a name given back has to be able to open sessions again"
+        );
+    }
+
     /// A `Session` with no worker behind it, for the routing tests. Its queue has no consumer,
     /// which is all these need: they never submit a call.
     fn dormant(id: &str, state: SessionState) -> Arc<Session> {

--- a/src/listen.rs
+++ b/src/listen.rs
@@ -281,6 +281,13 @@ struct Presence {
     /// Tracked rather than inferred from `deadline`, so the adoption line says something true: it
     /// is the difference between "you picked up what you left" and "you are the first one here".
     left_open: bool,
+    /// This credential has been **taken out of the configuration**, rather than merely gone quiet.
+    ///
+    /// The difference is what the sweeper does when it finishes: a client that timed out keeps its
+    /// entry and may come back to it, while a revoked one is [forgotten](Lease::forget) — lease
+    /// state is keyed by client *name*, and an entry left behind is one a client re-added under
+    /// that name would inherit, session ids and all.
+    revoked: bool,
 }
 
 /// What a swept lease left behind.
@@ -293,6 +300,8 @@ struct Expired {
     /// alone would leave those MCP sessions resident and their ids still accepted, and every
     /// disconnect-and-reconnect cycle would add another that no lease will ever sweep again.
     mcp: Vec<String>,
+    /// Whether this was a revocation rather than a client going quiet — see [`Presence::revoked`].
+    revoked: bool,
 }
 
 /// What this listener decided about one request before the MCP service saw it.
@@ -521,7 +530,10 @@ impl Lease {
                 state.deadline = None;
                 state.left_open = false;
                 state.releasing = true;
-                Some(Expired { mcp })
+                Some(Expired {
+                    mcp,
+                    revoked: state.revoked,
+                })
             }
             _ => None,
         }
@@ -538,19 +550,26 @@ impl Lease {
         self.state_of(client).releasing = false;
     }
 
-    /// A client is **no longer configured**: take everything it holds, whatever its clock says.
+    /// A client is **no longer configured**: expire its lease now.
     ///
-    /// [`Self::expired_for`] with the deadline removed from the question, because a revocation is
-    /// not a client that went quiet — it is a credential that has stopped existing, and waiting out
-    /// a grace for one would leave its MCP sessions resident and its ids accepted for as long as
-    /// the grace lasts.
-    fn revoked_for(&self, client: &crate::client::Client) -> Expired {
+    /// **A revocation is an expiry that does not wait**, and saying it that way is the whole design.
+    /// The sweeper already releases an expired client's debug sessions, closes the MCP sessions it
+    /// left resident and clears its state — the three steps a revocation needs, in that order, on a
+    /// path that has been carrying live kernel targets since before this existed. So a revocation
+    /// sets the clock to now instead of growing a second teardown beside it, and the sweeper picks
+    /// it up on its next pass (at most [`SWEEP`] away).
+    ///
+    /// What the grace bought is not lost by skipping it, because it was never about this: a lease
+    /// waits so that a client which merely went quiet can come back to what it left. A credential
+    /// that has been taken out of the configuration is not coming back — the next request carrying
+    /// it is a `401` — so there is nothing for a grace to protect.
+    ///
+    /// The teardown that follows is the sweeper's, not this command's, so nothing an operator waits
+    /// on is behind a live kernel letting go.
+    fn revoke(&self, client: &crate::client::Client) {
         let mut state = self.state_of(client);
-        let mcp = std::mem::take(&mut state.mcp).into_iter().collect();
-        state.deadline = None;
-        state.left_open = false;
-        state.releasing = true;
-        Expired { mcp }
+        state.revoked = true;
+        state.deadline = Some(Instant::now());
     }
 
     /// Drops a revoked client's entry entirely, once its teardown is done.
@@ -716,21 +735,11 @@ pub async fn serve(
     // Only under the service, which is the only role with a control channel to be asked on. See
     // [`reloaded`] for what the answer is when there is no such channel.
     if let Some(asked) = reload {
-        // Two tasks, because they answer to different clocks: the first is what a client command
-        // waits on and must never be slow, the second releases targets and may take as long as a
-        // live kernel does. See [`reloaded`].
-        let (work, queued) = tokio::sync::mpsc::unbounded_channel();
-        tokio::spawn(torn_down(
-            queued,
-            sessions.clone(),
-            lease.clone(),
-            manager.clone(),
-        ));
         tokio::spawn(reloaded(
             asked,
             Arc::clone(&credentials),
             sessions.clone(),
-            work,
+            lease.clone(),
         ));
     }
 
@@ -929,18 +938,20 @@ fn refuse(status: StatusCode, why: &str) -> Response<BoxBody<Bytes, Infallible>>
 /// rather than every client locked out of a live kernel target. The set is only ever replaced by
 /// one that would have started this listener from cold.
 ///
-/// **Everything slow happens somewhere else** ([`torn_down`]), and this loop does only what the
-/// asking command is waiting on: read, swap, close the gate on revoked clients, answer. Releasing a
-/// revoked client's targets takes as long as a live kernel takes to let go, and doing it here would
-/// block the *next* command's reload behind it — which for a `--remove` or `--rotate` is reported
-/// as a failure, since those cannot tell "not applied yet" from "not applied" (review on #189).
+/// **Everything here is instant, and that is deliberate.** Reading a file, swapping a pointer and
+/// setting two flags — no `await` between the request and the answer. The command that asked is
+/// holding the SCM's control handler open until this replies, and releasing a revoked client's
+/// targets takes as long as a live kernel takes to let go: doing it here would time that
+/// acknowledgement out, and for a `--remove` or `--rotate` that reads as a *failed revocation*,
+/// since neither can tell "not applied yet" from "not applied" (review on #189). The teardown is
+/// [`sweep`]'s, which was already releasing expired clients' targets before this existed.
 ///
 /// Ends when the sender is dropped, which is the service's runtime going away.
 async fn reloaded(
     mut asked: tokio::sync::mpsc::UnboundedReceiver<std::sync::mpsc::SyncSender<bool>>,
     accepted: Arc<crate::client::Accepted>,
     sessions: Sessions,
-    work: tokio::sync::mpsc::UnboundedSender<crate::client::Change>,
+    lease: Arc<Lease>,
 ) {
     while let Some(answer) = asked.recv().await {
         // The same function that decided whether this listener could start at all, and
@@ -961,19 +972,22 @@ async fn reloaded(
             }
         };
         let change = accepted.replace(fresh);
-        // **The gate closes here, not in the teardown.** A revocation has a window a lease expiry
-        // does not: the token stops being accepted at the swap above, but a call that got past
-        // authentication a moment earlier is still running, and an opener can be seconds from
-        // registering. So this has to be shut before anything else is allowed to happen — and it
-        // can be, because it is a flag under the registry lock rather than work. What it is *not*
-        // is something to leave until the teardown reaches this client, which may be a live kernel
-        // release away.
         for name in &change.removed {
-            sessions.revoke(&crate::client::Client::new(name));
+            let gone = crate::client::Client::new(name);
+            // **The gate closes before the answer goes out**, because a revocation has a window a
+            // lease expiry does not. An expiry only fires after the client has been silent for
+            // longer than any call can keep it quiet, so nothing of that credential's can still be
+            // in flight; here the token stops being accepted at the swap above, but a call that got
+            // past authentication a moment earlier is still running and an opener can be seconds
+            // from registering. A session admitted behind the sweep would belong to a client
+            // nothing can authenticate as and nothing will ever come back for. Taken off again by
+            // the sweep, once that client's sessions are gone.
+            sessions.revoke(&gone);
+            // And the clock to now, which is all a revocation is: the sweeper does the rest.
+            lease.revoke(&gone);
         }
-        // **Answered once the swap and the gate are both done**, which is exactly what the asking
-        // command claims when it returns. Everything after this point is cleanup the operator is
-        // not waiting on.
+        // **Answered once the swap and the gates are done** — which is exactly what the asking
+        // command claims when it returns, and all of it is memory.
         let _ = answer.send(true);
         tracing::info!(
             "re-read the clients: {}",
@@ -990,58 +1004,6 @@ async fn reloaded(
                 ),
             }
         );
-        // Dropped only when the runtime is going away, in which case there is nothing to tear down.
-        let _ = work.send(change);
-    }
-}
-
-/// Releases what a revoked client left behind, one reload at a time.
-///
-/// **A queue rather than a task per client**, and the ordering is the whole reason. Spawning the
-/// teardown freely would let a client re-added under a revoked name have its fresh lease state
-/// wiped by the `forget` of the incarnation before it — remove `ci`, add `ci` again while the first
-/// release is still running, and the late `forget` takes the new one's sessions with it. Draining
-/// in the order the reloads happened makes that unreachable rather than unlikely.
-///
-/// Which is also why `unrevoke` is *here* and not in [`reloaded`]: it has to land after the
-/// `forget` of the previous holder, not before it. For an ordinary new client it is a no-op —
-/// nothing revoked that name — so the common case waits for nothing.
-async fn torn_down(
-    mut work: tokio::sync::mpsc::UnboundedReceiver<crate::client::Change>,
-    sessions: Sessions,
-    lease: Arc<Lease>,
-    manager: Arc<LocalSessionManager>,
-) {
-    while let Some(change) = work.recv().await {
-        for name in change.removed {
-            let gone = crate::client::Client::new(&name);
-            // Claimed as an expiry does: this marks the client `releasing` and takes its MCP ids
-            // under the same lock, so nothing can be admitted to what is being torn down.
-            // Unconditional, because the credential is gone rather than quiet.
-            let held = lease.revoked_for(&gone);
-            if sessions.live_count_for(&gone) > 0 {
-                tracing::info!(
-                    "client `{name}` is no longer configured; releasing the sessions it left open"
-                );
-                sessions.release_leased(&gone).await;
-            }
-            // The debug sessions are the expensive half and not the whole of it — the same three
-            // steps the sweep takes, for the same reasons. A revoked client sent no `DELETE`s, so
-            // without this its MCP sessions stay resident in the service for ever.
-            for id in held.mcp {
-                if let Err(e) = manager.close_session(&id.into()).await {
-                    tracing::warn!("could not close a revoked client's MCP session: {e}");
-                }
-            }
-            // And then the entry itself, which is what an expiry does *not* do: a name that may be
-            // re-added must not inherit the ids of whoever held it before.
-            lease.forget(&gone);
-        }
-        // After the removals above, so a name given back is ungated only once its predecessor has
-        // been forgotten.
-        for name in &change.added {
-            sessions.unrevoke(&crate::client::Client::new(name));
-        }
     }
 }
 
@@ -1085,9 +1047,20 @@ async fn sweep(
                     );
                 }
             }
-            // Only now may this client be admitted again: until here, an arriving request would be
-            // let in to sessions this release is closing.
-            lease.released_leases(&client);
+            if expired.revoked {
+                // **A revocation ends differently, and this is the only place that has to know.**
+                // The entry goes rather than being cleared, because lease state is keyed by name: a
+                // client re-added under this one must not inherit the ids of whoever held it
+                // before. And the admission gate `reloaded` closed comes off last of all — a name
+                // given back is ungated only once its predecessor's sessions are gone, which is
+                // what makes "re-added during a teardown" safe without anything sequencing it.
+                lease.forget(&client);
+                sessions.unrevoke(&client);
+            } else {
+                // Only now may this client be admitted again: until here, an arriving request would
+                // be let in to sessions this release is closing.
+                lease.released_leases(&client);
+            }
         }
     }
 }
@@ -1136,8 +1109,8 @@ mod tests {
             self.lease.released_leases(&self.client);
         }
 
-        fn revoked(&self) -> Expired {
-            self.lease.revoked_for(&self.client)
+        fn revoke(&self) {
+            self.lease.revoke(&self.client);
         }
 
         fn forget(&self) {
@@ -1669,40 +1642,46 @@ mod tests {
         assert!(lease.state().mcp.is_empty());
     }
 
-    /// A revoked client's MCP sessions come back whatever its clock says, and its entry then goes.
+    /// A revocation is an expiry that does not wait, and the sweeper is told which one it swept.
     ///
-    /// Two failures, and neither one shows up as anything until much later. Waiting for the
-    /// deadline would leave a removed credential's MCP sessions resident in the service for a whole
-    /// grace, since nothing else will ever close them — a revocation is not a client that went
-    /// quiet. And lease state is keyed by client *name*, so leaving the entry behind means a client
-    /// re-added under that name inherits the session ids of whoever held it before.
+    /// Three things, and each one is a failure that shows up only much later. Waiting out the grace
+    /// would leave a removed credential's sessions live for as long as it lasts — a grace is there
+    /// so a client that went *quiet* can come back to what it left, and a revoked one is never
+    /// coming back. The sessions have to come back from the sweep, or nothing ever closes them. And
+    /// the `revoked` flag has to travel with them, because it is what tells the sweeper to forget
+    /// the entry rather than clear it: lease state is keyed by client *name*, so an entry left
+    /// behind is one a client re-added under that name would inherit, session ids and all.
     #[test]
-    fn revoking_a_client_takes_its_sessions_now_and_leaves_no_entry_behind() {
+    fn revoking_a_client_expires_it_now_and_says_so_to_the_sweeper() {
         let lease = For::new(unchecked(Duration::from_secs(300)), "ci");
         request(&lease, None, Some("session-a"), true);
         request(&lease, None, Some("session-b"), true);
         // Deliberately *not* expired: the grace is the full one and no time has passed.
         assert!(
             lease.expired().is_none(),
-            "this client's lease has not run out; the point is that revocation does not care"
+            "this client's lease has not run out — the point is that a revocation does not wait"
         );
 
-        let held = lease.revoked();
+        lease.revoke();
+        let swept = lease
+            .expired()
+            .expect("a revoked client is expired now, not one grace later");
         assert_eq!(
-            held.mcp,
+            swept.mcp,
             vec!["session-a".to_string(), "session-b".to_string()],
             "a revoked client's MCP sessions have to come back, or nothing ever closes them"
         );
         assert!(
-            lease.state().releasing,
-            "the teardown has to be claimed under the same lock that took the sessions"
+            swept.revoked,
+            "the sweeper cannot tell which ending to use unless the expiry says which kind it was"
         );
 
         lease.forget();
         // Asking for the state again is exactly what a client re-added under this name does:
         // `state_of` creates the entry it does not find. It has to find nothing.
+        let state = lease.state();
         assert!(
-            lease.state().mcp.is_empty() && !lease.state().releasing,
+            state.mcp.is_empty() && !state.releasing && !state.revoked,
             "a name re-added after a revocation inherited the entry of whoever held it before"
         );
     }

--- a/src/listen.rs
+++ b/src/listen.rs
@@ -716,12 +716,21 @@ pub async fn serve(
     // Only under the service, which is the only role with a control channel to be asked on. See
     // [`reloaded`] for what the answer is when there is no such channel.
     if let Some(asked) = reload {
+        // Two tasks, because they answer to different clocks: the first is what a client command
+        // waits on and must never be slow, the second releases targets and may take as long as a
+        // live kernel does. See [`reloaded`].
+        let (work, queued) = tokio::sync::mpsc::unbounded_channel();
+        tokio::spawn(torn_down(
+            queued,
+            sessions.clone(),
+            lease.clone(),
+            manager.clone(),
+        ));
         tokio::spawn(reloaded(
             asked,
             Arc::clone(&credentials),
             sessions.clone(),
-            lease.clone(),
-            manager.clone(),
+            work,
         ));
     }
 
@@ -907,7 +916,7 @@ fn refuse(status: StatusCode, why: &str) -> Response<BoxBody<Bytes, Infallible>>
         .expect("a constant response is well-formed")
 }
 
-/// Re-reads the credential file whenever the service is asked to, and acts on what changed.
+/// Re-reads the credential file whenever the service is asked to, and says what changed.
 ///
 /// **The other half of the client commands** (`FOLLOWUPS.md` item 34). Without it,
 /// `--add-listen-client` writes a file nothing reads until the next start — and a *restart* drops
@@ -920,19 +929,18 @@ fn refuse(status: StatusCode, why: &str) -> Response<BoxBody<Bytes, Infallible>>
 /// rather than every client locked out of a live kernel target. The set is only ever replaced by
 /// one that would have started this listener from cold.
 ///
-/// **A removed client's sessions are released, not refused.** The command that removed it could
-/// not have refused on their account — it runs in another process and cannot see them — and
-/// blocking a revocation on the sessions it is trying to revoke is the wrong way round anyway. So
-/// they go down the path a lease expiry already uses, which for a live kernel is the orderly
-/// release rather than a worker killed and a guest left frozen.
+/// **Everything slow happens somewhere else** ([`torn_down`]), and this loop does only what the
+/// asking command is waiting on: read, swap, close the gate on revoked clients, answer. Releasing a
+/// revoked client's targets takes as long as a live kernel takes to let go, and doing it here would
+/// block the *next* command's reload behind it — which for a `--remove` or `--rotate` is reported
+/// as a failure, since those cannot tell "not applied yet" from "not applied" (review on #189).
 ///
 /// Ends when the sender is dropped, which is the service's runtime going away.
 async fn reloaded(
     mut asked: tokio::sync::mpsc::UnboundedReceiver<std::sync::mpsc::SyncSender<bool>>,
     accepted: Arc<crate::client::Accepted>,
     sessions: Sessions,
-    lease: Arc<Lease>,
-    manager: Arc<LocalSessionManager>,
+    work: tokio::sync::mpsc::UnboundedSender<crate::client::Change>,
 ) {
     while let Some(answer) = asked.recv().await {
         // The same function that decided whether this listener could start at all, and
@@ -953,10 +961,19 @@ async fn reloaded(
             }
         };
         let change = accepted.replace(fresh);
-        // **Answered here, before the releases below.** The swap is what the asking command is
-        // waiting to be true, and it now is; releasing a revoked client's targets can take as long
-        // as a live kernel takes to let go, and holding the SCM's control handler for that would
-        // make a routine command look like a hung service.
+        // **The gate closes here, not in the teardown.** A revocation has a window a lease expiry
+        // does not: the token stops being accepted at the swap above, but a call that got past
+        // authentication a moment earlier is still running, and an opener can be seconds from
+        // registering. So this has to be shut before anything else is allowed to happen — and it
+        // can be, because it is a flag under the registry lock rather than work. What it is *not*
+        // is something to leave until the teardown reaches this client, which may be a live kernel
+        // release away.
+        for name in &change.removed {
+            sessions.revoke(&crate::client::Client::new(name));
+        }
+        // **Answered once the swap and the gate are both done**, which is exactly what the asking
+        // command claims when it returns. Everything after this point is cleanup the operator is
+        // not waiting on.
         let _ = answer.send(true);
         tracing::info!(
             "re-read the clients: {}",
@@ -973,25 +990,34 @@ async fn reloaded(
                 ),
             }
         );
-        // **Before the removals**, so a name being given back does not stay gated by the mark its
-        // previous holder left. A single reload cannot both add and remove one name — `Change` is a
-        // diff — but two reloads can, and the second must be able to open sessions.
-        for name in &change.added {
-            sessions.unrevoke(&crate::client::Client::new(name));
-        }
+        // Dropped only when the runtime is going away, in which case there is nothing to tear down.
+        let _ = work.send(change);
+    }
+}
+
+/// Releases what a revoked client left behind, one reload at a time.
+///
+/// **A queue rather than a task per client**, and the ordering is the whole reason. Spawning the
+/// teardown freely would let a client re-added under a revoked name have its fresh lease state
+/// wiped by the `forget` of the incarnation before it — remove `ci`, add `ci` again while the first
+/// release is still running, and the late `forget` takes the new one's sessions with it. Draining
+/// in the order the reloads happened makes that unreachable rather than unlikely.
+///
+/// Which is also why `unrevoke` is *here* and not in [`reloaded`]: it has to land after the
+/// `forget` of the previous holder, not before it. For an ordinary new client it is a no-op —
+/// nothing revoked that name — so the common case waits for nothing.
+async fn torn_down(
+    mut work: tokio::sync::mpsc::UnboundedReceiver<crate::client::Change>,
+    sessions: Sessions,
+    lease: Arc<Lease>,
+    manager: Arc<LocalSessionManager>,
+) {
+    while let Some(change) = work.recv().await {
         for name in change.removed {
             let gone = crate::client::Client::new(&name);
-            // **The gate closes before anything is walked.** A revocation has a window a lease
-            // expiry does not: the token stops being accepted at the swap above, but a call that
-            // got past authentication a moment earlier is still running, and an opener can be
-            // seconds from registering. Without this the release below is one pass over a
-            // snapshot, and a session registered behind it belongs to a client nothing can
-            // authenticate as and nothing will ever come back for — a live kernel target held by
-            // nobody (review on #189).
-            sessions.revoke(&gone);
-            // Claimed next, exactly as an expiry does: this marks the client `releasing` and takes
-            // its MCP ids under the same lock, so nothing can be admitted to what is being torn
-            // down. Unconditional, because the credential is gone rather than quiet.
+            // Claimed as an expiry does: this marks the client `releasing` and takes its MCP ids
+            // under the same lock, so nothing can be admitted to what is being torn down.
+            // Unconditional, because the credential is gone rather than quiet.
             let held = lease.revoked_for(&gone);
             if sessions.live_count_for(&gone) > 0 {
                 tracing::info!(
@@ -1010,6 +1036,11 @@ async fn reloaded(
             // And then the entry itself, which is what an expiry does *not* do: a name that may be
             // re-added must not inherit the ids of whoever held it before.
             lease.forget(&gone);
+        }
+        // After the removals above, so a name given back is ungated only once its predecessor has
+        // been forgotten.
+        for name in &change.added {
+            sessions.unrevoke(&crate::client::Client::new(name));
         }
     }
 }

--- a/src/listen.rs
+++ b/src/listen.rs
@@ -433,7 +433,16 @@ impl Lease {
         let mut state = self.state_of(client);
         // Nothing is served while a teardown is in flight. Briefly refusing a client that could
         // have been served costs it a reconnect; serving one costs it the session mid-call.
-        if state.releasing {
+        //
+        // **`revoked` counts as in flight**, and it is the sharper of the two. A revocation decides
+        // the teardown and the sweep runs it, so in between this presence is a credential that has
+        // gone — and the *name* may already have been handed to a different one, since a client is
+        // identified by its name and `--add-listen-client ci` after `--remove-listen-client ci`
+        // names the same one. Serving that request would let the new credential renew the
+        // revocation's deadline and route to its predecessor's debug sessions, which is the
+        // isolation this whole ownership boundary exists to provide. Refusing costs it a `409` and
+        // one retry, until the sweep forgets the entry.
+        if state.releasing || state.revoked {
             return Admission::Releasing;
         }
         // **Renewed if there is one; never created.** "Any request renews the lease" is what keeps a
@@ -492,8 +501,18 @@ impl Lease {
         };
         let mut state = self.state_of(client);
         let adopted = state.left_open;
+        // Recorded whatever else is true, so the sweep closes it: an MCP session minted for a
+        // credential that has since been revoked is one nothing else will ever close.
         state.mcp.insert(session.to_string());
-        state.deadline = Some(Instant::now() + self.grace);
+        // **But a revoked lease is never renewed.** [`Self::admit`] refuses this credential, so the
+        // only request that reaches here after a revocation is one that was already inside the MCP
+        // service when the set was swapped — and renewing on its way out would push the deadline a
+        // whole grace into the future, so the sweep that was to run on its next pass does not, and
+        // the revoked client's debug sessions stay live for as long as the client kept talking. The
+        // clock a revocation set is the one that has to fire.
+        if !state.revoked {
+            state.deadline = Some(Instant::now() + self.grace);
+        }
         state.left_open = false;
         adopted
     }
@@ -1683,6 +1702,59 @@ mod tests {
         assert!(
             state.mcp.is_empty() && !state.releasing && !state.revoked,
             "a name re-added after a revocation inherited the entry of whoever held it before"
+        );
+    }
+
+    /// A name handed to a new credential before the sweep runs reaches none of its predecessor.
+    ///
+    /// **A client is identified by its name**, so `--remove-listen-client ci` followed by
+    /// `--add-listen-client ci` produces two different credentials that every mechanism keyed on
+    /// identity — session ownership, routing, lease state — cannot tell apart. Between the
+    /// revocation and the sweep that acts on it, the entry still holds the *previous* holder's
+    /// sessions, so serving the new one would hand it debug sessions opened by a credential that
+    /// has been revoked. That is the isolation this ownership boundary exists to provide, and it is
+    /// the one thing a rotation deliberately does *not* do — `--rotate-listen-client` keeps the
+    /// name and so keeps the sessions, which is the supported way to change a token.
+    ///
+    /// The second half is what makes the refusal load-bearing rather than tidy: a request that
+    /// renewed would push the revocation's deadline a whole grace out, so the sweep that was to run
+    /// on its next pass would not, and the revoked client's targets would stay live for as long as
+    /// somebody kept talking to that name.
+    #[test]
+    fn a_revoked_name_serves_nobody_until_the_sweep_has_forgotten_it() {
+        let lease = For::new(unchecked(Duration::from_secs(300)), "ci");
+        request(&lease, None, Some("session-a"), true);
+        lease.revoke();
+
+        assert_eq!(
+            lease.admit(None),
+            Admission::Releasing,
+            "a name whose revocation has not been swept was served — to whoever holds it now"
+        );
+
+        // The in-flight request of the *old* credential: it passed `admit` before the revocation
+        // and settles afterwards. It may record its MCP session, so the sweep closes that too, but
+        // it must not move the clock.
+        let deadline = lease.state().deadline;
+        lease.settle(None, Some("session-b"), true);
+        assert_eq!(
+            lease.state().deadline,
+            deadline,
+            "a request settling after the revocation renewed its lease, so the sweep never fires"
+        );
+        assert!(
+            lease.state().mcp.contains("session-b"),
+            "an MCP session minted for a revoked credential is one nothing else will ever close"
+        );
+
+        // And the sweep's ending is what lets the name be used again.
+        let swept = lease.expired().expect("revoked, so expired now");
+        assert!(swept.revoked);
+        lease.forget();
+        assert_eq!(
+            lease.admit(None),
+            Admission::Serve,
+            "once the predecessor is forgotten the name is an ordinary client again"
         );
     }
 

--- a/src/listen.rs
+++ b/src/listen.rs
@@ -613,10 +613,11 @@ pub async fn serve(
     sessions: Sessions,
     addr: SocketAddr,
     call_timeout: Duration,
+    reload: Option<tokio::sync::mpsc::UnboundedReceiver<()>>,
     shutdown: impl Future<Output = ()>,
     ready: impl FnOnce(),
 ) -> Result<()> {
-    let credentials = Arc::new(credentials()?);
+    let credentials = Arc::new(crate::client::Accepted::new(credentials()?));
 
     let grace = match std::env::var(GRACE_ENV).ok().and_then(|v| v.parse().ok()) {
         Some(secs) if secs > 0 => Duration::from_secs(secs),
@@ -686,6 +687,12 @@ pub async fn serve(
         credentials.names().join(", ")
     );
 
+    // Only under the service, which is the only role with a control channel to be asked on. See
+    // [`reloaded`] for what the answer is when there is no such channel.
+    if let Some(asked) = reload {
+        tokio::spawn(reloaded(asked, Arc::clone(&credentials), sessions.clone()));
+    }
+
     tokio::spawn(sweep(
         sessions.clone(),
         lease.clone(),
@@ -739,7 +746,7 @@ async fn gate(
     req: Request<Incoming>,
     mcp: Arc<StreamableHttpService<WindbgServer, LocalSessionManager>>,
     lease: Arc<Lease>,
-    credentials: Arc<crate::client::Credentials>,
+    credentials: Arc<crate::client::Accepted>,
     peer: SocketAddr,
 ) -> Result<Response<BoxBody<Bytes, Infallible>>, Infallible> {
     let Some(caller) = authorised(&req, &credentials) else {
@@ -851,14 +858,13 @@ fn is_departure(method: &hyper::Method, status: StatusCode) -> bool {
 /// transport whose protocol no longer has sessions in it.
 fn authorised(
     req: &Request<Incoming>,
-    credentials: &crate::client::Credentials,
+    credentials: &crate::client::Accepted,
 ) -> Option<crate::client::Client> {
     req.headers()
         .get(AUTHORIZATION)
         .and_then(|v| v.to_str().ok())
         .and_then(|v| v.strip_prefix("Bearer "))
         .and_then(|presented| credentials.client_for(presented))
-        .cloned()
 }
 
 fn refuse(status: StatusCode, why: &str) -> Response<BoxBody<Bytes, Infallible>> {
@@ -867,6 +873,74 @@ fn refuse(status: StatusCode, why: &str) -> Response<BoxBody<Bytes, Infallible>>
         .body(Full::new(Bytes::from(why.to_string())).boxed())
         // The builder only fails on a malformed status or header, and both are literals here.
         .expect("a constant response is well-formed")
+}
+
+/// Re-reads the credential file whenever the service is asked to, and acts on what changed.
+///
+/// **The other half of the client commands** (`FOLLOWUPS.md` item 34). Without it,
+/// `--add-listen-client` writes a file nothing reads until the next start — and a *restart* drops
+/// every session the service holds, which is most of what made the reinstall it replaces
+/// unfriendly. So the commands would be an improvement in ergonomics and not in outcome.
+///
+/// **A failed read changes nothing.** [`credentials`] refuses a file it cannot parse and one that
+/// names nobody, and neither of those may become a listener that has forgotten who may connect: an
+/// operator with a typo in a file gets a loud log line and a service still serving its old set,
+/// rather than every client locked out of a live kernel target. The set is only ever replaced by
+/// one that would have started this listener from cold.
+///
+/// **A removed client's sessions are released, not refused.** The command that removed it could
+/// not have refused on their account — it runs in another process and cannot see them — and
+/// blocking a revocation on the sessions it is trying to revoke is the wrong way round anyway. So
+/// they go down the path a lease expiry already uses, which for a live kernel is the orderly
+/// release rather than a worker killed and a guest left frozen.
+///
+/// Ends when the sender is dropped, which is the service's runtime going away.
+async fn reloaded(
+    mut asked: tokio::sync::mpsc::UnboundedReceiver<()>,
+    accepted: Arc<crate::client::Accepted>,
+    sessions: Sessions,
+) {
+    while asked.recv().await.is_some() {
+        // The same function that decided whether this listener could start at all, and
+        // deliberately so: a set that would not have started it does not get to replace the one
+        // that did.
+        let fresh = match credentials() {
+            Ok(fresh) => fresh,
+            Err(e) => {
+                tracing::error!(
+                    "asked to re-read the clients, and could not ({e:#}) — still serving the {} \
+                     configured at startup",
+                    accepted.names().len()
+                );
+                continue;
+            }
+        };
+        let change = accepted.replace(fresh);
+        tracing::info!(
+            "re-read the clients: {}",
+            match change.is_empty() {
+                // A rotation, which changes a token and no name. Worth a line of its own: from
+                // out here it looks like nothing happened, and the client whose token moved is
+                // about to start failing to authenticate with the old one.
+                true => "the same clients, one or more of which may now present a different token"
+                    .to_string(),
+                false => format!(
+                    "added [{}], removed [{}]",
+                    change.added.join(", "),
+                    change.removed.join(", ")
+                ),
+            }
+        );
+        for name in change.removed {
+            let gone = crate::client::Client::new(&name);
+            if sessions.live_count_for(&gone) > 0 {
+                tracing::info!(
+                    "client `{name}` is no longer configured; releasing the sessions it left open"
+                );
+                sessions.release_leased(&gone).await;
+            }
+        }
+    }
 }
 
 /// Releases what an absent client left behind, once its lease runs out.

--- a/src/listen.rs
+++ b/src/listen.rs
@@ -991,6 +991,19 @@ async fn reloaded(
             }
         };
         let change = accepted.replace(fresh);
+        // **Lifted by a name being given back, not by a teardown finishing.** This is the only
+        // event that requires the gate off, and hanging it on anything else — the release running
+        // out of sessions to release, say — lifts it while a revoked credential's opener may still
+        // be seconds from registering. A name that is revoked and never configured again keeps its
+        // gate for the life of the process, which is a client name held in a set and exactly the
+        // behaviour wanted: nothing that credential started may ever register.
+        //
+        // It needs no sequencing against the teardown below, because `Lease::admit` refuses a
+        // revoked presence until the sweep forgets it: a name given back inside that window is held
+        // at a `409` by the lease, not by this.
+        for name in &change.added {
+            sessions.unrevoke(&crate::client::Client::new(name));
+        }
         for name in &change.removed {
             let gone = crate::client::Client::new(name);
             // **The gate closes before the answer goes out**, because a revocation has a window a
@@ -1070,11 +1083,18 @@ async fn sweep(
                 // **A revocation ends differently, and this is the only place that has to know.**
                 // The entry goes rather than being cleared, because lease state is keyed by name: a
                 // client re-added under this one must not inherit the ids of whoever held it
-                // before. And the admission gate `reloaded` closed comes off last of all — a name
-                // given back is ungated only once its predecessor's sessions are gone, which is
-                // what makes "re-added during a teardown" safe without anything sequencing it.
+                // before.
+                //
+                // The admission gate is **not** lifted here, and that is the point of it. This
+                // release is one pass over a snapshot, so a revoked credential's opener that had
+                // authenticated but not yet registered is invisible to it — an `attach_kernel` is
+                // seconds of worker spawn and link wait away from registering — and lifting on
+                // "nothing left to release" would let that opener register a target owned by a
+                // credential nothing can authenticate as, stranded until the process ends
+                // ([#189](https://github.com/glslang/windbg-mcp/pull/189) review). The gate comes
+                // off when the *name is given back*, in [`reloaded`], because that is the event
+                // that needs it off; until then it stays shut however long the opener takes.
                 lease.forget(&client);
-                sessions.unrevoke(&client);
             } else {
                 // Only now may this client be admitted again: until here, an arriving request would
                 // be let in to sessions this release is closing.

--- a/src/listen.rs
+++ b/src/listen.rs
@@ -973,9 +973,23 @@ async fn reloaded(
                 ),
             }
         );
+        // **Before the removals**, so a name being given back does not stay gated by the mark its
+        // previous holder left. A single reload cannot both add and remove one name — `Change` is a
+        // diff — but two reloads can, and the second must be able to open sessions.
+        for name in &change.added {
+            sessions.unrevoke(&crate::client::Client::new(name));
+        }
         for name in change.removed {
             let gone = crate::client::Client::new(&name);
-            // Claimed first, exactly as an expiry does: this marks the client `releasing` and takes
+            // **The gate closes before anything is walked.** A revocation has a window a lease
+            // expiry does not: the token stops being accepted at the swap above, but a call that
+            // got past authentication a moment earlier is still running, and an opener can be
+            // seconds from registering. Without this the release below is one pass over a
+            // snapshot, and a session registered behind it belongs to a client nothing can
+            // authenticate as and nothing will ever come back for — a live kernel target held by
+            // nobody (review on #189).
+            sessions.revoke(&gone);
+            // Claimed next, exactly as an expiry does: this marks the client `releasing` and takes
             // its MCP ids under the same lock, so nothing can be admitted to what is being torn
             // down. Unconditional, because the credential is gone rather than quiet.
             let held = lease.revoked_for(&gone);

--- a/src/listen.rs
+++ b/src/listen.rs
@@ -537,6 +537,32 @@ impl Lease {
     fn released_leases(&self, client: &crate::client::Client) {
         self.state_of(client).releasing = false;
     }
+
+    /// A client is **no longer configured**: take everything it holds, whatever its clock says.
+    ///
+    /// [`Self::expired_for`] with the deadline removed from the question, because a revocation is
+    /// not a client that went quiet — it is a credential that has stopped existing, and waiting out
+    /// a grace for one would leave its MCP sessions resident and its ids accepted for as long as
+    /// the grace lasts.
+    fn revoked_for(&self, client: &crate::client::Client) -> Expired {
+        let mut state = self.state_of(client);
+        let mcp = std::mem::take(&mut state.mcp).into_iter().collect();
+        state.deadline = None;
+        state.left_open = false;
+        state.releasing = true;
+        Expired { mcp }
+    }
+
+    /// Drops a revoked client's entry entirely, once its teardown is done.
+    ///
+    /// **Not the same as [`Self::released_leases`]**, and the difference is what review found: that
+    /// one clears the `releasing` flag and leaves the entry, which is right for a client that may
+    /// come back. Lease state is keyed by client *name*, so an entry left behind is one a client
+    /// re-added under the same name inherits — including MCP session ids belonging to whoever held
+    /// that name before. A revoked name has to start from nothing.
+    fn forget(&self, client: &crate::client::Client) {
+        self.all().remove(client);
+    }
 }
 /// How long to keep retrying a bind that fails because the address is not there yet.
 ///
@@ -613,7 +639,7 @@ pub async fn serve(
     sessions: Sessions,
     addr: SocketAddr,
     call_timeout: Duration,
-    reload: Option<tokio::sync::mpsc::UnboundedReceiver<()>>,
+    reload: Option<tokio::sync::mpsc::UnboundedReceiver<std::sync::mpsc::SyncSender<bool>>>,
     shutdown: impl Future<Output = ()>,
     ready: impl FnOnce(),
 ) -> Result<()> {
@@ -690,7 +716,13 @@ pub async fn serve(
     // Only under the service, which is the only role with a control channel to be asked on. See
     // [`reloaded`] for what the answer is when there is no such channel.
     if let Some(asked) = reload {
-        tokio::spawn(reloaded(asked, Arc::clone(&credentials), sessions.clone()));
+        tokio::spawn(reloaded(
+            asked,
+            Arc::clone(&credentials),
+            sessions.clone(),
+            lease.clone(),
+            manager.clone(),
+        ));
     }
 
     tokio::spawn(sweep(
@@ -896,11 +928,13 @@ fn refuse(status: StatusCode, why: &str) -> Response<BoxBody<Bytes, Infallible>>
 ///
 /// Ends when the sender is dropped, which is the service's runtime going away.
 async fn reloaded(
-    mut asked: tokio::sync::mpsc::UnboundedReceiver<()>,
+    mut asked: tokio::sync::mpsc::UnboundedReceiver<std::sync::mpsc::SyncSender<bool>>,
     accepted: Arc<crate::client::Accepted>,
     sessions: Sessions,
+    lease: Arc<Lease>,
+    manager: Arc<LocalSessionManager>,
 ) {
-    while asked.recv().await.is_some() {
+    while let Some(answer) = asked.recv().await {
         // The same function that decided whether this listener could start at all, and
         // deliberately so: a set that would not have started it does not get to replace the one
         // that did.
@@ -909,13 +943,21 @@ async fn reloaded(
             Err(e) => {
                 tracing::error!(
                     "asked to re-read the clients, and could not ({e:#}) — still serving the {} \
-                     configured at startup",
+                     this listener already had",
                     accepted.names().len()
                 );
+                // Told, rather than left to time out: the command that asked prints what happened,
+                // and "it would not have that file" is the useful half of it.
+                let _ = answer.send(false);
                 continue;
             }
         };
         let change = accepted.replace(fresh);
+        // **Answered here, before the releases below.** The swap is what the asking command is
+        // waiting to be true, and it now is; releasing a revoked client's targets can take as long
+        // as a live kernel takes to let go, and holding the SCM's control handler for that would
+        // make a routine command look like a hung service.
+        let _ = answer.send(true);
         tracing::info!(
             "re-read the clients: {}",
             match change.is_empty() {
@@ -933,12 +975,27 @@ async fn reloaded(
         );
         for name in change.removed {
             let gone = crate::client::Client::new(&name);
+            // Claimed first, exactly as an expiry does: this marks the client `releasing` and takes
+            // its MCP ids under the same lock, so nothing can be admitted to what is being torn
+            // down. Unconditional, because the credential is gone rather than quiet.
+            let held = lease.revoked_for(&gone);
             if sessions.live_count_for(&gone) > 0 {
                 tracing::info!(
                     "client `{name}` is no longer configured; releasing the sessions it left open"
                 );
                 sessions.release_leased(&gone).await;
             }
+            // The debug sessions are the expensive half and not the whole of it — the same three
+            // steps the sweep takes, for the same reasons. A revoked client sent no `DELETE`s, so
+            // without this its MCP sessions stay resident in the service for ever.
+            for id in held.mcp {
+                if let Err(e) = manager.close_session(&id.into()).await {
+                    tracing::warn!("could not close a revoked client's MCP session: {e}");
+                }
+            }
+            // And then the entry itself, which is what an expiry does *not* do: a name that may be
+            // re-added must not inherit the ids of whoever held it before.
+            lease.forget(&gone);
         }
     }
 }
@@ -1032,6 +1089,14 @@ mod tests {
 
         fn released_leases(&self) {
             self.lease.released_leases(&self.client);
+        }
+
+        fn revoked(&self) -> Expired {
+            self.lease.revoked_for(&self.client)
+        }
+
+        fn forget(&self) {
+            self.lease.forget(&self.client);
         }
 
         fn state(&self) -> PresenceGuard<'_> {
@@ -1557,6 +1622,44 @@ mod tests {
              already-released set of sessions on each pass"
         );
         assert!(lease.state().mcp.is_empty());
+    }
+
+    /// A revoked client's MCP sessions come back whatever its clock says, and its entry then goes.
+    ///
+    /// Two failures, and neither one shows up as anything until much later. Waiting for the
+    /// deadline would leave a removed credential's MCP sessions resident in the service for a whole
+    /// grace, since nothing else will ever close them — a revocation is not a client that went
+    /// quiet. And lease state is keyed by client *name*, so leaving the entry behind means a client
+    /// re-added under that name inherits the session ids of whoever held it before.
+    #[test]
+    fn revoking_a_client_takes_its_sessions_now_and_leaves_no_entry_behind() {
+        let lease = For::new(unchecked(Duration::from_secs(300)), "ci");
+        request(&lease, None, Some("session-a"), true);
+        request(&lease, None, Some("session-b"), true);
+        // Deliberately *not* expired: the grace is the full one and no time has passed.
+        assert!(
+            lease.expired().is_none(),
+            "this client's lease has not run out; the point is that revocation does not care"
+        );
+
+        let held = lease.revoked();
+        assert_eq!(
+            held.mcp,
+            vec!["session-a".to_string(), "session-b".to_string()],
+            "a revoked client's MCP sessions have to come back, or nothing ever closes them"
+        );
+        assert!(
+            lease.state().releasing,
+            "the teardown has to be claimed under the same lock that took the sessions"
+        );
+
+        lease.forget();
+        // Asking for the state again is exactly what a client re-added under this name does:
+        // `state_of` creates the entry it does not find. It has to find nothing.
+        assert!(
+            lease.state().mcp.is_empty() && !lease.state().releasing,
+            "a name re-added after a revocation inherited the entry of whoever held it before"
+        );
     }
 
     /// A swept lease says what it left in the service, so the sweeper can close that too.

--- a/src/main.rs
+++ b/src/main.rs
@@ -94,6 +94,10 @@ fn main() -> Result<()> {
             ),
             service::Role::Uninstall => service::uninstall(),
             service::Role::Run => service::run(),
+            // Touches the SCM and one file, like installing — and like installing, it must not
+            // build a runtime: the reload it asks for happens in the *service's* process, not
+            // this one.
+            service::Role::Client(edit, name) => service::edit_client(edit, &name, &args),
         };
     }
 
@@ -112,7 +116,11 @@ fn main() -> Result<()> {
                 // A foreground listener has nobody to ask it to stop — Ctrl+C ends the process and
                 // each worker releases its target when its pipe closes — so the shutdown it hands
                 // over is one that never fires. Only the service role has a stop to deliver.
-                Some(addr) => serve_http(addr, std::future::pending(), || {}).await,
+                // No reload either, and for the same reason as the shutdown above: the signal
+                // is a service control code, and a foreground listener has no SCM to receive one
+                // from. Its clients come from the environment it was started with, which is a set
+                // that cannot change without the process changing too.
+                Some(addr) => serve_http(addr, None, std::future::pending(), || {}).await,
                 None => serve().await,
             }
         })
@@ -125,11 +133,20 @@ fn main() -> Result<()> {
 /// a client going away is handled by its lease instead.
 pub(crate) async fn serve_http(
     addr: std::net::SocketAddr,
+    reload: Option<tokio::sync::mpsc::UnboundedReceiver<()>>,
     shutdown: impl std::future::Future<Output = ()>,
     ready: impl FnOnce(),
 ) -> Result<()> {
     let sessions = Sessions::new(call_timeout()).recording(record::Recorder::from_env());
-    let outcome = listen::serve(sessions.clone(), addr, call_timeout(), shutdown, ready).await;
+    let outcome = listen::serve(
+        sessions.clone(),
+        addr,
+        call_timeout(),
+        reload,
+        shutdown,
+        ready,
+    )
+    .await;
     // Runs on every route out of `serve`, which is why the shutdown future ends the accept loop
     // rather than the process: a service asked to stop has to reach this line, or it leaves a live
     // kernel frozen — see [`service`].

--- a/src/main.rs
+++ b/src/main.rs
@@ -97,7 +97,7 @@ fn main() -> Result<()> {
             // Touches the SCM and one file, like installing — and like installing, it must not
             // build a runtime: the reload it asks for happens in the *service's* process, not
             // this one.
-            service::Role::Client(edit, name) => service::edit_client(edit, &name, &args),
+            service::Role::Client(edit, name) => service::edit_client(edit, &name),
         };
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -133,7 +133,7 @@ fn main() -> Result<()> {
 /// a client going away is handled by its lease instead.
 pub(crate) async fn serve_http(
     addr: std::net::SocketAddr,
-    reload: Option<tokio::sync::mpsc::UnboundedReceiver<()>>,
+    reload: Option<tokio::sync::mpsc::UnboundedReceiver<std::sync::mpsc::SyncSender<bool>>>,
     shutdown: impl std::future::Future<Output = ()>,
     ready: impl FnOnce(),
 ) -> Result<()> {

--- a/src/service.rs
+++ b/src/service.rs
@@ -159,6 +159,16 @@ impl ClientEdit {
     fn mints_a_token(self) -> bool {
         matches!(self, Self::Add | Self::Rotate)
     }
+
+    /// Whether this command takes a working credential *out* of service.
+    ///
+    /// The two are not the same set, and the difference decides whether a reload that could not be
+    /// delivered is a warning or an error: an add that has not landed yet costs nobody anything,
+    /// while a removal or a rotation that has not landed means the token you were revoking is
+    /// still being accepted.
+    fn revokes_a_token(self) -> bool {
+        matches!(self, Self::Remove | Self::Rotate)
+    }
 }
 
 /// Reads the role off the command line. `None` for every ordinary invocation.
@@ -187,14 +197,26 @@ pub fn requested(args: &[String]) -> Option<Role> {
         edits
             .iter()
             .find(|(flag, _)| *flag == arg)
-            .map(|(_, edit)| Role::Client(*edit, args.get(at + 1).cloned().unwrap_or_default()))
+            .map(|(_, edit)| Role::Client(*edit, value_at(args, at).unwrap_or_default()))
     })
 }
 
 /// The value following `flag`, if the command line carries one.
 fn valued(args: &[String], flag: &str) -> Option<String> {
-    let at = args.iter().position(|arg| arg == flag)?;
-    args.get(at + 1).cloned()
+    value_at(args, args.iter().position(|arg| arg == flag)?)
+}
+
+/// The argument after position `at`, **unless it is itself a flag**.
+///
+/// Without the second half, `--add-listen-client --token-out C:\x` takes `--token-out` as the
+/// client's *name* — and `--token-out` passes [`crate::client::client_name`], since a name may
+/// contain `-`. So the command would succeed, mint a credential for a client called
+/// `--token-out`, and leave the operator's actual intent nowhere. A leading `-` is the one thing
+/// a value here can never legitimately start with: neither a client name nor a path does.
+fn value_at(args: &[String], at: usize) -> Option<String> {
+    args.get(at + 1)
+        .filter(|value| !value.starts_with('-'))
+        .cloned()
 }
 
 /// Where the service logs, since it has no console to log to.
@@ -444,6 +466,18 @@ fn finish_install(
 /// vocabulary. Nothing else sends this service anything, so the number is the whole protocol.
 const RELOAD_CODE: u32 = 128;
 
+/// The longest the SCM's own thread will wait for the reload to have happened.
+///
+/// It is waiting on a file read and a pointer swap, so this is not a budget — it is the point past
+/// which the runtime is wedged and hanging the control handler has stopped being useful. Well
+/// inside the 30 seconds the SCM allows a handler.
+const RELOAD_ACK_WAIT: Duration = Duration::from_secs(10);
+
+/// What the handler reports when the reload could not put the file's clients into force, and when
+/// there is no longer a runtime to ask. Both reach the command as a failed control code.
+const ERROR_INVALID_DATA: u32 = 13;
+const ERROR_SERVICE_NOT_ACTIVE: u32 = 1062;
+
 /// Whether a control code the SCM delivered is the reload.
 ///
 /// A predicate rather than a match arm so the [dispatcher](serve_as_service) and the [sender](
@@ -522,6 +556,10 @@ pub fn edit_client(edit: ClientEdit, name: &str, args: &[String]) -> Result<()> 
             )
         })?;
 
+    // Held until this function returns, which is what makes the read, the edit, the write and the
+    // reload below one transaction rather than four steps two shells can interleave.
+    let _lock = lock_credentials()?;
+
     let at = token_file();
     let existing = match std::fs::read_to_string(&at) {
         Ok(text) => Some(crate::client::TokenFile::parse(&text, &at)?.credentials()?),
@@ -556,9 +594,9 @@ pub fn edit_client(edit: ClientEdit, name: &str, args: &[String]) -> Result<()> 
     };
     let started_empty = credentials.is_empty();
 
-    let held = credentials.iter().position(|(held, _)| *held == name);
+    let held_at = credentials.iter().position(|(held, _)| *held == name);
     let mut minted = None;
-    match (edit, held) {
+    match (edit, held_at) {
         (ClientEdit::Add, Some(_)) => bail!(
             "`{NAME}` already has a client called `{name}`. To give it a new token without \
              disturbing what it has open, `{ROTATE_CLIENT_FLAG} {name}`; to take it away, \
@@ -573,8 +611,8 @@ pub fn edit_client(edit: ClientEdit, name: &str, args: &[String]) -> Result<()> 
             "`{NAME}` has no client called `{name}`. It holds: {}.",
             roster(&credentials)
         ),
-        (ClientEdit::Remove, Some(at)) => {
-            credentials.remove(at);
+        (ClientEdit::Remove, Some(index)) => {
+            credentials.remove(index);
             // **Refused, because a listener with no credentials will not start.** Revoking the
             // last one is not an incremental change; it is a decision to stop serving, and
             // `--uninstall-service` is the command that says so — and takes the file with it
@@ -588,10 +626,10 @@ pub fn edit_client(edit: ClientEdit, name: &str, args: &[String]) -> Result<()> 
                 );
             }
         }
-        (ClientEdit::Rotate, Some(at)) => {
+        (ClientEdit::Rotate, Some(index)) => {
             let token = crate::client::generate_token()?;
             minted = Some(token.clone());
-            credentials[at].1 = token;
+            credentials[index].1 = token;
         }
     }
     credentials.sort_by(|a, b| a.0.cmp(&b.0));
@@ -660,12 +698,28 @@ pub fn edit_client(edit: ClientEdit, name: &str, args: &[String]) -> Result<()> 
     }
     match ask_to_reload(&service) {
         Ok(true) => println!("\n`{NAME}` re-read its clients; nothing was stopped."),
+        // Not running is not a failure even for a revocation: nothing is accepting that credential
+        // either, and the file it will read at its next start is the one this command wrote.
         Ok(false) => println!("\n`{NAME}` is not running, so it will read this at its next start."),
-        // Not an error: the file is written and correct, and a restart applies it. Saying so
-        // beats failing a command that did what it was asked.
+        // **A revocation that could not be delivered is a failed revocation**, and this used to
+        // exit 0 on it (review on #189). For an add, a reload that did not happen means the new
+        // client cannot connect yet, which the next start fixes and nothing depends on. For a
+        // removal or a rotation it means the credential you were taking out of service **is still
+        // being accepted** — which is exactly the thing you ran the command to stop, so it has to
+        // be an error the shell can see.
+        Err(e) if edit.revokes_a_token() => {
+            return Err(e.context(format!(
+                "the client `{name}` was {past} in {}, but `{NAME}` is still running with the \
+                 credential you took out of service. Restart it (`Restart-Service {NAME}`, which \
+                 does drop the sessions it holds) and check its log — until then that token still \
+                 authenticates",
+                at.display()
+            )));
+        }
         Err(e) => println!(
             "\nwarning: `{NAME}` could not be told to re-read its clients ({e:#}). The file is \
-             written; restart the service to apply it — which does drop the sessions it holds."
+             written, and `{name}` can connect from the service's next start; nothing that works \
+             today has stopped working."
         ),
     }
     Ok(())
@@ -683,16 +737,28 @@ fn roster(credentials: &[(String, String)]) -> String {
         .join(", ")
 }
 
-/// Writes a generated token where the operator asked for it, and locks it down.
+/// Writes a generated token where the operator asked for it, and locks it down *first*.
 ///
 /// Given the same ACL as the credential file, which is not ceremony: this is a working credential
 /// for a listener that has `launch` on it, and the obvious place to ask for it is a profile
 /// directory other local accounts can read. `create_new` rather than a truncating create, so a
 /// mistyped path that happens to name something is a refusal rather than a file destroyed.
+///
+/// **The ACL goes on before the secret does**, and the file is created empty to make that possible.
+/// Writing first leaves an interval in which the token sits in a file still carrying whatever the
+/// parent directory grants — and changing a DACL does not revoke access through a handle already
+/// opened, so anything that got in during that interval keeps reading. Locked down as `F` for the
+/// write and re-applied as `R` afterwards: at no point is a principal outside `SYSTEM` and
+/// `Administrators` on that ACL.
+///
+/// **And a failure here is fatal**, where it used to warn. The alternative is this command
+/// activating a credential and then telling the operator, in passing, that the copy it just wrote
+/// is readable by the machine — which is a thing to refuse, not to mention. The half-written file
+/// is removed, so a retry is not blocked by the `create_new` it would hit.
 fn write_token_out(path: &std::path::Path, token: &str) -> Result<()> {
     use std::io::Write;
 
-    let mut file = std::fs::OpenOptions::new()
+    std::fs::OpenOptions::new()
         .write(true)
         .create_new(true)
         .open(path)
@@ -703,22 +769,71 @@ fn write_token_out(path: &std::path::Path, token: &str) -> Result<()> {
                 path.display()
             )
         })?;
-    file.write_all(token.as_bytes())
-        .and_then(|()| file.write_all(b"\n"))
-        .with_context(|| format!("cannot write {}", path.display()))?;
-    drop(file);
-    // Best-effort *after* the write, and reported rather than fatal: the token is already where
-    // the operator asked for it, and failing here would leave them a file they were told did not
-    // get written. What they need to know is that it is not protected.
-    if let Err(e) = restrict_to_administrators(path, "R") {
-        println!(
-            "warning: {} was written but could not be locked down to SYSTEM and Administrators \
-             ({e:#}). Treat it as readable by anyone who can reach that directory — move it and \
-             delete it now, or rotate the client again.",
+    // From here anything that fails takes the file with it: an empty file at a path the operator
+    // named would otherwise block the retry, and a locked-down one they cannot read is worse.
+    let guarded = (|| -> Result<()> {
+        restrict_to_administrators(path, "F")?;
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .open(path)
+            .with_context(|| format!("cannot open {} to write the token", path.display()))?;
+        file.write_all(token.as_bytes())
+            .and_then(|()| file.write_all(b"\n"))
+            .with_context(|| format!("cannot write {}", path.display()))?;
+        drop(file);
+        restrict_to_administrators(path, "R")
+    })();
+    if let Err(e) = guarded {
+        let _ = std::fs::remove_file(path);
+        return Err(e.context(format!(
+            "{} could not be given an ACL of SYSTEM and Administrators only, so no token was \
+             written there — a credential for a listener that runs `launch` as LocalSystem is not \
+             something to leave in a file the machine can read",
             path.display()
-        );
+        )));
     }
     Ok(())
+}
+
+/// Holds the credential file against another copy of this command, for one read-modify-write.
+///
+/// **Two elevated shells editing clients at once is the failure this closes.** Each reads the same
+/// file, each computes a complete replacement from that snapshot, and the second write silently
+/// discards the first — so an `--add-listen-client` and a `--remove-listen-client` run together can
+/// report success while the revocation never happened. Not a likely accident, and not one anything
+/// would notice afterwards, which is what makes it worth a lock rather than a note.
+///
+/// A file of its own rather than the credential file itself, because the transaction *ends* by
+/// renaming a new file over that one: a handle held open on the old name would block the rename,
+/// so the lock has to be on something the write does not touch. `share_mode(0)` is the whole
+/// mechanism — a second holder cannot open it at all, and Windows drops it when the process ends,
+/// including if it is killed, so there is no stale lock to clear by hand.
+///
+/// It lives in the state directory, which is already `Administrators`-only, so this is also where
+/// an unelevated caller is turned away: it needs write access to a directory it cannot write.
+fn lock_credentials() -> Result<std::fs::File> {
+    use std::os::windows::fs::OpenOptionsExt;
+
+    let at = state_dir().join("token.lock");
+    std::fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .share_mode(0)
+        .open(&at)
+        .map_err(|e| match e.kind() {
+            std::io::ErrorKind::PermissionDenied => anyhow::Error::new(e).context(format!(
+                "cannot open {} — that directory is SYSTEM and Administrators only, so changing a \
+                 client needs an elevated shell (\"Run as administrator\")",
+                at.display()
+            )),
+            _ => anyhow::Error::new(e).context(format!(
+                "cannot take {} — another `--add`/`--remove`/`--rotate-listen-client` is running. \
+                 Two of them editing at once would each write a whole file from its own snapshot, \
+                 and the second would discard the first. Wait for it and try again.",
+                at.display()
+            )),
+        })
 }
 
 /// Writes [`token_file`] from a set of credentials: a fresh file, renamed over whatever was there.
@@ -763,21 +878,30 @@ fn write_credentials(credentials: &[(String, String)]) -> Result<()> {
         .with_context(|| format!("cannot move {} over {}", staged.display(), at.display()))
 }
 
-/// Asks a running service to re-read its clients. `false` if it is not running to be asked.
+/// Asks a running service to re-read its clients, **and waits for it to have done so**. `false` if
+/// it is not running to be asked.
 ///
 /// A control code rather than a restart, because a restart is the thing item 34 exists to avoid:
 /// it drops every session the service holds. Rather than a file watcher, because this is explicit,
 /// needs nothing running in the background, and fits the plumbing that already handles Stop and
 /// Preshutdown.
+///
+/// **The waiting is not incidental.** `ControlService` returns once the handler does, and the first
+/// version of that handler only *enqueued* the reload — so this command printed "re-read its
+/// clients" while the swap had not happened, and a caller acting on that could find a removed token
+/// still authenticating or an added one still refused (review on #189). The handler now blocks on
+/// the reload task's answer, and reports a failed re-read as a control-code failure, which arrives
+/// here as an `Err`. So `Ok(true)` means the set in force is the set this command wrote.
 fn ask_to_reload(service: &windows_service::service::Service) -> Result<bool> {
     if service.query_status()?.current_state != ServiceState::Running {
         return Ok(false);
     }
     let code = windows_service::service::UserEventCode::from_raw(RELOAD_CODE)
         .map_err(|e| anyhow::anyhow!("{RELOAD_CODE} is not a user-defined control code: {e}"))?;
-    service
-        .notify(code)
-        .context("the service refused the reload control code")?;
+    service.notify(code).context(
+        "the service did not re-read its clients — the control code came back a failure, which \
+         means it could not read or accept the file this command just wrote (its log says why)",
+    )?;
     Ok(true)
 }
 
@@ -1049,7 +1173,13 @@ fn serve_as_service() -> Result<()> {
     // return promptly, so it cannot be one that waits for room. Nothing bounds how often an
     // administrator may run a client command, but each one is a file read on a task, so a flood is
     // slow rather than unsafe.
-    let (reload_tx, reload_rx) = tokio::sync::mpsc::unbounded_channel::<()>();
+    //
+    // **Each request carries a channel to answer on**, which is what lets the command that sent it
+    // report the truth. A synchronous `SyncSender` because the receiving end of it is the SCM's own
+    // thread, which has no runtime to await on; capacity 1 so the task never blocks handing an
+    // answer back, including to a handler that has already given up waiting.
+    let (reload_tx, reload_rx) =
+        tokio::sync::mpsc::unbounded_channel::<std::sync::mpsc::SyncSender<bool>>();
     let status_handle = service_control_handler::register(NAME, move |control| match control {
         // Answering this is not optional: a service that does not is reported as not responding.
         ServiceControl::Interrogate => ServiceControlHandlerResult::NoError,
@@ -1065,8 +1195,22 @@ fn serve_as_service() -> Result<()> {
         // the reload happens on the runtime, and reporting `NoError` here says the request was
         // accepted rather than that it succeeded. What it did lands in the log.
         control if is_reload(&control) => {
-            let _ = reload_tx.send(());
-            ServiceControlHandlerResult::NoError
+            let (answer, wait) = std::sync::mpsc::sync_channel::<bool>(1);
+            if reload_tx.send(answer).is_err() {
+                // The runtime is gone, which means we are stopping. Nothing will re-read anything.
+                return ServiceControlHandlerResult::Other(ERROR_SERVICE_NOT_ACTIVE);
+            }
+            // **Bounded**, because a control handler that never returns is a service the SCM will
+            // call hung. The work being waited on is a file read and a pointer swap — the session
+            // releases a removal triggers happen *after* the answer — so a wait this long means
+            // the runtime is wedged, and reporting that beats hanging on it.
+            match wait.recv_timeout(RELOAD_ACK_WAIT) {
+                Ok(true) => ServiceControlHandlerResult::NoError,
+                // It read the file and would not have it, or it never answered. Either way the set
+                // in force is not the one the command wrote, and the command has to say so rather
+                // than print that the service re-read its clients.
+                Ok(false) | Err(_) => ServiceControlHandlerResult::Other(ERROR_INVALID_DATA),
+            }
         }
         _ => ServiceControlHandlerResult::NotImplemented,
     })

--- a/src/service.rs
+++ b/src/service.rs
@@ -753,30 +753,41 @@ fn write_token_out(name: &str, token: &str) -> Result<PathBuf> {
 
     let dir = secured_state_dir()?;
     let at = dir.join(format!("{name}.token"));
-    {
+    std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&at)
+        .with_context(|| {
+            format!(
+                "cannot create {} — a token for `{name}` is already sitting there from an earlier \
+                 command. Move it to the client machine and delete it, then run this again: \
+                 overwriting it would destroy the only copy of a credential that may still be the \
+                 one in service.",
+                at.display()
+            )
+        })?;
+    // **From the moment the file exists, anything that fails takes it with it.** Including the
+    // write itself, which review found returning early past the cleanup: a `write_all` that fails
+    // part-way — a full disk is the plausible one — used to leave a truncated `<name>.token` that
+    // no credential matches, and every retry then failed at the `create_new` above claiming a token
+    // from an earlier command was present. An operator would have to work out for themselves that
+    // the file in the way is inert.
+    let guarded = (|| -> Result<()> {
         let mut file = std::fs::OpenOptions::new()
             .write(true)
-            .create_new(true)
             .open(&at)
-            .with_context(|| {
-                format!(
-                    "cannot create {} — a token for `{name}` is already sitting there from an \
-                     earlier command. Move it to the client machine and delete it, then run this \
-                     again: overwriting it would destroy the only copy of a credential that may \
-                     still be the one in service.",
-                    at.display()
-                )
-            })?;
+            .with_context(|| format!("cannot open {} to write the token", at.display()))?;
         file.write_all(token.as_bytes())
             .and_then(|()| file.write_all(b"\n"))
             .with_context(|| format!("cannot write {}", at.display()))?;
-    }
-    // From here anything that fails takes the file with it, so a retry is not blocked by the
-    // `create_new` above and no half-protected credential is left behind.
-    if let Err(e) = restrict_to_administrators(&at, "R") {
+        drop(file);
+        restrict_to_administrators(&at, "R")
+    })();
+    if let Err(e) = guarded {
         let _ = std::fs::remove_file(&at);
         return Err(e.context(format!(
-            "{} could not be given an ACL of its own, so no token was written there",
+            "no token was written to {} — it was removed, so running this again is not blocked by \
+             a file that matches no credential",
             at.display()
         )));
     }

--- a/src/service.rs
+++ b/src/service.rs
@@ -84,6 +84,15 @@ pub const UNINSTALL_FLAG: &str = "--uninstall-service";
 /// Acknowledges installing from a directory Windows does not protect. See [`under_protected_root`].
 pub const ALLOW_UNPROTECTED_FLAG: &str = "--allow-unprotected-path";
 
+/// Gives the installed service a client it did not have. Takes the client's name.
+pub const ADD_CLIENT_FLAG: &str = "--add-listen-client";
+/// Takes a client away again, releasing whatever it still held.
+pub const REMOVE_CLIENT_FLAG: &str = "--remove-listen-client";
+/// Replaces a client's token, keeping its name — and so its sessions.
+pub const ROTATE_CLIENT_FLAG: &str = "--rotate-listen-client";
+/// Where a generated token is written, since it is the one thing these commands will not print.
+pub const TOKEN_OUT_FLAG: &str = "--token-out";
+
 /// Overrides where the service writes its log.
 pub const LOG_ENV: &str = "WINDBG_MCP_SERVICE_LOG";
 
@@ -119,12 +128,37 @@ fn stop_bound() -> Duration {
 }
 
 /// Which service role, if any, this command line asks for.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Role {
     /// The SCM started us.
     Run,
     Install,
     Uninstall,
+    /// One of the client commands, and which client it names.
+    Client(ClientEdit, String),
+}
+
+/// What a client command does to the service's credential file.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ClientEdit {
+    Add,
+    Remove,
+    Rotate,
+}
+
+impl ClientEdit {
+    fn flag(self) -> &'static str {
+        match self {
+            Self::Add => ADD_CLIENT_FLAG,
+            Self::Remove => REMOVE_CLIENT_FLAG,
+            Self::Rotate => ROTATE_CLIENT_FLAG,
+        }
+    }
+
+    /// Whether this command mints a token, and so needs somewhere to put it.
+    fn mints_a_token(self) -> bool {
+        matches!(self, Self::Add | Self::Rotate)
+    }
 }
 
 /// Reads the role off the command line. `None` for every ordinary invocation.
@@ -132,13 +166,35 @@ pub enum Role {
 /// A free function over the arguments, like [`crate::listen::requested`], so the role can be
 /// decided before a runtime exists — installing touches the SCM and nothing else, and the service
 /// role has to build its runtime *inside* the SCM's own thread rather than around it.
+///
+/// **A client flag with nothing after it still yields its role**, with an empty name, rather than
+/// `None`. Falling through would run the ordinary stdio server instead, which for a typo on an
+/// administrative command line is the least helpful thing that could happen; the empty name is
+/// refused by the same rule that refuses any other name that is not one, and says so.
 pub fn requested(args: &[String]) -> Option<Role> {
-    args.iter().find_map(|arg| match arg.as_str() {
-        SERVICE_FLAG => Some(Role::Run),
-        INSTALL_FLAG => Some(Role::Install),
-        UNINSTALL_FLAG => Some(Role::Uninstall),
-        _ => None,
+    let edits = [
+        (ADD_CLIENT_FLAG, ClientEdit::Add),
+        (REMOVE_CLIENT_FLAG, ClientEdit::Remove),
+        (ROTATE_CLIENT_FLAG, ClientEdit::Rotate),
+    ];
+    args.iter().enumerate().find_map(|(at, arg)| {
+        match arg.as_str() {
+            SERVICE_FLAG => return Some(Role::Run),
+            INSTALL_FLAG => return Some(Role::Install),
+            UNINSTALL_FLAG => return Some(Role::Uninstall),
+            _ => {}
+        }
+        edits
+            .iter()
+            .find(|(flag, _)| *flag == arg)
+            .map(|(_, edit)| Role::Client(*edit, args.get(at + 1).cloned().unwrap_or_default()))
     })
+}
+
+/// The value following `flag`, if the command line carries one.
+fn valued(args: &[String], flag: &str) -> Option<String> {
+    let at = args.iter().position(|arg| arg == flag)?;
+    args.get(at + 1).cloned()
 }
 
 /// Where the service logs, since it has no console to log to.
@@ -372,29 +428,357 @@ fn finish_install(
         .set_preshutdown_timeout(stop_bound())
         .context("the service's preshutdown timeout could not be set")?;
 
-    let token_at = token_file();
-    secured_state_dir()?;
-    // Never reuse an object we did not create: a pre-existing file at this path is an unprivileged
-    // user's to own, and writing into it would leave them owning the credential. Removed and
-    // created fresh, with `create_new`, so losing a race is a refusal rather than a silent reuse.
-    let _ = std::fs::remove_file(&token_at);
+    // The same writer the client commands use, so the file an install leaves and the file an
+    // `--add-listen-client` leaves are written to one standard: a fresh file created with
+    // `create_new` in the protected directory, ACL'd there, and renamed over whatever was at the
+    // real path. Never through an object we did not create — a pre-existing file there is an
+    // unprivileged user's to own, and writing into it would leave them owning the credential.
+    write_credentials(credentials)
+}
+
+/// The control code that tells a running service to re-read its token file.
+///
+/// **A user-defined code (128–255) rather than `SERVICE_CONTROL_PARAMCHANGE`**, which is the one
+/// that *means* this: the SCM wrapper this crate uses can only send user-defined codes, and a
+/// hand-rolled `ControlService` call to gain the canonical name would be FFI written for
+/// vocabulary. Nothing else sends this service anything, so the number is the whole protocol.
+const RELOAD_CODE: u32 = 128;
+
+/// Whether a control code the SCM delivered is the reload.
+///
+/// A predicate rather than a match arm so the [dispatcher](serve_as_service) and the [sender](
+/// ask_to_reload) cannot drift apart on the number.
+fn is_reload(control: &ServiceControl) -> bool {
+    matches!(control, ServiceControl::UserEvent(code) if code.to_raw() == RELOAD_CODE)
+}
+
+/// Adds, removes or rotates one of the installed service's clients, without a reinstall.
+///
+/// **The problem this replaces.** `--install-service` was the only writer of [`token_file`], and
+/// the SCM refuses a second registration under the same name — so giving a service-hosted listener
+/// a client of its own meant `--uninstall-service`, setting every credential variable again,
+/// installing, and starting. That drops every session the service holds, a parked kernel attach
+/// included (`FOLLOWUPS.md` item 34). Nobody chose that; it fell out of there being no other
+/// writer.
+///
+/// **The two properties that were chosen stay exactly as they are.** "Only the installer writes
+/// this file" becomes "only *this program*, running elevated, writes it" — the command below is
+/// the same binary. And "never write through a file it did not create" survives, because
+/// [`write_credentials`] creates a fresh file with `create_new` in the same protected directory
+/// and renames it over the old one, which is also what makes the replacement atomic for a service
+/// that may be reading it.
+///
+/// **The token is generated here and never printed.** What reaches standard output is a
+/// [fingerprint](crate::client::fingerprint); the secret goes to the file
+/// [`TOKEN_OUT_FLAG`] names, created fresh and ACL'd like the credential file it came from. That
+/// is what keeps a working token out of a shell history and out of an agent's transcript, and it
+/// is why these commands are narrow enough to allow-list in a permission rule where "let this
+/// write `%ProgramData%`" would not be.
+pub fn edit_client(edit: ClientEdit, name: &str, args: &[String]) -> Result<()> {
+    let name = crate::client::client_name(name).with_context(|| {
+        format!(
+            "`{}` needs the name of a client — `{} bench`",
+            edit.flag(),
+            edit.flag()
+        )
+    })?;
+    // Read before anything is touched, so a command missing half its arguments fails as a usage
+    // error rather than after the credential file has been rewritten.
+    let token_out = match edit.mints_a_token() {
+        true => Some(PathBuf::from(valued(args, TOKEN_OUT_FLAG).ok_or_else(|| {
+            anyhow::anyhow!(
+                "`{} {name}` needs `{TOKEN_OUT_FLAG} <path>`: it generates the token itself and \
+                 will not print one, so there has to be somewhere to put it.\n    {} {name} \
+                 {TOKEN_OUT_FLAG} C:\\Users\\you\\{name}.token\n\nMove that file to the client \
+                 machine and delete it here. The token is never shown on this console, which is \
+                 the point — a console is a shell history, and on this host frequently an agent's \
+                 transcript too.",
+                edit.flag(),
+                edit.flag()
+            )
+        })?)),
+        false => None,
+    };
+
+    // **This handle does not prove elevation**, and it is worth being clear about that rather than
+    // implying it: a service's default DACL grants `SERVICE_USER_DEFINED_CONTROL` to Authenticated
+    // Users, so an ordinary account opens it fine. What refuses an unelevated caller is the
+    // credential file's own ACL, a few lines down — which is the check that matters, since it is
+    // the object being protected. Opening the service first only buys a better error for the more
+    // common mistake: running this where no service is installed at all.
+    let manager = ServiceManager::local_computer(None::<&OsStr>, ServiceManagerAccess::CONNECT)
+        .context("cannot open the service manager")?;
+    let service = manager
+        .open_service(
+            NAME,
+            ServiceAccess::QUERY_STATUS | ServiceAccess::USER_DEFINED_CONTROL,
+        )
+        .with_context(|| {
+            format!(
+                "no service named `{NAME}` is installed, so there is no client list to change. \
+                 These commands edit the credential file a *service* reads ({}); a foreground \
+                 listener takes its clients from the environment instead.",
+                token_file().display()
+            )
+        })?;
+
+    let at = token_file();
+    let existing = match std::fs::read_to_string(&at) {
+        Ok(text) => Some(crate::client::TokenFile::parse(&text, &at)?.credentials()?),
+        // **Add repairs this; the other two cannot.** A missing file is a service that will not
+        // start, and writing one client into it is a working listener again — whereas removing
+        // from nothing, or rotating a client that is not there, is a command whose premise is
+        // already false.
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => None,
+        // The refusal an unelevated shell gets, since that file grants read to `SYSTEM` and
+        // `Administrators` only — so this is where "run as administrator" belongs, rather than on
+        // the service handle above, which any account may open.
+        Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied => {
+            return Err(anyhow::Error::new(e).context(format!(
+                "cannot read {} — it grants read to SYSTEM and Administrators only, so changing \
+                 a client needs an elevated shell (\"Run as administrator\")",
+                at.display()
+            )));
+        }
+        Err(e) => {
+            return Err(anyhow::Error::new(e).context(format!("cannot read {}", at.display())));
+        }
+    };
+    let mut credentials = match (existing, edit) {
+        (Some(credentials), _) => credentials,
+        (None, ClientEdit::Add) => Vec::new(),
+        (None, _) => bail!(
+            "{} does not exist, so `{NAME}` has no clients to change — and will not start until \
+             it does. `{ADD_CLIENT_FLAG} <name>` writes a new file with one client in it, or \
+             reinstall the service.",
+            at.display()
+        ),
+    };
+    let started_empty = credentials.is_empty();
+
+    let held = credentials.iter().position(|(held, _)| *held == name);
+    let mut minted = None;
+    match (edit, held) {
+        (ClientEdit::Add, Some(_)) => bail!(
+            "`{NAME}` already has a client called `{name}`. To give it a new token without \
+             disturbing what it has open, `{ROTATE_CLIENT_FLAG} {name}`; to take it away, \
+             `{REMOVE_CLIENT_FLAG} {name}`."
+        ),
+        (ClientEdit::Add, None) => {
+            let token = crate::client::generate_token()?;
+            minted = Some(token.clone());
+            credentials.push((name.clone(), token));
+        }
+        (ClientEdit::Remove, None) | (ClientEdit::Rotate, None) => bail!(
+            "`{NAME}` has no client called `{name}`. It holds: {}.",
+            roster(&credentials)
+        ),
+        (ClientEdit::Remove, Some(at)) => {
+            credentials.remove(at);
+            // **Refused, because a listener with no credentials will not start.** Revoking the
+            // last one is not an incremental change; it is a decision to stop serving, and
+            // `--uninstall-service` is the command that says so — and takes the file with it
+            // rather than leaving a service registered that fails at every start.
+            if credentials.is_empty() {
+                bail!(
+                    "`{name}` is the only client `{NAME}` has, and a listener with no credentials \
+                     refuses to start — it exposes every tool this server has, including the ones \
+                     that write to a live kernel. Add the replacement first \
+                     (`{ADD_CLIENT_FLAG} <name>`), or `{UNINSTALL_FLAG}` if the service is done."
+                );
+            }
+        }
+        (ClientEdit::Rotate, Some(at)) => {
+            let token = crate::client::generate_token()?;
+            minted = Some(token.clone());
+            credentials[at].1 = token;
+        }
+    }
+    credentials.sort_by(|a, b| a.0.cmp(&b.0));
+
+    // **Written before the credential file, and removed again if that write fails.** The order is
+    // what keeps the two from disagreeing: a token accepted by the service that the operator has
+    // no copy of is unrecoverable without another rotation, while a token file naming a credential
+    // nothing accepts is inert. `create_new` refuses an existing path rather than overwriting it,
+    // for the same reason the credential file does.
+    if let (Some(path), Some(token)) = (token_out.as_deref(), minted.as_deref()) {
+        write_token_out(path, token)?;
+    }
+    if let Err(e) = write_credentials(&credentials) {
+        if let Some(path) = token_out.as_deref() {
+            let _ = std::fs::remove_file(path);
+        }
+        return Err(e.context(format!(
+            "nothing was changed — `{NAME}` still holds the clients it did"
+        )));
+    }
+
+    // **None of these says when it takes effect**, because that is the reload's line to write at
+    // the bottom — and it is the one thing this command cannot know until it has asked. Saying
+    // "once the service has re-read its file" here and "it re-read them" three lines later is one
+    // command contradicting itself about the property it exists to provide.
+    let (past, changed) = match edit {
+        ClientEdit::Add => (
+            "added",
+            "it gets the whole tool surface, as every client here does — a token separates \
+             clients from each other, it does not limit one",
+        ),
+        ClientEdit::Remove => (
+            "removed",
+            "it can no longer connect, and the sessions it still held go with it",
+        ),
+        ClientEdit::Rotate => (
+            "rotated",
+            "it keeps its name, and so keeps the sessions it has open — it just presents the new \
+             token",
+        ),
+    };
+    println!(
+        "{past} the client `{name}` ({}) — {changed}.\n`{NAME}` now holds: {}.",
+        match minted.as_deref() {
+            Some(token) => crate::client::fingerprint(token),
+            None => "no longer configured".to_string(),
+        },
+        roster(&credentials)
+    );
+    if started_empty {
+        println!(
+            "\nNote: {} did not exist, so `{name}` is now the only client `{NAME}` has. Anything \
+             that used to connect to it does not any more.",
+            at.display()
+        );
+    }
+    if let Some(path) = token_out.as_deref() {
+        println!(
+            "\nIts token is in {} — readable by SYSTEM and Administrators only, like the \
+             credential file it came from. Move it to the client machine, set it there as `{}`, \
+             and delete this copy. It is not printed here and cannot be read back out of the \
+             service; a lost token costs a `{ROTATE_CLIENT_FLAG} {name}` and nothing else.",
+            path.display(),
+            crate::listen::TOKEN_ENV,
+        );
+    }
+    match ask_to_reload(&service) {
+        Ok(true) => println!("\n`{NAME}` re-read its clients; nothing was stopped."),
+        Ok(false) => println!("\n`{NAME}` is not running, so it will read this at its next start."),
+        // Not an error: the file is written and correct, and a restart applies it. Saying so
+        // beats failing a command that did what it was asked.
+        Err(e) => println!(
+            "\nwarning: `{NAME}` could not be told to re-read its clients ({e:#}). The file is \
+             written; restart the service to apply it — which does drop the sessions it holds."
+        ),
+    }
+    Ok(())
+}
+
+/// Every configured client, by name and fingerprint — what these commands print instead of a file.
+fn roster(credentials: &[(String, String)]) -> String {
+    if credentials.is_empty() {
+        return "no clients".to_string();
+    }
+    credentials
+        .iter()
+        .map(|(name, token)| format!("`{name}` ({})", crate::client::fingerprint(token)))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+/// Writes a generated token where the operator asked for it, and locks it down.
+///
+/// Given the same ACL as the credential file, which is not ceremony: this is a working credential
+/// for a listener that has `launch` on it, and the obvious place to ask for it is a profile
+/// directory other local accounts can read. `create_new` rather than a truncating create, so a
+/// mistyped path that happens to name something is a refusal rather than a file destroyed.
+fn write_token_out(path: &std::path::Path, token: &str) -> Result<()> {
+    use std::io::Write;
+
+    let mut file = std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(path)
+        .with_context(|| {
+            format!(
+                "cannot create {} — it will not write through a file that already exists, since \
+                 the one it would overwrite may be a credential something still uses",
+                path.display()
+            )
+        })?;
+    file.write_all(token.as_bytes())
+        .and_then(|()| file.write_all(b"\n"))
+        .with_context(|| format!("cannot write {}", path.display()))?;
+    drop(file);
+    // Best-effort *after* the write, and reported rather than fatal: the token is already where
+    // the operator asked for it, and failing here would leave them a file they were told did not
+    // get written. What they need to know is that it is not protected.
+    if let Err(e) = restrict_to_administrators(path, "R") {
+        println!(
+            "warning: {} was written but could not be locked down to SYSTEM and Administrators \
+             ({e:#}). Treat it as readable by anyone who can reach that directory — move it and \
+             delete it now, or rotate the client again.",
+            path.display()
+        );
+    }
+    Ok(())
+}
+
+/// Writes [`token_file`] from a set of credentials: a fresh file, renamed over whatever was there.
+///
+/// **Never through a file it did not create**, which is the rule the installer's ACL exists to
+/// support — an unprivileged user who pre-creates that path owns the credential. So the content is
+/// written to a fresh sibling with `create_new`, given the ACL there, and moved over the old name.
+/// Two things fall out of doing it that way rather than truncating in place: the replacement is
+/// atomic, so a service reading the file concurrently sees one version or the other and never a
+/// half-written one; and the protective ACL is on the file before it is ever reachable under its
+/// real name.
+///
+/// Shared with [`finish_install`] rather than restated, so the client commands and the installer
+/// cannot end up writing that file to two different standards.
+fn write_credentials(credentials: &[(String, String)]) -> Result<()> {
+    use std::io::Write;
+
+    let dir = secured_state_dir()?;
+    let at = token_file();
+    let staged = dir.join("token.new");
+    // A leftover from a command that died between creating this and renaming it. Removing it is
+    // safe in a directory only Administrators can write, and `create_new` below still refuses if
+    // anything wins a race to recreate it.
+    let _ = std::fs::remove_file(&staged);
     {
-        use std::io::Write;
         let mut file = std::fs::OpenOptions::new()
             .write(true)
             .create_new(true)
-            .open(&token_at)
+            .open(&staged)
             .with_context(|| {
                 format!(
-                    "cannot create {} — something else created it first, which for a credential is \
-                     a refusal rather than something to write through",
-                    token_at.display()
+                    "cannot create {} — something else created it first, which for a credential \
+                     is a refusal rather than something to write through",
+                    staged.display()
                 )
             })?;
         file.write_all(token_file_contents(credentials).as_bytes())
-            .with_context(|| format!("cannot write {}", token_at.display()))?;
+            .with_context(|| format!("cannot write {}", staged.display()))?;
     }
-    restrict_to_administrators(&token_at, "R")
+    restrict_to_administrators(&staged, "R")?;
+    std::fs::rename(&staged, &at)
+        .with_context(|| format!("cannot move {} over {}", staged.display(), at.display()))
+}
+
+/// Asks a running service to re-read its clients. `false` if it is not running to be asked.
+///
+/// A control code rather than a restart, because a restart is the thing item 34 exists to avoid:
+/// it drops every session the service holds. Rather than a file watcher, because this is explicit,
+/// needs nothing running in the background, and fits the plumbing that already handles Stop and
+/// Preshutdown.
+fn ask_to_reload(service: &windows_service::service::Service) -> Result<bool> {
+    if service.query_status()?.current_state != ServiceState::Running {
+        return Ok(false);
+    }
+    let code = windows_service::service::UserEventCode::from_raw(RELOAD_CODE)
+        .map_err(|e| anyhow::anyhow!("{RELOAD_CODE} is not a user-defined control code: {e}"))?;
+    service
+        .notify(code)
+        .context("the service refused the reload control code")?;
+    Ok(true)
 }
 
 /// Registers the service to run this exe with `--service --listen <addr>`.
@@ -661,6 +1045,11 @@ fn serve_as_service() -> Result<()> {
     // *ask*, and the runtime below does the releasing.
     let (stop_tx, stop_rx) = tokio::sync::oneshot::channel::<()>();
     let mut stop_tx = Some(stop_tx);
+    // Unbounded, and sent to from the SCM's own thread: the handler may only *ask*, and must
+    // return promptly, so it cannot be one that waits for room. Nothing bounds how often an
+    // administrator may run a client command, but each one is a file read on a task, so a flood is
+    // slow rather than unsafe.
+    let (reload_tx, reload_rx) = tokio::sync::mpsc::unbounded_channel::<()>();
     let status_handle = service_control_handler::register(NAME, move |control| match control {
         // Answering this is not optional: a service that does not is reported as not responding.
         ServiceControl::Interrogate => ServiceControlHandlerResult::NoError,
@@ -668,6 +1057,15 @@ fn serve_as_service() -> Result<()> {
             if let Some(tx) = stop_tx.take() {
                 let _ = tx.send(());
             }
+            ServiceControlHandlerResult::NoError
+        }
+        // A client command has rewritten the token file and is telling us to pick it up — which is
+        // the half of `FOLLOWUPS.md` item 34 that makes the other half worth having, since a
+        // restart would still cost every session this service holds. The send is fire-and-forget:
+        // the reload happens on the runtime, and reporting `NoError` here says the request was
+        // accepted rather than that it succeeded. What it did lands in the log.
+        control if is_reload(&control) => {
+            let _ = reload_tx.send(());
             ServiceControlHandlerResult::NoError
         }
         _ => ServiceControlHandlerResult::NotImplemented,
@@ -727,6 +1125,7 @@ fn serve_as_service() -> Result<()> {
             let finished = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
             let served = crate::serve_http(
                 addr,
+                Some(reload_rx),
                 {
                     let finished = finished.clone();
                     async move {
@@ -810,6 +1209,101 @@ mod tests {
             requested(&argv(&["windbg-mcp", UNINSTALL_FLAG])),
             Some(Role::Uninstall)
         );
+    }
+
+    /// A client command carries the name that follows it, and takes its role even without one.
+    ///
+    /// The second half is the one worth asserting. A flag with nothing after it that yielded
+    /// `None` would fall through to the *stdio server*, so a typo on an administrative command
+    /// line would leave a debugger sitting on standard input rather than saying what was missing.
+    #[test]
+    fn a_client_command_carries_its_name_and_claims_its_role_without_one() {
+        let argv = |args: &[&str]| args.iter().map(|a| a.to_string()).collect::<Vec<_>>();
+        assert_eq!(
+            requested(&argv(&["windbg-mcp", ADD_CLIENT_FLAG, "bench"])),
+            Some(Role::Client(ClientEdit::Add, "bench".into()))
+        );
+        assert_eq!(
+            requested(&argv(&[
+                "windbg-mcp",
+                ROTATE_CLIENT_FLAG,
+                "ci",
+                TOKEN_OUT_FLAG,
+                r"C:\out\ci.token"
+            ])),
+            Some(Role::Client(ClientEdit::Rotate, "ci".into()))
+        );
+        assert_eq!(
+            requested(&argv(&["windbg-mcp", REMOVE_CLIENT_FLAG])),
+            Some(Role::Client(ClientEdit::Remove, String::new())),
+            "a client flag with no name has to keep its role, or it runs the stdio server instead"
+        );
+    }
+
+    /// The value behind `--token-out`, and nothing when it is not there to have one.
+    #[test]
+    fn a_flags_value_is_the_argument_after_it() {
+        let argv = |args: &[&str]| args.iter().map(|a| a.to_string()).collect::<Vec<_>>();
+        assert_eq!(
+            valued(
+                &argv(&["windbg-mcp", ADD_CLIENT_FLAG, "bench", TOKEN_OUT_FLAG, "t"]),
+                TOKEN_OUT_FLAG
+            )
+            .as_deref(),
+            Some("t")
+        );
+        assert_eq!(
+            valued(
+                &argv(&["windbg-mcp", ADD_CLIENT_FLAG, "bench"]),
+                TOKEN_OUT_FLAG
+            ),
+            None
+        );
+        assert_eq!(
+            valued(&argv(&["windbg-mcp", TOKEN_OUT_FLAG]), TOKEN_OUT_FLAG),
+            None,
+            "a trailing flag has no value, and must not borrow one from nowhere"
+        );
+    }
+
+    /// The code the dispatcher answers is the code the command sends, and nothing else is it.
+    ///
+    /// One number is the whole protocol between the two, and they are in different processes: a
+    /// drift here is a client command that reports success and a service that goes on serving the
+    /// clients it had, which is exactly the silent half-failure the reload exists to remove.
+    #[test]
+    fn the_reload_control_code_is_one_number_both_sides_agree_on() {
+        let sent = windows_service::service::UserEventCode::from_raw(RELOAD_CODE)
+            .expect("the reload code is a user-defined control code");
+        assert!(is_reload(&ServiceControl::UserEvent(sent)));
+        // A neighbouring user event is not it, and neither is anything the SCM sends of its own
+        // accord — a reload that answered `Stop` would be a service that stopped when asked to
+        // re-read a file.
+        let other = windows_service::service::UserEventCode::from_raw(RELOAD_CODE + 1)
+            .expect("129 is also a user-defined control code");
+        assert!(!is_reload(&ServiceControl::UserEvent(other)));
+        assert!(!is_reload(&ServiceControl::Stop));
+        assert!(!is_reload(&ServiceControl::Preshutdown));
+        assert!(!is_reload(&ServiceControl::Interrogate));
+    }
+
+    /// The roster a client command prints names every client and quotes no token.
+    ///
+    /// This string is the whole of what these commands say about the credential file, and it goes
+    /// to a console — which on this host is frequently an agent's transcript. A roster that
+    /// carried a token would put every one of them there on any change to any of them.
+    #[test]
+    fn the_roster_names_clients_and_quotes_no_token() {
+        let credentials = [
+            ("ci".to_string(), "ci-token-value".to_string()),
+            ("local".to_string(), "local-token-value".to_string()),
+        ];
+        let said = roster(&credentials);
+        assert!(said.contains("`ci`") && said.contains("`local`"), "{said}");
+        for (_, token) in &credentials {
+            assert!(!said.contains(token), "the roster quotes a token: {said}");
+        }
+        assert_eq!(roster(&[]), "no clients");
     }
 
     /// The SCM stores this once, at install time, and nothing re-derives it — so a service that

--- a/src/service.rs
+++ b/src/service.rs
@@ -626,6 +626,19 @@ pub fn edit_client(edit: ClientEdit, name: &str) -> Result<()> {
     // the bottom — and it is the one thing this command cannot know until it has asked. Saying
     // "once the service has re-read its file" here and "it re-read them" three lines later is one
     // command contradicting itself about the property it exists to provide.
+    // **A removal takes the token copy with it.** That file holds a credential this command has
+    // just made worthless, so keeping it protects nothing and costs two things: a dead secret left
+    // on disk, and a `create_new` that refuses the next `--add-listen-client` of the same name for
+    // a reason the operator has to go and look up. The credential file is written by then, so this
+    // cannot leave a client that can authenticate with no copy of its token.
+    let dropped_token = match edit {
+        ClientEdit::Remove => {
+            let stale = state_dir().join(format!("{name}.token"));
+            matches!(std::fs::remove_file(&stale), Ok(()))
+        }
+        _ => false,
+    };
+
     let (past, changed) = match edit {
         ClientEdit::Add => (
             "added",
@@ -650,6 +663,12 @@ pub fn edit_client(edit: ClientEdit, name: &str) -> Result<()> {
         },
         roster(&credentials)
     );
+    if dropped_token {
+        println!(
+            "\nIts token file went with it: that copy authenticated nothing from the moment this \
+             returned."
+        );
+    }
     if started_empty {
         println!(
             "\nNote: {} did not exist, so `{name}` is now the only client `{NAME}` has. Anything \

--- a/src/service.rs
+++ b/src/service.rs
@@ -90,8 +90,6 @@ pub const ADD_CLIENT_FLAG: &str = "--add-listen-client";
 pub const REMOVE_CLIENT_FLAG: &str = "--remove-listen-client";
 /// Replaces a client's token, keeping its name — and so its sessions.
 pub const ROTATE_CLIENT_FLAG: &str = "--rotate-listen-client";
-/// Where a generated token is written, since it is the one thing these commands will not print.
-pub const TOKEN_OUT_FLAG: &str = "--token-out";
 
 /// Overrides where the service writes its log.
 pub const LOG_ENV: &str = "WINDBG_MCP_SERVICE_LOG";
@@ -155,11 +153,6 @@ impl ClientEdit {
         }
     }
 
-    /// Whether this command mints a token, and so needs somewhere to put it.
-    fn mints_a_token(self) -> bool {
-        matches!(self, Self::Add | Self::Rotate)
-    }
-
     /// Whether this command takes a working credential *out* of service.
     ///
     /// The two are not the same set, and the difference decides whether a reload that could not be
@@ -201,18 +194,13 @@ pub fn requested(args: &[String]) -> Option<Role> {
     })
 }
 
-/// The value following `flag`, if the command line carries one.
-fn valued(args: &[String], flag: &str) -> Option<String> {
-    value_at(args, args.iter().position(|arg| arg == flag)?)
-}
-
 /// The argument after position `at`, **unless it is itself a flag**.
 ///
-/// Without the second half, `--add-listen-client --token-out C:\x` takes `--token-out` as the
-/// client's *name* — and `--token-out` passes [`crate::client::client_name`], since a name may
-/// contain `-`. So the command would succeed, mint a credential for a client called
-/// `--token-out`, and leave the operator's actual intent nowhere. A leading `-` is the one thing
-/// a value here can never legitimately start with: neither a client name nor a path does.
+/// Without the second half, a mistyped `--add-listen-client --whatever` takes `--whatever` as the
+/// client's *name* — and it passes [`crate::client::client_name`], since a name may contain `-`. So
+/// the command would succeed, mint a credential for a client nobody asked for, and leave the
+/// operator's actual intent nowhere. A leading `-` is the one thing a value here can never
+/// legitimately start with, so it is the one thing worth refusing.
 fn value_at(args: &[String], at: usize) -> Option<String> {
     args.get(at + 1)
         .filter(|value| !value.starts_with('-'))
@@ -503,12 +491,13 @@ fn is_reload(control: &ServiceControl) -> bool {
 /// that may be reading it.
 ///
 /// **The token is generated here and never printed.** What reaches standard output is a
-/// [fingerprint](crate::client::fingerprint); the secret goes to the file
-/// [`TOKEN_OUT_FLAG`] names, created fresh and ACL'd like the credential file it came from. That
-/// is what keeps a working token out of a shell history and out of an agent's transcript, and it
-/// is why these commands are narrow enough to allow-list in a permission rule where "let this
-/// write `%ProgramData%`" would not be.
-pub fn edit_client(edit: ClientEdit, name: &str, args: &[String]) -> Result<()> {
+/// [fingerprint](crate::client::fingerprint); the secret goes
+/// beside the credential file, in the same `SYSTEM`-and-`Administrators` directory
+/// ([`write_token_out`], which says why the operator does not get to name that path). That is what
+/// keeps a working token out of a shell history and out of an agent's transcript, and it is why
+/// these commands are narrow enough to allow-list in a permission rule where "let this write
+/// `%ProgramData%`" would not be.
+pub fn edit_client(edit: ClientEdit, name: &str) -> Result<()> {
     let name = crate::client::client_name(name).with_context(|| {
         format!(
             "`{}` needs the name of a client — `{} bench`",
@@ -516,24 +505,6 @@ pub fn edit_client(edit: ClientEdit, name: &str, args: &[String]) -> Result<()> 
             edit.flag()
         )
     })?;
-    // Read before anything is touched, so a command missing half its arguments fails as a usage
-    // error rather than after the credential file has been rewritten.
-    let token_out = match edit.mints_a_token() {
-        true => Some(PathBuf::from(valued(args, TOKEN_OUT_FLAG).ok_or_else(|| {
-            anyhow::anyhow!(
-                "`{} {name}` needs `{TOKEN_OUT_FLAG} <path>`: it generates the token itself and \
-                 will not print one, so there has to be somewhere to put it.\n    {} {name} \
-                 {TOKEN_OUT_FLAG} C:\\Users\\you\\{name}.token\n\nMove that file to the client \
-                 machine and delete it here. The token is never shown on this console, which is \
-                 the point — a console is a shell history, and on this host frequently an agent's \
-                 transcript too.",
-                edit.flag(),
-                edit.flag()
-            )
-        })?)),
-        false => None,
-    };
-
     // **This handle does not prove elevation**, and it is worth being clear about that rather than
     // implying it: a service's default DACL grants `SERVICE_USER_DEFINED_CONTROL` to Authenticated
     // Users, so an ordinary account opens it fine. What refuses an unelevated caller is the
@@ -636,14 +607,14 @@ pub fn edit_client(edit: ClientEdit, name: &str, args: &[String]) -> Result<()> 
 
     // **Written before the credential file, and removed again if that write fails.** The order is
     // what keeps the two from disagreeing: a token accepted by the service that the operator has
-    // no copy of is unrecoverable without another rotation, while a token file naming a credential
-    // nothing accepts is inert. `create_new` refuses an existing path rather than overwriting it,
-    // for the same reason the credential file does.
-    if let (Some(path), Some(token)) = (token_out.as_deref(), minted.as_deref()) {
-        write_token_out(path, token)?;
-    }
+    // no copy of is unrecoverable without another rotation, while a token beside the credential
+    // file that nothing accepts is inert.
+    let token_at = match minted.as_deref() {
+        Some(token) => Some(write_token_out(&name, token)?),
+        None => None,
+    };
     if let Err(e) = write_credentials(&credentials) {
-        if let Some(path) = token_out.as_deref() {
+        if let Some(path) = token_at.as_deref() {
             let _ = std::fs::remove_file(path);
         }
         return Err(e.context(format!(
@@ -686,12 +657,13 @@ pub fn edit_client(edit: ClientEdit, name: &str, args: &[String]) -> Result<()> 
             at.display()
         );
     }
-    if let Some(path) = token_out.as_deref() {
+    if let Some(path) = token_at.as_deref() {
         println!(
-            "\nIts token is in {} — readable by SYSTEM and Administrators only, like the \
-             credential file it came from. Move it to the client machine, set it there as `{}`, \
-             and delete this copy. It is not printed here and cannot be read back out of the \
-             service; a lost token costs a `{ROTATE_CLIENT_FLAG} {name}` and nothing else.",
+            "\nIts token is in {} — the same SYSTEM-and-Administrators directory the credential \
+             file is in, which is why it goes there and not somewhere you name. Move it to the \
+             client machine, set it there as `{}`, and delete this copy. It is not printed here \
+             and cannot be read back out of the service; a lost token costs a \
+             `{ROTATE_CLIENT_FLAG} {name}` and nothing else.",
             path.display(),
             crate::listen::TOKEN_ENV,
         );
@@ -737,62 +709,59 @@ fn roster(credentials: &[(String, String)]) -> String {
         .join(", ")
 }
 
-/// Writes a generated token where the operator asked for it, and locks it down *first*.
+/// Writes a generated token beside the credential file, and says where it went.
 ///
-/// Given the same ACL as the credential file, which is not ceremony: this is a working credential
-/// for a listener that has `launch` on it, and the obvious place to ask for it is a profile
-/// directory other local accounts can read. `create_new` rather than a truncating create, so a
-/// mistyped path that happens to name something is a refusal rather than a file destroyed.
+/// **The operator does not choose the path, and that is the fix rather than a limitation.** This
+/// took a `--token-out <path>` and wrote the secret there, which review took two rounds to get
+/// right and was not right yet: the ACL had to go on before the write, since a DACL change does not
+/// revoke access through a handle already opened — and doing that by path means creating the file,
+/// closing it, ACL'ing it and reopening it, which hands anyone who can write that directory a
+/// window to substitute a file of their own and keep a read handle to it. Every fix for that is
+/// another turn of the same screw. What generates all of them is the choice: a secret written into
+/// a directory whose protection this program does not control.
 ///
-/// **The ACL goes on before the secret does**, and the file is created empty to make that possible.
-/// Writing first leaves an interval in which the token sits in a file still carrying whatever the
-/// parent directory grants — and changing a DACL does not revoke access through a handle already
-/// opened, so anything that got in during that interval keeps reading. Locked down as `F` for the
-/// write and re-applied as `R` afterwards: at no point is a principal outside `SYSTEM` and
-/// `Administrators` on that ACL.
+/// So it goes in the state directory, which [`secured_state_dir`] has already made `SYSTEM` and
+/// `Administrators` only — no traverse for anyone else, so there is no window to race and nothing
+/// to substitute, because an unprivileged process cannot name a path inside it, let alone create
+/// one. `create_new` still refuses an existing file: a token already sitting there is one an
+/// earlier command wrote and nobody has moved yet, and overwriting it would destroy the only copy
+/// of a credential that may still be in service.
 ///
-/// **And a failure here is fatal**, where it used to warn. The alternative is this command
-/// activating a credential and then telling the operator, in passing, that the copy it just wrote
-/// is readable by the machine — which is a thing to refuse, not to mention. The half-written file
-/// is removed, so a retry is not blocked by the `create_new` it would hit.
-fn write_token_out(path: &std::path::Path, token: &str) -> Result<()> {
+/// The file is ACL'd afterwards anyway. It is belt and braces — the directory is what protects it —
+/// and cheap enough to keep for the case where somebody widens that directory later.
+fn write_token_out(name: &str, token: &str) -> Result<PathBuf> {
     use std::io::Write;
 
-    std::fs::OpenOptions::new()
-        .write(true)
-        .create_new(true)
-        .open(path)
-        .with_context(|| {
-            format!(
-                "cannot create {} — it will not write through a file that already exists, since \
-                 the one it would overwrite may be a credential something still uses",
-                path.display()
-            )
-        })?;
-    // From here anything that fails takes the file with it: an empty file at a path the operator
-    // named would otherwise block the retry, and a locked-down one they cannot read is worse.
-    let guarded = (|| -> Result<()> {
-        restrict_to_administrators(path, "F")?;
+    let dir = secured_state_dir()?;
+    let at = dir.join(format!("{name}.token"));
+    {
         let mut file = std::fs::OpenOptions::new()
             .write(true)
-            .open(path)
-            .with_context(|| format!("cannot open {} to write the token", path.display()))?;
+            .create_new(true)
+            .open(&at)
+            .with_context(|| {
+                format!(
+                    "cannot create {} — a token for `{name}` is already sitting there from an \
+                     earlier command. Move it to the client machine and delete it, then run this \
+                     again: overwriting it would destroy the only copy of a credential that may \
+                     still be the one in service.",
+                    at.display()
+                )
+            })?;
         file.write_all(token.as_bytes())
             .and_then(|()| file.write_all(b"\n"))
-            .with_context(|| format!("cannot write {}", path.display()))?;
-        drop(file);
-        restrict_to_administrators(path, "R")
-    })();
-    if let Err(e) = guarded {
-        let _ = std::fs::remove_file(path);
+            .with_context(|| format!("cannot write {}", at.display()))?;
+    }
+    // From here anything that fails takes the file with it, so a retry is not blocked by the
+    // `create_new` above and no half-protected credential is left behind.
+    if let Err(e) = restrict_to_administrators(&at, "R") {
+        let _ = std::fs::remove_file(&at);
         return Err(e.context(format!(
-            "{} could not be given an ACL of SYSTEM and Administrators only, so no token was \
-             written there — a credential for a listener that runs `launch` as LocalSystem is not \
-             something to leave in a file the machine can read",
-            path.display()
+            "{} could not be given an ACL of its own, so no token was written there",
+            at.display()
         )));
     }
-    Ok(())
+    Ok(at)
 }
 
 /// Holds the credential file against another copy of this command, for one read-modify-write.
@@ -1368,13 +1337,7 @@ mod tests {
             Some(Role::Client(ClientEdit::Add, "bench".into()))
         );
         assert_eq!(
-            requested(&argv(&[
-                "windbg-mcp",
-                ROTATE_CLIENT_FLAG,
-                "ci",
-                TOKEN_OUT_FLAG,
-                r"C:\out\ci.token"
-            ])),
+            requested(&argv(&["windbg-mcp", ROTATE_CLIENT_FLAG, "ci"])),
             Some(Role::Client(ClientEdit::Rotate, "ci".into()))
         );
         assert_eq!(
@@ -1384,29 +1347,35 @@ mod tests {
         );
     }
 
-    /// The value behind `--token-out`, and nothing when it is not there to have one.
+    /// A flag's value is the argument after it — and never another flag.
+    ///
+    /// The last cases are the ones with a bug behind them: a mistyped `--add-listen-client --flag`
+    /// took `--flag` as the client's *name*, which passes the name rule since a name may contain
+    /// `-`, so the command would have minted a credential for a client nobody asked for.
     #[test]
-    fn a_flags_value_is_the_argument_after_it() {
+    fn a_flags_value_is_the_argument_after_it_and_never_another_flag() {
         let argv = |args: &[&str]| args.iter().map(|a| a.to_string()).collect::<Vec<_>>();
         assert_eq!(
-            valued(
-                &argv(&["windbg-mcp", ADD_CLIENT_FLAG, "bench", TOKEN_OUT_FLAG, "t"]),
-                TOKEN_OUT_FLAG
-            )
-            .as_deref(),
-            Some("t")
+            value_at(&argv(&["windbg-mcp", ADD_CLIENT_FLAG, "bench"]), 1).as_deref(),
+            Some("bench")
         );
         assert_eq!(
-            valued(
-                &argv(&["windbg-mcp", ADD_CLIENT_FLAG, "bench"]),
-                TOKEN_OUT_FLAG
-            ),
-            None
-        );
-        assert_eq!(
-            valued(&argv(&["windbg-mcp", TOKEN_OUT_FLAG]), TOKEN_OUT_FLAG),
+            value_at(&argv(&["windbg-mcp", ADD_CLIENT_FLAG]), 1),
             None,
             "a trailing flag has no value, and must not borrow one from nowhere"
+        );
+        assert_eq!(
+            value_at(
+                &argv(&["windbg-mcp", ADD_CLIENT_FLAG, "--something-else"]),
+                1
+            ),
+            None,
+            "a flag is never another flag's value"
+        );
+        assert_eq!(
+            requested(&argv(&["windbg-mcp", ADD_CLIENT_FLAG, "--else"])),
+            Some(Role::Client(ClientEdit::Add, String::new())),
+            "a flag standing where a name belongs is a missing name, not a client called `--else`"
         );
     }
 

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -3077,6 +3077,70 @@ fn installing_the_service_without_an_address_is_refused_before_anything_is_regis
     );
 }
 
+/// A client command that is missing something is refused *before* it opens the SCM or the file.
+///
+/// The ordering is the assertion, and it is what makes this test run the same on a host that has
+/// the service installed and one that does not: both refusals below are usage errors, so neither
+/// reaches the credential file — and a run on a developer's own host cannot disturb the clients
+/// their listener is serving.
+///
+/// The `--token-out` half is the one with a property behind it rather than a convention. These
+/// commands generate the token and will not print it, so a command with nowhere to put one would
+/// otherwise mint a credential, write it into the service's file, and leave the operator no way to
+/// learn it short of rotating again.
+#[test]
+fn a_client_command_says_what_is_missing_before_it_touches_anything() {
+    let registered = service_is_registered();
+    let refusal = |args: &[&str]| {
+        let out = Command::new(EXE)
+            .args(args)
+            .stdin(Stdio::null())
+            .output()
+            .unwrap_or_else(|e| panic!("failed to spawn {EXE}: {e}"));
+        assert!(
+            !out.status.success(),
+            "`{args:?}` should have been refused, and was not"
+        );
+        String::from_utf8_lossy(&out.stderr).to_string()
+    };
+
+    let no_name = refusal(&["--add-listen-client"]);
+    assert!(
+        no_name.contains("--add-listen-client"),
+        "a client command with no name has to name the flag it belongs to: {no_name}"
+    );
+    let no_out = refusal(&["--add-listen-client", "smoke-test-client"]);
+    assert!(
+        no_out.contains("--token-out"),
+        "a command that mints a token has to say where it wanted to put it: {no_out}"
+    );
+    assert!(
+        !no_out.contains("no service named"),
+        "the SCM was consulted before the command line was checked, which makes a usage error \
+         depend on whether the service happens to be installed: {no_out}"
+    );
+    let bad_name = refusal(&[
+        "--rotate-listen-client",
+        "two words",
+        "--token-out",
+        "unreachable.token",
+    ]);
+    assert!(
+        bad_name.contains("not a client name"),
+        "a name that is not one has to be refused as that: {bad_name}"
+    );
+    // A refusal must not have written a token to a path the command never got as far as using.
+    assert!(
+        !std::path::Path::new("unreachable.token").exists(),
+        "a refused command left a generated token behind"
+    );
+    assert_eq!(
+        registered,
+        service_is_registered(),
+        "a refused client command changed whether `windbg-mcp` is registered with the SCM"
+    );
+}
+
 /// Whether the SCM has a service by this name, for the assertion above to compare against itself.
 fn service_is_registered() -> bool {
     Command::new("sc.exe")

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -3119,11 +3119,16 @@ fn a_client_command_says_what_is_missing_before_it_touches_anything() {
         "the SCM was consulted before the command line was checked, which makes a usage error \
          depend on whether the service happens to be installed: {no_out}"
     );
+    // Under the temp directory rather than the crate root: nothing should be written there, and
+    // this test asserts exactly that — but a path that names the working tree turns a regression
+    // into a stray credential in somebody's checkout rather than a failed assertion.
+    let unreachable = std::env::temp_dir().join("windbg-mcp-smoke-unreachable.token");
+    let _ = std::fs::remove_file(&unreachable);
     let bad_name = refusal(&[
         "--rotate-listen-client",
         "two words",
         "--token-out",
-        "unreachable.token",
+        &unreachable.display().to_string(),
     ]);
     assert!(
         bad_name.contains("not a client name"),
@@ -3131,8 +3136,18 @@ fn a_client_command_says_what_is_missing_before_it_touches_anything() {
     );
     // A refusal must not have written a token to a path the command never got as far as using.
     assert!(
-        !std::path::Path::new("unreachable.token").exists(),
-        "a refused command left a generated token behind"
+        !unreachable.exists(),
+        "a refused command left a generated token behind at {}",
+        unreachable.display()
+    );
+
+    // **A flag is never a value.** Without this, the name would be `--token-out` — which passes the
+    // client-name rule, since a name may contain `-` — and the command would mint a credential for
+    // a client nobody asked for.
+    let flag_as_name = refusal(&["--add-listen-client", "--token-out", "/dev/null"]);
+    assert!(
+        flag_as_name.contains("--add-listen-client"),
+        "a flag standing where a name belongs has to be refused as a missing name: {flag_as_name}"
     );
     assert_eq!(
         registered,

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -3080,14 +3080,9 @@ fn installing_the_service_without_an_address_is_refused_before_anything_is_regis
 /// A client command that is missing something is refused *before* it opens the SCM or the file.
 ///
 /// The ordering is the assertion, and it is what makes this test run the same on a host that has
-/// the service installed and one that does not: both refusals below are usage errors, so neither
-/// reaches the credential file — and a run on a developer's own host cannot disturb the clients
-/// their listener is serving.
-///
-/// The `--token-out` half is the one with a property behind it rather than a convention. These
-/// commands generate the token and will not print it, so a command with nowhere to put one would
-/// otherwise mint a credential, write it into the service's file, and leave the operator no way to
-/// learn it short of rotating again.
+/// the service installed and one that does not: every refusal below is a usage error, so none of
+/// them reaches the credential file — and a run on a developer's own host cannot disturb the
+/// clients their listener is serving.
 #[test]
 fn a_client_command_says_what_is_missing_before_it_touches_anything() {
     let registered = service_is_registered();
@@ -3109,42 +3104,21 @@ fn a_client_command_says_what_is_missing_before_it_touches_anything() {
         no_name.contains("--add-listen-client"),
         "a client command with no name has to name the flag it belongs to: {no_name}"
     );
-    let no_out = refusal(&["--add-listen-client", "smoke-test-client"]);
-    assert!(
-        no_out.contains("--token-out"),
-        "a command that mints a token has to say where it wanted to put it: {no_out}"
-    );
-    assert!(
-        !no_out.contains("no service named"),
-        "the SCM was consulted before the command line was checked, which makes a usage error \
-         depend on whether the service happens to be installed: {no_out}"
-    );
-    // Under the temp directory rather than the crate root: nothing should be written there, and
-    // this test asserts exactly that — but a path that names the working tree turns a regression
-    // into a stray credential in somebody's checkout rather than a failed assertion.
-    let unreachable = std::env::temp_dir().join("windbg-mcp-smoke-unreachable.token");
-    let _ = std::fs::remove_file(&unreachable);
-    let bad_name = refusal(&[
-        "--rotate-listen-client",
-        "two words",
-        "--token-out",
-        &unreachable.display().to_string(),
-    ]);
+    let bad_name = refusal(&["--rotate-listen-client", "two words"]);
     assert!(
         bad_name.contains("not a client name"),
         "a name that is not one has to be refused as that: {bad_name}"
     );
-    // A refusal must not have written a token to a path the command never got as far as using.
     assert!(
-        !unreachable.exists(),
-        "a refused command left a generated token behind at {}",
-        unreachable.display()
+        !bad_name.contains("no service named"),
+        "the SCM was consulted before the command line was checked, which makes a usage error \
+         depend on whether the service happens to be installed: {bad_name}"
     );
 
-    // **A flag is never a value.** Without this, the name would be `--token-out` — which passes the
-    // client-name rule, since a name may contain `-` — and the command would mint a credential for
-    // a client nobody asked for.
-    let flag_as_name = refusal(&["--add-listen-client", "--token-out", "/dev/null"]);
+    // **A flag is never a name.** Without this the name would be `--force`, which passes the
+    // client-name rule since a name may contain `-`, and the command would mint a credential for a
+    // client nobody asked for.
+    let flag_as_name = refusal(&["--add-listen-client", "--force"]);
     assert!(
         flag_as_name.contains("--add-listen-client"),
         "a flag standing where a name belongs has to be refused as a missing name: {flag_as_name}"


### PR DESCRIPTION
Closes `FOLLOWUPS.md` item 34.

## The problem

`--install-service` was the only writer of `%ProgramData%\windbg-mcp\token`, and the SCM refuses a second registration under the same name. So adding or rotating a client meant `--uninstall-service`, set every credential variable again, `--install-service`, `Start-Service` — which **drops every session the service holds**, a parked kernel attach included.

That was never a decision anyone made; it fell out of there being no writer but the installer. Two properties *were* chosen deliberately — "only the installer writes this file" and "never write through a file it did not create" — and neither of them requires the reinstall.

## What this adds

Three commands, from an elevated shell:

```pwsh
windbg-mcp.exe --add-listen-client    ci
windbg-mcp.exe --rotate-listen-client ci
windbg-mcp.exe --remove-listen-client ci
```

Each rewrites the credential file and then tells the running service to re-read it, **waiting for it to have done so** — so the set in force when the command returns is the set it wrote. Nothing is stopped and nothing is restarted.

**They generate the token and will not print it.** Standard output carries a fingerprint (`sha256:076C14953E1DE5EF`); the token goes to `<name>.token` beside the credential file. A token you typed has been through a shell history, and on a machine driven by an agent, through a transcript; one this server generated has been through neither. That is also what makes these narrow enough to allow-list in a permission rule, where "let this write `%ProgramData%`" is not.

**The operator does not name that path, and that is the fix rather than a limitation.** An earlier revision took `--token-out <path>`, which meant writing a live credential into a directory this program does not control the protection of: the ACL has to go on before the write (a DACL change does not revoke access through an already-open handle), doing that by path means create/close/ACL/reopen, and that hands anyone who can write the directory a window to substitute a file and keep a read handle to it. The state directory is already SYSTEM-and-Administrators-only with no traverse for anyone else, so there is no window to race and nothing to substitute.

## How the two hardened properties survive

- *Only the installer writes this file* becomes **only this program, running elevated, writes it** — the command is the same binary.
- *Never write through a file it did not create* survives as `service::write_credentials`: a fresh sibling created with `create_new` in the protected directory, ACL'd there, renamed over the old name. That also makes the replacement **atomic** for a service reading it concurrently. `finish_install` now shares that writer.

The ACL is untouched, and the environment is still read only by `--install-service`.

## The reload is the other half, not a footnote

Without it these commands would be an improvement in ergonomics and not in outcome, since a *restart* still costs the sessions. User-defined control code **128**, sent by the command and answered in `serve_as_service`'s handler, reaches `listen::reloaded` — which re-reads through the same `credentials()` that decides whether the listener may start at all (so a set that would not have started it cannot replace the one that did), swaps it into `client::Accepted`, and tears down a departed client.

The handler **blocks on the reload task's answer** (bounded at 10s, well inside the SCM's 30) and reports a failed re-read as a failed control code, so the command's printed claim is one it can back.

Three decisions worth reviewing on their merits:

- **A rotation keeps the name, and so keeps the sessions.** `Change` reports it as neither an arrival nor a departure — which is what stops the reload tearing down exactly the targets rotation exists to preserve.
- **A removal releases rather than refuses**, and closes the gate before it walks anything. A lease expiry needs no gate: it fires only after the client has been silent longer than any call can keep it quiet. A revocation has no quiet period — an opener that authenticated a moment earlier can be seconds from registering — so `Sessions::revoke` marks the owner under the registry lock and `admit` refuses it, the same shape `closing` gives shutdown. A session admitted behind a one-pass release would be a live kernel target owned by a client nothing can authenticate as.
- **Removing the last client is refused.** A listener with no credentials will not start, so that is a decision to stop serving rather than an incremental change — which is `--uninstall-service`.

A revocation whose reload could not be delivered **fails the command**: the credential you were taking out of service is still being accepted, which is not something to mention in passing. An `--add` in the same position is a warning. Two of these commands cannot run at once (`token.lock`, opened with no sharing): both would compute a whole file from their own snapshot and the later write would silently discard the earlier.

## Dependencies

CNG supplies both credential primitives — `BCryptGenRandom` for the token, `BCryptHash` against the SHA-256 pseudo-handle for the fingerprint — so this pulls in **no crypto crate**, just one `windows-sys` feature.

## Verification

`cargo clippy --all-targets -- -D warnings` clean, `cargo fmt --all --check` clean, **496 unit + 70 smoke** tests pass on the ARM64 bench.

New coverage: token generation is held to the same presentability rule every configured credential is; a known-answer test for the digest; the fingerprint carries none of its token; `Accepted::replace` reports what moved and a rotation reports nothing; `Lease::revoked_for`/`forget` take a revoked client's sessions now and leave no entry a re-added name could inherit; a flag is never a value; the roster quotes no token; the reload code is one number both sides agree on; and a smoke test that a client command says what is missing **before** it opens the SCM or the file — which is what makes it safe to run on a host that has the service installed.

**Driven end to end against the installed service**, one process throughout, never restarted:

| step | result |
|---|---|
| `--add-listen-client bench` | log: `re-read the clients: added [bench], removed []`; the token answers `200` on an MCP `initialize` **the instant the command returns**; its file is `SYSTEM:Read \| Administrators:Read` in the protected directory |
| a second `--add-listen-client bench` | refused — the client exists |
| `--rotate-listen-client bench` | refused while the previous token file is still there ("would destroy the only copy"); succeeds once moved, old token `401`, new one `200` |
| `--remove-listen-client bench` | `401` immediately, and the log shows that client's MCP sessions being closed |
| `--remove-listen-client local` | refused — it was the only client left |
| a second command while the lock is held | refused, and writes nothing |

Across an earlier add/rotate/remove cycle the credential file came back **byte-for-byte** to its pre-test hash, with `local` untouched and the file returned from the JSON shape to the bare one.

## Docs

`docs/remote-listener.md`'s "Adding or rotating a client afterwards costs a reinstall" is replaced by the procedure that does not; the second foreground listener is re-framed as the development workflow it is rather than the fallback for this. The `windbg-debugging` skill's `setup.md` gains one clause and defers to that file. README and CHANGELOG updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
