### PR TITLE
Serve a surface per client, not per server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,9 +34,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and revokes none. A `--tools` beside `--rotate-` or `--remove-listen-client` is refused rather
   than ignored, because it reads exactly like a command that had narrowed that client.
 
-  **A surface change reaches a client on its next connection**, and nothing announces one. The
-  surface is fixed where the caller is identified — `initialize` for a client holding an MCP
-  session, every request for one on `2026-07-28` — and no `notifications/tools/list_changed` is
+  **A surface change reaches a client the next time it is identified**, and nothing announces one.
+  The surface is fixed at that moment — `initialize` for a client holding an MCP session, every
+  request for one on `2026-07-28`, which therefore picks the change up with nothing done to it —
+  and no `notifications/tools/list_changed` is
   sent: this server keeps no handle to notify a session through, and the sessionless revision has
   no session to notify, so it would be a guarantee on one revision and silence on the other. The
   command that changes a surface says so.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **A tool surface per client, not just per server** (`FOLLOWUPS.md` item 36, which closes it). A
+  `--listen` server names its clients already, and they do not have one budget between them: the
+  arrangement this listener exists for is a local model that can hold twenty tools beside a hosted
+  client that can hold fifty-one, on the same box and against the same debug sessions. So a client
+  may be configured with a `--tools` spec of its own — `WINDBG_MCP_TOOLS_<NAME>` beside its token,
+  or a `tools` field in the credential file — and two credentials on one port get two `tools/list`
+  answers.
+
+  **The run's `--tools` is the default rather than a ceiling.** A client with no spec of its own is
+  served whatever the run serves; a client with one is served that instead, wider or narrower,
+  because an intersection would produce a surface neither the operator nor the client ever named.
+  `session` is added to a client's spec exactly as it is to a run's.
+
+  The credential file's entries may now be objects — `{"bench": {"token": "…", "tools": "crash"}}` —
+  beside the bare tokens they always were, which keep meaning what they meant. A spec naming a
+  client nothing configures a token for is **refused at startup**, on the precedent of the two
+  collisions that file already refuses: a surface no credential can reach is a setting that would
+  never take effect, and the way to write one is the typo that makes the two variables disagree.
+
+  **`--set-listen-client-tools <name> --tools <spec>`** changes a service-hosted listener's client
+  surface without a reinstall or a restart, the way item 34's three commands change a token; with
+  no `--tools` at all it puts the client back on the service's own surface. It mints no credential
+  and revokes none. A `--tools` beside `--rotate-` or `--remove-listen-client` is refused rather
+  than ignored, because it reads exactly like a command that had narrowed that client.
+
+  **A surface change reaches a client on its next connection**, and nothing announces one. The
+  surface is fixed where the caller is identified — `initialize` for a client holding an MCP
+  session, every request for one on `2026-07-28` — and no `notifications/tools/list_changed` is
+  sent: this server keeps no handle to notify a session through, and the sessionless revision has
+  no session to notify, so it would be a guarantee on one revision and silence on the other. The
+  command that changes a surface says so.
+
+  A tool that exists and is not served is still refused by name rather than as an unknown tool, and
+  the message now names **which** configuration to widen — the run's flag, or that client's own
+  entry — since the caller can see neither.
+
 - **`--tools` serves a named subset of the tool surface** (`FOLLOWUPS.md` item 24's last finding,
   which closes that item). All 51 tools cost a model **67,658 B — about 17k tokens — once per
   conversation, before it has asked anything**. `--tools session,inspect,crash` makes that 20 tools
@@ -30,10 +66,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   by name ("not on the surface this run advertises") rather than as an unknown tool, because the
   remedy is a flag on a command line the caller cannot see.
 
-  Server-wide: on the stdio command line, on a `--listen` one, or on `--install-service`, where it
-  is written into the command line the SCM stores and read back at every start - the only place an
-  install's choice survives to. Per-caller, on a listener whose clients are already named, is filed
-  as item 36.
+  On the stdio command line, on a `--listen` one, or on `--install-service`, where it is written
+  into the command line the SCM stores and read back at every start - the only place an install's
+  choice survives to. It was server-wide when it landed; the entry above makes it a run's default
+  that a named client may replace.
 
 - **A service-hosted listener's clients can be changed without a reinstall**
   (`FOLLOWUPS.md` item 34). `--add-listen-client <name>`, `--remove-listen-client <name>` and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -497,11 +497,17 @@ it — it starts a server with all eight group names and asserts that equals the
 There is no such thing as a tool in two groups, and a group named after a tool is refused by a unit
 test, because `Toolset::parse` resolves group names first and would decide it silently.
 
-Two rules worth knowing before touching it. **`session` is in every surface** whatever the spec
+Three rules worth knowing before touching it. **`session` is in every surface** whatever the spec
 says, because every other tool routes by a `session_id` this server alone issues — so `--tools
-crash` is eleven tools and 12,161 B is the floor. And **output schemas carry no prose at all**
+crash` is eleven tools and 12,161 B is the floor. **Output schemas carry no prose at all**
 (`src/schema.rs`): declare one with `schema::constraints_of`, never rmcp's `schema_for_output`, or
-the tool ships every doc comment in its `$defs` closure and the wire ceiling notices.
+the tool ships every doc comment in its `$defs` closure and the wire ceiling notices. And **a
+surface is per client, not per run** (item 36): `--tools` is the run's *default*, and a listener's
+client may be configured with a spec of its own (`WINDBG_MCP_TOOLS_<NAME>`, or a `tools` field in
+the credential file) that replaces it. So a change to a group is a change to what several
+differently-budgeted callers see, and the assertion that catches a per-client mistake is two
+credentials on one port — `two_clients_on_one_listener_are_served_two_surfaces`, not a unit test,
+for the reason the next section gives.
 
 ## Several clients on one listener (`src/client.rs`)
 
@@ -513,6 +519,13 @@ a service-hosted listener holds more than one, and `--install-service` copies ev
 variable in the shell rather than the unnamed one alone. Under stdio everything runs as `local`,
 so there is one set of rules and no transport exception. `docs/remote-listener.md` is the operator's
 half; what follows is what bites while editing.
+
+**A credential also carries a tool surface**, since item 36: `WINDBG_MCP_TOOLS_<NAME>` beside the
+token, or a `tools` field in a file entry that is then an object rather than a string. That
+follows the same precedence — a configured file is the whole configuration, so the variable is not
+read on a host that has one — for a reason that is not secrecy but arithmetic: one file answering
+who may connect and another answering what they get is two files to keep in step and a precedence
+rule to remember.
 
 **Identity is ambient inside a call, carried by the instance, and by name outside both.**
 `crate::client::current()` reads a task-local, which is why no tool signature carries a caller. What
@@ -528,6 +541,16 @@ the two-client smoke tier found it (`FOLLOWUPS.md` item 29): every call ran as t
 so both clients' sessions were owned by `local` and each could see, route to and end the other's,
 while every unit test passed — each sets the identity itself, and the tier ran one client, for whom
 `local` is the right answer.
+
+**The factory now decides a second thing on that line, with the same failure mode**: which tools
+this client is served (item 36). A client may carry a `Toolset` beside its name, so
+`credentials.surface_for(&client)` is read there and nowhere later — a surface resolved after the
+factory would be resolved for whichever task rmcp happened to serve the call from, which is exactly
+the bug above wearing a different hat. It is covered the only way that shape can be:
+`two_clients_on_one_listener_are_served_two_surfaces` puts two tokens on one port and asserts two
+different `tools/list` answers, on the session-bearing route and the stateless one. One client
+cannot state the claim — with one credential, "this client's spec" and "the run's spec" are the same
+answer.
 
 Anything running *outside* a call — the listener's own diagnostics, a sweep, a shutdown — gets the
 default `local` instead of an error, so it must take the client as a parameter

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -1472,7 +1472,7 @@ factory is the line that sets both. What the work actually was:
   keeps no peer handle to notify an MCP session through, and `2026-07-28` has no session to notify
   at all, so it would be a guarantee on one revision and silence on the other. A surface is instead
   fixed where the caller is identified — `initialize`, or every request on the stateless
-  revision — so a change reaches a client when it next connects, one sentence for both.
+  revision — so a change reaches a client the next time it is identified, one rule for both.
   `--set-listen-client-tools` says so where an operator reads it.
 
 **The run's flag became a default rather than a ceiling.** A client's own spec replaces it, wider or

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -833,8 +833,8 @@ landed on their own so that each of the items below can be argued, and measured,
   per half was the first thing tried here, and this repo had already argued it down one tool over.
 
 **This item is done.** Every bullet is fixed, measured-and-declined, or answered; what came out of
-it that is still open is one *new* item — a per-caller tool surface, item 36 — rather than anything
-left over here.
+it was one *new* item — a per-caller tool surface, item 36, itself since closed — rather than
+anything left over here.
 
 **Where this bites first is a local model**, whose window is bought in RAM rather than rented:
 [`docs/local-model.md`](./docs/local-model.md) is the runbook, and it names the three client-side
@@ -1440,7 +1440,7 @@ asserted against whatever architecture the host is
 - **What it is worth if reopened:** ~1.8 KB of a ~6.3 KB answer, on ARM64 only. Real, and smaller
   than the 6.3 KB item 24 already took off the same tool.
 
-## 36. [windbg-mcp] The tool surface is server-wide, not per caller
+## 36. [windbg-mcp] The tool surface is server-wide, not per caller — **done** (2026-08-22)
 
 `--tools` (item 24's last bullet) narrows what a run advertises, and it narrows it for *everybody*
 on that run. That is the right answer for stdio, which has one client by construction, and it is
@@ -1449,31 +1449,42 @@ listener was built for: a local model that can hold twenty tools and a hosted cl
 fifty-one, pointed at the same Windows box and the same debug sessions, told apart by their bearer
 tokens already.
 
-**What it would take.** The identity is already there — `client::Client`, one credential per client
-(`WINDBG_MCP_LISTEN_TOKEN_<NAME>`), captured in the listener's service factory and carried by the
-`WindbgServer` instance. `Toolset` is already an instance field beside it, and `listen.rs`'s factory
-is the single line that sets it. So the work is not plumbing, it is:
+**It was three lines of plumbing and three decisions**, which is what the item predicted: the
+identity was already there, `Toolset` was already an instance field beside it, and `listen.rs`'s
+factory is the line that sets both. What the work actually was:
 
-- **A per-client spec, from a source that already exists.** `WINDBG_MCP_TOOLS_<NAME>` beside the
-  token variable is the obvious spelling, which means it also belongs in the credential *file* the
-  service reads — and that file is the thing `--add-listen-client` writes, so a client's surface
-  becomes something an operator changes without a reinstall, the same way its token is.
-  `Credentials::from_entries` is where the parsing goes, and its two collision refusals are the
-  precedent for what to do with a spec naming a client that has no token.
-- **Two-client coverage**, which is the half that has bitten before. `FOLLOWUPS.md` item 29 was
-  filed as call-site coverage and its first assertion failed for real: every call ran as the default
-  `local`, because a task-local does not cross rmcp's `initialize` spawn. A per-client surface has
-  exactly that shape — right in every unit test, wrong on the wire — so the assertion that matters
-  is two clients on one listener seeing two different `tools/list` answers.
-- **A decision about `tools/list_changed`.** rmcp's router can notify, and a reload
-  (`--add-listen-client`, `--rotate-listen-client`) can now change a client's set while it is
-  connected. Whether a surface change is announced or only seen on reconnect is a real choice, and
-  the reload path is where it would go.
+- **A per-client spec, from the source that already existed.** `WINDBG_MCP_TOOLS_<NAME>` beside the
+  token variable, and a `tools` field in the credential file — where an entry may now be
+  `{"token": "…", "tools": "session,crash"}` as well as the bare token it always was.
+  `Credentials::build` parses it with the flag's own parser, so a spec the listener would refuse is
+  refused at startup rather than served as an empty tool list; `Toolset::parse_from` takes the
+  source's rendered name, because the vocabulary is written down in three places now and a refusal
+  that always said `--tools` would send an operator to a command line they never typed. A spec
+  naming a client with no token is refused on the precedent the item pointed at — the collision
+  refusals — since it is a setting that could never take effect.
 
-**Depends on** item 24's `--tools`, which is what defines a spec and a group. **Worth doing when**
-there is a second client with a different budget — the measurement that motivates it is in
-[`docs/local-model.md`](./docs/local-model.md), and until then one server-wide flag is the same
-thing with less to get wrong.
+- **Two-client coverage**, which is the half the item said had bitten before, and it is
+  `mcp_smoke::two_clients_on_one_listener_are_served_two_surfaces`: two tokens on one port, two
+  `tools/list` answers, on the session-bearing route *and* the stateless one. Protocol tier — a
+  tool list and a surface refusal need no target, and the tier's contract is that they must not.
 
-Picks up at [`src/toolset.rs`](./src/toolset.rs), `listen.rs`'s service factory, and
-[`src/client.rs`](./src/client.rs).
+- **`tools/list_changed` is not sent**, and that is the decision rather than a gap. This server
+  keeps no peer handle to notify an MCP session through, and `2026-07-28` has no session to notify
+  at all, so it would be a guarantee on one revision and silence on the other. A surface is instead
+  fixed where the caller is identified — `initialize`, or every request on the stateless
+  revision — so a change reaches a client when it next connects, one sentence for both.
+  `--set-listen-client-tools` says so where an operator reads it.
+
+**The run's flag became a default rather than a ceiling.** A client's own spec replaces it, wider or
+narrower: intersecting the two can produce a surface neither the operator nor the client ever named,
+and "which of these two is in force" is a question with an answer either way, while "what is the
+overlap of these two" is not one anybody would predict.
+
+**Two things the change had to correct rather than add.** The refusal for a tool off the surface
+told every caller to widen `--tools`, which is the wrong command for a client with an entry of its
+own — it now names whichever configuration chose the surface (`Toolset::refusal`, `Chosen`). And
+`--add-listen-client` printed "it gets the whole tool surface, as every client here does", which
+this makes false; it says what the client is actually served.
+
+Landed in [`src/toolset.rs`](./src/toolset.rs), [`src/client.rs`](./src/client.rs),
+[`src/listen.rs`](./src/listen.rs) and [`src/service.rs`](./src/service.rs).

--- a/README.md
+++ b/README.md
@@ -231,20 +231,22 @@ logout, starts at boot, and gets a defined `PATH` and working directory — whic
 whether the engine DLLs beside the exe are the ones that load. `Stop-Service` releases every debug
 target before exiting, because a live kernel that is merely killed is left frozen. Its clients are
 changed in place — `--add-listen-client`, `--remove-listen-client`, `--rotate-listen-client`, each
-generating the token itself, writing it beside the credential file and printing only a fingerprint —
-so adding or revoking one costs neither a reinstall nor the sessions the service is holding.
+generating the token itself, writing it beside the credential file and printing only a fingerprint,
+and `--set-listen-client-tools` for which tools one of them is served — so adding, revoking or
+re-toolling one costs neither a reinstall nor the sessions the service is holding.
 
 **Bind loopback and forward over SSH.** This endpoint runs `execute`, `debug_batch` and `launch`
 against a live kernel, and the token is sent in clear — a hypervisor's guest network is not private
 when the machine being debugged shares it. [`docs/remote-listener.md`](./docs/remote-listener.md)
-covers the tokens — **one per client**, each with its own sessions, so two people or two agents on
-one listener cannot reach each other's targets — the session lease and its grace, and the one thing
-a `409` means: this credential's own expired sessions are still being released, so ask again in a
-moment. Nothing else is refused for contention — a credential may hold several MCP sessions, and
-requests of one client never wait on another's. For a one-off, [`docs/remote-phase0.md`](./docs/remote-phase0.md) does the same
-job over plain `ssh` with no listener; for driving it from a **local model** rather than a hosted
-one, [`docs/local-model.md`](./docs/local-model.md) is the runbook and the numbers that decide
-whether it fits.
+covers the tokens — **one per client**, each with its own sessions and, where you want one, its own
+tool surface, so two people or two agents on one listener cannot reach each other's targets and need
+not share a budget — the session lease and its grace, and the one thing a `409` means: this
+credential's own expired sessions are still being released, so ask again in a moment. Nothing else
+is refused for contention — a credential may hold several MCP sessions, and requests of one client
+never wait on another's. For a one-off, [`docs/remote-phase0.md`](./docs/remote-phase0.md) does the
+same job over plain `ssh` with no listener; for driving it from a **local model** rather than a
+hosted one, [`docs/local-model.md`](./docs/local-model.md) is the runbook and the numbers that
+decide whether it fits.
 
 ### As a Claude Code plugin
 
@@ -396,9 +398,25 @@ Two things worth knowing:
   run advertises" — rather than as an unknown tool, because the remedy is a flag on a command line
   the caller cannot see.
 
-It is a **server-wide** choice: `--tools` on the stdio command line, on a `--listen` one, or on
-`--install-service` (where it is written into the command line the SCM stores, and read back at
-every start).
+`--tools` goes on the stdio command line, on a `--listen` one, or on `--install-service` (where it
+is written into the command line the SCM stores, and read back at every start). That is the
+**run's** surface, and under stdio it is the whole story: one process, one client.
+
+A `--listen` server names its clients, and **a client may be served a surface of its own** — which
+is what lets one listener hold a local model that can fit twenty tools beside a hosted client that
+can hold fifty-one, against the same debug sessions:
+
+```pwsh
+setx WINDBG_MCP_LISTEN_TOKEN_BENCH "<a long random string>"
+setx WINDBG_MCP_TOOLS_BENCH        "session,inspect,crash"
+```
+
+A client with no spec of its own is served the run's, so the flag above is a **default rather than
+a ceiling** — a client's own spec replaces it, wider or narrower. Under a Windows service the same
+thing lives in the credential file, and `--set-listen-client-tools <name> --tools <spec>` changes it
+without a reinstall or a restart. [`docs/remote-listener.md`](docs/remote-listener.md#a-tool-surface-per-client)
+is the operator's half, including when a change reaches a client (its next connection) and why
+nothing announces one.
 
 ### Sessions and session handles
 

--- a/README.md
+++ b/README.md
@@ -415,8 +415,8 @@ A client with no spec of its own is served the run's, so the flag above is a **d
 a ceiling** — a client's own spec replaces it, wider or narrower. Under a Windows service the same
 thing lives in the credential file, and `--set-listen-client-tools <name> --tools <spec>` changes it
 without a reinstall or a restart. [`docs/remote-listener.md`](docs/remote-listener.md#a-tool-surface-per-client)
-is the operator's half, including when a change reaches a client (its next connection) and why
-nothing announces one.
+is the operator's half, including when a change reaches a client (the next time it is identified —
+its next handshake, or its next request if it holds no session) and why nothing announces one.
 
 ### Sessions and session handles
 

--- a/docs/local-model.md
+++ b/docs/local-model.md
@@ -58,13 +58,17 @@ WINDBG_MCP_TOKEN="<the driver's token>" python3 tools/local_model_drive.py [task
 **A credential of its own is the requirement; a listener of its own is how to get one.** The script
 refuses to run on the token your editor is registered with, because a shared credential is a shared
 namespace: the run would see, route to, and at the four-session cap cause the reclamation of your
-targets. And a *service*-hosted listener cannot be given a second client without an uninstall and a
-reinstall, which drops every session it is holding ([`remote-listener.md`](./remote-listener.md#adding-or-rotating-a-client-afterwards-costs-a-reinstall)).
-Neither of those is a thing to do for a measurement.
+targets. A surface of its own is *not* the reason — `WINDBG_MCP_TOOLS_<NAME>` gives one client a
+smaller surface on a listener it shares, so the budget alone no longer argues for a second process.
 
-A foreground listener on a second port costs nothing and disappears when you close it. Generate the
-token on the machine that will *use* it, and pass it over **stdin** — never on a command line, where
-every process on the box can read it:
+A foreground listener on a second port costs nothing and disappears when you close it, which is
+still the right shape for a bench: no privileged write, nothing to clean up, and a build that is
+not the installed one. (A service-hosted listener can be given a client without a reinstall these
+days — `--add-listen-client` — so that is an option rather than the obstacle it was; see
+[`remote-listener.md`](./remote-listener.md#adding-revoking-rotating-and-re-toolling-a-client-without-stopping-anything).)
+
+Generate the token on the machine that will *use* it, and pass it over **stdin** — never on a
+command line, where every process on the box can read it:
 
 ```pwsh
 # on the debug host, from a script run over ssh with the token on stdin:
