### PR TITLE
Make a service read the credential file its own commands write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -182,10 +182,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   halves do not exist. An inherited override is ignored with a warning; the variable is unchanged
   for a foreground listener, which is what it is documented for.
 
-  And a **starting** service is now asked to re-read rather than treated as stopped. Credentials are
-  read before the bind, so a `StartPending` listener is already serving the old set — and a
-  non-loopback bind at boot can hold it there for `BIND_PATIENCE`, a minute and a half. The reload
-  task is started before the bind too, so there is something there to answer.
+  And a **starting** service is no longer treated as a stopped one. Credentials are read before the
+  bind, so a `StartPending` listener is already serving the old set — and a non-loopback bind at boot
+  can hold it there for `BIND_PATIENCE`, a minute and a half — while "it will read this at its next
+  start" was true only of a start that had not happened. It cannot be told either: the SCM refuses a
+  control code to a service in that state (`ERROR_SERVICE_CANNOT_ACCEPT_CTRL`, measured against a
+  real service held there by an address not on the host). So the command says that, and for a
+  `--remove` or `--rotate` it exits non-zero — a restart is the only thing that applies it.
 
 - **`tools/ioctl_harness.ps1` could not run under Windows PowerShell 5.1**, which is the only
   PowerShell a stock debuggee has. Three faults, each fatal before an IOCTL was sent: em dashes in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,26 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-
