### PR TITLE
Warn when the SCM runs another copy of this program

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **The client commands warn when the SCM starts a different copy of this program than the one you
+  ran** (`FOLLOWUPS.md` item 38, which closes it). 0.11.0 gave the credential file a shape earlier
+  builds refuse — an entry that is an object, carrying a client's `--tools` beside its token — so
+  `--add-listen-client <name> --tools …` or `--set-listen-client-tools`, run from a newer copy than
+  the one the SCM starts, writes a file the running service cannot read. **Nothing breaks at the
+  time, which is the problem**: a reload only ever swaps in a set that would have started this
+  listener from cold, so the service goes on serving the clients it had and says so in its log. It
+  is the *next start* that fails, a reboot away from the cause. A fresh install cannot reach this
+  and neither can an ordinary upgrade, since Windows will not overwrite a running image — a
+  development tree with two builds in it is the case that does.
+
+  All five commands print it, with both paths: the four that edit the file, and
+  `--list-listen-clients`, which is where an operator goes when a service did not come back after a
+  reboot and which was otherwise printing one build's reading of a file another build has to read.
+  **A warning and never a refusal** — a path is all there is to compare, since nothing carries a
+  version between the two, and running a client command from a second copy of the *same* build is
+  legitimate and looks identical from here.
+
 - **`--list-listen-clients`, the one client command that changes nothing** (`FOLLOWUPS.md` item 37,
   which closes it). The four commands that edit a service's credential file each print the whole
   roster afterwards — name, token fingerprint, and the `--tools` spec where one is set — and until

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -600,6 +600,19 @@ rather than print a shorter list — a dropped entry is a service that will not 
 service serving fewer people. And an unelevated caller is turned away by the *credential file's* own ACL rather
 than by the lock, which is the object being protected rather than a thing beside it.
 
+**All five warn when the SCM's image is not the one running the command** (item 38), and two things
+about that bite. **`Service::query_config()` does not return a path**: the field is called
+`executable_path` and `QueryServiceConfigW` fills it from `lpBinaryPathName`, which is the whole
+line the SCM starts — exe *and* `--service --listen <addr>`. Compared as it comes it differs from
+`current_exe()` on every host, correct ones included, so the warning would be a warning that is
+always wrong. `image_in` reads the image back out of the line; a real service on this bench shows
+both shapes it has to handle (`WinDefend`'s path is quoted, this service's is not). And the config
+is read on a **handle of its own** rather than on the one `edit_client` already holds: adding
+`QUERY_CONFIG` there would let a host with a narrowed service descriptor fail
+`--remove-listen-client` because a warning wanted a right. It is a warning and never a refusal, for
+the reason that is easy to try to "fix" — nothing carries a version between the two, so a second
+copy of the *same* build is indistinguishable from a stale one.
+
 **Identity is ambient inside a call, carried by the instance, and by name outside both.**
 `crate::client::current()` reads a task-local, which is why no tool signature carries a caller. What
 sets it around a tool call is **`call_tool`**, from the client its `WindbgServer` was built with —

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -1588,7 +1588,7 @@ qualified correctly.
 Landed in [`src/service.rs`](./src/service.rs) (`list_clients`, `in_force`, `service_clients`,
 `shell_clients`), [`src/listen.rs`](./src/listen.rs) and [`src/main.rs`](./src/main.rs).
 
-## 38. [windbg-mcp] A client command can write a file the installed service cannot read
+## 38. [windbg-mcp] A client command can write a file the installed service cannot read — **done** (2026-08-23)
 
 Item 36 (0.11.0) let a credential file entry be an **object** — `{"bench": {"token": "…", "tools":
 "crash"}}` — beside the bare tokens it always held. A service installed from an earlier build
@@ -1624,3 +1624,49 @@ restart, and run the client commands from the binary the service runs.
 
 Picks up at [`src/service.rs`](./src/service.rs) (`edit_client`, where the SCM handle is already
 open) and [`docs/remote-listener.md`](./docs/remote-listener.md).
