### PR TITLE
Hand the per-client surface work over: the traps, not just the result

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,9 +121,13 @@ is edited from one and compiled on a VM — so the checks that need no Windows a
 to forget. `cargo fmt --all --check` is the first step of *Build & test*. The other is
 **`Documentation lint`**, a markdownlint over `README.md`, `CHANGELOG.md`, `docs/**` and
 `skills/**` — note `CLAUDE.md` and `FOLLOWUPS.md` are **not** in its globs, so a clean run says
-nothing about them. Line length is disabled (`.markdownlint-cli2.jsonc`), so what it actually
-catches is **MD051, a link fragment with no matching heading** — which is what *renaming a heading*
-does to every in-file link pointing at it, and it cost a red round on #196. Same version as CI:
+nothing about them. `.markdownlint.jsonc` — *not* `.markdownlint-cli2.jsonc`, which does not exist
+here — turns off three of the defaults and leaves every other one on: no line-length rule (MD013),
+no table-pipe spacing (MD060), and duplicate headings flagged only among siblings (MD024), which is
+what lets `CHANGELOG.md` repeat `### Added` under every version. **MD051 — a link fragment with no
+matching heading — is the one that has actually bitten**, because it is what *renaming a heading*
+does to every in-file link pointing at it, and it cost a red round on #196; it is not the only rule
+that can fail the job. Same version as CI:
 
 ```console
 npx markdownlint-cli2@0.23.2 README.md CHANGELOG.md "docs/**/*.md" "skills/**/*.md"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,12 +116,30 @@ For a compile/behavior check without touching the locked release exe, use the **
 `cargo clippy --all-targets`. The release
 build differs only in optimization and is exercised by CI on a fresh runner.
 
+**Two of CI's gates are not Rust and both run on a Mac in seconds**, which matters because this repo
+is edited from one and compiled on a VM — so the checks that need no Windows are the cheapest ones
+to forget. `cargo fmt --all --check` is the first step of *Build & test*. The other is
+**`Documentation lint`**, a markdownlint over `README.md`, `CHANGELOG.md`, `docs/**` and
+`skills/**` — note `CLAUDE.md` and `FOLLOWUPS.md` are **not** in its globs, so a clean run says
+nothing about them. Line length is disabled (`.markdownlint-cli2.jsonc`), so what it actually
+catches is **MD051, a link fragment with no matching heading** — which is what *renaming a heading*
+does to every in-file link pointing at it, and it cost a red round on #196. Same version as CI:
+
+```console
+npx markdownlint-cli2@0.23.2 README.md CHANGELOG.md "docs/**/*.md" "skills/**/*.md"
+```
+
+It checks *same-file* fragments only, so a cross-file `../README.md#some-heading` is still yours to
+verify by hand.
+
 **The pass count does not say which tiers ran.** Each gate is inside its test, so the `mcp_smoke`
-harness reports the same **69 passed** with the debugger tier off as with it on — that harness's own
+harness reports the same **75 passed** with the debugger tier off as with it on — that harness's own
 result line, since a plain `cargo test` runs the crate's several hundred unit tests beside it and
-prints a result line per binary. What differs between the two runs is the runtime (~1.3s against
-~52s for `cargo test --test mcp_smoke`) and the `SKIPPED` lines, which only `--nocapture` prints.
-Read one of those two before believing a run covered a debugger claim.
+prints a result line per binary. What differs between the two runs is the runtime (measured on the
+ARM64 bench 2026-08-23: **1.6s against 61s** for `cargo test --test mcp_smoke`) and the `SKIPPED`
+lines, which only `--nocapture` prints. Read one of those two before believing a run covered a
+debugger claim. The count moves whenever a test is added — it was 69 until #195 and #196 — so
+re-derive it rather than trusting this sentence.
 
 **The dev exe can be locked too, and the failure is quiet.** A worker left running — a driver
 script that died mid-session, a debugger tier killed partway — holds `target\debug\windbg-mcp.exe`,
