### PR TITLE
Make a client an incarnation of a name, not the name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,7 +82,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   A request already inside the MCP service when the set was swapped still settles against the client
   that is going, and records its MCP session so the sweep closes it — but does not renew the clock,
   since a renewal would push the revocation a whole grace out and the sweep that was to run on its
-  next pass would not.
+  next pass would not. A request of that credential's which authenticated a moment before the swap
+  and reaches the lease after it is refused, so a revoked client cannot route to its sessions once
+  more; one already *inside* the service runs to completion, as it must, because a call against a
+  live kernel cannot be abandoned half way.
 
   The registry gate a revocation closes is **never lifted**, and no longer needs to be. It marks the
   incarnation rather than the name, so a client configured under that name afterwards is simply not

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,21 +68,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   registering — and a session admitted behind the sweep would belong to a client nothing can
   authenticate as and nothing will ever come back for.
 
-  **A name is not reusable until the sweep has forgotten it.** A client is identified by its name,
-  so `--remove-listen-client ci` followed by `--add-listen-client ci` makes two credentials that
-  nothing keyed on identity can tell apart; in between, the lease entry still holds the previous
-  holder's sessions. Requests on a revoked name are refused with a `409` ("ask again in a moment")
-  rather than served, and a request already inside the MCP service when the set was swapped records
-  its MCP session but does not renew the clock — a renewal would push the revocation a whole grace
-  out and the sweep that was to run on its next pass would not. Changing a token *without* losing
-  the sessions is what `--rotate-listen-client` is for.
+  **A name given back is a different client**
+  ([#190](https://github.com/glslang/windbg-mcp/issues/190)). A client used to *be* its name, so
+  `--remove-listen-client ci` followed by `--add-listen-client ci` produced two credentials that
+  nothing keyed on identity could tell apart, and the second reached the debug sessions, MCP session
+  ids and lease of the first. Identity is now `(name, incarnation)`: the name is still the whole of
+  what is rendered — log lines, refusals and `session_status` say exactly what they did — and the
+  incarnation is minted in one place, when a set of credentials is swapped in, which is the only
+  code that can tell a name *carrying on* from a name *being given back*. So a
+  `--rotate-listen-client` keeps the client and therefore its sessions, which is what it is for, and
+  a removal-and-re-add keeps only the name.
 
-  The registry gate a revocation closes is lifted **when the name is configured again**, not when
-  the teardown finishes. That release is one pass over the sessions that exist, so an opener which
-  authenticated before the revocation and has not registered yet — an `attach_kernel` is a worker
-  spawn away — is invisible to it, and lifting on "nothing left to release" let that opener register
-  a target owned by a credential nothing can authenticate as. A name revoked and never given back
-  keeps its gate for the life of the process, which is the answer wanted.
+  A request already inside the MCP service when the set was swapped still settles against the client
+  that is going, and records its MCP session so the sweep closes it — but does not renew the clock,
+  since a renewal would push the revocation a whole grace out and the sweep that was to run on its
+  next pass would not.
+
+  The registry gate a revocation closes is **never lifted**, and no longer needs to be. It marks the
+  incarnation rather than the name, so a client configured under that name afterwards is simply not
+  the one it gates — which deleted the question of *when* to take a gate off, where two separate
+  findings had lived. It exists because the release is one pass over the sessions that exist, so an
+  opener which authenticated before the revocation and has not registered yet — an `attach_kernel`
+  is a worker spawn away — is invisible to it. What it leaves behind is a name and a `u64` per
+  revocation.
 
 ### Changed
 

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -1326,8 +1326,12 @@ ambiguity, and the four fixes that shipped (a `409` on a revoked presence, a lea
 renew for one, an admission gate on the owner name, and lifting that gate on re-add rather than on
 an empty release) each narrow the window without closing it: at the moment a session registers there
 is nothing in it that says *which* `ci` opened it. Giving `Client` an incarnation would delete all
-four rather than add a fifth. Not urgent — the residual needs two elevated commands issued during
-one open, and nothing a client can do reaches it. Two elevated shells
+four rather than add a fifth. **Done** (2026-08-22): identity is `(name, incarnation)`, minted only
+where a set of credentials is swapped in — the one place that can tell a name carrying on from a
+name being given back — and the name stays the whole of what is rendered. That deleted the `409` a
+re-added name used to wait out, `Sessions::unrevoke` and the question of when to lift a gate, and it
+closed the residual: an in-flight opener of the revoked credential registers against an identity no
+live client shares. Two elevated shells
 could each write a whole file from its own snapshot (`token.lock`, `share_mode(0)`). And
 `--add-listen-client --token-out C:\x` took `--token-out` as the client *name*, which passes the
 name rule since a name may contain `-`.

--- a/docs/remote-listener.md
+++ b/docs/remote-listener.md
@@ -474,9 +474,15 @@ belongs to a client you are done with, to remove that client, which deletes it.
 
 Four behaviours worth knowing before you need them:
 
-- **A rotation keeps the client's name, and so keeps its sessions.** Only the token moves: the old
-  one starts answering `401` and the new one reaches the same debug sessions, because it is the same
+- **A rotation keeps the client, and so keeps its sessions.** Only the token moves: the old one
+  starts answering `401` and the new one reaches the same debug sessions, because it *is* the same
   client. Rotating is the cheap operation — a lost token costs a rotation and nothing else.
+- **A name given back is not the client that had it.** `--remove-listen-client ci` then
+  `--add-listen-client ci` leaves a client called `ci`, and that is all the two share: the second
+  cannot reach the first's debug sessions, its MCP session ids or its lease. A client's identity is
+  its name *and* which holder of that name it is; only the name is ever shown, so nothing you read
+  changes. Use `--rotate-listen-client` when you want the sessions kept — that is the difference
+  between the two commands.
 - **A removal releases what that client still held**, down the path a lease expiry already uses, so
   a live kernel is let go rather than left frozen. It is not refused on their account: the command
   runs in another process and cannot see them, and blocking a revocation on the sessions it is

--- a/src/client.rs
+++ b/src/client.rs
@@ -58,8 +58,31 @@ const NAME_LIMIT: usize = 64;
 /// A name rather than an opaque id so it can be said out loud — in a log line, in `session_status`,
 /// in the message a caller gets when it asks for a session that is not its own. It is chosen by
 /// whoever configured the token, never by the client presenting it.
+///
+/// # The name is what you see; the identity is the pair
+///
+/// **A name can be given back**, and until this it was the whole of a client's identity. So
+/// `--remove-listen-client ci` followed by `--add-listen-client ci` produced two credentials that
+/// every structure keyed on identity — session ownership, routing, lease state, the four-session
+/// cap — could not tell apart, and the second reached what the first had opened
+/// ([#190](https://github.com/glslang/windbg-mcp/issues/190)). That is exactly the isolation this
+/// type exists to provide, and exactly what `--rotate-listen-client` exists to do *deliberately*:
+/// rotation keeps the name, so it keeps the sessions, while a removal must not.
+///
+/// So identity is `(name, incarnation)`. The incarnation is invisible — [`Display`](Self::fmt) and
+/// [`name`](Self::name) render the name alone, so every log line, refusal and `session_status` row
+/// says what it always did — and it is minted in exactly one place, [`Accepted::replace`], which is
+/// the only code that knows whether a name is *being given back* or *carrying on*.
+///
+/// [`Self::new`] deliberately does **not** mint one. It builds the sole holder of a name, which is
+/// what stdio has, what every in-process test wants, and what makes `Client::new("ci")` twice mean
+/// one client rather than two.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub struct Client(Arc<str>);
+pub struct Client {
+    name: Arc<str>,
+    /// Which holder of that name. `0` is "the only one there has ever been" — see [`Self::new`].
+    incarnation: u64,
+}
 
 impl Client {
     /// The client every stdio call belongs to.
@@ -69,29 +92,61 @@ impl Client {
     /// transports rather than one rule and an exception.
     pub const LOCAL: &'static str = "local";
 
+    /// The sole holder of `name`.
+    ///
+    /// Incarnation `0`, which nothing minted and nothing will mint again: under stdio there is one
+    /// client and no configuration to give it back to anybody, and in a test two mentions of a name
+    /// mean one client. A listener's clients are [minted](Accepted::replace) from `1` up, so they
+    /// can never collide with this — and the two never coexist anyway, since a process is one
+    /// transport or the other.
     pub fn new(name: impl AsRef<str>) -> Self {
-        Self(Arc::from(name.as_ref()))
+        Self {
+            name: Arc::from(name.as_ref()),
+            incarnation: 0,
+        }
+    }
+
+    /// The `n`th holder of `name`, for the one caller that knows what `n` is.
+    ///
+    /// Crate-visible only so tests elsewhere can build two clients that share a name — in a running
+    /// server [`Accepted::replace`] is the sole caller, because it is the only code that can tell a
+    /// name carrying on from a name being given back.
+    pub(crate) fn incarnate(name: &str, incarnation: u64) -> Self {
+        Self {
+            name: Arc::from(name),
+            incarnation,
+        }
     }
 
     pub fn local() -> Self {
         Self::new(Self::LOCAL)
     }
 
+    /// **The name alone**, which is the whole of what may be rendered. Two clients that share a
+    /// name are two clients, and nothing outside this module has any use for which is which — a log
+    /// line saying `ci#7` would be noise to an operator who configured one client called `ci`.
     pub fn name(&self) -> &str {
-        &self.0
+        &self.name
     }
 }
 
 impl std::fmt::Display for Client {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(&self.0)
+        f.write_str(&self.name)
     }
 }
 
-/// The tokens this listener accepts, and the client each one names.
+/// The tokens this listener accepts, and the client each one **names**.
+///
+/// A name rather than a [`Client`], and that is the division of labour behind
+/// [#190](https://github.com/glslang/windbg-mcp/issues/190): a configuration says which names may
+/// connect, and only [`Accepted`] — which can see the set that was in force a moment ago — knows
+/// whether a name appearing here is one carrying on or one being given back. Minting an identity
+/// from a file that cannot answer that question is what let a re-added name inherit its
+/// predecessor's sessions.
 #[derive(Clone, Default)]
 pub struct Credentials {
-    by_token: HashMap<String, Client>,
+    by_token: HashMap<String, String>,
 }
 
 /// **The names, never the tokens** — the same reason [`crate::kdconn::Connection`]'s is redacted.
@@ -106,9 +161,9 @@ impl std::fmt::Debug for Credentials {
 }
 
 impl Credentials {
-    /// The client presenting `token`, or `None` if nothing here accepts it.
-    pub fn client_for(&self, token: &str) -> Option<&Client> {
-        self.by_token.get(token)
+    /// The **name** of the client presenting `token`, or `None` if nothing here accepts it.
+    pub fn client_for(&self, token: &str) -> Option<&str> {
+        self.by_token.get(token).map(String::as_str)
     }
 
     pub fn len(&self) -> usize {
@@ -117,7 +172,7 @@ impl Credentials {
 
     /// Every configured name, sorted — for the one log line that says who may connect.
     pub fn names(&self) -> Vec<&str> {
-        let mut names: Vec<&str> = self.by_token.values().map(Client::name).collect();
+        let mut names: Vec<&str> = self.by_token.values().map(String::as_str).collect();
         names.sort_unstable();
         names
     }
@@ -157,7 +212,7 @@ impl Credentials {
     /// a caller's sessions land under whichever name won a `HashMap` insertion, which is a rule
     /// nobody could predict and a boundary that would move.
     fn build(configured: &[Configured]) -> Result<Self> {
-        let mut by_token: HashMap<String, Client> = HashMap::new();
+        let mut by_token: HashMap<String, String> = HashMap::new();
         // Client name to *what configured it* — never to the token. Both refusals below are
         // printed at startup, to stderr in the foreground and to the service log under the SCM, so
         // a message quoting the credential it is complaining about would write a working listener
@@ -179,7 +234,7 @@ impl Credentials {
                 // One client is one credential (the check below), so whatever configured this
                 // token is what configured that client.
                 let first = named
-                    .get(existing.name())
+                    .get(existing.as_str())
                     .copied()
                     .unwrap_or("another entry");
                 bail!(
@@ -204,61 +259,109 @@ impl Credentials {
                 );
             }
             named.insert(name.as_str(), from.as_str());
-            by_token.insert(token.clone(), Client::new(name));
+            by_token.insert(token.clone(), name.clone());
         }
         Ok(Self { by_token })
     }
 }
 
-/// The credentials a listener is serving *right now*, replaceable while it runs.
+/// The credentials a listener is serving *right now*, replaceable while it runs — and the one
+/// place a client's identity is minted.
 ///
-/// [`Credentials`] is what a configuration says; this is what the running listener accepts, and
-/// the difference is a whole feature. Built once at startup, a service-hosted listener's client
-/// list is fixed until the next start — and a restart drops every session it holds, which for a
-/// parked kernel attach is the outage that made adding a client a planned one (`FOLLOWUPS.md`
-/// item 34). So the set lives behind a lock that [`crate::service::reload`] can swap under the
-/// accept loop, and a client added to the token file is admitted without anything being stopped.
+/// [`Credentials`] is what a configuration says; this is what the running listener accepts, and the
+/// difference is two whole features. Built once at startup, a service-hosted listener's client list
+/// would be fixed until the next start, and a restart drops every session it holds — which for a
+/// parked kernel attach is the outage that made adding a client a planned one (`FOLLOWUPS.md` item
+/// 34). So the set lives behind a lock that [`crate::service::edit_client`] can swap under the
+/// accept loop.
+///
+/// **And swapping is the only moment anyone can tell a name carrying on from a name being given
+/// back**, which is why incarnations are minted here and nowhere else
+/// ([#190](https://github.com/glslang/windbg-mcp/issues/190)). A name in the new set that was in
+/// the old one keeps its identity — that is a `--rotate-listen-client`, which changes a token and
+/// deliberately keeps the sessions. A name that was absent gets a fresh one, so a
+/// `--remove-listen-client` followed by an `--add-listen-client` yields a client that shares a name
+/// with its predecessor and *nothing else*: it cannot route to its sessions, inherit its MCP session
+/// ids, or renew its lease, because none of those match on a name.
 ///
 /// **A read lock on the authentication path**, which is the cheapest thing that is also correct: a
 /// request takes it uncontended, and the one writer runs once per administrative command. And it
-/// is [recovered from poisoning](Self::current) rather than unwrapped — a panic anywhere near the
+/// is [recovered from poisoning](Self::state) rather than unwrapped — a panic anywhere near the
 /// swap must not turn into a listener that refuses every caller for the rest of its life.
 pub struct Accepted {
-    current: std::sync::RwLock<Arc<Credentials>>,
+    current: std::sync::RwLock<Arc<State>>,
+    /// The next incarnation to hand out. Never reset, so a name given back is never confused with
+    /// the holder before it however many times it changes hands.
+    next: std::sync::atomic::AtomicU64,
 }
 
-/// What a [reload](Accepted::replace) changed, by name.
+/// One generation of the configuration: the tokens, and which holder of each name is current.
+struct State {
+    credentials: Credentials,
+    /// Name to incarnation, for every name [`State::credentials`] accepts.
+    incarnations: HashMap<String, u64>,
+}
+
+impl State {
+    fn client_for(&self, token: &str) -> Option<Client> {
+        let name = self.credentials.client_for(token)?;
+        // A name the credentials accept always has an incarnation: they are built together in
+        // `Accepted::replace`, which is the only writer of either.
+        let incarnation = *self.incarnations.get(name)?;
+        Some(Client::incarnate(name, incarnation))
+    }
+}
+
+/// What a [reload](Accepted::replace) changed.
 ///
-/// **Names, not tokens**, so the caller can log it: this is what the listener says out loud when a
-/// client appears or goes. A rotation shows up as neither — the name is unchanged, so nothing this
-/// describes moved, and the sessions that client holds are untouched by design.
+/// **Clients, not names**, because the caller acts on them: a removal has to release the sessions
+/// of the incarnation that is going, and a name is no longer enough to say which that is. A
+/// rotation shows up as neither — the name is unchanged and so is its identity, which is what makes
+/// rotation keep the sessions it is documented to keep.
 #[derive(Debug, Default, PartialEq, Eq)]
 pub struct Change {
-    pub added: Vec<String>,
-    pub removed: Vec<String>,
+    pub added: Vec<Client>,
+    pub removed: Vec<Client>,
 }
 
 impl Change {
     pub fn is_empty(&self) -> bool {
         self.added.is_empty() && self.removed.is_empty()
     }
+
+    /// The names on one side of the change, for a log line.
+    pub fn names(clients: &[Client]) -> String {
+        clients
+            .iter()
+            .map(Client::name)
+            .collect::<Vec<_>>()
+            .join(", ")
+    }
 }
 
 impl Accepted {
     pub fn new(credentials: Credentials) -> Self {
-        Self {
-            current: std::sync::RwLock::new(Arc::new(credentials)),
-        }
+        let accepted = Self {
+            current: std::sync::RwLock::new(Arc::new(State {
+                credentials: Credentials::default(),
+                incarnations: HashMap::new(),
+            })),
+            // From 1, so nothing a listener mints can collide with the `0` [`Client::new`] gives
+            // the sole holder of a name.
+            next: std::sync::atomic::AtomicU64::new(1),
+        };
+        accepted.replace(credentials);
+        accepted
     }
 
-    /// The set in force, past a poisoned lock.
+    /// The generation in force, past a poisoned lock.
     ///
     /// `into_inner` rather than `unwrap`, because of what the two do on the request path. The lock
     /// guards an `Arc` that is only ever read or replaced wholesale, so a panic while it was held
     /// cannot have left a half-written set behind — there is no invariant to protect. Propagating
     /// the poison would instead take a listener holding live kernel targets and have it refuse
     /// every caller, its own operator included, until someone restarted it.
-    fn current(&self) -> Arc<Credentials> {
+    fn state(&self) -> Arc<State> {
         match self.current.read() {
             Ok(guard) => Arc::clone(&guard),
             Err(poisoned) => Arc::clone(&poisoned.into_inner()),
@@ -267,12 +370,13 @@ impl Accepted {
 
     /// The client presenting `token`, or `None` if nothing here accepts it.
     pub fn client_for(&self, token: &str) -> Option<Client> {
-        self.current().client_for(token).cloned()
+        self.state().client_for(token)
     }
 
     /// Every configured name, sorted — for the lines that say who may connect.
     pub fn names(&self) -> Vec<String> {
-        self.current()
+        self.state()
+            .credentials
             .names()
             .into_iter()
             .map(str::to_owned)
@@ -286,23 +390,39 @@ impl Accepted {
     /// listener releases them down the path the lease sweep already uses. See
     /// [`crate::listen::reloaded`].
     pub fn replace(&self, credentials: Credentials) -> Change {
-        let before = self.names();
-        let after: Vec<String> = credentials.names().into_iter().map(str::to_owned).collect();
+        let before = self.state();
+        let mut incarnations = HashMap::new();
+        let mut added = Vec::new();
+        for name in credentials.names() {
+            // **Carrying on, or being given back.** The only question this function exists to
+            // answer, and the only place in the program that can.
+            match before.incarnations.get(name) {
+                Some(&existing) => {
+                    incarnations.insert(name.to_string(), existing);
+                }
+                None => {
+                    let minted = self.next.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    incarnations.insert(name.to_string(), minted);
+                    added.push(Client::incarnate(name, minted));
+                }
+            }
+        }
+        let removed = before
+            .incarnations
+            .iter()
+            .filter(|(name, _)| !incarnations.contains_key(name.as_str()))
+            .map(|(name, &incarnation)| Client::incarnate(name, incarnation))
+            .collect();
+
+        let fresh = Arc::new(State {
+            credentials,
+            incarnations,
+        });
         match self.current.write() {
-            Ok(mut guard) => *guard = Arc::new(credentials),
-            Err(poisoned) => *poisoned.into_inner() = Arc::new(credentials),
+            Ok(mut guard) => *guard = fresh,
+            Err(poisoned) => *poisoned.into_inner() = fresh,
         }
-        Change {
-            added: after
-                .iter()
-                .filter(|name| !before.contains(name))
-                .cloned()
-                .collect(),
-            removed: before
-                .into_iter()
-                .filter(|name| !after.contains(name))
-                .collect(),
-        }
+        Change { added, removed }
     }
 }
 
@@ -850,7 +970,7 @@ mod tests {
     #[test]
     fn the_unnamed_token_names_the_local_client() {
         let creds = Credentials::from_entries(vars(&[(TOKEN_ENV, "s3cret")]), None).expect("valid");
-        assert_eq!(creds.client_for("s3cret").map(Client::name), Some("local"));
+        assert_eq!(creds.client_for("s3cret"), Some("local"));
         assert_eq!(creds.client_for("wrong"), None);
     }
 
@@ -865,11 +985,8 @@ mod tests {
             None,
         )
         .expect("valid");
-        assert_eq!(creds.client_for("ci-token").map(Client::name), Some("ci"));
-        assert_eq!(
-            creds.client_for("laptop-token").map(Client::name),
-            Some("laptop")
-        );
+        assert_eq!(creds.client_for("ci-token"), Some("ci"));
+        assert_eq!(creds.client_for("laptop-token"), Some("laptop"));
         assert_eq!(creds.names(), vec!["ci", "laptop"]);
     }
 
@@ -960,8 +1077,8 @@ mod tests {
             None,
         )
         .expect("valid");
-        assert_eq!(creds.client_for("unnamed").map(Client::name), Some("local"));
-        assert_eq!(creds.client_for("for-ci").map(Client::name), Some("ci"));
+        assert_eq!(creds.client_for("unnamed"), Some("local"));
+        assert_eq!(creds.client_for("for-ci"), Some("ci"));
         // And the file variable is still not a token, whatever its casing.
         assert!(is_token_file("Windbg_Mcp_Listen_Token_File"));
         assert!(credential_suffix("Windbg_Mcp_Listen_Token_File").is_some());
@@ -982,10 +1099,7 @@ mod tests {
             Some(file("from-the-file")),
         )
         .expect("valid");
-        assert_eq!(
-            creds.client_for("from-the-file").map(Client::name),
-            Some("local")
-        );
+        assert_eq!(creds.client_for("from-the-file"), Some("local"));
         assert_eq!(creds.len(), 1, "the environment must not add credentials");
         assert_eq!(creds.client_for("from-the-environment"), None);
         assert_eq!(creds.client_for("also-from-the-environment"), None);
@@ -1015,7 +1129,7 @@ mod tests {
             Some(file(&format!(r#"{{"local": "{legacy}"}}"#))),
         )
         .expect("the same token, in the shape this file now takes");
-        assert_eq!(creds.client_for(legacy).map(Client::name), Some("local"));
+        assert_eq!(creds.client_for(legacy), Some("local"));
     }
 
     /// **And because it is the only credential, it has to be able to name more than one.** A
@@ -1032,11 +1146,8 @@ mod tests {
         )
         .expect("valid");
         assert_eq!(creds.names(), vec!["ci", "laptop", "local"]);
-        assert_eq!(creds.client_for("for-ci").map(Client::name), Some("ci"));
-        assert_eq!(
-            creds.client_for("for-laptop").map(Client::name),
-            Some("laptop")
-        );
+        assert_eq!(creds.client_for("for-ci"), Some("ci"));
+        assert_eq!(creds.client_for("for-laptop"), Some("laptop"));
         // Still the only credential: naming several clients does not let the environment back in.
         assert_eq!(creds.client_for("from-the-environment"), None);
     }
@@ -1059,11 +1170,7 @@ mod tests {
         ] {
             let creds = Credentials::from_entries(vars(&[]), Some(file(text)))
                 .unwrap_or_else(|e| panic!("{text:?} is a token file: {e}"));
-            assert_eq!(
-                creds.client_for("plain-token").map(Client::name),
-                Some(whose),
-                "{text:?}"
-            );
+            assert_eq!(creds.client_for("plain-token"), Some(whose), "{text:?}");
         }
     }
 
@@ -1229,10 +1336,7 @@ mod tests {
             Some(file("from-the-file")),
         )
         .expect("valid");
-        assert_eq!(
-            creds.client_for("from-the-file").map(Client::name),
-            Some("local")
-        );
+        assert_eq!(creds.client_for("from-the-file"), Some("local"));
         assert_eq!(creds.client_for(r"C:\somewhere\token"), None);
     }
 
@@ -1252,7 +1356,7 @@ mod tests {
             "`{first}` cannot travel in a header"
         );
         let creds = Credentials::from_entries(vars(&[(TOKEN_ENV, &first)]), None).expect("valid");
-        assert_eq!(creds.client_for(&first).map(Client::name), Some("local"));
+        assert_eq!(creds.client_for(&first), Some("local"));
     }
 
     /// A fingerprint is stable, distinguishing, and says nothing about the token it describes.
@@ -1373,8 +1477,8 @@ mod tests {
             )
             .expect("valid"),
         );
-        assert_eq!(change.added, vec!["bench"]);
-        assert_eq!(change.removed, vec!["ci"]);
+        assert_eq!(crate::client::Change::names(&change.added), "bench");
+        assert_eq!(crate::client::Change::names(&change.removed), "ci");
         assert_eq!(accepted.names(), vec!["bench", "local"]);
         assert_eq!(
             accepted.client_for("c"),
@@ -1384,6 +1488,65 @@ mod tests {
         assert_eq!(
             accepted.client_for("b").map(|c| c.name().to_string()),
             Some("bench".into())
+        );
+    }
+
+    /// **The distinction the whole of #190 exists to make**: a rotation is the same client, a
+    /// removal-and-re-add is not.
+    ///
+    /// Both leave a set holding a client called `ci`, and until identity was a pair nothing could
+    /// tell them apart — so a name given back reached the debug sessions, MCP session ids and lease
+    /// of the credential it replaced. Which is precisely what `--rotate-listen-client` is *for*, and
+    /// precisely what `--remove-listen-client` must not do.
+    ///
+    /// Asserted on identity rather than on any downstream effect, because identity is what every
+    /// downstream structure keys on: session ownership, routing, the lease map, the four-session
+    /// cap. Get this right and they are all right; get it wrong and they are all wrong in the same
+    /// way, which is how one ambiguity produced four separate findings.
+    #[test]
+    fn a_rotation_is_the_same_client_and_a_name_given_back_is_not() {
+        let set = |token: &str| {
+            Credentials::from_entries(vars(&[("WINDBG_MCP_LISTEN_TOKEN_CI", token)]), None)
+                .expect("valid")
+        };
+        let accepted = Accepted::new(set("first"));
+        let original = accepted.client_for("first").expect("configured");
+
+        // A rotation: the name never leaves the set, so the client never changes.
+        let rotated = accepted.replace(set("second"));
+        assert!(
+            rotated.is_empty(),
+            "a rotation reported a client coming or going: {rotated:?}"
+        );
+        assert_eq!(
+            accepted.client_for("second"),
+            Some(original.clone()),
+            "a rotation minted a new identity, which would strand the sessions it must keep"
+        );
+        assert_eq!(
+            accepted.client_for("first"),
+            None,
+            "the old token still worked"
+        );
+
+        // A removal and an add. Same name, and that is all they share.
+        let removal = accepted.replace(
+            Credentials::from_entries(vars(&[("WINDBG_MCP_LISTEN_TOKEN_OTHER", "o")]), None)
+                .expect("valid"),
+        );
+        assert_eq!(removal.removed, vec![original.clone()]);
+        accepted.replace(set("third"));
+        let given_back = accepted.client_for("third").expect("configured again");
+
+        assert_eq!(
+            given_back.name(),
+            original.name(),
+            "the operator configured a client called `ci`, and that is what it must be called"
+        );
+        assert_ne!(
+            given_back, original,
+            "a name given back is the same client as the one it replaced, so it reaches its \
+             sessions — which is the isolation this boundary exists to provide"
         );
     }
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1101,19 +1101,14 @@ impl Sessions {
     /// `closing` gives shutdown. The in-flight call fails, which is the right answer: its
     /// credential was revoked while it ran.
     ///
-    /// Marked rather than cleared on its own, because a name may be configured again later —
-    /// [`Self::unrevoke`] is what a re-added client gets, and it is a different client with the
-    /// same name.
+    /// **Never lifted**, and it used to need lifting. A [`crate::client::Client`] is an incarnation
+    /// rather than a name ([#190](https://github.com/glslang/windbg-mcp/issues/190)), so a client
+    /// configured under the same name afterwards is simply not this one and is not gated by this
+    /// mark — which deleted the question of *when* to take it off, and with it two findings that
+    /// lived there. What it leaves behind is a name and a `u64` per revocation, for the life of the
+    /// process.
     pub fn revoke(&self, owner: &crate::client::Client) {
         self.registry().revoked.insert(owner.clone());
-    }
-
-    /// A name is configured again: it may open sessions.
-    ///
-    /// Not the same client — the credential is new — but the registry keys on the name, so the
-    /// mark has to be lifted or a re-added client could never open anything.
-    pub fn unrevoke(&self, owner: &crate::client::Client) {
-        self.registry().revoked.remove(owner);
     }
 
     pub fn snapshot(&self) -> Vec<SessionSnapshot> {
@@ -3456,10 +3451,22 @@ mod tests {
             "revoking one client refused another one's session"
         );
 
-        sessions.unrevoke(&gone);
+        // **A name given back is a different client, and is not gated by its predecessor's mark.**
+        // Nothing lifts the mark — nothing has to, which is the whole of what an incarnation buys
+        // here: the question of *when* to take a gate off is where two separate findings lived
+        // ([#190](https://github.com/glslang/windbg-mcp/issues/190)).
+        let again = crate::client::Client::incarnate("ci", 2);
+        assert_ne!(again, gone, "a re-added name has to be a different client");
+        assert_eq!(again.name(), gone.name(), "and has to still be called `ci`");
+        let session = dormant("sess-after", SessionState::Open);
         assert!(
-            sessions.admit(&mine("sess-after")).is_ok(),
-            "a name given back has to be able to open sessions again"
+            sessions
+                .admit(&Arc::new(Session {
+                    owner: again,
+                    ..Arc::into_inner(session).expect("`dormant` hands back the only reference")
+                }))
+                .is_ok(),
+            "a client configured under a revoked name could not open a session"
         );
     }
 

--- a/src/listen.rs
+++ b/src/listen.rs
@@ -434,12 +434,22 @@ impl Lease {
         // Nothing is served while a teardown is in flight. Briefly refusing a client that could
         // have been served costs it a reconnect; serving one costs it the session mid-call.
         //
-        // **A revoked credential does not need refusing here**, and used to. While a client was
-        // identified by its name alone, a name given back reached this same `Presence` and had to
-        // be held at a `409` until the sweep forgot it. It is a different [`Client`] now
-        // ([#190](https://github.com/glslang/windbg-mcp/issues/190)), so it arrives at a `Presence`
-        // of its own and is served at once — there is nothing of its predecessor's for it to reach.
-        if state.releasing {
+        // **`revoked` is refused too, and for a different reason than it used to be.** It once
+        // stood in for identity: a client was its name, so a name given back reached this same
+        // `Presence` and had to be held at a `409` until the sweep forgot it. That is not what it
+        // is doing any more — a name given back is a different [`Client`]
+        // ([#190](https://github.com/glslang/windbg-mcp/issues/190)) arriving at a `Presence` of its
+        // own, and it is served at once.
+        //
+        // What is left is the *revoked incarnation's own* request: one that authenticated in the
+        // moment before its credential was swapped out, and reaches here after. Serving it lets a
+        // credential the operator has been told is gone route to its sessions once more.
+        //
+        // **It narrows the window rather than closing it**, and the comment should say so: a
+        // request already inside the MCP service when the swap happened is past every check here
+        // and runs to completion, as it must — a call against a live kernel cannot be abandoned
+        // half way. Revocation stops what has not started, and the sweep releases the rest.
+        if state.releasing || state.revoked {
             return Admission::Releasing;
         }
         // **Renewed if there is one; never created.** "Any request renews the lease" is what keeps a
@@ -1755,25 +1765,31 @@ mod tests {
             "an MCP session minted for a revoked credential is one nothing else will ever close"
         );
 
-        // The name, given back. Same `Lease`, same name, different client.
-        let given_back = For {
-            lease: lease.lease,
-            client: crate::client::Client::incarnate("ci", 2),
-        };
+        // The name, given back: same `Lease`, same name, different client.
+        let given_back = crate::client::Client::incarnate("ci", 2);
         assert_eq!(
-            given_back.admit(None),
+            lease.lease.admit(&given_back, None),
             Admission::Serve,
             "a client configured under a revoked name was made to wait for a teardown that is not \
              its own"
         );
         assert!(
-            given_back.state().mcp.is_empty(),
+            lease.lease.state_of(&given_back).mcp.is_empty(),
             "it inherited the MCP session ids of whoever held that name before"
         );
         assert_eq!(
-            given_back.state().deadline,
+            lease.lease.state_of(&given_back).deadline,
             None,
             "it inherited a clock that was set for its predecessor's revocation"
+        );
+
+        // And the incarnation that *was* revoked is still refused — a separate property from the
+        // one above, and one briefly lost in gaining it: a request of its own that authenticated in
+        // the moment before the swap must not be served afterwards.
+        assert_eq!(
+            lease.admit(None),
+            Admission::Releasing,
+            "the revoked credential was served after its removal had been reported complete"
         );
     }
 

--- a/src/listen.rs
+++ b/src/listen.rs
@@ -434,15 +434,12 @@ impl Lease {
         // Nothing is served while a teardown is in flight. Briefly refusing a client that could
         // have been served costs it a reconnect; serving one costs it the session mid-call.
         //
-        // **`revoked` counts as in flight**, and it is the sharper of the two. A revocation decides
-        // the teardown and the sweep runs it, so in between this presence is a credential that has
-        // gone — and the *name* may already have been handed to a different one, since a client is
-        // identified by its name and `--add-listen-client ci` after `--remove-listen-client ci`
-        // names the same one. Serving that request would let the new credential renew the
-        // revocation's deadline and route to its predecessor's debug sessions, which is the
-        // isolation this whole ownership boundary exists to provide. Refusing costs it a `409` and
-        // one retry, until the sweep forgets the entry.
-        if state.releasing || state.revoked {
+        // **A revoked credential does not need refusing here**, and used to. While a client was
+        // identified by its name alone, a name given back reached this same `Presence` and had to
+        // be held at a `409` until the sweep forgot it. It is a different [`Client`] now
+        // ([#190](https://github.com/glslang/windbg-mcp/issues/190)), so it arrives at a `Presence`
+        // of its own and is served at once — there is nothing of its predecessor's for it to reach.
+        if state.releasing {
             return Admission::Releasing;
         }
         // **Renewed if there is one; never created.** "Any request renews the lease" is what keeps a
@@ -998,32 +995,22 @@ async fn reloaded(
             }
         };
         let change = accepted.replace(fresh);
-        // **Lifted by a name being given back, not by a teardown finishing.** This is the only
-        // event that requires the gate off, and hanging it on anything else — the release running
-        // out of sessions to release, say — lifts it while a revoked credential's opener may still
-        // be seconds from registering. A name that is revoked and never configured again keeps its
-        // gate for the life of the process, which is a client name held in a set and exactly the
-        // behaviour wanted: nothing that credential started may ever register.
-        //
-        // It needs no sequencing against the teardown below, because `Lease::admit` refuses a
-        // revoked presence until the sweep forgets it: a name given back inside that window is held
-        // at a `409` by the lease, not by this.
-        for name in &change.added {
-            sessions.unrevoke(&crate::client::Client::new(name));
-        }
-        for name in &change.removed {
-            let gone = crate::client::Client::new(name);
+        for gone in &change.removed {
             // **The gate closes before the answer goes out**, because a revocation has a window a
             // lease expiry does not. An expiry only fires after the client has been silent for
             // longer than any call can keep it quiet, so nothing of that credential's can still be
             // in flight; here the token stops being accepted at the swap above, but a call that got
             // past authentication a moment earlier is still running and an opener can be seconds
-            // from registering. A session admitted behind the sweep would belong to a client
-            // nothing can authenticate as and nothing will ever come back for. Taken off again by
-            // the sweep, once that client's sessions are gone.
-            sessions.revoke(&gone);
+            // from registering, so the sweep below cannot see it.
+            //
+            // **Never lifted, and it no longer needs to be.** It marks this incarnation, not this
+            // name, so a client configured under the same name later is not gated by it — which is
+            // what the whole of [#190](https://github.com/glslang/windbg-mcp/issues/190) bought,
+            // and it deleted the question of when to take a gate off, which was where two separate
+            // findings lived. What is left behind is one name and a `u64` per revocation.
+            sessions.revoke(gone);
             // And the clock to now, which is all a revocation is: the sweeper does the rest.
-            lease.revoke(&gone);
+            lease.revoke(gone);
         }
         // **Answered once the swap and the gates are done** — which is exactly what the asking
         // command claims when it returns, and all of it is memory.
@@ -1038,8 +1025,8 @@ async fn reloaded(
                     .to_string(),
                 false => format!(
                     "added [{}], removed [{}]",
-                    change.added.join(", "),
-                    change.removed.join(", ")
+                    crate::client::Change::names(&change.added),
+                    crate::client::Change::names(&change.removed)
                 ),
             }
         );
@@ -1732,36 +1719,30 @@ mod tests {
         );
     }
 
-    /// A name handed to a new credential before the sweep runs reaches none of its predecessor.
+    /// A name given back reaches none of its predecessor's lease, and does not wait to be served.
     ///
-    /// **A client is identified by its name**, so `--remove-listen-client ci` followed by
-    /// `--add-listen-client ci` produces two different credentials that every mechanism keyed on
-    /// identity — session ownership, routing, lease state — cannot tell apart. Between the
-    /// revocation and the sweep that acts on it, the entry still holds the *previous* holder's
-    /// sessions, so serving the new one would hand it debug sessions opened by a credential that
-    /// has been revoked. That is the isolation this ownership boundary exists to provide, and it is
-    /// the one thing a rotation deliberately does *not* do — `--rotate-listen-client` keeps the
-    /// name and so keeps the sessions, which is the supported way to change a token.
+    /// **Both halves changed when a client stopped being a name**
+    /// ([#190](https://github.com/glslang/windbg-mcp/issues/190)). While it was one,
+    /// `--remove-listen-client ci` then `--add-listen-client ci` produced two credentials that this
+    /// map could not tell apart, so the new one had to be held at a `409` until the sweep forgot the
+    /// entry — a refusal that existed only because the key was ambiguous. It is a different
+    /// [`crate::client::Client`] now, so it arrives at a `Presence` of its own: served at once, and
+    /// with nothing of its predecessor's in reach.
     ///
-    /// The second half is what makes the refusal load-bearing rather than tidy: a request that
-    /// renewed would push the revocation's deadline a whole grace out, so the sweep that was to run
-    /// on its next pass would not, and the revoked client's targets would stay live for as long as
-    /// somebody kept talking to that name.
+    /// What has *not* changed is the second half, and it is the one with teeth. A request already
+    /// inside the MCP service when the set was swapped still settles against the **old** client, and
+    /// renewing there would push the revocation's deadline a whole grace out — so the sweep that was
+    /// to run on its next pass would not, and that credential's targets would stay live for another
+    /// six minutes. An incarnation does not help with that: it is the same client, arriving late.
     #[test]
-    fn a_revoked_name_serves_nobody_until_the_sweep_has_forgotten_it() {
-        let lease = For::new(unchecked(Duration::from_secs(300)), "ci");
+    fn a_name_given_back_is_a_different_lease_and_waits_for_nothing() {
+        let grace = Duration::from_secs(300);
+        let lease = For::new(unchecked(grace), "ci");
         request(&lease, None, Some("session-a"), true);
         lease.revoke();
 
-        assert_eq!(
-            lease.admit(None),
-            Admission::Releasing,
-            "a name whose revocation has not been swept was served — to whoever holds it now"
-        );
-
-        // The in-flight request of the *old* credential: it passed `admit` before the revocation
-        // and settles afterwards. It may record its MCP session, so the sweep closes that too, but
-        // it must not move the clock.
+        // The in-flight request of the *revoked* credential. It may record its MCP session, so the
+        // sweep closes that too, but it must not move the clock.
         let deadline = lease.state().deadline;
         lease.settle(None, Some("session-b"), true);
         assert_eq!(
@@ -1774,14 +1755,25 @@ mod tests {
             "an MCP session minted for a revoked credential is one nothing else will ever close"
         );
 
-        // And the sweep's ending is what lets the name be used again.
-        let swept = lease.expired().expect("revoked, so expired now");
-        assert!(swept.revoked);
-        lease.forget();
+        // The name, given back. Same `Lease`, same name, different client.
+        let given_back = For {
+            lease: lease.lease,
+            client: crate::client::Client::incarnate("ci", 2),
+        };
         assert_eq!(
-            lease.admit(None),
+            given_back.admit(None),
             Admission::Serve,
-            "once the predecessor is forgotten the name is an ordinary client again"
+            "a client configured under a revoked name was made to wait for a teardown that is not \
+             its own"
+        );
+        assert!(
+            given_back.state().mcp.is_empty(),
+            "it inherited the MCP session ids of whoever held that name before"
+        );
+        assert_eq!(
+            given_back.state().deadline,
+            None,
+            "it inherited a clock that was set for its predecessor's revocation"
         );
     }
 

--- a/src/service.rs
+++ b/src/service.rs
@@ -311,7 +311,7 @@ fn reads_back_bare(token: &str) -> bool {
             creds.len() == 1
                 && creds
                     .client_for(token)
-                    .is_some_and(|client| client.name() == crate::client::Client::LOCAL)
+                    .is_some_and(|name| name == crate::client::Client::LOCAL)
         })
 }
 
@@ -1600,10 +1600,7 @@ mod tests {
         )];
         let written = token_file_contents(&one);
         assert_eq!(written, "s3cret", "a single local token is written bare");
-        assert_eq!(
-            read_back(&written).client_for("s3cret").map(|c| c.name()),
-            Some("local")
-        );
+        assert_eq!(read_back(&written).client_for("s3cret"), Some("local"));
 
         // Anything else is the JSON object, which is the only shape that can carry more than one —
         // and under a service the only way to have a second client at all.
@@ -1631,11 +1628,7 @@ mod tests {
             let creds = read_back(&written);
             assert_eq!(creds.len(), credentials.len());
             for (name, token) in &credentials {
-                assert_eq!(
-                    creds.client_for(token).map(|c| c.name()),
-                    Some(name.as_str()),
-                    "{written}"
-                );
+                assert_eq!(creds.client_for(token), Some(name.as_str()), "{written}");
             }
         }
     }


### PR DESCRIPTION
Closes #190, which was split out of #189 after four of that PR's findings turned out to be one ambiguity seen from four consumers.

## The ambiguity

`Client` was an `Arc<str>`, and everything that decides what a request may reach keys on it: session ownership, routing (including "that client's newest session"), lease state, the four-session cap, closed-session history.

So `--remove-listen-client ci` followed by `--add-listen-client ci` produced **two credentials that none of them could tell apart**. The second cannot present the first's token and the first's token is refused — they are not one client by any definition the operator would recognise — yet the second reached everything the first had opened. Which is exactly what `--rotate-listen-client` exists to do *deliberately*, and exactly what a removal must not.

## Identity is the pair; the name is still all you see

`Display` and `name()` render the name alone, so every log line, refusal and `session_status` row says what it always did. `Client::new` still builds the sole holder of a name — incarnation `0` — which is what stdio has and what makes `Client::new("ci")` twice mean one client in a test.

**Minted in exactly one place**, `Accepted::replace`, because it is the only code in the program that can answer the question: a name in the new set that was in the old one is *carrying on*; a name that was absent is *being given back*. Two consequences fall out of putting it there:

- `Credentials` now maps a token to a **name**. A file cannot tell you whether a name is carrying on, so it should not be asked to.
- `Change` carries **clients** rather than names, since a removal has to say which incarnation is going.

## What it deleted, rather than added

- **The `409` a re-added name waited out.** It arrives at a `Presence` of its own now, so it is served at once. That refusal existed only because the key was ambiguous.
- **`Sessions::unrevoke`, and the question of *when* to lift the registry gate** — where two separate findings had lived. The gate marks an incarnation, so a client configured under that name later is not the one it gates, and it never comes off. What it leaves behind is a name and a `u64` per revocation.

What it did **not** delete, and should not: `Presence::revoked`. A request already inside the MCP service when the set was swapped settles against the client that is going, and renewing there would push the revocation a whole grace out. An incarnation does not help with that — it is the same client, arriving late.

## Verification

`cargo clippy --all-targets -- -D warnings` clean, `cargo fmt --all --check` clean, **500 unit + 70 smoke** pass on the ARM64 bench.

The new unit tests assert identity directly — a rotation is the same client, a name given back is not — because identity is what every downstream structure keys on. Get it right and they are all right; get it wrong and they are all wrong the same way, which is how one ambiguity produced four findings.

**Driven end to end against the installed service, and this is the claim the issue was about:**

| step | result |
|---|---|
| client `iso` opens a crash dump | `session_status` shows `sess-…-1`, engine pid 2520 |
| `--remove-listen-client iso`, then `--add-listen-client iso` | a different token |
| the **new** `iso` asks `session_status` | **"No debug session is open."** |

Before this, the new `iso` would have inherited that session and been able to route to it. The orphan is released by the sweep on its next pass (`the lease of client 'iso' ran out; releasing the sessions it left open`), leaving one process. A re-added name is also now served immediately rather than after a `409`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
