### PR TITLE
Ask who may connect without changing anything

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   is the case an operator would run this to check. A surface's: a reload that *succeeded* still
   does not reach a client holding an MCP session, which goes on listing the tools it listed when it
   connected — so that gap is named wherever a client carries a spec of its own. The running service
-  cannot be asked what it holds: its only channel carries a status code and no data.
+  cannot be asked what it holds: its only channel carries a status code and no data, so what is
+  reported beside the roster is the state that service is in, across every state it can reach —
+  including **stopping**, which is not stopped: a stop ends the accept loop and then releases every
+  target, and the connections already accepted are served until the process exits.
 
 ## [0.11.0] - 2026-08-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,8 +34,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   beside it, because the two differ in two unrelated ways. A credential's: a `--remove` or
   `--rotate` whose reload failed leaves a token authenticating that the file no longer names, which
   is the case an operator would run this to check. A surface's: a reload that *succeeded* still
-  does not reach a client holding an MCP session, which goes on listing the tools it listed when it
-  connected — so that gap is named wherever a client carries a spec of its own. The running service
+  does not reach a client holding an MCP session, which goes on being served what it had when it
+  connected — including when the change was to *clear* the last spec, so the caveat is
+  unconditional rather than gated on the file still holding one. The running service
   cannot be asked what it holds: its only channel carries a status code and no data, so what is
   reported beside the roster is the state that service is in, across every state it can reach —
   including **stopping**, which is not stopped: a stop ends the accept loop and then releases every

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ignored, on the same rule as `--rotate-` and `--remove-listen-client`: it reads exactly like a
   filter over the list it is about to print.
 
+  **And it says it is reading the file rather than the service**, with the state that service is in
+  beside it. The two normally agree, since every editing command waits for the re-read and exits
+  non-zero if it did not land — but a `--remove` or `--rotate` in exactly that failure leaves a
+  token authenticating that the file no longer names, which is the case an operator would run this
+  to check. The running service cannot be asked what it holds: its only channel carries a status
+  code and no data.
+
 ## [0.11.0] - 2026-08-23
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,11 +30,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   filter over the list it is about to print.
 
   **And it says it is reading the file rather than the service**, with the state that service is in
-  beside it. The two normally agree, since every editing command waits for the re-read and exits
-  non-zero if it did not land — but a `--remove` or `--rotate` in exactly that failure leaves a
-  token authenticating that the file no longer names, which is the case an operator would run this
-  to check. The running service cannot be asked what it holds: its only channel carries a status
-  code and no data.
+  beside it, because the two differ in two unrelated ways. A credential's: a `--remove` or
+  `--rotate` whose reload failed leaves a token authenticating that the file no longer names, which
+  is the case an operator would run this to check. A surface's: a reload that *succeeded* still
+  does not reach a client holding an MCP session, which goes on listing the tools it listed when it
+  connected — so that gap is named wherever a client carries a spec of its own. The running service
+  cannot be asked what it holds: its only channel carries a status code and no data.
 
 ## [0.11.0] - 2026-08-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   while every client was served the same surface, because "who may connect" had one other answer in
   the listener's startup line; a client's own spec has no such second answer.
 
-  It takes the same lock the edits take, reads the same file through the same parser and prints the
-  same fingerprints, and it writes nothing: no token minted, no reload asked for. **A file it
-  cannot read in full refuses rather than printing a shorter roster** — one entry this server would
+  It reads the same file through the same parser as the edits and prints the same fingerprints,
+  and it writes nothing whatever: no token minted, no reload asked for, and not even the credential
+  lock the four editors take — that lock is a file this program creates, and creating one is a
+  write. **A file it cannot read in full refuses rather than printing a shorter roster** — one entry this server would
   refuse at startup is a file that will not start the service, and a list that quietly dropped the
   client it could not parse would be the most misleading thing this command could print.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`--list-listen-clients`, the one client command that changes nothing** (`FOLLOWUPS.md` item 37,
+  which closes it). The four commands that edit a service's credential file each print the whole
+  roster afterwards — name, token fingerprint, and the `--tools` spec where one is set — and until
+  now that roster could only be had by making a change you may not have wanted. That was survivable
+  while every client was served the same surface, because "who may connect" had one other answer in
+  the listener's startup line; a client's own spec has no such second answer.
+
+  It takes the same lock the edits take, reads the same file through the same parser and prints the
+  same fingerprints, and it writes nothing: no token minted, no reload asked for. **A file it
+  cannot read in full refuses rather than printing a shorter roster** — one entry this server would
+  refuse at startup is a file that will not start the service, and a list that quietly dropped the
+  client it could not parse would be the most misleading thing this command could print.
+
+  **It says which of the two sources it answered for.** A service's clients are in the credential
+  file; a foreground listener's are the environment it was started with, and no command edits
+  those — so where no service is installed this answers for the environment instead of refusing,
+  and where both are configured it prints both. A `--tools` beside it is refused rather than
+  ignored, on the same rule as `--rotate-` and `--remove-listen-client`: it reads exactly like a
+  filter over the list it is about to print.
+
 ## [0.11.0] - 2026-08-23
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -584,16 +584,19 @@ who may connect and another answering what they get is two files to keep in step
 rule to remember.
 
 **Five client commands, and the fifth only reads.** `--list-listen-clients` (item 37) prints the
-same `roster` the four editors print, under the same lock, with no write and no reload. Two things
-bite when touching it. It answers for **both** sources — a service's clients are in the credential
+same `roster` the four editors print, with no write and no reload — and **not under the credential
+lock**, which is the trap: `lock_credentials` opens its file with `create(true)` and nothing else
+creates it, so a reader that locked would write into `%ProgramData%` on any host where no edit had
+yet run, which is exactly the property this command sells. It buys almost nothing either, since
+`write_credentials` renames a finished file over the old one. Two more things bite when touching
+it. It answers for **both** sources — a service's clients are in the credential
 file, a foreground listener's are the environment it was started with — and the environment half
 goes through `listen::named_token_file`, *not* `client::env_credentials` alone: a shell naming
 `WINDBG_MCP_LISTEN_TOKEN_FILE` has its token variables ignored by the listener, so listing them
 would be a roster of credentials nothing accepts. And a file it cannot read in full has to refuse
 rather than print a shorter list — a dropped entry is a service that will not start, reported as a
