### PR TITLE
Stop a served tool's description advertising one the client cannot call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `session,inspect,crash`, and **927 for `crash`** — a 53% cut, worth ~265 tokens to a client that
   reads it, on the surface that exists to be small.
 
+- **And no served tool's description advertises one the client cannot call** (`FOLLOWUPS.md` item
+  41, which closes it). Item 40 fixed one of the two channels above; this is the other and the
+  larger. A tool's description cross-references other tools — `open_dump` said the module table is
+  "what `modules` lists", `interrupt` and `end_session` both named `debug_batch`, `crash_triage`
+  named `backtrace` — and on `--tools crash` those five sentences named four tools the client is
+  refused. The eval measured them: with item 40 live, 13 of 61 calls on that surface still asked
+  for `modules` or `debug_batch`, three times what the instructions were costing. Every such
+  sentence now lives in `TOOL_NOTES` beside the tools it names and is appended only to a client
+  served all of them, so `--tools crash` reads **14,138 B instead of 15,073** (−6.2%) and names
+  nothing it cannot call, `session` alone 11,265 instead of 12,161, and the fifty-one-tool client
+  keeps every pointer for 108 bytes more (67,766). Twenty-two (tool, tool-it-names) pairs across
+  sixteen descriptions, not the five one surface showed: a spec may name a single tool, and six of
+  the pairs — four pointing at `execute`, the three pool tools at each other — are inside one group
+  where no group spec reaches them.
+
 - **`--list-listen-clients` sorts both halves of what it prints.** A credential file's entries
   already came back sorted; the environment's arrived in the order the variables were scanned,
   which on Windows is by *variable* name — so `WINDBG_MCP_LISTEN_TOKEN` came before

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -545,7 +545,7 @@ as the parser having made things worse.
 
 Two files, not one. A tool is declared in `src/server.rs` as always, and its name also goes in a
 **group** in `src/toolset.rs` — the table behind `--tools`, which advertises a named subset of the
-surface because 74% of the 67,658-byte tool surface is prose a model needs and cannot be trimmed
+surface because 74% of the 67,766-byte tool surface is prose a model needs and cannot be trimmed
 (`docs/token-budget.md` finding 8).
 
 Forgetting the second half fails in the one direction nothing would notice: the *default* surface
@@ -555,9 +555,9 @@ it — it starts a server with all eight group names and asserts that equals the
 There is no such thing as a tool in two groups, and a group named after a tool is refused by a unit
 test, because `Toolset::parse` resolves group names first and would decide it silently.
 
-Three rules worth knowing before touching it. **`session` is in every surface** whatever the spec
+Four rules worth knowing before touching it. **`session` is in every surface** whatever the spec
 says, because every other tool routes by a `session_id` this server alone issues — so `--tools
-crash` is eleven tools and 12,161 B is the floor. **Output schemas carry no prose at all**
+crash` is eleven tools and 11,265 B is the floor. **Output schemas carry no prose at all**
 (`src/schema.rs`): declare one with `schema::constraints_of`, never rmcp's `schema_for_output`, or
 the tool ships every doc comment in its `$defs` closure and the wire ceiling notices. And **a
 surface is per client, not per run** (item 36): `--tools` is the run's *default*, and a listener's
@@ -566,6 +566,21 @@ the credential file) that replaces it. So a change to a group is a change to wha
 differently-budgeted callers see, and the assertion that catches a per-client mistake is two
 credentials on one port — `two_clients_on_one_listener_are_served_two_surfaces`, not a unit test,
 for the reason the next section gives.
+
+And **a description that names another tool is data, not a doc comment** (item 41). A
+cross-reference lives in `TOOL_NOTES` beside the tools it names, and `annotate` appends it in
+`router()` only when the surface has every one of them — so the doc comment itself must name no
+tool but the always-served ones, and `no_description_names_a_tool_the_client_cannot_call` fails the
+build if a new tool's prose points at one its own single-tool spec does not serve. Three
+consequences when you add one. The invariant is checked on `--tools <that tool>` and nowhere else,
+because that is the tightest surface it can be served on and every wider one is covered by
+construction. **Group bytes no longer add up to a surface's**: `crash` is 14,138 B against the
+15,093 its two groups sum to in `docs/token-budget.md`, since narrowing shortens what stays as well
+as dropping what goes. And the check for "names a tool" is deliberately not word containment — this
+prose says frames are "attributed to modules" and that a stuck session "does not let go", while a
+TTD description quotes `dx @$cursession.TTD.Calls(...)`, which is the debugger command and not the
+`dx` tool; the rule is a code span that *is* the name or opens a call with it, plus bare-if-it-has-
+an-underscore, which is what caught `step_back`'s "Reverse of step_into.".
 
 ## Several clients on one listener (`src/client.rs`)
 
@@ -825,14 +840,19 @@ not comparable with the ollama rows — its own system prompt is most of it — 
 so rather than quoting it.
 
 **A model "inventing" tools on a narrowed surface is almost always this server advertising them,
-and there are two channels, of which only one is now narrowed.** The `instructions` string is
-per-client since item 40; a *tool's description* is not, and the descriptions of tools a `crash`
-client **is** served still name `modules` (`open_dump`), `debug_batch` (`interrupt`,
-`end_session`), `backtrace` (`crash_triage`) and `go` (`interrupt`) - five references on an
-eleven-tool surface. Re-running the five `min` cells against item 40's fix (2026-08-24) moved unserved
-calls 17 -> 14, with 13 of the remainder naming exactly those - `FOLLOWUPS.md` item 41. So the
+and there were two channels; both are narrowed now.** The `instructions` string went per-client
+with item 40, and a *tool's description* with item 41 - the descriptions of tools a `crash` client
+**is** served used to name `modules` (`open_dump`), `debug_batch` (`interrupt`, `end_session`),
+`backtrace` (`crash_triage`) and `go` (`interrupt`), five references on an eleven-tool surface.
+Re-running the five `min` cells against item 40's fix (2026-08-24) moved unserved calls 17 -> 14,
+and **13 of the remainder named exactly those five**, which is what item 41 then removed. So the
 metric is still `unserved` rather than "hallucinated", and it still measures the server before it
 measures the model. One call in 61 was a genuine invention, which is the floor.
+
+**The grid has not been re-run against item 41**, so 13-in-61 is what those descriptions were
+costing and not what they now cost. That re-run is worth more than item 40's was: a composition
+going 13 -> 0 by name is several times the noise five cells of one sample each showed, where item
+40's own effect was the size of a single dropped call.
 
 **And the ollama rows never read the `instructions` at all**, which is what nearly made that fix
 look bigger than it is. `tools/local_model_drive.py`'s handshake keeps the negotiated protocol

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -1784,20 +1784,20 @@ did not move by one. The 12%-of-prompt figure describes a client like Claude Cod
 at ~27,500 tokens on this surface — where the saving is ~265 tokens, about 1%. The wasted *turns*
 were always the larger cost of the two this item names.
 
-## 41. [windbg-mcp] A served tool's description advertises tools the client is not served
+## 41. [windbg-mcp] A served tool's description advertises tools the client is not served — **done** (2026-08-24)
 
 Item 40 narrowed the `instructions` string per client. It is not the only prose a client reads: the
 **description of every tool it is served** is the other, and those cross-reference tools that a
 narrowed surface has removed. On `--tools crash` (eleven tools) there are five such references,
 naming four tools:
 
-| The client is served | and its description names | at |
-| --- | --- | --- |
-| `open_dump` | `modules` — "not its module table, which `modules` lists" | `src/server.rs:2594` |
-| `interrupt` | `go` — "a broad `s` search, a `go` that …" | `:3291` |
-| `interrupt` | `debug_batch` | `:3313` |
-| `end_session` | `debug_batch` | `:3358` |
-| `crash_triage` | `backtrace` | `:3061` |
+| The client is served | and its description names |
+| --- | --- |
+| `open_dump` | `modules` — "not its module table, which `modules` lists" |
+| `interrupt` | `go` — "a broad `s` search, a `go` that …" |
+| `interrupt` | `debug_batch` |
+| `end_session` | `debug_batch` |
+| `crash_triage` | `backtrace` |
 
 `--tools session,inspect,crash` keeps the three on `interrupt` and `end_session`; the whole surface
 has none, by definition. Count them with a scan that skips plain `//` comments as well as code:
@@ -1811,27 +1811,67 @@ this entry first said four.
 `list_modules`, is a name this server does not have anywhere, which is the floor this class has:
 narrowing every string cannot take it to zero.
 
-**Why it is deferred rather than done with item 40, and why it may not be worth doing at all.**
-Item 40 had an assembly point — one string, built per client, so the fragment for a group nobody is
-served simply is not appended. A description has none: it is one literal per tool, shipped in
-`tools/list`, and the sentence naming `modules` is *correct and useful* for the client that has
-`modules`. So the shapes available are all worse than the one item 40 used:
+**What it took.** The shape item 40 used, moved one level down: a cross-reference comes out of the
+doc comment into `TOOL_NOTES` (`src/server.rs`), which pairs the sentence with **every tool it
+names**, and `WindbgServer::annotate` appends it in `router()` — after `Toolset::narrow`, so a note
+whose own tool was dropped has nothing to attach to. `router()` is what `list_tools`, `get_tool`
+and `call_tool` all take, so the surface is applied in one place and the call path pays sixteen
+`format!`s it never reads, which is the trade the alternative (a second assembly for listing alone)
+would have bought back at the price of a second place to get the surface wrong.
 
