### PR TITLE
Re-run the narrow cells against the fix they argued for

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   call eleven tools and was told about twenty-one, so it would ask for `modules`, `execute` or
   `debug_batch` and be refused; driving this server with local models measured every one of those
   wasted calls (`docs/local-model-eval.md`) and read them as models inventing tool names. They were
-  reading this server. The string is now a base plus a fragment per group, assembled for the
-  client's own surface: 1,983 characters for the whole surface against the constant's 1,990, 1,220
-  for `session,inspect,crash`, and **927 for `crash`** — which also removes ~12% of that client's
-  prompt, on the surface that exists to be small.
+  reading this server — through this string where the client injects it into its prompt, and
+  through the descriptions of tools they *are* served where it does not (`FOLLOWUPS.md` item 41).
+  The string is now a base plus a fragment per group, assembled for the client's own surface:
+  1,983 characters for the whole surface against the constant's 1,990, 1,220 for
+  `session,inspect,crash`, and **927 for `crash`** — a 53% cut, worth ~265 tokens to a client that
+  reads it, on the surface that exists to be small.
 
 - **`--list-listen-clients` sorts both halves of what it prints.** A credential file's entries
   already came back sorted; the environment's arrived in the order the variables were scanned,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -824,13 +824,23 @@ directory**, since Claude Code reads the project it is started in. Its prompt-to
 not comparable with the ollama rows — its own system prompt is most of it — and the document says
 so rather than quoting it.
 
-**`--tools` narrows the router and not the `instructions`, and that shows up as a model
-"inventing" tools.** The string on `#[rmcp::tool_handler]` is a compile-time constant naming
-twenty-one tools, sent identically to every client: a `crash`-surface client is served 11 tools and
-told about 21, of which 17 it cannot call. Every off-surface call the grid recorded is one of those
-seventeen, so a count of them measures this server's advertising rather than any model's
-imagination - the metric is `unserved` for that reason, and `FOLLOWUPS.md` item 40 is the fix.
-Worth knowing before reading any tool-selection result from a narrowed surface.
+**A model "inventing" tools on a narrowed surface is almost always this server advertising them,
+and there are two channels, of which only one is now narrowed.** The `instructions` string is
+per-client since item 40; a *tool's description* is not, and the descriptions of tools a `crash`
+client **is** served still name `modules` (`open_dump`), `debug_batch` (`interrupt`,
+`end_session`), `backtrace` (`crash_triage`) and `go` (`interrupt`) - five references on an
+eleven-tool surface. Re-running the five `min` cells against item 40's fix (2026-08-24) moved unserved
+calls 17 -> 14, with 13 of the remainder naming exactly those - `FOLLOWUPS.md` item 41. So the
+metric is still `unserved` rather than "hallucinated", and it still measures the server before it
+measures the model. One call in 61 was a genuine invention, which is the floor.
+
+**And the ollama rows never read the `instructions` at all**, which is what nearly made that fix
+look bigger than it is. `tools/local_model_drive.py`'s handshake keeps the negotiated protocol
+version and discards the rest of the `initialize` result, so a local row's prompt is the
+one-sentence system prompt plus `tools/list`: narrowing that string cannot move those prompt-token
+columns by one token, and it did not. Claude Code injects a server's instructions into its own
+system prompt, so the two control rows are the only ones any instructions measurement is about.
+Check which half of the bench a prose change can reach before predicting what it will do.
 
 **The bench listener is the shipped per-client feature in anger.** `tools/bench_listener.ps1`
 serves `full`, `lean` and `min` from one foreground process, tokens arriving on **stdin**; its

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -23,7 +23,9 @@ service's clients fixed at install time (both 2026-08-22), and items 37–38 fro
 file gaining a fourth writer while still having no reader, and from exercising what that reader
 says against a real service (both 2026-08-23), and items 39–40 from running the surface, the window
 and the model as a **grid** rather than as a sighting, and from what that grid found leaking
