### PR TITLE
Say which review findings are worth acting on, and which are not

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -207,16 +207,23 @@ behind `FOLLOWUPS.md` item 34 (#189 to #192), all from the same reviewer:
   right fix was a message that stopped claiming otherwise.
 
 So: **verify the fact against the current code, then decide the remedy yourself.** A correct finding
-does not make its suggested fix correct, and a confident one is not evidence of anything. Declining
-with a stated reason is a normal outcome — put it in the commit message, or the next round will
-raise it again and nothing will record why it was not taken. Measuring beats arguing whenever the
-claim is about behaviour: most of these were settled in one experiment.
+does not make its suggested fix correct, and a confident one is not evidence of anything. Measuring
+beats arguing whenever the claim is about behaviour: most of these were settled in one experiment.
+
+**Declining is a normal outcome, and where the reason goes depends on whether the decline shaped a
+change.** If you are committing anyway — you took the fact and rejected the remedy — the reason
+belongs in *that* commit message, because the next round will raise it again against code that by
+then looks deliberate, and nothing else will record why it is the way it is. If nothing changed,
+there is nothing to attach a reason to and nothing to protect: repeating the decline next round
+costs a sentence, so tell whoever is driving the work and leave it there. Do not manufacture a
+commit, and do not argue with the bot in a reply — neither is read by the round that follows.
 
 **A finding about *prose* is acted on only if the prose is wrong, or inconsistent with the code.**
 Everything else — rewording, hedging, "consider splitting this rule across the three files that
-state it" — is declined. A decline needs no commit and no reply to the bot, but **say it to whoever
-is driving the work**, in one line, so the count of what was waved through stays visible to them
-rather than only to you.
+state it" — is declined, which by the rule above means no commit and no reply: nothing changed.
+**Say it to whoever is driving the work**, in one line, so the count of what was waved through
+stays visible to them rather than only to you.
+
 The rule exists because the review pressure here is almost entirely on sentences: across #196, #198
 and #199, **every** bot finding was about one, and none was about the code those PRs changed. Most
 of that pressure pushes toward making correct sentences longer, which is churn and costs a CI round

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -212,6 +212,32 @@ with a stated reason is a normal outcome — put it in the commit message, or th
 raise it again and nothing will record why it was not taken. Measuring beats arguing whenever the
 claim is about behaviour: most of these were settled in one experiment.
 
+**A finding about *prose* is acted on only if the prose is wrong, or inconsistent with the code.**
+Everything else — rewording, hedging, "consider splitting this rule across the three files that
+state it" — is declined. A decline needs no commit and no reply to the bot, but **say it to whoever
+is driving the work**, in one line, so the count of what was waved through stays visible to them
+rather than only to you.
+The rule exists because the review pressure here is almost entirely on sentences: across #196, #198
+and #199, **every** bot finding was about one, and none was about the code those PRs changed. Most
+of that pressure pushes toward making correct sentences longer, which is churn and costs a CI round
+each time. What the rule still catches, all from those three PRs:
+
+- **Wrong.** A config documented as `.markdownlint-cli2.jsonc`; the file is `.markdownlint.jsonc`.
+  And a skill saying `--set-listen-client-tools <name>` changes a client's surface, when with no
+  `--tools` beside it that command *clears* the spec — an operator following it removes the
+  restriction they meant to change.
+- **Inconsistent with the code.** A refusal telling every caller to run a service-only command,
+  when a foreground listener's clients come from the environment. And "a change reaches a client
+  when it next connects", which describes one MCP revision while the listener's factory identifies
+  a sessionless client on *every request*. Neither sentence is false on its face; both produce the
+  wrong action.
+- **Inconsistent with its own cited source.** A list of the three handoff files, contradicted by
+  one of the PRs named as its origin.
+
+When a sentence does have to change, prefer **making the one rule true** over splitting it into two
+— that is what the last of those became, and it kept a single summary line that is now correct for
+both revisions rather than two rules in three files.
+
 **When findings keep landing on one mechanism, delete the choice generating them rather than fixing
 them one at a time.** Each finding is locally real and each fix is locally correct, which is exactly
 what makes the pattern hard to see from inside it: the count of mechanisms goes up every round and


### PR DESCRIPTION
`CLAUDE.md` only, one paragraph and a short list, added beside the existing review-bot guidance.

Across #196, #198 and #199, **every bot finding was about a sentence** and none was about the code those PRs changed. Most of that pressure pushes toward making correct sentences longer, which is churn and costs a CI round each time. So the rule is now written down:

> A finding about *prose* is acted on only if the prose is wrong, or inconsistent with the code.

## The second clause is the one doing the work

Two of the findings worth taking were not false sentences at all:

- A refusal telling **every** caller to run `--set-listen-client-tools`, which edits the file a *service* reads — a foreground listener's clients come from the environment, so its operator cannot take that advice.
- *"A change reaches a client when it next connects"*, which describes one MCP revision while the listener's factory identifies a sessionless client on **every request**.

Both read as true. Both produce the wrong action. A plain "is it wrong" test would have waved them through, which is why the rule is not just "wrong".

The list in the section also keeps the two that were plainly wrong — a config documented under a filename that does not exist, and a skill saying `--set-listen-client-tools <name>` changes a surface when without `--tools` beside it that command *clears* the spec — plus the one that contradicted its own cited source.

## What is excluded

Rewording, hedging, and "consider splitting this rule across the three files that state it". A decline needs no commit and no reply to the bot — but **it is said to whoever is driving the work**, so the count of what was waved through stays visible to them rather than only to the person declining.

And when a sentence does have to change, prefer **making the one rule true** over splitting it in two. That is what the revision-boundary finding became: one summary line that is now correct for both revisions, rather than two rules restated in three files.

---

No code, no tests. `CLAUDE.md` is not in CI's markdownlint globs; pointed at it anyway, this change adds none of the nine pre-existing errors and no line over 100 columns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