-- **Two ways a client command could report a revocation that had not happened** (found reviewing
-  [#189](https://github.com/glslang/windbg-mcp/pull/189), after it merged). Both ended the same way:
-  `--remove-listen-client` or `--rotate-listen-client` printing success while the credential it took
-  out of service went on being accepted, which is the worst thing these commands can do.
-
-  A service now reads **the credential file its own commands write**, unconditionally. It used to
-  defer to a `WINDBG_MCP_LISTEN_TOKEN_FILE` already in its environment, which left it serving one
-  file while the commands edited another — and the reload then succeeded, re-reading the unchanged
-  override. `%ProgramData%\windbg-mcp\token` is what the installer writes, the commands edit and
-  `--uninstall-service` deletes, so a service reading elsewhere is a configuration whose other three
-  halves do not exist. An inherited override is ignored with a warning; the variable is unchanged
-  for a foreground listener, which is what it is documented for.
-
-  And a **starting** service is now asked to re-read rather than treated as stopped. Credentials are
-  read before the bind, so a `StartPending` listener is already serving the old set — and a
-  non-loopback bind at boot can hold it there for `BIND_PATIENCE`, a minute and a half. The reload
-  task is started before the bind too, so there is something there to answer.
-
 ### Added
 
 - **A service-hosted listener's clients can be changed without a reinstall**
@@ -188,6 +168,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   holds on ARM64 and does not hold on the x64 runner image.
 
 ### Fixed
+
+- **Two ways a client command could report a revocation that had not happened** (found reviewing
+  [#189](https://github.com/glslang/windbg-mcp/pull/189), after it merged). Both ended the same way:
+  `--remove-listen-client` or `--rotate-listen-client` printing success while the credential it took
+  out of service went on being accepted, which is the worst thing these commands can do.
+
+  A service now reads **the credential file its own commands write**, unconditionally. It used to
+  defer to a `WINDBG_MCP_LISTEN_TOKEN_FILE` already in its environment, which left it serving one
+  file while the commands edited another — and the reload then succeeded, re-reading the unchanged
+  override. `%ProgramData%\windbg-mcp\token` is what the installer writes, the commands edit and
+  `--uninstall-service` deletes, so a service reading elsewhere is a configuration whose other three
+  halves do not exist. An inherited override is ignored with a warning; the variable is unchanged
+  for a foreground listener, which is what it is documented for.
+
+  And a **starting** service is now asked to re-read rather than treated as stopped. Credentials are
+  read before the bind, so a `StartPending` listener is already serving the old set — and a
+  non-loopback bind at boot can hold it there for `BIND_PATIENCE`, a minute and a half. The reload
+  task is started before the bind too, so there is something there to answer.
 
 - **`tools/ioctl_harness.ps1` could not run under Windows PowerShell 5.1**, which is the only
   PowerShell a stock debuggee has. Three faults, each fatal before an IOCTL was sent: em dashes in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Two ways a client command could report a revocation that had not happened** (found reviewing
+  [#189](https://github.com/glslang/windbg-mcp/pull/189), after it merged). Both ended the same way:
+  `--remove-listen-client` or `--rotate-listen-client` printing success while the credential it took
+  out of service went on being accepted, which is the worst thing these commands can do.
+
+  A service now reads **the credential file its own commands write**, unconditionally. It used to
+  defer to a `WINDBG_MCP_LISTEN_TOKEN_FILE` already in its environment, which left it serving one
+  file while the commands edited another — and the reload then succeeded, re-reading the unchanged
+  override. `%ProgramData%\windbg-mcp\token` is what the installer writes, the commands edit and
+  `--uninstall-service` deletes, so a service reading elsewhere is a configuration whose other three
+  halves do not exist. An inherited override is ignored with a warning; the variable is unchanged
+  for a foreground listener, which is what it is documented for.
+
+  And a **starting** service is now asked to re-read rather than treated as stopped. Credentials are
+  read before the bind, so a `StartPending` listener is already serving the old set — and a
+  non-loopback bind at boot can hold it there for `BIND_PATIENCE`, a minute and a half. The reload
+  task is started before the bind too, so there is something there to answer.
+
 ### Added
 
 - **A service-hosted listener's clients can be changed without a reinstall**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -187,8 +187,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   can hold it there for `BIND_PATIENCE`, a minute and a half — while "it will read this at its next
   start" was true only of a start that had not happened. It cannot be told either: the SCM refuses a
   control code to a service in that state (`ERROR_SERVICE_CANNOT_ACCEPT_CTRL`, measured against a
-  real service held there by an address not on the host). So the command says that, and for a
-  `--remove` or `--rotate` it exits non-zero — a restart is the only thing that applies it.
+  real service held there by an address not on the host). So the command says the change was not
+  handed over, says that whether the start picked it up by itself cannot be told from outside, and
+  points at the `clients: …` line the listener logs when it comes up. A `--remove` or `--rotate`
+  exits non-zero, because "may still authenticate" is the same thing to act on as "does".
 
 - **`tools/ioctl_harness.ps1` could not run under Windows PowerShell 5.1**, which is the only
   PowerShell a stock debuggee has. Three faults, each fatal before an IOCTL was sent: em dashes in

--- a/docs/remote-listener.md
+++ b/docs/remote-listener.md
@@ -494,8 +494,12 @@ Four behaviours worth knowing before you need them:
   simply cannot connect until the next start, and nothing that worked has stopped working.
 
 If the service is not running, the file is written anyway and the command says it will be read at
-the next start — a service that is still *starting* is asked all the same, because it has read its
-credentials by then and is already serving the old set. If it is not *installed*, the commands refuse — a foreground listener takes its
+the next start. A service that is still **starting** is the one case in between, and it is reported
+as a failure rather than a note: it read its clients before it began binding, so the start under way
+is serving the set from before your change — and the SCM will not carry a control code to a service
+in that state, so it cannot be told. `Restart-Service` is the fix, and for a `--remove` or
+`--rotate` the command exits non-zero to say so. You will only meet this at boot on a non-loopback
+address, which is the one bind that can take a while. If it is not *installed*, the commands refuse — a foreground listener takes its
 clients from the environment it was started with, which is a set that cannot change without the
 process changing too.
 

--- a/docs/remote-listener.md
+++ b/docs/remote-listener.md
@@ -494,12 +494,14 @@ Four behaviours worth knowing before you need them:
   simply cannot connect until the next start, and nothing that worked has stopped working.
 
 If the service is not running, the file is written anyway and the command says it will be read at
-the next start. A service that is still **starting** is the one case in between, and it is reported
-as a failure rather than a note: it read its clients before it began binding, so the start under way
-is serving the set from before your change — and the SCM will not carry a control code to a service
-in that state, so it cannot be told. `Restart-Service` is the fix, and for a `--remove` or
-`--rotate` the command exits non-zero to say so. You will only meet this at boot on a non-loopback
-address, which is the one bind that can take a while. If it is not *installed*, the commands refuse — a foreground listener takes its
+the next start. A service that is still **starting** is the one case in between, and it is
+reported as a failure rather than a note: the SCM will not carry a control code to a service in that
+state, so the change is not handed to it, and whether the start under way picked the file up by
+itself cannot be told from outside — it reads its clients moments after starting and then binds, and
+binding is the slow part. When it comes up it logs the clients it is serving (`clients: …`); if the
+one you changed is not as you left it, `Restart-Service`. A `--remove` or `--rotate` exits non-zero
+here, because "may still authenticate" is the same thing to act on as "does". You will only meet
+this at boot on a non-loopback address, which is the one bind that can take a while. If it is not *installed*, the commands refuse — a foreground listener takes its
 clients from the environment it was started with, which is a set that cannot change without the
 process changing too.
 

--- a/docs/remote-listener.md
+++ b/docs/remote-listener.md
@@ -429,6 +429,13 @@ Two commands cannot run at once. The second is refused rather than queued, becau
 compute a whole file from their own snapshot of it and the later write would silently discard the
 earlier — an add and a revocation run together, both reporting success, and the revocation gone.
 
+**A service reads the file its own commands write**, and nothing else. Setting
+`WINDBG_MCP_LISTEN_TOKEN_FILE` in a service's environment does not repoint it: the installer writes
+`%ProgramData%\windbg-mcp\token`, these commands edit it and `--uninstall-service` deletes it, so
+a service reading somewhere else would be a configuration whose other three halves do not exist —
+and the failure was silent, a revocation reporting success while the credential went on being
+accepted. The variable is unchanged for a **foreground** listener, which is what it is for.
+
 **The file is still not yours to edit.** It grants `SYSTEM` and `Administrators` *read*, so an
 administrator who opens it in an editor is told `Access to the path is denied` — that is the ACL
 working rather than something to route around, and taking ownership to write it anyway leaves a
@@ -487,7 +494,8 @@ Four behaviours worth knowing before you need them:
   simply cannot connect until the next start, and nothing that worked has stopped working.
 
 If the service is not running, the file is written anyway and the command says it will be read at
-the next start. If it is not *installed*, the commands refuse — a foreground listener takes its
+the next start — a service that is still *starting* is asked all the same, because it has read its
+credentials by then and is already serving the old set. If it is not *installed*, the commands refuse — a foreground listener takes its
 clients from the environment it was started with, which is a set that cannot change without the
 process changing too.
 

--- a/src/listen.rs
+++ b/src/listen.rs
@@ -727,22 +727,6 @@ pub async fn serve(
         ))
     };
 
-    // **Started before the bind, not after the listener is up.** Credentials are read above, so
-    // from this point the process is already serving a *set* even though it has no socket yet — and
-    // a non-loopback bind at boot can sit below for [`BIND_PATIENCE`]. A client command issued in
-    // that window has to be answered by this task or it times out, and a `--remove-listen-client`
-    // that times out reports a revocation that did not happen while this start goes on accepting
-    // the credential it revoked (#189 review). Only under the service, which is the only role with
-    // a control channel to be asked on.
-    if let Some(asked) = reload {
-        tokio::spawn(reloaded(
-            asked,
-            Arc::clone(&credentials),
-            sessions.clone(),
-            lease.clone(),
-        ));
-    }
-
     // Pinned here rather than at the accept loop, because the bind is raced against it: a stop
     // arriving while a not-yet-assigned address is being waited for must be answered now, not in
     // ninety seconds' time. Without this the service would sit `Running` with no endpoint and no
@@ -766,6 +750,24 @@ pub async fn serve(
         },
         credentials.names().join(", ")
     );
+
+    // Only under the service, which is the only role with a control channel to be asked on.
+    //
+    // **After the bind, and it was briefly moved before it on a premise that turned out to be
+    // false.** The idea was to have something ready to answer a command issued while a slow
+    // non-loopback bind held the service in `StartPending` — but the SCM will not deliver a control
+    // code to a service in that state at all (`ERROR_SERVICE_CANNOT_ACCEPT_CTRL`, measured), so
+    // there was never a request to answer. The only gap left is between the service reporting
+    // itself started and this line, which is a `spawn` away and covered anyway: the channel is
+    // unbounded, so the handler's send lands and its wait is answered as soon as this task runs.
+    if let Some(asked) = reload {
+        tokio::spawn(reloaded(
+            asked,
+            Arc::clone(&credentials),
+            sessions.clone(),
+            lease.clone(),
+        ));
+    }
 
     tokio::spawn(sweep(
         sessions.clone(),

--- a/src/listen.rs
+++ b/src/listen.rs
@@ -727,6 +727,22 @@ pub async fn serve(
         ))
     };
 
+    // **Started before the bind, not after the listener is up.** Credentials are read above, so
+    // from this point the process is already serving a *set* even though it has no socket yet — and
+    // a non-loopback bind at boot can sit below for [`BIND_PATIENCE`]. A client command issued in
+    // that window has to be answered by this task or it times out, and a `--remove-listen-client`
+    // that times out reports a revocation that did not happen while this start goes on accepting
+    // the credential it revoked (#189 review). Only under the service, which is the only role with
+    // a control channel to be asked on.
+    if let Some(asked) = reload {
+        tokio::spawn(reloaded(
+            asked,
+            Arc::clone(&credentials),
+            sessions.clone(),
+            lease.clone(),
+        ));
+    }
+
     // Pinned here rather than at the accept loop, because the bind is raced against it: a stop
     // arriving while a not-yet-assigned address is being waited for must be answered now, not in
     // ninety seconds' time. Without this the service would sit `Running` with no endpoint and no
@@ -750,17 +766,6 @@ pub async fn serve(
         },
         credentials.names().join(", ")
     );
-
-    // Only under the service, which is the only role with a control channel to be asked on. See
-    // [`reloaded`] for what the answer is when there is no such channel.
-    if let Some(asked) = reload {
-        tokio::spawn(reloaded(
-            asked,
-            Arc::clone(&credentials),
-            sessions.clone(),
-            lease.clone(),
-        ));
-    }
 
     tokio::spawn(sweep(
         sessions.clone(),

--- a/src/service.rs
+++ b/src/service.rs
@@ -699,11 +699,16 @@ pub fn edit_client(edit: ClientEdit, name: &str) -> Result<()> {
         // being accepted** — which is exactly the thing you ran the command to stop, so it has to
         // be an error the shell can see.
         Err(e) if edit.revokes_a_token() => {
+            // **"was not handed to" rather than "is still running with"**, because one of the two
+            // ways this fails cannot know the latter — a service caught starting may have read the
+            // file on its own. Asserting it would have this message contradict the cause printed
+            // directly beneath it. The urgency is unchanged: for a revocation, "may still
+            // authenticate" is the same thing to act on as "does".
             return Err(e.context(format!(
-                "the client `{name}` was {past} in {}, but `{NAME}` is still running with the \
-                 credential you took out of service. Restart it (`Restart-Service {NAME}`, which \
-                 does drop the sessions it holds) and check its log — until then that token still \
-                 authenticates",
+                "the client `{name}` was {past} in {}, but the change was not handed to `{NAME}` — \
+                 so the credential you took out of service may still be authenticating. Restart it \
+                 (`Restart-Service {NAME}`, which does drop the sessions it holds) and check its \
+                 log",
                 at.display()
             )));
         }
@@ -894,24 +899,38 @@ fn write_credentials(credentials: &[(String, String)]) -> Result<()> {
 fn ask_to_reload(service: &windows_service::service::Service) -> Result<bool> {
     let state = service.query_status()?.current_state;
     // **A starting service is neither of the two easy answers, and it used to be given the wrong
-    // one.** It has already read its credentials — that happens before the bind — so it is serving
-    // the *old* set, and a non-loopback bind at boot can hold it here for
-    // [`crate::listen::BIND_PATIENCE`], a minute and a half. Reporting "it will read this at its
-    // next start" was false of the start already under way, and for a revocation that is a
-    // credential the operator believes is gone.
+    // one.** Reporting "it will read this at its next start" was false of the start already under
+    // way, and for a revocation that is a credential the operator has been told is gone.
     //
     // It cannot be told, either: the SCM refuses a control code to a service in this state with
     // `ERROR_SERVICE_CANNOT_ACCEPT_CTRL`, which was measured rather than assumed — binding an
     // address that is not on the host holds a real service here, and `notify` comes back
-    // `os error 1061`. So this says the true thing instead, and says it *without* going through
-    // `notify`, whose refusal at this point would otherwise be reported as the service having read
-    // the file and rejected it.
+    // `os error 1061`. So this answers without going through `notify`, whose refusal would
+    // otherwise be reported as the service having read the file and rejected it.
+    //
+    // **What it does not do is claim to know whether this start read the new file**, because it
+    // cannot. Credentials are read a moment after the SCM is told `StartPending` — the runtime is
+    // built in between — and the long part of this state is the *bind* that follows, which is
+    // instant on loopback and up to [`crate::listen::BIND_PATIENCE`] on a non-loopback address at
+    // boot. So an edit landing here is almost always too late for this start and occasionally in
+    // time for it, and the split is milliseconds wide.
+    //
+    // Left as an honest "cannot tell" rather than resolved, which was a deliberate call when review
+    // raised it. Resolving it means the service publishing *which* it has done — overloading the
+    // status checkpoint, which means progress, or adding a channel — to distinguish two outcomes
+    // whose costs are a restart of a service that has just started and is therefore holding
+    // nothing, against a credential believed revoked that is not. The wrong answer here is already
+    // the safe one; what it owed the operator was the truth and a way to settle it, which is the
+    // line the listener logs when it comes up.
     if state == ServiceState::StartPending {
         bail!(
             "`{NAME}` is still starting, and the Service Control Manager will not deliver a \
-             control code to a service in that state. It has already read its clients, though — \
-             that happens before it binds — so the start now under way is serving the set from \
-             *before* this change, and will go on doing so until it is restarted."
+             control code to a service in that state — so this change has not been handed to it. \
+             Whether the start now under way picked the file up on its own cannot be told from \
+             here: it reads its clients moments after starting and then binds, and binding is the \
+             part that can take a while. When it comes up it logs the clients it is serving \
+             (`clients: …`, in {}); if the one you changed is not as you left it, restart it.",
+            log_path().display()
         );
     }
     if state != ServiceState::Running {

--- a/src/service.rs
+++ b/src/service.rs
@@ -466,6 +466,21 @@ const RELOAD_ACK_WAIT: Duration = Duration::from_secs(10);
 const ERROR_INVALID_DATA: u32 = 13;
 const ERROR_SERVICE_NOT_ACTIVE: u32 = 1062;
 
+/// Whether a service in this state can be asked to re-read its clients.
+///
+/// **`StartPending` counts, and getting that wrong reported a failed revocation as a success.** A
+/// starting listener has already read its credentials — that happens before the bind — so it is
+/// serving the *old* set even though the SCM has not called it `Running` yet. A non-loopback bind
+/// at boot can hold it there for [`crate::listen::BIND_PATIENCE`], and a `--remove-listen-client`
+/// issued in that window used to print "it will read this at its next start" while this start went
+/// on accepting the credential just revoked (#189 review).
+///
+/// So it is asked, and the reload task is running by then to answer. Everything else is a service
+/// with nothing loaded or on its way out, for which "at its next start" is the truth.
+fn is_askable(state: ServiceState) -> bool {
+    matches!(state, ServiceState::Running | ServiceState::StartPending)
+}
+
 /// Whether a control code the SCM delivered is the reload.
 ///
 /// A predicate rather than a match arm so the [dispatcher](serve_as_service) and the [sender](
@@ -892,7 +907,7 @@ fn write_credentials(credentials: &[(String, String)]) -> Result<()> {
 /// the reload task's answer, and reports a failed re-read as a control-code failure, which arrives
 /// here as an `Err`. So `Ok(true)` means the set in force is the set this command wrote.
 fn ask_to_reload(service: &windows_service::service::Service) -> Result<bool> {
-    if service.query_status()?.current_state != ServiceState::Running {
+    if !is_askable(service.query_status()?.current_state) {
         return Ok(false);
     }
     let code = windows_service::service::UserEventCode::from_raw(RELOAD_CODE)
@@ -1133,13 +1148,39 @@ fn serve_as_service() -> Result<()> {
     // command line the SCM stores, because that line is readable by every process on the machine —
     // which is the exact property the file exists to restore.
     //
+    // **An inherited override is ignored, not honoured**, and that is a deliberate narrowing. This
+    // used to defer to a `WINDBG_MCP_LISTEN_TOKEN_FILE` already in the environment, which left the
+    // service reading one file while [`edit_client`] wrote another: an `--add-listen-client` then
+    // produced a token nothing accepted, and — far worse — a `--remove-listen-client` reported
+    // success while the credential it revoked went on being accepted, because the reload
+    // successfully re-read the unchanged override (#189 review). A silent failed revocation is the
+    // worst thing this feature can do.
+    //
+    // The fix is to make the mismatch impossible rather than detected. `token_file()` is the file
+    // the installer writes, the client commands edit, and `--uninstall-service` deletes; a service
+    // reading anywhere else is a configuration whose other three halves do not exist. The variable
+    // keeps working exactly as before for a **foreground** listener, which is what it is documented
+    // for.
+    //
     // SAFETY: this runs on the SCM's dispatcher thread before the async runtime exists and before
     // any thread of ours has been started, so there is no concurrent reader of the environment.
-    if std::env::var_os(crate::listen::TOKEN_FILE_ENV).is_none() {
-        let file = token_file();
-        if file.exists() {
-            unsafe { std::env::set_var(crate::listen::TOKEN_FILE_ENV, &file) };
+    let file = token_file();
+    if file.exists() {
+        if let Some(overridden) = std::env::var_os(crate::listen::TOKEN_FILE_ENV)
+            && overridden != file
+        {
+            // Said out loud, because it is the one case where an operator's configuration is being
+            // disregarded, and they would otherwise be left wondering why their clients are not the
+            // ones being served.
+            tracing::warn!(
+                "{} names {} in this service's environment, and is being ignored: a service reads \
+                 the credential file its own installer wrote and its own client commands edit ({}).",
+                crate::listen::TOKEN_FILE_ENV,
+                std::path::Path::new(&overridden).display(),
+                file.display()
+            );
         }
+        unsafe { std::env::set_var(crate::listen::TOKEN_FILE_ENV, &file) };
     }
 
     // **Re-applied at every start, not just at install.** The bound is derived from
@@ -1407,6 +1448,36 @@ mod tests {
             Some(Role::Client(ClientEdit::Add, String::new())),
             "a flag standing where a name belongs is a missing name, not a client called `--else`"
         );
+    }
+
+    /// A starting service is asked to re-read, because it has already read.
+    ///
+    /// The bug this pins reported a **failed revocation as a success**: credentials are read before
+    /// the bind, so a `StartPending` listener is already serving the old set, and a non-loopback
+    /// bind at boot can hold it there for `BIND_PATIENCE` — a minute and a half. Treating that as
+    /// "not running" printed "it will read this at its next start" while *this* start went on
+    /// accepting the credential the operator had just revoked.
+    #[test]
+    fn a_starting_service_is_asked_to_reload_because_it_has_already_read_its_clients() {
+        assert!(is_askable(ServiceState::Running));
+        assert!(
+            is_askable(ServiceState::StartPending),
+            "a starting listener has read its credentials already — it is serving the old set, so \
+             it is exactly the one that has to be told"
+        );
+        // Nothing is loaded, or it is on the way out: "at its next start" is then the truth.
+        for settled in [
+            ServiceState::Stopped,
+            ServiceState::StopPending,
+            ServiceState::Paused,
+            ServiceState::PausePending,
+            ServiceState::ContinuePending,
+        ] {
+            assert!(
+                !is_askable(settled),
+                "{settled:?} was treated as reloadable"
+            );
+        }
     }
 
     /// The code the dispatcher answers is the code the command sends, and nothing else is it.

--- a/src/service.rs
+++ b/src/service.rs
@@ -466,21 +466,6 @@ const RELOAD_ACK_WAIT: Duration = Duration::from_secs(10);
 const ERROR_INVALID_DATA: u32 = 13;
 const ERROR_SERVICE_NOT_ACTIVE: u32 = 1062;
 
-/// Whether a service in this state can be asked to re-read its clients.
-///
-/// **`StartPending` counts, and getting that wrong reported a failed revocation as a success.** A
-/// starting listener has already read its credentials — that happens before the bind — so it is
-/// serving the *old* set even though the SCM has not called it `Running` yet. A non-loopback bind
-/// at boot can hold it there for [`crate::listen::BIND_PATIENCE`], and a `--remove-listen-client`
-/// issued in that window used to print "it will read this at its next start" while this start went
-/// on accepting the credential just revoked (#189 review).
-///
-/// So it is asked, and the reload task is running by then to answer. Everything else is a service
-/// with nothing loaded or on its way out, for which "at its next start" is the truth.
-fn is_askable(state: ServiceState) -> bool {
-    matches!(state, ServiceState::Running | ServiceState::StartPending)
-}
-
 /// Whether a control code the SCM delivered is the reload.
 ///
 /// A predicate rather than a match arm so the [dispatcher](serve_as_service) and the [sender](
@@ -907,14 +892,41 @@ fn write_credentials(credentials: &[(String, String)]) -> Result<()> {
 /// the reload task's answer, and reports a failed re-read as a control-code failure, which arrives
 /// here as an `Err`. So `Ok(true)` means the set in force is the set this command wrote.
 fn ask_to_reload(service: &windows_service::service::Service) -> Result<bool> {
-    if !is_askable(service.query_status()?.current_state) {
+    let state = service.query_status()?.current_state;
+    // **A starting service is neither of the two easy answers, and it used to be given the wrong
+    // one.** It has already read its credentials — that happens before the bind — so it is serving
+    // the *old* set, and a non-loopback bind at boot can hold it here for
+    // [`crate::listen::BIND_PATIENCE`], a minute and a half. Reporting "it will read this at its
+    // next start" was false of the start already under way, and for a revocation that is a
+    // credential the operator believes is gone.
+    //
+    // It cannot be told, either: the SCM refuses a control code to a service in this state with
+    // `ERROR_SERVICE_CANNOT_ACCEPT_CTRL`, which was measured rather than assumed — binding an
+    // address that is not on the host holds a real service here, and `notify` comes back
+    // `os error 1061`. So this says the true thing instead, and says it *without* going through
+    // `notify`, whose refusal at this point would otherwise be reported as the service having read
+    // the file and rejected it.
+    if state == ServiceState::StartPending {
+        bail!(
+            "`{NAME}` is still starting, and the Service Control Manager will not deliver a \
+             control code to a service in that state. It has already read its clients, though — \
+             that happens before it binds — so the start now under way is serving the set from \
+             *before* this change, and will go on doing so until it is restarted."
+        );
+    }
+    if state != ServiceState::Running {
         return Ok(false);
     }
     let code = windows_service::service::UserEventCode::from_raw(RELOAD_CODE)
         .map_err(|e| anyhow::anyhow!("{RELOAD_CODE} is not a user-defined control code: {e}"))?;
+    // **The context says what a failure here does and does not mean.** It used to assert the
+    // service "could not read or accept the file this command just wrote", which is only one of the
+    // ways this fails and sends an operator to a log that has nothing in it — the SCM refusing to
+    // deliver the code at all is the other, and the service never saw the file in that case.
     service.notify(code).context(
-        "the service did not re-read its clients — the control code came back a failure, which \
-         means it could not read or accept the file this command just wrote (its log says why)",
+        "the service did not re-read its clients: the control code came back a failure. Either it \
+         read the file and would not have it — its log says so — or the Service Control Manager \
+         would not deliver the code, which it does not say anything about",
     )?;
     Ok(true)
 }
@@ -1164,24 +1176,28 @@ fn serve_as_service() -> Result<()> {
     //
     // SAFETY: this runs on the SCM's dispatcher thread before the async runtime exists and before
     // any thread of ours has been started, so there is no concurrent reader of the environment.
+    // **Set whether or not the file is there**, which is the half review caught: guarding on
+    // `exists()` left an inherited override standing whenever the canonical file was missing —
+    // exactly the split-brain this is here to remove, and the case where it does most damage, since
+    // an `--add-listen-client` then *creates* the canonical file and the running service goes on
+    // reading the override. A service with no credential file is broken either way; the difference
+    // is whether it says so at startup or serves somebody else's clients.
     let file = token_file();
-    if file.exists() {
-        if let Some(overridden) = std::env::var_os(crate::listen::TOKEN_FILE_ENV)
-            && overridden != file
-        {
-            // Said out loud, because it is the one case where an operator's configuration is being
-            // disregarded, and they would otherwise be left wondering why their clients are not the
-            // ones being served.
-            tracing::warn!(
-                "{} names {} in this service's environment, and is being ignored: a service reads \
+    if let Some(overridden) = std::env::var_os(crate::listen::TOKEN_FILE_ENV)
+        && overridden != file
+    {
+        // Said out loud, because it is the one case where an operator's configuration is being
+        // disregarded, and they would otherwise be left wondering why their clients are not the
+        // ones being served.
+        tracing::warn!(
+            "{} names {} in this service's environment, and is being ignored: a service reads \
                  the credential file its own installer wrote and its own client commands edit ({}).",
-                crate::listen::TOKEN_FILE_ENV,
-                std::path::Path::new(&overridden).display(),
-                file.display()
-            );
-        }
-        unsafe { std::env::set_var(crate::listen::TOKEN_FILE_ENV, &file) };
+            crate::listen::TOKEN_FILE_ENV,
+            std::path::Path::new(&overridden).display(),
+            file.display()
+        );
     }
+    unsafe { std::env::set_var(crate::listen::TOKEN_FILE_ENV, &file) };
 
     // **Re-applied at every start, not just at install.** The bound is derived from
     // `WINDBG_MCP_CALL_TIMEOUT_SECS`, which an operator can raise long after installing — and the
@@ -1450,37 +1466,40 @@ mod tests {
         );
     }
 
-    /// A starting service is asked to re-read, because it has already read.
+    /// A revocation the service could not be told about is an **error**, not a note.
     ///
-    /// The bug this pins reported a **failed revocation as a success**: credentials are read before
-    /// the bind, so a `StartPending` listener is already serving the old set, and a non-loopback
-    /// bind at boot can hold it there for `BIND_PATIENCE` — a minute and a half. Treating that as
-    /// "not running" printed "it will read this at its next start" while *this* start went on
-    /// accepting the credential the operator had just revoked.
+    /// Which is the whole of what the `StartPending` handling is for. Three states, three
+    /// truths, and only the middle one is safe to report quietly:
+    ///
+    /// * running and told — the set in force is the set just written;
+    /// * stopped — nothing is serving anything, and the next start reads the new file;
+    /// * **starting** — it read its credentials before it began binding, so it is serving the
+    ///   *old* set, and the SCM will not carry a control code to it
+    ///   (`ERROR_SERVICE_CANNOT_ACCEPT_CTRL`, measured against a real service held there by an
+    ///   address that is not on the host).
+    ///
+    /// The third used to be reported as the second. For an `--add-listen-client` that is merely
+    /// early; for a `--remove-listen-client` it is a credential the operator has been told is gone
+    /// and which still authenticates. So the two commands that revoke turn a reload that did not
+    /// happen into a non-zero exit, and the one that does not stays a warning — asserted here
+    /// because the distinction is the point, and a refactor that lost it would lose it silently.
     #[test]
-    fn a_starting_service_is_asked_to_reload_because_it_has_already_read_its_clients() {
-        assert!(is_askable(ServiceState::Running));
+    fn only_the_commands_that_revoke_a_credential_fail_when_the_reload_does_not_land() {
         assert!(
-            is_askable(ServiceState::StartPending),
-            "a starting listener has read its credentials already — it is serving the old set, so \
-             it is exactly the one that has to be told"
+            ClientEdit::Remove.revokes_a_token(),
+            "a removal whose reload did not land leaves the removed token authenticating"
         );
-        // Nothing is loaded, or it is on the way out: "at its next start" is then the truth.
-        for settled in [
-            ServiceState::Stopped,
-            ServiceState::StopPending,
-            ServiceState::Paused,
-            ServiceState::PausePending,
-            ServiceState::ContinuePending,
-        ] {
-            assert!(
-                !is_askable(settled),
-                "{settled:?} was treated as reloadable"
-            );
-        }
+        assert!(
+            ClientEdit::Rotate.revokes_a_token(),
+            "a rotation is a revocation of the token it replaces"
+        );
+        assert!(
+            !ClientEdit::Add.revokes_a_token(),
+            "an add that has not landed costs nobody anything — nothing that worked has stopped"
+        );
     }
 
-    /// The code the dispatcher answers is the code the command sends, and nothing else is it.
+    /// The code the dispatcher answers is the code the command sends, and nothing else is it.    /// The code the dispatcher answers is the code the command sends, and nothing else is it.
     ///
     /// One number is the whole protocol between the two, and they are in different processes: a
     /// drift here is a client command that reports success and a service that goes on serving the


### PR DESCRIPTION
Two P1s from the last review round on #189, which arrived after it merged. Neither is that PR's recurring root cause — they are not about client identity, so they do not belong in #190 — but both end the same way, and it is the worst thing these commands can do: **`--remove-listen-client` or `--rotate-listen-client` printing success while the credential it took out of service goes on being accepted.**

## An inherited token-file override left the service reading elsewhere

`serve_as_service` deferred to a `WINDBG_MCP_LISTEN_TOKEN_FILE` already in its environment, while `edit_client` always writes `token_file()`. So with an override in place:

- `--add-listen-client` produced a token nothing accepted, and
- `--remove-listen-client` reported success — because the reload *succeeded*, re-reading the unchanged override.

Made impossible rather than detected. `%ProgramData%\windbg-mcp\token` is what the installer writes, what the client commands edit, and what `--uninstall-service` deletes; a service reading anywhere else is a configuration whose other three halves do not exist. An inherited value is now ignored, with a warning naming it — the one place an operator's configuration is being disregarded, so it says so out loud. The variable is untouched for a **foreground** listener, which is what it is documented for.

## A starting service was treated as a stopped one

Credentials are read *before* the bind, so a `StartPending` listener is already serving the old set — and `BIND_PATIENCE` gives a non-loopback bind at boot ninety seconds to sit there. `ask_to_reload` returned "not running" for it, and the command printed "it will read this at its next start", which was false of the start already under way.

`is_askable` now counts `StartPending`, and the reload task is spawned **before** the bind rather than after `ready()`, so there is something there to answer. Without that move the control code would time out instead — louder, but still not the truth.

## Verification

`cargo clippy --all-targets -- -D warnings` clean, `cargo fmt --all --check` clean, **499 unit + 70 smoke** pass on the ARM64 bench.

Driven against the installed service, one process throughout (pid 6472) — the lifecycle is unchanged by the spawn move:

| step | result |
|---|---|
| `--add-listen-client bench` | `200` the instant the command returns |
| remove, then immediately re-add the same name | `409` inside the sweep window, `200` after it |
| the revoked token, throughout | `401` |

The new unit test pins the state predicate, which is where the second bug lived. The first is structural — there is no longer a path by which the service and its commands can disagree about which file they mean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