-through the one thing `--tools` does not narrow (both 2026-08-23). Each item notes its repo,
+through the one thing `--tools` does not narrow (both 2026-08-23), and item 41 from re-running
+the narrowed cells against that fix and finding two of the same names arriving by a second route
+(2026-08-24). Each item notes its repo,
 why it was deferred, and where it picks up. See [`DECISIONS.md`](./DECISIONS.md) for the design rationale (D1–D5) items 1–6 extend,
 and the 2026-08-02 entries that items 13–14 and item 10 extend.
 
@@ -1767,3 +1769,69 @@ characters**: the whole-surface assembly is 1,983 against the constant's 1,990, 
 part of this a golden can see. What it cannot see is the direction that mattered — `crash` reading
 927 characters instead of 1,990 — so that is asserted with two credentials on one listener, which
 is the same shape every other per-client property here needs.
+
+**What it actually bought, measured** (2026-08-24, the five `min` cells of
+[`docs/local-model-eval.md`](./docs/local-model-eval.md) re-run against the fix). Unserved calls
+went from 17 to 14, and both names that lived nowhere but the instructions — `execute` (3 calls)
+and `decode_ioctl` (1) — went to zero and stayed there. The other two did not move: `debug_batch`
+(9 calls, then 10) and `modules` (4, then 3), because the tools a `min` client *is* served name
+them in their own descriptions. That remainder is item 41.
+
+And **the context half of this entry is smaller than it reads** for anything but a client that
+injects the string. The eval's own ollama driver discards `initialize`'s result past the protocol
+version, so the three local rows' prompts never carried the 1,990 characters and their token counts
+did not move by one. The 12%-of-prompt figure describes a client like Claude Code, whose rows sit
+at ~27,500 tokens on this surface — where the saving is ~265 tokens, about 1%. The wasted *turns*
+were always the larger cost of the two this item names.
+
+## 41. [windbg-mcp] A served tool's description advertises tools the client is not served
+
+Item 40 narrowed the `instructions` string per client. It is not the only prose a client reads: the
+**description of every tool it is served** is the other, and those cross-reference tools that a
+narrowed surface has removed. On `--tools crash` (eleven tools) there are five such references,
+naming four tools:
+
+| The client is served | and its description names | at |
+| --- | --- | --- |
+| `open_dump` | `modules` — "not its module table, which `modules` lists" | `src/server.rs:2594` |
+| `interrupt` | `go` — "a broad `s` search, a `go` that …" | `:3291` |
+| `interrupt` | `debug_batch` | `:3313` |
+| `end_session` | `debug_batch` | `:3358` |
+| `crash_triage` | `backtrace` | `:3061` |
+
+`--tools session,inspect,crash` keeps the three on `interrupt` and `end_session`; the whole surface
+has none, by definition. Count them with a scan that skips plain `//` comments as well as code:
+`interrupt`'s doc block is separated from its `#[rmcp::tool(…)]` by a note to the reader of the
+source, so a walk-back that stops at the first non-`///` line misses two of the five — which is how
+this entry first said four.
+
+**Measured, on the same bench that found item 40** (2026-08-24): with item 40's fix live, the five
+`min` cells still produced **14** unserved calls, and **13 of them** name `modules` or
+`debug_batch` — exactly the three descriptions above. The fourteenth, Opus asking for
+`list_modules`, is a name this server does not have anywhere, which is the floor this class has:
+narrowing every string cannot take it to zero.
+
+**Why it is deferred rather than done with item 40, and why it may not be worth doing at all.**
+Item 40 had an assembly point — one string, built per client, so the fragment for a group nobody is
+served simply is not appended. A description has none: it is one literal per tool, shipped in
+`tools/list`, and the sentence naming `modules` is *correct and useful* for the client that has
+`modules`. So the shapes available are all worse than the one item 40 used:
+
+- **Delete the cross-reference.** Cheapest, and it costs every `full`-surface client a pointer that
+  is doing real work — "the opener does not give you the module table, `modules` does" is how a
+  model learns the second call.
+- **Assemble descriptions per client, as item 40 does for instructions.** Correct, and it makes
+  every tool's description a function of the surface: the tool-budget golden then has to record a
+  surface rather than a tool (`docs/token-budget.md`'s per-tool rows lose their meaning), and
+  `schema::constraints_of` is no longer the only thing standing between a doc comment and the wire.
+- **Say it without the name** — "the module table has a tool of its own". Keeps the pointer, loses
+  the exact string a model can copy into a call, and reads worse for the 51-tool client who is the
+  one that can act on it.
+
+**Where it picks up.** The test is the cheap half and already has a sibling to copy:
+`instructions_never_name_a_tool_the_client_cannot_call` walks eight specs; the same walk over each
+served tool's `description` fails today on the five references above. Land that as an `#[ignore]`d
+or `should_panic` assertion only if a remedy is chosen — a red test with no intended fix is worse
+than this entry. The number worth having first is the cost: **13 wasted turns in 61 calls** is what
+the descriptions bought, against the four calls the instructions were costing, so the question is
+whether a turn is worth more than a cross-reference to the clients that keep it.

--- a/docs/local-model-eval.md
+++ b/docs/local-model-eval.md
@@ -117,7 +117,8 @@ Mechanical, and stated so it can be argued with:
   question), `off_surface` (the server refused it — on a narrowed surface, the tool is not served),
   `refused` (the harness's read-only fence), and `errored`.
 - **`unserved`** — a call naming a tool this client is not served. It was called `hallucinated`
-  until the run was read properly; see below, because the server is where those names came from.
+  until the run was read properly; see below, because the server is where all but one of those
+  names came from.
 
 Nothing is graded by a model. A substring check accepts an answer a reader would not in exactly one
 direction — a model that lists every bug check code including the right one — and every cell's raw
@@ -239,7 +240,9 @@ python3 tools/local_model_eval.py --grade results.jsonl tools/eval_tasks.json
 
 Run 2026-08-23, on the ARM64 bench described in `local-model.md`: 33 cells, 144 task runs, about
 three hours of wall clock. The raw log, every answer and every tool call are what the tables below
-are reduced from.
+are reduced from. A second, narrow run followed on 2026-08-24 — the five `min` cells against the
+server fix this one found — and is reported in its own section rather than folded into these
+numbers, because a table that mixed two servers would answer neither question.
 
 ### At the window this bench actually serves
 
@@ -263,7 +266,9 @@ qwen tries and gets it wrong — twice, in prose, in full view.
 rows drop `arm64_pc` on the narrowest surface — the cell two sections down. Read that as the task
 set being within reach rather than as a ranking: four of the five models are within one answer of
 each other, the fifth is five behind, and the control's own miss is the most useful single result
-here, since a question the frontier gets wrong is a question worth re-reading.
+here, since a question the frontier gets wrong is a question worth re-reading. **And read the sweep
+itself as one draw**: re-running the `min` column alone took that cell from 4/4 to 2/4 with nothing
+changed that qwen reads (below), which is what a single sample per cell is worth.
 
 That is not a claim that local models are as good. It is a claim about *these questions*, which
 are the shape a debugger MCP server is asked most often — open a target, read a field, name a
@@ -277,39 +282,50 @@ because `crash_triage`'s frame 0 is the `pc` that `registers` reports. Facts her
 more than one route, and the narrow surface keeps the routes that matter.
 
 What the cut *does* produce, in every row including the control, is **calls to tools that are not
-there** — and the reason is this server, not the models:
+there** — and most of the reason is this server, not the models. The **after** column is the same
+five cells re-run against the fix, two sections down:
 
-| Cell | Unserved calls | What it asked for |
-| --- | --- | --- |
-| gemma4 `min` | 9 | `debug_batch`, every one of them — five on one task, four on another |
-| Opus `min` | 4 | `execute` twice, `modules`, `decode_ioctl` |
-| Sonnet `min` | 2 | `modules`, `execute` |
-| nemotron `min` | 2 | `modules`, twice |
-| every `full` and `lean` cell | 0 | — |
+| Cell | Unserved calls | After | What it asks for now |
+| --- | --- | --- | --- |
+| gemma4 `min` | 9 | 9 | `debug_batch`, every one of them — five on one task, four on another |
+| Opus `min` | 4 | 3 | `modules`, `debug_batch`, and `list_modules`, which no surface serves |
+| Sonnet `min` | 2 | 1 | `modules` |
+| nemotron `min` | 2 | 1 | `modules` |
+| qwen `min` | 0 | 0 | — |
+| every `full` and `lean` cell | 0 | not re-run | — |
 
-**The models were told about those tools by the server.** `#196` narrows `tools/list` per client;
-it does not narrow the `instructions` string the server sends at `initialize`, which is a compile-
-time constant naming twenty-one tools by name — `modules`, `execute`, `decode_ioctl` and
-`debug_batch` among them. Measured against this bench: the `min` client is served **11** tools and
-told about **21**, of which **17 it cannot call**. Every off-surface call in the table above is one
-of those seventeen.
+**The models were told about those tools by the server**, and the re-run corrected *which part* of
+the server told them. `#196` narrows `tools/list` per client; it did not narrow the `instructions`
+string sent at `initialize`, which was a compile-time constant naming twenty-one tools — `modules`,
+`execute`, `decode_ioctl` and `debug_batch` among them. Measured against this bench: the `min`
+client is served **11** tools and told about **21**, of which **17 it cannot call**. Every
+off-surface call in the table above is one of those seventeen.
 
-So this is not invention, and the column that used to be called `hallucinated` is now `unserved`.
-It is a real cost — wasted turns, and gemma's whole turn budget on one task — but it is the cost of
-the server advertising what it will then refuse. The refusal (`#196` again, which names the client's
-own surface) is what makes it recoverable: Opus and qwen decline honestly after it, gemma re-asks
+**Only the two control rows ever read that string, though.** `tools/local_model_drive.py`'s
+handshake keeps the negotiated protocol version and discards the rest of the `initialize` result,
+so an ollama row's prompt is the one-sentence system prompt plus `tools/list` and nothing else.
+Claude Code injects an MCP server's instructions into its own system prompt; the bare `/api/chat`
+loop does not. So gemma's nine `debug_batch` calls and nemotron's `modules` came from the *other*
+place this server names tools a client may not be served — the **descriptions of the tools it is
+served**. `open_dump`'s says the module table is "what `modules` lists"; `interrupt`'s and
+`end_session`'s both name `debug_batch`; `crash_triage`'s names `backtrace`; `interrupt`'s also
+names `go`. Five references on the 11-tool surface, naming four tools it cannot call.
+
+So this is not invention: not one of the seventeen is a name this server does not have, which is
+why the column that used to be called `hallucinated` is `unserved`. (The re-run turned up exactly
+one that is — Opus asking for `list_modules` — so the floor is not zero.) It
+is a real cost — wasted turns, and gemma's whole turn budget
+on one task — but it is the cost of the server advertising what it will then refuse. What makes it
+recoverable is *a* refusal rather than the server's: `debug_batch` is on the harness's read-only
+fence, so gemma's loop never reaches the listener at all and is answered `refused: debug_batch is
+not permitted in this harness`. Opus and qwen decline honestly after either wording; gemma re-asks
 until it runs out.
 
-The same string is also **1,990 characters (~497 tokens) charged to every client identically**, of
-which **59% is sentences naming only tools the `min` client cannot call** — about 12% of that
-client's entire prompt. A narrowed surface drops 54,000 bytes of schemas and keeps every word of
+The instructions string is also **1,990 characters (~497 tokens) charged identically to every
+client that reads it**, of which **59% is sentences naming only tools the `min` client cannot
+call** — about 12% of such a client's entire prompt, and 0% of the three ollama prompts here,
+which never carried it. A narrowed surface drops 54,000 bytes of schemas and keeps every word of
 the prose advertising what was dropped.
-
-**Fixed after this run, in the follow-up that `FOLLOWUPS.md` item 40 describes**: the instructions
-are now a base plus a fragment per group, assembled for the client's own surface, so the `min`
-client reads 927 characters naming only what it is served. Every number on this page was measured
-against the behaviour above, which is the behaviour every model here met; a re-run would find fewer
-unserved calls, and that is the point of having measured it.
 
 ### Same surface, same tool output, three different outcomes
 
@@ -328,6 +344,74 @@ them:
 exactly". On the narrowest surface the 27B local model was the only one to get it right. Failure
 modes, not scores, are what separate these rows: only one of those three failures is visible to
 whoever asked the question.
+
+**And on the re-run, qwen made it too** — same cell, same surface, same two tool calls, and the
+answer was `0x0000019e7b820000` with a paragraph explaining that it matches parameter 1. Nothing
+about the cell changed but the instructions string qwen never reads. So the failure modes are the
+finding and *the ranking is not*: one sample per cell is enough to say that three models fail this
+question in three distinguishable ways, and not enough to say which model gets it right.
+
+### Re-running the narrow cells against the fix
+
+2026-08-24, once `FOLLOWUPS.md` item 40 had landed: the same three-client listener on a rebuilt
+server, `min` only, at 262,144, five rows, six tasks — 30 records. `full` and `lean` were not
+re-run, because both were already 0 unserved and the fix costs the `full` surface seven characters.
+
+The fix was confirmed live before the time was spent, by reading `initialize` per client:
+**1,983** characters for `full`, **1,220** for `lean`, **927** for `min` — and `min`'s naming only
+`crash_triage`, `end_session`, `interrupt` and `session_status`, every one of them served.
+
+**Seventeen unserved calls became fourteen**, and the total is the least interesting part of
+that — read it by name, because the composition is what moved:
+
+| Name asked for | First run | Re-run | Still advertised to a `min` client by |
+| --- | --- | --- | --- |
+| `debug_batch` | 9 | 10 | the descriptions of `interrupt` and `end_session` |
+| `modules` | 4 | 3 | the description of `open_dump` |
+| `execute` | 3 | 0 | nothing — it was named only in the instructions |
+| `decode_ioctl` | 1 | 0 | nothing — likewise |
+| `list_modules` | 0 | 1 | nothing; no surface here serves it |
+| **total** | **17** | **14** | |
+
+Both names the fix could reach went to zero, and neither came back — and they went to zero in the
+**two control rows**, which are exactly the two that read the string. That is as close to a
+controlled test of the injection claim above as this bench offers: the rows whose prompts carried
+the instructions stopped asking for what the instructions no longer name, and the rows whose
+prompts never carried them did not change at all. **Thirteen of the fourteen
+that remain name a tool the `min` client is still told about by the description of a tool it *is*
+served** — one advertising channel narrowed, the other untouched, which is `FOLLOWUPS.md` item 41.
+The fourteenth is a name this server does not have anywhere, so the invention rate this page
+originally reported as zero is not: it is one call in the re-run's 61.
+
+**The prompt-token columns did not move by a token**, which is the same finding wearing its other
+face — an ollama row's prompt never carried the string, so there was nothing in it to save:
+
+| Model | `min` prompt, first run | Re-run |
+| --- | --- | --- |
+| gemma4:31b | 3,447 | 3,447–3,489 |
+| qwen3.8:27b | 3,838 | 3,838–3,878 |
+| nemotron-3.5-lightning:30b | 3,926 | 3,926–3,965 |
+
+The cut is real for a client that does read the instructions: the two Claude rows sit at
+27,493–27,659 tokens on this surface, where ~265 tokens is about 1% of the prompt. Which is the
+honest size of that half of item 40 — the wasted *turns* were always the larger cost.
+
+**One score moved, and not for this reason.** Four of the five cells scored exactly what they
+scored before, and this time all five lost `arm64_pc`:
+
+| Cell | First run | Re-run |
+| --- | --- | --- |
+| Opus `min` | 3/4 **+1** | 3/4 **+1** |
+| Sonnet `min` | 3/4 **+1** | 3/4 **+1** |
+| qwen3.8 `min` | 4/4 | 2/4 **+1** |
+| gemma4 `min` | 3/4 | 3/4 **+1** |
+| nemotron `min` | 3/4 | 3/4 |
+
+qwen lost two, with 0 unserved calls in both runs and no exposure to the string that changed. On
+`arm64_pc` it made nemotron's mistake (above); on `bugcheck` it opened the dump, called
+`end_session`, and answered *"Session closed."* — throwing away a fact its opener had already
+handed it. Both are single-sample variance, and so is the **+1** appearing in two cells it had not
+appeared in. Read the correctness columns of any one cell here as one draw, not as a rating.
 
 ### The context axis did not bite, and nearly reported that it did
 

--- a/docs/local-model-eval.md
+++ b/docs/local-model-eval.md
@@ -373,11 +373,12 @@ that — read it by name, because the composition is what moved:
 | `list_modules` | 0 | 1 | nothing; no surface here serves it |
 | **total** | **17** | **14** | |
 
-Both names the fix could reach went to zero, and neither came back — and they went to zero in the
-**two control rows**, which are exactly the two that read the string. That is as close to a
-controlled test of the injection claim above as this bench offers: the rows whose prompts carried
-the instructions stopped asking for what the instructions no longer name, and the rows whose
-prompts never carried them did not change at all. **Thirteen of the fourteen
+Both names the fix could reach went to zero, and neither came back. Both were also asked for by
+**only the two rows that read the string** — before the fix as much as after — which is consistent
+with the injection claim above rather than a test of it. It cannot be a test: these are five cells
+of one sample each, nemotron's single dropped call (a `modules`, which `open_dump` still advertises)
+is the same size as the effect being claimed, and the variance that took qwen's score from 4/4 to
+2/4 two sections down is larger than either. **Thirteen of the fourteen
 that remain name a tool the `min` client is still told about by the description of a tool it *is*
 served** — one advertising channel narrowed, the other untouched, which is `FOLLOWUPS.md` item 41.
 The fourteenth is a name this server does not have anywhere, so the invention rate this page

--- a/docs/token-budget.md
+++ b/docs/token-budget.md
@@ -215,6 +215,15 @@ None of these is a bug. They are recorded because they were invisible, and
    1,220 for `session,inspect,crash`, **927 for `crash`**. The number in the table above is the
    whole-surface one, which is the only one a golden can pin; the other two are asserted by two
    credentials on one listener.
+
+   **Whether any of it reaches the model is the client's choice**, which the eval bench settled by
+   accident (2026-08-24, `docs/local-model-eval.md`): Claude Code injects a server's instructions
+   into its own system prompt, while `tools/local_model_drive.py`'s bare `/api/chat` loop keeps the
+   negotiated revision out of the `initialize` result and discards the rest. So the *yes, all of it*
+   in the table is a ceiling rather than a measurement of any particular caller — a client that
+   never injects the string pays nothing for it, and narrowing it saves that client nothing. Two
+   consequences: budget this row as a cost you cannot count on paying, and do not read a
+   prompt-token measurement taken on such a client as evidence about instructions.
 5. **`modules` had neither a `limit` nor a cap**, alone among the high-volume tools — **fixed**.
    53,875 B here; more on a live kernel. It now takes a `limit` (default 64 rows, maximum 2000)
    that bounds the **whole** listing, the loaded and unloaded halves sharing it through the same


### PR DESCRIPTION
`FOLLOWUPS.md` item 40 narrowed the `instructions` string per client on the strength of a grid that
had run against the *old* behaviour. This re-runs the five cells that could have moved — `min` only,
262,144, five rows, six tasks, 30 records — against a server with the fix live, and reports what it
found, including where it corrected the page that asked for it.

Docs only: no code changed, and `docs/smoke-test.md` does not move because no test does.

## What the re-run measured

Unserved calls went **17 → 14**, and the composition is the finding rather than the total:

| Name asked for | First run | Re-run | Still advertised to a `min` client by |
| --- | --- | --- | --- |
| `debug_batch` | 9 | 10 | the descriptions of `interrupt` and `end_session` |
| `modules` | 4 | 3 | the description of `open_dump` |
| `execute` | 3 | 0 | nothing — it was named only in the instructions |
| `decode_ioctl` | 1 | 0 | nothing — likewise |
| `list_modules` | 0 | 1 | nothing; no surface here serves it |
| **total** | **17** | **14** | |

Both names the fix could reach went to zero and stayed there, and both were asked for by only the
two rows that read the string — before the fix as much as after. That is consistent with the
injection claim below rather than a test of it; five cells of one sample each cannot separate the
fix from the variance that moved qwen's score. **Thirteen of the fourteen that remain** name a tool the
client is still told about by the description of a tool it *is* served, which item 40 did not touch
and **item 41** now owns.

The fix was confirmed live before the time was spent: `initialize` reads 1,983 / 1,220 / **927**
characters for `full` / `lean` / `min`, and `min`'s names only `crash_triage`, `end_session`,
`interrupt`, `session_status` — every one served.

## Two corrections to claims already published

- **Only the control rows ever read the instructions.** `tools/local_model_drive.py`'s handshake
  keeps the negotiated revision and discards the rest of the `initialize` result, so an ollama row's
  prompt is the one-sentence system prompt plus `tools/list`. "The models were told about those
  tools by the server" was right about the server and wrong about which part of it — and the
  prompt-token columns could not move for those rows. Measured: they did not, to the token. The
  12%-of-prompt figure describes a client that injects the string; the Claude rows sit at ~27,500
  tokens here, where the cut is ~1%. `CHANGELOG.md` and `docs/token-budget.md` carry the same
  correction.
- **One score moved, and not for this reason.** qwen went 4/4 → 2/4 with 0 unserved calls in both
  runs: `arm64_pc` became nemotron's mistake, and on `bugcheck` it opened the dump, called
  `end_session` and answered *"Session closed."* So the page's most quotable line — the 27B model
  alone getting `arm64_pc` right — is one draw, and now says so where it is written.

## Item 41, and why it argues against itself

A served tool's description names tools the client is not served: five references on `--tools
crash`, naming four tools. The remedy item 40 used is not available — a description has no assembly
point, it is one literal per tool, and the sentence naming `modules` is correct and useful for the
client that has `modules`. The entry records the cost (13 wasted turns in 61 calls, against the four
the instructions were costing) and leaves the trade open rather than proposing a fix nobody has
argued for.

## Traps recorded where they bit

- The `FOLLOWUPS.md` header's "twenty clusters" was one ahead of the spans it enumerates; adding
  item 41 makes it true.
- Those five references read as **four** to a scan that walks back from `#[rmcp::tool(…)]` to the
  first non-`///` line — `interrupt`'s doc block is separated from its attribute by a plain `//`
  note, so two of the five sit above it. This PR's first draft said four.

## Verification

- `npx markdownlint-cli2@0.23.2 README.md CHANGELOG.md "docs/**/*.md" "skills/**/*.md"` — 35 files,
  0 issues.
- The run itself: rebuilt release exe on the ARM64 bench at `21abecc`, `tools/bench_listener.ps1`
  with three clients on one port, plan and log kept out of the tree. Listener stopped by the PID
  owning the port, tokens deleted, service restarted on the new build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017KHzgze3DM5NUNzfkeHVmZ