@@ -97,13 +101,19 @@ uses:
 
 ```console
 setx WINDBG_MCP_LISTEN_TOKEN_DRIVER "<another long random string>"
+setx WINDBG_MCP_TOOLS_DRIVER        "session,inspect,crash"
 ```
 
-That is not a nicety. A shared credential is a shared **namespace**: the driver would see and route
-to the editor's sessions, and — the part no fence in a script can prevent — a client over the
-four-session cap has its oldest *idle* session reclaimed by the server, so a dump the driver opens
-can evict the editor's target without any tool call naming it. The script therefore refuses to run
-without a token rather than borrowing one; it cannot tell one token from another, so supplying a
+The second line is what makes this work on a listener the editor also uses: the driver is served 20
+tools and 25,265 B while every other client on that listener keeps all 51. Leave it out and the
+driver is served whatever the listener was started with, which is the older behaviour and is the
+right one when the listener is the driver's own.
+
+The first line is not a nicety. A shared credential is a shared **namespace**: the driver would see
+and route to the editor's sessions, and — the part no fence in a script can prevent — a client over
+the four-session cap has its oldest *idle* session reclaimed by the server, so a dump the driver
+opens can evict the editor's target without any tool call naming it. The script therefore refuses to
+run without a token rather than borrowing one; it cannot tell one token from another, so supplying a
 credential that really is its own is yours to get right.
 
 **Under the service, that variable is not where the token goes.** The installer points the service
@@ -310,8 +320,11 @@ client-side.**
   67,658 — `--tools crash` is 11 and 15,073 B, which is the difference between "roughly twice an 8k
   window" and "half of one". Nothing is reworded: the tools that remain are the tools they were.
   The whole table is in [`token-budget.md`](./token-budget.md) under finding 8, and the README has
-  the operator's half. It is server-wide rather than per client, which for the arrangement on this
-  page — one listener, one local model — is the same thing.
+  the operator's half. **And it is per client as well as per run** (2026-08-22): a listener's
+  clients are named already, so `WINDBG_MCP_TOOLS_<NAME>` beside the token gives one of them its
+  own surface — which is what lets the bench below share a listener with a hosted client rather
+  than needing one of its own for the budget's sake. The credential is still the reason to run a
+  second one; see the next section.
 - **The response budget arrived per tool**, not caller-wide: `modules`' `limit`, above.
 - **The text-or-data switch is still unbuilt**, and is the one that needs a client rather than a
   server change: which half of a result reaches the model is the client's forwarding policy.

--- a/docs/remote-listener.md
+++ b/docs/remote-listener.md
@@ -296,11 +296,13 @@ Three things follow from where the surface is decided:
 - **Calling a tool that is not on your surface** is refused as exactly that, rather than as an
   unknown tool — and the message names which configuration to widen, since a caller can see
   neither.
-- **A change reaches a client when it next connects.** The surface is fixed at the moment the
-  caller is identified, which is `initialize` for a client holding an MCP session and every request
-  for one on `2026-07-28`. Nothing sends `notifications/tools/list_changed`: this server keeps no
-  handle to notify a session through, and the sessionless revision has no session to notify, so it
-  would be a guarantee on one revision and silence on the other. Reconnect the client.
+- **A change reaches a client the next time it is identified** — its next handshake, or its next
+  *request* if it makes no session. The surface is fixed at that moment, which is `initialize` for
+  a client holding an MCP session and every request for one on `2026-07-28`; a client on that
+  revision therefore picks a change up with nothing done to it. Nothing sends
+  `notifications/tools/list_changed`: this server keeps no handle to notify a session through, and
+  the sessionless revision has no session to notify, so it would be a guarantee on one revision and
+  silence on the other. Reconnect a client that holds a session.
 
 The startup line says what each client is served, and only mentions the ones that differ:
 
@@ -553,9 +555,10 @@ Seven behaviours worth knowing before you need them:
   nothing else, so it mints no token, writes no `<name>.token`, and is not a revocation. Its
   `--tools` spec is validated before anything is written — a spec this server could not serve is
   refused here rather than becoming a service that will not start.
-- **A client sees its new surface when it next connects.** The reload is delivered and waited for
-  like any other, but a connected client's tool list was decided when it connected and nothing tells
-  it otherwise; the command says so. Reconnect it, or restart whatever is driving it.
+- **A client sees its new surface the next time it is identified.** The reload is delivered and
+  waited for like any other, but a client holding an MCP session had its tool list decided at
+  `initialize` and nothing tells it otherwise; the command says so. Reconnect it, or restart
+  whatever is driving it — a client on `2026-07-28` holds no session and needs nothing.
 - **A rotation keeps the client, and so keeps its sessions.** Only the token moves: the old one
   starts answering `401` and the new one reaches the same debug sessions, because it *is* the same
   client. Rotating is the cheap operation — a lost token costs a rotation and nothing else.

--- a/docs/remote-listener.md
+++ b/docs/remote-listener.md
@@ -8,8 +8,9 @@ the machine DbgEng needs — a Mac driving a Windows VM, say.
 may be a local model whose window is bought in RAM. `--listen 127.0.0.1:8765 --tools
 session,inspect,crash` serves 20 tools and 25,265 B of model context instead of 51 and 67,658 — the
 README has the table, and [`local-model.md`](./local-model.md) is the runbook it was measured for.
