### PR TITLE
Put the constraints in an output schema and not the prose nobody reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **An `outputSchema` carries constraints now, not prose** (`FOLLOWUPS.md` item 24's finding 1).
+  The whole `tools/list` payload went **394,883 B -> 177,460 B, a 55% cut**, and what a model reads
+  did not move by a byte. `schemars` emits each output schema self-contained, so every type
+  reachable from a tool's answer is inlined into that tool's `$defs`: `ErrorCategory`'s doc comment
+  shipped 33 times, `ModuleInfo`'s seven, the allocator subtree's nine - 222,579 B of duplication.
+  That duplication cannot be removed, because MCP gives each tool one schema and no document above
+  it for a `$ref` to reach. What could be removed is what was being multiplied: **68% of every
+  `outputSchema` byte was a `description`**, and `ErrorCategory` is 2,089 B with its prose and 324 B
+  without.
+
+  Nothing read it there. No model is given an output schema - the measurement
+  `docs/token-budget.md` opens with - and `description` is an annotation keyword, so every instance
+  that validated before validates now. The prose stays where it is read: the rustdoc it is generated
+  from, `README.md`'s structured-results table, and each tool's own model-visible `description`.
+
+  The strip is **structural, not textual** (`src/schema.rs`): a field named `description` is a
+  property name, so removing every `"description"` key would delete the field rather than its
+  documentation. No structured type has such a field, which is precisely why nothing would have
+  reported it - there is a unit test for the case, and a smoke assertion reading `tools/list` off
+  the wire, because the change comes undone by one import line. `WIRE_CEILING` 460,000 -> 205,000.
+
 - **A default `registers` answer stopped carrying the vector bank** (`FOLLOWUPS.md` item 24's
   finding 7). The `all` argument documents the default as excluding the x87 and vector registers,
   and it did not: DbgEng exposes `xmm0` twice - as 128 bits of `bytes`, and as `xmm0/0` … `xmm0/3`,

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -725,20 +725,41 @@ measurement found. None of them is a bug; all of them were invisible.
 later fix would be a diff against a number somebody had already tidied. The tests and the golden
 landed on their own so that each of the items below can be argued, and measured, separately.
 
-- **`$defs` are inlined per tool** — `schemars` emits each output schema self-contained, so
-  `ErrorCategory` (2,089 B) ships 31 times and the allocator/pool subtree nine. **200,571 B, 70% of
-  all `outputSchema`.** Wire and client-parse cost only; no model reads it. The lever is
-  `output_schema = schema_for_output::<T>()` on each `#[rmcp::tool]`, or a `list_tools` that emits
-  shared definitions.
+- **`$defs` are inlined per tool** — **done** (2026-08-22), and neither lever this bullet named
+  was the one. `schemars` emits each output schema self-contained, so `ErrorCategory` (2,089 B)
+  shipped 33 times and the allocator/pool subtree nine: **222,579 B, 69% of all `outputSchema`**,
+  duplicated beyond its first copy. Wire and client-parse cost only; no model reads it.
 
-  **This one has a price now** (2026-08-18): adding `PdbInfo`, one optional four-field type on one
+  **The duplication cannot be removed.** MCP gives each tool one `outputSchema` and no document
+  above it, and `#/$defs/…` resolves against the schema it appears in, so there is nowhere a client
+  could look up a definition another tool declared — "a `list_tools` that emits shared definitions"
+  has no reader. And `output_schema = schema_for_output::<T>()` was already on every tool; it names
+  the type, not where the type is written.
+
+  What moved was **what gets multiplied**. Measuring the payload found **68% of every `outputSchema`
+  byte was a `description`** — 217,423 B of 320,365 B, 55% of the whole answer — so the schemas now
+  carry constraints and nothing else (`src/schema.rs`): **394,883 → 177,460 B, model-visible
+  unmoved.** `WIRE_CEILING` 460,000 → 205,000. The prose is not lost; it stays in the rustdoc it is
+  generated from and in `README.md`'s structured-results table, which is where it is read. Nothing
+  reads it in a schema — no model is given one, and `description` is an annotation keyword, so an
+  instance that validated before validates now.
+
+  Two things worth carrying. The strip is **structural, not textual**: a field named `description`
+  is a property *name*, and dropping every `"description"` key would delete the field rather than
+  its documentation — no structured type has such a field today, which is exactly why nothing would
+  have reported it. And the same answer does **not** transfer to the input schemas below: there the
+  prose is most of what tells a model how to drive the tool.
+
+  **This one had a price** (2026-08-18): adding `PdbInfo`, one optional four-field type on one
   field of `ModuleInfo`, grew the wire by **15,610 B** and model context by **zero**, because
   `ModuleInfo` is embedded in the openers' summary, in `modules` and in the allocator shapes. That
-  is the compounding this finding predicts, measured on a change small enough that nobody would
-  have thought to look. `WIRE_CEILING` moved 412,000 → 460,000 to record it; the next such type
-  costs the same again, and fixing this item is what stops that.
-- **Six openers carry a byte-identical 11,093 B output schema**, six step tools a byte-identical
-  4,418 B one. 77,555 B of the above, and the cheapest to collapse.
+  is the compounding this finding predicted, measured on a change small enough that nobody would
+  have thought to look. The multiplier is still there — it is the protocol's — but the same type
+  costs roughly a seventh of that now.
+- **Six openers carry a byte-identical 13,386 B output schema**, six step tools a byte-identical
+  4,433 B one. 89,095 B of the above, and it looked like the cheapest to collapse. It is the same
+  protocol fact as the bullet above with the same answer: those schemas are 3,838 B and 1,185 B
+  each now, and there is still nowhere to say either of them once.
 - **`session_id` was documented in three wordings** — **done**, and the figure in this bullet was
   wrong. It counted the copies inside `outputSchema`, which no model reads; the model-visible total
   was 4,695 B across 32 fields, not 9,514 across 43. One shared wording — plus documenting the five
@@ -768,6 +789,12 @@ landed on their own so that each of the items below can be argued, and measured,
   waste but one tool honestly describing a rich argument. The levers are design choices: a smaller
   step vocabulary, a `$ref` the client resolves, or a surface that does not offer every tool to
   every caller.
+
+  **The first bullet's answer does not transfer**, which is worth saying now that it has landed:
+  prose came out of the output schemas because nothing read it, and prose in an *input* schema is
+  most of what tells a model how to drive the tool. `debug_batch` is the one where getting that
+  wrong leaves a patched byte in a running kernel. This bullet is still the whole of what remains
+  in this item, and it stays a design question rather than a strip.
 - **`modules` had neither a `limit` nor a cap**, alone among the high-volume tools — **done**
   (2026-08-21). Everything else uncapped is raw debugger text — `ttd_calls`, `ttd_memory`,
   `threads`, `execute`, `dx`, `ioctl_trace`, `reachable_from_dispatch` — and `read_memory` returns
@@ -785,6 +812,9 @@ landed on their own so that each of the items below can be argued, and measured,
   `split_row_budget` the heap diagnostics already used, whose own test says why: two sections that
   each restart the budget quietly double the ceiling it was chosen to be. Reaching for a cap
   per half was the first thing tried here, and this repo had already argued it down one tool over.
+
+**What is left of this item is the bullet above**, the five input schemas. Everything else in it
+is done or measured-and-declined; the wire half closed with the first bullet.
 
 **Where this bites first is a local model**, whose window is bought in RAM rather than rented:
 [`docs/local-model.md`](./docs/local-model.md) is the runbook, and it names the three client-side

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -160,6 +160,12 @@ It deliberately excludes descriptions, so prose edits do not churn it while a `s
 switch, an `rmcp` annotation-casing change, a discriminator that stops being emitted, or an
 accidental tool rename all land as a readable line diff.
 
+Beside it, `output_schemas_carry_constraints_not_prose` asserts that an output schema carries no
+descriptions **at all** — 68% of every `outputSchema` byte used to be rustdoc that no model is given
+and no validator reads, which is `FOLLOWUPS.md` item 24's first finding. It reads `tools/list` off
+the wire because the way that comes undone is one tool declaring its schema with rmcp's
+`schema_for_output` instead of `schema::constraints_of`, and nothing else would report it.
+
 Re-record after an *intended* change, and read the diff before committing:
 
 ```pwsh

--- a/docs/token-budget.md
+++ b/docs/token-budget.md
@@ -7,7 +7,8 @@ answer this server returns. That makes payload size a correctness-adjacent prope
 call that spends 13k tokens has not failed, but it has taken the space the investigation needed.
 Nothing measured this until [`tests/mcp_smoke.rs`](../tests/mcp_smoke.rs) grew the two tests below,
 and the numbers turned out to be larger than anyone had guessed — a careful reading of the source
-put the tool surface at 90–130 KB, and the wire is 391 KB.
+put the tool surface at 90–130 KB, and the wire was 391 KB. It is 177 KB now, and finding 1 below
+is where the other 217 KB went.
 
 ## Two costs, and they are not the same
 
@@ -27,8 +28,10 @@ There is a second split inside the first, and it is the one that matters most:
 Both rows in the second half were measured against a real client rather than assumed:
 
 - A tool definition reaching the model carries name, description and input schema only. The
-  Anthropic tool spec has no field for an output schema, so the 286 KB of `outputSchema` this
-  server emits is a client-side parse, validation and memory cost — never a context cost.
+  Anthropic tool spec has no field for an output schema, so the `outputSchema` this server emits is
+  a client-side parse, validation and memory cost — never a context cost. It was 286 KB when that
+  was measured, and finding 1 is what followed from the measurement: if nothing reads it, the
+  documentation inside it is being paid for and never delivered.
 - `structuredContent` **replaces** the text block rather than accompanying it. A `session_status`
   call arrives as `{"max_sessions":4,…}` with the human summary dropped; `decode_ioctl`, which
   emits no structured content, arrives as text.
@@ -36,7 +39,7 @@ Both rows in the second half were measured against a real client rather than ass
 The second point reverses an assumption in [`DECISIONS.md`](../DECISIONS.md) ("A typed result is a
 second channel, not a replacement", 2026-08-12, #84). That decision was argued for machine
 parseability, against a Python client scraping prose, and it is still right for that reader. What
-it did not consider is that a *model* client picks one — so for the 31 tools with an output schema,
+it did not consider is that a *model* client picks one — so for the 33 tools with an output schema,
 the rendering is paid for on the wire and read by nobody, and the half the model does read is the
 larger one. `src/structured.rs:1651` already made the other call for `debug_batch`, and states the
 reason: carrying both "would make the typed answer the larger of the two channels while adding no
@@ -59,19 +62,26 @@ authority — the tables below are a reading of it at the time of writing.
 
 ### Tool surface (51 tools)
 
-| Component | Bytes | Reaches the model |
-|---|---:|---|
-| **Whole `tools/list` payload** | **391,172** | partly |
-| — the 51 tools themselves | 391,054 | partly |
-| — result-level fields (`resultType`, `ttlMs`, `cacheScope`) | 118 | no |
-| `outputSchema` (the 33 tools that have one) | 317,236 | no |
-| `inputSchema` (all 51) | 39,667 | yes |
-| `description` (all 51) | 24,752 | yes |
-| `annotations` | 5,449 | no |
-| **Model-visible total** | **67,076** (~16k tokens) | — |
-| `initialize` instructions | 1,996 | yes, **all of it** |
+The first column is the baseline this page was written from; the second is today, and the only
+thing between them is finding 1 — the prose taken out of every `outputSchema`.
 
-Worst single tool: `debug_batch` at 9,757 model-visible bytes, because its `inputSchema` pulls the
+| Component | Baseline | Today | Reaches the model |
+|---|---:|---:|---|
+| **Whole `tools/list` payload** | **391,172** | **177,460** | partly |
+| — the 51 tools themselves | 391,054 | 177,342 | partly |
+| — result-level fields (`resultType`, `ttlMs`, `cacheScope`) | 118 | 118 | no |
+| `outputSchema` (the 33 tools that have one) | 317,236 | 102,942 | no |
+| `inputSchema` (all 51) | 39,667 | 40,207 | yes |
+| `description` (all 51) | 24,752 | 24,794 | yes |
+| `annotations` | 5,449 | 5,449 | no |
+| **Model-visible total** | **67,076** | **67,658** (~17k tokens) | — |
+| `initialize` instructions | 1,996 | 1,990 | yes, **all of it** |
+
+The two halves moved independently, which is the whole argument for measuring them apart: the wire
+fell by 55% and the model-visible column did not move at all except for what the tools themselves
+have accumulated since.
+
+Worst single tool: `debug_batch` at 9,746 model-visible bytes, because its `inputSchema` pulls the
 whole `StepAction`/`Check` vocabulary out of `src/batch.rs`.
 
 The payload is measured as the **serialized result**, not as the sum of its tools, and the 118-byte
@@ -81,8 +91,8 @@ server at two revisions shows what a sum would miss:
 
 | Revision | payload | sum of tools | result-level |
 |---|---:|---:|---|
-| `2026-07-28` | 391,172 | 391,054 | `resultType`, `ttlMs`, `cacheScope` |
-| `2025-06-18` | 391,116 | 391,054 | none |
+| `2026-07-28` | 177,460 | 177,342 | `resultType`, `ttlMs`, `cacheScope` |
+| `2025-06-18` | 177,404 | 177,342 | none |
 
 The sum is **identical** across the two; only the payload figure can tell them apart. The golden
 records both, so the gap stays visible.
@@ -129,19 +139,50 @@ what it has since done about it.
 None of these is a bug. They are recorded because they were invisible, and
 [`FOLLOWUPS.md`](../FOLLOWUPS.md) item 24 tracks them.
 
-1. **`$defs` are inlined per tool.** `schemars` emits each output schema self-contained, so
-   `ErrorCategory` (2,089 B) ships **31 times**, `WalkGaps` (2,886 B) and the whole
-   allocator/pool subtree nine times each. **200,571 bytes — 70% of all `outputSchema`** — is
-   duplicated beyond its first copy.
-1b. **And finding 1 has a price tag now.** Adding `PdbInfo` — one optional four-field type, on one
+1. **`$defs` are inlined per tool** — **fixed** (2026-08-22), though not by removing the
+   duplication, which cannot be done. `schemars` emits each output schema self-contained, so
+   `ErrorCategory` (2,089 B) shipped **33 times**, `ModuleInfo` (3,524 B) seven and the
+   allocator/pool subtree nine: **222,579 bytes, 69% of all `outputSchema`**, duplicated beyond its
+   first copy.
+
+   The lever this finding named — hoisting the shared definitions — is not available. MCP gives
+   each tool one `outputSchema` and no document above it, and `#/$defs/…` resolves against the
+   schema it appears in, so a client has nowhere to look up a definition another tool declared. The
+   multiplier is the protocol's, and it stays.
+
+   What is available is **what gets multiplied**. Measuring the payload found that **68% of every
+   `outputSchema` byte was a `description`** — 217,423 B of 320,365 B, and 55% of the whole answer.
+   `ErrorCategory` is 2,089 B with its doc comment and **324 B** without. So the schemas now carry
+   constraints and nothing else (`src/schema.rs`), and the payload is **394,883 → 177,460 B** with
+   the model-visible column unmoved.
+
+   That trade is one-sided because `description` had no reader in this position. No model is given
+   an output schema — the measurement at the top of this page. No validator reads one either:
+   `description` is an annotation keyword, so every instance that validated before validates now.
+   And a human has three better copies — the rustdoc these strings are generated from, the
+   structured-results table in `README.md`, and the tool's own model-visible `description`.
+
+   The strip is **structural, not textual**, which is the one place it could have gone wrong
+   quietly: a field named `description` renders as `properties: { "description": … }`, and dropping
+   every `"description"` key would delete the field rather than its documentation. `src/schema.rs`
+   descends only where a JSON Schema keyword says a subschema lives, and has a unit test for
+   exactly that case — no structured type has such a field today, and the one that does is the one
+   this would have broken.
+
+1b. **And finding 1 had a price tag.** Adding `PdbInfo` — one optional four-field type, on one
    field of `ModuleInfo` — grew the wire by **15,610 B**, because `ModuleInfo` is embedded in the
    openers' `TargetSummary`, in `modules`, and in the allocator shapes, and `schemars` inlines the
    new type into every one of them. Model-visible cost: **zero**, since no model reads an
-   `outputSchema`. That ratio — 15 KB of wire for 0 B of context — is the whole of finding 1 in a
-   single change, and it is why the ceiling below moved rather than the type being argued about.
+   `outputSchema`. That ratio — 15 KB of wire for 0 B of context — was the whole of finding 1 in a
+   single change, and it is why the ceiling moved 412,000 → 460,000 rather than the type being
+   argued about. The same type costs roughly a seventh of that now, and the ceiling has come back
+   down to 205,000: what changed is not how many times a type is copied but how much of it there is
+   to copy.
 
-2. **Whole schemas repeat.** The six openers carry a byte-identical 11,093 B output schema; the six
-   step tools a byte-identical 4,418 B one. 77,555 B of the above.
+2. **Whole schemas repeat.** The six openers carried a byte-identical 13,386 B output schema; the
+   six step tools a byte-identical 4,433 B one — 89,095 B of the above. This is the same protocol
+   fact as finding 1 and has the same answer: there is nowhere to say it once. Those schemas are
+   3,838 B and 1,185 B each now.
 3. **`session_id` was documented in three different wordings** — **fixed**, and the original figure
    here was wrong in an instructive way. It said 9,514 B across 43 sites; the model-visible total was
    **4,695 B across 32**, because the count had included the copies inside `outputSchema`, which the
@@ -227,6 +268,12 @@ None of these is a bug. They are recorded because they were invisible, and
    vocabulary, a `$ref` the client resolves, or a tool surface that does not offer every tool to
    every caller. Worth measuring before choosing, which is what this table is for.
 
+   **Finding 1's answer does not transfer here, and it is worth saying why.** Prose came out of the
+   output schemas because nothing read it. Prose in an *input* schema is the opposite: it is most of
+   what tells a model how to drive the tool, and `debug_batch` is the tool where getting that wrong
+   leaves a patched byte in a running kernel. Cutting bytes there costs correctness, so the 21,961 B
+   below is a design question and not a strip.
+
 One interaction worth flagging before acting on any of it: `FOLLOWUPS.md` item 11 proposes *adding*
 `structuredContent` to `ttd_calls`, `ttd_memory` and `driver_object` — three of the highest-volume
 text-only tools. Under the rule measured above that replaces their text rather than supplementing
@@ -239,6 +286,11 @@ The surface budget needs no debugger and rides the ordinary test run:
 ```pwsh
 cargo test --test mcp_smoke -- --nocapture tool_surface_stays_within_its_token_budget
 ```
+
+Beside it, and needing no debugger either, `output_schemas_carry_constraints_not_prose` is the
+assertion that finding 1 stays fixed. It reads `tools/list` off the wire, so it catches the way that
+change comes undone — one tool declaring its schema with rmcp's `schema_for_output` instead of
+`schema::constraints_of` — which is an import line nothing else would report.
 
 The result budget needs the debugger tier:
 
@@ -290,7 +342,10 @@ The **ceilings** (`MODEL_VISIBLE_CEILING`, `WIRE_CEILING`, `WORST_TOOL_CEILING` 
 `tests/mcp_smoke.rs`) stop what the golden cannot: a golden re-recorded on every diff is a rubber
 stamp, and thirty accepted 2% growths are a doubling nobody voted for. They sit ~15% over today's
 figures. Raising one is a normal thing to do — a new tool has to fit somewhere — but do it in its
-own commit, with the reason, and update the tables here.
+own commit, with the reason, and update the tables here. **Lowering one is the same act**, and
+`WIRE_CEILING` has now been both: 412,000 → 460,000 for `PdbInfo`, then → 205,000 when finding 1
+landed. A ceiling left where a fix found it is a ceiling that would have absorbed the next
+regression in silence.
 
 Result budgets are **not** goldened. Their sizes move with what the runner can resolve: a symbol
 server that answers turns `deferred` into paths and grows `lm` a column, and the debugger tier runs

--- a/docs/token-budget.md
+++ b/docs/token-budget.md
@@ -169,15 +169,15 @@ None of these is a bug. They are recorded because they were invisible, and
    exactly that case — no structured type has such a field today, and the one that does is the one
    this would have broken.
 
-1b. **And finding 1 had a price tag.** Adding `PdbInfo` — one optional four-field type, on one
-   field of `ModuleInfo` — grew the wire by **15,610 B**, because `ModuleInfo` is embedded in the
-   openers' `TargetSummary`, in `modules`, and in the allocator shapes, and `schemars` inlines the
-   new type into every one of them. Model-visible cost: **zero**, since no model reads an
-   `outputSchema`. That ratio — 15 KB of wire for 0 B of context — was the whole of finding 1 in a
-   single change, and it is why the ceiling moved 412,000 → 460,000 rather than the type being
-   argued about. The same type costs roughly a seventh of that now, and the ceiling has come back
-   down to 205,000: what changed is not how many times a type is copied but how much of it there is
-   to copy.
+   **And this finding had a price tag before it was fixed.** Adding `PdbInfo` — one optional
+   four-field type, on one field of `ModuleInfo` — grew the wire by **15,610 B**, because
+   `ModuleInfo` is embedded in the openers' `TargetSummary`, in `modules`, and in the allocator
+   shapes, and `schemars` inlines the new type into every one of them. Model-visible cost:
+   **zero**, since no model reads an `outputSchema`. That ratio — 15 KB of wire for 0 B of context
+   — was the whole of this finding in a single change, and it is why the ceiling moved
+   412,000 → 460,000 rather than the type being argued about. The same type costs roughly a seventh
+   of that now, and the ceiling has come back down to 205,000: what changed is not how many times a
+   type is copied but how much of it there is to copy.
 
 2. **Whole schemas repeat.** The six openers carried a byte-identical 13,386 B output schema; the
    six step tools a byte-identical 4,433 B one — 89,095 B of the above. This is the same protocol

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,7 @@ mod logbridge;
 mod progress;
 mod proto;
 mod record;
+mod schema;
 mod server;
 mod service;
 mod structured;

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -1,0 +1,301 @@
+//! What a tool's `outputSchema` carries: the constraints, and not the prose.
+//!
+//! Every typed tool declares an output schema generated from the [`crate::structured`] types, and
+//! `schemars` emits each one as a self-contained document — so every type reachable from a tool's
+//! answer is inlined into that tool's `$defs`, doc comments and all. That is fine once. It is
+//! [`ErrorCategory`](crate::structured::ErrorCategory) thirty-three times, because every tool that
+//! can fail answers with an [`Outcome`](crate::structured::Outcome).
+//!
+//! Measured on the payload rather than reasoned about: **68% of every `outputSchema` byte this
+//! server emits was a `description`** — 217,423 B of 320,365 B, which is 55% of the whole
+//! `tools/list` answer. [`strip_descriptions`] removes them, and the payload goes 394,883 B →
+//! 177,460 B with **not one byte** of change to what a model reads.
+//!
+//! The reason that trade is one-sided is that `description` has no reader here:
+//!
+//! * A model never sees an `outputSchema` at all. That is the measurement
+//!   [`docs/token-budget.md`](../docs/token-budget.md) opens with, taken against a real client:
+//!   a tool definition reaches a model as name, description and *input* schema.
+//! * A validator does not read it either. `description` is an annotation keyword in JSON Schema —
+//!   it constrains nothing, so an instance that validated before validates now.
+//! * A human has three better copies: the rustdoc these strings are generated from, the
+//!   structured-results table in `README.md`, and the tool's own model-visible `description`.
+//!
+//! So the prose stays where it is written and is charged for where it is read. What the schema
+//! keeps is the part that is *load-bearing* — the `status` discriminator, the `const` vocabularies,
+//! `required`, the types — which is what `DECISIONS.md`'s "A typed result is a second channel"
+//! entry was actually arguing for when it made one schema cover both branches of a result.
+//!
+//! This also ends the compounding, which is the half that matters going forward. Adding `PdbInfo`
+//! — one optional four-field type on one field of `ModuleInfo` — cost 15,610 B of wire and 0 B of
+//! model context, because `ModuleInfo` is embedded in six output shapes. The same type costs
+//! roughly a seventh of that now: the multiplier is unchanged, but what is being multiplied is a
+//! handful of keywords rather than a paragraph.
+
+use std::any::{Any, TypeId};
+use std::collections::HashMap;
+use std::sync::{Arc, LazyLock, RwLock};
+
+use rmcp::model::JsonObject;
+use schemars::JsonSchema;
+use serde_json::Value;
+
+/// The `outputSchema` a tool declares, with the prose taken out.
+///
+/// A drop-in for `rmcp`'s `schema_for_output`, and the only thing `src/server.rs` should call —
+/// deliberately *not* named after it, because the point of the module docs above is lost the
+/// moment one tool declares its schema the other way round, and a name one import line away from
+/// the original is a name that will come back.
+///
+/// Cached by type, like the function it wraps, because `tools/list` rebuilds the whole router and
+/// there are thirty-three of these to walk.
+pub fn constraints_of<T: JsonSchema + Any>() -> Arc<JsonObject> {
+    static CACHE: LazyLock<RwLock<HashMap<TypeId, Arc<JsonObject>>>> =
+        LazyLock::new(Default::default);
+
+    if let Some(cached) = CACHE
+        .read()
+        .expect("output schema cache poisoned")
+        .get(&TypeId::of::<T>())
+    {
+        return cached.clone();
+    }
+
+    let lean = Arc::new(strip_descriptions(
+        &rmcp::handler::server::tool::schema_for_output::<T>(),
+    ));
+    CACHE
+        .write()
+        .expect("output schema cache poisoned")
+        .insert(TypeId::of::<T>(), lean.clone());
+    lean
+}
+
+/// Every `description` in a JSON Schema document, removed.
+///
+/// **Structurally, not by key name.** The obvious implementation — walk the whole JSON and drop
+/// every `"description"` wherever it appears — is wrong in a way nothing would report: a struct
+/// with a field *called* `description` renders as `properties: { "description": { … } }`, and
+/// blind removal deletes that field from the schema rather than its documentation. No structured
+/// type has such a field today; the one that does is the one this would break.
+///
+/// So the walk only descends where a JSON Schema keyword says a subschema lives, and only removes
+/// `description` from a position that is itself a schema.
+fn strip_descriptions(schema: &JsonObject) -> JsonObject {
+    let mut lean = schema.clone();
+    strip_in_place(&mut lean);
+    lean
+}
+
+/// Keywords whose value is one subschema. `items` is here rather than below because 2020-12 gives
+/// it a single schema; an array form from an older dialect is handled by the walk anyway.
+const SUBSCHEMA: &[&str] = &[
+    "items",
+    "additionalProperties",
+    "additionalItems",
+    "unevaluatedItems",
+    "unevaluatedProperties",
+    "propertyNames",
+    "contains",
+    "not",
+    "if",
+    "then",
+    "else",
+];
+
+/// Keywords whose value is an **array** of subschemas.
+const SUBSCHEMA_LIST: &[&str] = &["oneOf", "anyOf", "allOf", "prefixItems"];
+
+/// Keywords whose value is a **map** of name to subschema. The names are the caller's — a field
+/// name, a definition name — which is exactly why the walk has to know they are not keywords.
+const SUBSCHEMA_MAP: &[&str] = &["properties", "patternProperties", "$defs", "definitions"];
+
+fn strip_in_place(schema: &mut JsonObject) {
+    schema.remove("description");
+
+    for key in SUBSCHEMA {
+        if let Some(value) = schema.get_mut(*key) {
+            strip_value(value);
+        }
+    }
+    for key in SUBSCHEMA_LIST {
+        if let Some(Value::Array(items)) = schema.get_mut(*key) {
+            for item in items {
+                strip_value(item);
+            }
+        }
+    }
+    for key in SUBSCHEMA_MAP {
+        if let Some(Value::Object(members)) = schema.get_mut(*key) {
+            for (_, member) in members.iter_mut() {
+                strip_value(member);
+            }
+        }
+    }
+}
+
+/// A position that holds a subschema: an object is one, an array is a list of them (the older
+/// `items` form), and `true`/`false` are the two schemas that carry nothing to strip.
+fn strip_value(value: &mut Value) {
+    match value {
+        Value::Object(object) => strip_in_place(object),
+        Value::Array(items) => items.iter_mut().for_each(strip_value),
+        _ => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn strip(value: serde_json::Value) -> serde_json::Value {
+        let object = value.as_object().expect("a schema is an object").clone();
+        Value::Object(strip_descriptions(&object))
+    }
+
+    #[test]
+    fn the_root_description_goes() {
+        assert_eq!(
+            strip(json!({ "description": "why", "type": "object" })),
+            json!({ "type": "object" })
+        );
+    }
+
+    #[test]
+    fn descriptions_go_from_every_schema_position() {
+        let stripped = strip(json!({
+            "description": "root",
+            "type": "object",
+            "properties": {
+                "one": { "description": "a field", "type": "string" },
+                "many": {
+                    "type": "array",
+                    "items": { "description": "an element", "type": "integer" }
+                }
+            },
+            "oneOf": [
+                { "description": "a branch", "const": "ok" },
+                { "description": "the other", "const": "error" }
+            ],
+            "$defs": {
+                "Shared": { "description": "a shared type", "type": "string" }
+            }
+        }));
+
+        assert_eq!(
+            stripped,
+            json!({
+                "type": "object",
+                "properties": {
+                    "one": { "type": "string" },
+                    "many": { "type": "array", "items": { "type": "integer" } }
+                },
+                "oneOf": [{ "const": "ok" }, { "const": "error" }],
+                "$defs": { "Shared": { "type": "string" } }
+            })
+        );
+    }
+
+    /// The failure mode the structural walk exists for: a *field* named `description` is a
+    /// property name, not a keyword, and a walk that removed it by name would delete the field.
+    #[test]
+    fn a_field_called_description_survives() {
+        let stripped = strip(json!({
+            "description": "the type's own doc, which goes",
+            "type": "object",
+            "properties": {
+                "description": { "description": "the field's doc, which goes", "type": "string" }
+            },
+            "required": ["description"]
+        }));
+
+        assert_eq!(
+            stripped,
+            json!({
+                "type": "object",
+                "properties": { "description": { "type": "string" } },
+                "required": ["description"]
+            })
+        );
+    }
+
+    /// A `$defs` entry may be named after a keyword too — the map's keys are type names, and
+    /// nothing stops a type being called `Items` or, in some other generator, `oneOf`.
+    #[test]
+    fn a_definition_named_after_a_keyword_survives() {
+        let stripped = strip(json!({
+            "$defs": {
+                "oneOf": { "description": "a type with an awkward name", "type": "string" }
+            },
+            "$ref": "#/$defs/oneOf"
+        }));
+
+        assert_eq!(
+            stripped,
+            json!({
+                "$defs": { "oneOf": { "type": "string" } },
+                "$ref": "#/$defs/oneOf"
+            })
+        );
+    }
+
+    /// `additionalProperties: false` is a schema, and a boolean one has nothing to walk into.
+    #[test]
+    fn a_boolean_schema_is_left_alone() {
+        let stripped = strip(json!({
+            "type": "object",
+            "additionalProperties": false,
+            "description": "gone"
+        }));
+
+        assert_eq!(
+            stripped,
+            json!({ "type": "object", "additionalProperties": false })
+        );
+    }
+
+    /// Nothing but `description` moves: `default`, `const` and `enum` are values a client acts on,
+    /// and `format`/`minimum` are constraints. Stripping any of them would change what validates.
+    #[test]
+    fn every_other_keyword_stays() {
+        let schema = json!({
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0,
+            "default": 64,
+            "enum": [1, 2, 3]
+        });
+
+        assert_eq!(strip(schema.clone()), schema);
+    }
+
+    /// The real thing, end to end: a tool's declared schema keeps its shape and loses its prose.
+    #[test]
+    fn a_real_output_schema_keeps_its_discriminator() {
+        let schema =
+            constraints_of::<crate::structured::Outcome<crate::structured::SessionEnded>>();
+        let rendered = serde_json::to_string(&schema).expect("a schema serializes");
+
+        assert!(
+            !rendered.contains("\"description\""),
+            "a declared output schema still carries prose: {rendered}"
+        );
+        assert!(
+            rendered.contains("\"status\""),
+            "the branch discriminator is what the schema is for: {rendered}"
+        );
+        assert!(
+            rendered.contains("\"stale_session\""),
+            "the ErrorCategory vocabulary is a constraint, not prose: {rendered}"
+        );
+    }
+
+    /// Two calls hand back the same cached document rather than two walks of the same one.
+    #[test]
+    fn the_same_type_is_walked_once() {
+        let first = constraints_of::<crate::structured::OpenOutcome>();
+        let second = constraints_of::<crate::structured::OpenOutcome>();
+        assert!(Arc::ptr_eq(&first, &second));
+    }
+}

--- a/src/server.rs
+++ b/src/server.rs
@@ -9,7 +9,6 @@ use std::collections::{HashMap, HashSet, VecDeque};
 use std::time::Duration;
 
 use rmcp::ErrorData;
-use rmcp::handler::server::tool::schema_for_output;
 use rmcp::handler::server::wrapper::Parameters;
 use rmcp::model::{CallToolResult, ContentBlock};
 use schemars::JsonSchema;
@@ -24,6 +23,7 @@ use crate::kdconn;
 use crate::proto::{
     EngineOp, HeapBackendFilter, HeapOp, HeapStateFilter, Output, PoolOp, ReachabilityOp,
 };
+use crate::schema::constraints_of;
 use crate::structured::{self, ErrorCategory, Outcome, TargetCreated};
 use crate::ttd;
 use crate::walk;
@@ -2543,7 +2543,7 @@ impl WindbgServer {
             idempotent_hint = false,
             open_world_hint = true
         ),
-        output_schema = schema_for_output::<structured::OpenOutcome>()
+        output_schema = constraints_of::<structured::OpenOutcome>()
     )]
     async fn open_dump(
         &self,
@@ -2568,7 +2568,7 @@ impl WindbgServer {
             idempotent_hint = false,
             open_world_hint = true
         ),
-        output_schema = schema_for_output::<structured::OpenOutcome>()
+        output_schema = constraints_of::<structured::OpenOutcome>()
     )]
     async fn open_trace(
         &self,
@@ -2593,7 +2593,7 @@ impl WindbgServer {
             idempotent_hint = false,
             open_world_hint = true
         ),
-        output_schema = schema_for_output::<structured::OpenOutcome>()
+        output_schema = constraints_of::<structured::OpenOutcome>()
     )]
     async fn attach_kernel_local(&self) -> Result<CallToolResult, ErrorData> {
         self.opened(
@@ -2626,7 +2626,7 @@ impl WindbgServer {
             idempotent_hint = false,
             open_world_hint = true
         ),
-        output_schema = schema_for_output::<structured::OpenOutcome>()
+        output_schema = constraints_of::<structured::OpenOutcome>()
     )]
     async fn attach_kernel(
         &self,
@@ -2699,7 +2699,7 @@ impl WindbgServer {
             idempotent_hint = true,
             open_world_hint = true
         ),
-        output_schema = schema_for_output::<Outcome<structured::PoolTagMatches>>()
+        output_schema = constraints_of::<Outcome<structured::PoolTagMatches>>()
     )]
     async fn pool_find_tag(
         &self,
@@ -2739,7 +2739,7 @@ impl WindbgServer {
             idempotent_hint = true,
             open_world_hint = true
         ),
-        output_schema = schema_for_output::<Outcome<structured::PoolChunkAt>>()
+        output_schema = constraints_of::<Outcome<structured::PoolChunkAt>>()
     )]
     async fn pool_chunk(
         &self,
@@ -2776,7 +2776,7 @@ impl WindbgServer {
             idempotent_hint = true,
             open_world_hint = true
         ),
-        output_schema = schema_for_output::<Outcome<structured::PoolDiagnosticsReport>>()
+        output_schema = constraints_of::<Outcome<structured::PoolDiagnosticsReport>>()
     )]
     async fn pool_diagnostics(
         &self,
@@ -2804,7 +2804,7 @@ impl WindbgServer {
             idempotent_hint = true,
             open_world_hint = true
         ),
-        output_schema = schema_for_output::<Outcome<structured::PoolCensus>>()
+        output_schema = constraints_of::<Outcome<structured::PoolCensus>>()
     )]
     async fn pool_census(
         &self,
@@ -2831,7 +2831,7 @@ impl WindbgServer {
             idempotent_hint = true,
             open_world_hint = true
         ),
-        output_schema = schema_for_output::<Outcome<structured::HeapListResult>>()
+        output_schema = constraints_of::<Outcome<structured::HeapListResult>>()
     )]
     async fn heap_list(
         &self,
@@ -2857,7 +2857,7 @@ impl WindbgServer {
             idempotent_hint = true,
             open_world_hint = true
         ),
-        output_schema = schema_for_output::<Outcome<structured::HeapAllocationsResult>>()
+        output_schema = constraints_of::<Outcome<structured::HeapAllocationsResult>>()
     )]
     async fn heap_allocations(
         &self,
@@ -2915,7 +2915,7 @@ impl WindbgServer {
             idempotent_hint = true,
             open_world_hint = true
         ),
-        output_schema = schema_for_output::<Outcome<structured::HeapChunkResult>>()
+        output_schema = constraints_of::<Outcome<structured::HeapChunkResult>>()
     )]
     async fn heap_chunk(
         &self,
@@ -2941,7 +2941,7 @@ impl WindbgServer {
             idempotent_hint = true,
             open_world_hint = true
         ),
-        output_schema = schema_for_output::<Outcome<structured::HeapCensusResult>>()
+        output_schema = constraints_of::<Outcome<structured::HeapCensusResult>>()
     )]
     async fn heap_census(
         &self,
@@ -2967,7 +2967,7 @@ impl WindbgServer {
             idempotent_hint = true,
             open_world_hint = true
         ),
-        output_schema = schema_for_output::<Outcome<structured::HeapDiagnosticsResult>>()
+        output_schema = constraints_of::<Outcome<structured::HeapDiagnosticsResult>>()
     )]
     async fn heap_diagnostics(
         &self,
@@ -3029,7 +3029,7 @@ impl WindbgServer {
             idempotent_hint = true,
             open_world_hint = true
         ),
-        output_schema = schema_for_output::<Outcome<structured::CrashTriage>>()
+        output_schema = constraints_of::<Outcome<structured::CrashTriage>>()
     )]
     async fn crash_triage(
         &self,
@@ -3063,7 +3063,7 @@ impl WindbgServer {
             idempotent_hint = false,
             open_world_hint = true
         ),
-        output_schema = schema_for_output::<structured::OpenOutcome>()
+        output_schema = constraints_of::<structured::OpenOutcome>()
     )]
     async fn attach_process(
         &self,
@@ -3088,7 +3088,7 @@ impl WindbgServer {
             idempotent_hint = false,
             open_world_hint = true
         ),
-        output_schema = schema_for_output::<structured::OpenOutcome>()
+        output_schema = constraints_of::<structured::OpenOutcome>()
     )]
     async fn launch(
         &self,
@@ -3125,7 +3125,7 @@ impl WindbgServer {
             read_only_hint = true,
             open_world_hint = false
         ),
-        output_schema = schema_for_output::<Outcome<structured::SessionsReport>>()
+        output_schema = constraints_of::<Outcome<structured::SessionsReport>>()
     )]
     async fn session_status(
         &self,
@@ -3202,7 +3202,7 @@ impl WindbgServer {
             read_only_hint = true,
             open_world_hint = false
         ),
-        output_schema = schema_for_output::<Outcome<structured::LogReport>>()
+        output_schema = constraints_of::<Outcome<structured::LogReport>>()
     )]
     async fn server_log(
         &self,
@@ -3309,7 +3309,7 @@ impl WindbgServer {
             idempotent_hint = true,
             open_world_hint = true
         ),
-        output_schema = schema_for_output::<Outcome<structured::SessionEnded>>()
+        output_schema = constraints_of::<Outcome<structured::SessionEnded>>()
     )]
     async fn end_session(
         &self,
@@ -3383,7 +3383,7 @@ impl WindbgServer {
             idempotent_hint = false,
             open_world_hint = true
         ),
-        output_schema = schema_for_output::<Outcome<structured::BatchReportInfo>>()
+        output_schema = constraints_of::<Outcome<structured::BatchReportInfo>>()
     )]
     async fn debug_batch(
         &self,
@@ -3436,7 +3436,7 @@ impl WindbgServer {
             read_only_hint = true,
             open_world_hint = true
         ),
-        output_schema = schema_for_output::<Outcome<structured::RegisterSet>>()
+        output_schema = constraints_of::<Outcome<structured::RegisterSet>>()
     )]
     async fn registers(
         &self,
@@ -3515,7 +3515,7 @@ impl WindbgServer {
             idempotent_hint = true,
             open_world_hint = true
         ),
-        output_schema = schema_for_output::<Outcome<structured::MemoryWalk>>()
+        output_schema = constraints_of::<Outcome<structured::MemoryWalk>>()
     )]
     async fn walk_memory(
         &self,
@@ -3561,7 +3561,7 @@ impl WindbgServer {
             read_only_hint = true,
             open_world_hint = true
         ),
-        output_schema = schema_for_output::<Outcome<structured::StackTrace>>()
+        output_schema = constraints_of::<Outcome<structured::StackTrace>>()
     )]
     async fn backtrace(
         &self,
@@ -3596,7 +3596,7 @@ impl WindbgServer {
             read_only_hint = true,
             open_world_hint = true
         ),
-        output_schema = schema_for_output::<Outcome<structured::ModuleList>>()
+        output_schema = constraints_of::<Outcome<structured::ModuleList>>()
     )]
     async fn modules(
         &self,
@@ -3668,7 +3668,7 @@ impl WindbgServer {
             read_only_hint = true,
             open_world_hint = true
         ),
-        output_schema = schema_for_output::<Outcome<structured::Disassembly>>()
+        output_schema = constraints_of::<Outcome<structured::Disassembly>>()
     )]
     async fn disassemble(
         &self,
@@ -3840,7 +3840,7 @@ impl WindbgServer {
             idempotent_hint = false,
             open_world_hint = true
         ),
-        output_schema = schema_for_output::<Outcome<structured::BreakpointSet>>()
+        output_schema = constraints_of::<Outcome<structured::BreakpointSet>>()
     )]
     async fn set_breakpoint(
         &self,
@@ -3869,7 +3869,7 @@ impl WindbgServer {
             idempotent_hint = false,
             open_world_hint = true
         ),
-        output_schema = schema_for_output::<Outcome<structured::StopReport>>()
+        output_schema = constraints_of::<Outcome<structured::StopReport>>()
     )]
     async fn go(
         &self,
@@ -3901,7 +3901,7 @@ impl WindbgServer {
             idempotent_hint = false,
             open_world_hint = true
         ),
-        output_schema = schema_for_output::<Outcome<structured::RunToReport>>()
+        output_schema = constraints_of::<Outcome<structured::RunToReport>>()
     )]
     async fn run_to_address(
         &self,
@@ -3931,7 +3931,7 @@ impl WindbgServer {
             idempotent_hint = false,
             open_world_hint = true
         ),
-        output_schema = schema_for_output::<Outcome<structured::StopReport>>()
+        output_schema = constraints_of::<Outcome<structured::StopReport>>()
     )]
     async fn step_over(
         &self,
@@ -3958,7 +3958,7 @@ impl WindbgServer {
             idempotent_hint = false,
             open_world_hint = true
         ),
-        output_schema = schema_for_output::<Outcome<structured::StopReport>>()
+        output_schema = constraints_of::<Outcome<structured::StopReport>>()
     )]
     async fn step_into(
         &self,
@@ -3987,7 +3987,7 @@ impl WindbgServer {
             idempotent_hint = false,
             open_world_hint = true
         ),
-        output_schema = schema_for_output::<Outcome<structured::StopReport>>()
+        output_schema = constraints_of::<Outcome<structured::StopReport>>()
     )]
     async fn step_back(
         &self,
@@ -4014,7 +4014,7 @@ impl WindbgServer {
             idempotent_hint = false,
             open_world_hint = true
         ),
-        output_schema = schema_for_output::<Outcome<structured::StopReport>>()
+        output_schema = constraints_of::<Outcome<structured::StopReport>>()
     )]
     async fn step_over_back(
         &self,
@@ -4041,7 +4041,7 @@ impl WindbgServer {
             idempotent_hint = false,
             open_world_hint = true
         ),
-        output_schema = schema_for_output::<Outcome<structured::StopReport>>()
+        output_schema = constraints_of::<Outcome<structured::StopReport>>()
     )]
     async fn reverse_go(
         &self,

--- a/src/structured.rs
+++ b/src/structured.rs
@@ -12,6 +12,12 @@
 //! describing it. The text is unchanged, deliberately — this adds a channel rather than
 //! replacing one.
 //!
+//! **The doc comments below do not reach that schema**, and are not meant to: `schemars` inlines
+//! every type into the `$defs` of every tool that can reach it, so one paragraph here was shipping
+//! thirty-three times to a field no model is given and no validator reads. [`crate::schema`] takes
+//! them out and says why. Write them for whoever edits this file; `README.md`'s
+//! structured-results table is where a caller reads the same facts.
+//!
 //! # Where the values come from
 //!
 //! Nothing here is parsed out of debugger output. Each type is built from a value: win-kexp's

--- a/tests/golden/tool_budget.json
+++ b/tests/golden/tool_budget.json
@@ -6,8 +6,8 @@
       "inputSchema": 904,
       "modelVisible": 2001,
       "name": "attach_kernel",
-      "outputSchema": 13323,
-      "wire": 15478
+      "outputSchema": 3838,
+      "wire": 5993
     },
     {
       "annotations": 122,
@@ -15,8 +15,8 @@
       "inputSchema": 33,
       "modelVisible": 330,
       "name": "attach_kernel_local",
-      "outputSchema": 13323,
-      "wire": 13806
+      "outputSchema": 3838,
+      "wire": 4321
     },
     {
       "annotations": 117,
@@ -24,8 +24,8 @@
       "inputSchema": 204,
       "modelVisible": 499,
       "name": "attach_process",
-      "outputSchema": 13323,
-      "wire": 13970
+      "outputSchema": 3838,
+      "wire": 4485
     },
     {
       "annotations": 68,
@@ -33,8 +33,8 @@
       "inputSchema": 463,
       "modelVisible": 1123,
       "name": "backtrace",
-      "outputSchema": 7733,
-      "wire": 8955
+      "outputSchema": 1501,
+      "wire": 2723
     },
     {
       "annotations": 117,
@@ -42,8 +42,8 @@
       "inputSchema": 1308,
       "modelVisible": 2912,
       "name": "crash_triage",
-      "outputSchema": 13663,
-      "wire": 16723
+      "outputSchema": 2511,
+      "wire": 5571
     },
     {
       "annotations": 134,
@@ -51,8 +51,8 @@
       "inputSchema": 7980,
       "modelVisible": 9746,
       "name": "debug_batch",
-      "outputSchema": 9458,
-      "wire": 19369
+      "outputSchema": 2904,
+      "wire": 12815
     },
     {
       "annotations": 79,
@@ -78,8 +78,8 @@
       "inputSchema": 629,
       "modelVisible": 1471,
       "name": "disassemble",
-      "outputSchema": 7136,
-      "wire": 8702
+      "outputSchema": 1478,
+      "wire": 3044
     },
     {
       "annotations": 74,
@@ -105,8 +105,8 @@
       "inputSchema": 314,
       "modelVisible": 1081,
       "name": "end_session",
-      "outputSchema": 4216,
-      "wire": 5444
+      "outputSchema": 1242,
+      "wire": 2470
     },
     {
       "annotations": 124,
@@ -123,8 +123,8 @@
       "inputSchema": 314,
       "modelVisible": 440,
       "name": "go",
-      "outputSchema": 4418,
-      "wire": 5007
+      "outputSchema": 1185,
+      "wire": 1774
     },
     {
       "annotations": 118,
@@ -141,8 +141,8 @@
       "inputSchema": 1153,
       "modelVisible": 1430,
       "name": "heap_allocations",
-      "outputSchema": 12627,
-      "wire": 14216
+      "outputSchema": 5449,
+      "wire": 7038
     },
     {
       "annotations": 124,
@@ -150,8 +150,8 @@
       "inputSchema": 618,
       "modelVisible": 864,
       "name": "heap_census",
-      "outputSchema": 12461,
-      "wire": 13480
+      "outputSchema": 5283,
+      "wire": 6302
     },
     {
       "annotations": 126,
@@ -159,8 +159,8 @@
       "inputSchema": 493,
       "modelVisible": 900,
       "name": "heap_chunk",
-      "outputSchema": 13342,
-      "wire": 14399
+      "outputSchema": 5639,
+      "wire": 6696
     },
     {
       "annotations": 130,
@@ -168,8 +168,8 @@
       "inputSchema": 762,
       "modelVisible": 1078,
       "name": "heap_diagnostics",
-      "outputSchema": 12568,
-      "wire": 13807
+      "outputSchema": 5115,
+      "wire": 6354
     },
     {
       "annotations": 119,
@@ -177,8 +177,8 @@
       "inputSchema": 465,
       "modelVisible": 821,
       "name": "heap_list",
-      "outputSchema": 12157,
-      "wire": 13128
+      "outputSchema": 4979,
+      "wire": 5950
     },
     {
       "annotations": 120,
@@ -222,8 +222,8 @@
       "inputSchema": 229,
       "modelVisible": 542,
       "name": "launch",
-      "outputSchema": 13323,
-      "wire": 14025
+      "outputSchema": 3838,
+      "wire": 4540
     },
     {
       "annotations": 65,
@@ -231,8 +231,8 @@
       "inputSchema": 1640,
       "modelVisible": 2411,
       "name": "modules",
-      "outputSchema": 12008,
-      "wire": 14515
+      "outputSchema": 3223,
+      "wire": 5730
     },
     {
       "annotations": 128,
@@ -240,8 +240,8 @@
       "inputSchema": 211,
       "modelVisible": 712,
       "name": "open_dump",
-      "outputSchema": 13323,
-      "wire": 14194
+      "outputSchema": 3838,
+      "wire": 4709
     },
     {
       "annotations": 114,
@@ -249,8 +249,8 @@
       "inputSchema": 211,
       "modelVisible": 534,
       "name": "open_trace",
-      "outputSchema": 13323,
-      "wire": 14002
+      "outputSchema": 3838,
+      "wire": 4517
     },
     {
       "annotations": 123,
@@ -258,8 +258,8 @@
       "inputSchema": 602,
       "modelVisible": 1025,
       "name": "pool_census",
-      "outputSchema": 12863,
-      "wire": 14042
+      "outputSchema": 4679,
+      "wire": 5858
     },
     {
       "annotations": 129,
@@ -267,8 +267,8 @@
       "inputSchema": 760,
       "modelVisible": 1752,
       "name": "pool_chunk",
-      "outputSchema": 14288,
-      "wire": 16200
+      "outputSchema": 5447,
+      "wire": 7359
     },
     {
       "annotations": 127,
@@ -276,8 +276,8 @@
       "inputSchema": 831,
       "modelVisible": 1983,
       "name": "pool_diagnostics",
-      "outputSchema": 12945,
-      "wire": 15086
+      "outputSchema": 4616,
+      "wire": 6757
     },
     {
       "annotations": 122,
@@ -285,8 +285,8 @@
       "inputSchema": 1420,
       "modelVisible": 1985,
       "name": "pool_find_tag",
-      "outputSchema": 14554,
-      "wire": 16692
+      "outputSchema": 5499,
+      "wire": 7637
     },
     {
       "annotations": 90,
@@ -321,8 +321,8 @@
       "inputSchema": 630,
       "modelVisible": 1008,
       "name": "registers",
-      "outputSchema": 6683,
-      "wire": 7789
+      "outputSchema": 2097,
+      "wire": 3203
     },
     {
       "annotations": 123,
@@ -330,8 +330,8 @@
       "inputSchema": 314,
       "modelVisible": 451,
       "name": "reverse_go",
-      "outputSchema": 4418,
-      "wire": 5023
+      "outputSchema": 1185,
+      "wire": 1790
     },
     {
       "annotations": 114,
@@ -339,8 +339,8 @@
       "inputSchema": 791,
       "modelVisible": 1306,
       "name": "run_to_address",
-      "outputSchema": 4520,
-      "wire": 5971
+      "outputSchema": 1406,
+      "wire": 2857
     },
     {
       "annotations": 75,
@@ -348,8 +348,8 @@
       "inputSchema": 1608,
       "modelVisible": 2599,
       "name": "server_log",
-      "outputSchema": 6153,
-      "wire": 8858
+      "outputSchema": 1820,
+      "wire": 4525
     },
     {
       "annotations": 73,
@@ -357,8 +357,8 @@
       "inputSchema": 314,
       "modelVisible": 1389,
       "name": "session_status",
-      "outputSchema": 7201,
-      "wire": 8694
+      "outputSchema": 2726,
+      "wire": 4219
     },
     {
       "annotations": 115,
@@ -366,8 +366,8 @@
       "inputSchema": 467,
       "modelVisible": 852,
       "name": "set_breakpoint",
-      "outputSchema": 6777,
-      "wire": 7775
+      "outputSchema": 2236,
+      "wire": 3234
     },
     {
       "annotations": 123,
@@ -384,8 +384,8 @@
       "inputSchema": 314,
       "modelVisible": 440,
       "name": "step_back",
-      "outputSchema": 4418,
-      "wire": 5005
+      "outputSchema": 1185,
+      "wire": 1772
     },
     {
       "annotations": 109,
@@ -393,8 +393,8 @@
       "inputSchema": 314,
       "modelVisible": 398,
       "name": "step_into",
-      "outputSchema": 4418,
-      "wire": 4956
+      "outputSchema": 1185,
+      "wire": 1723
     },
     {
       "annotations": 109,
@@ -402,8 +402,8 @@
       "inputSchema": 314,
       "modelVisible": 410,
       "name": "step_over",
-      "outputSchema": 4418,
-      "wire": 4968
+      "outputSchema": 1185,
+      "wire": 1735
     },
     {
       "annotations": 121,
@@ -411,8 +411,8 @@
       "inputSchema": 314,
       "modelVisible": 443,
       "name": "step_over_back",
-      "outputSchema": 4418,
-      "wire": 5013
+      "outputSchema": 1185,
+      "wire": 1780
     },
     {
       "annotations": 65,
@@ -456,8 +456,8 @@
       "inputSchema": 2713,
       "modelVisible": 4076,
       "name": "walk_memory",
-      "outputSchema": 10566,
-      "wire": 14798
+      "outputSchema": 2954,
+      "wire": 7186
     }
   ],
   "totals": {
@@ -466,10 +466,10 @@
     "inputSchema": 40207,
     "instructions": 1990,
     "modelVisible": 67658,
-    "outputSchema": 320365,
-    "payload": 394883,
+    "outputSchema": 102942,
+    "payload": 177460,
     "tools": 51,
-    "wire": 394765,
+    "wire": 177342,
     "worstTool": "debug_batch",
     "worstToolModelVisible": 9746
   }

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -1377,10 +1377,11 @@ fn json_bytes(value: &Value) -> usize {
 /// `outputSchema` and `annotations` are not in it: the Anthropic tool spec carries name,
 /// description and input schema, and the rest of a `tools/list` entry is the client's own
 /// business — validation, display — never spent on a context window. That split is why this
-/// report has two totals instead of one, and it is not a detail: ~80% of what this server puts on
+/// report has two totals instead of one, and it is not a detail: ~58% of what this server puts on
 /// the wire is `outputSchema`, and none of it is read by a model. Optimising the two halves means
 /// optimising for different things, so conflating them would point any future work at the wrong
-/// 280 KB.
+/// 100 KB — and the split is what let finding 1 cut that figure from 280 KB without anybody having
+/// to argue about whether the model would miss it.
 fn model_visible_bytes(tool: &Value) -> usize {
     json_bytes(&json!({
         "name": tool["name"],
@@ -1462,20 +1463,24 @@ fn budget_report(result: &Value, instructions: &str) -> Value {
 const MODEL_VISIBLE_CEILING: usize = 76_000;
 
 /// Ceiling on the whole `tools/list` payload — the serialized result, not the sum of its tools, so
-/// the array's own punctuation and every result-level field are inside it. 391,172 bytes today,
-/// ~80% of that `outputSchema` no model reads, which is why this is a separate and much looser
+/// the array's own punctuation and every result-level field are inside it. 177,460 bytes today,
+/// 58% of that `outputSchema` no model reads, which is why this is a separate and much looser
 /// number rather than a scaled version of the one above.
 ///
 /// It is a client-side parse and memory cost, and it is the one that grows silently: `schemars`
-/// inlines `$defs` per tool, so adding one shared type to one more output shape can add tens of
-/// kilobytes here while [`MODEL_VISIBLE_CEILING`] does not move.
+/// inlines `$defs` per tool, so adding one shared type to one more output shape still lands here
+/// several times over while [`MODEL_VISIBLE_CEILING`] does not move.
 ///
-/// **Raised from 412,000 once**, when `PdbInfo` — one optional four-field type on `ModuleInfo` —
-/// cost 15,610 B of wire and nothing at all of model context, because `ModuleInfo` is embedded in
-/// half a dozen output shapes and each inlines its own copy. That is `FOLLOWUPS.md` item 24's
-/// first finding priced, and it is recorded in `docs/token-budget.md` rather than absorbed
-/// quietly: this number moving is the only warning that the duplication is compounding.
-const WIRE_CEILING: usize = 460_000;
+/// **The history is the point.** It was raised 412,000 → 460,000 once, when `PdbInfo` — one
+/// optional four-field type on `ModuleInfo` — cost 15,610 B of wire and nothing at all of model
+/// context, because `ModuleInfo` is embedded in half a dozen output shapes and each inlined its
+/// own copy. Then it came down to 205,000, because `src/schema.rs` stopped putting `description`
+/// in an output schema at all: 68% of every one of those bytes was rustdoc prose that no model is
+/// given and no validator reads, and dropping it took the payload 394,883 → 177,460. The
+/// multiplier is unchanged — the next shared type is still inlined everywhere it can be reached —
+/// but what is multiplied is a handful of keywords rather than a paragraph, which is `FOLLOWUPS.md`
+/// item 24's first finding done rather than priced.
+const WIRE_CEILING: usize = 205_000;
 
 /// Ceiling on any single tool's model-visible definition. `debug_batch` is the worst at 9,757
 /// bytes, because its `inputSchema` pulls the whole `StepAction`/`Check` vocabulary from
@@ -1536,7 +1541,8 @@ fn tool_surface_stays_within_its_token_budget() {
         "the tools/list payload is now {payload} B, over its {WIRE_CEILING} B ceiling ({} B of \
          that is the tools themselves, the rest result-level fields). This is mostly \
          outputSchema, which no model reads — check whether a shared type just got inlined into \
-         another tool's $defs before raising the ceiling.",
+         another tool's $defs, or whether a tool declared its schema with rmcp's \
+         `schema_for_output` instead of `schema::constraints_of`, before raising the ceiling.",
         totals["wire"],
     );
     assert!(
@@ -1612,6 +1618,86 @@ fn tool_schemas_declare_one_dialect_and_are_self_contained() {
              `{other_tool}` declares {other}"
         );
     }
+}
+
+/// An `outputSchema` carries constraints; the prose stays in the source and the README.
+///
+/// 68% of every `outputSchema` byte this server emitted was a `description` — 217,423 B of
+/// 320,365 B, and 55% of the whole `tools/list` answer — because `schemars` inlines each type into
+/// the `$defs` of every tool that can reach it, so `ErrorCategory`'s doc comment shipped 33 times.
+/// None of it had a reader: no model is given an output schema (the measurement
+/// `docs/token-budget.md` opens with), and `description` is an annotation keyword, so a validator
+/// ignores it. `src/schema.rs` removes them; this is the assertion that they stay removed, because
+/// the change is one import line away from being undone and nothing else would report it.
+///
+/// The **input** schemas are checked in the same pass, as a positive control. They are the half a
+/// model does read, their descriptions are load-bearing, and a strip that reached them would be a
+/// silent regression in how well this server can be driven — not a size win.
+#[test]
+fn output_schemas_carry_constraints_not_prose() {
+    /// Counts `description` **keywords**, which is not the same as `description` keys: the members
+    /// of `properties` and `$defs` are named by the type being described, so a field called
+    /// `description` is a name in that position and not documentation. Kept separate from
+    /// `src/schema.rs`'s own walk on purpose, and **deliberately the blunter of the two**: that one
+    /// descends only where a JSON Schema keyword says a subschema lives, this one descends into
+    /// everything. So a keyword it does not know about is a keyword whose prose survives the strip
+    /// and fails here — which is the direction the pair has to fail in.
+    fn prose(node: &Value, names_not_keywords: bool, found: &mut usize) {
+        const NAME_MAPS: &[&str] = &["properties", "patternProperties", "$defs", "definitions"];
+        match node {
+            Value::Object(members) => {
+                for (key, value) in members {
+                    let keyword = !names_not_keywords;
+                    if keyword && key == "description" {
+                        *found += 1;
+                    }
+                    prose(value, keyword && NAME_MAPS.contains(&key.as_str()), found);
+                }
+            }
+            Value::Array(items) => items.iter().for_each(|item| prose(item, false, found)),
+            _ => {}
+        }
+    }
+
+    let mut server = Server::started();
+    let response = server.request("tools/list", json!({}), STEP);
+    let tools = response["result"]["tools"]
+        .as_array()
+        .expect("tools/list returns an array")
+        .clone();
+
+    let mut with_schema = 0;
+    let mut input_prose = 0;
+    for tool in &tools {
+        let name = tool["name"].as_str().unwrap_or("<unnamed>");
+
+        if let Some(schema) = tool.get("outputSchema").filter(|s| !s.is_null()) {
+            with_schema += 1;
+            let mut found = 0;
+            prose(schema, false, &mut found);
+            assert_eq!(
+                found, 0,
+                "`{name}`'s outputSchema carries {found} description(s). No model reads an \
+                 output schema and no validator reads a description, and every type in it is \
+                 inlined into every other tool that can reach it — so each one is paid for once \
+                 per tool. Declare it with `schema::constraints_of`, not rmcp's \
+                 `schema_for_output`."
+            );
+        }
+
+        prose(&tool["inputSchema"], false, &mut input_prose);
+    }
+
+    assert!(
+        with_schema > 20,
+        "only {with_schema} tools declare an output schema — this test has stopped covering the \
+         surface it is about"
+    );
+    assert!(
+        input_prose > 100,
+        "input schemas carry only {input_prose} descriptions: the strip has reached the half a \
+         model actually reads"
+    );
 }
 
 /// A tool that declares an `outputSchema` must return `structuredContent` — on **both** paths.


### PR DESCRIPTION
`FOLLOWUPS.md` item 24's first finding. The whole `tools/list` payload goes **394,883 B → 177,460 B, a 55% cut**, and what a model reads does not move by a byte.

| | before | after |
|---|---:|---:|
| `tools/list` payload | 394,883 | **177,460** |
| — `outputSchema` (33 tools) | 320,365 | 102,942 |
| — model-visible (`name`+`description`+`inputSchema`) | 67,658 | **67,658** |
| `WIRE_CEILING` | 460,000 | 205,000 |

## The duplication is real and cannot be removed

`schemars` emits each output schema self-contained, so every type reachable from a tool's answer is inlined into that tool's `$defs`: `ErrorCategory` shipped **33 times**, `ModuleInfo` seven, the allocator/pool subtree nine — **222,579 B, 69% of all `outputSchema`**, duplicated beyond its first copy.

Neither lever the finding named works.

- **"A `list_tools` that emits shared definitions."** MCP gives each tool one `outputSchema` and no document above it, and `#/$defs/…` resolves against the schema it appears in. There is nowhere to put a shared definition and no client that would look one up.
- **"`output_schema = schema_for_output::<T>()` on each `#[rmcp::tool]`."** That was already on all 33 tools. It names the type, not where the type is written.

So the multiplier is the protocol's and it stays. What can change is **what gets multiplied**.

## 68% of every output schema was prose

Measured on the payload rather than read off the source: **217,423 B of 320,365 B were `description` strings.** `ErrorCategory` is 2,089 B with its doc comment and **324 B** without.

Nothing reads it in that position:

- **No model is given an output schema** — the measurement `docs/token-budget.md` opens with, taken against a real client. A tool definition reaches a model as name, description and *input* schema.
- **No validator reads it either.** `description` is an annotation keyword in JSON Schema; it constrains nothing, so every instance that validated before validates now.
- **A human has three better copies** — the rustdoc these strings are generated from, `README.md`'s structured-results table, and the tool's own model-visible `description`.

The prose is not lost. It is charged for where it is read.

## The one way this could have broken quietly

The strip is **structural, not textual**. A field named `description` renders as `properties: { "description": … }`, and dropping every `"description"` key would delete the field rather than its documentation. `src/schema.rs` descends only where a JSON Schema keyword says a subschema lives, and has a unit test for exactly that case — no structured type has such a field today, which is precisely why nothing would have reported it.

## Two guards, because one import line undoes this

- **`output_schemas_carry_constraints_not_prose`** reads `tools/list` off the wire and is deliberately the *blunter* of the two walks: `src/schema.rs` descends only into known keyword positions, this one descends into everything. So a keyword the strip does not know about is prose that survives it and fails here — the direction the pair has to fail in. It also checks the input schemas still carry their descriptions, as a positive control: a strip that reached the half a model reads would be a correctness regression, not a size win.
- **`WIRE_CEILING` comes down** 460,000 → 205,000. It was raised 412,000 → 460,000 for `PdbInfo` (15,610 B of wire for 0 B of context — finding 1 priced, in one change). A ceiling left where a fix found it would absorb the next regression in silence.

## What this does *not* do

The same answer does not transfer to the input schemas, which is the rest of item 24 — `debug_batch` 9,746 B, `walk_memory` 4,076, `crash_triage` 2,912, `reachable_from_dispatch` 2,628, `server_log` 2,599, a third of the model-visible surface. There the prose is most of what tells a model how to drive the tool, and `debug_batch` is the one where getting that wrong leaves a patched byte in a running kernel. Both `FOLLOWUPS.md` and `docs/token-budget.md` now say so where the bullet is.

## Verification

On the ARM64 bench: `cargo fmt --all --check` and `cargo clippy --all-targets -- -D warnings` clean, **508 unit + 71 smoke** pass, and the debugger tier (`WINDBG_MCP_SMOKE_DUMP=1`) green in 53.4s with no `SKIPPED` lines.

Goldens re-recorded and read rather than rubber-stamped: `tests/golden/tools_list.json` (the *shape* golden) is byte-identical — no dialect, discriminator or `$ref` moved — and in `tool_budget.json` the only fields that changed are `outputSchema` and `wire`. `modelVisible`, `description`, `inputSchema` and `annotations` are untouched on all 51 rows.

The payload was also re-measured at every supported revision, since the budget test's `payload` figure includes result-level fields: 177,460 on `2026-07-28` and 177,404 on the four older ones, the same 56-byte gap as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
