### PR TITLE
Sort both halves of the client listing, and say that upgrading a service means restarting it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`--list-listen-clients` sorts both halves of what it prints.** A credential file's entries
+  already came back sorted; the environment's arrived in the order the variables were scanned,
+  which on Windows is by *variable* name — so `WINDBG_MCP_LISTEN_TOKEN` came before
+  `…_TOKEN_BENCH` and `local` led a roster whose other half was alphabetical. The same command
+  formatted its two answers differently, and neither could be diffed against the other.
+
 ### Added
 
 - **`--list-listen-clients`, the one client command that changes nothing** (`FOLLOWUPS.md` item 37,

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -19,8 +19,9 @@ the stateless revision concurrently (#168 / #169, 2026-08-19), item 31 from givi
 listener more than one client (2026-08-20), item 32 from running the debugger tier on the
 ARM64 runner image that replaces `windows-11-arm` in September 2026, and items 33–34 from driving
 the server with a **local model** — the lease grace measured against the wrong slow party, and a
-service's clients fixed at install time (both 2026-08-22), and item 37 from the credential file
-gaining a fourth writer while still having no reader (2026-08-23). Each item notes its repo,
+service's clients fixed at install time (both 2026-08-22), and items 37–38 from the credential
+file gaining a fourth writer while still having no reader, and from exercising what that reader
+says against a real service (both 2026-08-23). Each item notes its repo,
 why it was deferred, and where it picks up. See [`DECISIONS.md`](./DECISIONS.md) for the design rationale (D1–D5) items 1–6 extend,
 and the 2026-08-02 entries that items 13–14 and item 10 extend.
 
@@ -1586,3 +1587,40 @@ qualified correctly.
 
 Landed in [`src/service.rs`](./src/service.rs) (`list_clients`, `in_force`, `service_clients`,
 `shell_clients`), [`src/listen.rs`](./src/listen.rs) and [`src/main.rs`](./src/main.rs).
+
+## 38. [windbg-mcp] A client command can write a file the installed service cannot read
+
+Item 36 (0.11.0) let a credential file entry be an **object** — `{"bench": {"token": "…", "tools":
+"crash"}}` — beside the bare tokens it always held. A service installed from an earlier build
+refuses that shape, so `--add-listen-client x --tools …` or `--set-listen-client-tools`, run from a
+*newer* copy of this program than the one the SCM starts, writes a file the running service cannot
+read.
+
+**Nothing breaks at the time, which is the problem.** The reload only ever swaps in a set that
+would have started this listener from cold, so a file it cannot parse changes nothing, says so in
+the service log, and the command reports it. The failure is the **next start** — a reboot away from
+the cause, and by then the command that caused it is far out of mind.
+
+Measured on the ARM64 bench (2026-08-23) while exercising item 37's listing against a real service:
+the installed service was running `target\release` from before item 36 while the client commands
+were being run from `target\debug` after it. A fresh install cannot reach this, and neither can an
+ordinary upgrade — Windows will not overwrite a running image, so an operator replacing the exe has
+already stopped the service. A development tree with two builds in it is the case that does.
+
+- **What to build:** a warning, not an error. [`edit_client`](./src/service.rs) already holds the
+  service handle, and `Service::query_config()` returns the `executable_path` the SCM stores, so
+  comparing that against `std::env::current_exe()` names the divergence at the moment it matters —
+  no new channel, and the same shape as the other notes that command prints. It must not refuse:
+  running the command from another copy of the *same* version is legitimate, and this cannot tell
+  versions apart, only paths.
+- **Not the version.** There is no channel that carries one: the only thing reaching the running
+  service is a control code, which returns a status and no data (`FOLLOWUPS.md` item 37 settled
+  that). A path comparison is a proxy, and the warning has to be worded as one.
+
+**Worth doing when** a second service-hosted deployment exists, or the next time this tree grows a
+third build. Until then `docs/remote-listener.md` says the operational half: replace the exe *and*
+restart, and run the client commands from the binary the service runs.
+**Not blocked on anything.**
+
+Picks up at [`src/service.rs`](./src/service.rs) (`edit_client`, where the SCM handle is already
+open) and [`docs/remote-listener.md`](./docs/remote-listener.md).

--- a/docs/remote-listener.md
+++ b/docs/remote-listener.md
@@ -482,6 +482,17 @@ because the SCM registers a service once and a bad credential then fails it at e
 `windbg-mcp.exe --uninstall-service` removes it, stopping it first and waiting for it — a delete
 issued against a running service only marks it, and this one has debug targets to let go of.
 
+**Upgrading means replacing the exe *and restarting* — and running the client commands from the
+binary the service actually runs.** The credential file gained a shape in 0.11.0 that an earlier
+service refuses (an entry that is an object, carrying a client's `--tools` beside its token), so a
+`--set-listen-client-tools` issued from a newer copy while an older service is installed writes a
+file that service cannot read. Nothing breaks at the time: a reload only ever swaps in a set that
+would have started this listener from cold, so the running service goes on serving the clients it
+had and says so in its log. It is the **next start** that fails, which is a reboot away from the
+cause. Windows will not overwrite a running image, so an ordinary upgrade cannot drift this way —
+you have already stopped the service to replace the file. A *development* tree with two builds in
+it can, and did (`FOLLOWUPS.md` item 38).
+
 ### Adding, revoking, rotating and re-toolling a client, without stopping anything
 
 Four commands, from an **elevated** shell, and none of them costs you a session:

--- a/src/service.rs
+++ b/src/service.rs
@@ -1145,20 +1145,29 @@ fn service_clients(at: &std::path::Path) -> Result<Vec<crate::client::ClientEntr
 /// at all beside one ([`crate::client::Credentials::from_entries`]). Listing the variables on a
 /// host that names a file would be a roster of credentials nothing accepts.
 fn shell_clients() -> Result<(String, Vec<crate::client::ClientEntry>)> {
-    match crate::listen::named_token_file()? {
-        Some((path, file)) => Ok((
+    let (source, mut clients) = match crate::listen::named_token_file()? {
+        Some((path, file)) => (
             format!(
                 "the credential file `{}` names ({})",
                 crate::listen::TOKEN_FILE_ENV,
                 path.display()
             ),
             file.credentials()?,
-        )),
-        None => Ok((
+        ),
+        None => (
             format!("the `{}` variables", crate::listen::TOKEN_ENV),
             crate::client::env_credentials(std::env::vars())?,
-        )),
-    }
+        ),
+    };
+    // **Sorted here, because the two halves of one report are read against each other.** A file's
+    // entries already arrive sorted ([`crate::client::TokenFile::credentials`], for the reason
+    // this shares: an operator diffing two of these should see only what changed). The
+    // environment's arrive in the order the variables were scanned, which on Windows is by
+    // *variable* name — so `WINDBG_MCP_LISTEN_TOKEN` came before `…_TOKEN_BENCH` and `local` led a
+    // roster whose other half was alphabetical. One order for both, or the same command formats
+    // its two answers differently.
+    clients.sort_by(|a, b| a.name.cmp(&b.name));
+    Ok((source, clients))
 }
 
 /// Writes a generated token beside the credential file, and says where it went.


### PR DESCRIPTION
Two small things that came out of exercising [#201](https://github.com/glslang/windbg-mcp/pull/201)'s
`--list-listen-clients` against a real service on the ARM64 bench, after it merged.

## The listing sorted one half and not the other

A credential file's entries already came back sorted — `TokenFile::credentials` does it, and its doc
says why: *an operator diffing two of these should see only what changed.* The environment's did
not. They arrive in the order the variables were scanned, which on Windows is by **variable** name,
so `WINDBG_MCP_LISTEN_TOKEN` sorts before `…_TOKEN_BENCH`:

```text
before:  `local` (sha256:16518B…), `bench` (sha256:A9C009…, --tools session,inspect,crash), `ci` (…)
after:   `bench` (sha256:A9C009…, --tools session,inspect,crash), `ci` (…), `local` (sha256:16518B…)
```

One command, two answers, formatted differently and neither comparable with the other — printed
directly under a service roster that *was* alphabetical. Found by running it, not by reading it.

## An upgrade can leave a file the running service cannot read (item 38, recorded not fixed)

Item 36 let a credential file entry be an object carrying a client's `--tools` beside its token. A
service installed from an earlier build refuses that shape, so `--set-listen-client-tools` run from
a **newer copy of this program than the one the SCM starts** writes a file that service cannot read.

Nothing breaks at the time, which is exactly what makes it worth writing down. The reload only ever
swaps in a set that would have started the listener from cold, so the running service goes on
serving the clients it had and says so in its log. The **next start** is what fails — a reboot away
from the cause.

I met this on the bench: the installed service was running `target\release` from before item 36
while the client commands came from `target\debug` after it. A fresh install cannot reach it, and
neither can an ordinary upgrade — Windows will not overwrite a running image, so replacing the exe
means the service is already stopped. A development tree with two builds in it is the case that
does.

Recorded as `FOLLOWUPS.md` item 38 with the shape a fix would take: a **warning** off the
`executable_path` the SCM already stores, which `edit_client` can read from the handle it already
holds. It cannot be an error (running another copy of the *same* version is legitimate) and it
cannot compare versions — there is no channel that carries one, which item 37 already settled.
`docs/remote-listener.md` carries the operational half.

## Verification

- `cargo fmt --all --check` and CI's markdownlint clean; on the ARM64 bench `cargo clippy
  --all-targets` clean, 528 unit + 76 smoke tests pass.
- The sort confirmed **live** against the installed service, not just compiled — three clients in
  the shell, one carrying a spec, printed `bench, ci, local`.
- `FOLLOWUPS.md`'s header re-derived mechanically after adding item 38: headings 1–38, contiguous,
  every one named. Still eighteen clusters — 38 shares 37's clause, and my first pass wrote
  "nineteen" before I checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