+
+**Built as a warning printed by all five client commands** (2026-08-23), and
+verified against the real service on the ARM64 bench — installed from `target\release`, told about
+by `target\debug`, which is the arrangement the entry was measured in. Four things the entry did not
+anticipate, one of which would have shipped a warning that was wrong on every host.
+
+**`query_config()` does not return a path.** The entry says it "returns the `executable_path` the
+SCM stores", and the field is called that, but `QueryServiceConfigW` hands back `lpBinaryPathName` —
+the whole line the SCM starts, the exe *and* the `--service --listen 127.0.0.1:8765` after it.
+Compared against `current_exe()` as it comes, it differs from the running image on **every** host
+including every correct one, so the feature would have been a warning that is always wrong: worse
+than the silence it replaces, since it trains an operator to ignore the one time it is right. The
+image is read back out of the line (`image_in`), which is exact rather than approximate for a
+reason worth writing down — `windows-service` escapes the line the way `CommandLineToArgvW` reads
+it, and the only characters escaping introduces are `\"` and a doubled trailing `\`, neither of
+which a Windows path can hold. So there are two shapes and they are the two the SCM shows: quoted
+when the path has a space in it (`WinDefend` on this bench), bare when it does not (this service).
+
+**"`edit_client` already holds the service handle" is a trap rather than a shortcut.** That handle
+is opened with `QUERY_STATUS | USER_DEFINED_CONTROL`, the rights the command needs; adding
+`QUERY_CONFIG` to it means a host that has narrowed the service's security descriptor cannot run
+`--remove-listen-client` at all, because a *warning* wanted a right. The default descriptor grants
+that right to Authenticated Users so it would almost always work, which is exactly what makes it
+the wrong shape. The config is read on a handle of its own, and a refusal there costs the warning
+rather than the command.
+
+**It belongs on the reader too, and the entry scopes it to the writer.** `edit_client` is where the
+divergence is *created*, but `--list-listen-clients` (item 37) is where an operator goes when a
+service did not come back after a reboot — and the roster it prints is **this** build's reading of
+a file **that** build has to read, under a clause (`in_force`) saying the running service re-reads
+that file whenever a client command changes it, which on a divergent host it may not be able to do
+at all. Silence there is the shape item 37's fourth review round ruled on: it may not assert
+anything about a process it cannot see. Both print the warning, each naming its own stake in one
+clause; everything after that clause is one string.
+
+**Where it prints is decided by the path that fails.** Beside the notes at the bottom of
+`edit_client` it would be skipped exactly when it explains most: a revocation whose reload did not
+land returns an error before reaching them, and a service that cannot read the new file is one of
+the two ways that reload fails. So it is printed before the change, which also settles the gate the
+entry did not raise — a reload that lands *is* proof the other copy read what this one wrote, and
+a warning printed first cannot be conditioned on it. It says what was compared rather than what it
+concluded, which stays true whatever the reload goes on to do.
+
+Landed in [`src/service.rs`](./src/service.rs) (`image_in`, `same_image`, `foreign_image`, and one
+call in each of `edit_client` and `list_clients`) and
+[`docs/remote-listener.md`](./docs/remote-listener.md).

--- a/docs/remote-listener.md
+++ b/docs/remote-listener.md
@@ -493,6 +493,19 @@ cause. Windows will not overwrite a running image, so an ordinary upgrade cannot
 you have already stopped the service to replace the file. A *development* tree with two builds in
 it can, and did (`FOLLOWUPS.md` item 38).
 
+**All five client commands say so now.** Each compares the image the SCM is registered to start
+against the copy you ran, and prints both paths when they differ. It is a warning and never a
+refusal, because a path is all there is to compare: running a client command from a second copy of
+the *same* build is legitimate and looks identical from here, and nothing carries a version between
+the two — the only channel to a running service is a control code, which comes back as a status and
+no data.
+
+```text
+warning: `windbg-mcp` is registered to run a different copy of this program than this one.
+    the SCM starts  C:\workspace\windbg-mcp\target\release\windbg-mcp.exe
+    this command is C:\workspace\windbg-mcp\target\debug\windbg-mcp.exe
+```
+
 ### Adding, revoking, rotating and re-toolling a client, without stopping anything
 
 Four commands, from an **elevated** shell, and none of them costs you a session:
@@ -655,7 +668,7 @@ does not even take the credential lock, because that lock is a file this program
 creating one is a write. The roster is the state of the file as it stood. That is what makes it the
 one command in the family worth allow-listing.
 
-Three things about it:
+Five things about it:
 
 - **It says which of the two sources it answered for.** A service's clients are in the credential
   file; a foreground listener's are the environment it was started with. Where a service is
@@ -681,6 +694,11 @@ Three things about it:
   gaps in the running one, unconditionally. Stopping is not stopped: a stop ends the accept loop and
   then releases every target, which on a host holding a live kernel is minutes, and the connections
   already accepted are served until the process exits.
+- **And it names a third difference, which is about *which program* reads the file rather than
+  when.** Where the SCM is registered to start a copy of this program other than the one you ran,
+  the roster above it is one build's reading of a file another build has to read — so the command
+  prints both paths and says so. This is the command an operator reaches for when a service did not
+  come back after a reboot, and that divergence is the reason it did not.
 
 **Stopping is graceful, and that is the point.** `Stop-Service` takes the same path a client
 disconnect takes: every session is asked to release its target before the process exits, and the SCM

--- a/src/service.rs
+++ b/src/service.rs
@@ -534,6 +534,128 @@ fn is_reload(control: &ServiceControl) -> bool {
     matches!(control, ServiceControl::UserEvent(code) if code.to_raw() == RELOAD_CODE)
 }
 
+/// The image out of a service's stored command line.
+///
+/// **`ServiceConfig::executable_path` is not a path.** `QueryServiceConfigW` hands back
+/// `lpBinaryPathName`, which is the whole line the SCM starts — the exe *and* the
+/// `--service --listen <addr>` [`install`] put after it — and `windows-service` builds that line by
+/// escaping each part the way `CommandLineToArgvW` reads it. So the image is either quoted or holds
+/// no space, and those are the only two shapes to undo.
+///
+/// **No escape can appear inside the quoted form**, which is what makes reading to the next quote
+/// exact rather than approximate: escaping introduces `\"` and a doubled trailing `\`, and a
+/// Windows path can hold neither — `"` is not a legal filename character, and an exe path does not
+/// end in a separator.
+///
+/// Wide units rather than [`std::ffi::OsStr::to_string_lossy`], because two paths that differ can
+/// share a lossy rendering and this exists to tell two paths apart.
+fn image_in(command_line: &OsStr) -> PathBuf {
+    use std::os::windows::ffi::{OsStrExt, OsStringExt};
+
+    const QUOTE: u16 = b'"' as u16;
+    const SPACE: u16 = b' ' as u16;
+    let line: Vec<u16> = command_line.encode_wide().collect();
+    let image = if line.first() == Some(&QUOTE) {
+        let rest = &line[1..];
+        &rest[..rest.iter().position(|c| *c == QUOTE).unwrap_or(rest.len())]
+    } else {
+        &line[..line.iter().position(|c| *c == SPACE).unwrap_or(line.len())]
+    };
+    PathBuf::from(OsString::from_wide(image))
+}
+
+/// Whether two paths name the same file, as far as anything outside the SCM can tell.
+///
+/// Canonicalised first: one side is whatever [`install`] handed the SCM that day and the other is
+/// read back out of this running process, so a `..`, an 8.3 short name and a symlinked directory
+/// all have to fold together. Where either canonicalisation fails — the likeliest reason being that
+/// the service's image is not there any more, which is a divergence of its own — the raw paths are
+/// compared without case, because Windows paths are.
+fn same_image(installed: &std::path::Path, running: &std::path::Path) -> bool {
+    match (
+        std::fs::canonicalize(installed),
+        std::fs::canonicalize(running),
+    ) {
+        (Ok(installed), Ok(running)) => installed == running,
+        _ => installed
+            .as_os_str()
+            .eq_ignore_ascii_case(running.as_os_str()),
+    }
+}
+
+/// The caveat to print when the SCM starts a **different copy of this program** than the one
+/// running the command, `stake` naming what that costs the command printing it.
+///
+/// **The failure it is here to name is silent and arrives late** (`FOLLOWUPS.md` item 38). Item 36
+/// gave the credential file a shape earlier builds refuse — an entry that is an object, carrying a
+/// client's surface beside its token — so a `--set-listen-client-tools` run from a newer copy than
+/// the one the SCM starts writes a file that service cannot read. Nothing breaks at the time: a
+/// reload only ever swaps in a set that would have started this listener from cold, so the running
+/// service goes on serving the clients it had and says so in its log. It is the **next start** that
+/// fails, a reboot away from the command that caused it. A fresh install cannot reach this and
+/// neither can an ordinary upgrade, since Windows will not overwrite a running image — a
+/// development tree with two builds in it is the case that does, and did.
+///
+/// **A warning and never a refusal**, because a path is all there is to compare. Nothing carries a
+/// *version* between the two: the only thing that reaches a running service is a control code,
+/// which comes back as a status and no data. Two copies of the same build differ by path and agree
+/// about everything that matters here, and this cannot tell them from two builds — so it says what
+/// it compared rather than what it concluded.
+///
+/// **Opened on a handle of its own** rather than added to the one the caller already holds. A
+/// service's default security descriptor grants `SERVICE_QUERY_CONFIG` to Authenticated Users, so
+/// this ordinarily costs nothing — but on a host that has narrowed it, asking for the right on the
+/// command's own handle would fail the command outright, and a `--remove-listen-client` that will
+/// not run because a warning wanted a right is a worse trade than the warning is worth.
+fn foreign_image(manager: &ServiceManager, stake: &str) -> Option<String> {
+    let installed = manager
+        .open_service(NAME, ServiceAccess::QUERY_CONFIG)
+        .and_then(|service| service.query_config())
+        .map(|config| image_in(config.executable_path.as_os_str()));
+    let (installed, running) = match (installed, std::env::current_exe()) {
+        (Ok(installed), Ok(running)) => (installed, running),
+        // **Said rather than swallowed.** Silence here is indistinguishable from the check having
+        // been made and passed, so a host where it cannot be made would be offered a guarantee
+        // nothing checked. Neither of these fails the command: the divergence is a caveat on what
+        // it did, not a precondition for doing it.
+        (Err(e), _) => {
+            return Some(format!(
+                "note: which copy of this program `{NAME}` is registered to run could not be read \
+                 from the SCM ({e}), so whether it is this one is not known from here."
+            ));
+        }
+        (_, Err(e)) => {
+            return Some(format!(
+                "note: this program's own path could not be read ({e}), so whether it is the copy \
+                 `{NAME}` is registered to run is not known from here."
+            ));
+        }
+    };
+    if same_image(&installed, &running) {
+        return None;
+    }
+    // Built apart from the sentences below so the two indented lines can carry their own leading
+    // spaces: a `\` continuation in a Rust string eats the next line's indentation, which is what
+    // makes the rest of this file's long messages readable and would silently flatten these.
+    let paths = format!(
+        "    the SCM starts  {}\n    this command is {}",
+        installed.display(),
+        running.display()
+    );
+    Some(format!(
+        "warning: `{NAME}` is registered to run a different copy of this program than this \
+         one.\n{paths}\n{stake}, and two builds need not agree on what may be in it — an entry \
+         carrying a client's `{}` beside its token is a shape 0.11.0 introduced, and a service \
+         older than that refuses the whole file rather than that one entry. Such a file leaves the \
+         running service serving the clients it already had — a reload only ever swaps in a set \
+         that would have started it from cold — and stops it starting the next time, which is a \
+         reboot away from here. Only the paths are comparable from here, so this cannot tell a \
+         stale build from a second copy of the same one: run the client commands from the binary \
+         the SCM starts, or replace that binary and restart the service.",
+        crate::toolset::FLAG,
+    ))
+}
+
 /// Adds, removes or rotates one of the installed service's clients, without a reinstall.
 ///
 /// **The problem this replaces.** `--install-service` was the only writer of [`token_file`], and