-service serving fewer people. `lock_credentials` takes what its caller came to do, because "changing
-a client needs an elevated shell" is the wrong sentence for a reader; adding a sixth command means
-that argument, this listing, and the message naming the family.
+service serving fewer people. And an unelevated caller is turned away by the *credential file's* own ACL rather
+than by the lock, which is the object being protected rather than a thing beside it.
 
 **Identity is ambient inside a call, carried by the instance, and by name outside both.**
 `crate::client::current()` reads a task-local, which is why no tool signature carries a caller. What

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,12 +137,13 @@ It checks *same-file* fragments only, so a cross-file `../README.md#some-heading
 verify by hand.
 
 **The pass count does not say which tiers ran.** Each gate is inside its test, so the `mcp_smoke`
-harness reports the same **75 passed** with the debugger tier off as with it on — that harness's own
+harness reports the same **76 passed** with the debugger tier off as with it on — that harness's own
 result line, since a plain `cargo test` runs the crate's several hundred unit tests beside it and
 prints a result line per binary. What differs between the two runs is the runtime (measured on the
 ARM64 bench 2026-08-23: **1.6s against 61s** for `cargo test --test mcp_smoke`) and the `SKIPPED`
 lines, which only `--nocapture` prints. Read one of those two before believing a run covered a
-debugger claim. The count moves whenever a test is added — it was 69 until #195 and #196 — so
+debugger claim. The count moves whenever a test is added — it was 69 until #195 and #196, and 75
+until item 37 — so
 re-derive it rather than trusting this sentence.
 
 **The dev exe can be locked too, and the failure is quiet.** A worker left running — a driver
@@ -581,6 +582,18 @@ follows the same precedence — a configured file is the whole configuration, so
 read on a host that has one — for a reason that is not secrecy but arithmetic: one file answering
 who may connect and another answering what they get is two files to keep in step and a precedence
 rule to remember.
+
+**Five client commands, and the fifth only reads.** `--list-listen-clients` (item 37) prints the
+same `roster` the four editors print, under the same lock, with no write and no reload. Two things
+bite when touching it. It answers for **both** sources — a service's clients are in the credential
+file, a foreground listener's are the environment it was started with — and the environment half
+goes through `listen::named_token_file`, *not* `client::env_credentials` alone: a shell naming
+`WINDBG_MCP_LISTEN_TOKEN_FILE` has its token variables ignored by the listener, so listing them
+would be a roster of credentials nothing accepts. And a file it cannot read in full has to refuse
+rather than print a shorter list — a dropped entry is a service that will not start, reported as a
+service serving fewer people. `lock_credentials` takes what its caller came to do, because "changing
+a client needs an elevated shell" is the wrong sentence for a reader; adding a sixth command means
+that argument, this listing, and the message naming the family.
 
 **Identity is ambient inside a call, carried by the instance, and by name outside both.**
 `crate::client::current()` reads a task-local, which is why no tool signature carries a caller. What

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -1538,13 +1538,17 @@ accept rather than what one already running elsewhere does. It reads the environ
 `WINDBG_MCP_LISTEN_TOKEN_FILE` has its variables ignored by the listener — listing them would be a
 roster of credentials nothing accepts.
 
-Two things the entry did not anticipate. The **lock message** was written for writers only
-("another `--add`/`--remove`/`--rotate-listen-client` is running", which item 36 had already made
-wrong by adding a fourth), so `lock_credentials` now takes what its caller came to do; a reader
-holds the same lock for the reader's half of the same hazard, since a list taken mid-edit reports
-the set that is about to replace it. And **`--tools` beside it is refused** rather than ignored, on
-the rule `--rotate-` and `--remove-listen-client` already follow: it reads exactly like a filter
-over the list it is about to print.
+Two things the entry did not anticipate. **The entry's "take the lock" is wrong**, and review
+found it (fifth round): `lock_credentials` opens its file with `create(true)` and nothing else
+creates it — not the installer — so a reader that took the lock would write into `%ProgramData%`
+on any host where no client edit had yet run, which is the one property this command exists to
+have. It buys almost nothing anyway, because `write_credentials` renames a finished file over the
+old one, so a read racing an edit sees one complete version or the other. So the reader does not
+lock, and the unelevated refusal comes from the credential file's own ACL, which is the object
+being protected. (The lock's *message* was stale for a different reason and is fixed with it: it
+named three commands of four, item 36 having added the fourth.) And **`--tools` beside it is
+refused** rather than ignored, on the rule `--rotate-` and `--remove-listen-client` already follow:
+it reads exactly like a filter over the list it is about to print.
 
 A third thing came out of review: the roster is the **file**, and `edit_client` deliberately leaves
 a window where the file and the running service disagree — a `--remove` or `--rotate` whose reload

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -1552,7 +1552,11 @@ could not be delivered writes the file, exits non-zero, and says the credential 
 authenticating. An operator checking *that* with this command would have read "`windbg-mcp` holds"
 as proof the token was gone. There is no live roster to ask for (a service control code carries a
 status back and no data), so the answer is the caveat plus the state the service is in: `in_force`,
-three arms, one sentence each.
+three arms, one sentence each. The next round found the *other* half of the same gap, and it is
+not the same claim: a credential is in force at the reload every editing command waits for, while a
+**surface** is fixed when the client is identified, so a reload that succeeded still leaves a
+connected client listing what it listed then. That one is said wherever a client carries a spec of
+its own and the service is running — the two conditions the gap needs.
 
 Landed in [`src/service.rs`](./src/service.rs) (`list_clients`, `in_force`, `service_clients`,
 `shell_clients`), [`src/listen.rs`](./src/listen.rs) and [`src/main.rs`](./src/main.rs).

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -1558,5 +1558,16 @@ not the same claim: a credential is in force at the reload every editing command
 connected client listing what it listed then. That one is said wherever a client carries a spec of
 its own and the service is running — the two conditions the gap needs.
 
+**Three rounds all landed on that one clause, and they had one cause**: every wrong sentence was a
+claim about what the service was *accepting*, made by a command that reads a file. The seam is
+bounded rather than open — this service accepts `STOP` and `PRESHUTDOWN` and no pause control, so
+the SCM can only put it in four states — so the answer was to enumerate all four and let no arm
+claim acceptance where it cannot know it. The catch-all had been claiming "nothing is accepting
+anything", which is false of `StopPending`: a stop ends the accept loop and then releases every
+target (minutes, on a host holding a live kernel) while the connections already accepted go on
+being served by tasks nothing awaits or aborts. The comment in [`src/listen.rs`](./src/listen.rs)
+that said those connections "are dropped" is what produced the wrong sentence, and it is now
+exact — the shutdown ends the *accepting*, not the serving.
+
 Landed in [`src/service.rs`](./src/service.rs) (`list_clients`, `in_force`, `service_clients`,
 `shell_clients`), [`src/listen.rs`](./src/listen.rs) and [`src/main.rs`](./src/main.rs).

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -1491,7 +1491,7 @@ this makes false; it says what the client is actually served.
 Landed in [`src/toolset.rs`](./src/toolset.rs), [`src/client.rs`](./src/client.rs),
 [`src/listen.rs`](./src/listen.rs) and [`src/service.rs`](./src/service.rs).
 
-## 37. [windbg-mcp] The credential file has four writers and no reader
+## 37. [windbg-mcp] The credential file has four writers and no reader — **done** (2026-08-23)
 
 `--add-listen-client`, `--remove-listen-client`, `--rotate-listen-client` and now
 `--set-listen-client-tools` all edit `%ProgramData%\windbg-mcp\token`, and each prints the whole
@@ -1525,5 +1525,26 @@ to read the service's log file and hope the line has not aged out. The file itse
 the arrangement item 36 exists for — until then the startup line names everything there is to know.
 **Not blocked on anything.**
 
-Picks up at [`src/service.rs`](./src/service.rs) (`roster`, `requested`, `edit_client`'s read half)
-and [`src/client.rs`](./src/client.rs) (`ClientEntry`, `TokenFile::credentials`).
+**Built as `--list-listen-clients`** (2026-08-23), and the third bullet is the one that cost more
+than a line to get right. The other two fell out as written: the roster is `roster`, so no token
+can reach the output, and the parse is the listener's own, so a file with one bad entry refuses
+whole rather than printing a shorter list. The source question did not fall out. "Read whichever
+applies" is wrong on the host both apply to — a service *and* a developer's foreground bench, which
+`docs/remote-listener.md` recommends in the same breath — so the answer is **both, each saying what
+it is**: the file where a service is installed, this shell's credentials where none is or where it
+carries some anyway, and the shell's half labelled as what a listener started *from here* would
+accept rather than what one already running elsewhere does. It reads the environment through
+`listen::named_token_file` and not `client::env_credentials` alone, because a shell naming
+`WINDBG_MCP_LISTEN_TOKEN_FILE` has its variables ignored by the listener — listing them would be a
+roster of credentials nothing accepts.
+
+Two things the entry did not anticipate. The **lock message** was written for writers only
+("another `--add`/`--remove`/`--rotate-listen-client` is running", which item 36 had already made
+wrong by adding a fourth), so `lock_credentials` now takes what its caller came to do; a reader
+holds the same lock for the reader's half of the same hazard, since a list taken mid-edit reports
+the set that is about to replace it. And **`--tools` beside it is refused** rather than ignored, on
+the rule `--rotate-` and `--remove-listen-client` already follow: it reads exactly like a filter
+over the list it is about to print.
+
+Landed in [`src/service.rs`](./src/service.rs) (`list_clients`, `service_clients`, `shell_clients`),
+[`src/listen.rs`](./src/listen.rs) and [`src/main.rs`](./src/main.rs).

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -1546,5 +1546,13 @@ the set that is about to replace it. And **`--tools` beside it is refused** rath
 the rule `--rotate-` and `--remove-listen-client` already follow: it reads exactly like a filter
 over the list it is about to print.
 
-Landed in [`src/service.rs`](./src/service.rs) (`list_clients`, `service_clients`, `shell_clients`),
-[`src/listen.rs`](./src/listen.rs) and [`src/main.rs`](./src/main.rs).
+A third thing came out of review: the roster is the **file**, and `edit_client` deliberately leaves
+a window where the file and the running service disagree — a `--remove` or `--rotate` whose reload
+could not be delivered writes the file, exits non-zero, and says the credential may still be
+authenticating. An operator checking *that* with this command would have read "`windbg-mcp` holds"
+as proof the token was gone. There is no live roster to ask for (a service control code carries a
+status back and no data), so the answer is the caveat plus the state the service is in: `in_force`,
+three arms, one sentence each.
+
+Landed in [`src/service.rs`](./src/service.rs) (`list_clients`, `in_force`, `service_clients`,
+`shell_clients`), [`src/listen.rs`](./src/listen.rs) and [`src/main.rs`](./src/main.rs).

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -1569,5 +1569,12 @@ being served by tasks nothing awaits or aborts. The comment in [`src/listen.rs`]
 that said those connections "are dropped" is what produced the wrong sentence, and it is now
 exact — the shutdown ends the *accepting*, not the serving.
 
+A fourth round found the same shape one sentence over, and it is worth recording as the rule this
+command is really under: **it may not assert anything about a process it cannot see.** The empty
+environment branch said the service's roster was "the whole of what this host has", which a second
+foreground listener on another port — recommended two paragraphs earlier in
+`docs/remote-listener.md` — makes false, and which the non-empty branch beside it had always
+qualified correctly.
+
 Landed in [`src/service.rs`](./src/service.rs) (`list_clients`, `in_force`, `service_clients`,
 `shell_clients`), [`src/listen.rs`](./src/listen.rs) and [`src/main.rs`](./src/main.rs).

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -1560,7 +1560,11 @@ three arms, one sentence each. The next round found the *other* half of the same
 not the same claim: a credential is in force at the reload every editing command waits for, while a
 **surface** is fixed when the client is identified, so a reload that succeeded still leaves a
 connected client listing what it listed then. That one is said wherever a client carries a spec of
-its own and the service is running — the two conditions the gap needs.
+its own and the service is running. That gate was itself wrong, three rounds later: clearing the
+*last* per-client spec leaves a file with no surface in it and a connected client still being
+served the old one. So the gate is gone and the sentence is folded into the one clause that was
+already about file-versus-service — one rule, true whenever the service is running, rather than two
+conditions each with a state it is wrong in.
 
 **Three rounds all landed on that one clause, and they had one cause**: every wrong sentence was a
 claim about what the service was *accepting*, made by a command that reads a file. The seam is

--- a/README.md
+++ b/README.md
@@ -234,6 +234,8 @@ changed in place — `--add-listen-client`, `--remove-listen-client`, `--rotate-
 generating the token itself, writing it beside the credential file and printing only a fingerprint,
 and `--set-listen-client-tools` for which tools one of them is served — so adding, revoking or
 re-toolling one costs neither a reinstall nor the sessions the service is holding.
+`--list-listen-clients` asks who may connect and what each is served **without changing anything**,
+and answers for the environment instead where no service is installed.
 
 **Bind loopback and forward over SSH.** This endpoint runs `execute`, `debug_batch` and `launch`
 against a live kernel, and the token is sent in clear — a hypervisor's guest network is not private
@@ -414,7 +416,8 @@ setx WINDBG_MCP_TOOLS_BENCH        "session,inspect,crash"
 A client with no spec of its own is served the run's, so the flag above is a **default rather than
 a ceiling** — a client's own spec replaces it, wider or narrower. Under a Windows service the same
 thing lives in the credential file, and `--set-listen-client-tools <name> --tools <spec>` changes it
