### PR TITLE
Run the surface, the window and the model as a grid

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,7 @@ package-lock.json
 
 # Local Claude Code config
 .claude/
+
+# Output of the local-model eval (`tools/local_model_eval.py`), which the checked-in plan
+# writes here: run logs and one JSON record per task. Measurements, not sources.
+eval-out/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   listener that serves all three surfaces — which is 0.11.0's per-client `--tools` doing the
   narrowing, rather than a test double.
 
+  It also found a defect in this server, filed as `FOLLOWUPS.md` item 40: **`--tools` narrows
+  `tools/list` and not the `instructions` string**, which is one compile-time constant naming
+  twenty-one tools and is sent to every client whatever its surface. A `crash`-surface client is
+  served 11 tools and told about 21, of which 17 it cannot call - which is where every "invented"
+  tool call in the grid came from, and 59% of a 497-token string that client pays for in full.
+
   Three findings worth the run. **The window was not the binding constraint**: at a *served*
   8,192-token window a 17,300-token surface answered all six tasks correctly, multi-turn tasks with
   10,000-character results included, so the "will it fit" arithmetic in `docs/local-model.md`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **The local-model eval: a grid where there were two sightings**
+  ([`docs/local-model-eval.md`](./docs/local-model-eval.md), `FOLLOWUPS.md` item 39). Three ~30B
+  local models against three tool surfaces and three context windows, with Claude Code as the
+  control, scored against an answer key read off the checked-in sample dumps with this server's own
+  tools before any model saw them. `tools/local_model_eval.py` runs the grid and grades it,
+  `tools/claude_code_drive.py` is the control row, `tools/bench_listener.ps1` stands up the one
+  listener that serves all three surfaces — which is 0.11.0's per-client `--tools` doing the
+  narrowing, rather than a test double.
+
+  Three findings worth the run. **The window was not the binding constraint**: at a *served*
+  8,192-token window a 17,300-token surface answered all six tasks correctly, multi-turn tasks with
+  10,000-character results included, so the "will it fit" arithmetic in `docs/local-model.md`
+  predicted a failure that does not happen on this runtime. **The surface axis costs fewer answers
+  than tools** — 51 tools down to 11 removes 40 tools and 2 of 6 answers, because `open_dump`'s
+  summary and `crash_triage`'s frames carry facts that `modules` and `registers` also carry. And
+  **a narrowed surface makes every model call tools that are not there**, the control included, so
+  the refusal that names the client's own surface is load-bearing rather than cosmetic.
+
 - **The client commands warn when the SCM starts a different copy of this program than the one you
   ran** (`FOLLOWUPS.md` item 38, which closes it). 0.11.0 gave the credential file a shape earlier
   builds refuse — an entry that is an object, carrying a client's `--tools` beside its token — so

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -775,6 +775,60 @@ everything the debugger printed — stack frames, strings, whatever the guest ho
 secrets is masked, so treat the file like a crash dump: keep it out of the repo, and delete it when
 the investigation is done. It is **appended** to, so a path reused across runs accumulates.
 
+## Benchmarking a model against this server (`tools/local_model_eval.py`)
+
+`docs/local-model-eval.md` is the result; this is what bites while running it again. The grid is
+three scripts — the ollama driver, the Claude Code driver, and the matrix runner that spawns either
+one per cell and grades the log afterwards.
+
+**Record what the runtime *served*, not what you asked for.** `num_ctx` on a request does not
+shrink an instance ollama already holds: with a 32,768 instance loaded, cells asking for 8,192 are
+served 32,768 and look perfectly healthy — a 17,300-token prompt "fitting" in 8k, which is the
+result the context axis exists to find and would have been fiction. `/api/ps` is the only place
+the truth appears. Every record carries `served_context`, the grader marks a cell where the two
+disagree with `?`, and the runner evicts the model between windows. The first run of the grid
+recorded five such cells; they were dropped and re-run.
+
+**The grader's three matching rules each came from a real wrong verdict**, and all three are in
+`present()`:
+
+- A number matches only **between hex boundaries** — `0x22` is the device type `ioctl_decode` asks
+  for and `0x22200B` is the code in the question, so plain containment passed for any answer that
+  repeated the question. One model scored correct while saying `FILE_DEVICE_KEYBOARD`.
+- Leading zeros are formatting — the tool prints `0x802` and a model writing `0x0802` agrees with
+  it. That one marked a *correct* control answer wrong.
+- A separator between hex digits is formatting too. WinDbg writes ``fffff801`3c65bca8``; Opus
+  writes `0xfffff801_3c65bca8`. Both name the address the key holds.
+
+Two of those three were found by reading the **control's** answers, which is the argument for
+having a frontier row at all.
+
+**`possible_on` in the task file is a prediction, and predictions about this server are wrong in
+one direction: too pessimistic.** Facts here are reachable by more than one route —
+`open_dump`'s summary carries the bug check *and* the module count, `crash_triage`'s frame 0 is the
+`pc` that `registers` reports — so a task the tool table says needs `inspect` may be answerable
+with `crash` alone. Verify against the dump before scoring a model wrong for finding the other
+route; the `arm64_pc` entry was corrected mid-run for exactly this.
+
+**Resume is per *cell*, so the log legitimately holds a task twice.** An outstanding task re-runs
+its cell's whole list, and the grader keeps the **last** record per (cell, task). Do not "fix" a
+duplicated task id by deleting rows.
+
+**The Claude Code row needs four fences or it measures something else.** `--strict-mcp-config` (or
+it falls back to the editor's registered `windbg-vm`, whose credential is a different client and
+gets the whole 51-tool surface — the surface axis then measures nothing); `--disallowedTools` for
+the built-ins (or it answers a question about a sample dump by grepping this repository);
+`ENABLE_TOOL_SEARCH=false` (or MCP tool schemas are deferred and fetched with `ToolSearch`, so the
+surface costs that row almost nothing while every other row pays in full); and a **neutral working
+directory**, since Claude Code reads the project it is started in. Its prompt-token column is still
+not comparable with the ollama rows — its own system prompt is most of it — and the document says
+so rather than quoting it.
+
+**The bench listener is the shipped per-client feature in anger.** `tools/bench_listener.ps1`
+serves `full`, `lean` and `min` from one foreground process, tokens arriving on **stdin**; its
+startup line naming the three clients and their surfaces is the check that the run is measuring
+what it thinks. A cell changes the bearer token and nothing else.
+
 ## Handing the work over
 
 "Update the handoff docs" means a specific set, discoverable only from what the handoff PRs touched

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -824,6 +824,14 @@ directory**, since Claude Code reads the project it is started in. Its prompt-to
 not comparable with the ollama rows — its own system prompt is most of it — and the document says
 so rather than quoting it.
 
+**`--tools` narrows the router and not the `instructions`, and that shows up as a model
+"inventing" tools.** The string on `#[rmcp::tool_handler]` is a compile-time constant naming
+twenty-one tools, sent identically to every client: a `crash`-surface client is served 11 tools and
+told about 21, of which 17 it cannot call. Every off-surface call the grid recorded is one of those
+seventeen, so a count of them measures this server's advertising rather than any model's
+imagination - the metric is `unserved` for that reason, and `FOLLOWUPS.md` item 40 is the fix.
+Worth knowing before reading any tool-selection result from a narrowed surface.
+
 **The bench listener is the shipped per-client feature in anger.** `tools/bench_listener.ps1`
 serves `full`, `lean` and `min` from one foreground process, tokens arriving on **stdin**; its
 startup line naming the three clients and their surfaces is the check that the run is measuring

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -1,6 +1,6 @@
 # Follow-ups
 