@@ -606,6 +728,21 @@ pub fn edit_client(edit: ClientEdit, name: &str, tools: Option<&str>) -> Result<
                 token_file().display()
             )
         })?;
+
+    // **Printed before the change rather than beside the notes at the bottom.** This command can
+    // fail before it ever reaches them — a revocation whose reload did not land returns an error —
+    // and a service that cannot read the file this warning is about is one of the two ways that
+    // reload fails, so the note that would explain it must not sit on the path being skipped.
+    //
+    // **Gated on nothing.** A reload that lands is evidence the other copy read what this one
+    // wrote, and the arms at the bottom report it; this says only what was compared, which stays
+    // true whatever the reload goes on to do.
+    if let Some(note) = foreign_image(
+        &manager,
+        "This command writes the credential file that copy reads",
+    ) {
+        println!("{note}\n");
+    }
 
     // Held until this function returns, which is what makes the read, the edit, the write and the
     // reload below one transaction rather than four steps two shells can interleave.
@@ -977,6 +1114,16 @@ pub fn list_clients(tools: Option<&str>) -> Result<()> {
             at.display(),
             in_force(&state),
         );
+        // **The other way the file and the running service can differ**, and the only one that is
+        // about which *program* reads it rather than when. Beneath [`in_force`] because it is the
+        // same caveat one step further out: that clause says the service may not have this file
+        // yet, and this one says it may not be able to read it at all.
+        if let Some(note) = foreign_image(
+            &manager,
+            "The roster above is what this copy makes of the credential file that one reads",
+        ) {
+            println!("\n{note}");
+        }
     } else {
         println!(
             "No service named `{NAME}` is installed, so this host has no client list in a file. A \
@@ -2098,6 +2245,69 @@ mod tests {
             ),
             Err(e) => panic!("an absent service came back as {e:?}"),
         }