-It is server-wide, so every client on this listener sees the same surface; per-caller is
-`FOLLOWUPS.md` item 36.
+It is this listener's **default**: a client may be given a surface of its own, which is what lets
+one server hold a local model and a hosted client at once — see [A tool surface per
+client](#a-tool-surface-per-client).
 
 If you only need that once, [`remote-phase0.md`](./remote-phase0.md) does it with no listener at
 all: register the MCP server as an `ssh` command and stdio tunnels for you. The listener is for
@@ -264,9 +265,49 @@ could never become the holder, and the classification behind it is gone with the
 Such a client also never installs a lease at all, which is why abandonment on this revision is the
 idle release's job rather than the grace's — see *A session nobody is using is released*, above.
 
-**This does not authorise anything beyond separation.** Every client that can authenticate has the
-whole tool surface, including `execute` and `launch`. Tokens separate clients from each other; they
-do not rank them.
+**This does not authorise anything beyond separation.** A token separates clients from each other;
+it does not rank them. A client may be served a smaller *tool surface* than another (below), and
+that is a budget rather than a privilege: it is enforced on the call, but any surface holds the
+openers, and `execute` — which is in `inspect` — runs any debugger command there is. Treat every
+client that can authenticate as holding the whole thing, including `launch`.
+
+### A tool surface per client
+
+The [`--tools` spec](../README.md#serving-fewer-tools---tools) narrows what a run advertises, and a
+client may be given one of its own — configured beside its token, under the same rule for the name:
+
+```console
+setx WINDBG_MCP_LISTEN_TOKEN_BENCH "<a long random string>"   # the client named `bench`
+setx WINDBG_MCP_TOOLS_BENCH        "session,inspect,crash"    # …and what it is served
+```
+
+This is what lets one listener serve a local model that can hold twenty tools beside a hosted client
+that can hold fifty-one, against the same debug sessions on the same box. A client with no spec of
+its own is served whatever the run serves — `--tools` on the listener's command line, or every tool
+if it has none — so **the run's flag is the default rather than a ceiling**: a client's own spec
+replaces it, wider or narrower, because an intersection would produce a surface neither of you
+named. `session` is added to every spec, here as on the command line.
+
+Three things follow from where the surface is decided:
+
+- **A spec for a client that has no token is refused at startup**, by name. A surface no credential
+  can reach is a setting that would never take effect, and the way to write one is the typo that
+  makes `WINDBG_MCP_TOOLS_BENCH` and `WINDBG_MCP_LISTEN_TOKEN_BENCH` disagree.
+- **Calling a tool that is not on your surface** is refused as exactly that, rather than as an
+  unknown tool — and the message names which configuration to widen, since a caller can see
+  neither.
+- **A change reaches a client when it next connects.** The surface is fixed at the moment the
+  caller is identified, which is `initialize` for a client holding an MCP session and every request
+  for one on `2026-07-28`. Nothing sends `notifications/tools/list_changed`: this server keeps no
+  handle to notify a session through, and the sessionless revision has no session to notify, so it
+  would be a guarantee on one revision and silence on the other. Reconnect the client.
+
+The startup line says what each client is served, and only mentions the ones that differ:
+
+```text
+windbg-mcp listening on http://127.0.0.1:8765 (… clients: bench, local, serving all 51 tools
+— except bench serves 20 of 51 tools (session, inspect, crash))
+```
 
 **One thing a client can still infer: that another one is busy.** `server_log`'s sequence numbers
 are assigned across the whole server, and that is what makes a `since` cursor exact under eviction —
@@ -301,6 +342,20 @@ profiles:
   "laptop": "<another>"
 }
 ```
+
+An entry may also be an **object**, which is how a client in this file gets a surface of its own —
+the file is the whole configuration when one is set, so `WINDBG_MCP_TOOLS_<NAME>` is not read on a
+host that has one:
+
+```json
+{
+  "local": "<a long random string>",
+  "bench": { "token": "<another>", "tools": "session,inspect,crash" }
+}
+```
+
+A bare string is the same entry it always was and means the client takes whatever the run serves,
+so a file written before any of this keeps meaning exactly what it meant.
 
 A leading `{` is what tells them apart, so a bare token may not begin with one — a file that does is
 refused at startup, by name, rather than read as the other thing. Keys are client names, values are
@@ -422,14 +477,19 @@ because the SCM registers a service once and a bad credential then fails it at e
 `windbg-mcp.exe --uninstall-service` removes it, stopping it first and waiting for it — a delete
 issued against a running service only marks it, and this one has debug targets to let go of.
 
-### Adding, revoking and rotating a client, without stopping anything
+### Adding, revoking, rotating and re-toolling a client, without stopping anything
 
-Three commands, from an **elevated** shell, and none of them costs you a session:
+Four commands, from an **elevated** shell, and none of them costs you a session:
 
 ```pwsh
 windbg-mcp.exe --add-listen-client    ci
 windbg-mcp.exe --rotate-listen-client ci
 windbg-mcp.exe --remove-listen-client ci
+
+# what a client is served — at creation, or afterwards
+windbg-mcp.exe --add-listen-client       bench --tools session,inspect,crash
+windbg-mcp.exe --set-listen-client-tools bench --tools crash
+windbg-mcp.exe --set-listen-client-tools bench            # back to the service's own surface
 ```
 
 Each one rewrites `%ProgramData%\windbg-mcp\token` and then tells the running service to re-read
@@ -459,8 +519,8 @@ service reading it at the same moment.
 **They generate the token, and they will not print it.** What reaches your console is a fingerprint:
 
 ```text
-added the client `ci` (sha256:076C14953E1DE5EF) — it gets the whole tool surface, as every client
-here does — a token separates clients from each other, it does not limit one.
+added the client `ci` (sha256:076C14953E1DE5EF) — it is served whatever `windbg-mcp` serves —
+`--tools` on the command line the SCM stores, or every tool if that has none.
 `windbg-mcp` now holds: `ci` (sha256:076C14953E1DE5EF), `local` (sha256:701E4CF334890225).
 
 Its token is in C:\ProgramData\windbg-mcp\ci.token — the same SYSTEM-and-Administrators
@@ -484,8 +544,15 @@ race and nothing to substitute. An existing `<name>.token` there is never overwr
 credential an earlier command wrote and nobody has moved yet, and the fix is to move it — or, if it
 belongs to a client you are done with, to remove that client, which deletes it.
 
-Four behaviours worth knowing before you need them:
+Seven behaviours worth knowing before you need them:
 
+- **Re-toolling touches no credential.** `--set-listen-client-tools` changes one entry's surface and
+  nothing else, so it mints no token, writes no `<name>.token`, and is not a revocation. Its
+  `--tools` spec is validated before anything is written — a spec this server could not serve is
+  refused here rather than becoming a service that will not start.
+- **A client sees its new surface when it next connects.** The reload is delivered and waited for
+  like any other, but a connected client's tool list was decided when it connected and nothing tells
+  it otherwise; the command says so. Reconnect it, or restart whatever is driving it.
 - **A rotation keeps the client, and so keeps its sessions.** Only the token moves: the old one
   starts answering `401` and the new one reaches the same debug sessions, because it *is* the same
   client. Rotating is the cheap operation — a lost token costs a rotation and nothing else.

--- a/docs/remote-listener.md
+++ b/docs/remote-listener.md
@@ -468,9 +468,12 @@ unprivileged process, which is the one property the foreground listener gets for
 **Every credential in the installing shell is copied, not just the unnamed one.** A service reads
 its file and nothing else, so the environment is only ever consulted *here*, at install — set
 `WINDBG_MCP_LISTEN_TOKEN_CI` beside `WINDBG_MCP_LISTEN_TOKEN` before installing and the file it
-writes names both. Afterwards the [client commands](#adding-revoking-and-rotating-a-client-without-stopping-anything)
-are how that set changes, and they neither read the environment nor need a reinstall. One client called `local` is written as a bare token, as it always was; anything
-else is the JSON object above. The install validates them the way the listener would, so a shell
+writes names both — and each client's `WINDBG_MCP_TOOLS_<NAME>` with it, so a surface that worked
+in the foreground does not vanish the moment the same setup is installed. Afterwards the [client
+commands](#adding-revoking-rotating-and-re-toolling-a-client-without-stopping-anything) are how
+that set changes, and they neither read the environment nor need a reinstall. One client called
+`local` with no surface of its own is written as a bare token, as it always was; anything else is
+the JSON object above. The install validates them the way the listener would, so a shell
 that could not start a foreground listener cannot register a service either — which matters here,
 because the SCM registers a service once and a bad credential then fails it at every start.
 

--- a/docs/token-budget.md
+++ b/docs/token-budget.md
@@ -307,8 +307,10 @@ None of these is a bug. They are recorded because they were invisible, and
 
    `session` is in every surface because every other tool routes by a `session_id` this server is
    the only issuer of — 12,161 B is the floor, and `crash` is eleven tools rather than one. The
-   choice is **server-wide**; a per-caller surface on the listener, where clients are already named,
-   is item 36.
+   flag is a **run's** choice, and on a listener it is the *default*: a named client may be
+   configured with a spec of its own (`WINDBG_MCP_TOOLS_<NAME>`), so the figures above are per
+   client rather than per server — which is what lets a local model and a hosted client share one
+   listener. Item 36.
 
 One interaction worth flagging before acting on any of it: `FOLLOWUPS.md` item 11 proposes *adding*
 `structuredContent` to `ttd_calls`, `ttd_memory` and `driver_object` — three of the highest-volume

--- a/skills/windbg-debugging/setup.md
+++ b/skills/windbg-debugging/setup.md
@@ -449,7 +449,9 @@ Four things decide whether that works, and each fails in a way that reads as som
   profiles have to be configured machine-wide for a service to see them. Giving it a **second
   client** later costs neither a reinstall nor the sessions it is holding —
   `--add-listen-client <name>`, elevated, which generates the token, leaves it beside the
-  credential file and prints only a fingerprint.
+  credential file and prints only a fingerprint. Add `--tools <spec>` to serve that client a
+  smaller surface than the rest (`--set-listen-client-tools <name>` changes it afterwards), which
+  is how a local model shares a listener with a full client.
 
 Two behaviours differ from stdio and are worth knowing before they surprise you.
 

--- a/skills/windbg-debugging/setup.md
+++ b/skills/windbg-debugging/setup.md
@@ -450,8 +450,10 @@ Four things decide whether that works, and each fails in a way that reads as som
   client** later costs neither a reinstall nor the sessions it is holding —
   `--add-listen-client <name>`, elevated, which generates the token, leaves it beside the
   credential file and prints only a fingerprint. Add `--tools <spec>` to serve that client a
-  smaller surface than the rest (`--set-listen-client-tools <name>` changes it afterwards), which
-  is how a local model shares a listener with a full client.
+  surface of its own — usually a smaller one, though the spec *replaces* the run's rather than
+  narrowing it, so a wider one is served too. `--set-listen-client-tools <name> --tools <spec>`
+  changes it afterwards, and the same command with **no** `--tools` puts the client back on the
+  run's surface. That is how a local model shares a listener with a full client.
 
 Two behaviours differ from stdio and are worth knowing before they surprise you.
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -32,6 +32,16 @@
 //! Under stdio there is nothing to authenticate and nothing to separate — one process, one client,
 //! by construction — so calls there run as [`Client::LOCAL`] and every lookup behaves as it always
 //! has.
+//!
+//! # What a name buys besides isolation
+//!
+//! A **tool surface of its own**. A client is a budget as much as it is a boundary: the
+//! arrangement this listener was built for is a local model that can hold twenty tools beside a
+//! hosted client that can hold fifty-one, on the same box and against the same debug sessions. So
+//! a credential may carry a [`crate::toolset::Toolset`] as well as a name — configured beside the
+//! token, under the same variable prefix or in the same file entry — and a client that names none
+//! is served whatever the run serves. That is `FOLLOWUPS.md` item 36, and the identity above is
+//! what made it a field rather than a feature.
 
 use std::collections::HashMap;
 use std::path::Path;
@@ -41,6 +51,16 @@ use anyhow::{Result, anyhow, bail};
 
 /// The unnamed token, and the prefix of a named one.
 const TOKEN_ENV: &str = "WINDBG_MCP_LISTEN_TOKEN";
+
+/// The unnamed tool-surface spec, and the prefix of a named one.
+///
+/// **Beside the token variable, and read by the same scan**, because a client's surface and a
+/// client's credential are configured by the same person in the same place — see
+/// [`crate::toolset`] for what a spec is and why one client's is not another's. It carries no
+/// secret, so it is not held to [`is_presentable`] and is not stripped from a child process; what
+/// it *is* held to is naming a client this listener actually accepts, which is
+/// [`from_env`]'s last refusal.
+pub const TOOLS_ENV: &str = "WINDBG_MCP_TOOLS";
 
 /// The variable naming a *file* to read credentials from, which shares that prefix and is not one.
 ///
@@ -147,6 +167,12 @@ impl std::fmt::Display for Client {
 #[derive(Clone, Default)]
 pub struct Credentials {
     by_token: HashMap<String, String>,
+    /// Name to the surface that client is served, for the clients configured with one of their
+    /// own. **Absent is not "every tool"** — it is "whatever this run serves", which is the run's
+    /// `--tools` and usually every tool. Keeping the two apart is what lets a listener started
+    /// with a narrow `--tools` still have a client that was given a wider spec, and what makes an
+    /// entry with no `tools` field mean exactly what it meant before there was one.
+    surfaces: HashMap<String, crate::toolset::Toolset>,
 }
 
 /// **The names, never the tokens** — the same reason [`crate::kdconn::Connection`]'s is redacted.
@@ -177,6 +203,23 @@ impl Credentials {
         names
     }
 
+    /// The surface configured for this client, or `None` for one that takes the run's.
+    pub fn surface_for(&self, name: &str) -> Option<&crate::toolset::Toolset> {
+        self.surfaces.get(name)
+    }
+
+    /// Every client with a surface of its own, as `(name, summary)`, sorted — for the startup and
+    /// reload lines. Empty on the configuration everyone has, where it costs those lines nothing.
+    pub fn surfaces(&self) -> Vec<(&str, String)> {
+        let mut rows: Vec<(&str, String)> = self
+            .surfaces
+            .iter()
+            .map(|(name, surface)| (name.as_str(), surface.summary()))
+            .collect();
+        rows.sort_unstable_by(|a, b| a.0.cmp(b.0));
+        rows
+    }
+
     /// Builds the set from `(variable, value)` pairs, or from the token file if there is one.
     ///
     /// Takes the variables rather than reading the environment for the reason
@@ -192,6 +235,12 @@ impl Credentials {
     /// file shuts the environment out entirely rather than merely outranking the unnamed variable,
     /// and names its own clients ([`TokenFile`]) rather than leaving the deployment that needs it
     /// most with room for one.
+    ///
+    /// **A tool surface follows its credential**, so a configured file is the only source of those
+    /// too and [`TOOLS_ENV`] is not read at all on a host that has one. Not because a spec is a
+    /// secret — it is a list of group names — but because one configuration answering "who may
+    /// connect" and another answering "what do they get" is two files to keep in step and a
+    /// precedence rule to remember. A client's surface is written where its token is.
     pub fn from_entries(
         vars: impl Iterator<Item = (String, String)>,
         file: Option<TokenFile>,
@@ -211,15 +260,26 @@ impl Credentials {
     /// A token appearing twice is refused rather than resolved. Two names for one credential means
     /// a caller's sessions land under whichever name won a `HashMap` insertion, which is a rule
     /// nobody could predict and a boundary that would move.
+    ///
+    /// A spec is parsed here too, and by the same call the listener's `--tools` goes through, so a
+    /// surface an operator writes down is one this server can actually serve — refused at startup
+    /// rather than discovered by a caller whose tool list came back empty.
     fn build(configured: &[Configured]) -> Result<Self> {
         let mut by_token: HashMap<String, String> = HashMap::new();
+        let mut surfaces: HashMap<String, crate::toolset::Toolset> = HashMap::new();
         // Client name to *what configured it* — never to the token. Both refusals below are
         // printed at startup, to stderr in the foreground and to the service log under the SCM, so
         // a message quoting the credential it is complaining about would write a working listener
         // token into whatever collects those. The source is also the more useful half: it is what
         // the operator has to go and change.
         let mut named: HashMap<&str, &str> = HashMap::new();
-        for Configured { name, token, from } in configured {
+        for Configured {
+            name,
+            token,
+            tools,
+            from,
+        } in configured
+        {
             if !is_presentable(token) {
                 bail!(
                     "the token in {from} cannot travel in an `Authorization` header, so nothing \
@@ -258,10 +318,20 @@ impl Credentials {
                      is the isolation this is for, silently absent."
                 );
             }
+            if let Some(spec) = tools {
+                // Held to the flag's own parser, so `session,inspect` means here what it means on
+                // a command line — and so `session` is added to a client's surface for the same
+                // reason it is added to a run's. The source is named rather than the flag: this
+                // spec was written in a variable or a file, and telling its operator to edit
+                // `--tools` would send them to a command line that has nothing to do with it.
+                let surface = crate::toolset::Toolset::parse_from(&spec.text, &spec.from)
+                    .map_err(|e| anyhow!("{e}"))?;
+                surfaces.insert(name.clone(), surface);
+            }
             named.insert(name.as_str(), from.as_str());
             by_token.insert(token.clone(), name.clone());
         }
-        Ok(Self { by_token })
+        Ok(Self { by_token, surfaces })
     }
 }
 
@@ -373,6 +443,27 @@ impl Accepted {
         self.state().client_for(token)
     }
 
+    /// The surface this client is served, or `None` for one that takes the run's.
+    ///
+    /// **Read where the identity is**, in the listener's service factory: that is the one moment
+    /// the caller is knowable, and a surface decided anywhere later would be decided for whichever
+    /// task rmcp happened to serve the call from. It is also what fixes when a reload takes
+    /// effect — see [`crate::toolset`].
+    pub fn surface_for(&self, client: &Client) -> Option<crate::toolset::Toolset> {
+        self.state().credentials.surface_for(client.name()).cloned()
+    }
+
+    /// Every client with a surface of its own, as `<name> serves <summary>`, for a log line.
+    /// Empty on the configuration everyone has.
+    pub fn surfaces(&self) -> Vec<String> {
+        self.state()
+            .credentials
+            .surfaces()
+            .into_iter()
+            .map(|(name, summary)| format!("{name} serves {summary}"))
+            .collect()
+    }
+
     /// Every configured name, sorted — for the lines that say who may connect.
     pub fn names(&self) -> Vec<String> {
         self.state()
@@ -436,7 +527,74 @@ impl Accepted {
 struct Configured {
     name: String,
     token: String,
+    /// The tool surface this client is served, or `None` for one that takes the run's. See
+    /// [`Credentials::surfaces`] for why those two are not the same answer.
+    tools: Option<Spec>,
     from: String,
+}
+
+/// A tool-surface spec as it was written down, and where that was.
+///
+/// **Two fields rather than one because the second is not the token's.** Configured from the
+/// environment a client's surface and its credential are two variables, so a refusal about the
+/// spec has to name the variable holding the spec — and [`Configured::from`] names the other one.
+/// In the credential file they are one entry, and this still renders as the field within it.
+struct Spec {
+    text: String,
+    from: String,
+}
+
+/// One client as a configuration writes it down.
+///
+/// What the [client commands](crate::service::edit_client) read out of the credential file, change
+/// one of, and write back — so it carries everything that file holds about a client and nothing
+/// about where it came from, which is [`Configured`]'s business and stays private.
+///
+/// **No `Debug`**, for the reason [`Credentials`]'s is hand-written: it holds a token, and the
+/// things that format a value like this are a log line and a test's panic message.
+pub struct ClientEntry {
+    pub name: String,
+    pub token: String,
+    /// The `--tools` spec this client is served, as text. `None` takes whatever the run serves,
+    /// which is what every client had before one could be set.
+    pub tools: Option<String>,
+}
+
+impl Configured {
+    /// The entry as a configuration to be validated, named after the client itself.
+    ///
+    /// For the writers — [`env_credentials`] and [`TokenFile::credentials`] hand their result
+    /// straight back to a caller that writes it to the file the service reads, and a set that
+    /// would not start a listener must not be written down as if it would.
+    fn of(entry: &ClientEntry, from: String) -> Self {
+        Self {
+            name: entry.name.clone(),
+            token: entry.token.clone(),
+            tools: entry.tools.as_ref().map(|text| Spec {
+                text: text.clone(),
+                from: from.clone(),
+            }),
+            from,
+        }
+    }
+
+    fn entry(self) -> ClientEntry {
+        ClientEntry {
+            name: self.name,
+            token: self.token,
+            tools: self.tools.map(|spec| spec.text),
+        }
+    }
+}
+
+/// Every [`ClientEntry`] a command is about to write, held to the rules a listener would hold it
+/// to — including that each spec is a surface this server can serve.
+pub fn check(entries: &[ClientEntry]) -> Result<()> {
+    let configured: Vec<Configured> = entries
+        .iter()
+        .map(|entry| Configured::of(entry, format!("`{}`", entry.name)))
+        .collect();
+    Credentials::build(&configured).map(|_| ())
 }
 
 /// The credentials a set of environment variables configures — names derived, nothing validated.
@@ -445,18 +603,55 @@ struct Configured {
 /// configuration to exactly one standard.
 fn from_env(vars: impl Iterator<Item = (String, String)>) -> Result<Vec<Configured>> {
     let mut configured = Vec::new();
+    // Collected rather than attached as they are read, because an iterator over the environment is
+    // in no order: `WINDBG_MCP_TOOLS_CI` may arrive before the token that names `ci` exists here.
+    let mut specs: HashMap<String, Spec> = HashMap::new();
     for (key, value) in vars {
-        let token = value.trim().to_string();
-        // An empty value is not a token — it is a variable somebody exported and never set.
-        if token.is_empty() || is_token_file(&key) {
+        let value = value.trim().to_string();
+        // An empty value is not a token — it is a variable somebody exported and never set. The
+        // same reading for a spec: an empty one is not "serve nothing", which is a surface with no
+        // opener in it and cannot be used at all.
+        if value.is_empty() || is_token_file(&key) {
             continue;
         }
+        if let Some(suffix) = tools_suffix(&key) {
+            let name = client_named_by(suffix);
+            if !is_client_name(&name) {
+                bail!(
+                    "`{key}` does not name a client. What follows `{TOOLS_ENV}_` is the name, and \
+                     a name is letters, digits, `-`, `_` or `.`, up to {NAME_LIMIT} characters — \
+                     `{TOOLS_ENV}_CI` is the tool surface served to `ci`."
+                );
+            }
+            // **Two spellings of one name are refused, not merged**, the same as two tokens for
+            // one client and for the same reason: names are folded, so `…_TOOLS_CI` and
+            // `…_TOOLS__CI` both name `ci`, and which surface won would be a `HashMap` ordering
+            // detail. Unlike a token this is not a boundary, so nothing leaks — but an operator
+            // reading two specs in their own shell and getting one of them silently is the shape
+            // this module refuses everywhere.
+            if let Some(other) = specs.get(&name) {
+                bail!(
+                    "`{key}` and {} both name the tool surface of the client `{name}`. Give it \
+                     one: which of the two took effect would be whichever the scan happened to \
+                     read last.",
+                    other.from
+                );
+            }
+            specs.insert(
+                name,
+                Spec {
+                    text: value,
+                    from: format!("`{key}`"),
+                },
+            );
+            continue;
+        }
+        let token = value;
         let name = match credential_suffix(&key) {
-            // The unnamed variable, which is what every existing setup uses.
-            Some("") => Client::LOCAL.to_string(),
-            // `WINDBG_MCP_LISTEN_TOKEN_CI` names the client `ci`, the same lowercasing a kernel
+            // `WINDBG_MCP_LISTEN_TOKEN` names `local` — the unnamed variable every existing setup
+            // uses — and `WINDBG_MCP_LISTEN_TOKEN_CI` names `ci`, the same lowercasing a kernel
             // profile's variable gets.
-            Some(suffix) => suffix.trim_start_matches('_').to_ascii_lowercase(),
+            Some(suffix) => client_named_by(suffix),
             None => continue,
         };
         // **Held to the same rule as a key in the file**, rather than skipped as it used to be.
@@ -477,23 +672,65 @@ fn from_env(vars: impl Iterator<Item = (String, String)>) -> Result<Vec<Configur
             from: format!("`{key}`"),
             name,
             token,
+            tools: None,
         });
+    }
+    for entry in &mut configured {
+        entry.tools = specs.remove(&entry.name);
+    }
+    // **What is left over is a surface for a client nothing can authenticate as**, which is a
+    // setting that would never take effect. Refused rather than ignored, on the precedent of the
+    // two collisions above: a spec the operator wrote, silently not configured, is the failure
+    // nobody sees — and the likeliest cause of it is the typo that makes `WINDBG_MCP_TOOLS_BENCH`
+    // and `WINDBG_MCP_LISTEN_TOKEN_BENCH` disagree about the name.
+    // Sorted, so two orphans do not produce a refusal that names a different one on every run —
+    // the same reason `Toolset::parse` validates a whole spec before returning on `all`. A message
+    // nobody can reproduce is worse than the one it replaced.
+    if let Some((name, spec)) = specs.into_iter().min_by(|a, b| a.0.cmp(&b.0)) {
+        bail!(
+            "{} is the tool surface of a client called `{name}`, and nothing here configures a \
+             token for it (`{}`). A surface no credential can reach is a setting that would never \
+             take effect.",
+            spec.from,
+            match name.as_str() {
+                // The unnamed variable is what configures `local`, and naming `…_TOKEN_LOCAL`
+                // instead would be advice to write the one variable that collides with it.
+                Client::LOCAL => TOKEN_ENV.to_string(),
+                named => format!("{TOKEN_ENV}_{}", named.to_ascii_uppercase()),
+            }
+        );
     }
     Ok(configured)
 }
 
-/// What this process's environment configures, as `(client, token)` pairs.
+/// The client a credential variable's suffix names: `local` for the unnamed one, the folded suffix
+/// otherwise.
+///
+/// One function because [`TOKEN_ENV`] and [`TOOLS_ENV`] have to agree about it exactly — a client
+/// whose token variable named `ci` and whose spec variable named `_ci` would be two clients, one
+/// of which has no token, and the refusal for that is at the bottom of [`from_env`] rather than
+/// anywhere an operator would look.
+fn client_named_by(suffix: &str) -> String {
+    match suffix {
+        "" => Client::LOCAL.to_string(),
+        suffix => suffix.trim_start_matches('_').to_ascii_lowercase(),
+    }
+}
+
+/// What this process's environment configures, one [`ClientEntry`] per client.
 ///
 /// For [`crate::service::install`], which copies the installing shell's credentials into the file
 /// the service reads. It validates by building the same [`Credentials`] the listener would, so an
 /// install cannot write a file the service then refuses to start on — which is the worst shape
 /// this can take, since the SCM registers a service once and it fails at every start afterwards.
-pub fn env_credentials(
-    vars: impl Iterator<Item = (String, String)>,
-) -> Result<Vec<(String, String)>> {
+///
+/// **Surfaces travel with the tokens**, because the file is the whole of what a service reads: a
+/// `WINDBG_MCP_TOOLS_CI` left behind in the installing shell would otherwise be a surface that
+/// worked in the foreground and vanished the moment the same setup was installed.
+pub fn env_credentials(vars: impl Iterator<Item = (String, String)>) -> Result<Vec<ClientEntry>> {
     let configured = from_env(vars)?;
     Credentials::build(&configured)?;
-    Ok(configured.into_iter().map(|c| (c.name, c.token)).collect())
+    Ok(configured.into_iter().map(Configured::entry).collect())
 }
 
 /// The credentials a token file holds.
@@ -582,6 +819,10 @@ impl TokenFile {
                 entries: vec![Configured {
                     name: Client::LOCAL.to_string(),
                     token: text.to_string(),
+                    // A bare token cannot carry one, which is not a gap: it is the file of a
+                    // single-client host, where the run's `--tools` and the client's surface are
+                    // the same choice. Setting one rewrites the file into the object shape.
+                    tools: None,
                     from: path.display().to_string(),
                 }],
             });
@@ -607,12 +848,7 @@ impl TokenFile {
                     path.display()
                 );
             }
-            let Some(token) = value.as_str() else {
-                bail!(
-                    "`{name}` in {} must be a string: the bearer token that client presents.",
-                    path.display()
-                );
-            };
+            let (token, tools) = Self::entry_of(&name, value, path)?;
             let token = token.trim();
             if token.is_empty() {
                 bail!(
@@ -635,6 +871,10 @@ impl TokenFile {
             }
             entries.push(Configured {
                 from: format!("`{name}` in {}", path.display()),
+                tools: tools.map(|text| Spec {
+                    text,
+                    from: format!("`{name}`'s `tools` in {}", path.display()),
+                }),
                 name,
                 token: token.to_string(),
             });
@@ -649,8 +889,67 @@ impl TokenFile {
         Ok(Self { entries })
     }
 
-    /// The clients this file names, as `(name, token)` pairs, validated the way the listener
-    /// validates them.
+    /// One client's entry: the bearer token, and the tool surface if it names one.
+    ///
+    /// **Two shapes here as well**, and for the same reason the file itself has two: a string is
+    /// the token and is what every entry written before this is, so a file nobody has touched
+    /// keeps meaning what it meant. An object is the entry that has something to say beyond the
+    /// token — today `tools`, which is the only reason it exists.
+    ///
+    /// **No refusal here quotes a value either.** The unknown-field one is the case worth naming:
+    /// a file written back to front puts a credential where a key goes, at every level, so the
+    /// message lists the two fields an entry may have rather than the one it found. An operator
+    /// can read their own file; a startup log going to a service's log file is not the place to
+    /// find out what is in it.
+    fn entry_of(
+        name: &str,
+        value: serde_json::Value,
+        path: &Path,
+    ) -> Result<(String, Option<String>)> {
+        match value {
+            serde_json::Value::String(token) => Ok((token, None)),
+            serde_json::Value::Object(fields) => {
+                let mut token = None;
+                let mut tools = None;
+                for (field, value) in fields {
+                    let slot = match field.trim().to_ascii_lowercase().as_str() {
+                        "token" => &mut token,
+                        "tools" => &mut tools,
+                        _ => bail!(
+                            "`{name}` in {} is an object with a field this does not know. An \
+                             entry names `token`, and optionally `tools` — the surface that \
+                             client is served, in the spelling `--tools` takes. The field is not \
+                             quoted here: a file written back to front makes a credential one.",
+                            path.display()
+                        ),
+                    };
+                    let Some(text) = value.as_str() else {
+                        bail!(
+                            "`{name}`'s `{field}` in {} must be a string.",
+                            path.display()
+                        );
+                    };
+                    *slot = Some(text.trim().to_string());
+                }
+                let Some(token) = token else {
+                    bail!(
+                        "`{name}` in {} is an object, so it needs a `token` field holding the \
+                         bearer token that client presents — `{{\"token\": \"<token>\", \
+                         \"tools\": \"session,crash\"}}`.",
+                        path.display()
+                    );
+                };
+                Ok((token, tools.filter(|spec| !spec.is_empty())))
+            }
+            _ => bail!(
+                "`{name}` in {} must be the bearer token that client presents, or an object \
+                 naming it — `{{\"token\": \"<token>\", \"tools\": \"session,crash\"}}`.",
+                path.display()
+            ),
+        }
+    }
+
+    /// The clients this file names, validated the way the listener validates them.
     ///
     /// For the [client commands](crate::service), which read the file to change one entry and
     /// write the rest back. It validates rather than merely handing over what parsed, for the
@@ -660,15 +959,12 @@ impl TokenFile {
     ///
     /// **Sorted by name**, so the file a command writes does not depend on the order the previous
     /// one happened to be in — an operator diffing two of these should see only what changed.
-    pub fn credentials(self) -> Result<Vec<(String, String)>> {
+    pub fn credentials(self) -> Result<Vec<ClientEntry>> {
         Credentials::build(&self.entries)?;
-        let mut pairs: Vec<(String, String)> = self
-            .entries
-            .into_iter()
-            .map(|c| (c.name, c.token))
-            .collect();
-        pairs.sort_by(|a, b| a.0.cmp(&b.0));
-        Ok(pairs)
+        let mut entries: Vec<ClientEntry> =
+            self.entries.into_iter().map(Configured::entry).collect();
+        entries.sort_by(|a, b| a.name.cmp(&b.name));
+        Ok(entries)
     }
 }
 
@@ -881,6 +1177,17 @@ fn credential_suffix(name: &str) -> Option<&str> {
         .then(|| &name[TOKEN_ENV.len()..])
 }
 
+/// The part of a tool-surface variable's name after the prefix, if it is one.
+///
+/// Case-insensitive for the same reason [`credential_suffix`] is. The two prefixes cannot overlap
+/// — `WINDBG_MCP_TOOLS` is not a prefix of `WINDBG_MCP_LISTEN_TOKEN` nor the other way round — so
+/// a variable is one kind or the other and never both.
+fn tools_suffix(name: &str) -> Option<&str> {
+    name.to_ascii_uppercase()
+        .starts_with(TOOLS_ENV)
+        .then(|| &name[TOOLS_ENV.len()..])
+}
+
 /// Whether this variable names the token *file* rather than carrying a token.
 fn is_token_file(name: &str) -> bool {
     name.eq_ignore_ascii_case(TOKEN_FILE_ENV)
@@ -894,6 +1201,11 @@ fn is_token_file(name: &str) -> bool {
 /// named token through — and the failure would be silent, a debuggee holding a credential nobody
 /// meant to hand it. The path in `…_TOKEN_FILE` is stripped for the same reason: a target that
 /// knows where the token lives can read it if the file is reachable at all.
+///
+/// **[`TOOLS_ENV`] is deliberately not stripped**, and sits right beside these, so it is worth
+/// saying rather than leaving to be tidied up: it holds a list of this server's own group names,
+/// not a credential. What it would leak is that a client called `bench` exists, which a debuggee
+/// learns from nothing it can act on.
 pub fn strip_credentials(command: &mut impl EnvRemove) {
     for (name, _) in std::env::vars() {
         if credential_suffix(&name).is_some() {
@@ -1190,8 +1502,22 @@ mod tests {
             ),
             ("{}", "names no clients"),
             (r#"{"ci": }"#, "not valid JSON"),
-            (r#"{"ci": 5}"#, "must be a string"),
+            (r#"{"ci": 5}"#, "or an object naming it"),
             (r#"{"ci": "  "}"#, "has no token"),
+            // The object shape's own three. A `tools` with no `token` beside it is the shape an
+            // operator reaches for when adding a surface to an entry and deleting the wrong line.
+            (r#"{"ci": {"tools": "crash"}}"#, "needs a `token` field"),
+            (r#"{"ci": {"token": 5}}"#, "must be a string"),
+            (
+                r#"{"ci": {"token": "t", "surface": "crash"}}"#,
+                "a field this does not know",
+            ),
+            // And a spec that names nothing this server has, which is the same refusal `--tools`
+            // gives — named after the entry it is in rather than after a flag nobody typed.
+            (
+                r#"{"ci": {"token": "t", "tools": "crash,ttdd"}}"#,
+                "`ttdd` is neither a group nor a tool",
+            ),
             // Written back to front, with a token no name could be — the detectable half of that
             // mistake. The other half is not: see `is_client_name`.
             (
@@ -1219,6 +1545,10 @@ mod tests {
             assert!(
                 why.contains(FILE),
                 "a refusal has to name the file it is about: {why}"
+            );
+            assert!(
+                !why.contains("\"t\"") && !why.contains("`t`"),
+                "a refusal quotes a value out of the file: {why}"
             );
         }
     }
@@ -1426,13 +1756,179 @@ mod tests {
             .credentials()
             .expect("a valid file");
         assert_eq!(
-            parsed,
+            rows(&parsed),
             vec![
-                ("ci".to_string(), "c".to_string()),
-                ("laptop".to_string(), "l".to_string()),
-                ("local".to_string(), "s".to_string()),
+                ("ci", "c", None),
+                ("laptop", "l", None),
+                ("local", "s", None)
             ]
         );
+    }
+
+    /// The surface a set of variables configures for one client, as its summary.
+    fn surface(vars_of: &[(&str, &str)], client: &str) -> Option<String> {
+        Credentials::from_entries(vars(vars_of), None)
+            .expect("a usable configuration")
+            .surface_for(client)
+            .map(crate::toolset::Toolset::summary)
+    }
+
+    /// A client's surface is configured beside its token, and a client that names none is served
+    /// whatever the run serves.
+    ///
+    /// **`None` rather than every tool** is the half worth asserting: a listener started with
+    /// `--tools crash` and one client given `inspect` serves that client `inspect` and everybody
+    /// else `crash`, which only works if "no surface configured" stays distinguishable from "all
+    /// fifty-one".
+    #[test]
+    fn a_client_may_be_configured_with_a_surface_of_its_own() {
+        let configured = &[
+            ("WINDBG_MCP_LISTEN_TOKEN", "for-local"),
+            ("WINDBG_MCP_LISTEN_TOKEN_BENCH", "for-bench"),
+            ("WINDBG_MCP_TOOLS_BENCH", "crash"),
+        ][..];
+        assert_eq!(
+            surface(configured, "bench").as_deref(),
+            Some("11 of 51 tools (session, crash)"),
+            "`bench` is served the surface its own variable names"
+        );
+        assert_eq!(
+            surface(configured, "local"),
+            None,
+            "a client with no spec takes the run's surface rather than every tool"
+        );
+        // And the unnamed variable names `local`'s, exactly as the unnamed token names `local`.
+        assert_eq!(
+            surface(
+                &[
+                    ("WINDBG_MCP_LISTEN_TOKEN", "for-local"),
+                    ("WINDBG_MCP_TOOLS", "inspect"),
+                ],
+                "local"
+            )
+            .as_deref(),
+            Some("19 of 51 tools (session, inspect)")
+        );
+    }
+
+    /// Every way a tool-surface variable can be configured wrong, refused at startup.
+    ///
+    /// The orphan is the one this is really for. A surface for a client no credential names is a
+    /// setting that would never take effect, and the likeliest way to write one is the typo that
+    /// makes the two variables disagree about the name — so it is refused on the precedent of the
+    /// two collisions [`Credentials::build`] already refuses, rather than ignored.
+    #[test]
+    fn a_surface_that_would_never_take_effect_is_refused() {
+        for (configured, expected) in [
+            (
+                &[
+                    ("WINDBG_MCP_LISTEN_TOKEN_CI", "for-ci"),
+                    ("WINDBG_MCP_TOOLS_BENCH", "crash"),
+                ][..],
+                "nothing here configures a token for it",
+            ),
+            // Two spellings of one name, which fold together — the same collision two tokens for
+            // one client are, decided by whichever the scan read last.
+            (
+                &[
+                    ("WINDBG_MCP_LISTEN_TOKEN_CI", "for-ci"),
+                    ("WINDBG_MCP_TOOLS_CI", "crash"),
+                    ("WINDBG_MCP_TOOLS__CI", "inspect"),
+                ][..],
+                "both name the tool surface of the client `ci`",
+            ),
+            // A spec naming something this server does not have, refused where a `--tools` spec
+            // is — and named after the variable, not after a flag nobody typed.
+            (
+                &[
+                    ("WINDBG_MCP_LISTEN_TOKEN_CI", "for-ci"),
+                    ("WINDBG_MCP_TOOLS_CI", "crash,ttdd"),
+                ][..],
+                "`ttdd` is neither a group nor a tool",
+            ),
+            (
+                &[
+                    ("WINDBG_MCP_LISTEN_TOKEN_CI", "for-ci"),
+                    ("WINDBG_MCP_TOOLS_two words", "crash"),
+                ][..],
+                "does not name a client",
+            ),
+        ] {
+            let why = Credentials::from_entries(vars(configured), None)
+                .expect_err(&format!("{configured:?} is not a usable configuration"))
+                .to_string();
+            assert!(
+                why.contains(expected),
+                "{configured:?} was refused with: {why}"
+            );
+            for (_, value) in configured {
+                assert!(
+                    !value.starts_with("for-") || !why.contains(value),
+                    "a refusal quotes a token: {why}"
+                );
+            }
+        }
+    }
+
+    /// A configured file is the whole configuration — surfaces included.
+    ///
+    /// The precedence is [`Credentials::from_entries`]'s and predates this, but a surface is the
+    /// first thing to be configured beside a token that is *not* a secret, so it is the first
+    /// thing anyone would be tempted to let the environment contribute. It does not: one file
+    /// answers who may connect and what they are served, rather than two sources and a rule.
+    #[test]
+    fn a_token_file_shuts_out_the_environments_surfaces_too() {
+        let creds = Credentials::from_entries(
+            vars(&[
+                ("WINDBG_MCP_LISTEN_TOKEN_CI", "ignored"),
+                ("WINDBG_MCP_TOOLS_CI", "inspect"),
+            ]),
+            Some(file(
+                r#"{"ci": {"token": "from-the-file", "tools": "crash"}}"#,
+            )),
+        )
+        .expect("a usable configuration");
+        assert_eq!(creds.client_for("ignored"), None);
+        assert_eq!(creds.client_for("from-the-file"), Some("ci"));
+        assert_eq!(
+            creds
+                .surface_for("ci")
+                .map(crate::toolset::Toolset::summary),
+            Some("11 of 51 tools (session, crash)".to_string()),
+            "the file's surface stands, not the variable's"
+        );
+    }
+
+    /// A file entry may still be a bare token, which is every entry written before there was
+    /// anything else to say — and it means the client takes the run's surface.
+    #[test]
+    fn a_file_entry_without_a_surface_is_the_entry_it_always_was() {
+        let creds = Credentials::from_entries(
+            vars(&[]),
+            Some(file(
+                r#"{"ci": "for-ci", "bench": {"token": "for-bench", "tools": "session"}}"#,
+            )),
+        )
+        .expect("a usable configuration");
+        assert_eq!(creds.client_for("for-ci"), Some("ci"));
+        assert_eq!(creds.surface_for("ci"), None);
+        assert_eq!(
+            creds.surfaces(),
+            vec![("bench", "10 of 51 tools (session)".to_string())],
+            "only the client that named one is listed"
+        );
+    }
+
+    /// [`ClientEntry`] as something a test can compare and print.
+    ///
+    /// It has no `Debug` on purpose — it holds a token, and a panic message is exactly the kind of
+    /// place one should not appear. These assertions are about a triple, and a test that writes
+    /// its own literal tokens is the one place quoting them costs nothing.
+    fn rows(entries: &[ClientEntry]) -> Vec<(&str, &str, Option<&str>)> {
+        entries
+            .iter()
+            .map(|e| (e.name.as_str(), e.token.as_str(), e.tools.as_deref()))
+            .collect()
     }
 
     /// A set that would not start a listener is refused on the way out, not just on the way in.

--- a/src/client.rs
+++ b/src/client.rs
@@ -901,29 +901,47 @@ impl TokenFile {
     /// message lists the two fields an entry may have rather than the one it found. An operator
     /// can read their own file; a startup log going to a service's log file is not the place to
     /// find out what is in it.
-    fn entry_of(
-        name: &str,
-        value: serde_json::Value,
-        path: &Path,
-    ) -> Result<(String, Option<String>)> {
+    fn entry_of(name: &str, value: Written, path: &Path) -> Result<(String, Option<String>)> {
         match value {
-            serde_json::Value::String(token) => Ok((token, None)),
-            serde_json::Value::Object(fields) => {
+            Written::Text(token) => Ok((token, None)),
+            Written::Fields(Entries(fields)) => {
                 let mut token = None;
                 let mut tools = None;
                 for (field, value) in fields {
-                    let slot = match field.trim().to_ascii_lowercase().as_str() {
+                    // **Matched exactly, not folded**, which is the opposite of the rule a client
+                    // *name* follows two lines up — and deliberately. A name is the operator's,
+                    // configured in two places and compared across them, so it is normalised;
+                    // `token` is a keyword in a file format. Folding it would make
+                    // `{"token": …, "TOKEN": …}` two spellings of one field with no way to say
+                    // which was meant, and the later one would silently be the credential. `TOKEN`
+                    // gets the refusal below, which names what an entry may hold.
+                    let slot = match field.as_str() {
                         "token" => &mut token,
                         "tools" => &mut tools,
                         _ => bail!(
                             "`{name}` in {} is an object with a field this does not know. An \
                              entry names `token`, and optionally `tools` — the surface that \
-                             client is served, in the spelling `--tools` takes. The field is not \
-                             quoted here: a file written back to front makes a credential one.",
+                             client is served, in the spelling `--tools` takes, and both spelled \
+                             in lower case. The field is not quoted here: a file written back to \
+                             front makes a credential one.",
                             path.display()
                         ),
                     };
-                    let Some(text) = value.as_str() else {
+                    // **A repeated field is refused, not resolved** — the rule [`Entries`] holds a
+                    // file's client names to, one level down and about the same secret. Reachable
+                    // only because that type keeps the pairs: a `serde_json::Map` would have
+                    // thrown one of these away before this loop ever ran.
+                    if slot.is_some() {
+                        bail!(
+                            "`{name}` in {} names `{field}` more than once. Give each field one \
+                             entry: which of the two took effect would be whichever the parser \
+                             kept, so the other is something the operator can read in the file \
+                             and nothing acts on. Neither is quoted here — one of them may be a \
+                             credential.",
+                            path.display()
+                        );
+                    }
+                    let Written::Text(text) = value else {
                         bail!(
                             "`{name}`'s `{field}` in {} must be a string.",
                             path.display()
@@ -941,7 +959,7 @@ impl TokenFile {
                 };
                 Ok((token, tools.filter(|spec| !spec.is_empty())))
             }
-            _ => bail!(
+            Written::Other => bail!(
                 "`{name}` in {} must be the bearer token that client presents, or an object \
                  naming it — `{{\"token\": \"<token>\", \"tools\": \"session,crash\"}}`.",
                 path.display()
@@ -1087,10 +1105,28 @@ fn is_presentable(token: &str) -> bool {
 /// token that lost is one the operator can read in the file and no client can present. Collecting
 /// the pairs is what lets [`TokenFile::parse`] refuse that.
 ///
-/// It quotes nothing either: keys arrive as `String` and values as `serde_json::Value`, so no
-/// serde type error can be raised about a value here — the check that a value is a string is
-/// [`TokenFile::parse`]'s, which names the key instead.
-struct Entries(Vec<(String, serde_json::Value)>);
+/// **The same one level down**, since an entry may itself be an object ([`Written`]): a
+/// `serde_json::Value` there would have collapsed `{"token": …, "token": …}` before this module
+/// ever saw it, which is the identical failure about the identical secret. So the value type is
+/// recursive and this rule holds wherever a key does.
+///
+/// It quotes nothing either: keys arrive as `String` and values as [`Written`], which accepts
+/// every JSON type rather than refusing one — so no serde type error can be raised about a value
+/// here, and the check that a value is a string is [`TokenFile::parse`]'s, which names the key
+/// instead.
+struct Entries(Vec<(String, Written)>);
+
+impl Entries {
+    /// Every pair a map access will yield. Shared by both visitors, because "duplicates and all"
+    /// has to mean the same thing at both levels.
+    fn every_pair<'de, M: serde::de::MapAccess<'de>>(mut map: M) -> Result<Self, M::Error> {
+        let mut pairs = Vec::new();
+        while let Some(pair) = map.next_entry::<String, Written>()? {
+            pairs.push(pair);
+        }
+        Ok(Entries(pairs))
+    }
+}
 
 impl<'de> serde::Deserialize<'de> for Entries {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
@@ -1102,18 +1138,87 @@ impl<'de> serde::Deserialize<'de> for Entries {
                 f.write_str("a JSON object of client name to token")
             }
 
-            fn visit_map<M: serde::de::MapAccess<'de>>(
-                self,
-                mut map: M,
-            ) -> Result<Entries, M::Error> {
-                let mut pairs = Vec::new();
-                while let Some(pair) = map.next_entry::<String, serde_json::Value>()? {
-                    pairs.push(pair);
-                }
-                Ok(Entries(pairs))
+            fn visit_map<M: serde::de::MapAccess<'de>>(self, map: M) -> Result<Entries, M::Error> {
+                Entries::every_pair(map)
             }
         }
         deserializer.deserialize_map(EveryPair)
+    }
+}
+
+/// One value out of the credential file, in the three shapes this module has anything to say about.
+///
+/// **Nothing here is a refusal**, which is the whole reason it exists rather than a typed struct: a
+/// value in this file is a credential, and serde's type errors quote what they rejected (`invalid
+/// type: integer 5`). So every JSON type is accepted into a variant and [`TokenFile::parse`] does
+/// the refusing, naming the *key*.
+enum Written {
+    /// A string. At the top level that is the bearer token, which is the whole of what an entry
+    /// was before one could say anything else; inside an entry it is a field's value.
+    Text(String),
+    /// An object: an entry naming `token` and, optionally, `tools`.
+    Fields(Entries),
+    /// A number, a list, `null` — anything that is neither of the above.
+    Other,
+}
+
+impl<'de> serde::Deserialize<'de> for Written {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct Anything;
+        impl<'de> serde::de::Visitor<'de> for Anything {
+            type Value = Written;
+
+            fn expecting(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.write_str("a bearer token, or an object naming one")
+            }
+
+            fn visit_str<E: serde::de::Error>(self, text: &str) -> Result<Written, E> {
+                Ok(Written::Text(text.to_string()))
+            }
+
+            fn visit_map<M: serde::de::MapAccess<'de>>(self, map: M) -> Result<Written, M::Error> {
+                Entries::every_pair(map).map(Written::Fields)
+            }
+
+            // The rest are `Other`, one line each, rather than serde's default — which is the
+            // `invalid_type` error this type exists to avoid raising.
+            fn visit_seq<S: serde::de::SeqAccess<'de>>(
+                self,
+                mut seq: S,
+            ) -> Result<Written, S::Error> {
+                while seq.next_element::<serde::de::IgnoredAny>()?.is_some() {}
+                Ok(Written::Other)
+            }
+
+            fn visit_bool<E: serde::de::Error>(self, _: bool) -> Result<Written, E> {
+                Ok(Written::Other)
+            }
+
+            fn visit_i64<E: serde::de::Error>(self, _: i64) -> Result<Written, E> {
+                Ok(Written::Other)
+            }
+
+            fn visit_u64<E: serde::de::Error>(self, _: u64) -> Result<Written, E> {
+                Ok(Written::Other)
+            }
+
+            fn visit_f64<E: serde::de::Error>(self, _: f64) -> Result<Written, E> {
+                Ok(Written::Other)
+            }
+
+            fn visit_unit<E: serde::de::Error>(self) -> Result<Written, E> {
+                Ok(Written::Other)
+            }
+
+            fn visit_none<E: serde::de::Error>(self) -> Result<Written, E> {
+                Ok(Written::Other)
+            }
+
+            fn visit_some<D: serde::Deserializer<'de>>(self, d: D) -> Result<Written, D::Error> {
+                d.deserialize_any(self)
+            }
+        }
+        deserializer.deserialize_any(Anything)
     }
 }
 
@@ -1512,6 +1617,29 @@ mod tests {
                 r#"{"ci": {"token": "t", "surface": "crash"}}"#,
                 "a field this does not know",
             ),
+            // **A field name is matched exactly**, so a case variant is an unknown field rather
+            // than a second spelling of a known one. Folding it is what would make this pair
+            // ambiguous, and the value that won would be the credential (review on #196).
+            (
+                r#"{"ci": {"token": "t", "TOKEN": "u"}}"#,
+                "a field this does not know",
+            ),
+            // And the exact repeat, which only reaches this module at all because `Entries` keeps
+            // every pair one level down as well: a `serde_json::Map` would have thrown one of
+            // these away and left a token in the file that nothing acts on.
+            (
+                r#"{"ci": {"token": "t", "token": "u"}}"#,
+                "names `token` more than once",
+            ),
+            (
+                r#"{"ci": {"token": "t", "tools": "crash", "tools": "inspect"}}"#,
+                "names `tools` more than once",
+            ),
+            // Every JSON type a value can be is carried into a variant rather than refused by
+            // serde, so no refusal here is one serde wrote — which is what keeps values unquoted.
+            (r#"{"ci": [1, 2]}"#, "or an object naming it"),
+            (r#"{"ci": null}"#, "or an object naming it"),
+            (r#"{"ci": {"token": ["t"]}}"#, "must be a string"),
             // And a spec that names nothing this server has, which is the same refusal `--tools`
             // gives — named after the entry it is in rather than after a flag nobody typed.
             (

--- a/src/listen.rs
+++ b/src/listen.rs
@@ -647,6 +647,18 @@ async fn bind_when_ready(addr: SocketAddr) -> Result<TcpListener> {
     }
 }
 
+/// The clients served something other than the run's own surface, as a clause to hang off a line
+/// that has already said what that is.
+///
+/// Two lines print it — the startup one and the reload one — and they have to agree, because the
+/// only way to see that a reload changed a surface is to compare them.
+fn own_surfaces(credentials: &crate::client::Accepted) -> String {
+    match credentials.surfaces() {
+        rows if rows.is_empty() => String::new(),
+        rows => format!(" — except {}", rows.join(", ")),
+    }
+}
+
 /// The credentials this listener accepts, from a file if one is named and from the environment
 /// otherwise.
 fn credentials() -> Result<crate::client::Credentials> {
@@ -715,6 +727,7 @@ pub async fn serve(
     let mcp = {
         let sessions = sessions.clone();
         let tools = tools.clone();
+        let credentials = Arc::clone(&credentials);
         Arc::new(StreamableHttpService::new(
             // **The one moment the caller is knowable.** rmcp builds a service instance per MCP
             // session — here, on the task handling that session's `initialize`, which
@@ -724,12 +737,17 @@ pub async fn serve(
             // `WindbgServer::client`. On the stateless revision there is no session and no spawn,
             // and this runs per request, which reaches the same answer by the shorter route.
             move || {
-                Ok(
-                    WindbgServer::for_client(sessions.clone(), crate::client::current())
-                        // Server-wide, so every client on this listener sees the same surface.
-                        // Per-caller is `FOLLOWUPS.md` item 36, and this is the line it changes.
-                        .with_tools(tools.clone()),
-                )
+                let client = crate::client::current();
+                // **And the one moment its surface is knowable, for the same reason.** A client
+                // configured with a spec of its own is served that; every other client is served
+                // whatever this run serves, which is `--tools` or all fifty-one. The run's flag is
+                // the default rather than a ceiling — see [`crate::toolset`], which also says why
+                // a change here reaches a client on its next connection and not before.
+                let (surface, chosen) = match credentials.surface_for(&client) {
+                    Some(own) => (own, crate::toolset::Chosen::ForThisClient),
+                    None => (tools.clone(), crate::toolset::Chosen::ForTheRun),
+                };
+                Ok(WindbgServer::for_client(sessions.clone(), client).with_tools(surface, chosen))
             },
             manager.clone(),
             // A tool call can be quiet for minutes; without a keep-alive the stream looks idle to
@@ -754,7 +772,8 @@ pub async fn serve(
     // *now*. See [`crate::service`], where "started" is a thing the SCM and its dependants act on.
     ready();
     tracing::info!(
-        "windbg-mcp listening on http://{addr} (lease grace {grace:?}, {}, clients: {}, serving {})",
+        "windbg-mcp listening on http://{addr} (lease grace {grace:?}, {}, clients: {}, serving \
+         {}{})",
         match idle_after {
             Some(after) => format!("idle sessions released after {}m", after.as_secs() / 60),
             None => "idle sessions never released".to_string(),
@@ -762,7 +781,10 @@ pub async fn serve(
         credentials.names().join(", "),
         // Named here for the same reason the client list is: `--tools` adds the `session` group
         // whatever the spec said, so the surface a run ends up with is not always the one typed.
-        tools.summary()
+        tools.summary(),
+        // And the clients that are not served that one. Empty — and costing this line nothing —
+        // on the configuration everyone has, where no client names a surface of its own.
+        own_surfaces(&credentials)
     );
 
     // Only under the service, which is the only role with a control channel to be asked on.
@@ -1033,19 +1055,27 @@ async fn reloaded(
         // command claims when it returns, and all of it is memory.
         let _ = answer.send(true);
         tracing::info!(
-            "re-read the clients: {}",
+            "re-read the clients: {}{}",
             match change.is_empty() {
                 // A rotation, which changes a token and no name. Worth a line of its own: from
                 // out here it looks like nothing happened, and the client whose token moved is
                 // about to start failing to authenticate with the old one.
-                true => "the same clients, one or more of which may now present a different token"
+                //
+                // **A surface change looks like this too**, and for the same reason — it moves no
+                // name — which is why the clause below is printed on every reload rather than
+                // when something was added or taken away.
+                true => "the same clients, one or more of which may now present a different token \
+                         or tool surface"
                     .to_string(),
                 false => format!(
                     "added [{}], removed [{}]",
                     crate::client::Change::names(&change.added),
                     crate::client::Change::names(&change.removed)
                 ),
-            }
+            },
+            // Absolute rather than a diff: the startup line prints the same clause, so the two
+            // together say what changed without this having to work it out.
+            own_surfaces(&accepted)
         );
     }
 }

--- a/src/listen.rs
+++ b/src/listen.rs
@@ -742,7 +742,7 @@ pub async fn serve(
                 // configured with a spec of its own is served that; every other client is served
                 // whatever this run serves, which is `--tools` or all fifty-one. The run's flag is
                 // the default rather than a ceiling — see [`crate::toolset`], which also says why
-                // a change here reaches a client on its next connection and not before.
+                // a change here reaches a client the next time it is identified and not before.
                 let (surface, chosen) = match credentials.surface_for(&client) {
                     Some(own) => (own, crate::toolset::Chosen::ForThisClient),
                     None => (tools.clone(), crate::toolset::Chosen::ForTheRun),

--- a/src/main.rs
+++ b/src/main.rs
@@ -94,7 +94,7 @@ fn main() -> Result<()> {
                 listen_address(&args)?,
                 // Validated here, by the same parser the service will use at every start, so a
                 // spec the running service would reject cannot be written into its command line.
-                installed_tools(&args)?.as_deref(),
+                tools_spec(&args)?.as_deref(),
                 args.iter().any(|a| a == service::ALLOW_UNPROTECTED_FLAG),
             ),
             service::Role::Uninstall => service::uninstall(),
@@ -102,7 +102,12 @@ fn main() -> Result<()> {
             // Touches the SCM and one file, like installing — and like installing, it must not
             // build a runtime: the reload it asks for happens in the *service's* process, not
             // this one.
-            service::Role::Client(edit, name) => service::edit_client(edit, &name),
+            // The `--tools` on this command line is the *client's* surface here, not this run's:
+            // this process serves nothing. `edit_client` refuses it on the edits it means nothing
+            // for, rather than accepting a flag it would then ignore.
+            service::Role::Client(edit, name) => {
+                service::edit_client(edit, &name, tools_spec(&args)?.as_deref())
+            }
         };
     }
 
@@ -168,12 +173,18 @@ pub(crate) async fn serve_http(
     outcome
 }
 
-/// The `--tools` spec an install was told to register, checked before it is stored.
+/// The `--tools` spec on this command line, as text, checked before it is written anywhere.
 ///
-/// The same reason [`listen_address`] exists, pointed at the other half of the stored command
-/// line: the SCM keeps that line and nothing re-derives it, so a spec that the service would
-/// refuse at start is a service that installs cleanly and never runs.
-fn installed_tools(args: &[String]) -> Result<Option<String>> {
+/// The same reason [`listen_address`] exists, and it now has two callers whose stored copy nothing
+/// re-derives: the command line the SCM keeps for the service, and a client's entry in the
+/// credential file. A spec the server would refuse at start is, in the first case, a service that
+/// installs cleanly and never runs.
+///
+/// **Text rather than a [`toolset::Toolset`]**, because both of those store what was typed and
+/// parse it again later — and `--tools` with nothing after it has to be the usage error
+/// [`toolset::Toolset::requested`] makes it, rather than the `None` that would silently mean "no
+/// spec given".
+fn tools_spec(args: &[String]) -> Result<Option<String>> {
     match toolset::Toolset::requested(args) {
         Some(Err(e)) => Err(anyhow::anyhow!(e)),
         Some(Ok(_)) => Ok(toolset::Toolset::spec_in(args).map(str::to_string)),
@@ -297,7 +308,9 @@ async fn serve(tools: toolset::Toolset) -> Result<()> {
     // rather than whatever the first tool call happened to be.
     let sessions = Sessions::new(call_timeout()).recording(record::Recorder::from_env());
     let surface = tools.summary();
-    let server = WindbgServer::new(sessions.clone()).with_tools(tools);
+    // `ForTheRun` without a branch: stdio has one client by construction and no configuration to
+    // give it a surface of its own, so `--tools` is the only thing that can have narrowed this.
+    let server = WindbgServer::new(sessions.clone()).with_tools(tools, toolset::Chosen::ForTheRun);
 
     tracing::info!("windbg-mcp starting on stdio, serving {surface}");
     let service = server.serve(stdio()).await?;

--- a/src/server.rs
+++ b/src/server.rs
@@ -59,12 +59,18 @@ pub struct WindbgServer {
     /// moment the caller is knowable, so the identity is captured there and re-entered around
     /// every call.
     client: crate::client::Client,
-    /// Which of the tools this run advertises — every one of them unless `--tools` said otherwise.
+    /// Which of the tools this instance advertises — every one of them unless something narrowed
+    /// it.
     ///
     /// Carried rather than read from a global, for the reason `Credentials::from_entries` is: a
-    /// process-wide cell set once from `argv` is state the whole test binary shares, and this is
-    /// decided at startup precisely so that a test can build two servers with different surfaces.
+    /// process-wide cell set once from `argv` is state the whole test binary shares. It is also
+    /// what makes the surface **per client** rather than per run: the listener builds an instance
+    /// where the caller is knowable and can pass that client's own spec, and two credentials on
+    /// one port therefore get two `tools/list` answers.
     surface: crate::toolset::Toolset,
+    /// Whether that was this run's choice or this client's, which is the only half of a refusal a
+    /// caller can act on — see [`crate::toolset::Chosen`].
+    chosen: crate::toolset::Chosen,
 }
 
 fn text_result(s: String) -> Result<CallToolResult, ErrorData> {
@@ -2534,16 +2540,23 @@ impl WindbgServer {
             sessions,
             client,
             surface: crate::toolset::Toolset::all(),
+            chosen: crate::toolset::Chosen::ForTheRun,
         }
     }
 
-    /// The same server, advertising only the tools `--tools` asked for.
+    /// The same server, advertising only the tools it was narrowed to — and knowing **whose
+    /// choice that was**, because that is what the refusal for a tool off the surface has to say.
     ///
     /// Separate from the constructors rather than a parameter on both, so every existing caller —
     /// the unit tests included — keeps the whole surface by construction and only a run that was
     /// told to narrow it does.
-    pub fn with_tools(mut self, surface: crate::toolset::Toolset) -> Self {
+    pub fn with_tools(
+        mut self,
+        surface: crate::toolset::Toolset,
+        chosen: crate::toolset::Chosen,
+    ) -> Self {
         self.surface = surface;
+        self.chosen = chosen;
         self
     }
 
@@ -4462,19 +4475,14 @@ impl WindbgServer {
         context: rmcp::service::RequestContext<rmcp::RoleServer>,
     ) -> Result<rmcp::model::CallToolResponse, ErrorData> {
         let tcc = rmcp::handler::server::tool::ToolCallContext::new(self, request, context);
-        // A tool this build has and this *surface* does not. rmcp would answer the router's own
-        // `tool not found`, which is the right status and the wrong sentence: it is what a typo
-        // gets, and this is not a typo — the tool exists, the operator narrowed the surface, and
-        // the remedy is a flag on a command line the caller cannot see. Said here rather than in
-        // the router because only this server knows the difference.
+        // A tool this build has and this *surface* does not. Said here rather than in the router
+        // because only this server knows the difference between that and a typo — and the message
+        // is [`Toolset::refusal`]'s because only the surface knows which of two configurations the
+        // caller's operator has to go and widen.
         if !self.surface.includes(tcc.name()) && crate::toolset::Toolset::exists(tcc.name()) {
             return Err(ErrorData::invalid_params(
-                format!(
-                    "`{}` is a tool this server has, but it is not on the surface this run                      advertises ({}). It was started with `{}`; widen that spec, or drop it to                      serve every tool.",
-                    tcc.name(),
-                    self.surface.summary(),
-                    crate::toolset::FLAG,
-                ),
+                self.surface
+                    .refusal(tcc.name(), self.client.name(), self.chosen),
                 None,
             ));
         }

--- a/src/service.rs
+++ b/src/service.rs
@@ -842,7 +842,7 @@ pub fn edit_client(edit: ClientEdit, name: &str, tools: Option<&str>) -> Result<
             }
         ),
     }
-    // **A surface reaches a client on its next connection, and a reload is not that.** Said here
+    // **A surface reaches a client the next time it is identified, and a reload is not that.** Said here
     // because the line above claims the service re-read its clients, which is true and is not the
     // same claim: a connected client's tool list was decided when it connected, and nothing sends
     // `notifications/tools/list_changed` to tell it otherwise (see [`crate::toolset`]). A
@@ -855,8 +855,9 @@ pub fn edit_client(edit: ClientEdit, name: &str, tools: Option<&str>) -> Result<
     // would have contradicted them two lines later.
     if in_force && matches!(edit, ClientEdit::SetTools) {
         println!(
-            "\n`{name}` sees this when it next connects. A client connected now goes on listing \
-             the tools it listed at the time — reconnect it, or restart whatever is driving it."
+            "\n`{name}` sees this the next time it is identified. A client that holds an MCP \
+             session goes on listing the tools it listed at the time — reconnect it, or restart \
+             whatever is driving it; one on the sessionless revision needs nothing."
         );
     }
     Ok(())

--- a/src/service.rs
+++ b/src/service.rs
@@ -795,7 +795,12 @@ pub fn edit_client(edit: ClientEdit, name: &str, tools: Option<&str>) -> Result<
             crate::listen::TOKEN_ENV,
         );
     }
-    match ask_to_reload(&service) {
+    // **Kept, because one line below depends on which of these arms ran.** A re-tooling's note is
+    // about a client that has to reconnect to see the change — which is only the remaining gap
+    // once the *service* has the change, and in every arm but the first it does not.
+    let outcome = ask_to_reload(&service);
+    let in_force = matches!(outcome, Ok(true));
+    match outcome {
         Ok(true) => println!("\n`{NAME}` re-read its clients; nothing was stopped."),
         // Not running is not a failure even for a revocation: nothing is accepting that credential
         // either, and the file it will read at its next start is the one this command wrote.
@@ -820,10 +825,21 @@ pub fn edit_client(edit: ClientEdit, name: &str, tools: Option<&str>) -> Result<
                 at.display()
             )));
         }
+        // **What has not changed is what this has to say**, and it is not the same sentence for
+        // all three: an add's client cannot connect yet, while a re-tooling's client can — it is
+        // simply still being served the surface it had, which is usually the wider one. Saying
+        // "`bench` can connect from the next start" of a client that is connected right now reads
+        // as a revocation that half-landed.
         Err(e) => println!(
             "\nwarning: `{NAME}` could not be told to re-read its clients ({e:#}). The file is \
-             written, and `{name}` can connect from the service's next start; nothing that works \
-             today has stopped working."
+             written, and {}; nothing that works today has stopped working.",
+            match edit {
+                ClientEdit::SetTools => format!(
+                    "`{name}` goes on being served the surface it had until the service's next \
+                     start"
+                ),
+                _ => format!("`{name}` can connect from the service's next start"),
+            }
         ),
     }
     // **A surface reaches a client on its next connection, and a reload is not that.** Said here
@@ -831,7 +847,13 @@ pub fn edit_client(edit: ClientEdit, name: &str, tools: Option<&str>) -> Result<
     // same claim: a connected client's tool list was decided when it connected, and nothing sends
     // `notifications/tools/list_changed` to tell it otherwise (see [`crate::toolset`]). A
     // revocation needs no such note — the credential stops being accepted at the swap.
-    if matches!(edit, ClientEdit::SetTools) {
+    //
+    // **Only when the reload landed** (review on #196). Printed unconditionally it told an
+    // operator whose reload had just failed that reconnecting would show the new surface, which is
+    // the opposite of true — the running service still holds the old set, so a reconnect gets the
+    // old surface until it re-reads the file. The arms above already say that happened; this line
+    // would have contradicted them two lines later.
+    if in_force && matches!(edit, ClientEdit::SetTools) {
         println!(
             "\n`{name}` sees this when it next connects. A client connected now goes on listing \
              the tools it listed at the time — reconnect it, or restart whatever is driving it."

--- a/src/service.rs
+++ b/src/service.rs
@@ -90,6 +90,10 @@ pub const ADD_CLIENT_FLAG: &str = "--add-listen-client";
 pub const REMOVE_CLIENT_FLAG: &str = "--remove-listen-client";
 /// Replaces a client's token, keeping its name — and so its sessions.
 pub const ROTATE_CLIENT_FLAG: &str = "--rotate-listen-client";
+/// Changes which tools one client is served. Takes the client's name, and the surface as
+/// [`crate::toolset::FLAG`] beside it — with no `--tools` at all, the client goes back to being
+/// served whatever the run serves.
+pub const SET_CLIENT_TOOLS_FLAG: &str = "--set-listen-client-tools";
 
 /// Overrides where the service writes its log.
 pub const LOG_ENV: &str = "WINDBG_MCP_SERVICE_LOG";
@@ -142,6 +146,7 @@ pub enum ClientEdit {
     Add,
     Remove,
     Rotate,
+    SetTools,
 }
 
 impl ClientEdit {
@@ -150,7 +155,18 @@ impl ClientEdit {
             Self::Add => ADD_CLIENT_FLAG,
             Self::Remove => REMOVE_CLIENT_FLAG,
             Self::Rotate => ROTATE_CLIENT_FLAG,
+            Self::SetTools => SET_CLIENT_TOOLS_FLAG,
         }
+    }
+
+    /// Whether a [`crate::toolset::FLAG`] beside this command means anything.
+    ///
+    /// Two of the four say what a client is served, and on the other two the flag is refused
+    /// rather than ignored: `--rotate-listen-client bench --tools crash` reads exactly like a
+    /// command that narrows `bench`, and accepting it silently would leave an operator believing
+    /// it had.
+    fn takes_a_surface(self) -> bool {
+        matches!(self, Self::Add | Self::SetTools)
     }
 
     /// Whether this command takes a working credential *out* of service.
@@ -179,6 +195,7 @@ pub fn requested(args: &[String]) -> Option<Role> {
         (ADD_CLIENT_FLAG, ClientEdit::Add),
         (REMOVE_CLIENT_FLAG, ClientEdit::Remove),
         (ROTATE_CLIENT_FLAG, ClientEdit::Rotate),
+        (SET_CLIENT_TOOLS_FLAG, ClientEdit::SetTools),
     ];
     args.iter().enumerate().find_map(|(at, arg)| {
         match arg.as_str() {
@@ -274,16 +291,33 @@ pub fn token_file() -> PathBuf {
 /// Both are read back by [`crate::client::TokenFile`], which is where the shapes are defined; this
 /// only has to pick between them — and picks by [asking it](reads_back_bare) rather than by
 /// restating its rule.
-fn token_file_contents(credentials: &[(String, String)]) -> String {
-    if let [(name, token)] = credentials
-        && name == crate::client::Client::LOCAL
-        && reads_back_bare(token)
+fn token_file_contents(credentials: &[crate::client::ClientEntry]) -> String {
+    if let [only] = credentials
+        && only.name == crate::client::Client::LOCAL
+        // **And nothing to say beyond the token.** A bare token is the whole entry, so a client
+        // with a surface of its own cannot be written as one — setting a spec on the file
+        // everybody has rewrites it into the object shape, which is the only place the spec fits.
+        && only.tools.is_none()
+        && reads_back_bare(&only.token)
     {
-        return token.clone();
+        return only.token.clone();
     }
-    let named: std::collections::BTreeMap<&str, &str> = credentials
+    let named: std::collections::BTreeMap<&str, Entry<'_>> = credentials
         .iter()
-        .map(|(name, token)| (name.as_str(), token.as_str()))
+        .map(|entry| {
+            (
+                entry.name.as_str(),
+                match entry.tools.as_deref() {
+                    // Written back as the string it was, so a file whose clients have no surfaces
+                    // is byte-for-byte the file this wrote before there were any.
+                    None => Entry::Token(entry.token.as_str()),
+                    Some(tools) => Entry::Named {
+                        token: entry.token.as_str(),
+                        tools,
+                    },
+                },
+            )
+        })
         .collect();
     // Pretty, and a trailing newline: this is a file an operator will open when something is wrong,
     // and `Get-Content` on a single long line is not a way to read one.
@@ -293,6 +327,19 @@ fn token_file_contents(credentials: &[(String, String)]) -> String {
     // a service that then refuses every caller — which is the exact outcome this path exists to
     // prevent.
     serde_json::to_string_pretty(&named).expect("a map of strings serializes") + "\n"
+}
+
+/// One client's entry as the file holds it: the token alone, or the object that can also carry a
+/// surface.
+///
+/// Untagged, because the two shapes are the file's own and [`crate::client::TokenFile`] tells them
+/// apart by their JSON types rather than by a discriminant — a `tag` here would write a field that
+/// reader would refuse as one it does not know.
+#[derive(serde::Serialize)]
+#[serde(untagged)]
+enum Entry<'a> {
+    Token(&'a str),
+    Named { token: &'a str, tools: &'a str },
 }
 
 /// Whether `token`, written on its own, reads back as the one `local` credential it is meant to be.
@@ -433,7 +480,7 @@ fn under_protected_root(exe: &std::path::Path) -> bool {
 /// here, so there is no window in which the file exists and something is serving with it.
 fn finish_install(
     service: &windows_service::service::Service,
-    credentials: &[(String, String)],
+    credentials: &[crate::client::ClientEntry],
 ) -> Result<()> {
     service
         .set_description(DESCRIPTION)
@@ -505,7 +552,7 @@ fn is_reload(control: &ServiceControl) -> bool {
 /// keeps a working token out of a shell history and out of an agent's transcript, and it is why
 /// these commands are narrow enough to allow-list in a permission rule where "let this write
 /// `%ProgramData%`" would not be.
-pub fn edit_client(edit: ClientEdit, name: &str) -> Result<()> {
+pub fn edit_client(edit: ClientEdit, name: &str, tools: Option<&str>) -> Result<()> {
     let name = crate::client::client_name(name).with_context(|| {
         format!(
             "`{}` needs the name of a client — `{} bench`",
@@ -513,6 +560,26 @@ pub fn edit_client(edit: ClientEdit, name: &str) -> Result<()> {
             edit.flag()
         )
     })?;
+    // **Checked before the SCM is opened and before the lock is taken**, because it is a fact
+    // about this command line and nothing else — and a usage error that only surfaces after a
+    // transaction has started is one that has to be unwound.
+    if let Some(spec) = tools {
+        if !edit.takes_a_surface() {
+            bail!(
+                "`{}` changes a client's token, not the tools it is served, so the `{}` beside it \
+                 would do nothing — and it reads exactly like a command that had narrowed \
+                 `{name}`. `{SET_CLIENT_TOOLS_FLAG} {name} {} {spec}` is that command.",
+                edit.flag(),
+                crate::toolset::FLAG,
+                crate::toolset::FLAG,
+            );
+        }
+        // By the same parser the service will use at every start, so a spec it would refuse
+        // cannot be written into the file it reads — the same rule the command line the SCM
+        // stores is held to. A second parse: `main` has already validated this, and this is the
+        // function that writes the file, so it does not take that on trust.
+        crate::toolset::Toolset::parse(spec).map_err(|e| anyhow::anyhow!(e))?;
+    }
     // **This handle does not prove elevation**, and it is worth being clear about that rather than
     // implying it: a service's default DACL grants `SERVICE_USER_DEFINED_CONTROL` to Authenticated
     // Users, so an ordinary account opens it fine. What refuses an unelevated caller is the
@@ -561,7 +628,7 @@ pub fn edit_client(edit: ClientEdit, name: &str) -> Result<()> {
             return Err(anyhow::Error::new(e).context(format!("cannot read {}", at.display())));
         }
     };
-    let mut credentials = match (existing, edit) {
+    let mut credentials: Vec<crate::client::ClientEntry> = match (existing, edit) {
         (Some(credentials), _) => credentials,
         (None, ClientEdit::Add) => Vec::new(),
         (None, _) => bail!(
@@ -573,23 +640,37 @@ pub fn edit_client(edit: ClientEdit, name: &str) -> Result<()> {
     };
     let started_empty = credentials.is_empty();
 
-    let held_at = credentials.iter().position(|(held, _)| *held == name);
+    let held_at = credentials.iter().position(|held| held.name == name);
     let mut minted = None;
     match (edit, held_at) {
         (ClientEdit::Add, Some(_)) => bail!(
             "`{NAME}` already has a client called `{name}`. To give it a new token without \
-             disturbing what it has open, `{ROTATE_CLIENT_FLAG} {name}`; to take it away, \
+             disturbing what it has open, `{ROTATE_CLIENT_FLAG} {name}`; to change which tools it \
+             is served, `{SET_CLIENT_TOOLS_FLAG} {name}`; to take it away, \
              `{REMOVE_CLIENT_FLAG} {name}`."
         ),
         (ClientEdit::Add, None) => {
             let token = crate::client::generate_token()?;
             minted = Some(token.clone());
-            credentials.push((name.clone(), token));
+            credentials.push(crate::client::ClientEntry {
+                name: name.clone(),
+                token,
+                tools: tools.map(str::to_string),
+            });
         }
-        (ClientEdit::Remove, None) | (ClientEdit::Rotate, None) => bail!(
-            "`{NAME}` has no client called `{name}`. It holds: {}.",
-            roster(&credentials)
-        ),
+        (ClientEdit::Remove, None) | (ClientEdit::Rotate, None) | (ClientEdit::SetTools, None) => {
+            bail!(
+                "`{NAME}` has no client called `{name}`. It holds: {}.",
+                roster(&credentials)
+            )
+        }
+        // **`None` is not the same as `all`**, and this is the command where the difference is
+        // visible: with no `--tools` at all the entry's spec is taken away, so the client goes
+        // back to being served whatever the service serves — which is what it had before anyone
+        // set one, and follows the service's own `--tools` if that ever changes.
+        (ClientEdit::SetTools, Some(index)) => {
+            credentials[index].tools = tools.map(str::to_string);
+        }
         (ClientEdit::Remove, Some(index)) => {
             credentials.remove(index);
             // **Refused, because a listener with no credentials will not start.** Revoking the
@@ -608,10 +689,15 @@ pub fn edit_client(edit: ClientEdit, name: &str) -> Result<()> {
         (ClientEdit::Rotate, Some(index)) => {
             let token = crate::client::generate_token()?;
             minted = Some(token.clone());
-            credentials[index].1 = token;
+            credentials[index].token = token;
         }
     }
-    credentials.sort_by(|a, b| a.0.cmp(&b.0));
+    credentials.sort_by(|a, b| a.name.cmp(&b.name));
+    // Held to the rules the listener holds a configuration to, before any of it is written down.
+    // The spec above went through the same parser already; what this adds is everything a *set*
+    // has to satisfy — and it is the check that keeps this command from writing a file the service
+    // then refuses to start on.
+    crate::client::check(&credentials)?;
 
     // **Written before the credential file, and removed again if that write fails.** The order is
     // what keeps the two from disagreeing: a token accepted by the service that the operator has
@@ -647,12 +733,19 @@ pub fn edit_client(edit: ClientEdit, name: &str) -> Result<()> {
         _ => false,
     };
 
-    let (past, changed) = match edit {
-        ClientEdit::Add => (
-            "added",
-            "it gets the whole tool surface, as every client here does — a token separates \
-             clients from each other, it does not limit one",
+    let served = match tools {
+        // Named as the *spec*, not as the surface it resolves to: `session` is added to it, so the
+        // two differ, and what an operator has to be able to hand back to this command is the spec
+        // they typed. The resolved surface is in the listener's own startup and reload lines.
+        Some(spec) => format!("it is served `{spec}`"),
+        None => format!(
+            "it is served whatever `{NAME}` serves — `{}` on the command line the SCM stores, or \
+             every tool if that has none",
+            crate::toolset::FLAG
         ),
+    };
+    let (past, changed) = match edit {
+        ClientEdit::Add => ("added", served.as_str()),
         ClientEdit::Remove => (
             "removed",
             "it can no longer connect, and the sessions it still held go with it",
@@ -662,12 +755,19 @@ pub fn edit_client(edit: ClientEdit, name: &str) -> Result<()> {
             "it keeps its name, and so keeps the sessions it has open — it just presents the new \
              token",
         ),
+        // **What it does not change is what it is worth saying**: the token is untouched, so this
+        // is not a revocation and nothing has to be moved to the client machine.
+        ClientEdit::SetTools => ("re-toolled", served.as_str()),
     };
     println!(
         "{past} the client `{name}` ({}) — {changed}.\n`{NAME}` now holds: {}.",
-        match minted.as_deref() {
-            Some(token) => crate::client::fingerprint(token),
-            None => "no longer configured".to_string(),
+        match (minted.as_deref(), edit) {
+            (Some(token), _) => crate::client::fingerprint(token),
+            // **Three answers, not two.** A removal's credential is gone; a re-toolling's is
+            // untouched, and saying "no longer configured" of it would read as a revocation that
+            // did not happen — the one thing an operator must not be told wrongly here.
+            (None, ClientEdit::Remove) => "no longer configured".to_string(),
+            (None, _) => "same token".to_string(),
         },
         roster(&credentials)
     );
@@ -726,17 +826,42 @@ pub fn edit_client(edit: ClientEdit, name: &str) -> Result<()> {
              today has stopped working."
         ),
     }
+    // **A surface reaches a client on its next connection, and a reload is not that.** Said here
+    // because the line above claims the service re-read its clients, which is true and is not the
+    // same claim: a connected client's tool list was decided when it connected, and nothing sends
+    // `notifications/tools/list_changed` to tell it otherwise (see [`crate::toolset`]). A
+    // revocation needs no such note — the credential stops being accepted at the swap.
+    if matches!(edit, ClientEdit::SetTools) {
+        println!(
+            "\n`{name}` sees this when it next connects. A client connected now goes on listing \
+             the tools it listed at the time — reconnect it, or restart whatever is driving it."
+        );
+    }
     Ok(())
 }
 
-/// Every configured client, by name and fingerprint — what these commands print instead of a file.
-fn roster(credentials: &[(String, String)]) -> String {
+/// Every configured client, by name, fingerprint and surface — what these commands print instead
+/// of a file.
+///
+/// The surface is named only where one is set, so the roster of the configuration everyone has is
+/// the line it always was, and a service serving two budgets says so in one line.
+fn roster(credentials: &[crate::client::ClientEntry]) -> String {
     if credentials.is_empty() {
         return "no clients".to_string();
     }
     credentials
         .iter()
-        .map(|(name, token)| format!("`{name}` ({})", crate::client::fingerprint(token)))
+        .map(|entry| {
+            format!(
+                "`{}` ({}{})",
+                entry.name,
+                crate::client::fingerprint(&entry.token),
+                match &entry.tools {
+                    Some(spec) => format!(", {} {spec}", crate::toolset::FLAG),
+                    None => String::new(),
+                }
+            )
+        })
         .collect::<Vec<_>>()
         .join(", ")
 }
@@ -860,7 +985,7 @@ fn lock_credentials() -> Result<std::fs::File> {
 ///
 /// Shared with [`finish_install`] rather than restated, so the client commands and the installer
 /// cannot end up writing that file to two different standards.
-fn write_credentials(credentials: &[(String, String)]) -> Result<()> {
+fn write_credentials(credentials: &[crate::client::ClientEntry]) -> Result<()> {
     use std::io::Write;
 
     let dir = secured_state_dir()?;
@@ -974,10 +1099,11 @@ pub fn install(addr: SocketAddr, tools: Option<&str>, allow_unprotected: bool) -
              LocalSystem.\n    $env:{} = \"<a long random string>\"\n\nEvery {}_<NAME> in this \
              shell is copied too, each naming a client of its own — which under a service is the \
              only way to have more than one, since the file it reads is the whole of what it \
-             accepts.",
+             accepts. So is each client's {}_<NAME>, if it has one.",
             crate::listen::TOKEN_ENV,
             crate::listen::TOKEN_ENV,
-            crate::listen::TOKEN_ENV
+            crate::listen::TOKEN_ENV,
+            crate::client::TOOLS_ENV
         );
     }
 
@@ -1566,15 +1692,59 @@ mod tests {
     #[test]
     fn the_roster_names_clients_and_quotes_no_token() {
         let credentials = [
-            ("ci".to_string(), "ci-token-value".to_string()),
-            ("local".to_string(), "local-token-value".to_string()),
+            entry("ci", "ci-token-value", Some("session,crash")),
+            entry("local", "local-token-value", None),
         ];
         let said = roster(&credentials);
         assert!(said.contains("`ci`") && said.contains("`local`"), "{said}");
-        for (_, token) in &credentials {
-            assert!(!said.contains(token), "the roster quotes a token: {said}");
+        // The surface *is* quoted, on the one client that has one: it is a list of this server's
+        // own group names, and it is what an operator has to see to know the two clients are not
+        // being served the same thing.
+        assert!(said.contains("--tools session,crash"), "{said}");
+        for held in &credentials {
+            assert!(
+                !said.contains(&held.token),
+                "the roster quotes a token: {said}"
+            );
         }
         assert_eq!(roster(&[]), "no clients");
+    }
+
+    /// A `--tools` on a command that does not take one is refused, not ignored.
+    ///
+    /// `--rotate-listen-client bench --tools crash` reads exactly like a command that narrowed
+    /// `bench`, and accepting it silently would leave an operator believing it had. Checked before
+    /// the SCM is opened and before the credential lock is taken, which is also what lets this be
+    /// a unit test: nothing about the machine has been touched by the time it returns.
+    #[test]
+    fn a_surface_on_a_command_that_does_not_take_one_is_refused() {
+        for edit in [ClientEdit::Remove, ClientEdit::Rotate] {
+            let why = edit_client(edit, "bench", Some("crash"))
+                .expect_err("a surface on a token command is a usage error")
+                .to_string();
+            assert!(why.contains(SET_CLIENT_TOOLS_FLAG), "{why}");
+            assert!(
+                why.contains("changes a client's token, not the tools it is served"),
+                "{why}"
+            );
+        }
+        // And a spec this server could not serve is refused on the commands that *do* take one,
+        // before anything is written — the same rule the installed command line is held to.
+        let why = edit_client(ClientEdit::Add, "bench", Some("crash,ttdd"))
+            .expect_err("`ttdd` is not a group")
+            .to_string();
+        assert!(
+            why.contains("`ttdd` is neither a group nor a tool"),
+            "{why}"
+        );
+    }
+
+    fn entry(name: &str, token: &str, tools: Option<&str>) -> crate::client::ClientEntry {
+        crate::client::ClientEntry {
+            name: name.to_string(),
+            token: token.to_string(),
+            tools: tools.map(str::to_string),
+        }
     }
 
     /// The SCM stores this once, at install time, and nothing re-derives it — so a service that
@@ -1638,10 +1808,7 @@ mod tests {
 
         // One client called `local` keeps the shape every existing install has: the token, and
         // nothing around it.
-        let one = [(
-            crate::client::Client::LOCAL.to_string(),
-            "s3cret".to_string(),
-        )];
+        let one = [entry(crate::client::Client::LOCAL, "s3cret", None)];
         let written = token_file_contents(&one);
         assert_eq!(written, "s3cret", "a single local token is written bare");
         assert_eq!(read_back(&written).client_for("s3cret"), Some("local"));
@@ -1650,29 +1817,49 @@ mod tests {
         // and under a service the only way to have a second client at all.
         for credentials in [
             vec![
-                ("local".to_string(), "for-local".to_string()),
-                ("ci".to_string(), "for-ci".to_string()),
+                entry("local", "for-local", None),
+                entry("ci", "for-ci", None),
             ],
             // A shell with only a named token configures no `local`, and that is not a special
             // case: it is one client, which happens not to be that one.
-            vec![("ci".to_string(), "for-ci".to_string())],
+            vec![entry("ci", "for-ci", None)],
             // And a lone `local` whose token begins with `{`, which the bare shape cannot carry:
             // the reader would take it for the JSON one. Nothing is wrong with the token, so it
             // goes in the object rather than being refused.
-            vec![("local".to_string(), "{not-json-just-a-token".to_string())],
+            vec![entry("local", "{not-json-just-a-token", None)],
             // The nastier one: a token that *is* a one-entry object naming `local`. Written bare
             // it parses — to a different token — so this asserts the whole credential survives,
             // not just the client's name.
-            vec![(
-                "local".to_string(),
-                r#"{"local":"replacement"}"#.to_string(),
-            )],
+            vec![entry("local", r#"{"local":"replacement"}"#, None)],
+            // **A surface takes the file out of the bare shape**, which is the one client the
+            // reader would otherwise have written as a token and read back with no spec at all.
+            vec![entry("local", "s3cret", Some("session,crash"))],
+            vec![
+                entry("local", "for-local", None),
+                entry("bench", "for-bench", Some("crash")),
+            ],
         ] {
             let written = token_file_contents(&credentials);
             let creds = read_back(&written);
             assert_eq!(creds.len(), credentials.len());
-            for (name, token) in &credentials {
-                assert_eq!(creds.client_for(token), Some(name.as_str()), "{written}");
+            for held in &credentials {
+                assert_eq!(
+                    creds.client_for(&held.token),
+                    Some(held.name.as_str()),
+                    "{written}"
+                );
+                // And the surface came back beside it, resolved the way the flag resolves one.
+                assert_eq!(
+                    creds
+                        .surface_for(&held.name)
+                        .map(crate::toolset::Toolset::summary),
+                    held.tools
+                        .as_deref()
+                        .map(|spec| crate::toolset::Toolset::parse(spec)
+                            .expect("the test's own spec parses")
+                            .summary()),
+                    "{written}"
+                );
             }
         }
     }

--- a/src/toolset.rs
+++ b/src/toolset.rs
@@ -35,14 +35,29 @@
 //! is the floor of any usable surface — `--tools crash` is eleven tools, not one, and the startup
 //! line says so rather than leaving the addition to be discovered.
 //!
-//! # Where this stops
+//! # Who a surface belongs to
 //!
-//! **Server-wide**, decided from `argv` before anything is built. The listener names its clients
-//! already ([`crate::client`]), so a per-caller surface — a local model getting twenty tools and a
-//! full client fifty-one on the same server — is the obvious next step and is `FOLLOWUPS.md` item
-//! 36. It is deliberately not this change: the router is `WindbgServer::tool_router()`, a
-//! static, and making it per-instance is a separate argument with its own two-client coverage to
-//! write.
+//! **A run has one, and a client may have its own.** `--tools` is the run's, decided from `argv`
+//! before anything is built, and it is the whole story under stdio — one process, one client, and
+//! the flag is right there on the command line that started it.
+//!
+//! A listener names its clients already ([`crate::client`]), and they do not have one budget
+//! between them: the arrangement this exists for is a local model that can hold twenty tools and a
+//! hosted client that can hold fifty-one, pointed at the same Windows box and the same debug
+//! sessions and told apart by their bearer tokens. So a client may be configured with a spec of
+//! its own — `WINDBG_MCP_TOOLS_<NAME>`, or a `tools` field in the credential file — and is served
+//! that instead of the run's. The run's `--tools` is the **default**, not a ceiling: a client's
+//! own spec replaces it rather than intersecting with it, because an intersection can produce a
+//! surface neither the operator nor the client ever named.
+//!
+//! **When a change takes effect is a decision, and the answer is "when the client next connects".**
+//! A surface is fixed on the line that captures the caller's identity — the listener's service
+//! factory, which rmcp runs once per MCP session and once per request on `2026-07-28`. Nothing
+//! sends `notifications/tools/list_changed` after a reload: this server keeps no peer handle to
+//! notify through, and the stateless revision has no session to notify at all, so it would be a
+//! guarantee on one revision and silence on the other. A client that reconnects sees the new
+//! surface; one that does not keeps the surface it listed. See [`Chosen`] for the other half of
+//! that — what a caller is told when it calls a tool the surface does not have.
 
 use std::collections::BTreeSet;
 
@@ -203,6 +218,18 @@ impl Toolset {
     /// tools I actually call" is a real answer. They are resolved against [`GROUPS`], so a spec can
     /// only ever name a tool this server has.
     pub fn parse(spec: &str) -> Result<Self, String> {
+        Self::parse_from(spec, &format!("`{FLAG} {spec}`"))
+    }
+
+    /// The same, told what to call the thing it is reading.
+    ///
+    /// The vocabulary is written down in three places now — this flag, a `WINDBG_MCP_TOOLS_<NAME>`
+    /// variable, and a client's entry in the credential file — and a refusal that named the wrong
+    /// one would send an operator to edit a command line they never typed. So the source arrives
+    /// already rendered, for the same reason a credential's source is in [`crate::client`]: how a
+    /// source is referred to is the source's business, and one template cannot render a flag, a
+    /// variable and a file entry.
+    pub fn parse_from(spec: &str, source: &str) -> Result<Self, String> {
         let mut included = BTreeSet::new();
         let mut named_anything = false;
         let mut everything = false;
@@ -231,7 +258,7 @@ impl Toolset {
                 }
                 None => {
                     return Err(format!(
-                        "`{FLAG} {spec}`: `{entry}` is neither a group nor a tool. {}",
+                        "{source}: `{entry}` is neither a group nor a tool. {}",
                         Self::vocabulary()
                     ));
                 }
@@ -239,10 +266,7 @@ impl Toolset {
         }
 
         if !named_anything {
-            return Err(format!(
-                "`{FLAG} {spec}` selects nothing. {}",
-                Self::vocabulary()
-            ));
+            return Err(format!("{source} selects nothing. {}", Self::vocabulary()));
         }
 
         // After the loop, so every name in the spec has been checked first. `all` beside a group is
@@ -352,6 +376,52 @@ impl Toolset {
     fn total() -> usize {
         GROUPS.iter().map(|g| g.tools.len()).sum()
     }
+
+    /// What a caller gets when it calls a tool this build has and this surface does not.
+    ///
+    /// rmcp would answer the router's own `tool not found`, which is the right status and the
+    /// wrong sentence: it is what a typo gets, and this is not a typo — the tool exists and an
+    /// operator narrowed the surface. The only part of that a caller can act on is **which of two
+    /// configurations to ask about**, since it can see neither this server's command line nor its
+    /// client list; that is [`Chosen`], and it is why this message is built here rather than
+    /// where the refusal is returned.
+    pub fn refusal(&self, tool: &str, client: &str, chosen: Chosen) -> String {
+        format!(
+            "`{tool}` is a tool this server has, but it is not on the surface {} ({}). {}",
+            match chosen {
+                Chosen::ForTheRun => "this run advertises".to_string(),
+                Chosen::ForThisClient => format!("it serves `{client}`"),
+            },
+            self.summary(),
+            match chosen {
+                Chosen::ForTheRun => format!(
+                    "It was started with `{FLAG}`; widen that spec, or drop it to serve every \
+                     tool."
+                ),
+                Chosen::ForThisClient => format!(
+                    "That is `{client}`'s own surface rather than this run's: \
+                     `{} {client} {FLAG} <spec>` widens it, and needs no restart.",
+                    crate::service::SET_CLIENT_TOOLS_FLAG
+                ),
+            }
+        )
+    }
+}
+
+/// Whose choice a surface was.
+///
+/// The only part of a [refusal](Toolset::refusal) a caller can act on. It can see neither this
+/// server's command line nor its client list, so a message that named the wrong one of the two
+/// would send its operator to widen a spec that is not the one in force — and the two are changed
+/// by different commands, on different machines' worth of privilege.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Chosen {
+    /// [`FLAG`] on this run's command line, or its absence. Every stdio run, and every client of a
+    /// listener that was not given a surface of its own.
+    ForTheRun,
+    /// This client's own entry in the listener's configuration — a `WINDBG_MCP_TOOLS_<NAME>`
+    /// variable, or a `tools` field in the credential file.
+    ForThisClient,
 }
 
 #[cfg(test)]
@@ -466,6 +536,58 @@ mod tests {
             .expect("the flag was given")
             .expect_err("with nothing after it");
         assert!(error.contains("needs a spec"), "{error}");
+    }
+
+    /// A refusal names the thing the operator has to go and edit, which is not always the flag.
+    ///
+    /// The vocabulary is written down in three places now — this flag, a `WINDBG_MCP_TOOLS_<NAME>`
+    /// variable, and a client's entry in the credential file — and a message that always said
+    /// `--tools` would send an operator to a command line that has nothing to do with the spec
+    /// they wrote.
+    #[test]
+    fn a_refusal_names_the_source_the_spec_was_written_in() {
+        let error = Toolset::parse_from("crash,ttdd", "`WINDBG_MCP_TOOLS_CI`")
+            .expect_err("`ttdd` is not a group");
+        assert!(error.starts_with("`WINDBG_MCP_TOOLS_CI`: "), "{error}");
+        assert!(
+            error.contains("`ttdd` is neither a group nor a tool"),
+            "{error}"
+        );
+        assert!(!error.contains(FLAG), "{error}");
+        // And the flag's own spelling of the same refusal is unchanged, which is what `parse`
+        // exists for.
+        assert!(
+            Toolset::parse("crash,ttdd")
+                .expect_err("`ttdd` is not a group")
+                .starts_with("`--tools crash,ttdd`: "),
+        );
+    }
+
+    /// The surface a client is refused from is described by whoever chose it.
+    ///
+    /// A caller can see neither this server's command line nor its client list, so the only part
+    /// of this message worth anything is which of the two its operator has to widen — and naming
+    /// the wrong one sends them to a spec that is not in force.
+    #[test]
+    fn a_refusal_points_at_whichever_configuration_chose_the_surface() {
+        let surface = Toolset::parse("crash").expect("`crash` is a group");
+
+        let run = surface.refusal("debug_batch", "bench", Chosen::ForTheRun);
+        assert!(run.contains("this run advertises"), "{run}");
+        assert!(run.contains("It was started with `--tools`"), "{run}");
+        assert!(!run.contains("bench"), "a run's surface is nobody's: {run}");
+
+        let own = surface.refusal("debug_batch", "bench", Chosen::ForThisClient);
+        assert!(own.contains("it serves `bench`"), "{own}");
+        assert!(
+            own.contains("--set-listen-client-tools bench --tools <spec>"),
+            "the remedy has to be the command that changes *this* surface: {own}"
+        );
+        // Both name the tool and what is served, because those do not depend on who chose it.
+        for said in [&run, &own] {
+            assert!(said.contains("`debug_batch`"), "{said}");
+            assert!(said.contains("11 of 51 tools (session, crash)"), "{said}");
+        }
     }
 
     #[test]

--- a/src/toolset.rs
+++ b/src/toolset.rs
@@ -50,13 +50,15 @@
 //! own spec replaces it rather than intersecting with it, because an intersection can produce a
 //! surface neither the operator nor the client ever named.
 //!
-//! **When a change takes effect is a decision, and the answer is "when the client next connects".**
-//! A surface is fixed on the line that captures the caller's identity — the listener's service
-//! factory, which rmcp runs once per MCP session and once per request on `2026-07-28`. Nothing
+//! **When a change takes effect is a decision, and the answer is "the next time the client is
+//! identified".** A surface is fixed on the line that captures the caller's identity — the
+//! listener's service factory, which rmcp runs once per MCP session and once per request on
+//! `2026-07-28`, so a client on that revision picks a change up with nothing done to it. Nothing
 //! sends `notifications/tools/list_changed` after a reload: this server keeps no peer handle to
 //! notify through, and the stateless revision has no session to notify at all, so it would be a
-//! guarantee on one revision and silence on the other. A client that reconnects sees the new
-//! surface; one that does not keeps the surface it listed. See [`Chosen`] for the other half of
+//! guarantee on one revision and silence on the other. A client holding a session sees the new
+//! surface when it reconnects, and keeps the one it listed until then. See [`Chosen`] for the
+//! other half of
 //! that — what a caller is told when it calls a tool the surface does not have.
 
 use std::collections::BTreeSet;
@@ -398,10 +400,18 @@ impl Toolset {
                     "It was started with `{FLAG}`; widen that spec, or drop it to serve every \
                      tool."
                 ),
+                // **Both sources, because only one of them exists on any given host.** The
+                // command edits the credential file a *service* reads and refuses outright where
+                // no service is installed — so naming it alone is advice a foreground listener's
+                // operator cannot take, and that is the deployment a narrowed client is most
+                // likely to be on (review on #196).
                 Chosen::ForThisClient => format!(
-                    "That is `{client}`'s own surface rather than this run's: \
-                     `{} {client} {FLAG} <spec>` widens it, and needs no restart.",
-                    crate::service::SET_CLIENT_TOOLS_FLAG
+                    "That is `{client}`'s own surface rather than this run's, so widening it is a \
+                     change to this listener's client list: `{} {client} {FLAG} <spec>` under a \
+                     service, or `{}_{}` for a foreground one. Neither needs a restart.",
+                    crate::service::SET_CLIENT_TOOLS_FLAG,
+                    crate::client::TOOLS_ENV,
+                    client.to_ascii_uppercase(),
                 ),
             }
         )
@@ -582,6 +592,13 @@ mod tests {
         assert!(
             own.contains("--set-listen-client-tools bench --tools <spec>"),
             "the remedy has to be the command that changes *this* surface: {own}"
+        );
+        // **And the other place that surface can be configured.** That command edits the file a
+        // *service* reads and refuses where none is installed, so naming it alone is advice a
+        // foreground listener's operator cannot take (review on #196).
+        assert!(
+            own.contains("WINDBG_MCP_TOOLS_BENCH"),
+            "a foreground listener's operator has no such command: {own}"
         );
         // Both name the tool and what is served, because those do not depend on who chose it.
         for said in [&run, &own] {

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -2706,6 +2706,117 @@ fn a_listener_serves_the_narrowed_surface_it_was_started_with() {
     );
 }
 
+/// Two clients on one listener get two `tools/list` answers.
+///
+/// **The assertion that matters for a per-client surface**, and it is the one shape unit tests
+/// cannot reach. The surface is chosen on the same line the caller's identity is captured on, and
+/// that line was wrong for two months — every call ran as the default `local`, right in every unit
+/// test and wrong on the wire, because a task-local does not cross the task rmcp spawns at
+/// `initialize` (`FOLLOWUPS.md` item 29). A surface resolved from the wrong client is exactly that
+/// bug again, and one client cannot state it: with one credential, "this client's spec" and "the
+/// run's spec" are the same answer.
+///
+/// Protocol tier, not the debugger one: `tools/list` needs no target, and neither does a refusal
+/// for a tool that is not on the surface — it is answered before anything is routed.
+#[test]
+fn two_clients_on_one_listener_are_served_two_surfaces() {
+    let bench_token = format!("smoke-bench-{}", std::process::id());
+    // The run's own `--tools` is the *default*, not a ceiling: `bench` names `crash` and is served
+    // that instead, which is neither a subset nor a superset of what everybody else gets.
+    let mut server = Listener::start_with_args(
+        &[
+            ("WINDBG_MCP_LISTEN_TOKEN_BENCH", &bench_token),
+            ("WINDBG_MCP_TOOLS_BENCH", "crash"),
+        ],
+        &["--tools", "session,inspect"],
+    );
+    let local_token = server.token.clone();
+    assert!(
+        server.wait_for_stderr(
+            "serving 19 of 51 tools (session, inspect) — except bench serves 11 of 51 tools \
+             (session, crash)",
+            Duration::from_secs(30)
+        ),
+        "the startup line does not say what each client is served:\n{}",
+        server.stderr()
+    );
+
+    let local_mcp = server.initialize_as(&local_token);
+    let bench_mcp = server.initialize_as(&bench_token);
+
+    let listed = |server: &mut Listener, token: &str, session: &str| -> Vec<String> {
+        let reply = server.call_as(token, Some(session), "tools/list", json!({}));
+        assert_eq!(reply.status, 200, "{}", reply.body);
+        reply.payload.clone().expect("a JSON-RPC payload")["result"]["tools"]
+            .as_array()
+            .expect("tools/list returns an array")
+            .iter()
+            .map(|t| t["name"].as_str().unwrap_or_default().to_string())
+            .collect()
+    };
+
+    let by_local = listed(&mut server, &local_token, &local_mcp);
+    let by_bench = listed(&mut server, &bench_token, &bench_mcp);
+    assert_eq!(by_local.len(), 19, "{by_local:?}");
+    assert_eq!(by_bench.len(), 11, "{by_bench:?}");
+    assert!(by_local.contains(&"registers".to_string()), "{by_local:?}");
+    assert!(
+        !by_local.contains(&"crash_triage".to_string()),
+        "{by_local:?}"
+    );
+    assert!(
+        by_bench.contains(&"crash_triage".to_string()),
+        "{by_bench:?}"
+    );
+    assert!(!by_bench.contains(&"registers".to_string()), "{by_bench:?}");
+    // Both hold the openers, because every other tool routes by a handle only this server issues.
+    for names in [&by_local, &by_bench] {
+        assert!(names.contains(&"open_dump".to_string()), "{names:?}");
+    }
+
+    // And a tool off the surface is refused by name, with the remedy for *this* caller: `local`
+    // takes the run's, so the flag is the answer; `bench` has one of its own, so the client
+    // command is. Naming the wrong one sends an operator to widen a spec that is not in force.
+    let refused = |server: &mut Listener, token: &str, session: &str, tool: &str| -> String {
+        let reply = server.call_as(
+            token,
+            Some(session),
+            "tools/call",
+            json!({ "name": tool, "arguments": {} }),
+        );
+        let payload = reply.payload.clone().expect("a JSON-RPC payload");
+        payload["error"]["message"]
+            .as_str()
+            .unwrap_or_else(|| panic!("`{tool}` was not refused: {}", reply.body))
+            .to_string()
+    };
+    let to_local = refused(&mut server, &local_token, &local_mcp, "crash_triage");
+    assert!(to_local.contains("this run advertises"), "{to_local}");
+    assert!(to_local.contains("started with `--tools`"), "{to_local}");
+    let to_bench = refused(&mut server, &bench_token, &bench_mcp, "registers");
+    assert!(to_bench.contains("it serves `bench`"), "{to_bench}");
+    assert!(
+        to_bench.contains("--set-listen-client-tools bench"),
+        "{to_bench}"
+    );
+
+    // The same question on `2026-07-28`, which reaches the surface by the other route: no MCP
+    // session, so no task spawned to serve one, and the identity arrives with the request itself.
+    // Both are asserted because the bug this shape has produced before was one of them losing it.
+    let stateless = server.stateless_as(&bench_token, "tools/list", json!({}));
+    assert_eq!(stateless.status, 200, "{}", stateless.body);
+    let names: Vec<String> = stateless.result("tools/list")["tools"]
+        .as_array()
+        .expect("tools/list returns an array")
+        .iter()
+        .map(|t| t["name"].as_str().unwrap_or_default().to_string())
+        .collect();
+    assert_eq!(
+        names, by_bench,
+        "a stateless client is served the same surface its session-bearing self is"
+    );
+}
+
 /// A `--listen` server, and just enough HTTP to drive it.
 struct Listener {
     child: Child,


### PR DESCRIPTION
Closes `FOLLOWUPS.md` item 36.

`--tools` ([#195](https://github.com/glslang/windbg-mcp/pull/195)) narrowed what a run advertises, and it narrowed it for *everybody* on that run. That is right for stdio, which has one client by construction. It is the wrong shape for what the listener exists for: a local model that can hold twenty tools and a hosted client that can hold fifty-one, pointed at the same box and the same debug sessions, told apart by their bearer tokens already.

So a client may now be configured with a spec of its own — `WINDBG_MCP_TOOLS_<NAME>` beside its token, or a `tools` field in a credential-file entry that is then an object rather than a string:

```pwsh
setx WINDBG_MCP_LISTEN_TOKEN_BENCH "<a long random string>"
setx WINDBG_MCP_TOOLS_BENCH        "session,inspect,crash"
```

```json
{
  "local": "<a long random string>",
  "bench": { "token": "<another>", "tools": "session,inspect,crash" }
}
```

Two credentials on one port get two `tools/list` answers.

## The three decisions

**The run's `--tools` is the default, not a ceiling.** A client's own spec replaces it, wider or narrower, rather than intersecting with it: an intersection can produce a surface neither the operator nor the client ever named, while "which of these two is in force" has an answer either way. `session` is added to a client's spec exactly as it is to a run's.

**A spec is parsed where a credential is validated.** `Credentials::build` runs it through the flag's own parser, so a surface this server could not serve is refused at startup rather than discovered by a caller whose tool list came back empty. `Toolset::parse_from` takes the source's rendered name — the vocabulary is written down in three places now, and a refusal that always said `--tools` would send an operator to a command line they never typed. A spec naming a client nothing configures a token for is refused too, on the precedent of the two collisions that configuration already refuses: it is a setting that could never take effect, and the way to write one is the typo that makes `WINDBG_MCP_TOOLS_BENCH` and `WINDBG_MCP_LISTEN_TOKEN_BENCH` disagree.

**Nothing sends `notifications/tools/list_changed`.** This server keeps no peer handle to notify an MCP session through, and `2026-07-28` has no session to notify at all, so it would be a guarantee on one revision and silence on the other. A surface is instead fixed where the caller is identified — `initialize`, or every request on the stateless revision — so a change reaches a client when it next connects, which is one sentence for both revisions. `--set-listen-client-tools` says so where an operator reads it.

## Two things this had to correct rather than add

- The refusal for a tool off the surface told **every** caller to widen `--tools`, which is the wrong command for a client with an entry of its own. It now names whichever configuration chose the surface (`Toolset::refusal`, `Chosen`).
- `--add-listen-client` printed *"it gets the whole tool surface, as every client here does"*, which this makes false. It says what the client is actually served.

## A fourth client command

`--set-listen-client-tools <name> --tools <spec>` changes a service-hosted client's surface without a reinstall or a restart, the way item 34's three commands change a token; with no `--tools` at all the client goes back to the service's own surface. It mints no credential and revokes none. A `--tools` beside `--rotate-` or `--remove-listen-client` is **refused** rather than ignored, because it reads exactly like a command that had narrowed that client.

## Coverage

The surface is resolved on the line that captures the caller's identity — which was wrong for two months and right in every unit test (item 29). So the assertion that matters is two tokens on one listener seeing two different `tools/list` answers, on the session-bearing route *and* the stateless one: `mcp_smoke::two_clients_on_one_listener_are_served_two_surfaces`. Protocol tier, because a tool list and a surface refusal need no debug target. Beside it: the env/file configuration paths, the orphan and collision refusals, the file's new object shape and its round trip through the installer's writer, and both halves of the refusal message.

Verified on the ARM64 bench (tree hash-matched to the branch first): `cargo clippy --all-targets -- -D warnings` clean, **526** unit tests, **75** smoke tests, and the debugger tier with `WINDBG_MCP_SMOKE_DUMP=1` (69.5 s, so it ran). `cargo fmt --all --check` clean.

Docs: README, `docs/remote-listener.md` (new *A tool surface per client* section, the file's object shape, the fourth command), `docs/local-model.md`, `docs/token-budget.md`, `CLAUDE.md`, `CHANGELOG.md`, `FOLLOWUPS.md`, and the setup skill. One stale claim corrected along the way: `local-model.md` still said a service-hosted listener needs a reinstall for a second client, which item 34 fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configure a distinct tool surface for each listener client using environment variables or credential files.
  * Add or update client tool settings without restarting the service; changes apply on the next connection.
  * Manage client tools through service commands, including assigning, changing, and clearing tool sets.
  * Display each client’s effective tool surface and provide clearer guidance when a requested tool is unavailable.

* **Documentation**
  * Updated listener, budgeting, setup, and local-model guidance to explain per-client tool configuration and precedence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->