-Deferred work, in eighteen clusters: items 1–6 come from the reachability-confirmation effort (path
+Deferred work, in nineteen clusters: items 1–6 come from the reachability-confirmation effort (path
 recipe + `run_to_address`, merged 2026-07-04), items 7–11 from surveying this server against the
 MCP `2026-07-28` extensions (tasks, apps), item 12 from the opener split
 (glslang/win-kexp#71, 2026-08-01), items 13–14 from the bounded-command coverage review
@@ -21,7 +21,8 @@ ARM64 runner image that replaces `windows-11-arm` in September 2026, and items 3
 the server with a **local model** — the lease grace measured against the wrong slow party, and a
 service's clients fixed at install time (both 2026-08-22), and items 37–38 from the credential
 file gaining a fourth writer while still having no reader, and from exercising what that reader
-says against a real service (both 2026-08-23). Each item notes its repo,
+says against a real service (both 2026-08-23), and item 39 from running the surface, the window
+and the model as a **grid** rather than as a sighting (2026-08-23). Each item notes its repo,
 why it was deferred, and where it picks up. See [`DECISIONS.md`](./DECISIONS.md) for the design rationale (D1–D5) items 1–6 extend,
 and the 2026-08-02 entries that items 13–14 and item 10 extend.
 
@@ -1670,3 +1671,43 @@ concluded, which stays true whatever the reload goes on to do.
 Landed in [`src/service.rs`](./src/service.rs) (`image_in`, `same_image`, `foreign_image`, and one
 call in each of `edit_client` and `list_clients`) and
 [`docs/remote-listener.md`](./docs/remote-listener.md).
+
+## 39. [windbg-mcp] The eval measures single questions, not an investigation
+
+[`docs/local-model-eval.md`](./docs/local-model-eval.md) runs six tasks across three tool surfaces,
+three context windows and five models, and its strongest finding is a negative one: at a **served**
+8,192-token window a 17,300-token surface was evaluated in full and answered correctly, so the
+window is not the binding constraint the plan expected. That finding is true of the conversations
+the grid runs, and **every one of them is short** - one question, one or two tool calls, an answer.
+
+What is untested is the case where the *transcript* fills the window rather than the surface. The
+surface is paid once per conversation and the runtime caches the prefix (`docs/local-model.md`
+measured 86.5s cold against under 5s warm); a growing investigation is paid in full, every turn,
+and a `modules` page or a `read_memory` answer lands in it whole. So the honest scope of "the
+window did not bite" is *a question at a time*, and the interesting failure - the tenth turn of a
+kernel triage, three large results deep - has not been run.
+
+**Why it was deferred rather than added.** The driver already has the mechanism:
+`WINDBG_MCP_SCENARIO=1` makes a task list one continuing investigation with one transcript and one
+set of sessions. What it does not have is a way to *grade* one. A scenario has no per-task answer
+key - a wrong turn at step 3 makes steps 4 to 8 unanswerable, so per-task scoring reports eight
+failures for one mistake, and the thing worth measuring is the step at which the run stopped being
+recoverable. That is a different unit of measurement and a different key, not a flag on this grid.
+
+**Where it picks up.** A scenario key would want: an ordered list of facts the run must have
+established by the end, the turn index at which each first appears, and the transcript length at
+that point. `local_model_eval.py` grades from records that already carry every turn's prompt token
+count, so the growth curve is in the log this eval already writes - what is missing is the key and
+a `--scenario` mode in the grader that reads it.
+
+Two smaller things the same run left open:
+
+- **Nothing measures the mutating tools.** The harness executes a read-only allow-list, so
+  `debug_batch`, `launch` and `execute` are offered and never run. gemma calling `debug_batch` four
+  times on a surface that does not serve it - and being refused four times - is a hint that this is
+  where a wrong pick would be expensive rather than merely wasted: a batch that *does* run patches
+  the target. Measuring it wants a throwaway target and a rollback assertion, which is the
+  live-kernel tier's shape rather than this one's.
+- **One bench, one architecture, for the timings.** Every wall-clock number in that document is an
+  ARM64 Mac serving MLX builds. The correctness columns should travel; the timings should not be
+  quoted anywhere else.

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -1,6 +1,6 @@
 # Follow-ups
 
-Deferred work, in nineteen clusters: items 1–6 come from the reachability-confirmation effort (path
+Deferred work, in twenty clusters: items 1–6 come from the reachability-confirmation effort (path
 recipe + `run_to_address`, merged 2026-07-04), items 7–11 from surveying this server against the
 MCP `2026-07-28` extensions (tasks, apps), item 12 from the opener split
 (glslang/win-kexp#71, 2026-08-01), items 13–14 from the bounded-command coverage review
@@ -21,8 +21,9 @@ ARM64 runner image that replaces `windows-11-arm` in September 2026, and items 3
 the server with a **local model** — the lease grace measured against the wrong slow party, and a
 service's clients fixed at install time (both 2026-08-22), and items 37–38 from the credential
 file gaining a fourth writer while still having no reader, and from exercising what that reader
-says against a real service (both 2026-08-23), and item 39 from running the surface, the window
-and the model as a **grid** rather than as a sighting (2026-08-23). Each item notes its repo,
+says against a real service (both 2026-08-23), and items 39–40 from running the surface, the window
+and the model as a **grid** rather than as a sighting, and from what that grid found leaking
+through the one thing `--tools` does not narrow (both 2026-08-23). Each item notes its repo,
 why it was deferred, and where it picks up. See [`DECISIONS.md`](./DECISIONS.md) for the design rationale (D1–D5) items 1–6 extend,
 and the 2026-08-02 entries that items 13–14 and item 10 extend.
 
@@ -1711,3 +1712,41 @@ Two smaller things the same run left open:
 - **One bench, one architecture, for the timings.** Every wall-clock number in that document is an
   ARM64 Mac serving MLX builds. The correctness columns should travel; the timings should not be
   quoted anywhere else.
+
+## 40. [windbg-mcp] `--tools` narrows the tool list and not the instructions
+
+A client's surface is per credential since [#196](https://github.com/glslang/windbg-mcp/pull/196),
+and what that narrows is the **router**: `tools/list` answers with the client's own set, and a call
+for anything else is refused by name. The `instructions` string sent at `initialize` is not
+narrowed. It is a compile-time constant on `#[rmcp::tool_handler]` in `src/server.rs`, it names
+**twenty-one tools**, and every client gets all of it.
+
+Measured on the eval bench (2026-08-23,
+[`docs/local-model-eval.md`](./docs/local-model-eval.md)): the `min` client is served **11** tools
+and told about **21**, of which **17 it cannot call** — `modules`, `execute`, `decode_ioctl`,
+`debug_batch`, the whole TTD family and the whole IOCTL family. Both halves of that are a cost:
+
+- **Wasted turns, and the eval measured them.** Every off-surface call in the grid is one of those
+  seventeen — gemma spent a task's entire turn budget re-asking for `debug_batch`, and both control
+  rows asked for `modules` and `execute`. The eval first recorded this as models *inventing* tool
+  names; they were reading this server's own advertising. The metric is now called `unserved`.
+- **Context, on the surface least able to pay it.** 1,990 characters, ~497 tokens, identical for
+  every client — of which **59% is sentences naming only tools a `min` client cannot call**, and
+  the whole string is ~12% of that client's prompt. `--tools crash` drops 54,000 bytes of schemas
+  and keeps every word of the prose selling what it dropped.
+
+**Why it was deferred rather than fixed with the eval.** The fix is not a filter over the existing
+text: the prose is sentences, each naming several tools, and cutting by keyword would leave
+mangled English in the one string a model reads before anything else. The shape that works is the
+same one the tool table already has — a base paragraph plus a fragment per **group**, assembled for
+the client's own `Toolset`, so `crash` gets the base and the crash sentence and nothing about TTD.
+That is a rewrite of the instructions as data rather than a constant, and it moves a string three
+tests assert on (`the_instructions_fit_what_the_client_reads`, the discovery assertion in
+`src/server.rs`, and the tool-budget golden).
+
+**Where it picks up.** `#[rmcp::tool_handler]` supplies `get_info` only when the impl does not —
+the same rule `call_tool` already relies on — so the override point is a hand-written `get_info`
+that assembles the text from the client the instance carries (`crate::client::current()` is not
+right here: the surface is captured in the listener's factory, and `WindbgServer` already holds
+it). The measurement to keep is the one above: instructions bytes against tools actually served,
+per client.

--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ This file is the map. Each topic is one document, and each document is the whole
 | [Walkthroughs](docs/walkthroughs.md) | Worked sessions end to end: crash-dump triage, TTD, a Flare-On solve, driver IOCTL surfaces |
 
 Operator and reference material: [remote listener](docs/remote-listener.md),
-[local model](docs/local-model.md), [disassembler coordinates](docs/coordinates.md),
-[smoke test](docs/smoke-test.md), [token budget](docs/token-budget.md),
-[releasing](docs/releasing.md).
+[local model](docs/local-model.md), [the local-model eval](docs/local-model-eval.md),
+[disassembler coordinates](docs/coordinates.md), [smoke test](docs/smoke-test.md),
+[token budget](docs/token-budget.md), [releasing](docs/releasing.md).
 
 ## Quick start
 

--- a/docs/local-model-eval.md
+++ b/docs/local-model-eval.md
@@ -30,9 +30,12 @@ which bearer token the driver presents:
 | `lean` | `session,inspect,crash` | 20 | 26,057 | 5,906 / 6,385 / 6,673 |
 | `min` | `crash` | 11 | 15,544 | 3,447 / 3,838 / 3,926 |
 
-Bytes are the surface as handed to the runtime — minified JSON in ollama's function shape, which
-is a little larger than the same surface as MCP reports it in
-[`token-budget.md`](./token-budget.md), and is what the model is actually served.
+Bytes are the surface **as handed to the runtime** — minified JSON in ollama's function shape,
+which is what the model is actually served. That is not the same measure as
+[`token-budget.md`](./token-budget.md)'s, which counts the surface as MCP reports it: 67,658 B for
+the same 51 tools, 25,265 for the same 20, 15,073 for the same 11. The function-call wrapper is the
+difference and it is a flat ~3% on all three, so either figure supports the arithmetic below —
+quote whichever matches what you are measuring, and do not mix them in one sum.
 
 **The last column is a finding, not a caption.** Identical bytes cost gemma 14,540 tokens, qwen
 17,270 and nemotron 18,501 — a 27% spread on the same surface, entirely tokenizer. So "does the
@@ -151,9 +154,8 @@ answers than the tool table suggests.
 
 Three pieces, and only the first is unusual.
 
-**A listener with three clients**, started in the foreground so it disappears with the ssh channel
-and holds no credential a service would keep. The tokens go in on **stdin**, never on a command
-line:
+**A listener with three clients**, started in the foreground so nothing is installed and no
+credential is written to disk. The tokens go in on **stdin**, never on a command line:
 
 ```console
 python3 -c "import json,secrets;print(json.dumps({n:secrets.token_urlsafe(32) for n in ('full','lean','min')}))" > bench-tokens.json
@@ -167,6 +169,20 @@ Its startup line is the check that it worked — it names the clients and what e
 ```text
 listening on http://127.0.0.1:8766 (… clients: full, lean, min, serving all 51 tools
  — except lean serves 20 of 51 tools (session, inspect, crash), min serves 11 of 51 tools (session, crash))
+```
+
+**Ending the ssh command stops it; *killing* the ssh client does not.** A graceful exit takes the
+listener with it (`remote-listener.md` measured that), but a tunnel that is killed from this side
+leaves sshd with no reason to tear anything down, and the listener keeps running and keeps the
+port — the next run then fails to bind with `Only one usage of each socket address` and looks like
+a busy machine rather than a leftover. Stop it **by the PID that owns the port**, never by image
+name: the installed service is the same executable, and taking that down drops the sessions
+whatever else is connected to this host is holding.
+
+```pwsh
+$svc = (Get-CimInstance Win32_Service -Filter "Name='windbg-mcp'").ProcessId
+$own = (Get-NetTCPConnection -State Listen -LocalPort 8766 -ErrorAction SilentlyContinue)[0].OwningProcess
+if ($own -and $own -ne $svc) { Stop-Process -Id $own -Force }
 ```
 
 **A plan**, naming the models, the surfaces, the contexts and the per-cell wall-clock budget. The
@@ -200,21 +216,25 @@ because two of the six have no tool to answer them on `min`:
 
 | | `full` (51 tools) | `lean` (20) | `min` (11) | answerable, total |
 | --- | --- | --- | --- | --- |
-| **Opus** *(control)* | 6/6 | 5/5 **+1** | 4/4 | **15/15** |
-| **Sonnet** *(control)* | 6/6 | 5/5 **+1** | 4/4 | **15/15** |
+| **Opus** *(control)* | 6/6 | 5/5 **+1** | 3/4 **+1** | **14/15** |
+| **Sonnet** *(control)* | 6/6 | 5/5 **+1** | 3/4 **+1** | **14/15** |
 | qwen3.8:27b | 6/6 | 5/5 | 4/4 | **15/15** |
 | gemma4:31b | 6/6 | 5/5 | 3/4 | **14/15** |
 | nemotron-3.5-lightning:30b | 4/6 | 3/5 | 3/4 | **10/15** |
 
-The **+1** is the trap task answered without the tool that answers it: both control rows decoded
-`0x22200B` correctly from the `CTL_CODE` layout on a surface where `decode_ioctl` is not served.
-gemma does it too at the reduced windows. qwen tries and gets it wrong — twice, in prose, in full
-view.
+The **+1** is the trap task answered without the tool that answers it, and it is kept outside the
+score rather than added to it: both control rows decoded `0x22200B` correctly from the `CTL_CODE`
+layout on a surface where `decode_ioctl` is not served. gemma does it too at the reduced windows.
+qwen tries and gets it wrong — twice, in prose, in full view.
 
-**The headline is the first column against the last.** A 27B local model matched the frontier
-control on every answerable task, at every surface size, on this task set. That is not a claim
-that local models are as good; it is a claim about *these questions*, which are the shape of
-question a debugger MCP server is asked most of the time — open a target, read a field, name a
+**The one clean sweep of answerable tasks belongs to the 27B local model**, because both control
+rows drop `arm64_pc` on the narrowest surface — the cell two sections down. Read that as the task
+set being within reach rather than as a ranking: four of the five models are within one answer of
+each other, the fifth is five behind, and the control's own miss is the most useful single result
+here, since a question the frontier gets wrong is a question worth re-reading.
+
+That is not a claim that local models are as good. It is a claim about *these questions*, which
+are the shape a debugger MCP server is asked most often — open a target, read a field, name a
 module, decode a constant.
 
 ### The surface axis cost less than the tool table predicts

--- a/docs/local-model-eval.md
+++ b/docs/local-model-eval.md
@@ -220,7 +220,9 @@ EVAL_TOKENS=bench-tokens.json python3 tools/local_model_eval.py tools/eval_plan.
 Cells are subprocesses and the log is append-only, so a run that dies in the middle leaves every
 finished cell on disk and re-running the same plan resumes rather than repeating. A cell that
 overruns its budget is killed and *that* is recorded — a model which cannot finish inside a
-generous wall clock has told you something.
+generous wall clock has told you something — and the kill is followed by a release pass with that
+cell's own credential, because a killed driver never reaches its own cleanup and whatever it had
+open would otherwise still be attached when the next cell on that surface starts.
 
 **Grading, separately**, over the log:
 

--- a/docs/local-model-eval.md
+++ b/docs/local-model-eval.md
@@ -1,0 +1,326 @@
+# The local-model eval
+
+[`local-model.md`](./local-model.md) is the runbook for pointing a local model at this server, and
+it records two runs of one model on one surface. This page is the **grid** those two runs argued
+for: three local models, three tool surfaces and three context windows, scored against an answer
+key, with a frontier model in the same harness as the control.
+
+It exists because the two sightings could not settle the question they raised. One model picking
+nine tools correctly says a 51-tool surface is drivable *by that model, at that window*; it says
+nothing about which of the three knobs — the model, the surface, the window — was carrying the
+result. A grid can, because it moves one at a time.
+
+- The harness is [`tools/local_model_eval.py`](../tools/local_model_eval.py), over
+  [`tools/local_model_drive.py`](../tools/local_model_drive.py) and
+  [`tools/claude_code_drive.py`](../tools/claude_code_drive.py).
+- The tasks and their answer key are [`tools/eval_tasks.json`](../tools/eval_tasks.json).
+- The listener the run drives is a foreground one with three clients:
+  [`tools/bench_listener.ps1`](../tools/bench_listener.ps1).
+
+## The three axes
+
+**The tool surface**, which is bytes of prose in every turn. Since
+[#196](https://github.com/glslang/windbg-mcp/pull/196) a surface is a property of the *client*
+rather than of the run, so all three exist on one listener at once and a cell changes nothing but
+which bearer token the driver presents:
+
+| Client | `--tools` spec | Tools | Surface bytes | Prompt tokens, by model |
+| --- | --- | --- | --- | --- |
+| `full` | *(none — the whole surface)* | 51 | 69,552 | 14,540 / 17,270 / 18,501 |
+| `lean` | `session,inspect,crash` | 20 | 26,057 | 5,906 / 6,385 / 6,673 |
+| `min` | `crash` | 11 | 15,544 | 3,447 / 3,838 / 3,926 |
+
+Bytes are the surface as handed to the runtime — minified JSON in ollama's function shape, which
+is a little larger than the same surface as MCP reports it in
+[`token-budget.md`](./token-budget.md), and is what the model is actually served.
+
+**The last column is a finding, not a caption.** Identical bytes cost gemma 14,540 tokens, qwen
+17,270 and nemotron 18,501 — a 27% spread on the same surface, entirely tokenizer. So "does the
+surface fit" has no single answer even at one surface size and one window, and the ≈4 B/token rule
+of thumb `local-model.md` records is a per-model constant rather than a shared one.
+
+**The context window**, which is what the runtime will actually hold — not what the model card
+says. `OLLAMA_CONTEXT_LENGTH` picks 4k, 32k or 256k from the box's memory, so the eval sets
+`num_ctx` per request instead of trusting a default: 262,144 (what this bench serves), 32,768, and
+8,192, which is smaller than the 51-tool surface and is in the grid precisely for that reason.
+
+**The model.** Three ~30B-class MLX builds, all declaring the `tools` capability and all with a
+262,144 context length on their card, plus Claude through Claude Code as the frontier control.
+
+## What is deliberately not an axis
+
+**The prompt.** One system prompt, one sentence long, identical everywhere:
+
+```text
+You are a Windows kernel debugging assistant. Use the provided tools to answer.
+Call one tool at a time and use its result. Be concise.
+```
+
+Nothing is tuned per model. A model that needs a bespoke prompt to drive this surface is a finding,
+not a cell to fix.
+
+**Thinking.** Every local model here can think, and every cell runs with `think: false`. That is a
+controlled variable rather than a recommendation — the two runs in `local-model.md` had already
+found that a thinking turn can outlive the listener's lease grace, which is a real cost with its
+own follow-up (`FOLLOWUPS.md` item 33) and would have confounded every timing here.
+
+**The tools themselves.** The harness executes a read-only allow-list and reports anything else
+back to the model as refused, so a wrong pick is *measured* rather than performed. `launch`,
+`execute` and `debug_batch` are on the surface and are never run: a debug host is the wrong place
+to discover unattended what a model does with them.
+
+## The tasks, and why these six
+
+Six questions with facts behind them, read off the checked-in sample dumps with this server's own
+tools **before any model saw them** and recorded in `tools/eval_tasks.json` as the answer key.
+
+| Task | Asks for | Answerable on |
+| --- | --- | --- |
+| `bugcheck` | the bug check of the x64 `MessageManager` dump | all three surfaces |
+| `driver_blame` | which third-party driver crashed, and at what offset | all three surfaces |
+| `module_count` | how many modules are loaded in the `0x9F` dump | all three surfaces |
+| `unloaded_driver` | whether `nvhda64v.sys` is loaded, and what is left of it | `full`, `lean` |
+| `arm64_pc` | the `pc` register in the ARM64 `0xFC` dump | all three surfaces |
+| `ioctl_decode` | the four `CTL_CODE` fields of `0x22200B` | `full` |
+
+The third column is the point of the surface axis, and it is why the grader reports **correct out
+of possible** rather than a bare score: on `min` two of the six tasks have no tool that can answer
+them, and counting those as failures would say a small surface makes a model stupid rather than
+that it makes tools absent.
+
+**Four of the six are answerable on every surface, and that is itself the finding.** `open_dump`'s
+own summary carries the bug check and the module count, so a model that reads its opener's answer
+needs neither `crash_triage` nor `modules`; `crash_triage`'s frame 0 carries the `pc` that
+`registers` reports. Cutting the surface from 51 tools to 11 removes far fewer *answers* than it
+removes tools, because the facts are reachable by more than one route — which is the opposite of
+what the tool table predicts, and is why the third column was written from the tools and then
+corrected from the run.
+
+`ioctl_decode` is the deliberate trap. The tool that answers it is on one surface of the three, and
+what the other two measure is what a model does when the tool it wants is not there: decline, ask
+for it anyway, or compute the answer itself — `CTL_CODE` is arithmetic, and a model that knows the
+macro can decode a code with no tool at all.
+
+## Grading
+
+Mechanical, and stated so it can be argued with:
+
+- **`correct`** — every group in the task's `expect` list appears in the final answer, any
+  alternative within a group counting, case-folded. So `0x13A` and `13a` both pass, and an answer
+  must carry *both* the code and the name.
+- **`possible`** — whether the answer key is reachable on that surface at all.
+- **Tool calls** are split five ways, because the ways a call can go wrong are not one finding:
+  `useful` (a tool the task needs, and it worked), `wasted` (worked, but nothing to do with the
+  question), `off_surface` (the server refused it — on a narrowed surface, the tool is not served),
+  `refused` (the harness's read-only fence), and `errored`.
+- **`hallucinated`** — a call naming a tool the surface never offered. The model was handed a tool
+  list; asking for something outside it is invention.
+
+Nothing is graded by a model. A substring check accepts an answer a reader would not in exactly one
+direction — a model that lists every bug check code including the right one — and every cell's raw
+transcript is kept so a suspicious pass can be read.
+
+### Two corrections the run forced, and why they are not cheating
+
+Grading happens **at the end, over the whole log**, so a key corrected mid-run scores every cell —
+the ones already recorded included — by the same final rule. Both corrections came from reading
+answers the first key had scored, and both made the key stricter or truer rather than kinder.
+
+**A number must not match inside a longer number.** `0x22` is the device type `ioctl_decode` asks
+for and `0x22200B` is the code in the question, so plain containment passed for any answer that
+merely repeated the question. One model, with no `decode_ioctl` on its surface, did the bit
+arithmetic in prose, miscounted twice in full view, and presented a confident table saying
+`FILE_DEVICE_KEYBOARD` and `FILE_READ_DATA` — both wrong — and scored correct. Numeric
+expectations now match only between hex boundaries.
+
+**`unloaded_driver` requires the count, which used to be a bonus.** On the 11-tool surface a model
+with no `modules` answered honestly that it could not check, added that "a kernel-mode dump does
+not retain a history of drivers that loaded-then-unloaded" — which is false, and is exactly what
+the tool would have told it — and scored correct on the words *not loaded* and *unloaded*. The 26
+unload records are the half of the question only the tool can answer, and every model that had the
+tool quoted the number, so requiring it separates reading from guessing.
+
+One prediction in the key was simply wrong, and the run found it: **`arm64_pc` is answerable on
+every surface**, not only where `registers` is served. `crash_triage`'s frame 0 on that dump is
+`0xfffff8013c65bca8`, which is the `pc` the register read reports — the same fact by another
+route. Verified against the dump before the key was changed, and it is the kind of thing a grid
+finds that a prediction does not: two tools carry one fact, so narrowing a surface removes fewer
+answers than the tool table suggests.
+
+## Running it
+
+Three pieces, and only the first is unusual.
+
+**A listener with three clients**, started in the foreground so it disappears with the ssh channel
+and holds no credential a service would keep. The tokens go in on **stdin**, never on a command
+line:
+
+```console
+python3 -c "import json,secrets;print(json.dumps({n:secrets.token_urlsafe(32) for n in ('full','lean','min')}))" > bench-tokens.json
+chmod 600 bench-tokens.json
+scp tools/bench_listener.ps1 <vm>:C:/Users/<you>/bench_listener.ps1
+ssh -L 8766:127.0.0.1:8766 <vm> 'powershell -NoProfile -File C:\Users\<you>\bench_listener.ps1' < bench-tokens.json
+```
+
+Its startup line is the check that it worked — it names the clients and what each is served:
+
+```text
+listening on http://127.0.0.1:8766 (… clients: full, lean, min, serving all 51 tools
+ — except lean serves 20 of 51 tools (session, inspect, crash), min serves 11 of 51 tools (session, crash))
+```
+
+**A plan**, naming the models, the surfaces, the contexts and the per-cell wall-clock budget. The
+tokens are *not* in it: a plan is checked in, a credential is not.
+
+```console
+EVAL_TOKENS=bench-tokens.json python3 tools/local_model_eval.py plan.json
+```
+
+Cells are subprocesses and the log is append-only, so a run that dies in the middle leaves every
+finished cell on disk and re-running the same plan resumes rather than repeating. A cell that
+overruns its budget is killed and *that* is recorded — a model which cannot finish inside a
+generous wall clock has told you something.
+
+**Grading, separately**, over the log:
+
+```console
+python3 tools/local_model_eval.py --grade results.jsonl tools/eval_tasks.json
+```
+
+## What one grid showed
+
+Run 2026-08-23, on the ARM64 bench described in `local-model.md`: 33 cells, 144 task runs, about
+three hours of wall clock. The raw log, every answer and every tool call are what the tables below
+are reduced from.
+
+### At the window this bench actually serves
+
+Six tasks, 262,144 tokens, **correct out of answerable** — the denominator moves with the surface
+because two of the six have no tool to answer them on `min`:
+
+| | `full` (51 tools) | `lean` (20) | `min` (11) | answerable, total |
+| --- | --- | --- | --- | --- |
+| **Opus** *(control)* | 6/6 | 5/5 **+1** | 4/4 | **15/15** |
+| **Sonnet** *(control)* | 6/6 | 5/5 **+1** | 4/4 | **15/15** |
+| qwen3.8:27b | 6/6 | 5/5 | 4/4 | **15/15** |
+| gemma4:31b | 6/6 | 5/5 | 3/4 | **14/15** |
+| nemotron-3.5-lightning:30b | 4/6 | 3/5 | 3/4 | **10/15** |
+
+The **+1** is the trap task answered without the tool that answers it: both control rows decoded
+`0x22200B` correctly from the `CTL_CODE` layout on a surface where `decode_ioctl` is not served.
+gemma does it too at the reduced windows. qwen tries and gets it wrong — twice, in prose, in full
+view.
+
+**The headline is the first column against the last.** A 27B local model matched the frontier
+control on every answerable task, at every surface size, on this task set. That is not a claim
+that local models are as good; it is a claim about *these questions*, which are the shape of
+question a debugger MCP server is asked most of the time — open a target, read a field, name a
+module, decode a constant.
+
+### The surface axis cost less than the tool table predicts
+
+Cutting 51 tools to 11 removes 40 tools and **two answers**. Two of the six tasks survive the cut
+because `open_dump`'s summary carries the bug check and the module count, and a third survives
+because `crash_triage`'s frame 0 is the `pc` that `registers` reports. Facts here are reachable by
+more than one route, and the narrow surface keeps the routes that matter.
+
+What the cut *does* produce, in every row including the control, is **calls to tools that are not
+there**:
+
+| Cell | Off-surface calls |
+| --- | --- |
+| gemma4 `min` | 8 — `debug_batch` four times on one task, plus `modules` |
+| Opus `min` | 4 |
+| Sonnet `min` | 2 |
+| nemotron `min` | 1 |
+| every `full` and `lean` cell | 0 |
+
+Nobody invents a tool when the surface is wide. Everybody does when it is narrow, and the server's
+refusal (`#196`, which names the client's own surface) is what turns that into a recoverable
+mistake rather than a wrong answer. Opus and qwen recover by declining honestly; gemma spends its
+whole turn budget re-asking and returns an **empty answer**.
+
+### Same surface, same tool output, three different outcomes
+
+The `arm64_pc` task on the 11-tool surface is the cell worth reading in full. All three local
+models opened the dump and ran `crash_triage`; all three had exactly the same text in front of
+them:
+
+- **qwen** reasoned that frame 0 of the bug-check stack *is* the `pc`, and answered
+  `0xfffff8013c65bca8`. Correct, by the route the answer key had not predicted.
+- **gemma** called `debug_batch` four times, was refused four times, ran out of turns and returned
+  nothing at all.
+- **nemotron** answered `0x0000019e7b820000` — bug check parameter 1, the address that was
+  executed. Confident, plausible, wrong.
+
+**Opus makes nemotron's mistake here**, reasoning explicitly that the value "matches parameter 1
+exactly". On the narrowest surface the 27B local model was the only one to get it right. Failure
+modes, not scores, are what separate these rows: only one of those three failures is visible to
+whoever asked the question.
+
+### The context axis did not bite, and nearly reported that it did
+
+The prediction going in — `local-model.md` says an 8k window is "roughly half" what the 51-tool
+surface needs — did not survive contact:
+
+| Window served | `full` (51 tools, ~17k tokens) | `lean` | `min` |
+| --- | --- | --- | --- |
+| 262,144 | works | works | works |
+| 32,768 | works | works | works |
+| 8,192 | **works** — 6/6 on the whole task set | works | works |
+
+At a **served** 8,192-token window, a 17,300-token prompt was evaluated in full and answered
+correctly, including picking `decode_ioctl` out of 51 tools. No refusal, no visible truncation, no
+degradation. On this runtime `num_ctx` is not a hard cap on prompt length for these MLX builds, so
+"will the surface fit" is the wrong question to spend the budget on.
+
+**That claim needed one more run before it was safe**, because the reduced-context cells use a
+three-task subset and nothing in them was multi-turn with a large result. So qwen ran the *whole*
+six-task list on the `full` surface at a served 8,192: **6 of 6 correct**, three of the tasks
+taking three turns, and two of them carrying tool results of 9,959 and 10,343 characters — roughly
+2,500 tokens of answer landing on top of a 17,300-token prompt, in an 8,192-token window. Whatever
+the runtime is doing with `num_ctx` for these builds, it is not the truncation the number implies.
+
+**It nearly went the other way, and the near-miss is the method lesson.** `num_ctx` on a request
+does not shrink an instance the runtime already holds: with a 32,768 instance loaded, five cells
+asking for 8,192 were served 32,768 and looked entirely healthy. Only `/api/ps` disagreed. Every
+record therefore carries `served_context` beside the number it asked for, the grader marks a cell
+where the two differ, and the runner evicts the model between windows. Those five records were
+dropped and re-run. **Record what was served, not what was requested.**
+
+One genuine context failure did turn up, and it is not about fitting: nemotron at 8k on `lean`
+emitted a malformed tool call and the runtime rejected the request outright —
+`XML syntax error on line 6: element <parameter> closed by </function>`. The tool-call *syntax*
+broke before the window did.
+
+### What it costs, in time and in tool output
+
+| | Wall clock, six tasks | Tool result bytes taken |
+| --- | --- | --- |
+| Opus / Sonnet (`full`) | 93s / 91s | 20,924 / 22,924 |
+| qwen3.8:27b (`full`) | 270s | 31,355 |
+| gemma4:31b (`full`) | 348s | 31,365 |
+| nemotron (`full`) | **74s** | 25,500 |
+
+**Fast is not a proxy for good, and here it is nearly the opposite.** nemotron is three to five
+times faster than the other two local models and gets ten of fifteen; its `module_count` answer —
+"134 loaded modules", against a true 227 — was produced with **no tool call at all**. The control
+rows are both quicker than every local model *and* take a third less tool output to get there,
+which is the clearest single measure of the gap: fewer calls, smaller answers, right the first
+time.
+
+Claude's prompt-token column is deliberately absent from these tables. It reads 49k on the `full`
+surface, and most of that is Claude Code's own system prompt rather than this server's — see the
+last section.
+
+## What this does not cover
+
+The same list `local-model.md` carries, minus what this closed. Still open: a long investigation
+where the transcript outgrows the surface (scenario mode exists and no cell here uses it), anything
+behind the read-only allow-list, a box smaller than this one, and any model but these.
+
+And one that this page adds: the Claude row is **Claude Code**, not the Claude API. Its token
+columns include a harness this server does not control — its own system prompt, its own
+conversation shape and prompt caching — so they are not comparable with the ollama rows and are
+marked as such. What is comparable is what the grid is about: which tools get picked out of a given
+surface, and whether the answer is right.

--- a/docs/local-model-eval.md
+++ b/docs/local-model-eval.md
@@ -136,12 +136,15 @@ arithmetic in prose, miscounted twice in full view, and presented a confident ta
 `FILE_DEVICE_KEYBOARD` and `FILE_READ_DATA` — both wrong — and scored correct. Numeric
 expectations now match only between hex boundaries.
 
-**`unloaded_driver` requires the count, which used to be a bonus.** On the 11-tool surface a model
-with no `modules` answered honestly that it could not check, added that "a kernel-mode dump does
-not retain a history of drivers that loaded-then-unloaded" — which is false, and is exactly what
-the tool would have told it — and scored correct on the words *not loaded* and *unloaded*. The 26
-unload records are the half of the question only the tool can answer, and every model that had the
-tool quoted the number, so requiring it separates reading from guessing.
+**`unloaded_driver` requires the count, and the prompt now asks for it.** On the 11-tool surface a
+model with no `modules` answered honestly that it could not check, added that "a kernel-mode dump
+does not retain a history of drivers that loaded-then-unloaded" — which is false, and is exactly
+what the tool would have told it — and scored correct on the words *not loaded* and *unloaded*. The
+26 unload records are the half of the question only the tool can answer, so requiring them
+separates reading from guessing. That first went in as a stricter key over an unchanged question,
+which review rightly called a key asking for a fact the prompt did not request; the question now
+asks *how many* records the dump still carries, and **every cell of that task was re-run under it**
+— no score moved, because every model that had the tool had already volunteered the number.
 
 One prediction in the key was simply wrong, and the run found it: **`arm64_pc` is answerable on
 every surface**, not only where `registers` is served. `crash_triage`'s frame 0 on that dump is
@@ -186,10 +189,32 @@ if ($own -and $own -ne $svc) { Stop-Process -Id $own -Force }
 ```
 
 **A plan**, naming the models, the surfaces, the contexts and the per-cell wall-clock budget. The
-tokens are *not* in it: a plan is checked in, a credential is not.
+one this page's run used is checked in as [`tools/eval_plan.json`](../tools/eval_plan.json), so the
+grid is re-runnable rather than described:
+
+```json
+{
+  "run": "2026-08-23",
+  "tasks": "tools/eval_tasks.json",
+  "url": "http://127.0.0.1:8766/",
+  "out": "eval-out/results.jsonl",
+  "surfaces": [{ "client": "full" }, { "client": "lean" }, { "client": "min" }],
+  "cells": [
+    { "backend": "ollama", "models": ["qwen3.8:27b-mlx"],
+      "contexts": [262144], "surfaces": ["full", "lean", "min"], "budget_s": 2400 }
+  ]
+}
+```
+
+`surfaces` at the top level names every client the run may present — each entry an object with a
+`client`, which is the name the token file uses. Inside a cell group, `surfaces` is a list of those
+same names as plain strings. Paths are resolved when the plan is read, so they may be relative to
+wherever you run it from.
+
+The tokens are *not* in the plan: a plan is checked in, a credential is not.
 
 ```console
-EVAL_TOKENS=bench-tokens.json python3 tools/local_model_eval.py plan.json
+EVAL_TOKENS=bench-tokens.json python3 tools/local_model_eval.py tools/eval_plan.json
 ```
 
 Cells are subprocesses and the log is append-only, so a run that dies in the middle leaves every
@@ -247,13 +272,13 @@ more than one route, and the narrow surface keeps the routes that matter.
 What the cut *does* produce, in every row including the control, is **calls to tools that are not
 there**:
 
-| Cell | Off-surface calls |
-| --- | --- |
-| gemma4 `min` | 8 — `debug_batch` four times on one task, plus `modules` |
-| Opus `min` | 4 |
-| Sonnet `min` | 2 |
-| nemotron `min` | 1 |
-| every `full` and `lean` cell | 0 |
+| Cell | Off-surface calls | What it asked for |
+| --- | --- | --- |
+| gemma4 `min` | 9 | `debug_batch`, every one of them — five on one task, four on another |
+| Opus `min` | 4 | `execute` twice, `modules`, `decode_ioctl` |
+| Sonnet `min` | 2 | `modules`, `execute` |
+| nemotron `min` | 2 | `modules`, twice |
+| every `full` and `lean` cell | 0 | — |
 
 Nobody invents a tool when the surface is wide. Everybody does when it is narrow, and the server's
 refusal (`#196`, which names the client's own surface) is what turns that into a recoverable

--- a/docs/local-model-eval.md
+++ b/docs/local-model-eval.md
@@ -116,8 +116,8 @@ Mechanical, and stated so it can be argued with:
   `useful` (a tool the task needs, and it worked), `wasted` (worked, but nothing to do with the
   question), `off_surface` (the server refused it — on a narrowed surface, the tool is not served),
   `refused` (the harness's read-only fence), and `errored`.
-- **`hallucinated`** — a call naming a tool the surface never offered. The model was handed a tool
-  list; asking for something outside it is invention.
+- **`unserved`** — a call naming a tool this client is not served. It was called `hallucinated`
+  until the run was read properly; see below, because the server is where those names came from.
 
 Nothing is graded by a model. A substring check accepts an answer a reader would not in exactly one
 direction — a model that lists every bug check code including the right one — and every cell's raw
@@ -270,9 +270,9 @@ because `crash_triage`'s frame 0 is the `pc` that `registers` reports. Facts her
 more than one route, and the narrow surface keeps the routes that matter.
 
 What the cut *does* produce, in every row including the control, is **calls to tools that are not
-there**:
+there** — and the reason is this server, not the models:
 
-| Cell | Off-surface calls | What it asked for |
+| Cell | Unserved calls | What it asked for |
 | --- | --- | --- |
 | gemma4 `min` | 9 | `debug_batch`, every one of them — five on one task, four on another |
 | Opus `min` | 4 | `execute` twice, `modules`, `decode_ioctl` |
@@ -280,10 +280,23 @@ there**:
 | nemotron `min` | 2 | `modules`, twice |
 | every `full` and `lean` cell | 0 | — |
 
-Nobody invents a tool when the surface is wide. Everybody does when it is narrow, and the server's
-refusal (`#196`, which names the client's own surface) is what turns that into a recoverable
-mistake rather than a wrong answer. Opus and qwen recover by declining honestly; gemma spends its
-whole turn budget re-asking and returns an **empty answer**.
+**The models were told about those tools by the server.** `#196` narrows `tools/list` per client;
+it does not narrow the `instructions` string the server sends at `initialize`, which is a compile-
+time constant naming twenty-one tools by name — `modules`, `execute`, `decode_ioctl` and
+`debug_batch` among them. Measured against this bench: the `min` client is served **11** tools and
+told about **21**, of which **17 it cannot call**. Every off-surface call in the table above is one
+of those seventeen.
+
+So this is not invention, and the column that used to be called `hallucinated` is now `unserved`.
+It is a real cost — wasted turns, and gemma's whole turn budget on one task — but it is the cost of
+the server advertising what it will then refuse. The refusal (`#196` again, which names the client's
+own surface) is what makes it recoverable: Opus and qwen decline honestly after it, gemma re-asks
+until it runs out.
+
+The same string is also **1,990 characters (~497 tokens) charged to every client identically**, of
+which **59% is sentences naming only tools the `min` client cannot call** — about 12% of that
+client's entire prompt. A narrowed surface drops 54,000 bytes of schemas and keeps every word of
+the prose advertising what was dropped. That is `FOLLOWUPS.md` item 40.
 
 ### Same surface, same tool output, three different outcomes
 

--- a/docs/local-model-eval.md
+++ b/docs/local-model-eval.md
@@ -220,9 +220,14 @@ EVAL_TOKENS=bench-tokens.json python3 tools/local_model_eval.py tools/eval_plan.
 Cells are subprocesses and the log is append-only, so a run that dies in the middle leaves every
 finished cell on disk and re-running the same plan resumes rather than repeating. A cell that
 overruns its budget is killed and *that* is recorded — a model which cannot finish inside a
-generous wall clock has told you something — and the kill is followed by a release pass with that
-cell's own credential, because a killed driver never reaches its own cleanup and whatever it had
-open would otherwise still be attached when the next cell on that surface starts.
+generous wall clock has told you something. **Each cell clears its own credential's sessions
+before it starts**, rather than the previous one tidying up after itself: however a cell ended —
+finished, killed, crashed — the next one begins with nothing of its own attached, and no cleanup
+has to have succeeded for that to hold.
+
+And a record whose *served* window is not the one it asked for is not scored at all: the runner
+evicts between windows to stop it happening, and the grader refuses to publish it if the eviction
+ever fails. Such a record is also not counted as done, so re-running the plan re-runs it.
 
 **Grading, separately**, over the log:
 

--- a/docs/local-model.md
+++ b/docs/local-model.md
@@ -7,6 +7,14 @@ listener you already have, a tunnel, and a client that happens to be pointed at 
 Read [`remote-listener.md`](./remote-listener.md) first for the listener itself; this page is only
 what is different when the thing driving it is not a hosted model.
 
+**For the measurements, go to [`local-model-eval.md`](./local-model-eval.md).** The two runs
+recorded here are one model on one surface at one window — sightings, and they say so. The eval is
+the grid they argued for: three local models against three tool surfaces and three context windows
+with a frontier control, scored against an answer key. Where the two disagree, the grid wins; the
+clearest case is the arithmetic under *What this server costs a model* below, which predicts that
+the 51-tool surface cannot fit an 8k window, and the grid answers all six tasks at a served 8,192
+anyway.
+
 ## The three pieces
 
 **1 — the engine plane.** The Windows machine runs the listener, bound to loopback, with its token
@@ -299,9 +307,14 @@ The claims worth testing are about the *client's* budget, not this server's corr
 smoke tiers cannot reach them — which is why the driver script exists and why the run above is
 written down rather than remembered:
 
-- **Does the surface fit**, at the context the runtime is actually serving.
+- **Does the surface fit**, at the context the runtime is actually serving. **Measured, and the
+  answer was no-question-asked yes** — see the eval: at a *served* 8,192 window a 17,300-token
+  surface answered every task. Note *served*: `num_ctx` does not shrink an instance the runtime
+  already holds, and asking `/api/ps` is the only way to know which of the two numbers you have.
 - **Does the model pick the right tool out of 51**, which is orthogonal to window size and is the
-  part a bigger context does not fix.
+  part a bigger context does not fix. **Measured, and it is the axis that separates models** —
+  three ~30B builds scored 15, 14 and 10 of 15 answerable tasks, and the interesting differences
+  are in *how* the failures look rather than in the totals.
 - **Do individual answers blow the window.** `read_memory` returns up to ~4 MiB by design, and is
   reachable in one careless call. `modules` was the other half of that and is **fixed** since
   2026-08-21: it answers with 64 rows unless a `limit` says otherwise, which on the checked-in

--- a/docs/remote-listener.md
+++ b/docs/remote-listener.md
@@ -74,6 +74,13 @@ left running when you are done:
 ssh -L 8765:127.0.0.1:8765 windbg-vm 'windbg-mcp.exe --listen 127.0.0.1:8765'
 ```
 
+**"As long as the tunnel" means as long as the ssh *command*, not as long as the client process.**
+End it normally — Ctrl-C, or the command returning — and the listener goes with it. Kill the ssh
+client instead and sshd is never told the connection ended, so the listener stays up and keeps the
+port; the next start fails to bind and reads like something else is using it. It is then stopped by
+the PID owning that port, and **not** by image name, since an installed service is the same
+executable and stopping it drops whatever sessions it is holding.
+
 The token comes from the environment `setx` put it in, which an ssh session inherits.
 
 **Know what that protects and what it does not.** This server strips `WINDBG_MCP_LISTEN_TOKEN` from

--- a/tools/bench_listener.ps1
+++ b/tools/bench_listener.ps1
@@ -44,6 +44,10 @@ foreach ($client in 'full', 'lean', 'min') {
 #   WINDBG_MCP_LISTEN_TOKEN       would name a client called `local`, which is what the *editor*
 #                                 connects as on the other listener - two clients of one name on
 #                                 two ports is a confusion this run does not need.
+#   WINDBG_MCP_TOOLS_LOCAL        has to go with it, and not for tidiness: a spec naming a client
+#                                 nothing configures a token for is refused at startup, so
+#                                 removing the token and leaving this one stops the listener from
+#                                 starting at all on an otherwise correctly configured host.
 #   WINDBG_MCP_LISTEN_TOKEN_FILE  is worse than it looks: a configured file is the *whole*
 #                                 configuration and shuts the environment out entirely, named
 #                                 tokens included, so the three below would create no clients at
@@ -53,6 +57,7 @@ foreach ($client in 'full', 'lean', 'min') {
 #                                 still announces `full (all)` - a benchmark measuring a surface
 #                                 nobody chose.
 Remove-Item Env:WINDBG_MCP_LISTEN_TOKEN -ErrorAction SilentlyContinue
+Remove-Item Env:WINDBG_MCP_TOOLS_LOCAL -ErrorAction SilentlyContinue
 Remove-Item Env:WINDBG_MCP_LISTEN_TOKEN_FILE -ErrorAction SilentlyContinue
 Remove-Item Env:WINDBG_MCP_TOOLS_FULL -ErrorAction SilentlyContinue
 

--- a/tools/bench_listener.ps1
+++ b/tools/bench_listener.ps1
@@ -1,0 +1,37 @@
+# A foreground listener for a benchmark run: three clients, three tool surfaces, one port.
+#
+# The eval measures the tool surface as an axis, and since PR #196 a surface is a property of
+# the *client* rather than of the run - so one listener serves all three, told apart by which
+# bearer token the driver presents. Nothing is installed and nothing is left behind: the
+# listener lives as long as the ssh channel that started it.
+#
+# The three tokens arrive as JSON on **stdin**, never on a command line, where every process
+# on the box could read them:
+#
+#     ssh -L 8766:127.0.0.1:8766 <vm> 'powershell -NoProfile -File C:\path\bench_listener.ps1' `
+#       < bench-tokens.json
+#
+# Windows PowerShell 5.1 is the only PowerShell a debuggee is guaranteed to have, so this file
+# stays ASCII - see CLAUDE.md on what a BOM-less non-ASCII character does to a 5.1 parse.
+$ErrorActionPreference = 'Stop'
+
+$exe = $env:WINDBG_MCP_EXE
+if (-not $exe) { $exe = 'C:\workspace\windbg-mcp\target\release\windbg-mcp.exe' }
+$listen = $env:WINDBG_MCP_BENCH_ADDR
+if (-not $listen) { $listen = '127.0.0.1:8766' }
+
+$cfg = [Console]::In.ReadToEnd() | ConvertFrom-Json
+
+# No unnamed token: that one would name a client called `local`, which is what the *editor*
+# connects as on the other listener. Two clients of one name on two ports is a confusion this
+# run does not need.
+Remove-Item Env:WINDBG_MCP_LISTEN_TOKEN -ErrorAction SilentlyContinue
+
+$env:WINDBG_MCP_LISTEN_TOKEN_FULL = $cfg.full
+$env:WINDBG_MCP_LISTEN_TOKEN_LEAN = $cfg.lean
+$env:WINDBG_MCP_TOOLS_LEAN        = 'session,inspect,crash'
+$env:WINDBG_MCP_LISTEN_TOKEN_MIN  = $cfg.min
+$env:WINDBG_MCP_TOOLS_MIN         = 'crash'
+
+Write-Host "starting $exe --listen $listen with clients: full (all), lean (session,inspect,crash), min (crash)"
+& $exe --listen $listen

--- a/tools/bench_listener.ps1
+++ b/tools/bench_listener.ps1
@@ -37,29 +37,22 @@ foreach ($client in 'full', 'lean', 'min') {
     }
 }
 
-# **Three inherited variables, each of which breaks this run in a different way.** The account
-# this lands in is whatever the ssh session gives you, and it may already be configured to run
-# this server.
+# **Nothing this server reads survives into the listener except what is set below.**
 #
-#   WINDBG_MCP_LISTEN_TOKEN       would name a client called `local`, which is what the *editor*
-#                                 connects as on the other listener - two clients of one name on
-#                                 two ports is a confusion this run does not need.
-#   WINDBG_MCP_TOOLS_LOCAL        has to go with it, and not for tidiness: a spec naming a client
-#                                 nothing configures a token for is refused at startup, so
-#                                 removing the token and leaving this one stops the listener from
-#                                 starting at all on an otherwise correctly configured host.
-#   WINDBG_MCP_LISTEN_TOKEN_FILE  is worse than it looks: a configured file is the *whole*
-#                                 configuration and shuts the environment out entirely, named
-#                                 tokens included, so the three below would create no clients at
-#                                 all and every cell would fail authentication.
-#   WINDBG_MCP_TOOLS_FULL         would pair an inherited spec with the token minted below, so the
-#                                 51-tool control would be silently narrowed while this script
-#                                 still announces `full (all)` - a benchmark measuring a surface
-#                                 nobody chose.
-Remove-Item Env:WINDBG_MCP_LISTEN_TOKEN -ErrorAction SilentlyContinue
-Remove-Item Env:WINDBG_MCP_TOOLS_LOCAL -ErrorAction SilentlyContinue
-Remove-Item Env:WINDBG_MCP_LISTEN_TOKEN_FILE -ErrorAction SilentlyContinue
-Remove-Item Env:WINDBG_MCP_TOOLS_FULL -ErrorAction SilentlyContinue
+# This started as one `Remove-Item` for `WINDBG_MCP_LISTEN_TOKEN`, and review found three more the
+# hard way: `WINDBG_MCP_TOOLS_LOCAL` (an orphaned spec is refused at startup, so the listener does
+# not start at all), `WINDBG_MCP_LISTEN_TOKEN_FILE` (a configured file is the *whole* configuration
+# and shuts the environment out, so the tokens below would create no clients), and
+# `WINDBG_MCP_TOOLS_FULL` (an inherited spec silently narrows the 51-tool control while this script
+# still announces `full (all)`).
+#
+# Each of those was a real defect and each fix was correct, which is exactly why the list kept
+# growing: subtracting the variables somebody thought of cannot cover the one added to the server
+# next. So the run does not inherit *any* of them. The two this script reads for itself are read
+# above, before the wipe.
+Get-ChildItem Env: |
+    Where-Object { $_.Name -like 'WINDBG_MCP_*' } |
+    ForEach-Object { Remove-Item -LiteralPath ("Env:" + $_.Name) }
 
 $env:WINDBG_MCP_LISTEN_TOKEN_FULL = $cfg.full
 $env:WINDBG_MCP_LISTEN_TOKEN_LEAN = $cfg.lean

--- a/tools/bench_listener.ps1
+++ b/tools/bench_listener.ps1
@@ -37,10 +37,24 @@ foreach ($client in 'full', 'lean', 'min') {
     }
 }
 
-# No unnamed token: that one would name a client called `local`, which is what the *editor*
-# connects as on the other listener. Two clients of one name on two ports is a confusion this
-# run does not need.
+# **Three inherited variables, each of which breaks this run in a different way.** The account
+# this lands in is whatever the ssh session gives you, and it may already be configured to run
+# this server.
+#
+#   WINDBG_MCP_LISTEN_TOKEN       would name a client called `local`, which is what the *editor*
+#                                 connects as on the other listener - two clients of one name on
+#                                 two ports is a confusion this run does not need.
+#   WINDBG_MCP_LISTEN_TOKEN_FILE  is worse than it looks: a configured file is the *whole*
+#                                 configuration and shuts the environment out entirely, named
+#                                 tokens included, so the three below would create no clients at
+#                                 all and every cell would fail authentication.
+#   WINDBG_MCP_TOOLS_FULL         would pair an inherited spec with the token minted below, so the
+#                                 51-tool control would be silently narrowed while this script
+#                                 still announces `full (all)` - a benchmark measuring a surface
+#                                 nobody chose.
 Remove-Item Env:WINDBG_MCP_LISTEN_TOKEN -ErrorAction SilentlyContinue
+Remove-Item Env:WINDBG_MCP_LISTEN_TOKEN_FILE -ErrorAction SilentlyContinue
+Remove-Item Env:WINDBG_MCP_TOOLS_FULL -ErrorAction SilentlyContinue
 
 $env:WINDBG_MCP_LISTEN_TOKEN_FULL = $cfg.full
 $env:WINDBG_MCP_LISTEN_TOKEN_LEAN = $cfg.lean

--- a/tools/bench_listener.ps1
+++ b/tools/bench_listener.ps1
@@ -20,7 +20,22 @@ if (-not $exe) { $exe = 'C:\workspace\windbg-mcp\target\release\windbg-mcp.exe' 
 $listen = $env:WINDBG_MCP_BENCH_ADDR
 if (-not $listen) { $listen = '127.0.0.1:8766' }
 
-$cfg = [Console]::In.ReadToEnd() | ConvertFrom-Json
+$raw = [Console]::In.ReadToEnd()
+if ([string]::IsNullOrWhiteSpace($raw)) {
+    throw 'nothing on stdin: pipe in the JSON token file, e.g. ... < bench-tokens.json'
+}
+$cfg = $raw | ConvertFrom-Json
+
+# Named here rather than discovered later. The server already refuses to start when a *tools*
+# spec names a client it has no token for, so a missing 'lean' or 'min' is caught - but a missing
+# 'full' has no spec beside it, so the listener would start happily with two clients and the
+# eval's whole first column would fail authentication one cell at a time. Say which surface is
+# missing, and never say what any of the values are.
+foreach ($client in 'full', 'lean', 'min') {
+    if ([string]::IsNullOrWhiteSpace($cfg.$client)) {
+        throw "the token file on stdin has no token for the '$client' client"
+    }
+}
 
 # No unnamed token: that one would name a client called `local`, which is what the *editor*
 # connects as on the other listener. Two clients of one name on two ports is a confusion this

--- a/tools/claude_code_drive.py
+++ b/tools/claude_code_drive.py
@@ -214,14 +214,14 @@ def release_new_sessions(before):
     except Exception as e:  # noqa: BLE001 - cleanup must not end the run
         print(f"  could not list sessions to clean up: {e}")
         return
-    for session in now:
-        if session in before:
-            continue
-        try:
-            drive.mcp("tools/call", {"name": "end_session", "arguments": {"session_id": session}})
-            print(f"  released {session}")
-        except Exception as e:  # noqa: BLE001
-            print(f"  could not release {session}: {e}")
+    # Through the shared helper, which reads the structured answer: this printed `released` for a
+    # session `end_session` had refused, and the next task then snapshotted that leftover as
+    # pre-existing - so it was skipped for ever and its target could take the following task's
+    # session-less calls.
+    kept = drive.end_sessions([s for s in now if s not in before])
+    if kept:
+        print(f"  {len(kept)} session(s) this task opened are still attached; the next task's "
+              f"isolation is not guaranteed")
 
 
 def main():

--- a/tools/claude_code_drive.py
+++ b/tools/claude_code_drive.py
@@ -30,6 +30,7 @@ import json
 import os
 import subprocess
 import sys
+import tempfile
 import time
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
@@ -53,20 +54,36 @@ SYSTEM = ("You are a Windows kernel debugging assistant. Use the provided tools 
           "Call one tool at a time and use its result. Be concise.")
 
 
-def mcp_config(path):
+def mcp_config(directory):
     """The one server this run may reach, carrying this cell's credential.
 
-    Written per run into the eval's own scratch directory rather than into the repo: it holds a
-    bearer token, and a config file in a checkout is a token in a checkout.
+    A file rather than an inline argument because `--mcp-config` also takes JSON on the command
+    line, and a token in `argv` is readable by every process on the box - the same rule the rest
+    of this bench follows.
+
+    Three things about *how* it is written, all of them the same lesson from
+    [#189](https://github.com/glslang/windbg-mcp/pull/189): do not write a secret into a
+    directory whose protection this program does not control.
+
+    - The directory is one this process makes (`mkdtemp`, mode 0700), unless `EVAL_SCRATCH`
+      names one. It is never the working directory - a fallback to `.` writes a bearer token
+      into the checkout the moment somebody runs this script by hand.
+    - The file is created **with** mode 0600 rather than chmod'd afterwards. Creating it under
+      the process umask and tightening it later leaves a window where the token is on disk and
+      world-readable.
+    - `O_EXCL`, so this never writes through a symlink somebody left in the directory.
+
+    The caller removes it on the way out.
     """
+    path = os.path.join(directory, f"mcp-{os.getpid()}.json")
     config = {"mcpServers": {SERVER: {
         "type": "http",
         "url": drive.MCP_URL,
         "headers": {"Authorization": drive.AUTH},
     }}}
-    with open(path, "w", encoding="utf-8") as f:
+    fd = os.open(path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+    with os.fdopen(fd, "w", encoding="utf-8") as f:
         json.dump(config, f)
-    os.chmod(path, 0o600)
     return path
 
 
@@ -198,9 +215,11 @@ def main():
     surface_bytes = len(json.dumps(offered, separators=(",", ":")))
     print(f"tools offered: {len(tools)} ({surface_bytes} B, measured as the ollama rows are)")
 
-    scratch = os.environ.get("EVAL_SCRATCH") or os.path.dirname(
-        os.environ.get("WINDBG_MCP_EVAL_OUT", "") or ".") or "."
-    config_path = mcp_config(os.path.join(scratch, f"mcp-{os.getpid()}.json"))
+    scratch = os.environ.get("EVAL_SCRATCH", "")
+    owned = not scratch
+    if owned:
+        scratch = tempfile.mkdtemp(prefix="windbg-eval-")
+    config_path = mcp_config(scratch)
     cell = {
         "run": os.environ.get("EVAL_RUN", time.strftime("%Y%m%dT%H%M%S")),
         "backend": "claude-code",
@@ -223,6 +242,8 @@ def main():
             release_new_sessions(before)
     finally:
         os.remove(config_path)
+        if owned:
+            os.rmdir(scratch)
         drive.close_transport_session()
 
 

--- a/tools/claude_code_drive.py
+++ b/tools/claude_code_drive.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""Drive this server from Claude Code headlessly, into the same eval record as a local model.
+
+The matrix in `local_model_eval.py` needs a frontier row, and the cheapest honest one is the
+harness that is already installed: `claude -p` speaks MCP to the same listener, presenting the
+same per-client bearer token, so **the surface axis works identically** - `full`, `lean` and
+`min` are the same three credentials, narrowed by the server rather than by anything here.
+
+    WINDBG_MCP_TOKEN=<the surface's token> CLAUDE_MODEL=opus \\
+      python3 tools/claude_code_drive.py tools/eval_tasks.json
+
+**What this row is not.** A local model here is a bare `POST /api/chat` loop: one system
+prompt, the tool list, nothing else. Claude Code brings its own system prompt, its own
+conversation shape and prompt caching, so the *token* columns are not comparable with the
+ollama rows and the record says so (`harness: claude-code`). What is comparable is what the
+matrix is actually about: which tools get picked out of a given surface, whether the answer
+is right, and what a task costs in tool results.
+
+Two fences, both deliberate:
+
+- `--strict-mcp-config` so the run cannot fall back on the editor's registered `windbg-vm`
+  server. That one carries a *different* credential, which would put these sessions in the
+  editor's namespace and silently give every cell the whole 51-tool surface - the surface
+  axis would then be measuring nothing.
+- `--disallowedTools` for the built-ins. Without it the frontier row can answer a question
+  about a dump by reading this repository's own documentation, which is a true answer to the
+  wrong question.
+"""
+import json
+import os
+import subprocess
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import local_model_drive as drive  # noqa: E402 - the MCP plumbing, one implementation of it
+
+MODEL = os.environ.get("CLAUDE_MODEL", "opus")
+MAX_TURNS = int(os.environ.get("MAX_STEPS", "6"))
+SERVER = "windbg"
+
+# The same read-only fence the local harness applies, in Claude Code's naming. Anything else -
+# `launch`, `execute`, `debug_batch` - is simply not allowed, so a wrong pick is refused rather
+# than performed, and the refusal is recorded.
+ALLOWED = [f"mcp__{SERVER}__{name}" for name in sorted(drive.ALLOWED)]
+
+# Everything the harness itself brings. A frontier model with `Bash` can answer "what bug check
+# is in that dump" by grepping this repo, which measures the repository rather than the server.
+DISALLOWED = ["Bash", "Read", "Write", "Edit", "MultiEdit", "NotebookEdit", "Glob", "Grep",
+              "WebFetch", "WebSearch", "Task", "Agent", "TodoWrite", "SlashCommand"]
+
+SYSTEM = ("You are a Windows kernel debugging assistant. Use the provided tools to answer. "
+          "Call one tool at a time and use its result. Be concise.")
+
+
+def mcp_config(path):
+    """The one server this run may reach, carrying this cell's credential.
+
+    Written per run into the eval's own scratch directory rather than into the repo: it holds a
+    bearer token, and a config file in a checkout is a token in a checkout.
+    """
+    config = {"mcpServers": {SERVER: {
+        "type": "http",
+        "url": drive.MCP_URL,
+        "headers": {"Authorization": drive.AUTH},
+    }}}
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(config, f)
+    os.chmod(path, 0o600)
+    return path
+
+
+def one_task(task, config_path):
+    """Run one task in its own `claude -p` conversation, and record what it did."""
+    prompt = task["prompt"] if isinstance(task, dict) else task
+    report = {"task": task.get("id") if isinstance(task, dict) else None, "prompt": prompt,
+              "turns": [], "calls": [], "answer": None, "steps": 0, "gave_up": False,
+              "error": None, "harness": "claude-code"}
+    argv = [
+        "claude", "-p", prompt,
+        "--model", MODEL,
+        "--mcp-config", config_path, "--strict-mcp-config",
+        "--allowedTools", ",".join(ALLOWED),
+        "--disallowedTools", ",".join(DISALLOWED),
+        "--system-prompt", SYSTEM,
+        "--max-turns", str(MAX_TURNS),
+        "--output-format", "stream-json", "--verbose",
+    ]
+    started = time.time()
+    proc = subprocess.run(argv, capture_output=True, text=True, timeout=1800)
+    report["wall_s"] = round(time.time() - started, 1)
+    if proc.returncode != 0:
+        report["error"] = f"claude exited {proc.returncode}: {proc.stderr[:400]}"
+        return report
+
+    pending = {}
+    for line in proc.stdout.splitlines():
+        line = line.strip()
+        if not line.startswith("{"):
+            continue
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        kind = event.get("type")
+        if kind == "assistant":
+            message = event.get("message", {})
+            usage = message.get("usage") or {}
+            report["turns"].append({
+                "prompt_tokens": (usage.get("input_tokens", 0)
+                                  + usage.get("cache_creation_input_tokens", 0)
+                                  + usage.get("cache_read_input_tokens", 0)),
+                "eval_tokens": usage.get("output_tokens"),
+            })
+            report["steps"] += 1
+            for block in message.get("content") or []:
+                if block.get("type") == "tool_use":
+                    raw = block.get("name") or ""
+                    name = raw.replace(f"mcp__{SERVER}__", "")
+                    pending[block.get("id")] = {
+                        "name": name, "args": block.get("input") or {}, "ok": None, "chars": 0,
+                        # A call that is not this server's is the *harness* working - Claude
+                        # Code's own `ToolSearch` fetching a deferred schema, say. Recorded, and
+                        # kept out of the tool-choice arithmetic: scoring it as a wrong pick
+                        # would blame the model for a feature of the client it runs in.
+                        "harness_tool": not raw.startswith(f"mcp__{SERVER}__"),
+                        "verdict": "unknown", "excerpt": ""}
+        elif kind == "user":
+            for block in (event.get("message", {}).get("content") or []):
+                if block.get("type") != "tool_result":
+                    continue
+                call = pending.pop(block.get("tool_use_id"), None)
+                if call is None:
+                    continue
+                content = block.get("content")
+                text = content if isinstance(content, str) else json.dumps(content)
+                call["chars"] = len(text)
+                call["excerpt"] = text[:300]
+                failed = bool(block.get("is_error"))
+                call["ok"] = not failed
+                # The same three-way split the local harness records, read off the only
+                # signal this route gives: a refusal names the tool, an off-surface call
+                # says so in the server's own words, and anything else that failed is an
+                # error the model made with a tool it did have.
+                lowered = text.lower()
+                if call["harness_tool"]:
+                    call["verdict"] = "harness_tool"
+                elif not failed:
+                    call["verdict"] = "ok"
+                elif "permission" in lowered or "not allowed" in lowered:
+                    call["verdict"] = "refused_by_harness"
+                else:
+                    call["verdict"] = "error"
+                report["calls"].append(call)
+        elif kind == "result":
+            report["answer"] = event.get("result")
+            report["usage"] = event.get("usage")
+            report["total_cost_usd"] = event.get("total_cost_usd")
+            if event.get("subtype") == "error_max_turns":
+                report["gave_up"] = True
+    report["first_prompt_tokens"] = (report["turns"][0]["prompt_tokens"]
+                                     if report["turns"] else None)
+    for call in pending.values():
+        # A tool call whose result never came back - the turn cap fell between them.
+        call["verdict"] = "unanswered"
+        report["calls"].append(call)
+    return report
+
+
+def release_new_sessions(before):
+    """End every session this credential gained while the task ran.
+
+    Claude Code has no idea it is being measured and will not tidy up after itself, and a dump
+    left open is a worker holding a target for the whole lease grace - which the next cell
+    then either adopts or trips the four-session cap against. Bounded by the snapshot for the
+    same reason the local harness bounds its own: what was already here is not this run's.
+    """
+    try:
+        now = drive.live_sessions()
+    except Exception as e:  # noqa: BLE001 - cleanup must not end the run
+        print(f"  could not list sessions to clean up: {e}")
+        return
+    for session in now:
+        if session in before:
+            continue
+        try:
+            drive.mcp("tools/call", {"name": "end_session", "arguments": {"session_id": session}})
+            print(f"  released {session}")
+        except Exception as e:  # noqa: BLE001
+            print(f"  could not release {session}: {e}")
+
+
+def main():
+    print(f"model: claude-code/{MODEL}")
+    print("MCP revision negotiated:", drive.handshake())
+    tools = drive.mcp("tools/list")["result"]["tools"]
+    offered = drive.as_ollama(tools)
+    surface_bytes = len(json.dumps(offered, separators=(",", ":")))
+    print(f"tools offered: {len(tools)} ({surface_bytes} B, measured as the ollama rows are)")
+
+    scratch = os.environ.get("EVAL_SCRATCH") or os.path.dirname(
+        os.environ.get("WINDBG_MCP_EVAL_OUT", "") or ".") or "."
+    config_path = mcp_config(os.path.join(scratch, f"mcp-{os.getpid()}.json"))
+    cell = {
+        "run": os.environ.get("EVAL_RUN", time.strftime("%Y%m%dT%H%M%S")),
+        "backend": "claude-code",
+        "model": MODEL,
+        "num_ctx": None,
+        "surface": {"client": os.environ.get("EVAL_SURFACE", ""), "tools": len(tools),
+                    "bytes": surface_bytes, "names": sorted(t["name"] for t in tools)},
+    }
+    tasks = drive.load_tasks(sys.argv[1]) if len(sys.argv) > 1 else []
+    try:
+        for i, task in enumerate(tasks, 1):
+            prompt = task["prompt"] if isinstance(task, dict) else task
+            print(f"\n=== task {i}: {prompt[:110]}")
+            before = set(drive.live_sessions())
+            report = one_task(task, config_path)
+            drive.write_record(dict(cell, **report))
+            print(f"  [{report['wall_s']}s] {len(report['calls'])} call(s): "
+                  f"{', '.join(c['name'] for c in report['calls']) or 'none'}")
+            print(f"  answer: {(report.get('answer') or report.get('error') or '')[:300]}")
+            release_new_sessions(before)
+    finally:
+        os.remove(config_path)
+        drive.close_transport_session()
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/claude_code_drive.py
+++ b/tools/claude_code_drive.py
@@ -104,10 +104,27 @@ def one_task(task, config_path):
         "--output-format", "stream-json", "--verbose",
     ]
     started = time.time()
-    proc = subprocess.run(argv, capture_output=True, text=True, timeout=1800)
+    try:
+        proc = subprocess.run(argv, capture_output=True, text=True, timeout=1800)
+    except subprocess.TimeoutExpired:
+        # **The task's result, not the run's accident.** Letting this escape would end the whole
+        # cell at whichever task hit it, leaving the ones after it with no record and the log with
+        # no reason - and the runner's own budget cannot be relied on to fire first, since a cell
+        # may be given a longer one than this.
+        report["error"] = "claude did not answer within 1800s"
+        report["wall_s"] = round(time.time() - started, 1)
+        return report
     report["wall_s"] = round(time.time() - started, 1)
     if proc.returncode != 0:
-        report["error"] = f"claude exited {proc.returncode}: {proc.stderr[:400]}"
+        # **The reason, not the first 400 bytes.** Claude Code prints a schema warning per
+        # `format` keyword this server's output schemas use, which is harmless and long enough to
+        # fill any prefix - the first cut of this reported `unknown format "uint" ignored` as the
+        # cause of every failure. Drop the known noise and keep the tail, which is where a real
+        # reason lands.
+        noise = [line for line in proc.stderr.splitlines()
+                 if "unknown format" not in line and line.strip()]
+        report["error"] = (f"claude exited {proc.returncode}: "
+                           + (" | ".join(noise[-4:])[:400] or "(no stderr but schema warnings)"))
         return report
 
     pending = {}

--- a/tools/eval_plan.json
+++ b/tools/eval_plan.json
@@ -1,0 +1,31 @@
+{
+  "run": "2026-08-23",
+  "tasks": "tools/eval_tasks.json",
+  "url": "http://127.0.0.1:8766/",
+  "out": "eval-out/results.jsonl",
+  "logs": "eval-out/logs",
+  "max_steps": 6,
+  "keep_alive": "10m",
+  "surfaces": [
+    { "client": "full", "spec": "all",                   "tools": 51 },
+    { "client": "lean", "spec": "session,inspect,crash", "tools": 20 },
+    { "client": "min",  "spec": "crash",                 "tools": 11 }
+  ],
+  "cells": [
+    { "backend": "ollama",
+      "models": ["qwen3.8:27b-mlx", "gemma4:31b-mlx", "nemotron-3.5-lightning:30b-mlx"],
+      "contexts": [262144],
+      "surfaces": ["full", "lean", "min"],
+      "budget_s": 2400 },
+    { "backend": "ollama",
+      "models": ["qwen3.8:27b-mlx", "gemma4:31b-mlx", "nemotron-3.5-lightning:30b-mlx"],
+      "contexts": [32768, 8192],
+      "surfaces": ["full", "lean", "min"],
+      "subset": "short",
+      "budget_s": 1200 },
+    { "backend": "claude-code",
+      "models": ["opus", "sonnet"],
+      "surfaces": ["full", "lean", "min"],
+      "budget_s": 1200 }
+  ]
+}

--- a/tools/eval_tasks.json
+++ b/tools/eval_tasks.json
@@ -40,9 +40,7 @@
       "expect": [
         [
           "messagemanager"
-        ]
-      ],
-      "bonus": [
+        ],
         [
           "0x1654",
           "1654"

--- a/tools/eval_tasks.json
+++ b/tools/eval_tasks.json
@@ -1,0 +1,180 @@
+{
+  "suite": "windbg-mcp local-model eval v1",
+  "note": "Six tasks with a mechanical answer key, read off the checked-in sample dumps with this server's own tools before any model saw them (2026-08-23). `needs` names the tool group a task cannot be answered without, which is what makes the surface axis predictive rather than decorative: `session` is in every surface, `crash` is in two of the three, `ioctl` only in the whole one. `expect` is a list of groups, all of which must appear in the final answer, any alternative within a group counting; `bonus` is recorded but never decides pass/fail. `possible_on` names the surfaces on which the answer key is reachable at all, which is what keeps a narrowed surface from being scored as a stupid model: on `min` three of the six tasks have no tool that can answer them. Two tasks are reachable on every surface because `open_dump`'s own summary carries the bug check and the module count - the opener is doing more work than the tool table suggests.",
+  "tasks": [
+    {
+      "id": "bugcheck",
+      "needs": "crash",
+      "possible_on": [
+        "full",
+        "lean",
+        "min"
+      ],
+      "prompt": "There is a Windows kernel crash dump on the debug host at C:\\workspace\\windbg-mcp\\docs\\samples\\081226-2187-01.dmp. What bug check did this machine stop on? Give the code and its name.",
+      "expect": [
+        [
+          "0x13a",
+          "13a"
+        ],
+        [
+          "heap corruption",
+          "heap_corruption"
+        ]
+      ],
+      "useful_tools": [
+        "open_dump",
+        "crash_triage",
+        "session_status",
+        "end_session"
+      ]
+    },
+    {
+      "id": "driver_blame",
+      "needs": "crash",
+      "possible_on": [
+        "full",
+        "lean",
+        "min"
+      ],
+      "prompt": "In the kernel crash dump C:\\workspace\\windbg-mcp\\docs\\samples\\081226-2187-01.dmp, which third-party driver is responsible for the crash, and at what offset into that driver did it fault?",
+      "expect": [
+        [
+          "messagemanager"
+        ]
+      ],
+      "bonus": [
+        [
+          "0x1654",
+          "1654"
+        ]
+      ],
+      "useful_tools": [
+        "open_dump",
+        "crash_triage",
+        "backtrace",
+        "modules",
+        "session_status",
+        "end_session"
+      ]
+    },
+    {
+      "id": "module_count",
+      "needs": "session",
+      "possible_on": [
+        "full",
+        "lean",
+        "min"
+      ],
+      "prompt": "How many modules are loaded in the kernel crash dump C:\\workspace\\windbg-mcp\\docs\\samples\\052126-34312-01.dmp?",
+      "expect": [
+        [
+          "227"
+        ]
+      ],
+      "useful_tools": [
+        "open_dump",
+        "modules",
+        "session_status",
+        "end_session"
+      ]
+    },
+    {
+      "id": "unloaded_driver",
+      "needs": "inspect",
+      "possible_on": [
+        "full",
+        "lean"
+      ],
+      "prompt": "In the kernel crash dump C:\\workspace\\windbg-mcp\\docs\\samples\\052126-34312-01.dmp, is the driver nvhda64v.sys loaded? If it is not, is there any record of it having been loaded earlier?",
+      "expect": [
+        [
+          "not loaded",
+          "no longer loaded",
+          "not currently",
+          "isn't loaded",
+          "is not loaded",
+          "unloaded"
+        ],
+        [
+          "unload"
+        ],
+        [
+          "26"
+        ]
+      ],
+      "useful_tools": [
+        "open_dump",
+        "modules",
+        "session_status",
+        "end_session"
+      ]
+    },
+    {
+      "id": "arm64_pc",
+      "needs": "inspect",
+      "possible_on": [
+        "full",
+        "lean",
+        "min"
+      ],
+      "prompt": "Open the ARM64 kernel crash dump C:\\workspace\\windbg-mcp\\docs\\samples\\121524-4703-01.dmp and tell me the value of the pc register at the point of the crash.",
+      "expect": [
+        [
+          "0xfffff8013c65bca8",
+          "fffff8013c65bca8",
+          "fffff801`3c65bca8"
+        ]
+      ],
+      "useful_tools": [
+        "open_dump",
+        "registers",
+        "backtrace",
+        "session_status",
+        "end_session"
+      ],
+      "note": "`registers` is the direct route; `crash_triage` frame 0 carries the same address on this dump, which is why every surface can reach it."
+    },
+    {
+      "id": "ioctl_decode",
+      "needs": "ioctl",
+      "possible_on": [
+        "full"
+      ],
+      "prompt": "Decode the Windows IOCTL control code 0x22200B: device type, function code, transfer method and required access.",
+      "expect": [
+        [
+          "0x22",
+          "0x0022"
+        ],
+        [
+          "0x802",
+          "802"
+        ],
+        [
+          "neither"
+        ],
+        [
+          "any access",
+          "any_access"
+        ]
+      ],
+      "useful_tools": [
+        "decode_ioctl"
+      ]
+    }
+  ],
+  "subsets": {
+    "short": [
+      "bugcheck",
+      "module_count",
+      "ioctl_decode"
+    ]
+  },
+  "answer_key": {
+    "081226-2187-01.dmp": "x64, 0x13a KERNEL_MODE_HEAP_CORRUPTION, 158 modules, faulting frame MessageManager+0x1654, process mm_exploit_v5.exe, pool tag TNf_",
+    "052126-34312-01.dmp": "x64, 0x9f DRIVER_POWER_STATE_FAILURE, 227 modules loaded, nvhda64v.sys not loaded with 26 unload records",
+    "121524-4703-01.dmp": "ARM64, 0xfc ATTEMPTED_EXECUTE_OF_NOEXECUTE_MEMORY, 177 modules, pc 0xfffff8013c65bca8",
+    "082126-7015-01.dmp": "ARM64, 0x139 KERNEL_SECURITY_CHECK_FAILURE, 181 modules, faulting frame HEVD+0x10dc, process powershell.exe",
+    "0x22200B": "DeviceType 0x0022, FunctionCode 0x802, METHOD_NEITHER, FILE_ANY_ACCESS"
+  }
+}

--- a/tools/eval_tasks.json
+++ b/tools/eval_tasks.json
@@ -1,6 +1,6 @@
 {
   "suite": "windbg-mcp local-model eval v1",
-  "note": "Six tasks with a mechanical answer key, read off the checked-in sample dumps with this server's own tools before any model saw them (2026-08-23). `needs` names the tool group a task cannot be answered without, which is what makes the surface axis predictive rather than decorative: `session` is in every surface, `crash` is in two of the three, `ioctl` only in the whole one. `expect` is a list of groups, all of which must appear in the final answer, any alternative within a group counting; `bonus` is recorded but never decides pass/fail. `possible_on` names the surfaces on which the answer key is reachable at all, which is what keeps a narrowed surface from being scored as a stupid model: on `min` three of the six tasks have no tool that can answer them. Two tasks are reachable on every surface because `open_dump`'s own summary carries the bug check and the module count - the opener is doing more work than the tool table suggests.",
+  "note": "Six tasks with a mechanical answer key, read off the checked-in sample dumps with this server's own tools before any model saw them (2026-08-23). `needs` names the tool group a task cannot be answered without, which is what makes the surface axis predictive rather than decorative: `session` is in every surface whatever a spec says, `crash` is in all three of these, `inspect` in two of them, and `ioctl` only in the whole one. `expect` is a list of groups, all of which must appear in the final answer, any alternative within a group counting; `bonus` is recorded but never decides pass/fail. `possible_on` names the surfaces on which the answer key is reachable at all, which is what keeps a narrowed surface from being scored as a stupid model: on `min` three of the six tasks have no tool that can answer them. Two tasks are reachable on every surface because `open_dump`'s own summary carries the bug check and the module count - the opener is doing more work than the tool table suggests.",
   "tasks": [
     {
       "id": "bugcheck",
@@ -83,7 +83,7 @@
         "full",
         "lean"
       ],
-      "prompt": "In the kernel crash dump C:\\workspace\\windbg-mcp\\docs\\samples\\052126-34312-01.dmp, is the driver nvhda64v.sys loaded? If it is not, is there any record of it having been loaded earlier?",
+      "prompt": "In the kernel crash dump C:\\workspace\\windbg-mcp\\docs\\samples\\052126-34312-01.dmp, is the driver nvhda64v.sys loaded? If it is not, how many records of it having been loaded earlier does the dump still carry?",
       "expect": [
         [
           "not loaded",
@@ -166,6 +166,9 @@
       "bugcheck",
       "module_count",
       "ioctl_decode"
+    ],
+    "unloaded": [
+      "unloaded_driver"
     ]
   },
   "answer_key": {

--- a/tools/local_model_drive.py
+++ b/tools/local_model_drive.py
@@ -524,6 +524,35 @@ def close_transport_session():
         SESSION = None
 
 
+def end_sessions(sessions):
+    """End each of these sessions; hand back the ones that are still there afterwards.
+
+    **Read the structured answer, not the absence of an exception.** `end_session` reports an
+    ordinary failure as a perfectly good MCP result carrying an error - a stale handle, a worker
+    that will not let go - so a caller that treats "no exception" as "released" announces a clean
+    namespace it has not got. Two of this bench's three cleanup paths did exactly that, in their
+    own words, which is why there is now one of these instead of three.
+
+    `stale_session` and `worker_lost` count as released: both mean the target is gone, which is
+    what the caller wanted.
+    """
+    kept = []
+    for session in sessions:
+        try:
+            out = mcp("tools/call", {"name": "end_session", "arguments": {"session_id": session}})
+            error = ((out.get("result") or {}).get("structuredContent") or {}).get("error") or {}
+            category = error.get("category")
+            if not error or category in ("stale_session", "worker_lost"):
+                print(f"  released {session}")
+                continue
+            kept.append(session)
+            print(f"  could not release {session}: {error.get('message', category)}")
+        except Exception as e:  # noqa: BLE001 - a cleanup failure is reported, never raised
+            kept.append(session)
+            print(f"  could not release {session}: {e}")
+    return kept
+
+
 def release_what_this_run_opened():
     """End the run's own sessions, so the next one starts from nothing.
 
@@ -535,24 +564,7 @@ def release_what_this_run_opened():
     # **What could not be released stays on the list.** Clearing it regardless would
     # leave the final pass with nothing to retry, and the next task routing its
     # session-less calls to a target this one was supposed to have let go.
-    kept = []
-    for session in list(OPENED):
-        try:
-            out = mcp("tools/call", {"name": "end_session", "arguments": {"session_id": session}})
-            error = ((out.get("result") or {}).get("structuredContent") or {}).get("error") or {}
-            category = error.get("category")
-            if not error:
-                print(f"  released {session}")
-            elif category in ("stale_session", "worker_lost"):
-                # Gone either way, so there is nothing left to retry.
-                print(f"  {session} was already gone ({category})")
-            else:
-                kept.append(session)
-                print(f"  could not release {session}: {error.get('message', category)}")
-        except Exception as e:
-            kept.append(session)
-            print(f"  could not release {session}: {e}")
-    OPENED[:] = kept
+    OPENED[:] = end_sessions(list(OPENED))
 
 
 def load_tasks(path):
@@ -631,13 +643,14 @@ def release_everything():
     except Exception as e:  # noqa: BLE001 - cleanup is best effort by construction
         print(f"  could not list sessions to release: {e}")
         sessions = []
-    for session in sessions:
-        try:
-            mcp("tools/call", {"name": "end_session", "arguments": {"session_id": session}})
-            print(f"  released {session}")
-        except Exception as e:  # noqa: BLE001
-            print(f"  could not release {session}: {e}")
+    kept = end_sessions(sessions)
     close_transport_session()
+    if kept:
+        # **The one caller reads this.** A preflight that cannot clear the namespace has not made
+        # the cell that follows it clean, and saying so is the whole difference between a
+        # best-effort cleanup and one that quietly did nothing.
+        raise SystemExit(f"{len(kept)} session(s) still attached after the release: "
+                         + ", ".join(kept))
 
 
 def main():

--- a/tools/local_model_drive.py
+++ b/tools/local_model_drive.py
@@ -310,6 +310,11 @@ def chat(messages, tools):
             return json.load(response)
     except urllib.error.HTTPError as e:
         raise ChatFailed(f"HTTP {e.code}: {e.read().decode('utf-8', 'replace')[:400]}") from e
+    except urllib.error.URLError as e:
+        # A runtime that died, was restarted, or refused the connection is the same kind of fact
+        # as one that returned 500 - the cell records it and the grid goes on. Ordered after
+        # `HTTPError`, which is a subclass of this.
+        raise ChatFailed(f"no answer from the runtime: {e.reason}") from e
 
 
 def call_tool(name, args):
@@ -562,7 +567,8 @@ def load_tasks(path):
     `EVAL_SUBSET` names one of the file's own `subsets`, which is how the reduced-context
     cells run three tasks rather than six without a second file to keep in step.
     """
-    loaded = json.load(open(path))
+    with open(path, encoding="utf-8") as f:
+        loaded = json.load(f)
     if isinstance(loaded, list):
         return loaded
     tasks = loaded["tasks"]

--- a/tools/local_model_drive.py
+++ b/tools/local_model_drive.py
@@ -612,8 +612,39 @@ def write_record(record):
         log.write(json.dumps(record, default=str) + "\n")
 
 
+def release_everything():
+    """End every session this credential holds, and say goodbye to the MCP session.
+
+    For the one case the per-run fence cannot cover: a cell killed at its wall-clock budget, whose
+    driver never reached its own cleanup. Whatever it had open then stays attached until the
+    listener's lease expires, and the next cell on the same surface either routes a
+    `session_id`-less call to a stranger's target or meets the four-session cap.
+
+    **Deliberately everything, not just what a run opened** - there is no run here to have opened
+    anything. That is only safe because of the rule the rest of this bench is built on: the
+    credential belongs to this run alone (`docs/local-model-eval.md`). Pointed at a shared token it
+    would end somebody's sessions, which is the same reason the script refuses to borrow one.
+    """
+    handshake()
+    try:
+        sessions = live_sessions()
+    except Exception as e:  # noqa: BLE001 - cleanup is best effort by construction
+        print(f"  could not list sessions to release: {e}")
+        sessions = []
+    for session in sessions:
+        try:
+            mcp("tools/call", {"name": "end_session", "arguments": {"session_id": session}})
+            print(f"  released {session}")
+        except Exception as e:  # noqa: BLE001
+            print(f"  could not release {session}: {e}")
+    close_transport_session()
+
+
 def main():
     global MODEL
+    if "--release" in sys.argv[1:]:
+        release_everything()
+        return
     MODEL = pick_model()
     print(f"model: {MODEL}")
     print("MCP revision negotiated:", handshake())

--- a/tools/local_model_drive.py
+++ b/tools/local_model_drive.py
@@ -31,6 +31,17 @@ Configuration:
                         than a conversation and a target apiece
     WINDBG_MCP_KEEPALIVE  seconds of silence after which this run pings the listener to
                         keep its lease alive (default 120; `0` disables) — see below
+    NUM_CTX             context window to serve this run at, in tokens; empty means
+                        whatever `OLLAMA_CONTEXT_LENGTH` already decides. This is the
+                        eval's context axis — see `chat`
+    OLLAMA_KEEP_ALIVE   how long the runtime keeps the model resident after a request
+                        (default `10m`); `0` evicts it, which is what frees the box
+                        between one model's cells and the next
+    WINDBG_MCP_EVAL_OUT a file to append one JSON record per task to, for
+                        `local_model_eval.py` to grade. Without it this script prints
+                        and keeps nothing, which is what it did before the eval existed
+    MAX_STEPS           tool-calling turns a task may take before it is given up on
+                        (default 6)
 
 **Why the keepalive exists.** The listener releases a client's sessions when its lease
 runs out, and the grace is derived from how long a *call* may take, on the assumption
@@ -45,11 +56,15 @@ import os
 import sys
 import threading
 import time
+import urllib.error
 import urllib.request
 
 MCP_URL = os.environ.get("WINDBG_MCP_URL", "http://127.0.0.1:8765/")
 OLLAMA = os.environ.get("OLLAMA_URL", "http://localhost:11434/api/chat")
 MODEL = os.environ.get("LOCAL_MODEL", "")
+NUM_CTX = int(os.environ.get("NUM_CTX", "0") or 0)
+KEEP_ALIVE = os.environ.get("OLLAMA_KEEP_ALIVE", "10m")
+EVAL_OUT = os.environ.get("WINDBG_MCP_EVAL_OUT", "")
 REVISION = "2025-06-18"
 
 # Tool calls this harness will actually execute. Everything else is reported back
@@ -66,7 +81,7 @@ ALLOWED = {
     "read_memory", "server_log",
 }
 
-MAX_STEPS = 6
+MAX_STEPS = int(os.environ.get("MAX_STEPS", "6"))
 
 # The debug sessions this run opened, which are the only ones it may end — and the
 # ones it ends on the way out, so a run does not leave a worker holding a target for
@@ -268,24 +283,60 @@ def as_ollama(tools):
     }} for tool in tools]
 
 
+class ChatFailed(Exception):
+    """The runtime refused the request, which for this harness is a result rather than a crash.
+
+    A surface that does not fit the served window is the whole point of the context axis, and
+    the way it presents is an HTTP error carrying a sentence about tokens — so a run that let
+    `urlopen` raise would lose the one fact the cell was measuring. The body travels with the
+    exception and into the record.
+    """
+
+
 def chat(messages, tools):
-    body = {"model": MODEL, "messages": messages, "tools": tools, "stream": False, "think": False}
+    body = {"model": MODEL, "messages": messages, "tools": tools, "stream": False,
+            "think": False, "keep_alive": KEEP_ALIVE}
+    if NUM_CTX:
+        # **The window is a property of the runtime, not of the model.** `ollama show` reports
+        # what the weights could take; what a request is actually served is
+        # `OLLAMA_CONTEXT_LENGTH` unless a request says otherwise, and this is that override —
+        # the eval's context axis is this number moving. Setting it *reloads* the model, so the
+        # matrix runs every surface at one context before it moves to the next.
+        body["options"] = {"num_ctx": NUM_CTX}
     req = urllib.request.Request(OLLAMA, data=json.dumps(body).encode(), method="POST")
     req.add_header("Content-Type", "application/json")
-    with urllib.request.urlopen(req, timeout=1800) as response:
-        return json.load(response)
+    try:
+        with urllib.request.urlopen(req, timeout=1800) as response:
+            return json.load(response)
+    except urllib.error.HTTPError as e:
+        raise ChatFailed(f"HTTP {e.code}: {e.read().decode('utf-8', 'replace')[:400]}") from e
 
 
 def call_tool(name, args):
-    """Run one tool call. Returns (text for the model, ok, full size in characters)."""
+    """Run one tool call, and hand back a record of it whose `text` is what the model sees.
+
+    A record rather than a bare answer because the eval grades *how* a call went, and the
+    three ways it can fail are not the same finding: `refused_by_harness` is this script's
+    read-only fence, `error` is the server saying no — which on a narrowed surface is the
+    tool not being served at all — and `transport_error` is the link. Counting them together
+    would report a model that invented a tool and a model that asked for a bad address as
+    having made the same mistake.
+    """
+    started = time.time()
+    def record(text, ok, chars, verdict):
+        return {"name": name, "args": args, "ok": ok, "chars": chars, "verdict": verdict,
+                "took_s": round(time.time() - started, 1), "text": text,
+                "excerpt": text[:300]}
     if name not in ALLOWED:
-        return f"refused: `{name}` is not permitted in this harness", None, 0
+        return record(f"refused: `{name}` is not permitted in this harness",
+                      None, 0, "refused_by_harness")
     if name == "end_session" and args.get("session_id") not in OPENED:
         # One rule, and it covers the call that names nothing: without a `session_id`
         # the server ends this credential's *current* session, which may be a
         # predecessor's leftover rather than anything this run opened.
-        return (f"refused: `{args.get('session_id') or 'the current session'}` was not opened by "
-                "this run, so it is not this harness's to end"), None, 0
+        return record(
+            f"refused: `{args.get('session_id') or 'the current session'}` was not opened by "
+            "this run, so it is not this harness's to end", None, 0, "refused_by_harness")
     try:
         out = mcp("tools/call", {"name": name, "arguments": args})
     except Exception as e:  # a transport failure is a result the model can react to
@@ -295,7 +346,7 @@ def call_tool(name, args):
             # ever name that handle: the model retries and gets a second target, and
             # the cleanup has nothing to release. Ask what exists instead of assuming.
             reconcile_opened()
-        return f"transport error: {e}", False, 0
+        return record(f"transport error: {e}", False, 0, "transport_error")
     result = out.get("result", {})
     # **Both kinds of failure.** A protocol error arrives as a top-level `error`; an
     # ordinary tool failure — a bad address, a stale handle — arrives as a perfectly
@@ -316,7 +367,7 @@ def call_tool(name, args):
         OPENED[:] = [s for s in OPENED if s != args.get("session_id")]
     if RESULT_LIMIT and size > RESULT_LIMIT:
         text = text[:RESULT_LIMIT] + f"\n[truncated by the harness: {size} characters in full]"
-    return text, ok, size
+    return record(text, ok, size, "ok" if ok else "error")
 
 
 def run(task, tools, transcript=None):
@@ -327,38 +378,74 @@ def run(task, tools, transcript=None):
     means something. Keeping the *session* and dropping the *messages* would be a
     continuing investigation the model cannot remember — target reuse dressed up as
     one, which is what the flag would then be lying about.
+
+    Beside the transcript it hands back a **record** of the task — turns, tokens, every
+    tool call and what became of it — which is what `WINDBG_MCP_EVAL_OUT` writes and
+    `local_model_eval.py` grades. Nothing here decides whether an answer is right: this
+    script drives, and grading against the answer key happens where the key is.
     """
+    prompt = task["prompt"] if isinstance(task, dict) else task
+    report = {
+        "task": task.get("id") if isinstance(task, dict) else None,
+        "prompt": prompt, "turns": [], "calls": [], "answer": None,
+        "steps": 0, "gave_up": False, "error": None,
+    }
+    started_task = time.time()
     messages = transcript or [
         {"role": "system", "content":
          "You are a Windows kernel debugging assistant. Use the provided tools to answer. "
          "Call one tool at a time and use its result. Be concise."},
     ]
-    messages.append({"role": "user", "content": task})
+    messages.append({"role": "user", "content": prompt})
     first_prompt_tokens = None
     for step in range(MAX_STEPS):
         started = time.time()
-        out = chat(messages, tools)
+        try:
+            out = chat(messages, tools)
+        except ChatFailed as e:
+            # The cell's answer, not its accident: a window too small for the surface, a
+            # runtime that would not load the model. Recorded and the task ends here.
+            report["error"] = str(e)
+            report["wall_s"] = round(time.time() - started_task, 1)
+            print(f"  chat failed: {e}")
+            return messages, report
         took = round(time.time() - started, 1)
         message = out.get("message", {})
+        report["steps"] = step + 1
+        report["turns"].append({
+            "took_s": took,
+            "prompt_tokens": out.get("prompt_eval_count"),
+            "eval_tokens": out.get("eval_count"),
+            "load_ms": round((out.get("load_duration") or 0) / 1e6),
+        })
         if first_prompt_tokens is None:
             first_prompt_tokens = out.get("prompt_eval_count")
+            report["first_prompt_tokens"] = first_prompt_tokens
             print(f"  prompt tokens: {first_prompt_tokens}")
         messages.append(message)
         calls = message.get("tool_calls") or []
         if not calls:
-            print(f"  [{took:>6}s] answer: {(message.get('content') or '')[:400]}")
-            return messages
+            answer = message.get("content") or ""
+            report["answer"] = answer
+            report["wall_s"] = round(time.time() - started_task, 1)
+            print(f"  [{took:>6}s] answer: {answer[:400]}")
+            return messages, report
         for call in calls:
             name = call["function"]["name"]
             args = call["function"].get("arguments") or {}
             if isinstance(args, str):
                 args = json.loads(args or "{}")
-            text, ok, size = call_tool(name, args)
-            print(f"  [{took:>6}s] -> {name}({json.dumps(args)[:120]}) ok={ok} result={size} chars")
+            call_record = call_tool(name, args)
+            text = call_record.pop("text")
+            report["calls"].append(call_record)
+            print(f"  [{took:>6}s] -> {name}({json.dumps(args)[:120]}) "
+                  f"{call_record['verdict']} result={call_record['chars']} chars")
             print(f"           {text[:200]}")
             messages.append({"role": "tool", "tool_name": name, "content": text})
+    report["gave_up"] = True
+    report["wall_s"] = round(time.time() - started_task, 1)
     print(f"  gave up after {MAX_STEPS} steps")
-    return messages
+    return messages, report
 
 
 def live_sessions():
@@ -463,6 +550,62 @@ def release_what_this_run_opened():
     OPENED[:] = kept
 
 
+def load_tasks(path):
+    """A task list, in either shape this harness accepts.
+
+    A bare JSON list of strings is what the first two runs used and still works. The eval
+    suite is an object — `{"tasks": [{"id", "prompt", "expect", ...}]}` — because a task
+    that is graded needs a name to be graded under and an answer key to be graded against.
+    Everything but `prompt` travels through this script untouched, into the record: the
+    driver's job is to drive, and nothing here reads `expect`.
+
+    `EVAL_SUBSET` names one of the file's own `subsets`, which is how the reduced-context
+    cells run three tasks rather than six without a second file to keep in step.
+    """
+    loaded = json.load(open(path))
+    if isinstance(loaded, list):
+        return loaded
+    tasks = loaded["tasks"]
+    subset = os.environ.get("EVAL_SUBSET", "")
+    if subset:
+        wanted = loaded.get("subsets", {}).get(subset)
+        if wanted is None:
+            raise SystemExit(f"{path} has no subset `{subset}`")
+        tasks = [t for t in tasks if t.get("id") in wanted]
+    return tasks
+
+
+def served_context():
+    """What the runtime is actually serving this model, which is not what it could serve.
+
+    Asked rather than assumed for the reason `docs/local-model.md` gives: the default
+    `OLLAMA_CONTEXT_LENGTH` picks 4k, 32k or 256k from the box's memory, so a model whose
+    card says 262144 is routinely served far less. Best effort — a runtime that does not
+    report it leaves the field null rather than failing a run over telemetry.
+    """
+    try:
+        for loaded in ollama("/api/ps").get("models", []):
+            if loaded.get("name") == MODEL or loaded.get("model") == MODEL:
+                return loaded.get("context_length")
+    except Exception:  # noqa: BLE001 - a missing figure must not end a run
+        return None
+    return None
+
+
+def write_record(record):
+    """Append one task's record to the eval log, if this run is part of an eval.
+
+    **Appended, one JSON object per line, flushed per task.** A matrix run is hours long
+    and its cells are separate processes; a run that died in the middle should still leave
+    every cell before it on disk, and a reader should be able to grade what is there while
+    the rest is still going.
+    """
+    if not EVAL_OUT:
+        return
+    with open(EVAL_OUT, "a", encoding="utf-8") as log:
+        log.write(json.dumps(record, default=str) + "\n")
+
+
 def main():
     global MODEL
     MODEL = pick_model()
@@ -473,17 +616,38 @@ def main():
     offered = as_ollama(tools)
     surface = len(json.dumps(offered, separators=(",", ":")))
     print(f"tools offered: {len(tools)} ({surface} B of minified JSON)")
+    if NUM_CTX:
+        print(f"context requested: {NUM_CTX}")
     if SCENARIO:
         print("scenario: sessions are kept between tasks")
     snapshot_existing()
-    tasks = json.load(open(sys.argv[1])) if len(sys.argv) > 1 else [
+    tasks = load_tasks(sys.argv[1]) if len(sys.argv) > 1 else [
         "What debug sessions do I currently have open on this server?"
     ]
+    cell = {
+        "run": os.environ.get("EVAL_RUN", time.strftime("%Y%m%dT%H%M%S")),
+        "backend": "ollama",
+        "model": MODEL,
+        "num_ctx": NUM_CTX or None,
+        "surface": {"client": os.environ.get("EVAL_SURFACE", ""),
+                    "tools": len(tools), "bytes": surface,
+                    "names": sorted(t["name"] for t in tools)},
+    }
     transcript = None
     try:
         for i, task in enumerate(tasks, 1):
-            print(f"\n=== task {i}: {task[:110]}")
-            transcript = run(task, offered, transcript)
+            prompt = task["prompt"] if isinstance(task, dict) else task
+            print(f"\n=== task {i}: {prompt[:110]}")
+            transcript, report = run(task, offered, transcript)
+            # Read *after* the first turn: nothing is loaded before one, so asking earlier
+            # reports the previous model's window or nothing at all.
+            record = dict(cell, served_context=served_context(), **report)
+            if NUM_CTX and record["served_context"] and record["served_context"] != NUM_CTX:
+                # Loudly, because it is invisible otherwise and it invalidates the cell: a
+                # request's `num_ctx` does not shrink an instance the runtime already holds.
+                print(f"  WARNING: asked for {NUM_CTX} tokens of context and was served "
+                      f"{record['served_context']} - evict the model before changing the window")
+            write_record(record)
             # Each task is its own conversation, so it gets its own targets: a session
             # left open would be routed to by the next task's `session_id`-less call,
             # which makes that task's measurement depend on the one before it. A task

--- a/tools/local_model_eval.py
+++ b/tools/local_model_eval.py
@@ -171,10 +171,17 @@ def run_cell(plan, tokens, backend, model, context, surface, subset, budget_s, l
             # attached under this cell's credential - and the next cell on the same surface would
             # inherit it, or meet the four-session cap because of it. Released here, with that
             # credential, before anything else runs.
-            release = subprocess.run([sys.executable, "-u", DRIVER, "--release"], env=env,
-                                     capture_output=True, text=True, timeout=120)
-            for line in release.stdout.splitlines():
-                print(f"    {line.strip()}")
+            try:
+                release = subprocess.run([sys.executable, "-u", DRIVER, "--release"], env=env,
+                                         capture_output=True, text=True, timeout=120)
+                for line in release.stdout.splitlines():
+                    print(f"    {line.strip()}")
+            except (subprocess.TimeoutExpired, OSError) as e:
+                # The listener is unreachable, or the release is slower than the whole budget it
+                # was given. Both leave sessions behind, and neither is a reason to abandon the
+                # cells after this one - which is the entire point of killing a cell rather than
+                # waiting for it.
+                print(f"    could not release this cell's sessions: {e}")
             note = {"run": plan["run"], "backend": backend, "model": model,
                     "num_ctx": context or None, "surface": {"client": surface},
                     "task": None, "error": f"cell exceeded its {budget_s}s budget"}
@@ -310,15 +317,28 @@ def records(log_path):
     both would inflate a cell's task count and average two runs that were never meant to be
     averaged.
     """
-    latest = {}
-    for line in open(log_path, encoding="utf-8"):
+    latest, seen_at = {}, {}
+    for at, line in enumerate(open(log_path, encoding="utf-8")):
         line = line.strip()
         if not line:
             continue
         record = json.loads(line)
         surface = (record.get("surface") or {})
-        latest[(record.get("backend"), record.get("model"), record.get("num_ctx"),
-                surface.get("client"), record.get("task"))] = record
+        cell = (record.get("backend"), record.get("model"), record.get("num_ctx"),
+                surface.get("client"))
+        latest[(*cell, record.get("task"))] = record
+        seen_at[(*cell, record.get("task"))] = at
+    # **A cell-level note is superseded by anything that cell recorded afterwards.** The note says
+    # "this cell failed"; it is keyed on `task: null`, so a successful resume - which writes only
+    # task records - leaves it in place and the summary goes on printing a finished cell as
+    # FAILED for ever.
+    for key in list(latest):
+        if key[-1] is not None:
+            continue
+        note_at = seen_at[key]
+        if any(other[:-1] == key[:-1] and other[-1] is not None and at > note_at
+               for other, at in seen_at.items()):
+            del latest[key]
     return list(latest.values())
 
 

--- a/tools/local_model_eval.py
+++ b/tools/local_model_eval.py
@@ -176,6 +176,12 @@ def run_cell(plan, tokens, backend, model, context, surface, subset, budget_s, l
                                          capture_output=True, text=True, timeout=120)
                 for line in release.stdout.splitlines():
                     print(f"    {line.strip()}")
+                if release.returncode:
+                    # It exits nonzero on a credential it cannot use or a listener it cannot
+                    # reach, and returns normally either way - so nothing above notices, and the
+                    # next cell on this surface inherits whatever the killed one still holds.
+                    print(f"    cleanup exited {release.returncode}; this cell's sessions may "
+                          f"still be attached: {release.stderr.strip()[:200]}")
             except (subprocess.TimeoutExpired, OSError) as e:
                 # The listener is unreachable, or the release is slower than the whole budget it
                 # was given. Both leave sessions behind, and neither is a reason to abandon the
@@ -354,11 +360,19 @@ def summarise(log_path, tasks_file):
             "backend": cell_id[0], "model": cell_id[1], "num_ctx": cell_id[2],
             "surface": cell_id[3], "tools": surface.get("tools"),
             "surface_bytes": surface.get("bytes"), "served_context": record.get("served_context"),
-            "tasks": [], "cell_error": None,
+            "tasks": [], "cell_error": None, "mis_served": 0,
         })
         if record.get("task") is None:
             # A cell-level note - a killed cell - rather than a task record.
             cell["cell_error"] = record.get("error")
+            continue
+        served, asked = record.get("served_context"), record.get("num_ctx")
+        if asked and served and asked != served:
+            # **Not scored, at all.** The record is a measurement of a window nobody asked for -
+            # the runtime served an instance it already had - so counting it would publish a
+            # result under the wrong context. `--matrix` marks these `?`; here they are simply
+            # not part of the arithmetic, and the row says how many were dropped.
+            cell["mis_served"] = cell.get("mis_served", 0) + 1
             continue
         task = key.get(record["task"])
         if task is None:
@@ -408,6 +422,8 @@ def print_table(cells):
         extra = c["correct"] - c["correct_of_possible"]
         score = f"{c['correct_of_possible']}/{c['possible']}" + (f"+{extra}" if extra else "")
         failed = " FAILED" if c.get("cell_error") else ""
+        if c.get("mis_served"):
+            failed += f" MIS-SERVED x{c['mis_served']}"
         print(f"{c['backend']:<12} {(c['model'] or '')[:28]:<28} "
               f"{str(c['num_ctx'] or 'dflt'):>7} {str(c['surface'] or '')[:6]:<6} "
               f"{str(c['tools'] or '-'):>5} "
@@ -540,7 +556,17 @@ def main():
                     # first run of this grid recorded five cells labelled 8192 that ran at
                     # 32768; `served_context` caught it, and eviction is what prevents it.
                     # It also keeps three 30B-class models from having to co-reside.
-                    subprocess.run(["ollama", "stop", model], capture_output=True)
+                    evicted = subprocess.run(["ollama", "stop", model], capture_output=True,
+                                         text=True)
+                if evicted.returncode:
+                    # Not cosmetic: the next context's cells would be served this instance's
+                    # window instead of the one they asked for, which is the 32k-served-as-8k
+                    # contamination this eviction exists to prevent. The grader refuses to score a
+                    # record whose served window is not the requested one, so the run cannot
+                    # publish it either way - this is what says *why* those cells went missing.
+                    print(f"    could not evict {model} ({evicted.returncode}): "
+                          f"{evicted.stderr.strip()[:200]}\n"
+                          f"    cells at the next context may be served this one's window")
 
     cells = summarise(log_path, plan["tasks"])
     print_table(cells)

--- a/tools/local_model_eval.py
+++ b/tools/local_model_eval.py
@@ -318,16 +318,22 @@ def summarise(log_path, tasks_file):
 
 def print_table(cells):
     head = (f"{'backend':<12} {'model':<28} {'ctx':>7} {'surface':<6} {'tools':>5} "
-            f"{'ok/possible':>12} {'tokens':>13} {'calls u/w/h/x':>14} {'wall':>6}")
+            f"{'ok/possible':>13} {'tokens':>13} {'calls u/w/h/x':>14} {'wall':>6}")
     print("\n" + head)
     print("-" * len(head))
     for c in sorted(cells, key=lambda c: (c["backend"], c["model"], -(c["num_ctx"] or 0),
                                           c["surface"] or "")):
         tokens = f"{c['prompt_tokens'][0]}-{c['prompt_tokens'][1]}" if c["prompt_tokens"] else "-"
+        # **The numerator is the answerable ones.** A task this surface cannot answer, answered
+        # anyway from the model's own knowledge, is counted in `correct` and not in `possible` -
+        # so printing one over the other reads `6/5`. The false positives are real and are worth
+        # seeing, so they travel beside the score as `+n` rather than inside it.
+        extra = c["correct"] - c["correct_of_possible"]
+        score = f"{c['correct_of_possible']}/{c['possible']}" + (f"+{extra}" if extra else "")
         print(f"{c['backend']:<12} {(c['model'] or '')[:28]:<28} "
               f"{str(c['num_ctx'] or 'dflt'):>7} {str(c['surface'] or '')[:6]:<6} "
               f"{str(c['tools'] or '-'):>5} "
-              f"{c['correct']}/{c['possible']} of {c['n']:<5} {tokens:>13} "
+              f"{score} of {c['n']:<5} {tokens:>13} "
               f"{c['useful']}/{c['wasted']}/{c['hallucinated']}/{c['errors']:<8} "
               f"{c['wall_s']:>5}s")
 
@@ -413,6 +419,15 @@ def main():
         return
 
     plan = load(sys.argv[1])
+    # **Resolved before anything runs, because one backend does not share this cwd.** The Claude
+    # cells are started in a neutral directory (see `run_cell`), so a plan naming
+    # `tools/eval_tasks.json` relative to where the runner was invoked would have that child
+    # looking for it under the log directory - and writing its records to a different
+    # `results.jsonl` than the grader later reads. Absolute paths make the two agree whatever
+    # directory a cell runs in.
+    for field in ("tasks", "out", "logs"):
+        if plan.get(field):
+            plan[field] = os.path.abspath(plan[field])
     tokens = tokens_for(plan)
     log_path = plan["out"]
     logs_dir = plan.get("logs", os.path.join(os.path.dirname(log_path), "logs"))

--- a/tools/local_model_eval.py
+++ b/tools/local_model_eval.py
@@ -245,7 +245,7 @@ def grade_record(record, task, surface_names):
     calls = record.get("calls") or []
     useful = set(task.get("useful_tools", []))
     verdicts = {"useful": 0, "wasted": 0, "off_surface": 0, "refused": 0, "errored": 0,
-                "hallucinated": 0, "harness_tool": 0}
+                "unserved": 0, "harness_tool": 0}
     for call in calls:
         name = call.get("name")
         verdict = call.get("verdict")
@@ -253,11 +253,15 @@ def grade_record(record, task, surface_names):
             # The client's own machinery, not a pick out of this server's surface.
             verdicts["harness_tool"] += 1
             continue
-        # **A name the surface never offered is the finding this axis exists for.** The model
-        # was handed a tool list; asking for something outside it is invention, whether the
-        # server then refuses it or the harness does.
+        # **A call for a tool this client is not served.** Named `unserved` rather than
+        # `hallucinated`, which is what it was called until the run was read properly: the
+        # server sends the same `instructions` string to every client, and that string names
+        # `modules`, `execute`, `decode_ioctl` and `debug_batch` whether or not the client is
+        # served them. A model asking for one of those was told about it by this server. The
+        # count is still worth having - it measures a real cost in wasted turns - but it is a
+        # measure of the server's advertising, not of the model's imagination.
         if surface_names and name not in surface_names:
-            verdicts["hallucinated"] += 1
+            verdicts["unserved"] += 1
         if verdict == "ok":
             verdicts["useful" if name in useful else "wasted"] += 1
         elif verdict == "refused_by_harness":
@@ -340,7 +344,7 @@ def summarise(log_path, tasks_file):
         cell["correct_of_possible"] = sum(1 for g in graded if g["correct"] and g["possible"])
         cell["false_positive"] = sum(1 for g in graded if g["correct"] and not g["possible"])
         cell["errors"] = sum(1 for g in graded if g["error"])
-        cell["hallucinated"] = sum(g["hallucinated"] for g in graded)
+        cell["unserved"] = sum(g["unserved"] for g in graded)
         cell["harness_tool"] = sum(g["harness_tool"] for g in graded)
         cell["off_surface"] = sum(g["off_surface"] for g in graded)
         cell["wasted"] = sum(g["wasted"] for g in graded)
@@ -371,7 +375,7 @@ def print_table(cells):
               f"{str(c['num_ctx'] or 'dflt'):>7} {str(c['surface'] or '')[:6]:<6} "
               f"{str(c['tools'] or '-'):>5} "
               f"{score} of {c['n']:<5} {tokens:>13} "
-              f"{c['useful']}/{c['wasted']}/{c['hallucinated']}/{c['errors']:<8} "
+              f"{c['useful']}/{c['wasted']}/{c['unserved']}/{c['errors']:<8} "
               f"{c['wall_s']:>5}s{failed}")
 
 

--- a/tools/local_model_eval.py
+++ b/tools/local_model_eval.py
@@ -77,7 +77,14 @@ def usable(record):
     never be re-run without hand-editing an append-only log.
     """
     served, asked = record.get("served_context"), record.get("num_ctx")
-    return not (asked and served and asked != served)
+    if not asked:
+        # Nothing was requested - a Claude cell, or a run left at the runtime's default - so
+        # there is no claim to check.
+        return True
+    # `served_context` is null when `/api/ps` was unavailable or did not know the tag. That is not
+    # agreement, it is silence: the harness never saw which window this ran at, and scoring it
+    # would publish the requested number as though it had been verified.
+    return served is not None and served == asked
 
 
 def already_done(log_path):
@@ -192,6 +199,7 @@ def run_cell(plan, tokens, backend, model, context, surface, subset, budget_s, l
                   f"{context or 'default'}_{surface}.log")
     print(f"\n=== cell {label} -> {os.path.basename(stdout_path)}")
     started = time.time()
+    killed = False
     with open(stdout_path, "w", encoding="utf-8") as out:
         # Its own process group, so the budget below can take the *cell* down rather than only
         # the driver: a Claude cell's driver has `claude` as a child, and killing the parent
@@ -211,6 +219,7 @@ def run_cell(plan, tokens, backend, model, context, surface, subset, budget_s, l
                 proc.kill()
             proc.wait()
             print(f"    budget of {budget_s}s exceeded; cell killed")
+            killed = True
             note = {"run": plan["run"], "backend": backend, "model": model,
                     "num_ctx": context or None, "surface": {"client": surface},
                     "task": None, "error": f"cell exceeded its {budget_s}s budget"}
@@ -221,7 +230,10 @@ def run_cell(plan, tokens, backend, model, context, surface, subset, budget_s, l
         # in, and a cell must not fail on the way out because its scratch was not empty.
         shutil.rmtree(cwd, ignore_errors=True)
     print(f"    {round(time.time() - started)}s, exit {proc.returncode}")
-    if proc.returncode:
+    # **Not after a kill.** `records()` keeps the last `task: null` note for a cell, so a generic
+    # `driver exited -9` written here would bury the budget-exceeded note above - which is the one
+    # that says why - and the summary would report the wrong reason for the only outcome it has.
+    if proc.returncode and not killed:
         # **A cell that failed is not a cell with fewer tasks.** A driver that dies on a bad
         # credential, an MCP handshake or a missing model writes some records or none, and
         # without this the summary shows a short row or no row at all - an incomplete grid

--- a/tools/local_model_eval.py
+++ b/tools/local_model_eval.py
@@ -33,6 +33,7 @@ a (model, context, surface, task) already in the log is not run again.
 import json
 import os
 import re
+import signal
 import subprocess
 import sys
 import time
@@ -138,7 +139,11 @@ def run_cell(plan, tokens, backend, model, context, surface, subset, budget_s, l
     print(f"\n=== cell {label} -> {os.path.basename(stdout_path)}")
     started = time.time()
     with open(stdout_path, "w", encoding="utf-8") as out:
-        proc = subprocess.Popen(argv, env=env, stdout=out, stderr=subprocess.STDOUT, cwd=cwd)
+        # Its own process group, so the budget below can take the *cell* down rather than only
+        # the driver: a Claude cell's driver has `claude` as a child, and killing the parent
+        # alone leaves that running against the listener the next cell is about to use.
+        proc = subprocess.Popen(argv, env=env, stdout=out, stderr=subprocess.STDOUT, cwd=cwd,
+                                start_new_session=True)
         try:
             proc.wait(timeout=budget_s)
         except subprocess.TimeoutExpired:
@@ -146,7 +151,10 @@ def run_cell(plan, tokens, backend, model, context, surface, subset, budget_s, l
             # inside a generous wall clock has told us something; a grid that waits for it
             # has not. The kill is recorded as the cell's outcome rather than as an error of
             # the harness.
-            proc.kill()
+            try:
+                os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+            except (ProcessLookupError, PermissionError):
+                proc.kill()
             proc.wait()
             print(f"    budget of {budget_s}s exceeded; cell killed")
             note = {"run": plan["run"], "backend": backend, "model": model,
@@ -295,7 +303,13 @@ def summarise(log_path, tasks_file):
             # A cell-level note - a killed cell - rather than a task record.
             cell["cell_error"] = record.get("error")
             continue
-        cell["tasks"].append(grade_record(record, key[record["task"]], surface.get("names")))
+        task = key.get(record["task"])
+        if task is None:
+            # A log outlives the suite: a task renamed or dropped since the run should cost its
+            # own row, not every row in the file.
+            print(f"  skipping unknown task `{record['task']}` in the log")
+            continue
+        cell["tasks"].append(grade_record(record, task, surface.get("names")))
     for cell in cells.values():
         graded = cell["tasks"]
         cell["n"] = len(graded)
@@ -356,7 +370,10 @@ def matrix(log_path, tasks_file):
         surface = record.get("surface") or {}
         row = rows.setdefault((record.get("backend"), record.get("model"), record.get("num_ctx"),
                                surface.get("client")), {})
-        graded = grade_record(record, key[record["task"]], surface.get("names"))
+        task = key.get(record["task"])
+        if task is None:
+            continue
+        graded = grade_record(record, task, surface.get("names"))
         served, asked = record.get("served_context"), record.get("num_ctx")
         if asked and served and asked != served:
             mark = "?"

--- a/tools/local_model_eval.py
+++ b/tools/local_model_eval.py
@@ -1,0 +1,455 @@
+#!/usr/bin/env python3
+"""Run the model x tool-surface x context matrix against this server, and grade it.
+
+`local_model_drive.py` answers "can *a* model drive this?" for one model, one surface and
+whatever window the runtime happened to serve. This runs that script across a grid and grades
+what comes back against the answer key in `tools/eval_tasks.json`, so the question becomes
+"which of these knobs actually decides whether a model can drive this?".
+
+    EVAL_TOKENS=<tokens.json> python3 tools/local_model_eval.py <plan.json>
+    python3 tools/local_model_eval.py --grade  <results.jsonl> [tasks.json]
+    python3 tools/local_model_eval.py --matrix <results.jsonl> [tasks.json]
+
+**Three axes, and they are not independent.** The tool surface is bytes of prose in every
+turn; the context is what the runtime will hold; the model is what can pick a tool out of
+whatever fits. A surface that does not fit is not a tool-selection result, and a model that
+cannot select is not a budget result - which is why every cell records both, and why the
+grader reports `possible` beside `correct`: three of the six tasks cannot be answered on the
+11-tool surface at all, and counting those as failures would say a small surface makes models
+stupid rather than that it makes tools absent.
+
+**The credentials do the narrowing, not a flag.** Each surface is a *client* of one listener
+(PR #196): `full` is served every tool, `lean` `session,inspect,crash`, `min` `crash`. So a
+cell changes which bearer token the driver presents and nothing else - no restart, no second
+process, and the thing under measurement is the shipped feature rather than a test double.
+The tokens live in a file of their own, named by `EVAL_TOKENS` and never in the plan, because
+a plan is checked in and a credential is not.
+
+**Cells are subprocesses, and the log is append-only.** A matrix run is hours long; a cell that
+wedges must not take the grid with it (`budget_s` kills it and records why), and a run that
+dies in the middle must leave every finished cell on disk. Re-running the same plan **resumes**:
+a (model, context, surface, task) already in the log is not run again.
+"""
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+DRIVER = os.path.join(HERE, "local_model_drive.py")
+CLAUDE_DRIVER = os.path.join(HERE, "claude_code_drive.py")
+
+
+def load(path):
+    with open(path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def tokens_for(plan):
+    """The bearer token per surface, from the file `EVAL_TOKENS` names.
+
+    Separate from the plan on purpose: the plan is the experiment and belongs in the repo,
+    the tokens are credentials of the run's own and belong in neither the repo nor a command
+    line. Nothing here prints one - a failure names the surface, never the value.
+    """
+    path = os.environ.get("EVAL_TOKENS", "")
+    if not path:
+        raise SystemExit("set EVAL_TOKENS to a JSON file of {surface: token} for this run's clients")
+    tokens = load(path)
+    missing = [s["client"] for s in plan["surfaces"] if s["client"] not in tokens]
+    if missing:
+        raise SystemExit(f"{path} has no token for: {', '.join(missing)}")
+    return tokens
+
+
+def already_done(log_path):
+    """Which (model, context, surface, task) the log already holds, so a re-run resumes.
+
+    Keyed on the four things a cell is identified by rather than on a cell id, because the
+    plan can grow a surface or a context between runs and everything already measured is
+    still valid - what must not happen is a task being run twice into one log and graded
+    twice.
+    """
+    seen = set()
+    if not os.path.exists(log_path):
+        return seen
+    with open(log_path, encoding="utf-8") as log:
+        for line in log:
+            line = line.strip()
+            if not line:
+                continue
+            r = json.loads(line)
+            seen.add((r.get("model"), r.get("num_ctx"), (r.get("surface") or {}).get("client"),
+                      r.get("task")))
+    return seen
+
+
+def cell_tasks(tasks_file, subset):
+    tasks = load(tasks_file)["tasks"]
+    if subset:
+        wanted = load(tasks_file)["subsets"][subset]
+        tasks = [t for t in tasks if t["id"] in wanted]
+    return tasks
+
+
+def run_cell(plan, tokens, backend, model, context, surface, subset, budget_s, log_path,
+             logs_dir):
+    """One (backend, model, context, surface) cell: a driver process over the task list."""
+    label = f"{backend}:{model} ctx={context or 'default'} surface={surface}"
+    env = dict(os.environ)
+    env.update({
+        "WINDBG_MCP_URL": plan["url"],
+        "WINDBG_MCP_TOKEN": tokens[surface],
+        "WINDBG_MCP_EVAL_OUT": log_path,
+        "EVAL_RUN": plan["run"],
+        "EVAL_SURFACE": surface,
+        "MAX_STEPS": str(plan.get("max_steps", 6)),
+    })
+    if subset:
+        env["EVAL_SUBSET"] = subset
+    if backend == "ollama":
+        env["LOCAL_MODEL"] = model
+        env["NUM_CTX"] = str(context or 0)
+        # Residency for the length of a cell, then eviction: the next cell is either the same
+        # model at another surface (keep it) or a different window, which reloads regardless.
+        env["OLLAMA_KEEP_ALIVE"] = plan.get("keep_alive", "10m")
+        argv = [sys.executable, "-u", DRIVER, plan["tasks"]]
+    elif backend == "claude-code":
+        env["CLAUDE_MODEL"] = model
+        # **Every tool in the prompt, as the local models get them.** Claude Code defers MCP
+        # tool schemas by default and fetches them with `ToolSearch`, which is a real feature
+        # and the wrong measurement here: it would make the surface axis cost this row almost
+        # nothing while charging every other row in full.
+        env["ENABLE_TOOL_SEARCH"] = "false"
+        argv = [sys.executable, "-u", CLAUDE_DRIVER, plan["tasks"]]
+    else:
+        raise SystemExit(f"unknown backend `{backend}`")
+
+    os.makedirs(logs_dir, exist_ok=True)
+    # Claude Code reads the project it is started in - `CLAUDE.md`, settings, the checkout
+    # itself. Started in this repository it would answer questions about the sample dumps from
+    # the documentation beside them, so its cells run somewhere with nothing in it.
+    cwd = logs_dir if backend == "claude-code" else None
+    stdout_path = os.path.join(
+        logs_dir, f"{backend}_{model.replace(':', '-').replace('/', '-')}_"
+                  f"{context or 'default'}_{surface}.log")
+    print(f"\n=== cell {label} -> {os.path.basename(stdout_path)}")
+    started = time.time()
+    with open(stdout_path, "w", encoding="utf-8") as out:
+        proc = subprocess.Popen(argv, env=env, stdout=out, stderr=subprocess.STDOUT, cwd=cwd)
+        try:
+            proc.wait(timeout=budget_s)
+        except subprocess.TimeoutExpired:
+            # **A budget is part of the measurement.** A model that cannot finish a task list
+            # inside a generous wall clock has told us something; a grid that waits for it
+            # has not. The kill is recorded as the cell's outcome rather than as an error of
+            # the harness.
+            proc.kill()
+            proc.wait()
+            print(f"    budget of {budget_s}s exceeded; cell killed")
+            note = {"run": plan["run"], "backend": backend, "model": model,
+                    "num_ctx": context or None, "surface": {"client": surface},
+                    "task": None, "error": f"cell exceeded its {budget_s}s budget"}
+            with open(log_path, "a", encoding="utf-8") as log:
+                log.write(json.dumps(note) + "\n")
+    print(f"    {round(time.time() - started)}s, exit {proc.returncode}")
+    return proc.returncode
+
+
+NUMERIC = re.compile(r"^(0x)?[0-9a-f]+$")
+# A separator *between* hex digits is how a reader is helped, not part of the value: WinDbg
+# writes `fffff801`3c65bca8` and the control row wrote `0xfffff801_3c65bca8`. Both name the
+# address the key holds, and the second was scored a miss until this existed.
+SEPARATOR = re.compile(r"(?<=[0-9a-f])[_`](?=[0-9a-f])")
+
+
+def normalise(answer):
+    return SEPARATOR.sub("", answer.lower())
+
+
+def present(alt, answer):
+    """Whether one alternative appears in an answer, as a *value* rather than as a substring.
+
+    Plain containment for prose, and containment **between hex boundaries** for a number - a
+    rule this grader learned the hard way. `0x22` is the device type `ioctl_decode` asks for,
+    and `0x22200b` is the code in the question: the first is inside the second, so the check
+    passed for every answer that merely repeated the question. One model's hand-decode scored
+    correct while saying the device type was `0x2` and the access `FILE_READ_DATA`, both wrong.
+
+    Only digits count as the boundary, not letters, because the leading `x` of `0x13a` would
+    otherwise stop the bare `13a` alternative from matching the very answers it is there for.
+    """
+    alt = alt.lower()
+    if not NUMERIC.match(alt):
+        return alt in answer
+    if alt.startswith("0x"):
+        # **Leading zeros are formatting, not value.** The tool prints `0x802` and a model
+        # writing the same field as `0x0802` is not wrong - the boundary rule alone marked one
+        # such answer incorrect while it agreed with the tool in every field.
+        digits = alt[2:].lstrip("0") or "0"
+        pattern = rf"(?<![0-9a-f])0x0*{re.escape(digits)}(?![0-9a-f])"
+    else:
+        pattern = rf"(?<![0-9a-f]){re.escape(alt)}(?![0-9a-f])"
+    return re.search(pattern, answer) is not None
+
+
+def matches(record, task):
+    """Whether the answer carries the facts the key requires.
+
+    Every group in `expect` must appear, any alternative within a group counting - so an
+    answer may say `0x13A` or `13a`, and must say both the code and the name. Case-folded and
+    otherwise literal: a grader that normalised harder would start accepting answers a reader
+    would not, and the failures it would then hide are exactly the ones worth reading.
+    """
+    answer = normalise(record.get("answer") or "")
+    if not answer:
+        return False
+    return all(any(present(alt, answer) for alt in group) for group in task.get("expect", []))
+
+
+def grade_record(record, task, surface_names):
+    """One task's outcome: was it answerable here, was it answered, and how were the tools used."""
+    possible = (record.get("surface") or {}).get("client") in task.get("possible_on", [])
+    calls = record.get("calls") or []
+    useful = set(task.get("useful_tools", []))
+    verdicts = {"useful": 0, "wasted": 0, "off_surface": 0, "refused": 0, "errored": 0,
+                "hallucinated": 0, "harness_tool": 0}
+    for call in calls:
+        name = call.get("name")
+        verdict = call.get("verdict")
+        if verdict == "harness_tool":
+            # The client's own machinery, not a pick out of this server's surface.
+            verdicts["harness_tool"] += 1
+            continue
+        # **A name the surface never offered is the finding this axis exists for.** The model
+        # was handed a tool list; asking for something outside it is invention, whether the
+        # server then refuses it or the harness does.
+        if surface_names and name not in surface_names:
+            verdicts["hallucinated"] += 1
+        if verdict == "ok":
+            verdicts["useful" if name in useful else "wasted"] += 1
+        elif verdict == "refused_by_harness":
+            verdicts["refused"] += 1
+        elif verdict == "error":
+            excerpt = (call.get("excerpt") or "").lower()
+            if "not on the surface" in excerpt or "tool not found" in excerpt:
+                verdicts["off_surface"] += 1
+            else:
+                verdicts["errored"] += 1
+        else:
+            verdicts["errored"] += 1
+    return {
+        "task": record.get("task"),
+        "possible": possible,
+        "correct": matches(record, task),
+        "bonus": all(any(present(alt, normalise(record.get("answer") or "")) for alt in g)
+                     for g in task.get("bonus", [])) if task.get("bonus") else None,
+        "answered": bool(record.get("answer")),
+        "gave_up": bool(record.get("gave_up")),
+        "error": record.get("error"),
+        "calls": len(calls),
+        "result_chars": sum(c.get("chars") or 0 for c in calls),
+        "first_prompt_tokens": record.get("first_prompt_tokens"),
+        "wall_s": record.get("wall_s"),
+        **verdicts,
+    }
+
+
+def records(log_path):
+    """Every record in the log, **deduplicated to the last run of each (cell, task)**.
+
+    Resume works at cell granularity - an outstanding task re-runs its cell's whole list - so a
+    log legitimately holds a task twice, and the second run is the one that counts. Counting
+    both would inflate a cell's task count and average two runs that were never meant to be
+    averaged.
+    """
+    latest = {}
+    for line in open(log_path, encoding="utf-8"):
+        line = line.strip()
+        if not line:
+            continue
+        record = json.loads(line)
+        surface = (record.get("surface") or {})
+        latest[(record.get("backend"), record.get("model"), record.get("num_ctx"),
+                surface.get("client"), record.get("task"))] = record
+    return list(latest.values())
+
+
+def summarise(log_path, tasks_file):
+    """Grade the whole log and reduce it to one row per cell."""
+    key = {t["id"]: t for t in load(tasks_file)["tasks"]}
+    cells = {}
+    for record in records(log_path):
+        surface = (record.get("surface") or {})
+        cell_id = (record.get("backend"), record.get("model"), record.get("num_ctx"),
+                   surface.get("client"))
+        cell = cells.setdefault(cell_id, {
+            "backend": cell_id[0], "model": cell_id[1], "num_ctx": cell_id[2],
+            "surface": cell_id[3], "tools": surface.get("tools"),
+            "surface_bytes": surface.get("bytes"), "served_context": record.get("served_context"),
+            "tasks": [], "cell_error": None,
+        })
+        if record.get("task") is None:
+            # A cell-level note - a killed cell - rather than a task record.
+            cell["cell_error"] = record.get("error")
+            continue
+        cell["tasks"].append(grade_record(record, key[record["task"]], surface.get("names")))
+    for cell in cells.values():
+        graded = cell["tasks"]
+        cell["n"] = len(graded)
+        cell["possible"] = sum(1 for g in graded if g["possible"])
+        cell["correct"] = sum(1 for g in graded if g["correct"])
+        cell["correct_of_possible"] = sum(1 for g in graded if g["correct"] and g["possible"])
+        cell["false_positive"] = sum(1 for g in graded if g["correct"] and not g["possible"])
+        cell["errors"] = sum(1 for g in graded if g["error"])
+        cell["hallucinated"] = sum(g["hallucinated"] for g in graded)
+        cell["harness_tool"] = sum(g["harness_tool"] for g in graded)
+        cell["off_surface"] = sum(g["off_surface"] for g in graded)
+        cell["wasted"] = sum(g["wasted"] for g in graded)
+        cell["useful"] = sum(g["useful"] for g in graded)
+        cell["result_chars"] = sum(g["result_chars"] or 0 for g in graded)
+        cell["wall_s"] = round(sum(g["wall_s"] or 0 for g in graded))
+        prompts = [g["first_prompt_tokens"] for g in graded if g["first_prompt_tokens"]]
+        cell["prompt_tokens"] = (min(prompts), max(prompts)) if prompts else None
+    return list(cells.values())
+
+
+def print_table(cells):
+    head = (f"{'backend':<12} {'model':<28} {'ctx':>7} {'surface':<6} {'tools':>5} "
+            f"{'ok/possible':>12} {'tokens':>13} {'calls u/w/h/x':>14} {'wall':>6}")
+    print("\n" + head)
+    print("-" * len(head))
+    for c in sorted(cells, key=lambda c: (c["backend"], c["model"], -(c["num_ctx"] or 0),
+                                          c["surface"] or "")):
+        tokens = f"{c['prompt_tokens'][0]}-{c['prompt_tokens'][1]}" if c["prompt_tokens"] else "-"
+        print(f"{c['backend']:<12} {(c['model'] or '')[:28]:<28} "
+              f"{str(c['num_ctx'] or 'dflt'):>7} {str(c['surface'] or '')[:6]:<6} "
+              f"{str(c['tools'] or '-'):>5} "
+              f"{c['correct']}/{c['possible']} of {c['n']:<5} {tokens:>13} "
+              f"{c['useful']}/{c['wasted']}/{c['hallucinated']}/{c['errors']:<8} "
+              f"{c['wall_s']:>5}s")
+
+
+def matrix(log_path, tasks_file):
+    """One row per cell, one column per task, for reading rather than for arithmetic.
+
+    The summary table answers "how many"; this answers "which", and the two fail differently.
+    A cell scoring 4 of 5 is not interesting until you know it is the same task every model
+    misses - at which point the finding is about the task, or about the tool it needs, rather
+    than about any of the models. It is also what the control is *for*: a task the frontier row
+    misses too is a bad question, not a weak local model.
+    """
+    key = {t["id"]: t for t in load(tasks_file)["tasks"]}
+    order = [t["id"] for t in load(tasks_file)["tasks"]]
+    rows = {}
+    for record in records(log_path):
+        if record.get("task") is None:
+            continue
+        surface = record.get("surface") or {}
+        row = rows.setdefault((record.get("backend"), record.get("model"), record.get("num_ctx"),
+                               surface.get("client")), {})
+        graded = grade_record(record, key[record["task"]], surface.get("names"))
+        served, asked = record.get("served_context"), record.get("num_ctx")
+        if asked and served and asked != served:
+            mark = "?"
+        elif graded["error"]:
+            mark = "!"
+        elif not graded["possible"]:
+            # Marked apart whether or not the model got there: an answer to a question this
+            # surface cannot reach is either knowledge or a lucky guess, and both are worth
+            # seeing rather than scoring.
+            mark = "o" if graded["correct"] else "-"
+        else:
+            mark = "Y" if graded["correct"] else "n"
+        row[record["task"]] = {"mark": mark, "calls": [c.get("name") for c in
+                                                       (record.get("calls") or [])],
+                               "wall_s": record.get("wall_s"),
+                               "answer": (record.get("answer") or "")[:2000],
+                               "error": record.get("error")}
+    return order, rows
+
+
+def print_matrix(order, rows):
+    width = max(len(t) for t in order) + 2
+    header = f"{'cell':<44}" + "".join(f"{t:<{width}}" for t in order)
+    print("\n" + header)
+    print("-" * len(header))
+    for cell, marks in sorted(rows.items(), key=lambda kv: (kv[0][0], kv[0][1],
+                                                            -(kv[0][2] or 0), kv[0][3] or "")):
+        backend, model, ctx, surface = cell
+        label = f"{model[:24]} {str(ctx or 'dflt'):>6} {surface}"
+        print(f"{label:<44}" + "".join(f"{marks.get(t, {}).get('mark', ' '):<{width}}"
+                                       for t in order))
+    print("\nY correct   n wrong   - not answerable on this surface   "
+          "o answered anyway   ! the runtime refused the request   "
+          "? served a different window than asked for")
+
+
+def main():
+    if sys.argv[1:2] == ["--matrix"]:
+        log_path = sys.argv[2]
+        tasks_file = sys.argv[3] if len(sys.argv) > 3 else os.path.join(HERE, "eval_tasks.json")
+        order, rows = matrix(log_path, tasks_file)
+        print_matrix(order, rows)
+        out = os.path.splitext(log_path)[0] + ".matrix.json"
+        with open(out, "w", encoding="utf-8") as f:
+            json.dump({"tasks": order,
+                       "rows": [{"backend": c[0], "model": c[1], "num_ctx": c[2],
+                                 "surface": c[3], "marks": m} for c, m in rows.items()]},
+                      f, indent=2)
+        print(f"\nwrote {out}")
+        return
+    if sys.argv[1:2] == ["--grade"]:
+        log_path = sys.argv[2]
+        tasks_file = sys.argv[3] if len(sys.argv) > 3 else os.path.join(HERE, "eval_tasks.json")
+        cells = summarise(log_path, tasks_file)
+        print_table(cells)
+        out = os.path.splitext(log_path)[0] + ".graded.json"
+        with open(out, "w", encoding="utf-8") as f:
+            json.dump(cells, f, indent=2)
+        print(f"\nwrote {out}")
+        return
+
+    plan = load(sys.argv[1])
+    tokens = tokens_for(plan)
+    log_path = plan["out"]
+    logs_dir = plan.get("logs", os.path.join(os.path.dirname(log_path), "logs"))
+    done = already_done(log_path)
+    print(f"plan {plan['run']}: {len(done)} task records already in {log_path}")
+
+    for group in plan["cells"]:
+        backend = group["backend"]
+        for model in group["models"]:
+            for context in group.get("contexts", [None]):
+                for surface in group["surfaces"]:
+                    subset = group.get("subset")
+                    wanted = cell_tasks(plan["tasks"], subset)
+                    outstanding = [t for t in wanted
+                                   if (model, context, surface, t["id"]) not in done]
+                    if not outstanding:
+                        print(f"  skipping {backend}:{model} ctx={context} {surface}: "
+                              f"all {len(wanted)} tasks already recorded")
+                        continue
+                    run_cell(plan, tokens, backend, model, context, surface, subset,
+                             group.get("budget_s", 1800), log_path, logs_dir)
+                    done = already_done(log_path)
+                if backend == "ollama":
+                    # **Evicted between contexts, not only between models** - and this is the
+                    # one that had to be learned. `num_ctx` on a request does not shrink an
+                    # instance the runtime already holds: asked for 8192 with a 32768 instance
+                    # loaded, ollama serves the 32768 one and says so only in `/api/ps`. The
+                    # first run of this grid recorded five cells labelled 8192 that ran at
+                    # 32768; `served_context` caught it, and eviction is what prevents it.
+                    # It also keeps three 30B-class models from having to co-reside.
+                    subprocess.run(["ollama", "stop", model], capture_output=True)
+
+    cells = summarise(log_path, plan["tasks"])
+    print_table(cells)
+    with open(os.path.splitext(log_path)[0] + ".graded.json", "w", encoding="utf-8") as f:
+        json.dump(cells, f, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/local_model_eval.py
+++ b/tools/local_model_eval.py
@@ -67,6 +67,19 @@ def tokens_for(plan):
     return tokens
 
 
+def usable(record):
+    """Whether a record measures what it says it does.
+
+    A cell asking for an 8,192-token window and served 32,768 - the runtime reusing an instance it
+    already holds - is not a measurement of either window. **One predicate, read by both the resume
+    set and the grader**, because they disagreed once and the disagreement was unreachable from
+    either side: grading excluded such a record while resume counted it as done, so the cell could
+    never be re-run without hand-editing an append-only log.
+    """
+    served, asked = record.get("served_context"), record.get("num_ctx")
+    return not (asked and served and asked != served)
+
+
 def already_done(log_path):
     """Which (model, context, surface, task) the log already holds, so a re-run resumes.
 
@@ -84,6 +97,10 @@ def already_done(log_path):
             if not line:
                 continue
             r = json.loads(line)
+            if not usable(r):
+                # Not done: it has to be run again, once whatever served the wrong window is
+                # evicted. The grader will not score it either.
+                continue
             # **Keyed by backend too.** Two groups can name the same model - an ollama tag
             # aliased `sonnet` beside the Claude Code row - and without this the first one's
             # records make the second's whole cell look finished.
@@ -98,6 +115,24 @@ def cell_tasks(tasks_file, subset):
         wanted = load(tasks_file)["subsets"][subset]
         tasks = [t for t in tasks if t["id"] in wanted]
     return tasks
+
+
+def release_sessions(env, why):
+    """End whatever this credential holds, best effort and never fatal.
+
+    Best effort *by construction*, not by neglect: the only caller runs it as a cell's own
+    precondition, so a release that fails costs that cell the four-session cap at worst and the
+    grid nothing. Nothing downstream reads a result from it, which is why it has none.
+    """
+    try:
+        done = subprocess.run([sys.executable, "-u", DRIVER, "--release"], env=env,
+                              capture_output=True, text=True, timeout=120)
+        released = [line for line in done.stdout.splitlines() if "released" in line]
+        if released or done.returncode:
+            print(f"    {why}: {len(released)} session(s) released"
+                  + (f", exit {done.returncode}" if done.returncode else ""))
+    except (subprocess.TimeoutExpired, OSError) as e:
+        print(f"    {why}: could not release ({e})")
 
 
 def run_cell(plan, tokens, backend, model, context, surface, subset, budget_s, log_path,
@@ -133,6 +168,15 @@ def run_cell(plan, tokens, backend, model, context, surface, subset, budget_s, l
     else:
         raise SystemExit(f"unknown backend `{backend}`")
 
+    # **This cell clears its own namespace before it starts, rather than the last one clearing up
+    # after itself.** Cleanup used to be a postcondition: kill the cell, then release what it had
+    # open, then check that the release worked, then handle its timeout, then handle its exit
+    # code - four rounds of review, each finding a way for the guarantee to be lost, because a
+    # postcondition can only be as good as the reporting of it. As a precondition it cannot be
+    # lost: however the previous cell died - killed, crashed, cleanly finished - this one begins
+    # with nothing of its own attached, and nothing has to notice.
+    release_sessions(env, f"before {label}")
+
     os.makedirs(logs_dir, exist_ok=True)
     # **Claude Code reads the project it is started in, and walks *up* to find it.** `CLAUDE.md`,
     # settings, the checkout itself - and this repository's `CLAUDE.md` now quotes two of the six
@@ -167,27 +211,6 @@ def run_cell(plan, tokens, backend, model, context, surface, subset, budget_s, l
                 proc.kill()
             proc.wait()
             print(f"    budget of {budget_s}s exceeded; cell killed")
-            # **The kill skipped the driver's own cleanup**, so whatever it had open is still
-            # attached under this cell's credential - and the next cell on the same surface would
-            # inherit it, or meet the four-session cap because of it. Released here, with that
-            # credential, before anything else runs.
-            try:
-                release = subprocess.run([sys.executable, "-u", DRIVER, "--release"], env=env,
-                                         capture_output=True, text=True, timeout=120)
-                for line in release.stdout.splitlines():
-                    print(f"    {line.strip()}")
-                if release.returncode:
-                    # It exits nonzero on a credential it cannot use or a listener it cannot
-                    # reach, and returns normally either way - so nothing above notices, and the
-                    # next cell on this surface inherits whatever the killed one still holds.
-                    print(f"    cleanup exited {release.returncode}; this cell's sessions may "
-                          f"still be attached: {release.stderr.strip()[:200]}")
-            except (subprocess.TimeoutExpired, OSError) as e:
-                # The listener is unreachable, or the release is slower than the whole budget it
-                # was given. Both leave sessions behind, and neither is a reason to abandon the
-                # cells after this one - which is the entire point of killing a cell rather than
-                # waiting for it.
-                print(f"    could not release this cell's sessions: {e}")
             note = {"run": plan["run"], "backend": backend, "model": model,
                     "num_ctx": context or None, "surface": {"client": surface},
                     "task": None, "error": f"cell exceeded its {budget_s}s budget"}
@@ -366,12 +389,9 @@ def summarise(log_path, tasks_file):
             # A cell-level note - a killed cell - rather than a task record.
             cell["cell_error"] = record.get("error")
             continue
-        served, asked = record.get("served_context"), record.get("num_ctx")
-        if asked and served and asked != served:
-            # **Not scored, at all.** The record is a measurement of a window nobody asked for -
-            # the runtime served an instance it already had - so counting it would publish a
-            # result under the wrong context. `--matrix` marks these `?`; here they are simply
-            # not part of the arithmetic, and the row says how many were dropped.
+        if not usable(record):
+            # **Not scored, at all** - counting it would publish a result under a window nobody
+            # asked for. `--matrix` marks these `?`; the row says how many were dropped.
             cell["mis_served"] = cell.get("mis_served", 0) + 1
             continue
         task = key.get(record["task"])
@@ -455,8 +475,7 @@ def matrix(log_path, tasks_file):
         if task is None:
             continue
         graded = grade_record(record, task, surface.get("names"))
-        served, asked = record.get("served_context"), record.get("num_ctx")
-        if asked and served and asked != served:
+        if not usable(record):
             mark = "?"
         elif graded["error"]:
             mark = "!"
@@ -557,16 +576,16 @@ def main():
                     # 32768; `served_context` caught it, and eviction is what prevents it.
                     # It also keeps three 30B-class models from having to co-reside.
                     evicted = subprocess.run(["ollama", "stop", model], capture_output=True,
-                                         text=True)
-                if evicted.returncode:
+                                             text=True)
+                    if evicted.returncode:
                     # Not cosmetic: the next context's cells would be served this instance's
                     # window instead of the one they asked for, which is the 32k-served-as-8k
                     # contamination this eviction exists to prevent. The grader refuses to score a
                     # record whose served window is not the requested one, so the run cannot
                     # publish it either way - this is what says *why* those cells went missing.
-                    print(f"    could not evict {model} ({evicted.returncode}): "
-                          f"{evicted.stderr.strip()[:200]}\n"
-                          f"    cells at the next context may be served this one's window")
+                        print(f"    could not evict {model} ({evicted.returncode}): "
+                              f"{evicted.stderr.strip()[:200]}\n"
+                              f"    cells at the next context may be served this one's window")
 
     cells = summarise(log_path, plan["tasks"])
     print_table(cells)

--- a/tools/local_model_eval.py
+++ b/tools/local_model_eval.py
@@ -33,9 +33,11 @@ a (model, context, surface, task) already in the log is not run again.
 import json
 import os
 import re
+import shutil
 import signal
 import subprocess
 import sys
+import tempfile
 import time
 
 HERE = os.path.dirname(os.path.abspath(__file__))
@@ -129,10 +131,15 @@ def run_cell(plan, tokens, backend, model, context, surface, subset, budget_s, l
         raise SystemExit(f"unknown backend `{backend}`")
 
     os.makedirs(logs_dir, exist_ok=True)
-    # Claude Code reads the project it is started in - `CLAUDE.md`, settings, the checkout
-    # itself. Started in this repository it would answer questions about the sample dumps from
-    # the documentation beside them, so its cells run somewhere with nothing in it.
-    cwd = logs_dir if backend == "claude-code" else None
+    # **Claude Code reads the project it is started in, and walks *up* to find it.** `CLAUDE.md`,
+    # settings, the checkout itself - and this repository's `CLAUDE.md` now quotes two of the six
+    # answers, in the section explaining how the grader was fixed. So a cell started anywhere
+    # under the checkout is handed part of the answer key before it calls a tool.
+    #
+    # `logs_dir` looked neutral and is not: the checked-in plan keeps logs in `eval-out/`, inside
+    # the tree. An empty directory of this process's own is the only one that is neutral wherever
+    # a plan puts its output.
+    cwd = tempfile.mkdtemp(prefix="windbg-eval-cwd-") if backend == "claude-code" else None
     stdout_path = os.path.join(
         logs_dir, f"{backend}_{model.replace(':', '-').replace('/', '-')}_"
                   f"{context or 'default'}_{surface}.log")
@@ -162,7 +169,22 @@ def run_cell(plan, tokens, backend, model, context, surface, subset, budget_s, l
                     "task": None, "error": f"cell exceeded its {budget_s}s budget"}
             with open(log_path, "a", encoding="utf-8") as log:
                 log.write(json.dumps(note) + "\n")
+    if cwd:
+        # `rmtree`, not `rmdir`: Claude Code may leave state of its own in the directory it ran
+        # in, and a cell must not fail on the way out because its scratch was not empty.
+        shutil.rmtree(cwd, ignore_errors=True)
     print(f"    {round(time.time() - started)}s, exit {proc.returncode}")
+    if proc.returncode:
+        # **A cell that failed is not a cell with fewer tasks.** A driver that dies on a bad
+        # credential, an MCP handshake or a missing model writes some records or none, and
+        # without this the summary shows a short row or no row at all - an incomplete grid
+        # reading as a finished one. The note gives the cell a row that says what happened.
+        note = {"run": plan["run"], "backend": backend, "model": model,
+                "num_ctx": context or None, "surface": {"client": surface},
+                "task": None,
+                "error": f"driver exited {proc.returncode}; see {os.path.basename(stdout_path)}"}
+        with open(log_path, "a", encoding="utf-8") as log:
+            log.write(json.dumps(note) + "\n")
     return proc.returncode
 
 
@@ -344,12 +366,13 @@ def print_table(cells):
         # seeing, so they travel beside the score as `+n` rather than inside it.
         extra = c["correct"] - c["correct_of_possible"]
         score = f"{c['correct_of_possible']}/{c['possible']}" + (f"+{extra}" if extra else "")
+        failed = " FAILED" if c.get("cell_error") else ""
         print(f"{c['backend']:<12} {(c['model'] or '')[:28]:<28} "
               f"{str(c['num_ctx'] or 'dflt'):>7} {str(c['surface'] or '')[:6]:<6} "
               f"{str(c['tools'] or '-'):>5} "
               f"{score} of {c['n']:<5} {tokens:>13} "
               f"{c['useful']}/{c['wasted']}/{c['hallucinated']}/{c['errors']:<8} "
-              f"{c['wall_s']:>5}s")
+              f"{c['wall_s']:>5}s{failed}")
 
 
 def matrix(log_path, tasks_file):

--- a/tools/local_model_eval.py
+++ b/tools/local_model_eval.py
@@ -67,15 +67,24 @@ def tokens_for(plan):
     return tokens
 
 
-def usable(record):
-    """Whether a record measures what it says it does.
+def usable(record, task=None):
+    """Whether a record still measures what this run is asking.
 
-    A cell asking for an 8,192-token window and served 32,768 - the runtime reusing an instance it
-    already holds - is not a measurement of either window. **One predicate, read by both the resume
-    set and the grader**, because they disagreed once and the disagreement was unreachable from
-    either side: grading excluded such a record while resume counted it as done, so the cell could
-    never be re-run without hand-editing an append-only log.
+    **One predicate, read by the resume set, the grader and the matrix**, because they disagreed
+    once and the disagreement was unreachable from either side: grading excluded a record while
+    resume counted it as done, so the cell could never be re-run without hand-editing an
+    append-only log. Every reason a record has stopped counting belongs here rather than in another
+    tuple element somebody has to remember.
+
+    Two reasons so far. A cell asking for an 8,192-token window and served 32,768 - the runtime
+    reusing an instance it already holds - is not a measurement of either window. And an answer to
+    a question the suite no longer asks is not an answer to the one it asks now: this run changed
+    `unloaded_driver`'s prompt mid-flight and had to delete those records **by hand**, because
+    resume would otherwise have skipped the task while the grader scored the old answers against
+    the new key.
     """
+    if task is not None and record.get("prompt") and record["prompt"] != task.get("prompt"):
+        return False
     served, asked = record.get("served_context"), record.get("num_ctx")
     if not asked:
         # Nothing was requested - a Claude cell, or a run left at the runtime's default - so
@@ -87,14 +96,18 @@ def usable(record):
     return served is not None and served == asked
 
 
-def already_done(log_path):
-    """Which (model, context, surface, task) the log already holds, so a re-run resumes.
+def already_done(log_path, tasks):
+    """Which (backend, model, context, surface, task) the log already holds, so a re-run resumes.
 
-    Keyed on the four things a cell is identified by rather than on a cell id, because the
-    plan can grow a surface or a context between runs and everything already measured is
-    still valid - what must not happen is a task being run twice into one log and graded
-    twice.
+    Keyed on the things a cell is identified by rather than on a cell id, because the plan can grow
+    a surface or a context between runs and everything already measured is still valid - what must
+    not happen is a task being run twice into one log and graded twice.
+
+    `tasks` is the suite as it is *now*, because [`usable`] compares each record against the
+    question currently being asked.
     """
+    by_id = {t["id"]: t for t in tasks}
+    stale = 0
     seen = set()
     if not os.path.exists(log_path):
         return seen
@@ -104,15 +117,19 @@ def already_done(log_path):
             if not line:
                 continue
             r = json.loads(line)
-            if not usable(r):
-                # Not done: it has to be run again, once whatever served the wrong window is
-                # evicted. The grader will not score it either.
+            if not usable(r, by_id.get(r.get("task"))):
+                # Not done: the window it ran at was not the one it asked for, or the question has
+                # changed since. It has to run again, and the grader will not score it either.
+                stale += 1
                 continue
             # **Keyed by backend too.** Two groups can name the same model - an ollama tag
             # aliased `sonnet` beside the Claude Code row - and without this the first one's
             # records make the second's whole cell look finished.
             seen.add((r.get("backend"), r.get("model"), r.get("num_ctx"),
                       (r.get("surface") or {}).get("client"), r.get("task")))
+    if stale:
+        print(f"  {stale} record(s) in the log no longer measure what this plan asks "
+              f"(a changed prompt, or a window that was not the one requested); they will run again")
     return seen
 
 
@@ -395,16 +412,17 @@ def summarise(log_path, tasks_file):
             "backend": cell_id[0], "model": cell_id[1], "num_ctx": cell_id[2],
             "surface": cell_id[3], "tools": surface.get("tools"),
             "surface_bytes": surface.get("bytes"), "served_context": record.get("served_context"),
-            "tasks": [], "cell_error": None, "mis_served": 0,
+            "tasks": [], "cell_error": None, "uncounted": 0,
         })
         if record.get("task") is None:
             # A cell-level note - a killed cell - rather than a task record.
             cell["cell_error"] = record.get("error")
             continue
-        if not usable(record):
+        if not usable(record, key.get(record.get("task"))):
             # **Not scored, at all** - counting it would publish a result under a window nobody
-            # asked for. `--matrix` marks these `?`; the row says how many were dropped.
-            cell["mis_served"] = cell.get("mis_served", 0) + 1
+            # asked for, or against a question the suite no longer asks. `--matrix` marks these
+            # `?`; the row says how many were dropped.
+            cell["uncounted"] = cell.get("uncounted", 0) + 1
             continue
         task = key.get(record["task"])
         if task is None:
@@ -454,8 +472,11 @@ def print_table(cells):
         extra = c["correct"] - c["correct_of_possible"]
         score = f"{c['correct_of_possible']}/{c['possible']}" + (f"+{extra}" if extra else "")
         failed = " FAILED" if c.get("cell_error") else ""
-        if c.get("mis_served"):
-            failed += f" MIS-SERVED x{c['mis_served']}"
+        if c.get("uncounted"):
+            # One counter for one predicate: a record can stop counting because the window it ran
+            # at was not the one it asked for, or because the question has changed since. Naming
+            # the row after either reason would be wrong half the time.
+            failed += f" UNCOUNTED x{c['uncounted']}"
         print(f"{c['backend']:<12} {(c['model'] or '')[:28]:<28} "
               f"{str(c['num_ctx'] or 'dflt'):>7} {str(c['surface'] or '')[:6]:<6} "
               f"{str(c['tools'] or '-'):>5} "
@@ -487,7 +508,7 @@ def matrix(log_path, tasks_file):
         if task is None:
             continue
         graded = grade_record(record, task, surface.get("names"))
-        if not usable(record):
+        if not usable(record, key.get(record.get("task"))):
             mark = "?"
         elif graded["error"]:
             mark = "!"
@@ -560,7 +581,8 @@ def main():
     tokens = tokens_for(plan)
     log_path = plan["out"]
     logs_dir = plan.get("logs", os.path.join(os.path.dirname(log_path), "logs"))
-    done = already_done(log_path)
+    suite = cell_tasks(plan["tasks"], None)
+    done = already_done(log_path, suite)
     print(f"plan {plan['run']}: {len(done)} task records already in {log_path}")
 
     for group in plan["cells"]:
@@ -578,7 +600,7 @@ def main():
                         continue
                     run_cell(plan, tokens, backend, model, context, surface, subset,
                              group.get("budget_s", 1800), log_path, logs_dir)
-                    done = already_done(log_path)
+                    done = already_done(log_path, suite)
                 if backend == "ollama":
                     # **Evicted between contexts, not only between models** - and this is the
                     # one that had to be learned. `num_ctx` on a request does not shrink an

--- a/tools/local_model_eval.py
+++ b/tools/local_model_eval.py
@@ -84,8 +84,11 @@ def already_done(log_path):
             if not line:
                 continue
             r = json.loads(line)
-            seen.add((r.get("model"), r.get("num_ctx"), (r.get("surface") or {}).get("client"),
-                      r.get("task")))
+            # **Keyed by backend too.** Two groups can name the same model - an ollama tag
+            # aliased `sonnet` beside the Claude Code row - and without this the first one's
+            # records make the second's whole cell look finished.
+            seen.add((r.get("backend"), r.get("model"), r.get("num_ctx"),
+                      (r.get("surface") or {}).get("client"), r.get("task")))
     return seen
 
 
@@ -164,6 +167,14 @@ def run_cell(plan, tokens, backend, model, context, surface, subset, budget_s, l
                 proc.kill()
             proc.wait()
             print(f"    budget of {budget_s}s exceeded; cell killed")
+            # **The kill skipped the driver's own cleanup**, so whatever it had open is still
+            # attached under this cell's credential - and the next cell on the same surface would
+            # inherit it, or meet the four-session cap because of it. Released here, with that
+            # credential, before anything else runs.
+            release = subprocess.run([sys.executable, "-u", DRIVER, "--release"], env=env,
+                                     capture_output=True, text=True, timeout=120)
+            for line in release.stdout.splitlines():
+                print(f"    {line.strip()}")
             note = {"run": plan["run"], "backend": backend, "model": model,
                     "num_ctx": context or None, "surface": {"client": surface},
                     "task": None, "error": f"cell exceeded its {budget_s}s budget"}
@@ -343,10 +354,16 @@ def summarise(log_path, tasks_file):
         cell["correct"] = sum(1 for g in graded if g["correct"])
         cell["correct_of_possible"] = sum(1 for g in graded if g["correct"] and g["possible"])
         cell["false_positive"] = sum(1 for g in graded if g["correct"] and not g["possible"])
+        # Task-level: the driver could not complete the task at all.
         cell["errors"] = sum(1 for g in graded if g["error"])
+        # Call-level, and kept apart from it: a tool call that failed or was fenced says
+        # something about the model's picks, while a task error says the run broke. Folding the
+        # two let a cell whose every call failed report no failures at all.
+        cell["call_errors"] = sum(g["errored"] for g in graded)
+        cell["refused"] = sum(g["refused"] for g in graded)
+        cell["off_surface"] = sum(g["off_surface"] for g in graded)
         cell["unserved"] = sum(g["unserved"] for g in graded)
         cell["harness_tool"] = sum(g["harness_tool"] for g in graded)
-        cell["off_surface"] = sum(g["off_surface"] for g in graded)
         cell["wasted"] = sum(g["wasted"] for g in graded)
         cell["useful"] = sum(g["useful"] for g in graded)
         cell["result_chars"] = sum(g["result_chars"] or 0 for g in graded)
@@ -358,7 +375,7 @@ def summarise(log_path, tasks_file):
 
 def print_table(cells):
     head = (f"{'backend':<12} {'model':<28} {'ctx':>7} {'surface':<6} {'tools':>5} "
-            f"{'ok/possible':>13} {'tokens':>13} {'calls u/w/h/x':>14} {'wall':>6}")
+            f"{'ok/possible':>13} {'tokens':>13} {'calls u/w/n/r/e':>16} {'wall':>6}")
     print("\n" + head)
     print("-" * len(head))
     for c in sorted(cells, key=lambda c: (c["backend"], c["model"], -(c["num_ctx"] or 0),
@@ -375,7 +392,8 @@ def print_table(cells):
               f"{str(c['num_ctx'] or 'dflt'):>7} {str(c['surface'] or '')[:6]:<6} "
               f"{str(c['tools'] or '-'):>5} "
               f"{score} of {c['n']:<5} {tokens:>13} "
-              f"{c['useful']}/{c['wasted']}/{c['unserved']}/{c['errors']:<8} "
+              f"{c['useful']}/{c['wasted']}/{c['unserved']}/{c['refused']}/"
+              f"{c['call_errors']:<8} "
               f"{c['wall_s']:>5}s{failed}")
 
 
@@ -486,7 +504,7 @@ def main():
                     subset = group.get("subset")
                     wanted = cell_tasks(plan["tasks"], subset)
                     outstanding = [t for t in wanted
-                                   if (model, context, surface, t["id"]) not in done]
+                                   if (backend, model, context, surface, t["id"]) not in done]
                     if not outstanding:
                         print(f"  skipping {backend}:{model} ctx={context} {surface}: "
                               f"all {len(wanted)} tasks already recorded")


### PR DESCRIPTION
Follow-up to [#196](https://github.com/glslang/windbg-mcp/pull/196), which made the tool surface a property of the *client*. That is the knob this uses: three surfaces are three credentials on one listener, so a cell changes the bearer token and nothing else — the feature under measurement is the shipped one rather than a test double.

`docs/local-model.md` had two runs of one model, on one surface, at one window. Both say a 51-tool surface is drivable; neither can say which knob carried the result. This runs the grid: **3 local models × 3 tool surfaces × 3 context windows, plus Claude Code as the control — 33 cells, 150 task runs, 80 minutes.**

## What it found

**The window was not the binding constraint.** At a *served* 8,192-token window a 17,300-token surface answered all six tasks correctly, including three multi-turn tasks and two carrying ~10,000 characters of tool output. The arithmetic in `local-model.md` predicted this could not work; it works. That page now says so and points at the eval.

**The surface axis costs fewer answers than tools.** 51 → 11 removes 40 tools and 2 of 6 answers, because `open_dump`'s summary carries the bug check *and* the module count, and `crash_triage`'s frame 0 is the `pc` that `registers` reports. What narrowing does produce is calls to tools that are not there — from **every** model including both control rows, and **never** from a 51-tool cell. The refusal that names the client's own surface is load-bearing.

**Failure modes separate the models more than scores do.** Same surface, same two tools, same `crash_triage` output: qwen derives the `pc` from frame 0, gemma asks four times for `debug_batch` (not served) and returns an empty answer, nemotron reports bug check parameter 1 as the `pc` with no hedging. Opus makes nemotron's mistake here — which is what a control is for.

Scores at 262k, correct out of answerable: Opus 15/15, Sonnet 15/15, qwen3.8:27b **15/15**, gemma4:31b 14/15, nemotron-3.5:30b 10/15.

## What is new

| | |
| --- | --- |
| `tools/local_model_eval.py` | the matrix runner and the grader (`--grade`, `--matrix`) |
| `tools/claude_code_drive.py` | the control row: `claude -p` through the same listener, same allow-list |
| `tools/eval_tasks.json` | six tasks and the answer key, read off the checked-in dumps with this server's own tools |
| `tools/bench_listener.ps1` | one foreground listener, three clients, three surfaces, tokens on stdin |
| `docs/local-model-eval.md` | the method and the results |

`tools/local_model_drive.py` grows only what a grid needs: `NUM_CTX`, a JSON record per task, and a three-way verdict per call.

## Two properties that are easy to lose

**Record what the runtime *served*, not what you asked for.** `num_ctx` does not shrink an instance ollama already holds — five cells asking for 8,192 were served 32,768 and looked perfectly healthy, which is exactly the result the context axis exists to find and would have been fiction. `/api/ps` was the only disagreement. The runner now evicts between windows, every record carries `served_context`, and the grader marks a cell where the two differ. Those five were dropped and re-run.

**The Claude row needs four fences or it measures something else**: `--strict-mcp-config` (or it falls back to the editor's registered server, a different credential with the whole surface), `--disallowedTools` for the built-ins (or it answers from this repository), `ENABLE_TOOL_SEARCH=false` (or its MCP schemas are deferred and the surface costs it nothing while every other row pays), and a neutral working directory. Its prompt-token column is not comparable with the ollama rows and the document says so rather than quoting it.

## Corrections, recorded rather than smoothed over

Three grader bugs, each of which had already produced a wrong verdict: `0x22` matching inside `0x22200B`; `0x0802` failing to match `0x802`; `0xfffff801_3c65bca8` failing to match the same address without its separator. **Two of the three were caught by reading the control's answers.** One answer-key prediction was wrong — `arm64_pc` is answerable on every surface, verified against the dump before the key changed. Grading runs over the whole log at the end, so every cell is scored by the same final key.

## Verification

`markdownlint-cli2@0.23.2` clean over CI's globs. No Rust changed, so no `cargo` gates move. The grid itself is the verification of the harness: 33 cells, resumed once mid-run after the eviction fix, with 0 mis-served cells in the final log.

`FOLLOWUPS.md` item 39 has what this does not cover: every conversation here is short, so the case where the transcript rather than the surface fills the window is untested, and grading an investigation needs a different key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a comprehensive local-model evaluation workflow covering models, tool surfaces, context windows, answer grading and benchmark reporting.
  - Added automated evaluation support for Claude Code and local model runs, including task isolation, resumable results and performance metrics.
  - Added benchmark listener support for configuring and launching different tool-surface profiles.

- **Documentation**
  - Added evaluation findings, limitations, methodology and usage guidance.
  - Updated project references with links to evaluation, disassembler coordinate and smoke-test documentation.
  - Recorded follow-up opportunities for multi-step investigations and mutating-tool evaluation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->