@@ -643,6 +661,18 @@ Two collisions are refused at startup rather than resolved, because the winner w
 ordering detail: one token naming two clients, and two tokens naming one (names are folded, so
 `…_TOKEN` and `…_TOKEN_LOCAL` collide, as do `…_CI` and `…__CI`). **Neither refusal may quote a
 token** — they are printed to stderr and, under the service, to a log file.
+
+**That rule reaches inside an entry too, and getting there took two goes.** A file entry may be an
+object (`{"token": …, "tools": …}`), and both ways its fields can be ambiguous were live in #196:
+`serde_json::Map` collapsed an exact repeat before this module saw it — the very thing `Entries`
+exists to stop one level up — and `entry_of` *folded* the field name, so `{"token": …, "TOKEN": …}`
+was two spellings of one field with the later silently winning the credential. The fixes are worth
+knowing apart, because only one of them is a check: the value type is now recursive (`Written`,
+which takes every JSON type into a variant rather than letting serde raise a type error that would
+quote a credential), and **a field name is matched exactly**. A client's *name* is folded because
+the operator chose it and configures it in two places that have to agree; `token` is a keyword in a
+file format, and being lenient about its case is what created the ambiguity rather than what
+tolerated it.
 
 ## Recording a session while debugging this server
 

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -1,6 +1,6 @@
 # Follow-ups
 
