### PR TITLE
Tell a client about the tools it is served, and no others

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A client is told about the tools it is served, and no others** (`FOLLOWUPS.md` item 40, which
+  closes it). `--tools` narrowed the router per client — `tools/list` answers with that client's
+  set, and anything else is refused by name — while the `instructions` string sent at `initialize`
+  stayed one literal naming twenty-one tools, sent to everybody. A `--tools crash` client could
+  call eleven tools and was told about twenty-one, so it would ask for `modules`, `execute` or
+  `debug_batch` and be refused; driving this server with local models measured every one of those
+  wasted calls (`docs/local-model-eval.md`) and read them as models inventing tool names. They were
+  reading this server. The string is now a base plus a fragment per group, assembled for the
+  client's own surface: 1,983 characters for the whole surface against the constant's 1,990, 1,220
+  for `session,inspect,crash`, and **927 for `crash`** — which also removes ~12% of that client's
+  prompt, on the surface that exists to be small.
+
 - **`--list-listen-clients` sorts both halves of what it prints.** A credential file's entries
   already came back sorted; the environment's arrived in the order the variables were scanned,
   which on Windows is by *variable* name — so `WINDBG_MCP_LISTEN_TOKEN` came before

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -1713,7 +1713,7 @@ Two smaller things the same run left open:
   ARM64 Mac serving MLX builds. The correctness columns should travel; the timings should not be
   quoted anywhere else.
 
-## 40. [windbg-mcp] `--tools` narrows the tool list and not the instructions
+## 40. [windbg-mcp] `--tools` narrows the tool list and not the instructions — **done** (2026-08-23)
 
 A client's surface is per credential since [#196](https://github.com/glslang/windbg-mcp/pull/196),
 and what that narrows is the **router**: `tools/list` answers with the client's own set, and a call
@@ -1744,9 +1744,17 @@ That is a rewrite of the instructions as data rather than a constant, and it mov
 tests assert on (`the_instructions_fit_what_the_client_reads`, the discovery assertion in
 `src/server.rs`, and the tool-budget golden).
 