-- **Delete the cross-reference.** Cheapest, and it costs every `full`-surface client a pointer that
-  is doing real work — "the opener does not give you the module table, `modules` does" is how a
-  model learns the second call.
-- **Assemble descriptions per client, as item 40 does for instructions.** Correct, and it makes
-  every tool's description a function of the surface: the tool-budget golden then has to record a
-  surface rather than a tool (`docs/token-budget.md`'s per-tool rows lose their meaning), and
-  `schema::constraints_of` is no longer the only thing standing between a doc comment and the wire.
-- **Say it without the name** — "the module table has a tool of its own". Keeps the pointer, loses
-  the exact string a model can copy into a call, and reads worse for the 51-tool client who is the
-  one that can act on it.
+Four things the entry did not anticipate, and the first is why the fix is bigger than the table
+above.
 
-**Where it picks up.** The test is the cheap half and already has a sibling to copy:
-`instructions_never_name_a_tool_the_client_cannot_call` walks eight specs; the same walk over each
-served tool's `description` fails today on the five references above. Land that as an `#[ignore]`d
-or `should_panic` assertion only if a remedy is chosen — a red test with no intended fix is worse
-than this entry. The number worth having first is the cost: **13 wasted turns in 61 calls** is what
-the descriptions bought, against the four calls the instructions were costing, so the question is
-whether a turn is worth more than a cross-reference to the clients that keep it.
+**Five was one surface's count, not the class.** Across *every* valid spec there are **22**
+(tool, tool-it-names) pairs in **16** descriptions, carried by fifteen sentences. Six of the pairs
+are inside one group — `backtrace`, `modules`,
+`disassemble` and `dx` all point at `execute`; the three pool tools point at each other — and no
+group spec reaches those, only `--tools <single tool>`, which is exactly the case review made this
+server honour on item 40. Two more (`step_back` → `step_into`, `step_over_back` → `step_over`) were
+invisible to any backtick-based count, because they were written bare.
+
+**"Names a tool" needed a predicate, and both obvious ones are wrong.** Plain word-boundary
+containment flags English: this prose says frames are "attributed to modules" and that a stuck
+session "does not let go", and a rule that forbids the words *modules* and *go* is not one anyone
+can write under. "Inside a backtick span" flags the debugger command a TTD tool quotes —
+`dx @$cursession.TTD.Calls(...)` names the command `dx` is built on, not the `dx` tool. What works,
+and is now shared with the instructions test: a code span that **is** the name or opens a call with
+it (`execute { "command": "k" }`), plus bare-if-underscored, since an underscored name is an
+identifier and never an English word. That last half is the only thing that catches `step_back`'s
+"Reverse of step_into." — as copyable as any backticked name.
+
+**The budget golden did not have to record a surface**, which this entry expected and used as an
+argument against the fix. A note is a `const` appended to the description the macro already built,
+so the *whole* surface reads what it read before plus 108 bytes and the golden still records
+one row per tool — `docs/token-budget.md`'s per-tool rows keep their meaning. Lifting a trailing
+paragraph out of a doc comment costs nothing at all: rmcp joins `///` lines with `\n`, so each
+newline becomes a space inside one literal and five of the sixteen tools moved by zero bytes. What
+*did* lose its meaning is **additivity of the group table**: `--tools crash` is 14,138 B against the
+15,093 its two groups sum to, because narrowing now shortens the descriptions of the tools that
+stay as well as dropping the ones it drops.
+
+**Three references were reworded rather than moved**, because a note appends at the end and a
+cross-reference in the middle of an argument does not survive the move. `interrupt`'s "a `go` that
+has not hit anything" and `walk_memory`'s "a MASM `.for` loop through `execute`" are illustrations
+rather than pointers — nobody calls either tool because they read the name there — and
+`step_back`/`step_over_back` now name the WinDbg command they reverse (`t`, `p`), which the line
+beside them already gives.
+
+**What it cost and what it bought, statically.** The whole surface grows 67,658 → **67,766 B**
+(+0.16%), which is the price of keeping the pointer for the client that can follow it. Every
+narrowed surface shrinks: `crash` 15,073 → **14,138** (−6.2%), `session,inspect,crash` 25,265 →
+**24,445**, and the floor — `session` alone — 12,161 → **11,265**. Off-surface names go to zero on
+every spec, asserted two ways: `no_description_names_a_tool_the_client_cannot_call` walks the
+tightest surface each tool can be served on (`--tools <that tool>`), which is the whole invariant
+rather than a sample of it — a note ships only when its own names are served, so all a wider
+surface can add is a sentence already cleared — and `two_clients_on_one_listener_are_served_two_surfaces`
+puts `crash` and `session,inspect` on one port, since a golden records one surface and cannot see
+the direction that matters. `the_whole_surface_reads_every_note` is the other direction, and is
+what stops the fix degenerating into the "delete the cross-reference" option: deleting them would
+pass every other assertion here.
+
+**Not measured: the bench.** The eval grid has not been re-run against this, so the 13-calls-in-61
+figure above is what the descriptions *were* costing rather than what they now cost. It is the
+re-run worth having — unlike item 40's, where the previous entry's own caveat holds (five cells of
+one sample each, and nemotron's single dropped call was the same size as the effect claimed), a
+composition going 13 → 0 by name would be several times the noise that run showed.

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -810,12 +810,14 @@ landed on their own so that each of the items below can be argued, and measured,
   description loses a word; a caller reading a crash dump stops paying for nine TTD tools and ten
   allocator ones. `session,inspect,crash` is 20 tools / 25,265 B; `crash` is 11 / 15,073 B against
   51 / 67,658 B. A spec names groups, individual tools, or `all`, and anything else is refused at
-  startup rather than quietly serving something different.
+  startup rather than quietly serving something different. (Every figure in this item is as
+  measured on 2026-08-17. Item 41 has since moved all of them — the narrowed surfaces down and the
+  whole one up; `docs/token-budget.md` carries today's.)
 
   Three things it settled that the bullet did not anticipate. **`session` has to be in every
   surface** — every other tool routes by a `session_id` this server is the only issuer of, so a
-  surface with `registers` and no opener is not a smaller surface but a broken one; 12,161 B is the
-  floor and `--tools crash` is eleven tools. **A tool that exists and is not served needs its own
+  surface with `registers` and no opener is not a smaller surface but a broken one; 12,161 B was
+  the floor then and `--tools crash` is eleven tools. **A tool that exists and is not served needs its own
   refusal**: rmcp answers `tool not found`, which is what a typo gets, while this is an operator's
   flag the caller cannot see. And **the group table needs joining to the live surface**, because a
   tool added to `src/server.rs` and not put in a group vanishes from every *narrowed* surface while

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Fifty-one tools in eight `--tools` groups; the rows below split some of those gr
 | Structure walk | `allocator` | `walk_memory` |
 | Raw     | `inspect` | `execute` — run any debugger command, returns full text output |
 
-All of them are served unless you say otherwise, and the definitions cost the model **67,658 bytes —
+All of them are served unless you say otherwise, and the definitions cost the model **67,766 bytes —
 about 17k tokens — before it has asked anything**. `--tools session,inspect,crash` cuts that to
 25,265 B for twenty tools, and a `--listen` client can be given a narrower surface than the run's
 default. [`docs/tool-surface.md`](docs/tool-surface.md) has the arithmetic, the rule that `session`

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Fifty-one tools in eight `--tools` groups; the rows below split some of those gr
 
 All of them are served unless you say otherwise, and the definitions cost the model **67,766 bytes —
 about 17k tokens — before it has asked anything**. `--tools session,inspect,crash` cuts that to
-25,265 B for twenty tools, and a `--listen` client can be given a narrower surface than the run's
+24,445 B for twenty tools, and a `--listen` client can be given a narrower surface than the run's
 default. [`docs/tool-surface.md`](docs/tool-surface.md) has the arithmetic, the rule that `session`
 is always included, and what a typed operand may not contain.
 

--- a/docs/local-model-eval.md
+++ b/docs/local-model-eval.md
@@ -37,6 +37,10 @@ the same 51 tools, 25,265 for the same 20, 15,073 for the same 11. The function-
 difference and it is a flat ~3% on all three, so either figure supports the arithmetic below —
 quote whichever matches what you are measuring, and do not mix them in one sum.
 
+Both columns are **the server this grid ran against**. `FOLLOWUPS.md` item 41 has since taken the
+narrowed surfaces down again — `crash` is 14,138 B rather than 15,073 — so read the table above as
+the run's conditions and [`token-budget.md`](./token-budget.md) for today's.
+
 **The last column is a finding, not a caption.** Identical bytes cost gemma 14,540 tokens, qwen
 17,270 and nemotron 18,501 — a 27% spread on the same surface, entirely tokenizer. So "does the
 surface fit" has no single answer even at one surface size and one window, and the ≈4 B/token rule
@@ -364,7 +368,7 @@ The fix was confirmed live before the time was spent, by reading `initialize` pe
 **Seventeen unserved calls became fourteen**, and the total is the least interesting part of
 that — read it by name, because the composition is what moved:
 
-| Name asked for | First run | Re-run | Still advertised to a `min` client by |
+| Name asked for | First run | Re-run | Advertised to a `min` client, then, by |
 | --- | --- | --- | --- |
 | `debug_batch` | 9 | 10 | the descriptions of `interrupt` and `end_session` |
 | `modules` | 4 | 3 | the description of `open_dump` |
@@ -383,6 +387,14 @@ that remain name a tool the `min` client is still told about by the description 
 served** — one advertising channel narrowed, the other untouched, which is `FOLLOWUPS.md` item 41.
 The fourteenth is a name this server does not have anywhere, so the invention rate this page
 originally reported as zero is not: it is one call in the re-run's 61.
+
+**Item 41 has since landed** (2026-08-24) and removed all three of those descriptions'
+cross-references: on `--tools crash` no served tool's description names a tool the client cannot
+call, asserted rather than inspected. **The grid has not been re-run against it**, so the thirteen
+above is what those sentences were costing and not a measurement of what they cost now. That re-run
+is worth more than this one was: thirteen calls going to zero by name is several times the noise
+five cells of one sample each can show, where the effect claimed here was the size of nemotron's
+one dropped call.
 
 **The prompt-token columns did not move by a token**, which is the same finding wearing its other
 face — an ollama row's prompt never carried the string, so there was nothing in it to save:

--- a/docs/local-model-eval.md
+++ b/docs/local-model-eval.md
@@ -38,8 +38,9 @@ difference and it is a flat ~3% on all three, so either figure supports the arit
 quote whichever matches what you are measuring, and do not mix them in one sum.
 
 Both columns are **the server this grid ran against**. `FOLLOWUPS.md` item 41 has since taken the
-narrowed surfaces down again — `crash` is 14,138 B rather than 15,073 — so read the table above as
-the run's conditions and [`token-budget.md`](./token-budget.md) for today's.
+narrowed surfaces down again — `crash` is 14,138 B rather than 15,073, `session,inspect,crash`
+24,445 rather than 25,265 — so read the table above as the run's conditions and
+[`token-budget.md`](./token-budget.md) for today's.
 
 **The last column is a finding, not a caption.** Identical bytes cost gemma 14,540 tokens, qwen
 17,270 and nemotron 18,501 — a 27% spread on the same surface, entirely tokenizer. So "does the

--- a/docs/local-model.md
+++ b/docs/local-model.md
@@ -113,7 +113,7 @@ setx WINDBG_MCP_TOOLS_DRIVER        "session,inspect,crash"
 ```
 
 The second line is what makes this work on a listener the editor also uses: the driver is served 20
-tools and 25,265 B while every other client on that listener keeps all 51. Leave it out and the
+tools and 24,445 B while every other client on that listener keeps all 51. Leave it out and the
 driver is served whatever the listener was started with, which is the older behaviour and is the
 right one when the listener is the driver's own.
 
@@ -174,9 +174,9 @@ decide whether a local model can hold this surface at all. Bytes of minified JSO
 
 | | bytes | ≈tokens |
 |---|---|---|
-| The tool surface, paid once per conversation | 67,076 (51 tools) | ~17k |
-| — the same surface as `--tools session,inspect,crash` | 25,265 (20 tools) | ~6k |
-| — as `--tools crash` | 15,073 (11 tools) | ~4k |
+| The tool surface, paid once per conversation | 67,766 (51 tools) | ~17k |
+| — the same surface as `--tools session,inspect,crash` | 24,445 (20 tools) | ~6k |
+| — as `--tools crash` | 14,138 (11 tools) | ~3.5k |
 | Its worst single tool (`debug_batch`) | 9,746 | ~2.4k |
 | The largest answer this server gives (`modules`) | 53,875 | ~13k |
 | `read_memory` at its design limit | ~4 MiB of hex | ~1M |
@@ -329,9 +329,10 @@ budget, a text-or-data content switch. **Two of the three now exist, and neither
 client-side.**
 
 - **The tool-surface profile is `--tools`** (2026-08-22). Start the listener with
-  `--tools session,inspect,crash` and the surface is 20 tools and 25,265 B instead of 51 and
+  `--tools session,inspect,crash` and the surface is 20 tools and 24,445 B instead of 51 and
   67,766 — `--tools crash` is 11 and 14,138 B, which is the difference between "roughly twice an 8k
-  window" and "half of one". Nothing is reworded: the tools that remain are the tools they were.
+  window" and "half of one". The tools that remain are the tools they were, less the sentences
+  pointing at ones that went (item 41).
   The whole table is in [`token-budget.md`](./token-budget.md) under finding 8, and the README has
   the operator's half. **And it is per client as well as per run** (2026-08-22): a listener's
   clients are named already, so `WINDBG_MCP_TOOLS_<NAME>` beside the token gives one of them its

--- a/docs/local-model.md
+++ b/docs/local-model.md
@@ -330,7 +330,7 @@ client-side.**
 
 - **The tool-surface profile is `--tools`** (2026-08-22). Start the listener with
   `--tools session,inspect,crash` and the surface is 20 tools and 25,265 B instead of 51 and
-  67,658 — `--tools crash` is 11 and 15,073 B, which is the difference between "roughly twice an 8k
+  67,766 — `--tools crash` is 11 and 14,138 B, which is the difference between "roughly twice an 8k
   window" and "half of one". Nothing is reworded: the tools that remain are the tools they were.
   The whole table is in [`token-budget.md`](./token-budget.md) under finding 8, and the README has
   the operator's half. **And it is per client as well as per run** (2026-08-22): a listener's

--- a/docs/remote-listener.md
+++ b/docs/remote-listener.md
@@ -6,7 +6,7 @@ the machine DbgEng needs — a Mac driving a Windows VM, say.
 
 **`--tools` works here exactly as it does on stdio**, and matters more: the client at the far end
 may be a local model whose window is bought in RAM. `--listen 127.0.0.1:8765 --tools
-session,inspect,crash` serves 20 tools and 25,265 B of model context instead of 51 and 67,658 — the
+session,inspect,crash` serves 20 tools and 24,445 B of model context instead of 51 and 67,766 — the
 README has the table, and [`local-model.md`](./local-model.md) is the runbook it was measured for.
 It is this listener's **default**: a client may be given a surface of its own, which is what lets
 one server hold a local model and a hosted client at once — see [A tool surface per

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -648,6 +648,16 @@ passed, because each supplies the identity itself.
   `local` is told to widen the run's `--tools`, `bench` is told about its own entry — since naming
   the wrong one sends an operator to a spec that is not in force. Both routes again, for the reason
   above.
+
+  **And the prose narrows with the list**, which is two more claims here because a golden records
+  one surface and can see neither. The `instructions` at `initialize` are assembled per client
+  (item 40), so `bench` reads 927 characters naming only tools it has where `local` reads its own;
+  and no description `bench` is served names `modules`, `debug_batch`, `go` or `backtrace` (item
+  41), while `local`'s `open_dump` still says which tool lists the module table. Both directions
+  are asserted, because deleting the cross-references outright would satisfy the first and lose the
+  pointer the fifty-one-tool client is the one that can use. Backticked names, not bare ones: this
+  surface says frames are "attributed to modules" and that a stuck session "does not let go", and
+  neither sentence points anywhere.
 - *A **token file** naming two clients serves both* — the item-31 test in the list further up,
   counted here as well because it is the third of the three: under a service that file is the whole
   of what is read, so it is the only place a second client can come from at all.

--- a/docs/token-budget.md
+++ b/docs/token-budget.md
@@ -282,8 +282,8 @@ None of these is a bug. They are recorded because they were invisible, and
    than their prose — **answered** (2026-08-22) by serving fewer tools rather than smaller ones.
    `debug_batch` alone is 9,746 B — 14% of everything a model is given before it asks anything — of
    which 7,980 B is the `StepAction`/`Check` vocabulary its schema pulls out of `src/batch.rs`.
-   Then `walk_memory` 4,076, `crash_triage` 2,912, `reachable_from_dispatch` 2,628, `server_log`
-   2,599: **21,961 B, 33%**, against a median tool of 900 B.
+   Then `walk_memory` 4,080, `crash_triage` 2,936, `reachable_from_dispatch` 2,628, `server_log`
+   2,599: **21,989 B, 33%**, against a median tool of 900 B.
 
    This is where the weight is, and it is a different kind of problem from findings 1–4. Those were
    duplication and waste — the same string paid for repeatedly, or a tail nobody reads. This is one
@@ -359,7 +359,7 @@ put in a group would vanish from every narrowed surface without a word — the d
 still carry it, so nothing else would notice. And
 `a_narrowed_tool_surface_serves_only_what_it_was_asked_for` starts a server with `--tools crash` and
 checks the three things that makes true: eleven tools, a refusal by name for a tool that exists and
-is not served, and a figure under half the whole surface (it prints 15,073 B).
+is not served, and a figure under half the whole surface (it prints 14,138 B).
 
 Beside them, `output_schemas_carry_constraints_not_prose` is the
 assertion that finding 1 stays fixed. It reads `tools/list` off the wire, so it catches the way that

--- a/docs/token-budget.md
+++ b/docs/token-budget.md
@@ -67,15 +67,21 @@ thing between them is finding 1 — the prose taken out of every `outputSchema`.
 
 | Component | Baseline | Today | Reaches the model |
 |---|---:|---:|---|
-| **Whole `tools/list` payload** | **391,172** | **177,460** | partly |
-| — the 51 tools themselves | 391,054 | 177,342 | partly |
+| **Whole `tools/list` payload** | **391,172** | **177,568** | partly |
+| — the 51 tools themselves | 391,054 | 177,450 | partly |
 | — result-level fields (`resultType`, `ttlMs`, `cacheScope`) | 118 | 118 | no |
 | `outputSchema` (the 33 tools that have one) | 317,236 | 102,942 | no |
 | `inputSchema` (all 51) | 39,667 | 40,207 | yes |
-| `description` (all 51) | 24,752 | 24,794 | yes |
+| `description` (all 51) | 24,752 | 24,902 | yes |
 | `annotations` | 5,449 | 5,449 | no |
-| **Model-visible total** | **67,076** | **67,658** (~17k tokens) | — |
+| **Model-visible total** | **67,076** | **67,766** (~17k tokens) | — |
 | `initialize` instructions | 1,996 | 1,983 | yes, **all of it** |
+
+**Every figure here is the *whole* surface**, which since `FOLLOWUPS.md` item 41 is the only one a
+golden can record: a description carries the sentences pointing at other tools only when the client
+is served all of them, so a narrowed surface reads shorter descriptions as well as fewer of them.
+That is 108 of the 150 bytes `description` has gained — the price the fifty-one-tool client pays so
+that the eleven-tool one stops reading about `modules`.
 
 The two halves moved independently, which is the whole argument for measuring them apart: the wire
 fell by 55% and the model-visible column did not move at all except for what the tools themselves
@@ -289,40 +295,46 @@ None of these is a bug. They are recorded because they were invisible, and
    output schemas because nothing read it. Prose in an *input* schema is the opposite: it is most of
    what tells a model how to drive the tool, and `debug_batch` is the tool where getting that wrong
    leaves a patched byte in a running kernel. Measured across all 51 tools, **74% of the
-   model-visible surface is prose** — 24,794 B of tool descriptions and 25,333 B inside the input
+   model-visible surface is prose** — 24,902 B of tool descriptions and 25,333 B inside the input
    schemas — so a strip here buys context by making the tools harder to drive correctly.
 
    The structural remainder does not pay for the risk either. Dropping `"default": null`, which
    schemars emits 109 times and which tells a model nothing an absent field does not, is 1,744 B —
    2.6%. The other candidates are not free: `$schema` is 2,850 B but is how a client picks a
    validator dialect (and `tool_schemas_declare_one_dialect_and_are_self_contained` pins it), and
-   `minimum`/`format` are constraints. **Roughly 1.7 KB of 67,658 is the whole honest total** for
+   `minimum`/`format` are constraints. **Roughly 1.7 KB of 67,766 is the whole honest total** for
    trimming the schemas.
 
-   So the third lever is the one taken: `--tools` (`src/toolset.rs`) advertises a named subset. No
-   description gets a word shorter; a caller that is reading a crash dump stops paying for nine TTD
-   tools and ten allocator ones. Where the bytes sit, and what each profile costs:
+   So the third lever is the one taken: `--tools` (`src/toolset.rs`) advertises a named subset. A
+   caller that is reading a crash dump stops paying for nine TTD tools and ten allocator ones —
+   and, since item 41, for the sentences the tools it keeps used to spend on pointing at them.
+   Where the bytes sit, and what each profile costs:
 
    | group | tools | bytes | share |
    |---|---:|---:|---:|
-   | `allocator` | 10 | 15,914 | 23.5% |
-   | `session` | 10 | 12,161 | 18.0% |
-   | `inspect` | 9 | 10,192 | 15.1% |
+   | `allocator` | 10 | 15,969 | 23.6% |
+   | `session` | 10 | 12,157 | 17.9% |
+   | `inspect` | 9 | 10,215 | 15.1% |
    | `batch` | 1 | 9,746 | 14.4% |
-   | `ttd` | 9 | 6,833 | 10.1% |
+   | `ttd` | 9 | 6,829 | 10.1% |
    | `ioctl` | 6 | 6,494 | 9.6% |
-   | `exec` | 5 | 3,406 | 5.0% |
-   | `crash` | 1 | 2,912 | 4.3% |
+   | `exec` | 5 | 3,420 | 5.0% |
+   | `crash` | 1 | 2,936 | 4.3% |
 
    | `--tools` | tools | model |
    |---|---:|---:|
-   | *(absent)* | 51 | 67,658 |
-   | `session,inspect,exec,crash` | 25 | 28,671 |
-   | `session,inspect,crash` | 20 | 25,265 |
-   | `crash` | 11 | 15,073 |
+   | *(absent)* | 51 | 67,766 |
+   | `session,inspect,exec,crash` | 25 | 27,807 |
+   | `session,inspect,crash` | 20 | 24,445 |
+   | `crash` | 11 | 14,138 |
+
+   **The two tables do not reconcile, and that is the point of item 41.** The first is each group's
+   share of the whole surface; the second is what a spec actually serves, which is less — `crash`
+   is 14,138 rather than the 15,093 its two rows sum to, because five cross-references leave with
+   the tools they name.
 
    `session` is in every surface because every other tool routes by a `session_id` this server is
-   the only issuer of — 12,161 B is the floor, and `crash` is eleven tools rather than one. The
+   the only issuer of — 11,265 B is the floor, and `crash` is eleven tools rather than one. The
    flag is a **run's** choice, and on a listener it is the *default*: a named client may be
    configured with a spec of its own (`WINDBG_MCP_TOOLS_<NAME>`), so the figures above are per
    client rather than per server — which is what lets a local model and a hosted client share one

--- a/docs/tool-surface.md
+++ b/docs/tool-surface.md
@@ -6,7 +6,7 @@ how much of that surface a run serves, and three behaviours the table has no roo
 ## Serving fewer tools (`--tools`)
 
 All fifty-one tools are served unless you say otherwise, and their definitions cost the model
-**67,658 bytes — about 17k tokens — before it has asked anything**, once per conversation. Three
+**67,766 bytes — about 17k tokens — before it has asked anything**, once per conversation. Three
 quarters of that is the prose that tells a model how to drive them, so it cannot be trimmed without
 making the tools harder to use correctly (see
 [`token-budget.md`](token-budget.md)). What *can* change is how many of them a given run
@@ -18,10 +18,10 @@ windbg-mcp.exe --tools session,inspect,crash
 
 | `--tools` | Tools | Model context |
 |---|---:|---:|
-| *(absent)* — every tool | 51 | 67,658 B |
-| `session,inspect,exec,crash` | 25 | 28,671 B |
-| `session,inspect,crash` | 20 | 25,265 B |
-| `crash` | 11 | 15,073 B |
+| *(absent)* — every tool | 51 | 67,766 B |
+| `session,inspect,exec,crash` | 25 | 27,807 B |
+| `session,inspect,crash` | 20 | 24,445 B |
+| `crash` | 11 | 14,138 B |
 
 The spec is a comma-separated list of the group names in the [tool table](../README.md#tools), of
 individual tool names, or `all`.
@@ -34,6 +34,11 @@ Two things worth knowing:
   `session_id`, and this server is the only thing that issues one, so a surface with `registers`
   and no opener cannot be used at all. That is why `--tools crash` is eleven tools rather than one.
   The startup log line names the surface it ended up with.
+- **The prose narrows with the list.** A client is told about the tools it has and no others: the
+  `instructions` sent at `initialize` are assembled from the surface, and a tool's description
+  carries its cross-references to *other* tools only when those are served too — so `open_dump` on
+  a `crash` surface no longer says the module table is what `modules` lists. That is most of why a
+  narrowed surface is smaller than its groups' shares add up to.
 - **Calling a tool that exists but is not served** is refused by name — "not on the surface this
   run advertises" — rather than as an unknown tool, because the remedy is a flag on a command line
   the caller cannot see.

--- a/src/server.rs
+++ b/src/server.rs
@@ -2560,10 +2560,6 @@ impl WindbgServer {
         self
     }
 
-    /// The router this instance answers from: rmcp's, minus whatever the surface excludes.
-    ///
-    /// Built per call, which is what `Self::tool_router()` already was — the schemas underneath it
-    /// are cached by type, so this is a map of fifty-one `Arc` clones and a `retain`.
     /// The instructions this client is served: the base, plus a fragment per group it has.
     ///
     /// The pair to [`Self::router`] - that decides which tools this client may call, and this
@@ -2581,17 +2577,49 @@ impl WindbgServer {
         text
     }
 
+    /// The router this instance answers from: rmcp's, minus whatever the surface excludes, plus
+    /// the cross-references this surface may read.
+    ///
+    /// Built per call, which is what `Self::tool_router()` already was — the schemas underneath it
+    /// are cached by type, so this is a map of fifty-one `Arc` clones and a `retain`.
+    ///
+    /// It is also the path `call_tool` takes, which pays for [`Self::annotate`] on every call and
+    /// reads none of it. That is deliberate: `list_tools` and `get_tool` are the macro's and take
+    /// whatever this returns, so a second assembly for them alone would be a second place for the
+    /// surface to be applied — and the cost is fifteen `format!`s against a debugger round trip.
     fn router(&self) -> rmcp::handler::server::tool::ToolRouter<Self> {
         let mut router = Self::tool_router();
         self.surface.narrow(&mut router);
+        self.annotate(&mut router);
         router
+    }
+
+    /// Append to each served tool's description the notes this surface has earned.
+    ///
+    /// Runs **after** [`crate::toolset::Toolset::narrow`], so a note whose own tool was dropped
+    /// finds nothing to attach to and is skipped rather than resurrecting it. Reaches `map`
+    /// directly for the same reason `narrow` does — there is no by-name accessor that hands back
+    /// a route to mutate.
+    fn annotate(&self, router: &mut rmcp::handler::server::tool::ToolRouter<Self>) {
+        for ToolNote { tool, names, note } in TOOL_NOTES {
+            if !names.iter().all(|named| self.surface.includes(named)) {
+                continue;
+            }
+            let Some(route) = router.map.get_mut(*tool) else {
+                continue;
+            };
+            route.attr.description = Some(match route.attr.description.take() {
+                Some(text) => format!("{text}\n{note}").into(),
+                None => (*note).into(),
+            });
+        }
     }
 
     /// Open a crash dump (.dmp) or a Time Travel Debugging trace (.run) and wait for it to load.
     /// Opens a new session in its own engine process — sessions already open are left alone —
     /// and returns a `session_id` that routes later calls to it. End it with `end_session`.
     /// The result is a summary of the target — build, kernel/primary image base, module count and
-    /// the bug check a crash dump stopped on — not its module table, which `modules` lists.
+    /// the bug check a crash dump stopped on — not its module table.
     #[rmcp::tool(
         annotations(
             title = "Open crash dump or TTD trace",
@@ -2744,10 +2772,9 @@ impl WindbgServer {
     /// Find every **allocated** kernel pool chunk carrying a tag, with its size, allocator
     /// and backend. Needs a broken-in x64 kernel target.
     /// This walks the pool's own descriptors rather than shelling out to `!poolused`, so the
-    /// result is structured and consistent with `pool_chunk`/`pool_census`.
+    /// result is structured.
     /// Only allocated chunks are indexed by tag — a freed chunk's tag is not reliably
-    /// preserved by the allocator, so this never reports freed memory. To ask whether one
-    /// specific address has been freed, use `pool_chunk`.
+    /// preserved by the allocator, so this never reports freed memory.
     #[rmcp::tool(
         annotations(
             title = "Find pool chunks by tag",
@@ -2813,11 +2840,10 @@ impl WindbgServer {
 
     /// The pool walk's own diagnostics, verbatim, optionally narrowed by substring.
     /// Needs a broken-in x64 kernel target.
-    /// Use this when a chunk you can see with `!pool` does not appear in `pool_find_tag`
-    /// or `pool_chunk`. A real walk emits tens of thousands of diagnostics across a
-    /// hundred-plus categories, so the summaries the other tools print are necessarily
-    /// truncated — and the one line explaining a specific heap is reliably not in the
-    /// truncated head. Filter by a heap address or a phrase to get at it.
+    /// A real walk emits tens of thousands of diagnostics across a hundred-plus categories, so
+    /// the summaries the other tools print are necessarily truncated — and the one line
+    /// explaining a specific heap is reliably not in the truncated head. Filter by a heap
+    /// address or a phrase to get at it.
     /// `walk.gaps` on any pool answer sizes the three things a walk *records* running into —
     /// pages a region query stalled on, chunk headers a decoder refused, and committed bytes it
     /// declined to decode because it could not say where a chunk began in them — in bytes and
@@ -2850,8 +2876,7 @@ impl WindbgServer {
 
     /// Per-tag census of the kernel pool: allocation counts and bytes, heaviest first.
     /// Needs a broken-in x64 kernel target.
-    /// The structured answer to what `!poolused` renders as text, taken from the same walk
-    /// as `pool_find_tag` and `pool_chunk` so the three cannot disagree. Useful for spotting
+    /// The structured answer to what `!poolused` renders as text. Useful for spotting
     /// which tag a driver's allocations are landing under before querying it by name.
     #[rmcp::tool(
         annotations(
@@ -3058,10 +3083,10 @@ impl WindbgServer {
     /// saved and restored around the call.
     /// The stack it reports is the target's default context — the crash, on a crash dump —
     /// whenever the `!analyze` ran to completion, since running it is what resets the scope
-    /// there. Otherwise it is whatever the session has selected, the same stack `backtrace`
-    /// would show: with `analyze: false`, when the analysis could not run (no time left in the
-    /// call, no `ext.dll` on the engine), and when it was cut short, since the reset happens
-    /// partway through the analysis and a truncated one may not have reached it.
+    /// there. Otherwise it is whatever the session has selected: with `analyze: false`, when the
+    /// analysis could not run (no time left in the call, no `ext.dll` on the engine), and when it
+    /// was cut short, since the reset happens partway through the analysis and a truncated one
+    /// may not have reached it.
     /// `analysis.ran` and `analysis.truncated` are what tell those apart.
     #[rmcp::tool(
         annotations(
@@ -3288,7 +3313,7 @@ impl WindbgServer {
     }
 
     /// Stop the operation a session is currently running, **keeping the session and its target**.
-    /// The graceful way out of a call that is taking too long — a broad `s` search, a `go` that
+    /// The graceful way out of a call that is taking too long — a broad `s` search, a run that
     /// has not hit anything, a pool walk over a slow KD link.
     ///
     /// This is a Ctrl+Break, exactly as at a WinDbg prompt. The interrupted operation ends at the
@@ -3309,15 +3334,6 @@ impl WindbgServer {
     /// operation that never polls for the break, and a live-kernel `attach_kernel` whose target has
     /// not connected yet (the documented case — see `session_status`). `end_session` is what ends
     /// those, at the cost of the target.
-    ///
-    /// A `debug_batch` interrupted this way stops at its next step and runs its `always` block, and
-    /// its own result reports `BATCH: INTERRUPTED` with the rollback state — so no step after the
-    /// interrupt is applied, and the session keeps its target (unlike `end_session`, which also
-    /// stops a batch but takes the session with it). Its **rollback cannot be interrupted**: a
-    /// restore cut short would report success while leaving the target changed, so a call aimed at
-    /// a batch that is unwinding, or repeated while one is still stopping, says so and sends
-    /// nothing. If a rollback will not end, `end_session` is the way out, at the cost of the
-    /// target.
     // `idempotent_hint = false`, which is not the intuitive reading: raising the same Ctrl+Break
     // twice on the same operation plainly has no second effect. But the hint is about *repeating
     // the call*, and what a repeat addresses is whichever job is running when it arrives — which
@@ -3354,10 +3370,6 @@ impl WindbgServer {
     /// within a short grace period — a live-kernel attach whose target never dialed in cannot,
     /// since nothing can interrupt that wait — its engine process is terminated outright. The
     /// session ends either way, and no other session is affected.
-    ///
-    /// A `debug_batch` running on the session is told to stop at its next step and run its
-    /// rollback before the target is released, and the batch's own call reports that; the grace
-    /// covers the step in flight and the rollback after it.
     #[rmcp::tool(
         annotations(
             title = "End debug session",
@@ -3549,10 +3561,10 @@ impl WindbgServer {
     /// Walk a structure and read named fields out of every node — **without one unreadable
     /// address ending the walk**.
     /// This is the tool for a list, a handle table or a pointer array where some entries are
-    /// freed: a MASM `.for` loop through `execute` aborts on the first unmapped dereference with
-    /// `0x80040205` and no partial output, which loses exactly the node worth looking at. Here an
-    /// unreadable value is `null` in its own field, an unreadable node is counted, and the walk
-    /// carries on.
+    /// freed: a MASM `.for` loop through a raw command aborts on the first unmapped dereference
+    /// with `0x80040205` and no partial output, which loses exactly the node worth looking at.
+    /// Here an unreadable value is `null` in its own field, an unreadable node is counted, and
+    /// the walk carries on.
     /// Three ways to name the nodes, one of them required: `addresses` (an explicit list — the
     /// bulk read), `start` + `stride` (an array), or `start` + `next_offset` (a pointer chain).
     /// `fields` says what to read from each node; offsets may be negative, so a pool header at
@@ -3608,10 +3620,8 @@ impl WindbgServer {
     /// Show the call stack of the current thread as typed frames. Each carries `module` + `rva` —
     /// the offset into the image, from its load base — beside the `module!Symbol` the debugger
     /// resolves: the symbol is missing on a driver with no PDB, the offset never is, and it stays
-    /// comparable across reboots and joins a disassembler's function list. Same records as
-    /// `crash_triage`'s `frames`. `frames_truncated` says when the stack went on past the cap.
-    /// `execute { "command": "k" }` gives the engine's own listing instead, with `Child-SP` /
-    /// `RetAddr` and the inline-frame rows a stack walk does not return.
+    /// comparable across reboots and joins a disassembler's function list.
+    /// `frames_truncated` says when the stack went on past the cap.
     #[rmcp::tool(
         annotations(
             title = "Show call stack",
@@ -3645,8 +3655,7 @@ impl WindbgServer {
     /// how many matched, so pass `filter` to ask about one driver rather than paging through a
     /// table of two hundred. The modules that have **unloaded** come back in their own
     /// `unloaded` list, narrowed by the same filter — that is what can name an address in a driver
-    /// that is no longer there. For the engine's own listing verbatim,
-    /// `execute { "command": "lm" }`.
+    /// that is no longer there.
     #[rmcp::tool(
         annotations(
             title = "List modules",
@@ -3717,8 +3726,7 @@ impl WindbgServer {
     /// pair per instruction rather than inheriting the first: a range can run off the end of an
     /// image, and an instruction in no module has neither half. Default 16 instructions, maximum
     /// 128; `stopped_early` says the code ended before the count, which is an answer rather than a
-    /// truncation. For the engine's own listing with its `module!Symbol+0x1c:` labels,
-    /// `execute { "command": "u" }` — or `uf` to follow a whole function.
+    /// truncation.
     #[rmcp::tool(
         annotations(
             title = "Disassemble",
@@ -3759,9 +3767,8 @@ impl WindbgServer {
     }
 
     /// Evaluate a data-model (LINQ) expression with `dx` — ideal for TTD queries.
-    /// The data model can also run debugger commands, so this is a second command hatch
-    /// alongside `execute` and is annotated and handle-checked as one; see
-    /// [`dx_executes_commands`].
+    /// The data model can also run debugger commands, so this is a command hatch and is
+    /// annotated and handle-checked as one; see [`dx_executes_commands`].
     #[rmcp::tool(annotations(
         title = "Evaluate data-model expression",
         read_only_hint = false,
@@ -3792,8 +3799,7 @@ impl WindbgServer {
 
     /// TTD: find every call to a function across the whole trace
     /// (`dx @$cursession.TTD.Calls(...)`). Each result carries the time, thread,
-    /// parameters, and return value. Append LINQ in a follow-up `dx`/`execute` to
-    /// filter (e.g. `.Where(c => c.ReturnValue != 0)`).
+    /// parameters, and return value.
     #[rmcp::tool(annotations(
         title = "TTD: find calls to a function",
         read_only_hint = true,
@@ -3948,8 +3954,8 @@ impl WindbgServer {
     /// disturb existing breakpoints) and report a structured verdict: HIT (reached it),
     /// STOPPED ELSEWHERE (another breakpoint/exception fired first), or TIMEOUT (not
     /// reached in time). Confirms *live* that the current input/state drives execution to
-    /// a block — e.g. one from `reachable_from_dispatch`. Needs a real KDNET/VM kernel
-    /// target (a local kernel can't set code breakpoints).
+    /// a block. Needs a real KDNET/VM kernel target (a local kernel can't set code
+    /// breakpoints).
     #[rmcp::tool(
         annotations(
             title = "Run to address",
@@ -4033,7 +4039,7 @@ impl WindbgServer {
         engine_result_for(args.session_id.as_deref(), out)
     }
 
-    /// Step backward one instruction in a TTD trace (`t-`). Reverse of step_into.
+    /// Step backward one instruction in a TTD trace (`t-`), the reverse of `t`.
     // The reverse-navigation tools only work on a TTD trace, which is a recorded replay:
     // moving through it cannot destroy state, unlike stepping a live target.
     #[rmcp::tool(
@@ -4062,7 +4068,7 @@ impl WindbgServer {
         engine_result_for(args.session_id.as_deref(), out)
     }
 
-    /// Step over one call backward in a TTD trace (`p-`). Reverse of step_over.
+    /// Step over one call backward in a TTD trace (`p-`), the reverse of `p`.
     #[rmcp::tool(
         annotations(
             title = "Step over back (TTD)",
@@ -4514,6 +4520,148 @@ const GROUP_INSTRUCTIONS: &[(&[&str], &str)] = &[
     ),
 ];
 
+/// A sentence in one tool's description that names **another** tool, held here rather than in the
+/// doc comment so it ships only to a client served every tool it names.
+///
+/// The other half of the prose a client reads, and the half that is bigger. `FOLLOWUPS.md` item
+/// 40 narrowed the `instructions`; item 41 measured what was left - on `--tools crash` five
+/// descriptions of tools the client *is* served named four it is not, and the eval bench put
+/// **13 of 61** calls on that surface into asking for `modules` or `debug_batch` because of them.
+/// That is three times what the instructions were costing.
+///
+/// **Why a table and not a filter.** A description has no assembly point the way the instructions
+/// do - it is one literal per tool, shipped by the macro - so the appending is what this adds. The
+/// alternative shapes are both worse: deleting the sentences costs the fifty-one-tool client a
+/// pointer that is doing real work ("the opener does not give you the module table, `modules`
+/// does" is how the second call gets made), and saying it without the name keeps the pointer while
+/// losing the one string a model can copy into a call.
+///
+/// **Where a note is the wrong tool, the sentence was reworded instead**, because a note appends
+/// at the end and a cross-reference in the middle of an argument does not survive the move. Three
+/// were: `interrupt`'s "a `go` that has not hit anything" and `walk_memory`'s "a MASM `.for` loop
+/// through `execute`" are illustrations rather than pointers - nobody calls either tool because
+/// they read the name there - and `step_back`/`step_over_back` now name the WinDbg command they
+/// reverse (`t`, `p`) rather than the forward tool, which the line beside them already gives.
+struct ToolNote {
+    /// The tool whose description this extends. A note for a tool the surface dropped has nothing
+    /// to attach to and is skipped.
+    tool: &'static str,
+    /// Every tool the sentence names; it ships only when the surface has all of them.
+    ///
+    /// The same rule as [`GROUP_INSTRUCTIONS`], and adopted for the same reason review gave there:
+    /// a spec may select part of a group (`--tools registers` is valid), so asking whether the
+    /// *group* was served would reintroduce this very defect for a partial surface. The
+    /// consequence is silence rather than a half-sentence - a client with `dx` and not `execute`
+    /// reads `ttd_calls`'s LINQ note not at all.
+    names: &'static [&'static str],
+    /// The sentence, appended to the description on a line of its own - which is how the doc
+    /// comment it came out of reached the wire, since rmcp joins `///` lines with `\n` and drops
+    /// the blank ones. So a paragraph lifted into a note costs the description no bytes: each
+    /// newline it used to carry becomes a space inside one literal.
+    note: &'static str,
+}
+
+/// Every cross-reference this server's descriptions make, in the order they are appended.
+///
+/// `no_description_names_a_tool_the_client_cannot_call` is what keeps this complete: it walks the
+/// tightest surface each tool can be served on (`--tools <that tool>`, which is `session` plus it)
+/// and fails on any name left behind in a doc comment. That single-tool walk is the whole
+/// invariant rather than a sample of it - a fragment only ever ships when its own names are
+/// served, so if the base description is clean on the tightest surface it is clean on every wider
+/// one.
+const TOOL_NOTES: &[ToolNote] = &[
+    ToolNote {
+        tool: "open_dump",
+        names: &["modules"],
+        note: "`modules` lists that table.",
+    },
+    ToolNote {
+        tool: "pool_find_tag",
+        names: &["pool_chunk", "pool_census"],
+        note: "It comes from the same walk as `pool_chunk` and `pool_census`, so the three cannot \
+               disagree.",
+    },
+    ToolNote {
+        tool: "pool_find_tag",
+        names: &["pool_chunk"],
+        note: "To ask whether one specific address has been freed, use `pool_chunk`.",
+    },
+    ToolNote {
+        tool: "pool_diagnostics",
+        names: &["pool_find_tag", "pool_chunk"],
+        note: "Use this when a chunk you can see with `!pool` does not appear in `pool_find_tag` \
+               or `pool_chunk`.",
+    },
+    ToolNote {
+        tool: "pool_census",
+        names: &["pool_find_tag", "pool_chunk"],
+        note: "It comes from the same walk as `pool_find_tag` and `pool_chunk`, so the three \
+               cannot disagree.",
+    },
+    ToolNote {
+        tool: "crash_triage",
+        names: &["backtrace"],
+        note: "The stack it falls back to is the one `backtrace` would show.",
+    },
+    ToolNote {
+        tool: "interrupt",
+        names: &["debug_batch", "end_session"],
+        note: "A `debug_batch` interrupted this way stops at its next step and runs its `always` \
+               block, and its own result reports `BATCH: INTERRUPTED` with the rollback state — so \
+               no step after the interrupt is applied, and the session keeps its target (unlike \
+               `end_session`, which also stops a batch but takes the session with it). Its \
+               **rollback cannot be interrupted**: a restore cut short would report success while \
+               leaving the target changed, so a call aimed at a batch that is unwinding, or \
+               repeated while one is still stopping, says so and sends nothing. If a rollback will \
+               not end, `end_session` is the way out, at the cost of the target.",
+    },
+    ToolNote {
+        tool: "end_session",
+        names: &["debug_batch"],
+        note: "A `debug_batch` running on the session is told to stop at its next step and run its \
+               rollback before the target is released, and the batch's own call reports that; the \
+               grace covers the step in flight and the rollback after it.",
+    },
+    ToolNote {
+        tool: "backtrace",
+        names: &["crash_triage"],
+        note: "Same records as `crash_triage`'s `frames`.",
+    },
+    ToolNote {
+        tool: "backtrace",
+        names: &["execute"],
+        note: "`execute { \"command\": \"k\" }` gives the engine's own listing instead, with \
+               `Child-SP` / `RetAddr` and the inline-frame rows a stack walk does not return.",
+    },
+    ToolNote {
+        tool: "modules",
+        names: &["execute"],
+        note: "For the engine's own listing verbatim, `execute { \"command\": \"lm\" }`.",
+    },
+    ToolNote {
+        tool: "disassemble",
+        names: &["execute"],
+        note: "For the engine's own listing with its `module!Symbol+0x1c:` labels, \
+               `execute { \"command\": \"u\" }` — or `uf` to follow a whole function.",
+    },
+    ToolNote {
+        tool: "dx",
+        names: &["execute"],
+        note: "It is the second such hatch, alongside `execute`.",
+    },
+    ToolNote {
+        tool: "ttd_calls",
+        names: &["dx", "execute"],
+        note: "Append LINQ in a follow-up `dx`/`execute` to filter \
+               (e.g. `.Where(c => c.ReturnValue != 0)`).",
+    },
+    ToolNote {
+        tool: "run_to_address",
+        names: &["reachable_from_dispatch"],
+        note: "The block can be one `reachable_from_dispatch` reported.",
+    },
+];
+
 // **Sized to what the client actually reads.** Measured at 2,048 characters, and the text this
 // replaced was 3,147 - so 1,099 characters were paid for on every connection and never arrived.
 // Kept ASCII so the count cannot differ between characters and bytes, and
@@ -4677,14 +4825,37 @@ mod tests {
         text
     }
 
-    /// Whether a tool's name appears in prose, as a word rather than inside another word — `go`
-    /// and `dx` are tool names and are also two letters long.
+    /// Whether prose **names a tool** — the check both the instructions and the descriptions are
+    /// held to, and the one thing that has to be right for either to mean anything.
+    ///
+    /// Two rules, each because the other alone gets a real sentence here wrong:
+    ///
+    /// - **Written as code**: a backtick span that *is* the name, or that opens a call with it
+    ///   (`execute { "command": "k" }`). Plain containment cannot be the rule, because several of
+    ///   these names are also English — `crash_triage` says frames are "attributed to modules",
+    ///   `end_session` says a stuck session "does not let go" — and a rule that forbids the words
+    ///   *modules* and *go* is not one anyone can write prose under. Nor can "anywhere inside a
+    ///   code span" be it: the TTD tools quote the expression they run,
+    ///   `dx @$cursession.TTD.Calls(...)`, which names the debugger command `dx` is built on and
+    ///   not the `dx` tool.
+    /// - **Or bare, if the name has an underscore**: `step_back`'s description said "Reverse of
+    ///   step_into.", as copyable as any backticked name and invisible to the first rule. An
+    ///   underscored name is an identifier and never an English word, so this half needs no
+    ///   exceptions.
     fn names_tool(text: &str, tool: &str) -> bool {
+        let as_code = text.split('`').skip(1).step_by(2).any(|span| {
+            span == tool
+                || span
+                    .strip_prefix(tool)
+                    .is_some_and(|rest| rest.starts_with(" {"))
+        });
         let boundary = |c: Option<char>| c.is_none_or(|c| !c.is_alphanumeric() && c != '_');
-        text.match_indices(tool).any(|(at, _)| {
-            boundary(text[..at].chars().next_back())
-                && boundary(text[at + tool.len()..].chars().next())
-        })
+        as_code
+            || (tool.contains('_')
+                && text.match_indices(tool).any(|(at, _)| {
+                    boundary(text[..at].chars().next_back())
+                        && boundary(text[at + tool.len()..].chars().next())
+                }))
     }
 
     /// **The property this whole split exists for**: whatever a client is served, its instructions
@@ -4746,6 +4917,114 @@ mod tests {
                 assert!(
                     crate::toolset::Toolset::exists(tool),
                     "`{tool}` is named in the instructions and is not a tool this server has"
+                );
+            }
+        }
+    }
+
+    // ---- the descriptions a client is served ---------------------------
+
+    /// Every description this surface serves, exactly as `tools/list` carries it.
+    ///
+    /// Through the real `router()` rather than a re-assembly beside it — the notes are appended
+    /// there, and a test that appended them itself would pass whatever `router()` did.
+    fn descriptions_for(spec: &str) -> Vec<(String, String)> {
+        let surface = crate::toolset::Toolset::parse(spec)
+            .unwrap_or_else(|e| panic!("`{spec}` should be a valid spec: {e}"));
+        WindbgServer::new(Sessions::new(Duration::from_secs(1)))
+            .with_tools(surface, crate::toolset::Chosen::ForTheRun)
+            .router()
+            .list_all()
+            .into_iter()
+            .map(|tool| {
+                (
+                    tool.name.to_string(),
+                    tool.description.unwrap_or_default().to_string(),
+                )
+            })
+            .collect()
+    }
+
+    /// **The same property as the instructions, on the prose that is bigger.** Whatever a client
+    /// is served, no description it reads names a tool it cannot call.
+    ///
+    /// Walked over the *tightest* surface each tool can be served on — `--tools <that tool>`,
+    /// which is `session` plus it — and that is the whole invariant rather than a sample of it. A
+    /// note ships only when every tool it names is served, so all a wider surface can add is a
+    /// sentence already cleared by its own list; what a narrow one exposes is whatever was left
+    /// behind in the doc comment, and the single-tool spec is where the doc comment stands barest.
+    #[test]
+    fn no_description_names_a_tool_the_client_cannot_call() {
+        for spec in crate::toolset::Toolset::every_tool() {
+            let surface = crate::toolset::Toolset::parse(spec).expect("a tool name is a spec");
+            for (name, description) in descriptions_for(spec) {
+                for tool in crate::toolset::Toolset::every_tool() {
+                    if surface.includes(tool) {
+                        continue;
+                    }
+                    assert!(
+                        !names_tool(&description, tool),
+                        "`--tools {spec}` is not served `{tool}` and `{name}`'s description \
+                         names it:\n{description}"
+                    );
+                }
+            }
+        }
+    }
+
+    /// And the other direction, which is the half worth having: the client that *can* act on a
+    /// pointer still reads it. On the whole surface every note is back in the description it came
+    /// out of — deleting the cross-references outright would pass the test above and fail this
+    /// one.
+    #[test]
+    fn the_whole_surface_reads_every_note() {
+        let served: std::collections::HashMap<String, String> =
+            descriptions_for(crate::toolset::ALL).into_iter().collect();
+        for ToolNote { tool, note, .. } in TOOL_NOTES {
+            let description = served
+                .get(*tool)
+                .unwrap_or_else(|| panic!("`{tool}` has a note and is not served at all"));
+            assert!(
+                description.contains(*note),
+                "`{tool}`'s note did not reach the surface that has every tool it names:\n{note}"
+            );
+        }
+    }
+
+    /// The tools beside each note are exactly what it says, so the two cannot drift. This is what
+    /// makes the walk above an invariant rather than a spot check: a name added to a note and left
+    /// out of its list would ship to a client that has neither, and only the surface that happens
+    /// to be walked would notice.
+    #[test]
+    fn every_note_declares_the_tools_it_names() {
+        for ToolNote { tool, names, note } in TOOL_NOTES {
+            for named in crate::toolset::Toolset::every_tool() {
+                let declared = names.contains(&named);
+                let said = names_tool(note, named);
+                assert_eq!(
+                    declared,
+                    said,
+                    "`{named}` is {} in `{tool}`'s note and {} beside it:\n{note}",
+                    if said { "named" } else { "absent" },
+                    if declared { "declared" } else { "not declared" },
+                );
+            }
+        }
+    }
+
+    /// A note attached to, or naming, a tool this server does not have would never be seen — and
+    /// a misspelled owner is the quiet half, since `annotate` skips a note it cannot place.
+    #[test]
+    fn every_note_names_real_tools() {
+        for ToolNote { tool, names, .. } in TOOL_NOTES {
+            assert!(
+                crate::toolset::Toolset::exists(tool),
+                "`{tool}` carries a note and is not a tool this server has"
+            );
+            for named in *names {
+                assert!(
+                    crate::toolset::Toolset::exists(named),
+                    "`{named}` is named in `{tool}`'s note and is not a tool this server has"
                 );
             }
         }

--- a/src/toolset.rs
+++ b/src/toolset.rs
@@ -1,39 +1,46 @@
 //! Which of this server's fifty-one tools a run advertises.
 //!
 //! The tool surface is paid **once per conversation, before anything is debugged**, and it is
-//! 67,658 bytes — roughly 17k tokens. Three quarters of that is prose, and the prose is what tells
+//! 67,766 bytes — roughly 17k tokens. Three quarters of that is prose, and the prose is what tells
 //! a model how to drive the tools, so there is no strip here the way there was in
 //! [`crate::schema`]: `FOLLOWUPS.md` item 24 measured it and the only honest lever left is the one
 //! this module is — **not offering every tool to every caller**.
 //!
-//! Nothing changes for a client that says nothing. `--tools` is the whole interface, the default is
-//! every tool, and a narrowed surface costs no description a word.
+//! Nothing changes for a client that says nothing. `--tools` is the whole interface and the default
+//! is every tool. A narrowed surface costs a description one thing only: the sentences pointing at
+//! tools it no longer has (`FOLLOWUPS.md` item 41, `TOOL_NOTES` in [`crate::server`]), which is why
+//! the bytes below do not add up to what a spec actually serves — see the note under the table.
 //!
 //! # What a group is
 //!
 //! A group is *an activity*, not a subsystem: the tools you reach for while doing one kind of
 //! debugging. A caller reading a crash dump has no use for the nine TTD tools or the ten allocator
-//! ones, and pays 22,747 bytes for them at the start of every conversation.
+//! ones, and pays 22,798 bytes for them at the start of every conversation.
 //!
 //! ```text
 //!   group      tools   bytes   what it is for
-//!   session       10   12,161  opening a target, ending it, and watching this server
-//!   allocator     10   15,914  pool and heap walks, and `walk_memory`
-//!   inspect        9   10,192  registers, stacks, memory, modules, symbols, raw commands
-//!   ttd            9    6,833  recording, indexing and querying a Time Travel trace
+//!   session       10   12,157  opening a target, ending it, and watching this server
+//!   allocator     10   15,969  pool and heap walks, and `walk_memory`
+//!   inspect        9   10,215  registers, stacks, memory, modules, symbols, raw commands
+//!   ttd            9    6,829  recording, indexing and querying a Time Travel trace
 //!   ioctl          6    6,494  driver objects, IRP stacks, and dispatch reachability
-//!   exec           5    3,406  breakpoints and execution control
+//!   exec           5    3,420  breakpoints and execution control
 //!   batch          1    9,746  `debug_batch`
-//!   crash          1    2,912  `crash_triage`
+//!   crash          1    2,936  `crash_triage`
 //! ```
+//!
+//! **Those are shares of the whole surface, and they do not sum to a narrowed one.** `crash` reads
+//! 14,138 bytes, not the 15,093 its two rows add to, because the eleven tools it keeps also stop
+//! carrying the five sentences that pointed at `modules`, `debug_batch`, `go` and `backtrace`. A
+//! spec is always cheaper than its rows suggest, never dearer.
 //!
 //! # `session` is always in the surface
 //!
 //! Not a convenience: every other tool here routes by a `session_id`, and this server is the only
 //! thing that can issue one. A surface with `registers` and no opener cannot be used at all, so a
-//! spec that leaves one out is asking for something that does not exist. It is 12,161 bytes, and it
-//! is the floor of any usable surface — `--tools crash` is eleven tools, not one, and the startup
-//! line says so rather than leaving the addition to be discovered.
+//! spec that leaves one out is asking for something that does not exist. On its own it is 11,265
+//! bytes, and that is the floor of any usable surface — `--tools crash` is eleven tools, not one,
+//! and the startup line says so rather than leaving the addition to be discovered.
 //!
 //! # Who a surface belongs to
 //!

--- a/tests/golden/tool_budget.json
+++ b/tests/golden/tool_budget.json
@@ -38,12 +38,12 @@
     },
     {
       "annotations": 117,
-      "description": 1551,
+      "description": 1575,
       "inputSchema": 1308,
-      "modelVisible": 2912,
+      "modelVisible": 2936,
       "name": "crash_triage",
       "outputSchema": 2511,
-      "wire": 5571
+      "wire": 5595
     },
     {
       "annotations": 134,
@@ -92,21 +92,21 @@
     },
     {
       "annotations": 130,
-      "description": 256,
+      "description": 279,
       "inputSchema": 467,
-      "modelVisible": 766,
+      "modelVisible": 789,
       "name": "dx",
       "outputSchema": 0,
-      "wire": 911
+      "wire": 934
     },
     {
       "annotations": 116,
-      "description": 715,
+      "description": 713,
       "inputSchema": 314,
-      "modelVisible": 1081,
+      "modelVisible": 1079,
       "name": "end_session",
       "outputSchema": 1242,
-      "wire": 2470
+      "wire": 2468
     },
     {
       "annotations": 124,
@@ -191,12 +191,12 @@
     },
     {
       "annotations": 132,
-      "description": 2110,
+      "description": 2102,
       "inputSchema": 314,
-      "modelVisible": 2474,
+      "modelVisible": 2466,
       "name": "interrupt",
       "outputSchema": 0,
-      "wire": 2621
+      "wire": 2613
     },
     {
       "annotations": 124,
@@ -236,12 +236,12 @@
     },
     {
       "annotations": 128,
-      "description": 451,
+      "description": 457,
       "inputSchema": 211,
-      "modelVisible": 712,
+      "modelVisible": 718,
       "name": "open_dump",
       "outputSchema": 3838,
-      "wire": 4709
+      "wire": 4715
     },
     {
       "annotations": 114,
@@ -254,12 +254,12 @@
     },
     {
       "annotations": 123,
-      "description": 371,
+      "description": 375,
       "inputSchema": 602,
-      "modelVisible": 1025,
+      "modelVisible": 1029,
       "name": "pool_census",
       "outputSchema": 4679,
-      "wire": 5858
+      "wire": 5862
     },
     {
       "annotations": 129,
@@ -281,12 +281,12 @@
     },
     {
       "annotations": 122,
-      "description": 511,
+      "description": 558,
       "inputSchema": 1420,
-      "modelVisible": 1985,
+      "modelVisible": 2032,
       "name": "pool_find_tag",
       "outputSchema": 5499,
-      "wire": 7637
+      "wire": 7684
     },
     {
       "annotations": 90,
@@ -335,12 +335,12 @@
     },
     {
       "annotations": 114,
-      "description": 460,
+      "description": 474,
       "inputSchema": 791,
-      "modelVisible": 1306,
+      "modelVisible": 1320,
       "name": "run_to_address",
       "outputSchema": 1406,
-      "wire": 2857
+      "wire": 2871
     },
     {
       "annotations": 75,
@@ -380,12 +380,12 @@
     },
     {
       "annotations": 116,
-      "description": 76,
+      "description": 74,
       "inputSchema": 314,
-      "modelVisible": 440,
+      "modelVisible": 438,
       "name": "step_back",
       "outputSchema": 1185,
-      "wire": 1772
+      "wire": 1770
     },
     {
       "annotations": 109,
@@ -407,12 +407,12 @@
     },
     {
       "annotations": 121,
-      "description": 74,
+      "description": 72,
       "inputSchema": 314,
-      "modelVisible": 443,
+      "modelVisible": 441,
       "name": "step_over_back",
       "outputSchema": 1185,
-      "wire": 1780
+      "wire": 1778
     },
     {
       "annotations": 65,
@@ -452,24 +452,24 @@
     },
     {
       "annotations": 125,
-      "description": 1311,
+      "description": 1315,
       "inputSchema": 2713,
-      "modelVisible": 4076,
+      "modelVisible": 4080,
       "name": "walk_memory",
       "outputSchema": 2954,
-      "wire": 7186
+      "wire": 7190
     }
   ],
   "totals": {
     "annotations": 5449,
-    "description": 24794,
+    "description": 24902,
     "inputSchema": 40207,
     "instructions": 1983,
-    "modelVisible": 67658,
+    "modelVisible": 67766,
     "outputSchema": 102942,
-    "payload": 177460,
+    "payload": 177568,
     "tools": 51,
-    "wire": 177342,
+    "wire": 177450,
     "worstTool": "debug_batch",
     "worstToolModelVisible": 9746
   }

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -1766,7 +1766,7 @@ fn every_tool_belongs_to_exactly_one_group() {
 
 /// A narrowed surface serves fewer tools, and says so rather than pretending the rest never were.
 ///
-/// The measurement behind `--tools` is that three quarters of the 67,658-byte tool surface is
+/// The measurement behind `--tools` is that three quarters of the 67,766-byte tool surface is
 /// prose a model needs, so the only way to spend less of a caller's context is to offer fewer
 /// tools — `FOLLOWUPS.md` item 24. This asserts the three things that makes true.
 #[test]
@@ -2834,6 +2834,65 @@ fn two_clients_on_one_listener_are_served_two_surfaces() {
         to_bench.len(),
         to_local.len()
     );
+
+    // **And so do the tool descriptions**, the third and largest channel of prose. Item 40 left
+    // them behind and `FOLLOWUPS.md` item 41 measured what that cost: on `--tools crash` five
+    // descriptions of tools the client *is* served named four it is not, and 13 of 61 calls on
+    // that surface went to asking for them — three times what the instructions were costing. The
+    // budget golden cannot see this, because it records one surface; so it is asserted the way
+    // every other per-client property here is, with two credentials on one port.
+    let described = |server: &mut Listener, token: &str, session: &str| -> Vec<(String, String)> {
+        let reply = server.call_as(token, Some(session), "tools/list", json!({}));
+        assert_eq!(reply.status, 200, "{}", reply.body);
+        reply.payload.clone().expect("a JSON-RPC payload")["result"]["tools"]
+            .as_array()
+            .expect("tools/list returns an array")
+            .iter()
+            .map(|t| {
+                (
+                    t["name"].as_str().unwrap_or_default().to_string(),
+                    t["description"].as_str().unwrap_or_default().to_string(),
+                )
+            })
+            .collect()
+    };
+    let prose_local = described(&mut server, &local_token, &local_mcp);
+    let prose_bench = described(&mut server, &bench_token, &bench_mcp);
+    // Backticked, because that is what "names a tool" means here and a bare word is not: this
+    // very surface says frames are "attributed to modules" and that a stuck session "does not let
+    // go", and neither sentence points anywhere.
+    for name in ["`modules`", "`debug_batch`", "`go`", "`backtrace`"] {
+        for (tool, text) in &prose_bench {
+            assert!(
+                !text.contains(name),
+                "`bench` is served crash and `{tool}`'s description names {name}:\n{text}"
+            );
+        }
+    }
+    let of = |tools: &[(String, String)], want: &str| -> String {
+        tools
+            .iter()
+            .find(|(name, _)| name == want)
+            .map(|(_, text)| text.clone())
+            .unwrap_or_else(|| panic!("`{want}` is not on this surface"))
+    };
+    // The other direction, which is the half worth keeping: the client that can act on a pointer
+    // still reads it. Deleting the cross-references outright would pass the loop above.
+    let opener_local = of(&prose_local, "open_dump");
+    let opener_bench = of(&prose_bench, "open_dump");
+    assert!(opener_local.contains("`modules`"), "{opener_local}");
+    assert!(
+        opener_bench.len() < opener_local.len(),
+        "the opener should read shorter on the surface that cannot follow its pointer: bench {} \
+         vs local {}",
+        opener_bench.len(),
+        opener_local.len()
+    );
+    // And it is per reference rather than per tool: `local` has `execute` and not `crash_triage`,
+    // so `backtrace` keeps one of its two notes and loses the other.
+    let stack = of(&prose_local, "backtrace");
+    assert!(!stack.contains("`crash_triage`"), "{stack}");
+    assert!(stack.contains(r#"`execute { "command": "k" }`"#), "{stack}");
 
     // And a tool off the surface is refused by name, with the remedy for *this* caller: `local`
     // takes the run's, so the flag is the answer; `bench` has one of its own, so the client


### PR DESCRIPTION
`FOLLOWUPS.md` item 41, which this closes. Item 40 ([#206](https://github.com/glslang/windbg-mcp/pull/206)) narrowed the `instructions` string per client; a **tool's description** is the other prose a client reads, and the larger of the two. On `--tools crash` five descriptions of tools the client *is* served named four it is not — and the eval bench measured 13 of 61 calls on that surface going to `modules` or `debug_batch` because of them, three times what the instructions were costing.

## The shape

Item 40's, one level down. A cross-reference comes out of its doc comment into `TOOL_NOTES` (`src/server.rs`), paired with **every tool it names**, and `WindbgServer::annotate` appends it in `router()` — after `Toolset::narrow`, so a note whose own tool was dropped has nothing to attach to. `router()` is what `list_tools`, `get_tool` and `call_tool` all take, so the surface is applied in one place; the call path pays fifteen `format!`s it never reads, which is the trade against a second assembly being a second place to get the surface wrong.

The three shapes item 41 weighed were each worse: deleting the cross-reference costs the fifty-one-tool client a pointer that is doing real work, and saying it without the name loses the string a model can copy into a call.

## Four things the entry did not anticipate

**Five was one surface's count, not the class.** Across every valid spec there are **22** (tool, tool-it-names) pairs in **16** descriptions, carried by fifteen sentences. Six pairs are inside a single group — `backtrace`, `modules`, `disassemble` and `dx` all point at `execute`, the three pool tools at each other — where no group spec reaches them, only `--tools <single tool>`, which is the case review made this server honour on item 40. Two more (`step_back` → `step_into`) were written bare and invisible to any backtick-based count.

**"Names a tool" needed a predicate, and both obvious ones are wrong.** Word containment flags English — this prose says frames are "attributed to modules" and that a stuck session "does not let go". "Inside a backtick span" flags the debugger command a TTD tool quotes: `dx @$cursession.TTD.Calls(...)` names the command `dx` is built on, not the `dx` tool. The rule that works, now shared with the instructions test: a code span that **is** the name or opens a call with it, plus bare-if-underscored, since an underscored name is an identifier and never an English word.

**The budget golden did not have to record a surface** — the entry's main argument against fixing this. A note is a `const` appended to what the macro already built, so the whole surface reads what it read plus 108 bytes and there is still one row per tool. Lifting a *trailing* paragraph costs nothing at all: rmcp joins `///` lines with `\n`, so each newline becomes a space inside one literal, and five of the sixteen tools moved by zero bytes. What did lose its meaning is **additivity of the group table**, which `docs/token-budget.md` now says outright.

**Three references were reworded rather than moved**, because a note appends at the end and a cross-reference mid-argument does not survive the move: `interrupt`'s "a `go` that has not hit anything" and `walk_memory`'s "a MASM `.for` loop through `execute`" are illustrations rather than pointers, and `step_back`/`step_over_back` now name the WinDbg command they reverse (`t`, `p`), which the line beside them already gives.

## Measured

| `--tools` | before | after |
|---|---:|---:|
| *(absent)* — every tool | 67,658 B | **67,766** (+0.16%) |
| `session,inspect,exec,crash` | 28,671 | **27,807** |
| `session,inspect,crash` | 25,265 | **24,445** |
| `crash` | 15,073 | **14,138** (−6.2%) |
| `session` (the floor) | 12,161 | **11,265** |

Off-surface names go to zero on every spec.

## Assertions

- `no_description_names_a_tool_the_client_cannot_call` walks the **tightest** surface each tool can be served on (`--tools <that tool>`). That is the whole invariant rather than a sample of it: a note ships only when its own names are served, so all a wider surface can add is a sentence already cleared, and what a narrow one exposes is whatever was left in the doc comment.
- `the_whole_surface_reads_every_note` is the other direction, and is what stops this degenerating into "delete the cross-reference" — that would pass everything else here.
- `every_note_declares_the_tools_it_names` / `every_note_names_real_tools` keep the sentence and its list from drifting.
- `two_clients_on_one_listener_are_served_two_surfaces` states the per-client claim the only way it can be stated: `crash` and `session,inspect` on one port, since a golden records one surface.

Green on the ARM64 bench: **537 unit + 76 smoke**, `cargo fmt --all --check`, markdownlint (CI's 0.23.2, 35 files, 0 issues), `cargo clippy --all-targets` clean but for the pre-existing `every_tool` dead-code warning.

## Not measured

The eval grid has **not** been re-run against this, so 13-in-61 is what those descriptions were costing rather than what they now cost. `FOLLOWUPS.md`, `CLAUDE.md` and `docs/local-model-eval.md` each say so rather than implying a result. That re-run is worth more than item 40's was: thirteen calls going to zero by name is several times the noise five cells of one sample each showed, where item 40's own effect was the size of nemotron's single dropped call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017KHzgze3DM5NUNzfkeHVmZ