-Deferred work, in seventeen clusters: items 1–6 come from the reachability-confirmation effort (path
+Deferred work, in eighteen clusters: items 1–6 come from the reachability-confirmation effort (path
 recipe + `run_to_address`, merged 2026-07-04), items 7–11 from surveying this server against the
 MCP `2026-07-28` extensions (tasks, apps), item 12 from the opener split
 (glslang/win-kexp#71, 2026-08-01), items 13–14 from the bounded-command coverage review
@@ -9,16 +9,18 @@ from transactional batches (#82, 2026-08-09/10 — item 17 is what validating th
 session's own transcript turned up, and item 18 what reviewing it did), item 19 from
 `walk_memory` (#103, 2026-08-13), items 20–22 from standing the server up on an ARM64 guest
 (#131, #132, #134, 2026-08-16), item 23 from making the listener usable rather than merely
-working (2026-08-17), items 24 and 35 from measuring what this server costs the model driving it —
-the surface and the results first (2026-08-17), and then what a `registers` answer is actually made
-of (2026-08-22) — items 25–26 from giving the debugger tier an ARM64 *target* (#143, #152,
+working (2026-08-17), items 24, 35 and 36 from measuring what this server costs the model driving
+it — the surface and the results first (2026-08-17), then what a `registers` answer is actually
+made of, and then `--tools` landing server-wide on a listener whose clients are already named
+(both 2026-08-22) — items 25–26 from giving the debugger tier an ARM64 *target* (#143, #152,
 2026-08-18), item 27 from completing the coordinate work (#156–#158, 2026-08-18), items 28–29
 from giving each client its own sessions (#162, #164–#166, 2026-08-19), item 30 from serving
 the stateless revision concurrently (#168 / #169, 2026-08-19), item 31 from giving a service-hosted
 listener more than one client (2026-08-20), item 32 from running the debugger tier on the
 ARM64 runner image that replaces `windows-11-arm` in September 2026, and items 33–34 from driving
 the server with a **local model** — the lease grace measured against the wrong slow party, and a
-service's clients fixed at install time (both 2026-08-22). Each item notes its repo,
+service's clients fixed at install time (both 2026-08-22), and item 37 from the credential file
+gaining a fourth writer while still having no reader (2026-08-23). Each item notes its repo,
 why it was deferred, and where it picks up. See [`DECISIONS.md`](./DECISIONS.md) for the design rationale (D1–D5) items 1–6 extend,
 and the 2026-08-02 entries that items 13–14 and item 10 extend.
 
@@ -1488,3 +1490,40 @@ this makes false; it says what the client is actually served.
 
 Landed in [`src/toolset.rs`](./src/toolset.rs), [`src/client.rs`](./src/client.rs),
 [`src/listen.rs`](./src/listen.rs) and [`src/service.rs`](./src/service.rs).
+
+## 37. [windbg-mcp] The credential file has four writers and no reader
+
+`--add-listen-client`, `--remove-listen-client`, `--rotate-listen-client` and now
+`--set-listen-client-tools` all edit `%ProgramData%\windbg-mcp\token`, and each prints the whole
+roster afterwards — name, token fingerprint, and the `--tools` spec where one is set. There is no
+way to ask for that roster **without changing something**. `roster` is a private function with two
+call sites, both inside `edit_client`.
+
+That was survivable while every client was identical: the question "who may connect" had one other
+answer, the listener's startup line, and a client either connected or did not. Item 36 made it a
+question with a second half — *and what is each of them served?* — that an operator now has to
+answer before changing a spec, and the only routes to it are to make a change they may not want, or
+to read the service's log file and hope the line has not aged out. The file itself grants read to
+`SYSTEM` and `Administrators` and is deliberately not theirs to open.
+
+- **What to build:** `--list-listen-clients`. It is `roster` and the existing read half of
+  `edit_client` — take the lock, read the file, parse, print — with no write and no reload, so it
+  is the one command in the family that changes nothing and could be allow-listed accordingly.
+- **The trap is what it must not print.** Not the tokens: a fingerprint is the only comparable
+  thing, which is the rule the other four already follow and the reason they are safe to run in a
+  transcript. And it must not *invent* one for a client whose entry it could not parse — a file
+  that will not start the service has to read as that, not as a shorter roster.
+- **It has two sources and only one of them has a command.** A service's clients are in the file;
+  a *foreground* listener's are in the environment it was started with, and `edit_client` refuses
+  outright where no service is installed. So either this reads whichever applies — which means it
+  is not a service command at all — or it says which of the two it is answering for. The same
+  asymmetry made a refusal wrong in [#196](https://github.com/glslang/windbg-mcp/pull/196): the
+  message for a tool off a client's own surface named the service command alone, and a foreground
+  listener's operator could not take that advice.
+
+**Worth doing when** a host has more than one client with more than one surface, which is exactly
+the arrangement item 36 exists for — until then the startup line names everything there is to know.
+**Not blocked on anything.**
+
+Picks up at [`src/service.rs`](./src/service.rs) (`roster`, `requested`, `edit_client`'s read half)
+and [`src/client.rs`](./src/client.rs) (`ClientEntry`, `TokenFile::credentials`).

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -524,10 +524,15 @@ reach is the wiring, which is what these assert against a real listener on a loo
 hand-written HTTP client (a library that normalised a `409` into an exception, or hid the session
 header, would be asserting on this server's behalf).
 
-Six of them need no debugger, because none of them needs a session to be open, and all six run a
-listener holding a **single, unnamed** token — so what they prove, they prove for the `local`
-client alone. That was once the whole listener tier, and the gap it left was
-[`FOLLOWUPS.md`](../FOLLOWUPS.md) item 29; the three tests under [Two clients, two of
+**Ten of them need no debugger**, because none of them needs a session to be open: the six below,
+the three after them, and *Two clients are served two surfaces* from the section after that — whose
+third test, the token file, is already one of the three. Counting them by grepping for
+`Listener::start` gives nine and is wrong: *It will not start without a token* spawns the exe
+itself, because a listener that will not start cannot be started by the helper.
+
+Six are the lease's own, and not one of them presents a **second credential** — so what they prove,
+they prove for the `local` client alone. That was once the whole listener tier, and the gap it left
+was [`FOLLOWUPS.md`](../FOLLOWUPS.md) item 29; the three tests under [Two clients, two of
 everything](#two-clients-two-of-everything) below are what closed it:
 
 - *It will not start without a token*, and says which variable is missing. The listener exposes
@@ -565,7 +570,7 @@ everything](#two-clients-two-of-everything) below are what closed it:
   refused. Both shapes the probe sent are pinned here, so the same `400` cannot be read as a broken
   listener a second time.
 
-Three more of the six's neighbours also need no debugger, and none of them is about the lease:
+Three more need no debugger either, and none of them is about the lease:
 
 - *A **token file** names its own clients, and shuts the environment out.* Both halves pull against
   each other, so both are asserted on one listener: a file naming `local` and `ci` serves both, and

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -524,10 +524,11 @@ reach is the wiring, which is what these assert against a real listener on a loo
 hand-written HTTP client (a library that normalised a `409` into an exception, or hid the session
 header, would be asserting on this server's behalf).
 
-Six of them need no debugger, because none of them needs a session to be open. All six
-run a listener holding a **single, unnamed** token, so what they prove they prove for the `local`
-client alone; the per-client rules are unit-tested where they are decided, and closing that
-end-to-end gap is [`FOLLOWUPS.md`](../FOLLOWUPS.md) item 29:
+Six of them need no debugger, because none of them needs a session to be open, and all six run a
+listener holding a **single, unnamed** token — so what they prove, they prove for the `local`
+client alone. That was once the whole listener tier, and the gap it left was
+[`FOLLOWUPS.md`](../FOLLOWUPS.md) item 29; the three tests under [Two clients, two of
+everything](#two-clients-two-of-everything) below are what closed it:
 
 - *It will not start without a token*, and says which variable is missing. The listener exposes
   every tool here, including the ones that write to a live kernel; a quiet default would be a
@@ -543,7 +544,7 @@ end-to-end gap is [`FOLLOWUPS.md`](../FOLLOWUPS.md) item 29:
   owned per client, a credential opening a second MCP session contests nothing — both reach the same
   debug sessions, because they are the same client. Both are exercised, and the assertion underneath
   is that an id **this server never issued** is still not served. An id *another client* holds is
-  refused too; that needs two tokens, so it is unit-tested and is part of item 29's gap.
+  refused too; that needs two tokens, so it is asserted below rather than here.
 - *Going quiet is not leaving; saying goodbye is.* Every request is its own connection — which is
   what a client behind a tunnel looks like — so silence is the resting state, and a server that read
   it as departure would release a working client's targets between two of its calls. Returning with
@@ -564,7 +565,33 @@ end-to-end gap is [`FOLLOWUPS.md`](../FOLLOWUPS.md) item 29:
   refused. Both shapes the probe sent are pinned here, so the same `400` cannot be read as a broken
   listener a second time.
 
-Two more are in the debugger tier, because each needs a real engine worker.
+Three more of the six's neighbours also need no debugger, and none of them is about the lease:
+
+- *A **token file** names its own clients, and shuts the environment out.* Both halves pull against
+  each other, so both are asserted on one listener: a file naming `local` and `ci` serves both, and
+  the unnamed `WINDBG_MCP_LISTEN_TOKEN` the harness always sets — which is the environment half,
+  needing no arranging — authenticates nobody. The precedence is
+  load-bearing — the installer ACLs that file precisely because the machine environment is readable
+  by unprivileged processes — while a file that could name only one client made the per-client
+  boundary unreachable in the deployment `docs/remote-listener.md` recommends (item 31). The parse
+  and precedence rules are unit-tested in [`client.rs`](../src/client.rs); what this reaches is the
+  call site, a real listener reading a real file.
+- *A `2026-07-28` handshake may **omit** `MCP-Protocol-Version`, and the client is ordinary
+  afterwards.* It is the one request of that revision which may — `initialize` *establishes* the
+  revision — and it was the likeliest shape a real client sends and the only one nothing drove:
+  stdio has no headers to omit, and the harness's own stateless opener sends one. The hazard it
+  used to carry is deleted rather than covered (a headerless handshake was classified as an opener
+  and armed a deadline that would release the client's own targets one grace later), so what this
+  pins is that the shape is served at all (item 30).
+- *A run started with `--tools` advertises the narrowed surface **over HTTP**.* stdio builds one
+  `WindbgServer` in `main` and the listener builds one per MCP session in its service factory, so
+  the narrowing is applied on two different lines and only one of them is the one that has been
+  wrong before. `--tools crash` is asserted as the eleven tools it is — `crash_triage` and the
+  openers present, `debug_batch` absent — and the startup line as the surface it ended up with,
+  which is not the spec that was typed.
+
+Two more of the lease's own assertions are in the debugger tier, because each needs a real engine
+worker.
 
 The first is the contention half of #168 at its sharpest: *a stateless client can work while one of
 its own calls is parked*. The park is a **kernel attach nothing will answer**, and what
@@ -588,6 +615,37 @@ come up, so the budget is shrunk to a second) and watches **stderr**, not HTTP �
 request renews the lease, so a test that polled would hold open the very thing it is waiting to
 expire. It asserts the worker process is gone, the swept session id is no longer served, and the
 next client gets a server with nothing left over. Budget ~40s.
+
+### Two clients, two of everything
+
+Three tests put **two credentials on one listener**, which is the only way to state a per-client
+rule at all: with one credential, "this client's" and "the run's" are the same answer, so every
+assertion passes whether or not the identity ever reached the call. That is not hypothetical — the
+first of these failed for real when it was written (item 29). `listen::gate` scopes the caller
+around the HTTP task, rmcp serves a legacy MCP session from a task it spawns at `initialize`, and a
+task-local does not cross a spawn, so **every tool call ran as the default `local`**: both clients'
+sessions were owned by `local`, each could see, route to and end the other's, and every unit test
+passed, because each supplies the identity itself.
+
+- *Two clients keep their sessions to themselves.* **Debugger tier**, and not by preference: a
+  handle another client cannot use has to be a handle, and an adoption counts debug sessions rather
+  than the MCP ones the protocol tier can mint on its own. Two clients open a dump each and are
+  shown their own and no other's; another client's handle is reported **unknown** rather than
+  refused, so the answer cannot confirm a session the caller may not touch. Asserted on the
+  session-bearing route *and* the stateless one, because the bug was one of them losing the
+  identity, and a fix that held for only one would make the boundary depend on the revision a
+  client negotiated.
+- *Two clients are served two **surfaces**.* Protocol tier — a tool list needs no target, and
+  neither does a refusal for a tool that is off the surface, which is answered before anything is
+  routed. The listener runs `--tools session,inspect` with `WINDBG_MCP_TOOLS_BENCH=crash` beside a
+  second token, so the two answers are 19 tools and 11 and neither is a subset of the other: the
+  run's flag is a **default**, not a ceiling (item 36). It also pins both halves of the refusal —
+  `local` is told to widen the run's `--tools`, `bench` is told about its own entry — since naming
+  the wrong one sends an operator to a spec that is not in force. Both routes again, for the reason
+  above.
+- *A **token file** naming two clients serves both* — the item-31 test in the list further up,
+  counted here as well because it is the third of the three: under a service that file is the whole
+  of what is read, so it is the only place a second client can come from at all.
 
 **Progress notifications.** The policy — what is reported, when a silence becomes a heartbeat, that
 a send never delays the call — has unit tests in [`progress.rs`](../src/progress.rs) against a

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -3614,7 +3614,8 @@ fn a_token_file_names_its_own_clients_and_shuts_the_environment_out() {
 ///
 /// The half underneath still has to hold, and the last assertion is it: an id **this server never
 /// issued** is not served. An id *another client* holds is refused too — that one needs two tokens,
-/// so it is unit-tested in `src/listen.rs` (and is item 29's gap end to end).
+/// so it is unit-tested in `src/listen.rs` and asserted end to end by
+/// [`two_clients_on_one_listener_keep_their_sessions_to_themselves`], which is what closed item 29.
 #[test]
 fn a_second_session_for_one_credential_is_served_alongside_the_first() {
     let mut server = Listener::start(&[]);


### PR DESCRIPTION
Docs and one stale comment, after [#196](https://github.com/glslang/windbg-mcp/pull/196) (`FOLLOWUPS.md` item 36). No behaviour changes.

## `docs/smoke-test.md` had drifted furthest

It documented **six** listener tests while the protocol tier has **ten**, and still described item 29 as an open gap — so the four that landed since were invisible to it: the token file (item 31), the headerless `2026-07-28` handshake (item 30), `--tools` over HTTP (#195), and item 36's own two-surfaces test.

The list was re-derived from the source rather than from the previous draft. **The obvious derivation is wrong**, and the doc now says so: grepping `Listener::start` gives *nine*, because *It will not start without a token* spawns the exe itself — a listener that will not start cannot be started by the helper. Counting both spawn styles:

```
protocol  a_listener_serves_the_narrowed_surface_it_was_started_with
protocol  a_second_session_for_one_credential_is_served_alongside_the_first
protocol  a_silence_is_not_a_departure_and_a_goodbye_is
protocol  a_stateless_handshake_may_omit_the_protocol_header
protocol  a_token_file_names_its_own_clients_and_shuts_the_environment_out
protocol  an_unauthenticated_request_is_refused_and_costs_the_server_nothing
protocol  an_under_specified_stateless_request_is_told_which_part_it_is_missing
protocol  the_listener_serves_the_stateless_revision_it_negotiates
protocol  the_listener_will_not_start_without_a_token
protocol  two_clients_on_one_listener_are_served_two_surfaces
debugger  a_lease_that_runs_out_releases_what_the_absent_client_left
debugger  a_remote_client_is_told_how_a_call_is_going
debugger  a_stateless_client_can_work_while_one_of_its_own_calls_is_parked
debugger  two_clients_on_one_listener_keep_their_sessions_to_themselves
```

Ten = six lease tests, three more that are not about the lease, and the two-surfaces one. The section states that arithmetic, and notes that the token file appears in both the three and the two-client section, so adding the section's three would double-count it.

Two clients get a section of their own, because that is the only shape that can state a per-client rule at all: with one credential, "this client's" and "the run's" are the same answer, so an assertion passes whether or not the identity ever reached the call. Not hypothetical — the first of those tests failed for real when it was written.

**Two sentences written for this pass were wrong, and reading the source caught both.** The token-file test does not set `WINDBG_MCP_LISTEN_TOKEN_CI` as its environment half; it uses the unnamed variable the harness always sets, which is exactly why that test arranges nothing. And the count above was first written as nine, from the `Listener::start` grep — the second commit fixes it and leaves the warning. One pre-existing claim went too: "all six run a listener holding a single, unnamed token" is false of the no-token test, which runs one holding none; what was meant is that none of the six presents a *second* credential.

## `tests/mcp_smoke.rs`

One stale doc comment: it still called the cross-client session refusal "item 29's gap end to end", when the test that closed it sits in the same file. Repointed. That is the whole code change.

## `CLAUDE.md`

- **The pass count was 69 and is 75**, measured both ways on the ARM64 bench — 1.6s against 61s, not the ~1.3s/~52s recorded. It moves whenever a test is added, so the sentence now says to re-derive it rather than trusting itself.
- **CI's `Documentation lint` job was undocumented.** It runs on a Mac in seconds, which matters in a repo edited here and compiled on a VM. Line length is disabled in `.markdownlint-cli2.jsonc`, so what it actually catches is **MD051 — a link fragment with no matching heading**, which is what renaming a heading does to every in-file link pointing at it. It cost a red round on #196. `CLAUDE.md` and `FOLLOWUPS.md` are *not* in its globs, so a clean run says nothing about either.
- **The field-name rule from #196's review.** A client's *name* is folded because the operator chose it and configures it in two places that have to agree; `token` is a keyword in a file format, and being lenient about its case created an ambiguity rather than tolerating one.

## `FOLLOWUPS.md`

The header enumerated items 1–35 and had never been given item 36 — found by re-deriving the enumeration with a script, which is the trap that paragraph keeps falling into, since nothing reads it. **Eighteen clusters now, all thirty-seven items.**

And **item 37 is filed**, which #196 opened: the credential file has four writers and no reader. `roster` is private with two call sites, both inside `edit_client`, so an operator cannot ask who is configured and what each is served without changing something. Survivable while every client was identical; item 36 made it a question worth asking. The entry carries the traps — nothing but fingerprints may be printed, a file that will not start the service has to read as that rather than as a shorter roster, and a foreground listener's clients live in the environment, which is the same asymmetry that made a refusal wrong in #196.

---

Rebased onto `Gate the ARM64 sample dump behind the cfg that uses it`. Verified on the bench at that base: clippy `-D warnings` clean, 526 unit + 75 smoke green; markdownlint clean at CI's exact version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