-without a reinstall or a restart. [`docs/remote-listener.md`](docs/remote-listener.md#a-tool-surface-per-client)
+without a reinstall or a restart; `--list-listen-clients` prints the whole set, name, fingerprint
+and surface, and changes nothing. [`docs/remote-listener.md`](docs/remote-listener.md#a-tool-surface-per-client)
 is the operator's half, including when a change reaches a client (the next time it is identified —
 its next handshake, or its next request if it holds no session) and why nothing announces one.
 

--- a/docs/remote-listener.md
+++ b/docs/remote-listener.md
@@ -665,8 +665,10 @@ Three things about it:
   that *succeeded* still does not reach a client holding an MCP session, which goes on listing the
   tools it listed when it connected. There is no way to ask the running service what it has in
   force (its only channel carries a status code and no data), so the command reports the state it
-  *is* in — running, starting, or stopped — and names the second gap wherever a client carries a
-  spec of its own.
+  *is* in — running, starting, **stopping** or stopped — and names the second gap wherever a client
+  carries a spec of its own. Stopping is not stopped: a stop ends the accept loop and then releases
+  every target, which on a host holding a live kernel is minutes, and the connections already
+  accepted are served until the process exits.
 
 **Stopping is graceful, and that is the point.** `Stop-Service` takes the same path a client
 disconnect takes: every session is asked to release its target before the process exits, and the SCM

--- a/docs/remote-listener.md
+++ b/docs/remote-listener.md
@@ -614,11 +614,14 @@ windbg-mcp.exe --list-listen-clients
 ```
 
 ```text
-`windbg-mcp` holds: `bench` (sha256:2F1A9C0B7D4E5A83, --tools session,inspect,crash),
+`windbg-mcp` is configured with: `bench` (sha256:2F1A9C0B7D4E5A83, --tools session,inspect,crash),
 `local` (sha256:701E4CF334890225).
 
 Read from C:\ProgramData\windbg-mcp\token, and nothing was changed — this is the one command
-here that only reads.
+here that only reads. It is the *file*, though, not a question put to the running service:
+`windbg-mcp` is running and re-reads this file whenever a client command changes it, and a
+command whose re-read did not land says so and exits non-zero — so a revocation that reported
+*that* is the one way a token this list no longer names can still be authenticating.
 
 A client with no `--tools` of its own is served whatever `windbg-mcp` serves — `--tools` on the
 command line the SCM stores, or every tool if that has none.
@@ -651,6 +654,12 @@ Three things about it:
 - **It needs the same elevated shell.** The credential file grants read to `SYSTEM` and
   `Administrators` only, which is what makes it worth having; an unelevated run is told so rather
   than shown a partial answer. On a host with no service there is no file and no elevation needed.
+- **It reads the file, not the service.** Normally those agree — every command above waits for the
+  re-read and exits non-zero if it did not land — but the one case they do not is exactly the case
+  you would run this to check: a `--remove` or `--rotate` whose reload failed leaves a token
+  authenticating that the file no longer names. There is no way to ask the running service what it
+  has in force (its only channel carries a status code and no data), so the command reports the
+  state it *is* in — running, starting, or stopped — and says which of those the roster means.
 
 **Stopping is graceful, and that is the point.** `Stop-Service` takes the same path a client
 disconnect takes: every session is asked to release its target before the process exits, and the SCM

--- a/docs/remote-listener.md
+++ b/docs/remote-listener.md
@@ -619,14 +619,11 @@ windbg-mcp.exe --list-listen-clients
 
 Read from C:\ProgramData\windbg-mcp\token, and nothing was changed — this is the one command
 here that only reads. It is the *file*, though, not a question put to the running service:
-`windbg-mcp` is running and re-reads this file whenever a client command changes it, and a
-command whose re-read did not land says so and exits non-zero — so a revocation that reported
-*that* is the one way a token this list no longer names can still be authenticating.
-
-A client's own `--tools` reaches it the next time it is identified, so this says what a client
-is *configured* with rather than what it is being served this minute: one holding an MCP session
-goes on listing the tools it listed at the time, until it reconnects. One on the sessionless
-revision is identified on every request and has no such gap.
+`windbg-mcp` is running, and it re-reads this file whenever a client command changes it — a
+command whose re-read did not land says so and exits non-zero. What a *client* is served is a
+step further behind: a surface is fixed when the client is identified, so one holding an MCP
+session goes on being served what it had when it connected, whatever this file says now. One on
+the sessionless revision is identified on every request and is never behind.
 
 A client with no `--tools` of its own is served whatever `windbg-mcp` serves — `--tools` on the
 command line the SCM stores, or every tool if that has none.
@@ -665,13 +662,14 @@ Three things about it:
 - **It reads the file, not the service**, and the two can differ in two unrelated ways. A
   credential's: a `--remove` or `--rotate` whose reload failed leaves a token authenticating that
   the file no longer names — exactly the case you would run this to check. A surface's: a reload
-  that *succeeded* still does not reach a client holding an MCP session, which goes on listing the
-  tools it listed when it connected. There is no way to ask the running service what it has in
-  force (its only channel carries a status code and no data), so the command reports the state it
-  *is* in — running, starting, **stopping** or stopped — and names the second gap wherever a client
-  carries a spec of its own. Stopping is not stopped: a stop ends the accept loop and then releases
-  every target, which on a host holding a live kernel is minutes, and the connections already
-  accepted are served until the process exits.
+  that *succeeded* still does not reach a client holding an MCP session, which goes on being served
+  what it had when it connected — including when the change was to *clear* the last spec, so a file
+  with no surfaces in it at all proves nothing about a connected client. There is no way to ask the
+  running service what it has in force (its only channel carries a status code and no data), so the
+  command reports the state it *is* in — running, starting, **stopping** or stopped — and says both
+  gaps in the running one, unconditionally. Stopping is not stopped: a stop ends the accept loop and
+  then releases every target, which on a host holding a live kernel is minutes, and the connections
+  already accepted are served until the process exits.
 
 **Stopping is graceful, and that is the point.** `Stop-Service` takes the same path a client
 disconnect takes: every session is asked to release its target before the process exits, and the SCM

--- a/docs/remote-listener.md
+++ b/docs/remote-listener.md
@@ -594,7 +594,9 @@ one you changed is not as you left it, `Restart-Service`. A `--remove` or `--rot
 here, because "may still authenticate" is the same thing to act on as "does". You will only meet
 this at boot on a non-loopback address, which is the one bind that can take a while. If it is not *installed*, the commands refuse — a foreground listener takes its
 clients from the environment it was started with, which is a set that cannot change without the
-process changing too.
+process changing too. The one exception is `--list-listen-clients`
+([below](#asking-who-may-connect-without-changing-anything)), which answers for that environment
+instead of refusing, because there is something to answer.
 
 **A second foreground listener is still the right answer for a bench**, and it is a *development*
 workflow rather than a way to operate a deployment — the commands above are what an operator uses.
@@ -604,6 +606,51 @@ one: run a *second, foreground* listener on another port with its own token, whi
 privileged write and disappears when you close it — [Driving it with a local model](#driving-it-with-a-local-model)
 has the recipe. Two listeners on one host is a normal arrangement; sessions belong to a listener's
 own process, so the two cannot see each other's.
+
+### Asking who may connect, without changing anything
+
+```pwsh
+windbg-mcp.exe --list-listen-clients
+```
+
+```text
+`windbg-mcp` holds: `bench` (sha256:2F1A9C0B7D4E5A83, --tools session,inspect,crash),
+`local` (sha256:701E4CF334890225).
+
+Read from C:\ProgramData\windbg-mcp\token, and nothing was changed — this is the one command
+here that only reads.
+
+A client with no `--tools` of its own is served whatever `windbg-mcp` serves — `--tools` on the
+command line the SCM stores, or every tool if that has none.
+
+This shell configures no listener credentials of its own (nothing in the
+`WINDBG_MCP_LISTEN_TOKEN` variables), so the list above is the whole of what this host has.
+```
+
+The other four all print that roster, and until this one there was no way to ask for it **without
+changing something**. That was survivable while every client was served the same surface, because
+"who may connect" had one other answer — the listener's own startup line. A client's own `--tools`
+spec has no such second answer, so the question grew a half that only a change could show you. It
+takes the same
+lock the edits take, reads the same file through the same parser, prints the same fingerprints, and
+writes nothing: no token is minted, no reload is asked for, and the roster is the state of the file
+as it stood. That makes it the one command in the family worth allow-listing.
+
+Three things about it:
+
+- **It says which of the two sources it answered for.** A service's clients are in the credential
+  file; a foreground listener's are the environment it was started with. Where a service is
+  installed this reads the file, and where none is it reads this shell — and it names the file or
+  the variables either way, because a roster with no source beside it is one you cannot act on. If
+  both are configured it prints both, the shell's clearly marked as what a listener started *from
+  here* would accept, which is not necessarily what one already running elsewhere does.
+- **A file it cannot read in full is reported as that, not as a shorter list.** One entry this
+  server would refuse at startup is a file that will not start the service, so the whole read
+  refuses and names the entry. A roster that quietly dropped the client it could not parse would
+  be the most misleading thing this command could print.
+- **It needs the same elevated shell.** The credential file grants read to `SYSTEM` and
+  `Administrators` only, which is what makes it worth having; an unelevated run is told so rather
+  than shown a partial answer. On a host with no service there is no file and no elevation needed.
 
 **Stopping is graceful, and that is the point.** `Stop-Service` takes the same path a client
 disconnect takes: every session is asked to release its target before the process exits, and the SCM

--- a/docs/remote-listener.md
+++ b/docs/remote-listener.md
@@ -623,6 +623,11 @@ here that only reads. It is the *file*, though, not a question put to the runnin
 command whose re-read did not land says so and exits non-zero — so a revocation that reported
 *that* is the one way a token this list no longer names can still be authenticating.
 
+A client's own `--tools` reaches it the next time it is identified, so this says what a client
+is *configured* with rather than what it is being served this minute: one holding an MCP session
+goes on listing the tools it listed at the time, until it reconnects. One on the sessionless
+revision is identified on every request and has no such gap.
+
 A client with no `--tools` of its own is served whatever `windbg-mcp` serves — `--tools` on the
 command line the SCM stores, or every tool if that has none.
 
@@ -654,12 +659,14 @@ Three things about it:
 - **It needs the same elevated shell.** The credential file grants read to `SYSTEM` and
   `Administrators` only, which is what makes it worth having; an unelevated run is told so rather
   than shown a partial answer. On a host with no service there is no file and no elevation needed.
-- **It reads the file, not the service.** Normally those agree — every command above waits for the
-  re-read and exits non-zero if it did not land — but the one case they do not is exactly the case
-  you would run this to check: a `--remove` or `--rotate` whose reload failed leaves a token
-  authenticating that the file no longer names. There is no way to ask the running service what it
-  has in force (its only channel carries a status code and no data), so the command reports the
-  state it *is* in — running, starting, or stopped — and says which of those the roster means.
+- **It reads the file, not the service**, and the two can differ in two unrelated ways. A
+  credential's: a `--remove` or `--rotate` whose reload failed leaves a token authenticating that
+  the file no longer names — exactly the case you would run this to check. A surface's: a reload
+  that *succeeded* still does not reach a client holding an MCP session, which goes on listing the
+  tools it listed when it connected. There is no way to ask the running service what it has in
+  force (its only channel carries a status code and no data), so the command reports the state it
+  *is* in — running, starting, or stopped — and names the second gap wherever a client carries a
+  spec of its own.
 
 **Stopping is graceful, and that is the point.** `Stop-Service` takes the same path a client
 disconnect takes: every session is asked to release its target before the process exits, and the SCM

--- a/docs/remote-listener.md
+++ b/docs/remote-listener.md
@@ -641,10 +641,11 @@ The other four all print that roster, and until this one there was no way to ask
 changing something**. That was survivable while every client was served the same surface, because
 "who may connect" had one other answer — the listener's own startup line. A client's own `--tools`
 spec has no such second answer, so the question grew a half that only a change could show you. It
-takes the same
-lock the edits take, reads the same file through the same parser, prints the same fingerprints, and
-writes nothing: no token is minted, no reload is asked for, and the roster is the state of the file
-as it stood. That makes it the one command in the family worth allow-listing.
+reads the same file through the same parser as the edits and prints the same fingerprints, and it
+**writes nothing at all**: no token is minted, no reload is asked for, and — unlike the four — it
+does not even take the credential lock, because that lock is a file this program creates and
+creating one is a write. The roster is the state of the file as it stood. That is what makes it the
+one command in the family worth allow-listing.
 
 Three things about it:
 

--- a/docs/remote-listener.md
+++ b/docs/remote-listener.md
@@ -632,7 +632,9 @@ A client with no `--tools` of its own is served whatever `windbg-mcp` serves —
 command line the SCM stores, or every tool if that has none.
 
 This shell configures no listener credentials of its own (nothing in the
-`WINDBG_MCP_LISTEN_TOKEN` variables), so the list above is the whole of what this host has.
+`WINDBG_MCP_LISTEN_TOKEN` variables), so there is no second set here to list — though a
+foreground listener started from *another* shell carries whatever that one configured, which
+nothing here can see.
 ```
 
 The other four all print that roster, and until this one there was no way to ask for it **without

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -652,6 +652,31 @@ passed, because each supplies the identity itself.
   counted here as well because it is the third of the three: under a service that file is the whole
   of what is read, so it is the only place a second client can come from at all.
 
+### The commands that install a service and edit its clients
+
+Three tests drive the exe as an **administrative command line** rather than as a server, so none of
+them starts a listener. They run in the protocol tier because every claim below is settled before
+the SCM is opened or the credential file is touched, which is also what makes them safe on a
+developer's own host: none can disturb the clients a service is serving, and each captures whether
+`windbg-mcp` is registered either side and asserts it did not move.
+
+- *An install with no address is refused **before anything is registered**.* The SCM stores the
+  command line once and nothing re-derives it, so a service registered without `--listen` is one
+  that installs cleanly and then fails at every start.
+- *A client command says what is missing before it touches anything.* A missing name, a name that
+  is not one, and a flag standing where a name belongs — the last because a name may contain `-`,
+  so `--add-listen-client --force` would otherwise mint a credential for a client nobody asked for.
+  It also asserts the refusal does **not** mention the service, since consulting the SCM first
+  would make a usage error depend on whether one happens to be installed.
+- *Listing the clients names its source and prints no token.* The one command that only reads
+  (item 37), and the only one of the three whose outcome depends on the host — a service host with
+  an elevated shell answers with the file's roster, one without answers with the ACL refusal, and a
+  host with no service answers for this shell's own credentials. So it asserts what holds in all
+  three: it names the source it answered for, and the token handed to it in the environment appears
+  nowhere in what it wrote. That second half is the trap the command was built around — a roster may
+  carry a fingerprint and nothing else, which is what makes this the one client command that is safe
+  to run in an agent's transcript.
+
 **Progress notifications.** The policy — what is reported, when a silence becomes a heartbeat, that
 a send never delays the call — has unit tests in [`progress.rs`](../src/progress.rs) against a
 collector. What those cannot reach is whether any of it leaves the process, so three assertions do:

--- a/skills/windbg-debugging/setup.md
+++ b/skills/windbg-debugging/setup.md
@@ -454,6 +454,8 @@ Four things decide whether that works, and each fails in a way that reads as som
   narrowing it, so a wider one is served too. `--set-listen-client-tools <name> --tools <spec>`
   changes it afterwards, and the same command with **no** `--tools` puts the client back on the
   run's surface. That is how a local model shares a listener with a full client.
+  `--list-listen-clients` prints who may connect and what each is served without changing
+  anything — the only one of the five that is safe to run when you just want to look.
 
 Two behaviours differ from stdio and are worth knowing before they surprise you.
 

--- a/src/listen.rs
+++ b/src/listen.rs
@@ -826,8 +826,16 @@ pub async fn serve(
         let (stream, peer) = tokio::select! {
             // Asked to stop. Returning here is the whole mechanism: the caller's `shutdown` on
             // `Sessions` runs next, and that is what releases a live kernel rather than leaving it
-            // frozen. Connections already in flight are dropped — a client mid-call loses that
-            // call, which is the lesser of the two, and its session is being released anyway.
+            // frozen.
+            //
+            // **What this ends is the accepting, not the serving** — worth being exact about,
+            // because the looser reading ("connections in flight are dropped") is wrong and put a
+            // wrong sentence into `service::in_force` (review on #201). Every accepted connection
+            // is served by a task spawned below, and nothing here awaits or aborts those: they go
+            // on authenticating and answering until the runtime is dropped, which is after the
+            // release above has finished. On a host holding a live kernel that is minutes. A
+            // client mid-call at the end loses that call, which is the lesser of the two, and its
+            // session is being released anyway.
             () = &mut shutdown => {
                 tracing::info!("no longer accepting connections on {addr}");
                 return Ok(());

--- a/src/listen.rs
+++ b/src/listen.rs
@@ -674,11 +674,20 @@ fn credentials() -> Result<crate::client::Credentials> {
 }
 
 /// The credentials in the file [`TOKEN_FILE_ENV`] names, if it names one.
+fn token_file() -> Result<Option<crate::client::TokenFile>> {
+    Ok(named_token_file()?.map(|(_, file)| file))
+}
+
+/// The same file, with the path it was read from.
 ///
 /// The read is here and the parse is in [`crate::client`], which is the same split every other
 /// rule about who may connect follows — and it lets the file's two shapes be asserted without a
 /// filesystem.
-fn token_file() -> Result<Option<crate::client::TokenFile>> {
+///
+/// **The path comes back because [`crate::service::list_clients`] has to say where a roster it
+/// prints was read from**, and deriving that separately would be a second reading of
+/// [`TOKEN_FILE_ENV`] that could name a different file from the one this opened.
+pub(crate) fn named_token_file() -> Result<Option<(std::path::PathBuf, crate::client::TokenFile)>> {
     let Some(path) = std::env::var_os(TOKEN_FILE_ENV) else {
         return Ok(None);
     };
@@ -689,7 +698,8 @@ fn token_file() -> Result<Option<crate::client::TokenFile>> {
             path.display()
         )
     })?;
-    crate::client::TokenFile::parse(&text, &path).map(Some)
+    let file = crate::client::TokenFile::parse(&text, &path)?;
+    Ok(Some((path, file)))
 }
 
 pub async fn serve(

--- a/src/main.rs
+++ b/src/main.rs
@@ -108,6 +108,10 @@ fn main() -> Result<()> {
             service::Role::Client(edit, name) => {
                 service::edit_client(edit, &name, tools_spec(&args)?.as_deref())
             }
+            // Reads the same file and touches nothing else, so it needs a runtime no more than
+            // the edits do. The `--tools` is passed for the same reason: it means nothing here
+            // either, and `list_clients` refuses it rather than accepting a flag it would ignore.
+            service::Role::ListClients => service::list_clients(tools_spec(&args)?.as_deref()),
         };
     }
 
@@ -211,9 +215,9 @@ fn listen_address(args: &[String]) -> Result<std::net::SocketAddr> {
 
 /// The renderer role: a transcript in, an asciicast out.
 ///
-/// The one place in this binary that prints to standard output, and it is safe to: this role
-/// never speaks MCP, so there is no JSON-RPC transport to corrupt. It exits before `serve` is ever
-/// reached.
+/// One of the roles that prints to standard output, and it is safe to for the reason they all
+/// are: none of them speaks MCP, so there is no JSON-RPC transport to corrupt. It exits before
+/// `serve` is ever reached, as the service and client roles do.
 fn render_cast(args: &[String]) -> Result<()> {
     let options = match cast::Options::parse(args) {
         Ok(options) => options,

--- a/src/service.rs
+++ b/src/service.rs
@@ -925,6 +925,9 @@ const ERROR_SERVICE_DOES_NOT_EXIST: u32 = 1060;
 /// file that will not start the service, and it has to read as *that* rather than as a shorter
 /// list. So the parse and the validation here are the ones the listener runs, and either failing
 /// refuses rather than dropping a client from the output.
+///
+/// **And it is the file, not the set the service is accepting** — see [`in_force`], which is the
+/// clause that says so and why the difference is not hypothetical.
 pub fn list_clients(tools: Option<&str>) -> Result<()> {
     // Refused rather than ignored, by the rule the other client commands are held to: this
     // command has no use for a surface, and `--list-listen-clients --tools crash` reads exactly
@@ -946,11 +949,11 @@ pub fn list_clients(tools: Option<&str>) -> Result<()> {
     let manager = ServiceManager::local_computer(None::<&OsStr>, ServiceManagerAccess::CONNECT)
         .context("cannot open the service manager")?;
     let installed = match manager.open_service(NAME, ServiceAccess::QUERY_STATUS) {
-        Ok(_) => true,
+        Ok(service) => Some(service),
         Err(windows_service::Error::Winapi(e))
             if e.raw_os_error() == Some(ERROR_SERVICE_DOES_NOT_EXIST as i32) =>
         {
-            false
+            None
         }
         // **Anything else is a failure, not a "no".** A service that is registered and cannot be
         // opened, reported as one that is not, would put this host's environment on screen under
@@ -963,14 +966,15 @@ pub fn list_clients(tools: Option<&str>) -> Result<()> {
         }
     };
 
-    if installed {
+    if let Some(service) = &installed {
         let at = token_file();
         let held = service_clients(&at)?;
-        println!("`{NAME}` holds: {}.", roster(&held));
+        println!("`{NAME}` is configured with: {}.", roster(&held));
         println!(
             "\nRead from {}, and nothing was changed — this is the one command here that only \
-             reads.",
-            at.display()
+             reads. It is the *file*, though, not a question put to the running service: {}",
+            at.display(),
+            in_force(service),
         );
         // Said only where there is a client it is about, which is what keeps it off the line on a
         // host where every client carries its own spec.
@@ -994,7 +998,7 @@ pub fn list_clients(tools: Option<&str>) -> Result<()> {
     // question and is introduced as one; where no service is installed, it is the answer. Either
     // way the claim is about a listener started from **this** shell — not about one already
     // running elsewhere, whose clients are the environment it was started with.
-    match (shell_clients(), installed) {
+    match (shell_clients(), installed.is_some()) {
         (Ok((source, clients)), true) if clients.is_empty() => println!(
             "\nThis shell configures no listener credentials of its own (nothing in {source}), so \
              the list above is the whole of what this host has."
@@ -1004,7 +1008,7 @@ pub fn list_clients(tools: Option<&str>) -> Result<()> {
              no clients in {source} either, and a listener without one exposes every tool this \
              server has."
         ),
-        (Ok((source, clients)), _) => println!(
+        (Ok((source, clients)), installed) => println!(
             "\n{}A foreground listener started from this shell would accept: {} — from {source}. \
              One already running elsewhere may accept something else: its clients are the \
              environment *it* was started with, and nothing changes them without restarting it.",
@@ -1031,6 +1035,49 @@ pub fn list_clients(tools: Option<&str>) -> Result<()> {
         }
     }
     Ok(())
+}
+
+/// Whether the file just printed is the set the service is actually accepting — as a clause to
+/// finish the line that says where it was read from.
+///
+/// **The reason this clause exists is a window [`edit_client`] deliberately leaves open** (review
+/// on #201). A `--remove-` or `--rotate-listen-client` whose reload could not be delivered writes
+/// the file, exits non-zero, and says the credential it took out of service may still be
+/// authenticating — so an operator who then runs this command to check is looking at a file that
+/// no longer names a token the service still accepts. "`windbg-mcp` holds" would have told them it
+/// was gone, which is the one thing they must not be told wrongly here.
+///
+/// **The live roster is not askable**, which is why this is a caveat rather than a better answer:
+/// the only channel to the running service is `ControlService`, which carries a status code back
+/// and no data. Reporting the state it *is* in says as much as can be said from outside, and each
+/// of the three says something different about the file underneath it.
+fn in_force(service: &windows_service::service::Service) -> String {
+    match service.query_status().map(|status| status.current_state) {
+        Ok(ServiceState::Running) => format!(
+            "`{NAME}` is running and re-reads this file whenever a client command changes it, and \
+             a command whose re-read did not land says so and exits non-zero — so a revocation \
+             that reported *that* is the one way a token this list no longer names can still be \
+             authenticating."
+        ),
+        // The state `ask_to_reload` refuses to guess about, for the same reason: the SCM will not
+        // carry a control code to a starting service, and it reads its clients moments after
+        // starting, so nothing outside can tell whether the start under way has this file or the
+        // one before it.
+        Ok(ServiceState::StartPending) => format!(
+            "`{NAME}` is starting, and whether the start under way has read this file cannot be \
+             told from outside — when it comes up it logs the clients it is serving."
+        ),
+        Ok(_) => format!(
+            "`{NAME}` is not running, so nothing is accepting anything and this is what it will \
+             read at its next start."
+        ),
+        // Not a failure. The roster above is what was asked for; this clause is the caveat on it,
+        // and a caveat that cannot be given is not a reason to withhold the answer.
+        Err(e) => format!(
+            "`{NAME}`'s own state could not be read ({e}), so whether it has this set in force is \
+             not known from here."
+        ),
+    }
 }
 
 /// The installed service's clients, read the way its own listener reads them.

--- a/src/service.rs
+++ b/src/service.rs
@@ -970,12 +970,32 @@ pub fn list_clients(tools: Option<&str>) -> Result<()> {
         let at = token_file();
         let held = service_clients(&at)?;
         println!("`{NAME}` is configured with: {}.", roster(&held));
+        // Read once and used twice — the caveat below turns on it as well, and asking the SCM
+        // twice could answer differently between two lines of one report.
+        let state = service.query_status().map(|status| status.current_state);
         println!(
             "\nRead from {}, and nothing was changed — this is the one command here that only \
              reads. It is the *file*, though, not a question put to the running service: {}",
             at.display(),
-            in_force(service),
+            in_force(&state),
         );
+        // **A client's own surface lags the file in a way its credential does not** (review on
+        // #201, second round). A credential is in force at the reload every editing command waits
+        // for; a surface is fixed when the client is *identified*, so one holding an MCP session
+        // goes on listing what it listed then. Said only where a client carries a spec of its own
+        // and only while the service is running, because those are the two things that have to be
+        // true for the gap to exist — and the arm above has just said nothing is being served at
+        // all where the second is false.
+        if matches!(state, Ok(ServiceState::Running)) && held.iter().any(|c| c.tools.is_some()) {
+            println!(
+                "\nA client's own `{}` reaches it the next time it is identified, so this says \
+                 what a client is *configured* with rather than what it is being served this \
+                 minute: one holding an MCP session goes on listing the tools it listed at the \
+                 time, until it reconnects. One on the sessionless revision is identified on every \
+                 request and has no such gap.",
+                crate::toolset::FLAG,
+            );
+        }
         // Said only where there is a client it is about, which is what keeps it off the line on a
         // host where every client carries its own spec.
         if held.iter().any(|client| client.tools.is_none()) {
@@ -1051,8 +1071,8 @@ pub fn list_clients(tools: Option<&str>) -> Result<()> {
 /// the only channel to the running service is `ControlService`, which carries a status code back
 /// and no data. Reporting the state it *is* in says as much as can be said from outside, and each
 /// of the three says something different about the file underneath it.
-fn in_force(service: &windows_service::service::Service) -> String {
-    match service.query_status().map(|status| status.current_state) {
+fn in_force(state: &Result<ServiceState, windows_service::Error>) -> String {
+    match state {
         Ok(ServiceState::Running) => format!(
             "`{NAME}` is running and re-reads this file whenever a client command changes it, and \
              a command whose re-read did not land says so and exits non-zero — so a revocation \

--- a/src/service.rs
+++ b/src/service.rs
@@ -1019,9 +1019,15 @@ pub fn list_clients(tools: Option<&str>) -> Result<()> {
     // way the claim is about a listener started from **this** shell — not about one already
     // running elsewhere, whose clients are the environment it was started with.
     match (shell_clients(), installed.is_some()) {
+        // **"No second set *here*", not "no second set at all"** (review on #201, fourth round).
+        // A second foreground listener on another port is a normal arrangement — this page's own
+        // docs recommend it for a bench — and it carries whatever the shell that started it
+        // configured, which nothing in this process can see. The non-empty arm below has always
+        // said so; this one claimed the roster above was the whole of the host.
         (Ok((source, clients)), true) if clients.is_empty() => println!(
             "\nThis shell configures no listener credentials of its own (nothing in {source}), so \
-             the list above is the whole of what this host has."
+             there is no second set here to list — though a foreground listener started from \
+             *another* shell carries whatever that one configured, which nothing here can see."
         ),
         (Ok((source, clients)), false) if clients.is_empty() => println!(
             "\nAnd a foreground listener started from this shell would refuse to start: there are \

--- a/src/service.rs
+++ b/src/service.rs
@@ -970,8 +970,6 @@ pub fn list_clients(tools: Option<&str>) -> Result<()> {
         let at = token_file();
         let held = service_clients(&at)?;
         println!("`{NAME}` is configured with: {}.", roster(&held));
-        // Read once and used twice — the caveat below turns on it as well, and asking the SCM
-        // twice could answer differently between two lines of one report.
         let state = service.query_status().map(|status| status.current_state);
         println!(
             "\nRead from {}, and nothing was changed — this is the one command here that only \
@@ -979,33 +977,6 @@ pub fn list_clients(tools: Option<&str>) -> Result<()> {
             at.display(),
             in_force(&state),
         );
-        // **A client's own surface lags the file in a way its credential does not** (review on
-        // #201, second round). A credential is in force at the reload every editing command waits
-        // for; a surface is fixed when the client is *identified*, so one holding an MCP session
-        // goes on listing what it listed then. Said only where a client carries a spec of its own
-        // and only while the service is running, because those are the two things that have to be
-        // true for the gap to exist — and the arm above has just said nothing is being served at
-        // all where the second is false.
-        if matches!(state, Ok(ServiceState::Running)) && held.iter().any(|c| c.tools.is_some()) {
-            println!(
-                "\nA client's own `{}` reaches it the next time it is identified, so this says \
-                 what a client is *configured* with rather than what it is being served this \
-                 minute: one holding an MCP session goes on listing the tools it listed at the \
-                 time, until it reconnects. One on the sessionless revision is identified on every \
-                 request and has no such gap.",
-                crate::toolset::FLAG,
-            );
-        }
-        // Said only where there is a client it is about, which is what keeps it off the line on a
-        // host where every client carries its own spec.
-        if held.iter().any(|client| client.tools.is_none()) {
-            println!(
-                "\nA client with no `{}` of its own is served whatever `{NAME}` serves — `{}` on \
-                 the command line the SCM stores, or every tool if that has none.",
-                crate::toolset::FLAG,
-                crate::toolset::FLAG,
-            );
-        }
     } else {
         println!(
             "No service named `{NAME}` is installed, so this host has no client list in a file. A \
@@ -1063,8 +1034,15 @@ pub fn list_clients(tools: Option<&str>) -> Result<()> {
     Ok(())
 }
 
-/// Whether the file just printed is the set the service is actually accepting — as a clause to
-/// finish the line that says where it was read from.
+/// Whether the file just printed is what the running service is actually doing with it — as a
+/// clause to finish the line that says where it was read from.
+///
+/// **One clause, not one per way they can differ.** Gating a second sentence on "some client has a
+/// spec of its own" was wrong for the case that clears the last one (review on #201, sixth round):
+/// the file then has no spec anywhere, and a client connected under the old one is still being
+/// served it. Three of six review rounds landed on this line, and every one of them was a
+/// condition that turned out to have a state it was wrong in — so the conditions are gone and the
+/// sentence is simply true whenever the service is running.
 ///
 /// **The reason this clause exists is a window [`edit_client`] deliberately leaves open** (review
 /// on #201). A `--remove-` or `--rotate-listen-client` whose reload could not be delivered writes
@@ -1081,7 +1059,11 @@ fn in_force(state: &Result<ServiceState, windows_service::Error>) -> String {
     match state {
         Ok(ServiceState::Running) => format!(
             "`{NAME}` is running, and it re-reads this file whenever a client command changes it — \
-             a command whose re-read did not land says so and exits non-zero."
+             a command whose re-read did not land says so and exits non-zero. What a *client* is \
+             served is a step further behind: a surface is fixed when the client is identified, so \
+             one holding an MCP session goes on being served what it had when it connected, \
+             whatever this file says now. One on the sessionless revision is identified on every \
+             request and is never behind."
         ),
         // The state `ask_to_reload` refuses to guess about, for the same reason: the SCM will not
         // carry a control code to a starting service, and it reads its clients moments after

--- a/src/service.rs
+++ b/src/service.rs
@@ -1074,10 +1074,8 @@ pub fn list_clients(tools: Option<&str>) -> Result<()> {
 fn in_force(state: &Result<ServiceState, windows_service::Error>) -> String {
     match state {
         Ok(ServiceState::Running) => format!(
-            "`{NAME}` is running and re-reads this file whenever a client command changes it, and \
-             a command whose re-read did not land says so and exits non-zero — so a revocation \
-             that reported *that* is the one way a token this list no longer names can still be \
-             authenticating."
+            "`{NAME}` is running, and it re-reads this file whenever a client command changes it — \
+             a command whose re-read did not land says so and exits non-zero."
         ),
         // The state `ask_to_reload` refuses to guess about, for the same reason: the SCM will not
         // carry a control code to a starting service, and it reads its clients moments after
@@ -1087,10 +1085,24 @@ fn in_force(state: &Result<ServiceState, windows_service::Error>) -> String {
             "`{NAME}` is starting, and whether the start under way has read this file cannot be \
              told from outside — when it comes up it logs the clients it is serving."
         ),
-        Ok(_) => format!(
+        // **Not the same as stopped, and this arm exists because collapsing the two was wrong**
+        // (review on #201, third round). A stop ends the accept loop and then releases every
+        // target, which is the slow part — `stop_bound` is minutes on a host holding a live
+        // kernel — and the connections already accepted are served by tasks that outlive it.
+        Ok(ServiceState::StopPending) => format!(
+            "`{NAME}` is stopping, which can take minutes while it releases the targets it holds. \
+             It goes on serving connections it had already accepted until the process exits, so a \
+             credential in this list may still be authenticating on one of them."
+        ),
+        Ok(ServiceState::Stopped) => format!(
             "`{NAME}` is not running, so nothing is accepting anything and this is what it will \
              read at its next start."
         ),
+        // **Unreachable rather than unhandled**, and it says nothing about what is being accepted
+        // because it cannot: this service accepts `STOP` and `PRESHUTDOWN` and no pause control,
+        // so the SCM has no way to put it in a paused state — and an arm that guessed at one
+        // would be the fourth wrong claim on this line rather than the first right one.
+        Ok(other) => format!("`{NAME}` reports itself {other:?}."),
         // Not a failure. The roster above is what was asked for; this clause is the caveat on it,
         // and a caveat that cannot be given is not a reason to withhold the answer.
         Err(e) => format!(

--- a/src/service.rs
+++ b/src/service.rs
@@ -94,6 +94,8 @@ pub const ROTATE_CLIENT_FLAG: &str = "--rotate-listen-client";
 /// [`crate::toolset::FLAG`] beside it — with no `--tools` at all, the client goes back to being
 /// served whatever the run serves.
 pub const SET_CLIENT_TOOLS_FLAG: &str = "--set-listen-client-tools";
+/// Prints who may connect and what each is served. Takes no name, and changes nothing.
+pub const LIST_CLIENTS_FLAG: &str = "--list-listen-clients";
 
 /// Overrides where the service writes its log.
 pub const LOG_ENV: &str = "WINDBG_MCP_SERVICE_LOG";
@@ -138,6 +140,8 @@ pub enum Role {
     Uninstall,
     /// One of the client commands, and which client it names.
     Client(ClientEdit, String),
+    /// The one that only reads. It names no client, because it answers for all of them.
+    ListClients,
 }
 
 /// What a client command does to the service's credential file.
@@ -202,6 +206,7 @@ pub fn requested(args: &[String]) -> Option<Role> {
             SERVICE_FLAG => return Some(Role::Run),
             INSTALL_FLAG => return Some(Role::Install),
             UNINSTALL_FLAG => return Some(Role::Uninstall),
+            LIST_CLIENTS_FLAG => return Some(Role::ListClients),
             _ => {}
         }
         edits
@@ -604,7 +609,7 @@ pub fn edit_client(edit: ClientEdit, name: &str, tools: Option<&str>) -> Result<
 
     // Held until this function returns, which is what makes the read, the edit, the write and the
     // reload below one transaction rather than four steps two shells can interleave.
-    let _lock = lock_credentials()?;
+    let _lock = lock_credentials("changing a client")?;
 
     let at = token_file();
     let existing = match std::fs::read_to_string(&at) {
@@ -889,6 +894,198 @@ fn roster(credentials: &[crate::client::ClientEntry]) -> String {
         .join(", ")
 }
 
+/// What the SCM answers when nothing by that name is registered — the one failure of
+/// `open_service` that [`list_clients`] treats as half an answer rather than as an error.
+const ERROR_SERVICE_DOES_NOT_EXIST: u32 = 1060;
+
+/// Prints who may connect and what each is served, and changes nothing.
+///
+/// **The question had no command until item 36 gave it a second half.** While every client was
+/// served the same surface, "who may connect" had another answer — the listener's own startup
+/// line — and a client either connected or did not. A client's own `--tools` spec is not visible
+/// from outside it, so once there was one, the only routes to it were to run a command that
+/// *changes* something and read the roster it prints afterwards, or to read the service's log and
+/// hope the line had not aged out of it.
+///
+/// **It says which source it answered for, and answers for both where both apply.** A service's
+/// clients are in [`token_file`]; a foreground listener's are the environment it was started with,
+/// and no command edits those. So this reads the file where a service is installed and the
+/// environment where none is — the asymmetry that made a refusal wrong in
+/// [#196](https://github.com/glslang/windbg-mcp/pull/196), where the message for a tool off a
+/// client's own surface named the service command alone and a foreground listener's operator could
+/// not take that advice. Where a service is installed *and* this shell carries credentials of its
+/// own, both are printed: that is two answers to one question, and printing one of them alone is
+/// what would make a roster read as the whole of it. A file half that *fails* still ends the
+/// command, deliberately — on a host with a service the question was about the service, and an
+/// answer for the environment printed beneath a refusal is not the one that was asked for.
+///
+/// **What it must not print is a token — and what it must not print more quietly is a roster it
+/// could not read in full.** The first is [`roster`]'s rule, which every command in this family
+/// already follows. The second is this one's: a file with an entry this server cannot parse is a
+/// file that will not start the service, and it has to read as *that* rather than as a shorter
+/// list. So the parse and the validation here are the ones the listener runs, and either failing
+/// refuses rather than dropping a client from the output.
+pub fn list_clients(tools: Option<&str>) -> Result<()> {
+    // Refused rather than ignored, by the rule the other client commands are held to: this
+    // command has no use for a surface, and `--list-listen-clients --tools crash` reads exactly
+    // like a filter over the list it is about to print.
+    if let Some(spec) = tools {
+        bail!(
+            "`{LIST_CLIENTS_FLAG}` reads the client list and changes nothing, so the `{}` beside \
+             it would do nothing — and it reads exactly like a filter over what it prints. Every \
+             client's surface is in that list already; `{SET_CLIENT_TOOLS_FLAG} <name> {} {spec}` \
+             is the command that sets one.",
+            crate::toolset::FLAG,
+            crate::toolset::FLAG,
+        );
+    }
+
+    // Opened for the reason [`edit_client`] opens it and answered differently. There, no service
+    // is a refusal: there is nothing to edit. Here it is half the answer — a host with no service
+    // still has clients, in the environment a foreground listener was started with.
+    let manager = ServiceManager::local_computer(None::<&OsStr>, ServiceManagerAccess::CONNECT)
+        .context("cannot open the service manager")?;
+    let installed = match manager.open_service(NAME, ServiceAccess::QUERY_STATUS) {
+        Ok(_) => true,
+        Err(windows_service::Error::Winapi(e))
+            if e.raw_os_error() == Some(ERROR_SERVICE_DOES_NOT_EXIST as i32) =>
+        {
+            false
+        }
+        // **Anything else is a failure, not a "no".** A service that is registered and cannot be
+        // opened, reported as one that is not, would put this host's environment on screen under
+        // a heading saying there was nothing else to see.
+        Err(e) => {
+            return Err(anyhow::Error::new(e).context(format!(
+                "cannot ask the SCM whether `{NAME}` is installed, so which clients this host has \
+                 is not known"
+            )));
+        }
+    };
+
+    if installed {
+        let at = token_file();
+        let held = service_clients(&at)?;
+        println!("`{NAME}` holds: {}.", roster(&held));
+        println!(
+            "\nRead from {}, and nothing was changed — this is the one command here that only \
+             reads.",
+            at.display()
+        );
+        // Said only where there is a client it is about, which is what keeps it off the line on a
+        // host where every client carries its own spec.
+        if held.iter().any(|client| client.tools.is_none()) {
+            println!(
+                "\nA client with no `{}` of its own is served whatever `{NAME}` serves — `{}` on \
+                 the command line the SCM stores, or every tool if that has none.",
+                crate::toolset::FLAG,
+                crate::toolset::FLAG,
+            );
+        }
+    } else {
+        println!(
+            "No service named `{NAME}` is installed, so this host has no client list in a file. A \
+             foreground listener takes its clients from the environment it was started with, and \
+             no command changes those."
+        );
+    }
+
+    // The other source. Where the file answered above, this is a *second* answer to the same
+    // question and is introduced as one; where no service is installed, it is the answer. Either
+    // way the claim is about a listener started from **this** shell — not about one already
+    // running elsewhere, whose clients are the environment it was started with.
+    match (shell_clients(), installed) {
+        (Ok((source, clients)), true) if clients.is_empty() => println!(
+            "\nThis shell configures no listener credentials of its own (nothing in {source}), so \
+             the list above is the whole of what this host has."
+        ),
+        (Ok((source, clients)), false) if clients.is_empty() => println!(
+            "\nAnd a foreground listener started from this shell would refuse to start: there are \
+             no clients in {source} either, and a listener without one exposes every tool this \
+             server has."
+        ),
+        (Ok((source, clients)), _) => println!(
+            "\n{}A foreground listener started from this shell would accept: {} — from {source}. \
+             One already running elsewhere may accept something else: its clients are the \
+             environment *it* was started with, and nothing changes them without restarting it.",
+            if installed {
+                "This shell also carries listener credentials, which a service never reads. "
+            } else {
+                ""
+            },
+            roster(&clients)
+        ),
+        // **Reported rather than returned where the file half already answered**, because the
+        // question was about the service and this is a second, unasked-for source: failing the
+        // command on it would withhold the answer it did have. Where there is no service it is
+        // the whole answer, so it is the command's failure.
+        (Err(e), true) => println!(
+            "\nThis shell also carries listener configuration of its own, which a service never \
+             reads — and it is not a set a listener would start on: {e:#}"
+        ),
+        (Err(e), false) => {
+            return Err(e.context(
+                "no service is installed, so this host's clients are the ones this shell \
+                 configures — and it does not configure a set a listener would start on",
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// The installed service's clients, read the way its own listener reads them.
+///
+/// **Under the lock the edits take**, so a roster is never a snapshot from the middle of one: an
+/// edit computes a whole file from what it read, and a list taken while that is in flight would
+/// report the set it is about to replace as the set in force.
+fn service_clients(at: &std::path::Path) -> Result<Vec<crate::client::ClientEntry>> {
+    let _lock = lock_credentials("reading the client list")?;
+    match std::fs::read_to_string(at) {
+        Ok(text) => crate::client::TokenFile::parse(&text, at)?.credentials(),
+        // A service registered against a file that is not there. Said as what it costs rather than
+        // as an empty roster, which would read as a service serving nobody instead of one that
+        // will not run.
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => bail!(
+            "`{NAME}` is installed and {} does not exist, so it has no clients and will not start \
+             until it does. `{ADD_CLIENT_FLAG} <name>` writes a new file with one client in it, or \
+             reinstall the service.",
+            at.display()
+        ),
+        // The refusal an unelevated shell gets, since that file grants read to `SYSTEM` and
+        // `Administrators` only.
+        Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied => Err(anyhow::Error::new(e)
+            .context(format!(
+                "cannot read {} — it grants read to SYSTEM and Administrators only, so listing \
+                 the clients needs an elevated shell (\"Run as administrator\")",
+                at.display()
+            ))),
+        Err(e) => Err(anyhow::Error::new(e).context(format!("cannot read {}", at.display()))),
+    }
+}
+
+/// What a foreground listener started from *this* shell would accept, and where it read it from.
+///
+/// **The listener's own precedence, not a second copy of it**: a configured
+/// `WINDBG_MCP_LISTEN_TOKEN_FILE` is the whole configuration, and the token variables are not read
+/// at all beside one ([`crate::client::Credentials::from_entries`]). Listing the variables on a
+/// host that names a file would be a roster of credentials nothing accepts.
+fn shell_clients() -> Result<(String, Vec<crate::client::ClientEntry>)> {
+    match crate::listen::named_token_file()? {
+        Some((path, file)) => Ok((
+            format!(
+                "the credential file `{}` names ({})",
+                crate::listen::TOKEN_FILE_ENV,
+                path.display()
+            ),
+            file.credentials()?,
+        )),
+        None => Ok((
+            format!("the `{}` variables", crate::listen::TOKEN_ENV),
+            crate::client::env_credentials(std::env::vars())?,
+        )),
+    }
+}
+
 /// Writes a generated token beside the credential file, and says where it went.
 ///
 /// **The operator does not choose the path, and that is the fix rather than a limitation.** This
@@ -971,7 +1168,12 @@ fn write_token_out(name: &str, token: &str) -> Result<PathBuf> {
 ///
 /// It lives in the state directory, which is already `Administrators`-only, so this is also where
 /// an unelevated caller is turned away: it needs write access to a directory it cannot write.
-fn lock_credentials() -> Result<std::fs::File> {
+///
+/// **`doing` is what this caller came to do**, because [`list_clients`] holds the same lock
+/// without writing anything and "changing a client needs an elevated shell" is the wrong sentence
+/// for it. The contention message is one both are held to: a read taken from the middle of an edit
+/// reports a set that is about to be replaced, which is the reader's half of the same hazard.
+fn lock_credentials(doing: &str) -> Result<std::fs::File> {
     use std::os::windows::fs::OpenOptionsExt;
 
     let at = state_dir().join("token.lock");
@@ -983,14 +1185,15 @@ fn lock_credentials() -> Result<std::fs::File> {
         .open(&at)
         .map_err(|e| match e.kind() {
             std::io::ErrorKind::PermissionDenied => anyhow::Error::new(e).context(format!(
-                "cannot open {} — that directory is SYSTEM and Administrators only, so changing a \
-                 client needs an elevated shell (\"Run as administrator\")",
+                "cannot open {} — that directory is SYSTEM and Administrators only, so {doing} \
+                 needs an elevated shell (\"Run as administrator\")",
                 at.display()
             )),
             _ => anyhow::Error::new(e).context(format!(
-                "cannot take {} — another `--add`/`--remove`/`--rotate-listen-client` is running. \
-                 Two of them editing at once would each write a whole file from its own snapshot, \
-                 and the second would discard the first. Wait for it and try again.",
+                "cannot take {} — another client command is holding it. Two of them at once would \
+                 each work from its own snapshot of the credential file: the second write would \
+                 discard the first, and a list read from the middle of an edit would report a set \
+                 that is about to be replaced. Wait for it and try again.",
                 at.display()
             )),
         })
@@ -1596,6 +1799,11 @@ mod tests {
             requested(&argv(&["windbg-mcp", UNINSTALL_FLAG])),
             Some(Role::Uninstall)
         );
+        // The one that names no client, because it answers for all of them.
+        assert_eq!(
+            requested(&argv(&["windbg-mcp", LIST_CLIENTS_FLAG])),
+            Some(Role::ListClients)
+        );
     }
 
     /// A client command carries the name that follows it, and takes its role even without one.
@@ -1760,6 +1968,54 @@ mod tests {
             why.contains("`ttdd` is neither a group nor a tool"),
             "{why}"
         );
+    }
+
+    /// The command that only reads takes no surface either, and refuses one rather than ignoring
+    /// it.
+    ///
+    /// `--list-listen-clients --tools crash` reads as a filter over the list it is about to
+    /// print, and every client's surface is in that list already. Refused before the SCM is
+    /// opened, which is what makes it a unit test — and what keeps the refusal identical on a
+    /// host that has the service installed and one that does not.
+    #[test]
+    fn the_command_that_only_reads_refuses_a_surface_it_would_have_ignored() {
+        let why = list_clients(Some("crash"))
+            .expect_err("a surface on the command that changes nothing is a usage error")
+            .to_string();
+        assert!(why.contains(LIST_CLIENTS_FLAG), "{why}");
+        // And it names the command that *does* set one — with its `--tools`, since
+        // `--set-listen-client-tools <name>` on its own takes a client's surface away.
+        assert!(
+            why.contains(SET_CLIENT_TOOLS_FLAG) && why.contains(crate::toolset::FLAG),
+            "{why}"
+        );
+    }
+
+    /// A service that is not registered has to be a **no**, not a failure.
+    ///
+    /// [`list_clients`] answers for the environment where none is installed, so it must tell
+    /// "there is none" from "one is there and cannot be opened" — and the only thing between them
+    /// is an error code the SCM returns and this crate hands back untouched. Drift here would turn
+    /// a legitimate answer into a refusal on every host without the service, which is most of them,
+    /// and the refusal would name the SCM rather than anything an operator could act on.
+    #[test]
+    fn a_service_that_is_not_registered_is_a_no_and_not_a_failure() {
+        let manager = ServiceManager::local_computer(None::<&OsStr>, ServiceManagerAccess::CONNECT)
+            .expect("every Windows host has an SCM, and connecting to it needs no elevation");
+        // A name nothing could plausibly have registered, since the point is to be told it is not
+        // there rather than to depend on this host not running the real one.
+        match manager.open_service(
+            "windbg-mcp-no-such-service-9f3c",
+            ServiceAccess::QUERY_STATUS,
+        ) {
+            Ok(_) => panic!("something is registered under the name this test picked to be absent"),
+            Err(windows_service::Error::Winapi(e)) => assert_eq!(
+                e.raw_os_error(),
+                Some(ERROR_SERVICE_DOES_NOT_EXIST as i32),
+                "the SCM reports an absent service some other way now: {e}"
+            ),
+            Err(e) => panic!("an absent service came back as {e:?}"),
+        }
     }
 
     fn entry(name: &str, token: &str, tools: Option<&str>) -> crate::client::ClientEntry {

--- a/src/service.rs
+++ b/src/service.rs
@@ -609,7 +609,7 @@ pub fn edit_client(edit: ClientEdit, name: &str, tools: Option<&str>) -> Result<
 
     // Held until this function returns, which is what makes the read, the edit, the write and the
     // reload below one transaction rather than four steps two shells can interleave.
-    let _lock = lock_credentials("changing a client")?;
+    let _lock = lock_credentials()?;
 
     let at = token_file();
     let existing = match std::fs::read_to_string(&at) {
@@ -1120,11 +1120,19 @@ fn in_force(state: &Result<ServiceState, windows_service::Error>) -> String {
 
 /// The installed service's clients, read the way its own listener reads them.
 ///
-/// **Under the lock the edits take**, so a roster is never a snapshot from the middle of one: an
-/// edit computes a whole file from what it read, and a list taken while that is in flight would
-/// report the set it is about to replace as the set in force.
+/// **It does not take the credential lock, and that is a decision rather than an omission**
+/// (review on #201, fifth round). [`lock_credentials`] opens its file with `create(true)`, and
+/// nothing else creates it — not [`install`] — so a reader that took the lock would write into
+/// `%ProgramData%` on every host where no client edit had yet run. That makes "changes nothing"
+/// false of the one command in this family that sells it, which is a worse trade than the lock is
+/// worth: [`write_credentials`] renames a finished file over the old one, so a read racing an edit
+/// sees one complete version or the other and never a torn one. The most the lock could have
+/// prevented is reporting the set an edit is in the middle of replacing — and a roster is stale
+/// the moment it is printed anyway.
+///
+/// The refusal an unelevated caller needs is not lost with it: it comes from the credential file's
+/// own ACL below, which is the object being protected rather than a lock beside it.
 fn service_clients(at: &std::path::Path) -> Result<Vec<crate::client::ClientEntry>> {
-    let _lock = lock_credentials("reading the client list")?;
     match std::fs::read_to_string(at) {
         Ok(text) => crate::client::TokenFile::parse(&text, at)?.credentials(),
         // A service registered against a file that is not there. Said as what it costs rather than
@@ -1254,11 +1262,10 @@ fn write_token_out(name: &str, token: &str) -> Result<PathBuf> {
 /// It lives in the state directory, which is already `Administrators`-only, so this is also where
 /// an unelevated caller is turned away: it needs write access to a directory it cannot write.
 ///
-/// **`doing` is what this caller came to do**, because [`list_clients`] holds the same lock
-/// without writing anything and "changing a client needs an elevated shell" is the wrong sentence
-/// for it. The contention message is one both are held to: a read taken from the middle of an edit
-/// reports a set that is about to be replaced, which is the reader's half of the same hazard.
-fn lock_credentials(doing: &str) -> Result<std::fs::File> {
+/// **Only the commands that write take it.** [`list_clients`] deliberately does not, because this
+/// creates the file it locks and that command's whole claim is that it changes nothing — see
+/// [`service_clients`] for why giving that up buys so little.
+fn lock_credentials() -> Result<std::fs::File> {
     use std::os::windows::fs::OpenOptionsExt;
 
     let at = state_dir().join("token.lock");
@@ -1270,15 +1277,14 @@ fn lock_credentials(doing: &str) -> Result<std::fs::File> {
         .open(&at)
         .map_err(|e| match e.kind() {
             std::io::ErrorKind::PermissionDenied => anyhow::Error::new(e).context(format!(
-                "cannot open {} — that directory is SYSTEM and Administrators only, so {doing} \
-                 needs an elevated shell (\"Run as administrator\")",
+                "cannot open {} — that directory is SYSTEM and Administrators only, so changing a \
+                 client needs an elevated shell (\"Run as administrator\")",
                 at.display()
             )),
             _ => anyhow::Error::new(e).context(format!(
                 "cannot take {} — another client command is holding it. Two of them at once would \
-                 each work from its own snapshot of the credential file: the second write would \
-                 discard the first, and a list read from the middle of an edit would report a set \
-                 that is about to be replaced. Wait for it and try again.",
+                 each compute a whole file from its own snapshot of this one, and the second write \
+                 would discard the first. Wait for it and try again.",
                 at.display()
             )),
         })

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -3497,6 +3497,53 @@ fn a_client_command_says_what_is_missing_before_it_touches_anything() {
     );
 }
 
+/// The command that only reads answers on any host, says which source it answered for, and never
+/// prints a token.
+///
+/// **Host-independent by construction**, which is what lets it live in the tier everyone runs.
+/// The three outcomes are a service host with an elevated shell (the credential file's roster), a
+/// service host without one (a refusal naming the ACL), and a host with no service (this shell's
+/// own credentials) — and the two claims asserted here hold in all three: it names the source it
+/// is answering for, and the token handed to it in the environment appears nowhere in what it
+/// wrote. The second is the trap this command was built around (`FOLLOWUPS.md` item 37): a
+/// fingerprint is the only comparable thing a roster may carry, and this is the one command in
+/// the family an operator would run *because* it is safe to run in a transcript.
+#[test]
+fn listing_the_clients_names_its_source_and_prints_no_token() {
+    let registered = service_is_registered();
+    // A token this test can look for. It is also a real one: on a host with no service installed
+    // this is the credential the command reports, so the run exercises the roster rather than
+    // only the refusal.
+    let secret = "this-token-must-not-be-printed-anywhere";
+    let out = Command::new(EXE)
+        .arg("--list-listen-clients")
+        .stdin(Stdio::null())
+        .env("WINDBG_MCP_LISTEN_TOKEN", secret)
+        .env_remove("WINDBG_MCP_LISTEN_TOKEN_FILE")
+        .output()
+        .unwrap_or_else(|e| panic!("failed to spawn {EXE}: {e}"));
+    let said = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        !said.contains(secret),
+        "the client list printed a token: {said}"
+    );
+    // Whichever of the two sources it answered for, it has to say which — a roster with no source
+    // beside it is one an operator cannot act on, and on this host either answer is legitimate.
+    assert!(
+        said.contains("WINDBG_MCP_LISTEN_TOKEN") || said.contains(r"windbg-mcp\token"),
+        "the client list has to name the source it answered for: {said}"
+    );
+    assert_eq!(
+        registered,
+        service_is_registered(),
+        "a command that only reads changed whether `windbg-mcp` is registered with the SCM"
+    );
+}
+
 /// Whether the SCM has a service by this name, for the assertion above to compare against itself.
 fn service_is_registered() -> bool {
     Command::new("sc.exe")


### PR DESCRIPTION
Closes `FOLLOWUPS.md` item 37.

The credential file had four writers and no reader. `--add-`, `--remove-`, `--rotate-` and `--set-listen-client-tools` each print the whole roster afterwards — name, token fingerprint, and the `--tools` spec where one is set — and there was no way to ask for that roster **without changing something**. Survivable while every client was served the same surface, because "who may connect" had one other answer in the listener's startup line; a client's own spec has no such second answer.

`--list-listen-clients` is `roster` and the read half of `edit_client`: same lock, same file, same parser, same fingerprints, no write and no reload. That makes it the one command in the family worth allow-listing.

```text
`windbg-mcp` holds: `bench` (sha256:2F1A9C0B7D4E5A83, --tools session,inspect,crash),
`local` (sha256:701E4CF334890225).

Read from C:\ProgramData\windbg-mcp\token, and nothing was changed — this is the one command
here that only reads.

A client with no `--tools` of its own is served whatever `windbg-mcp` serves — `--tools` on the
command line the SCM stores, or every tool if that has none.

This shell configures no listener credentials of its own (nothing in the
`WINDBG_MCP_LISTEN_TOKEN` variables), so the list above is the whole of what this host has.
```

## What the item got right, and the one thing it did not

Two of the three traps fell out as written. **No token reaches the output**, because `roster` is the only printer. And **a file this server cannot read in full refuses** rather than printing a shorter list, because the parse and the validation are the listener's own: one entry it would refuse at startup is a file that will not start the service, and a roster that quietly dropped the client it could not parse would be the most misleading thing this command could print.

The third did not. The item offered "read whichever source applies", which is wrong on the host both apply to — a service *and* a developer's foreground bench, which `docs/remote-listener.md` recommends in the same breath. So it **answers for both and says which is which**: the file where a service is installed, this shell where none is or where it carries credentials anyway, and the shell's half labelled as what a listener started *from here* would accept rather than what one already running elsewhere does. It reads that half through `listen::named_token_file` and not `client::env_credentials` alone, because a shell naming `WINDBG_MCP_LISTEN_TOKEN_FILE` has its token variables ignored by the listener — listing them would be a roster of credentials nothing accepts. A file half that *fails* still ends the command, deliberately: on a host with a service, the question was about the service.

Two things the item did not anticipate:

- **`lock_credentials` now takes what its caller came to do.** Its message was written for writers only — "another `--add`/`--remove`/`--rotate-listen-client` is running", which item 36 had already made wrong by adding a fourth — and "changing a client needs an elevated shell" is the wrong sentence for a reader. The reader holds the same lock for the reader's half of the same hazard: a list taken mid-edit reports the set that is about to replace it.
- **A `--tools` beside it is refused**, not ignored, on the rule `--rotate-` and `--remove-listen-client` already follow: it reads exactly like a filter over the list it is about to print.

## Tests

`listing_the_clients_names_its_source_and_prints_no_token` is host-independent by construction, because its outcome is not: a service host with an elevated shell answers with the file's roster, one without answers with the ACL refusal, and a host with no service answers for that shell's own credentials. What holds in all three is that it **names the source it answered for** and that **the token handed to it appears nowhere in what it wrote** — the trap this command was built around, and what makes it the one client command safe to run in an agent's transcript.

`a_service_that_is_not_registered_is_a_no_and_not_a_failure` pins the SCM error code the "no service installed" branch turns on. That branch cannot run on a host that has the service, so the code separating "there is none" from "one is there and cannot be opened" is asserted directly; drift there would turn a legitimate answer into a refusal on every host without the service.

## Verification

- `cargo fmt --all --check` and CI's markdownlint (`markdownlint-cli2@0.23.2`) clean.
- On the ARM64 bench: `cargo clippy --all-targets` clean, **528 unit tests and 76 smoke tests pass** (the protocol tier — 75 before this).
- The real binary driven by hand through five paths: a service host with both halves configured, the `--tools` refusal, a `WINDBG_MCP_LISTEN_TOKEN_FILE` shell, an orphan-spec shell, and an empty shell — with a programmatic check that the shell's real token appears nowhere in the output.
- The debugger tier was **not** run: nothing here touches a debug path.

Two stale sentences fixed on the way past: the lock's contention message named three commands of four, and `render_cast` claimed to be the only role in this binary that prints to standard output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