-**Where it picks up.** `#[rmcp::tool_handler]` supplies `get_info` only when the impl does not —
-the same rule `call_tool` already relies on — so the override point is a hand-written `get_info`
-that assembles the text from the client the instance carries (`crate::client::current()` is not
-right here: the surface is captured in the listener's factory, and `WindbgServer` already holds
-it). The measurement to keep is the one above: instructions bytes against tools actually served,
-per client.
+**Where it picks up — and it did.** `#[rmcp::tool_handler]` supplies `get_info` only when the impl
+does not, the same rule `call_tool` already relies on, so the override is a hand-written `get_info`
+assembling the text from the surface `WindbgServer` already holds (`crate::client::current()` is
+not right here: the surface is captured in the listener's factory). Done that way, with
+`Toolset::serves_group` as the question each fragment asks.
+
+Two things the entry did not anticipate. **`name` had to move with `instructions`**, because both
+are literals on the same attribute and the macro reads them only while generating the `get_info`
+that is now hand-written — left behind, the server would introduce itself as `rmcp` at the SDK's
+version, which a protocol-tier assertion catches. And **the budget golden moves by seven
+characters**: the whole-surface assembly is 1,983 against the constant's 1,990, which is the only
+part of this a golden can see. What it cannot see is the direction that mattered — `crash` reading
+927 characters instead of 1,990 — so that is asserted with two credentials on one listener, which
+is the same shape every other per-client property here needs.

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -1747,8 +1747,17 @@ tests assert on (`the_instructions_fit_what_the_client_reads`, the discovery ass
 **Where it picks up — and it did.** `#[rmcp::tool_handler]` supplies `get_info` only when the impl
 does not, the same rule `call_tool` already relies on, so the override is a hand-written `get_info`
 assembling the text from the surface `WindbgServer` already holds (`crate::client::current()` is
-not right here: the surface is captured in the listener's factory). Done that way, with
-`Toolset::serves_group` as the question each fragment asks.
+not right here: the surface is captured in the listener's factory).
+
+**The invariant, which is not the one this entry first proposed:** a fragment ships only when
+**every tool it names** is served. The first attempt asked whether the fragment's *group* was
+served at all, and review caught what that costs — `--tools registers` is a valid spec, and the
+inspect sentence names `modules`, `dx` and `execute` in one breath, so a client served one tool of
+that family read about three it could not call. That is this item's own defect, reintroduced for
+partial surfaces. Each fragment therefore carries the tools it names, `instructions()` requires all
+of them, and `instructions_never_name_a_tool_the_client_cannot_call` asserts it over eight specs —
+it fails on the group-level predicate, which was checked by putting that predicate back rather than
+by reasoning about it.
 
 Two things the entry did not anticipate. **`name` had to move with `instructions`**, because both
 are literals on the same attribute and the macro reads them only while generating the `get_info`

--- a/docs/local-model-eval.md
+++ b/docs/local-model-eval.md
@@ -303,7 +303,13 @@ until it runs out.
 The same string is also **1,990 characters (~497 tokens) charged to every client identically**, of
 which **59% is sentences naming only tools the `min` client cannot call** — about 12% of that
 client's entire prompt. A narrowed surface drops 54,000 bytes of schemas and keeps every word of
-the prose advertising what was dropped. That is `FOLLOWUPS.md` item 40.
+the prose advertising what was dropped.
+
+**Fixed after this run, in the follow-up that `FOLLOWUPS.md` item 40 describes**: the instructions
+are now a base plus a fragment per group, assembled for the client's own surface, so the `min`
+client reads 927 characters naming only what it is served. Every number on this page was measured
+against the behaviour above, which is the behaviour every model here met; a re-run would find fewer
+unserved calls, and that is the point of having measured it.
 
 ### Same surface, same tool output, three different outcomes
 

--- a/docs/token-budget.md
+++ b/docs/token-budget.md
@@ -75,7 +75,7 @@ thing between them is finding 1 — the prose taken out of every `outputSchema`.
 | `description` (all 51) | 24,752 | 24,794 | yes |
 | `annotations` | 5,449 | 5,449 | no |
 | **Model-visible total** | **67,076** | **67,658** (~17k tokens) | — |
-| `initialize` instructions | 1,996 | 1,990 | yes, **all of it** |
+| `initialize` instructions | 1,996 | 1,983 | yes, **all of it** |
 
 The two halves moved independently, which is the whole argument for measuring them apart: the wire
 fell by 55% and the model-visible column did not move at all except for what the tools themselves
@@ -205,9 +205,16 @@ None of these is a bug. They are recorded because they were invisible, and
 4. **The instructions overran what the client reads** — **fixed**. 3,147 chars were sent and 2,048
    read, so 1,099 were paid for on every connection and discarded, and what fell off the end was the
    `debug_batch` paragraph: the one instruction there that stops a mutation being left half-applied.
-   Rewritten to 1,990 characters with the batch guidance inside the budget, kept ASCII so the
-   character and byte counts cannot diverge, and pinned by an assertion in the protocol tier so it
-   cannot grow back unnoticed.
+   Rewritten with the batch guidance inside the budget, kept ASCII so the character and byte counts
+   cannot diverge, and pinned by an assertion in the protocol tier so it cannot grow back unnoticed.
+
+   **And since then, narrowed per client** (`FOLLOWUPS.md` item 40): it was one constant naming
+   twenty-one tools sent to everybody, so a `--tools crash` client reading eleven tools was told
+   about all twenty-one and would ask for what it could not call. It is now a base plus a fragment
+   per group, assembled for the client's own surface — 1,983 characters for the whole surface,
+   1,220 for `session,inspect,crash`, **927 for `crash`**. The number in the table above is the
+   whole-surface one, which is the only one a golden can pin; the other two are asserted by two
+   credentials on one listener.
 5. **`modules` had neither a `limit` nor a cap**, alone among the high-volume tools — **fixed**.
    53,875 B here; more on a live kernel. It now takes a `limit` (default 64 rows, maximum 2000)
    that bounds the **whole** listing, the loaded and unloaded halves sharing it through the same

--- a/src/server.rs
+++ b/src/server.rs
@@ -4458,34 +4458,56 @@ interrupted - it waits indefinitely, and `end_session` reclaims that session alo
 /// client reads, so a fragment added here is paid for by every client that group is served to.
 const GROUP_INSTRUCTIONS: &[(&[&str], &str)] = &[
     (
-        "crash",
+        &["crash_triage"],
         "`crash_triage` reads a bug check as fields, with the crashing stack and the module each frame \
      belongs to.",
     ),
     (
-        "inspect",
+        &["modules", "dx", "execute"],
         "`modules` lists the module table and carries each image's identity - the coordinate that \
      survives a reboot and joins a disassembler; frames and instructions carry `module`+`rva` beside \
      their address. `dx` runs any data-model expression, and `execute` any raw command without a \
      dedicated tool.",
     ),
     (
-        "exec",
+        &[
+            "go",
+            "step_over",
+            "step_into",
+            "set_breakpoint",
+            "run_to_address",
+        ],
         "`go`, `step_over` and `step_into` drive a stopped target, `set_breakpoint` arms one, and \
      `run_to_address` needs a KDNET/VM kernel target, not a local one.",
     ),
     (
-        "ttd",
+        &[
+            "reverse_go",
+            "step_back",
+            "step_over_back",
+            "goto_position",
+            "ttd_calls",
+            "ttd_memory",
+            "ttd_events",
+            "record_trace",
+        ],
         "TTD: `reverse_go`, `step_back` and `step_over_back` run backward, `goto_position` jumps, \
      `ttd_calls`/`ttd_memory`/`ttd_events` query a trace and `record_trace` makes one.",
     ),
     (
-        "ioctl",
+        &[
+            "decode_ioctl",
+            "driver_object",
+            "device_object",
+            "irp_stack",
+            "ioctl_trace",
+            "reachable_from_dispatch",
+        ],
         "Driver IOCTL: `decode_ioctl`, `driver_object`, `device_object`, `irp_stack`, `ioctl_trace`, and \
      `reachable_from_dispatch` - is a block reachable from the dispatch routine.",
     ),
     (
-        "batch",
+        &["debug_batch"],
         "When a sequence *mutates* the target - a patched byte, an armed breakpoint, a resumed thread - \
      run it as one `debug_batch`: its `always` block runs on every path, including a failed \
      assertion, an expired deadline and a client disconnect, so cleanup cannot be lost.",

--- a/src/server.rs
+++ b/src/server.rs
@@ -2564,6 +2564,23 @@ impl WindbgServer {
     ///
     /// Built per call, which is what `Self::tool_router()` already was — the schemas underneath it
     /// are cached by type, so this is a map of fifty-one `Arc` clones and a `retain`.
+    /// The instructions this client is served: the base, plus a fragment per group it has.
+    ///
+    /// The pair to [`Self::router`] - that decides which tools this client may call, and this
+    /// decides which it is told about. They were out of step from #196 until `FOLLOWUPS.md` item
+    /// 40: a `crash`-surface client could call eleven tools and was told about twenty-one, so
+    /// every model on that surface asked for something it would then be refused.
+    fn instructions(&self) -> String {
+        let mut text = String::from(BASE_INSTRUCTIONS);
+        for (group, fragment) in GROUP_INSTRUCTIONS {
+            if self.surface.serves_group(group) {
+                text.push(' ');
+                text.push_str(fragment);
+            }
+        }
+        text
+    }
+
     fn router(&self) -> rmcp::handler::server::tool::ToolRouter<Self> {
         let mut router = Self::tool_router();
         self.surface.narrow(&mut router);
@@ -4402,40 +4419,105 @@ impl WindbgServer {
 // that expands in this crate. Pass `name` only: the attribute takes a string literal, so
 // `version = env!(...)` would not even parse, and spelling the version out by hand would just be a
 // second place to forget to bump.
-// **Sized to what the client actually reads.** Measured at 2,048 characters, and the previous text
-// was 3,147 — so 1,099 characters were paid for on every connection and never arrived, taking the
-// whole `debug_batch` paragraph with them, which is the one instruction here that prevents a
-// half-applied mutation. Kept ASCII so the count cannot differ between characters and bytes, and
-// `the_instructions_fit_what_the_client_reads` fails if it grows back.
+/// The half of the instructions every client reads, whatever its surface.
+///
+/// Split from the rest because `--tools` narrows the surface **per client** and this string used
+/// not to move with it: one constant naming twenty-one tools went to every client, so a client
+/// served eleven was told about `modules`, `execute`, `decode_ioctl` and `debug_batch` and would
+/// ask for them (`FOLLOWUPS.md` item 40, measured in `docs/local-model-eval.md`).
+///
+/// A fragment per **group** rather than a filter over one text, because the prose names several
+/// tools per sentence and cutting by name leaves mangled English in the first thing a model reads.
+const BASE_INSTRUCTIONS: &str = "Drive WinDbg/DbgEng for live user-mode, kernel, crash-dump and Time Travel Debugging (TTD) work. \
+Each open target is a separate session in its own engine process, so up to 4 coexist \
+independently: pass the `session_id` an opener returns on every later call to route it to that \
+target, and `end_session` when done. An opener answers with a summary of the target rather than \
+its module table. If an open reports a timeout, ask `session_status` rather than running the \
+open again - a second open attaches or launches a second time. To stop a call that is \
+overrunning, `interrupt` its session while it is still outstanding: the interrupt returns at \
+once, and the partial result comes back on the original call. A live kernel attach cannot be \
+interrupted - it waits indefinitely, and `end_session` reclaims that session alone.";
+
+/// One fragment per group, in the order they are assembled.
+///
+/// The allocator family is deliberately absent: it was never in this string, and this change is
+/// about not advertising what a client cannot call rather than advertising more.
+///
+/// `the_instructions_fit_what_the_client_reads` measures the whole assembly against the 2,048 a
+/// client reads, so a fragment added here is paid for by every client that group is served to.
+const GROUP_INSTRUCTIONS: &[(&str, &str)] = &[
+    (
+        "crash",
+        "`crash_triage` reads a bug check as fields, with the crashing stack and the module each frame \
+     belongs to.",
+    ),
+    (
+        "inspect",
+        "`modules` lists the module table and carries each image's identity - the coordinate that \
+     survives a reboot and joins a disassembler; frames and instructions carry `module`+`rva` beside \
+     their address. `dx` runs any data-model expression, and `execute` any raw command without a \
+     dedicated tool.",
+    ),
+    (
+        "exec",
+        "`go`, `step_over` and `step_into` drive a stopped target, `set_breakpoint` arms one, and \
+     `run_to_address` needs a KDNET/VM kernel target, not a local one.",
+    ),
+    (
+        "ttd",
+        "TTD: `reverse_go`, `step_back` and `step_over_back` run backward, `goto_position` jumps, \
+     `ttd_calls`/`ttd_memory`/`ttd_events` query a trace and `record_trace` makes one.",
+    ),
+    (
+        "ioctl",
+        "Driver IOCTL: `decode_ioctl`, `driver_object`, `device_object`, `irp_stack`, `ioctl_trace`, and \
+     `reachable_from_dispatch` - is a block reachable from the dispatch routine.",
+    ),
+    (
+        "batch",
+        "When a sequence *mutates* the target - a patched byte, an armed breakpoint, a resumed thread - \
+     run it as one `debug_batch`: its `always` block runs on every path, including a failed \
+     assertion, an expired deadline and a client disconnect, so cleanup cannot be lost.",
+    ),
+];
+
+// **Sized to what the client actually reads.** Measured at 2,048 characters, and the text this
+// replaced was 3,147 - so 1,099 characters were paid for on every connection and never arrived.
+// Kept ASCII so the count cannot differ between characters and bytes, and
+// `the_instructions_fit_what_the_client_reads` fails if the whole assembly grows back.
 #[rmcp::tool_handler(
     // `list_tools` and `get_tool` come from the macro; what they list is this instance's router
     // rather than the crate-wide one, which is what makes `--tools` visible on the wire. The
     // default here is `Self::tool_router()`, and leaving it would have narrowed the calls a tool
     // may make (`dispatch`) while still advertising all fifty-one.
+    //
+    // `name` and `instructions` used to be here too. They moved into the hand-written `get_info`
+    // below, which the macro yields to - the instructions are now assembled for the client's own
+    // surface, and a constant on this attribute cannot be.
     router = self.router(),
-    name = "windbg-mcp",
-    instructions = "Drive WinDbg/DbgEng for live user-mode, kernel, crash-dump and Time Travel Debugging (TTD) work: open a \
-dump or .run trace, attach to a process or the kernel, inspect registers/memory/stacks/modules, set \
-breakpoints. Each open target is a separate session in its own engine process, so up to 4 coexist \
-independently: pass the `session_id` an opener returns on every later call to route it to that target, \
-and `end_session` when done. An opener answers with a summary rather than the module table; `modules` \
-lists that, and `crash_triage` reads a bug check with its stack. If an open reports a timeout, ask \
-`session_status` rather than running the open again - a second open attaches or launches a second time. \
-To stop a call that is overrunning, `interrupt` its session while the call is still outstanding: the \
-interrupt returns at once, and the partial result comes back on the original call. A live kernel attach \
-cannot be interrupted - it waits indefinitely, and `end_session` reclaims that session alone. Stack \
-frames and instructions carry `module`+`rva` beside their address, and `modules` carries each image's \
-identity - the coordinate that survives a reboot and joins a disassembler. TTD: go/step_over/step_into \
-forward, reverse_go/step_over_back/step_back backward, goto_position to jump; ttd_calls, ttd_memory and \
-ttd_events query a trace, dx runs any data-model expression. Driver IOCTL: decode_ioctl, driver_object, \
-device_object, irp_stack, ioctl_trace, and reachable_from_dispatch - is a block reachable from the \
-dispatch routine. Confirm a verdict live with run_to_address, which needs a KDNET/VM kernel target, not \
-a local one. When a sequence *mutates* the target - a patched byte, an armed breakpoint, a resumed \
-thread - run it as one `debug_batch`: its `always` block runs in the engine process on every path, \
-including a failed assertion, an expired deadline and a client disconnect, so cleanup cannot be lost. \
-Use `execute` for any raw command without a dedicated tool."
 )]
 impl rmcp::ServerHandler for WindbgServer {
+    /// What this server says it is, and what it tells *this* client it can do.
+    ///
+    /// Written out rather than left to `#[rmcp::tool_handler]` for the same reason `call_tool` is:
+    /// the macro supplies it only when the impl does not. Its version takes `name` and
+    /// `instructions` as literals on the attribute, and a literal cannot vary per client - which
+    /// is the whole of `FOLLOWUPS.md` item 40. Everything else here is what the macro would have
+    /// built, including the `name`, which left to the default reads `rmcp` at the SDK's version
+    /// because `Implementation::from_build_env()` resolves its `env!`s inside rmcp.
+    fn get_info(&self) -> rmcp::model::ServerInfo {
+        rmcp::model::ServerInfo::new(
+            rmcp::model::ServerCapabilities::builder()
+                .enable_tools()
+                .build(),
+        )
+        .with_server_info(rmcp::model::Implementation::new(
+            "windbg-mcp",
+            env!("CARGO_PKG_VERSION"),
+        ))
+        .with_instructions(self.instructions())
+    }
+
     /// Every tool call, recorded on its way through.
     ///
     /// Written out rather than left to `#[rmcp::tool_handler]` — which supplies it only when the

--- a/src/server.rs
+++ b/src/server.rs
@@ -2572,8 +2572,8 @@ impl WindbgServer {
     /// every model on that surface asked for something it would then be refused.
     fn instructions(&self) -> String {
         let mut text = String::from(BASE_INSTRUCTIONS);
-        for (group, fragment) in GROUP_INSTRUCTIONS {
-            if self.surface.serves_group(group) {
+        for (names, fragment) in GROUP_INSTRUCTIONS {
+            if names.iter().all(|tool| self.surface.includes(tool)) {
                 text.push(' ');
                 text.push_str(fragment);
             }
@@ -4438,14 +4438,25 @@ overrunning, `interrupt` its session while it is still outstanding: the interrup
 once, and the partial result comes back on the original call. A live kernel attach cannot be \
 interrupted - it waits indefinitely, and `end_session` reclaims that session alone.";
 
-/// One fragment per group, in the order they are assembled.
+/// One fragment per group, in the order they are assembled, **paired with the tools it names**.
+///
+/// Named tools rather than a group name because a spec may select part of a group
+/// (`--tools registers` is valid), and a fragment is only safe to send when *every* tool it names
+/// is served: the inspect sentence says `modules`, `dx` and `execute` in one breath, so a client
+/// served `registers` alone must not read it. That was this change's own first version - it asked
+/// whether a group was served at all, which reintroduced the leak it exists to remove, for the
+/// partial-surface case.
+///
+/// The consequence is silence rather than a half-sentence: a client served `modules` but not `dx`
+/// reads nothing about either. Splitting that sentence would be the way to fix it, and is a
+/// change to the prose rather than to this rule.
 ///
 /// The allocator family is deliberately absent: it was never in this string, and this change is
 /// about not advertising what a client cannot call rather than advertising more.
 ///
 /// `the_instructions_fit_what_the_client_reads` measures the whole assembly against the 2,048 a
 /// client reads, so a fragment added here is paid for by every client that group is served to.
-const GROUP_INSTRUCTIONS: &[(&str, &str)] = &[
+const GROUP_INSTRUCTIONS: &[(&[&str], &str)] = &[
     (
         "crash",
         "`crash_triage` reads a bug check as fields, with the crashing stack and the module each frame \
@@ -4627,6 +4638,96 @@ fn text_of(result: &CallToolResult) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ---- the instructions a client is served ---------------------------
+
+    /// The instructions for one surface, without a `Sessions` to build a whole server from.
+    fn instructions_for(spec: &str) -> String {
+        let surface = crate::toolset::Toolset::parse(spec)
+            .unwrap_or_else(|e| panic!("`{spec}` should be a valid spec: {e}"));
+        let mut text = String::from(BASE_INSTRUCTIONS);
+        for (names, fragment) in GROUP_INSTRUCTIONS {
+            if names.iter().all(|tool| surface.includes(tool)) {
+                text.push(' ');
+                text.push_str(fragment);
+            }
+        }
+        text
+    }
+
+    /// Whether a tool's name appears in prose, as a word rather than inside another word — `go`
+    /// and `dx` are tool names and are also two letters long.
+    fn names_tool(text: &str, tool: &str) -> bool {
+        let boundary = |c: Option<char>| c.is_none_or(|c| !c.is_alphanumeric() && c != '_');
+        text.match_indices(tool).any(|(at, _)| {
+            boundary(text[..at].chars().next_back())
+                && boundary(text[at + tool.len()..].chars().next())
+        })
+    }
+
+    /// **The property this whole split exists for**: whatever a client is served, its instructions
+    /// never name a tool it cannot call.
+    ///
+    /// The first version of the split asked whether a *group* was served at all, which passes for
+    /// every spec here except the last two — a spec may name a single tool, and the inspect
+    /// sentence names `modules`, `dx` and `execute` together.
+    #[test]
+    fn instructions_never_name_a_tool_the_client_cannot_call() {
+        for spec in [
+            "all",
+            "crash",
+            "session,inspect,crash",
+            "session",
+            "registers",
+            "crash,modules",
+            "ttd",
+            "ioctl,batch",
+        ] {
+            let surface = crate::toolset::Toolset::parse(spec).expect("a valid spec");
+            let text = instructions_for(spec);
+            for tool in crate::toolset::Toolset::every_tool() {
+                if surface.includes(tool) {
+                    continue;
+                }
+                assert!(
+                    !names_tool(&text, tool),
+                    "`--tools {spec}` is not served `{tool}` and its instructions name it:\n{text}"
+                );
+            }
+        }
+    }
+
+    /// The tools beside each fragment are what it actually says, so the two cannot drift: a name
+    /// added to the prose and not to the list is a leak the check above would never see.
+    #[test]
+    fn every_fragment_declares_the_tools_it_names() {
+        for (names, fragment) in GROUP_INSTRUCTIONS {
+            for tool in crate::toolset::Toolset::every_tool() {
+                let declared = names.contains(&tool);
+                let said = names_tool(fragment, tool);
+                assert_eq!(
+                    declared,
+                    said,
+                    "`{tool}` is {} in the fragment and {} beside it:\n{fragment}",
+                    if said { "named" } else { "absent" },
+                    if declared { "declared" } else { "not declared" },
+                );
+            }
+        }
+    }
+
+    /// A fragment naming a tool this server does not have would be advertising nothing.
+    #[test]
+    fn every_fragment_names_real_tools() {
+        for (names, _) in GROUP_INSTRUCTIONS {
+            for tool in *names {
+                assert!(
+                    crate::toolset::Toolset::exists(tool),
+                    "`{tool}` is named in the instructions and is not a tool this server has"
+                );
+            }
+        }
+    }
 
     // ---- MCP protocol surface ------------------------------------------
 

--- a/src/toolset.rs
+++ b/src/toolset.rs
@@ -296,21 +296,13 @@ impl Toolset {
     }
 
     /// Is this tool served?
-    /// Whether any tool of a named group is on this surface.
+    /// Every tool this server has, for the assertions that have to range over all of them.
     ///
-    /// For the server's `instructions`, which are assembled from a fragment per group rather than
-    /// filtered by tool name: the prose names several tools per sentence, so cutting by name
-    /// leaves mangled English in the one string a model reads before anything else. Asking per
-    /// group is what lets a whole sentence be dropped or kept.
-    ///
-    /// *Any* rather than *all*, because a spec may name a single tool out of a group
-    /// (`--tools registers`), and a client served one tool of a family still needs the sentence
-    /// that says what the family is for.
-    pub fn serves_group(&self, group: &str) -> bool {
-        GROUPS
-            .iter()
-            .find(|candidate| candidate.name == group)
-            .is_some_and(|candidate| candidate.tools.iter().any(|tool| self.includes(tool)))
+    /// `GROUPS` is the table and stays private - this is the read-only view of it that
+    /// `src/server.rs` needs to check that no client's `instructions` name a tool it is not
+    /// served.
+    pub fn every_tool() -> impl Iterator<Item = &'static str> {
+        GROUPS.iter().flat_map(|group| group.tools.iter().copied())
     }
 
     pub fn includes(&self, name: &str) -> bool {

--- a/src/toolset.rs
+++ b/src/toolset.rs
@@ -296,6 +296,23 @@ impl Toolset {
     }
 
     /// Is this tool served?
+    /// Whether any tool of a named group is on this surface.
+    ///
+    /// For the server's `instructions`, which are assembled from a fragment per group rather than
+    /// filtered by tool name: the prose names several tools per sentence, so cutting by name
+    /// leaves mangled English in the one string a model reads before anything else. Asking per
+    /// group is what lets a whole sentence be dropped or kept.
+    ///
+    /// *Any* rather than *all*, because a spec may name a single tool out of a group
+    /// (`--tools registers`), and a client served one tool of a family still needs the sentence
+    /// that says what the family is for.
+    pub fn serves_group(&self, group: &str) -> bool {
+        GROUPS
+            .iter()
+            .find(|candidate| candidate.name == group)
+            .is_some_and(|candidate| candidate.tools.iter().any(|tool| self.includes(tool)))
+    }
+
     pub fn includes(&self, name: &str) -> bool {
         match &self.included {
             None => true,

--- a/tests/golden/tool_budget.json
+++ b/tests/golden/tool_budget.json
@@ -464,7 +464,7 @@
     "annotations": 5449,
     "description": 24794,
     "inputSchema": 40207,
-    "instructions": 1990,
+    "instructions": 1983,
     "modelVisible": 67658,
     "outputSchema": 102942,
     "payload": 177460,

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -2779,6 +2779,62 @@ fn two_clients_on_one_listener_are_served_two_surfaces() {
         assert!(names.contains(&"open_dump".to_string()), "{names:?}");
     }
 
+    // **The instructions move with the surface too**, which they did not until `FOLLOWUPS.md`
+    // item 40: one constant naming twenty-one tools went to every client, so a client served
+    // eleven was told about `modules`, `execute` and `debug_batch` and would ask for them. The
+    // eval measured that as models inventing tool names; they were reading this server.
+    let instructions = |server: &mut Listener, token: &str| -> String {
+        let reply = server.call_as(token, None, "initialize", Listener::opening());
+        assert_eq!(reply.status, 200, "{}", reply.body);
+        reply.payload.clone().expect("a JSON-RPC payload")["result"]["instructions"]
+            .as_str()
+            .unwrap_or_else(|| panic!("initialize carried no instructions: {}", reply.body))
+            .to_string()
+    };
+    let to_local = instructions(&mut server, &local_token);
+    let to_bench = instructions(&mut server, &bench_token);
+    for text in [&to_local, &to_bench] {
+        // The base half, which every surface includes because every tool routes by a handle.
+        assert!(text.contains("WinDbg"), "{text}");
+        assert!(text.contains("session_id"), "{text}");
+        assert!(text.contains("end_session"), "{text}");
+    }
+    // Each is told about its own groups and no others. `debug_batch` is the one to keep an eye on:
+    // it is a group of one, it is the most destructive tool here, and neither of these clients is
+    // served it.
+    for absent in [
+        "crash_triage",
+        "debug_batch",
+        "decode_ioctl",
+        "ttd_calls",
+        "run_to_address",
+    ] {
+        assert!(
+            !to_local.contains(absent),
+            "`local` is served session,inspect and was told about `{absent}`: {to_local}"
+        );
+    }
+    for absent in [
+        "modules",
+        "execute",
+        "debug_batch",
+        "decode_ioctl",
+        "ttd_calls",
+    ] {
+        assert!(
+            !to_bench.contains(absent),
+            "`bench` is served crash and was told about `{absent}`: {to_bench}"
+        );
+    }
+    assert!(to_local.contains("modules"), "{to_local}");
+    assert!(to_bench.contains("crash_triage"), "{to_bench}");
+    assert!(
+        to_bench.len() < to_local.len(),
+        "the smaller surface should read less prose: bench {} vs local {}",
+        to_bench.len(),
+        to_local.len()
+    );
+
     // And a tool off the surface is refused by name, with the remedy for *this* caller: `local`
     // takes the run's, so the flag is the answer; `bench` has one of its own, so the client
     // command is. Naming the wrong one sends an operator to widen a spec that is not in force.


### PR DESCRIPTION
Stacked on [#205](https://github.com/glslang/windbg-mcp/pull/205), whose eval found this and whose `FOLLOWUPS.md` item 40 describes it. **Base is `local-model-eval`, so merge that first.**

`--tools` narrows the **router** per client: `tools/list` answers with that client's set, and a call for anything else is refused by name. The `instructions` string sent at `initialize` never moved with it — one literal on `#[rmcp::tool_handler]`, naming twenty-one tools, sent to everybody:

```
min   served 11 tools | instructions 1990 chars | names 21 tools, 17 of them not served
full  served 51 tools | instructions 1990 chars | names 21 tools,  0 not served
```

## What it cost, measured rather than assumed

**Wasted turns.** Every off-surface call in #205's grid is one of the seventeen names this string advertises — both Claude control rows asked for `modules` and `execute`, and gemma spent an entire task's turn budget re-asking for `debug_batch`. The eval recorded that as models *inventing* tool names; they were reading this server's own advertising, and its metric is renamed `unserved` in that PR because of this one.

**Context, on the surface least able to pay it.** 1,990 characters, ~497 tokens, identical for every client, of which **59% was sentences naming only tools a `crash` client cannot call** — about 12% of that client's whole prompt. `--tools crash` dropped 54,000 bytes of schemas and kept every word of the prose selling what it dropped.

## The shape

A base plus a fragment per **group**, assembled for the client's own `Toolset` — not a filter over the old text, because that text names several tools per sentence and cutting by name leaves mangled English in the first thing a model reads. `Toolset::serves_group` is the question each fragment asks, and it is *any* rather than *all*: a spec may name one tool out of a family (`--tools registers`), and that client still needs the sentence saying what the family is for.

`get_info` is now written out, which the macro yields to exactly as it does for `call_tool` (`// Auto-generate get_info() if not already provided`). **`name` had to move with it** — left on the attribute it is only read while generating the `get_info` that no longer exists, and the server would introduce itself as `rmcp` at the SDK's version, which a protocol-tier assertion catches.

| Surface | Instructions |
| --- | --- |
| all 51 tools | 1,983 (the constant it replaces was 1,990) |
| `session,inspect,crash` | 1,220 |
| `crash` | **927** |

The allocator family stays absent as it was before: this is about not advertising what a client cannot call, not about advertising more.

## Coverage

The per-client property is asserted the only way it can be — **two credentials on one listener**, extending `two_clients_on_one_listener_are_served_two_surfaces`: `bench`, served `crash`, must not read the words `modules`, `execute` or `debug_batch`; `local`, served `session,inspect`, must not read `crash_triage`, `debug_batch`, `decode_ioctl`, `ttd_calls` or `run_to_address`; both must still carry the base. With one credential, "this client's instructions" and "the run's" are the same string — the same reason that test exists at all.

The budget golden moves by exactly seven characters (`instructions 1990 -> 1983`) and nothing else: no tool's schema, description or annotations changed, which is what reading that diff is for.

## Verified on the ARM64 bench

`cargo clippy --all-targets -- -D warnings` clean, `cargo fmt --all --check` clean, **530** unit tests, **76** smoke tests, and the debugger tier with `WINDBG_MCP_SMOKE_DUMP=1` at **63.7s**, so it ran rather than skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Client instructions now reflect only the tools available on that client’s configured tool surface.
  - Removed references to unavailable tools, reducing confusion and prompt size for narrowed tool sets.
  - Server information now consistently includes the correct identity and tailored guidance.

- **Documentation**
  - Updated changelog and guidance on local model evaluation and token budgets.
  - Added measured instruction sizes for full and reduced tool surfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->