### PR TITLE
Gate the ARM64 sample dump behind the cfg that uses it

### DIFF
--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -132,6 +132,11 @@ const ARM64_DRIVER_CRASH_DUMP: &str = concat!(
 /// an ARM64 image's headers and an ARM64 stack's frames. Nothing else in this suite does
 /// ([#143](https://github.com/glslang/windbg-mcp/issues/143)); its provenance is in
 /// `docs/smoke-test.md`.
+///
+/// Gated to match its only use: [`NATIVE_SAMPLE`] below, whose other arm an x64 build takes
+/// instead. Ungated it is dead code on x64 - which is every run of this suite bar the ARM64
+/// leg of the matrix, so the warning was the common case rather than the rare one.
+#[cfg(target_arch = "aarch64")]
 const ARM64_SAMPLE_DUMP: &str = concat!(
     env!("CARGO_MANIFEST_DIR"),
     "/docs/samples/121524-4703-01.dmp"


### PR DESCRIPTION
`ARM64_SAMPLE_DUMP` is read from exactly one place — the `#[cfg(target_arch = "aarch64")]` arm of
`NATIVE_SAMPLE` — but the constant itself was ungated, so every x64 build reported it as dead code:

```
warning: constant `ARM64_SAMPLE_DUMP` is never used
   --> tests\mcp_smoke.rs:135:7
```

That is the common case rather than the rare one. The matrix runs one ARM64 leg and everything else
— CI's own `cargo clippy --all-targets` included — is x64.

### Why it survived

The warning was never fatal: CI does not pass `-D warnings`, so it has been non-blocking since
b01635d introduced the ARM64 pairing. It still cost something — it was the only warning the suite
emitted, and a lint that is always noisy is one nobody reads.

### Why gate rather than silence

`#[expect(dead_code)]` would work. Gating is the more honest statement: this fixture belongs to the
ARM64 arm, which is exactly what `NATIVE_SAMPLE` says immediately below it. `ARM64_DRIVER_CRASH_DUMP`
is deliberately left ungated — the driver-attribution table opens it on every host, so it is live on
both.

### Verification

Both arms, each clean with **zero** warnings — so the constant is still live where it is used, and
this is a no-op on ARM64:

| Command | Result |
| --- | --- |
| `cargo clippy --all-targets` | clean, 0 warnings |
| `cargo clippy --all-targets --target aarch64-pc-windows-msvc` | clean, 0 warnings |
| `cargo fmt --all --check` | clean |
| `cargo test` | 526 unit + 75 smoke, 0 failed |

Test-only change; no shipped code is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