+    }
+
+    /// The installed image is read out of the command line the SCM stores *around* it.
+    ///
+    /// `QueryServiceConfigW` hands back `lpBinaryPathName`, which is the exe and the
+    /// `--service --listen <addr>` after it — not a path — and `windows-service` quotes the exe
+    /// only when it has to. Both shapes therefore reach [`foreign_image`] on real hosts: an
+    /// install under `%ProgramFiles%` is quoted and one under `C:\tools` is not. Reading either
+    /// wrongly is a warning about a divergence that is not there, printed on every client command
+    /// on the hosts this feature is *for*.
+    #[test]
+    fn the_installed_image_is_read_out_of_the_line_the_scm_stores() {
+        let image = |line: &str| image_in(OsStr::new(line));
+        assert_eq!(
+            image(
+                r#""C:\Program Files\windbg-mcp\windbg-mcp.exe" --service --listen 127.0.0.1:8765"#
+            ),
+            PathBuf::from(r"C:\Program Files\windbg-mcp\windbg-mcp.exe"),
+            "a quoted image ends at its closing quote, not at the space inside it"
+        );
+        assert_eq!(
+            image(r"C:\tools\windbg-mcp.exe --service --listen 127.0.0.1:8765 --tools crash"),
+            PathBuf::from(r"C:\tools\windbg-mcp.exe"),
+            "an unquoted image ends at the first space, which is where its arguments start"
+        );
+        // Both with nothing after them, which is not how `install` registers this service but is
+        // how a hand-registered one can look — and is the one case with no terminator to find.
+        assert_eq!(
+            image(r"C:\tools\windbg-mcp.exe"),
+            PathBuf::from(r"C:\tools\windbg-mcp.exe")
+        );
+        assert_eq!(
+            image(r#""C:\Program Files\windbg-mcp\windbg-mcp.exe""#),
+            PathBuf::from(r"C:\Program Files\windbg-mcp\windbg-mcp.exe")
+        );
+    }
+
+    /// Two names for one file are the same image; two files are not.
+    ///
+    /// The last pair is the arrangement `FOLLOWUPS.md` item 38 was measured on — a service running
+    /// `target\release` from before item 36 while the client commands were run from `target\debug`
+    /// after it — and it is what the warning has to fire on.
+    ///
+    /// Neither of the first two paths exists, so this exercises the **fallback**: with
+    /// canonicalisation unavailable the raw paths are compared without case, because Windows paths
+    /// are. The pair after it is the canonicalising half, on the one file a test binary is certain
+    /// to have.
+    #[test]
+    fn a_path_that_differs_only_in_case_names_the_same_image() {
+        let path = std::path::Path::new;
+        assert!(same_image(
+            path(r"C:\tools\WinDbg-MCP.exe"),
+            path(r"c:\TOOLS\windbg-mcp.exe")
+        ));
+        let exe = std::env::current_exe().expect("a test binary knows its own path");
+        assert!(
+            same_image(&exe, &exe),
+            "a file that is there has to fold to itself through canonicalisation"
+        );
+        assert!(!same_image(
+            path(r"C:\Program Files\windbg-mcp\windbg-mcp.exe"),
+            path(r"C:\workspace\windbg-mcp\target\debug\windbg-mcp.exe")
+        ));
     }
 
     fn entry(name: &str, token: &str, tools: Option<&str>) -> crate::client::ClientEntry {


### PR DESCRIPTION
Closes `FOLLOWUPS.md` item 38, and is the other half of #202 — that PR wrote the
divergence down in `docs/remote-listener.md`; this one says it at the moment it
matters.

Item 36 (0.11.0) let a credential file entry be an object carrying a client's
`--tools` beside its token. A service installed from an earlier build refuses
that shape, so `--add-listen-client x --tools …` or `--set-listen-client-tools`,
run from a newer copy of this program than the one the SCM starts, writes a file
the running service cannot read. **Nothing breaks at the time, which is the
problem**: the reload only ever swaps in a set that would have started this
listener from cold, so the service goes on serving the clients it already had.
It is the next *start* that fails, a reboot away from the cause.

All five client commands now compare the image the SCM is registered to start
against `std::env::current_exe()`, and print both paths when they differ:

```text
warning: `windbg-mcp` is registered to run a different copy of this program than this one.
    the SCM starts  C:\workspace\windbg-mcp\target\release\windbg-mcp.exe
    this command is C:\workspace\windbg-mcp\target\debug\windbg-mcp.exe
This command writes the credential file that copy reads, and two builds need not agree on
what may be in it — an entry carrying a client's `--tools` beside its token is a shape
0.11.0 introduced, and a service older than that refuses the whole file rather than that
one entry. …
```

## Four things the item did not anticipate

The first would have shipped a warning that was wrong on every host.

- **`query_config()` does not return a path.** The field is called
  `executable_path`, but `QueryServiceConfigW` fills it from `lpBinaryPathName`
  — the whole line the SCM starts, exe *and* `--service --listen <addr>`.
  Compared as it comes it differs from `current_exe()` on every host, correct
  ones included. `image_in` reads the image back out of the line, which is exact
  rather than approximate because `windows-service` escapes it the way
  `CommandLineToArgvW` reads it, and the only characters escaping introduces are
  `\"` and a doubled trailing `\` — neither of which a Windows path can hold.
  Both shapes it has to handle are live on the bench: `WinDefend`'s path is
  quoted, this service's is not.
- **"`edit_client` already holds the service handle" is a trap.** That handle
  carries the rights the command needs; adding `QUERY_CONFIG` to it lets a host
  with a narrowed service descriptor fail `--remove-listen-client` because a
  *warning* wanted a right. The default descriptor grants that right to
  Authenticated Users, so it would almost always work — which is what makes it
  the wrong shape. The config is read on a handle of its own, and a refusal there
  costs the warning rather than the command.
- **It belongs on the reader too**, which the item scoped out.
  `--list-listen-clients` is where an operator goes when a service did not come
  back after a reboot, and the roster it prints is *this* build's reading of a
  file *that* build has to read — under a clause saying the running service
  re-reads that file whenever a client command changes it, which on a divergent
  host it may not be able to do at all.
- **It prints before the change, not beside the notes at the bottom.** A
  revocation whose reload did not land returns an error before reaching them, and
  a service that cannot read the new file is one of the two ways that reload
  fails, so the note explaining it must not sit on the path being skipped. That
  also settles a gate the item did not raise: a reload that lands *is* proof the
  other copy read what this one wrote, and a warning printed first cannot be
  conditioned on it. It says what was compared rather than what it concluded.

**A warning and never a refusal**, because a path is all there is to compare.
Nothing carries a version between the two — the only channel to a running service
is a control code, which comes back as a status and no data — so a second copy of
the same build is indistinguishable from a stale one.

## Verified

Measured against the real service on the ARM64 bench, which is registered from
`target\release` while the commands were run from `target\debug` — the exact
arrangement item 38 was filed from. Both the reading command and an editing
command's refusal path print it.

- ARM64 VM: **530 unit tests + 76 `mcp_smoke`**, 0 failed; `cargo clippy
  --all-targets` clean. The debugger tier was not run — this change touches no
  engine path.
- Mac: `cargo fmt --all --check` clean; `markdownlint-cli2@0.23.2` over CI's
  globs, 0 issues in 34 files.

## Also

While extending the `--list-listen-clients` bullet list in
`docs/remote-listener.md`, its lead-in said "Three things about it" over four
bullets — pre-existing drift. It is five now, and says so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
