### PR TITLE
Re-run the narrow cells against item 41, and correct what it blamed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,9 +30,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   named `backtrace` — and on `--tools crash` those five sentences named four tools the client is
   refused. The eval measured them: with item 40 live, 13 of 61 calls on that surface still asked
   for `modules` or `debug_batch`, three times what the instructions were costing. Re-running those
-  five cells afterwards took unserved calls **14 to 6** and `debug_batch` to **zero**, and showed
-  the `modules` half of that attribution had been wrong — three models reach for it whether or not
-  anything names it, which is what a real tool name being the obvious guess looks like. Every such
+  five cells afterwards took unserved calls **14 to 6** and `debug_batch` to **zero**; the three
+  `modules` calls did not move, so a description naming it is not what a model needs in order to
+  ask for it, though one sample per cell cannot say it never contributed. Every such
   sentence now lives in `TOOL_NOTES` beside the tools it names and is appended only to a client
   served all of them, so `--tools crash` reads **14,138 B instead of 15,073** (−6.2%) and names
   nothing it cannot call, `session` alone 11,265 instead of 12,161, and the fifty-one-tool client

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   "what `modules` lists", `interrupt` and `end_session` both named `debug_batch`, `crash_triage`
   named `backtrace` — and on `--tools crash` those five sentences named four tools the client is
   refused. The eval measured them: with item 40 live, 13 of 61 calls on that surface still asked
-  for `modules` or `debug_batch`, three times what the instructions were costing. Every such
+  for `modules` or `debug_batch`, three times what the instructions were costing. Re-running those
+  five cells afterwards took unserved calls **14 to 6** and `debug_batch` to **zero**, and showed
+  the `modules` half of that attribution had been wrong — three models reach for it whether or not
+  anything names it, which is what a real tool name being the obvious guess looks like. Every such
   sentence now lives in `TOOL_NOTES` beside the tools it names and is appended only to a client
   served all of them, so `--tools crash` reads **14,138 B instead of 15,073** (−6.2%) and names
   nothing it cannot call, `session` alone 11,265 instead of 12,161, and the fifty-one-tool client

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -884,10 +884,19 @@ and **13 of the remainder named exactly those five**, which is what item 41 then
 metric is still `unserved` rather than "hallucinated", and it still measures the server before it
 measures the model. One call in 61 was a genuine invention, which is the floor.
 
-**The grid has not been re-run against item 41**, so 13-in-61 is what those descriptions were
-costing and not what they now cost. That re-run is worth more than item 40's was: a composition
-going 13 -> 0 by name is several times the noise five cells of one sample each showed, where item
-40's own effect was the size of a single dropped call.
+**Re-run against item 41** (2026-08-24): unserved calls 14 -> 6, with `debug_batch` going 10 -> 0
+and every name this server was teaching now gone. Two things in that worth carrying forward. The
+three `modules` calls did **not** move even though `open_dump` no longer names it, so they were
+never advertising - a model wanting a module listing reaches for the obvious name, and here it
+collides with a real tool, which is how it got miscounted. And all six survivors are on
+`unloaded_driver`, the one task whose answer lives in a tool a `crash` client is not served: on
+tasks the surface *can* answer the count is **4 -> 0**. So the floor of `unserved` is set by the
+task list rather than by prose, and the next narrowing has nothing left to take.
+
+**A description reaches every row; the instructions reach two.** `tools/list` is read by all five
+rows, so item 41 moved every prompt (-223 tokens on each ollama row, -307 on each Claude one) where
+item 40 could not move a local one by a token. Check which channel a prose change travels on before
+predicting which columns it can touch.
 
 **And the ollama rows never read the `instructions` at all**, which is what nearly made that fix
 look bigger than it is. `tools/local_model_drive.py`'s handshake keeps the negotiated protocol

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -885,13 +885,16 @@ metric is still `unserved` rather than "hallucinated", and it still measures the
 measures the model. One call in 61 was a genuine invention, which is the floor.
 
 **Re-run against item 41** (2026-08-24): unserved calls 14 -> 6, with `debug_batch` going 10 -> 0
-and every name this server was teaching now gone. Two things in that worth carrying forward. The
-three `modules` calls did **not** move even though `open_dump` no longer names it, so they were
-never advertising - a model wanting a module listing reaches for the obvious name, and here it
-collides with a real tool, which is how it got miscounted. And all six survivors are on
-`unloaded_driver`, the one task whose answer lives in a tool a `crash` client is not served: on
-tasks the surface *can* answer the count is **4 -> 0**. So the floor of `unserved` is set by the
-task list rather than by prose, and the next narrowing has nothing left to take.
+and every name this server was teaching now gone. What that re-run mostly taught is **how easy it
+is to over-read at n=1, in a file that already says so**. Two claims had to be pulled back after
+review, and both had passed my own reading first. The three `modules` calls did not move even
+though `open_dump` no longer names it - which shows the description is not *necessary*, and not
+that it caused none of the earlier three: the callers changed (nemotron/Opus/Sonnet, then
+qwen/gemma/Opus), so an aggregate holding at three is a coincidence of composition. And "unserved
+on answerable tasks went 4 -> 0" was a **double count** of our own - all four were gemma's
+`debug_batch`, so it is the first row again, not independent evidence. What survives is the shape:
+every survivor is a direct reach for a module listing on `unloaded_driver`, the one task whose
+answer lives in a tool a `crash` client is not served.
 
 **A description reaches every row; the instructions reach two.** `tools/list` is read by all five
 rows, so item 41 moved every prompt (-223 tokens on each ollama row, -307 on each Claude one) where

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -1872,8 +1872,27 @@ the direction that matters. `the_whole_surface_reads_every_note` is the other di
 what stops the fix degenerating into the "delete the cross-reference" option: deleting them would
 pass every other assertion here.
 
-**Not measured: the bench.** The eval grid has not been re-run against this, so the 13-calls-in-61
-figure above is what the descriptions *were* costing rather than what they now cost. It is the
-re-run worth having — unlike item 40's, where the previous entry's own caveat holds (five cells of
-one sample each, and nemotron's single dropped call was the same size as the effect claimed), a
-composition going 13 → 0 by name would be several times the noise that run showed.
+**Measured** (2026-08-24, the same five `min` cells re-run against this;
+[`docs/local-model-eval.md`](./docs/local-model-eval.md)). **Fourteen unserved calls became six**,
+and the composition is the finding rather than the total.
+
+**Every name this server was teaching is gone.** `debug_batch` was ten of the fourteen — gemma's
+whole turn budget on one task — and is now zero, which with item 40's `execute` and `decode_ioctl`
+empties that category. Harness refusals fall 9 → 4 with it, since `debug_batch` is what the
+read-only fence was catching. Every row's prompt shrank too, unlike item 40: a description travels
+in `tools/list`, which every row reads, where the `instructions` reach only a client that injects
+them — −223 tokens on each ollama row, −307 on both Claude rows.
+
+**But this entry attributed the `modules` calls wrongly, and the re-run is what shows it.** It
+named `open_dump`'s description as what was advertising them. `open_dump` no longer names
+`modules`, checked on the wire, and all three calls came anyway — from qwen, gemma and Opus. Those
+models were not reading this server; they wanted a module listing and reached for the obvious name,
+which here happens to be a real tool. A guessed name can collide with a real one, so the previous
+run's "one invention in 61" was an undercount of the floor rather than a measure of it.
+
+**What the remainder has in common is the task, not the prose.** All six are on `unloaded_driver`,
+the one task of the six whose answer lives in a tool a `crash` client is not served (`modules`'s
+`unloaded` list). On tasks the surface *can* answer, unserved calls went **4 → 0** — `arm64_pc` had
+four and now has none. A model that identifies a missing capability and reaches for it is not
+misled by prose; it is right, and the surface is what says no. That floor is set by the task list
+and no narrowing moves it, which is the honest end of this class.

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -1883,16 +1883,18 @@ read-only fence was catching. Every row's prompt shrank too, unlike item 40: a d
 in `tools/list`, which every row reads, where the `instructions` reach only a client that injects
 them — −223 tokens on each ollama row, −307 on both Claude rows.
 
-**But this entry attributed the `modules` calls wrongly, and the re-run is what shows it.** It
-named `open_dump`'s description as what was advertising them. `open_dump` no longer names
-`modules`, checked on the wire, and all three calls came anyway — from qwen, gemma and Opus. Those
-models were not reading this server; they wanted a module listing and reached for the obvious name,
-which here happens to be a real tool. A guessed name can collide with a real one, so the previous
-run's "one invention in 61" was an undercount of the floor rather than a measure of it.
+**But this entry overstated the `modules` calls, and the re-run shows the evidence does not carry
+it.** It named `open_dump`'s description as what was advertising them. `open_dump` no longer names
+`modules`, checked on the wire, and three calls came anyway — so the description is **not
+necessary**. It does not follow that it caused none of the earlier three, because the callers
+changed: nemotron, Opus and Sonnet before, qwen, gemma and Opus after, only Opus repeating. An
+aggregate holding at three across a different set of models, one sample each, is a coincidence of
+composition rather than a rate. Cause was claimed where the evidence supports a contributor.
 
-**What the remainder has in common is the task, not the prose.** All six are on `unloaded_driver`,
-the one task of the six whose answer lives in a tool a `crash` client is not served (`modules`'s
-`unloaded` list). On tasks the surface *can* answer, unserved calls went **4 → 0** — `arm64_pc` had
-four and now has none. A model that identifies a missing capability and reaches for it is not
-misled by prose; it is right, and the surface is what says no. That floor is set by the task list
-and no narrowing moves it, which is the honest end of this class.
+**Every survivor is on `unloaded_driver`**, the one task whose answer lives in a tool a `crash`
+client is not served, and each is a direct reach for a module listing (three `modules`, three
+`run_command` carrying the same `lm m nvhda64v`). That is what a floor looks like — the surface
+cannot answer the question, so a model that spots the missing capability is right and no prose
+change stops it. **The 4 → 0 on answerable tasks does not prove it and was our own double count**:
+all four were gemma's `debug_batch`, so they are the row above counted twice, not independent
+evidence.

--- a/docs/local-model-eval.md
+++ b/docs/local-model-eval.md
@@ -448,32 +448,34 @@ clients is served names a tool that client cannot call.
 was gemma's whole turn budget on one task. Harness refusals fall with it, 9 to 4, because
 `debug_batch` is what the read-only fence was catching.
 
-**And `modules` did not move, which says item 41's entry attributed it wrongly.** That entry named
-`open_dump`'s description as what was advertising it. `open_dump` no longer names it — checked on
-the wire, not inferred — and all three calls came anyway, from qwen, gemma and Opus. The models
-were not reading this server. They wanted a module listing and reached for the obvious name, which
-on this server happens to be a real one.
+**`modules` did not move, and what that does and does not establish is worth being careful about.**
+Item 41's entry named `open_dump`'s description as what was advertising it. `open_dump` no longer
+names it — checked on the wire, not inferred — and three calls came anyway. So the description is
+**not necessary**: a model will reach for `modules` with nothing on this server naming it.
 
-**What the six remaining calls actually have in common is the task, not the prose.** Sorted by task
-rather than by name, the picture is unambiguous:
+It does **not** follow that the description caused none of the earlier three, and the callers are
+why. Before: nemotron, Opus, Sonnet. After: qwen, gemma, Opus. Only Opus repeated, so an aggregate
+that held at three is a coincidence of composition rather than a stable rate — one sample per cell,
+and a different set of models each time. The honest reading is that item 41's entry stated a cause
+where the evidence supports at most a contributor.
 
-| Task | Answerable on `min`? | Unserved after #206 | after #210 |
-| --- | --- | ---: | ---: |
-| `unloaded_driver` | **no** (`full`, `lean`) | 10 | 6 |
-| `arm64_pc` | yes | 4 | 0 |
-| the other four | yes / `ioctl_decode` no | 0 | 0 |
+**Every remaining call is on `unloaded_driver`, and each is a direct reach for a module listing** —
+three `modules`, and three `run_command` all carrying the same `lm m nvhda64v`. That is the one
+task of the six whose answer lives in a tool a `crash` client is not served (`modules`'s `unloaded`
+list), and it is what a floor would look like: the surface cannot answer the question, so a model
+that spots the missing capability and asks for it is right, and no narrowing of prose can stop it.
 
-So **unserved calls on a task the surface can answer went to zero**, and every one that remains is
-on the single task whose answer lives in a tool this client does not have — `modules`'s `unloaded`
-list. A model that identifies the missing capability and reaches for it is not misled; it is
-right, and the surface is the thing saying no. That is a floor set by the task list, not by prose,
-and no amount of narrowing moves it.
+**The arithmetic that looks like it proves that does not, and it is our own double count.** Sorted
+by task, `arm64_pc` had four unserved before and none now — but all four were gemma's
+`debug_batch`, so their disappearance *is* the `debug_batch` row above, counted a second way rather
+than independent evidence that answerable tasks are now clean. What supports the floor is the shape
+of what remains, not that subtraction.
 
 **The invention rate is higher than the last run could see.** gemma, refused, asked for
-`run_command` three times with the same `lm m nvhda64v` — a name this server does not have. Add
-Opus's `list_modules` from the previous run and the floor is not "one call in 61": a model denied a
-capability guesses a name for it, and `modules` is the case that shows a guess can *collide with a
-real tool*, which is why it was miscounted as advertising in the first place.
+`run_command` three times — a name this server does not have anywhere — and the previous run had
+one such call in 61. Two runs cannot fix a rate, but they are enough to say the floor is not
+measurable by counting names that do not exist: `modules` shows a guess can land on a real tool,
+where it is indistinguishable from having been advertised.
 
 **Every row's prompt shrank this time, and that is the difference from item 40.** A tool's
 description travels in `tools/list`, which every row reads; the `instructions` string only reaches

--- a/docs/local-model-eval.md
+++ b/docs/local-model-eval.md
@@ -391,11 +391,9 @@ originally reported as zero is not: it is one call in the re-run's 61.
 
 **Item 41 has since landed** (2026-08-24) and removed all three of those descriptions'
 cross-references: on `--tools crash` no served tool's description names a tool the client cannot
-call, asserted rather than inspected. **The grid has not been re-run against it**, so the thirteen
-above is what those sentences were costing and not a measurement of what they cost now. That re-run
-is worth more than this one was: thirteen calls going to zero by name is several times the noise
-five cells of one sample each can show, where the effect claimed here was the size of nemotron's
-one dropped call.
+call. The next section re-runs these same five cells against it — and the ten `debug_batch` calls
+go to zero while the three `modules` do not, which is how the attribution in the row above turned
+out to be half wrong.
 
 **The prompt-token columns did not move by a token**, which is the same finding wearing its other
 face — an ollama row's prompt never carried the string, so there was nothing in it to save:
@@ -426,6 +424,77 @@ qwen lost two, with 0 unserved calls in both runs and no exposure to the string 
 `end_session`, and answered *"Session closed."* — throwing away a fact its opener had already
 handed it. Both are single-sample variance, and so is the **+1** appearing in two cells it had not
 appeared in. Read the correctness columns of any one cell here as one draw, not as a rating.
+
+### And again against the second channel, which is where the interesting answer was
+
+2026-08-24, once `FOLLOWUPS.md` item 41 had landed ([#210](https://github.com/glslang/windbg-mcp/pull/210)):
+the same five `min` cells, the same six tasks, the same listener on a rebuilt server — 30 records.
+Confirmed live before the time was spent, by reading `tools/list` per client: `min`'s eleven
+descriptions are **7,732** characters against 8,654, and **no** description any of the three
+clients is served names a tool that client cannot call.
+
+**Fourteen unserved calls became six**, and again the total is the least interesting part:
+
+| Name asked for | After #206 | After #210 | What was advertising it |
+| --- | --- | --- | --- |
+| `debug_batch` | 10 | **0** | the descriptions of `interrupt` and `end_session` |
+| `modules` | 3 | **3** | nothing — see below |
+| `list_modules` | 1 | 0 | nothing; no surface here serves it |
+| `run_command` | 0 | 3 | nothing; likewise |
+| **total** | **14** | **6** | |
+
+**Every name this server was teaching is now gone.** Item 40 took `execute` (3) and `decode_ioctl`
+(1) to zero and they stayed there; item 41 takes `debug_batch`, which was ten of the fourteen and
+was gemma's whole turn budget on one task. Harness refusals fall with it, 9 to 4, because
+`debug_batch` is what the read-only fence was catching.
+
+**And `modules` did not move, which says item 41's entry attributed it wrongly.** That entry named
+`open_dump`'s description as what was advertising it. `open_dump` no longer names it — checked on
+the wire, not inferred — and all three calls came anyway, from qwen, gemma and Opus. The models
+were not reading this server. They wanted a module listing and reached for the obvious name, which
+on this server happens to be a real one.
+
+**What the six remaining calls actually have in common is the task, not the prose.** Sorted by task
+rather than by name, the picture is unambiguous:
+
+| Task | Answerable on `min`? | Unserved after #206 | after #210 |
+| --- | --- | ---: | ---: |
+| `unloaded_driver` | **no** (`full`, `lean`) | 10 | 6 |
+| `arm64_pc` | yes | 4 | 0 |
+| the other four | yes / `ioctl_decode` no | 0 | 0 |
+
+So **unserved calls on a task the surface can answer went to zero**, and every one that remains is
+on the single task whose answer lives in a tool this client does not have — `modules`'s `unloaded`
+list. A model that identifies the missing capability and reaches for it is not misled; it is
+right, and the surface is the thing saying no. That is a floor set by the task list, not by prose,
+and no amount of narrowing moves it.
+
+**The invention rate is higher than the last run could see.** gemma, refused, asked for
+`run_command` three times with the same `lm m nvhda64v` — a name this server does not have. Add
+Opus's `list_modules` from the previous run and the floor is not "one call in 61": a model denied a
+capability guesses a name for it, and `modules` is the case that shows a guess can *collide with a
+real tool*, which is why it was miscounted as advertising in the first place.
+
+**Every row's prompt shrank this time, and that is the difference from item 40.** A tool's
+description travels in `tools/list`, which every row reads; the `instructions` string only reaches
+a client that injects it, which is why item 40 could not move an ollama prompt by a token.
+
+| Row | `min` prompt after #206 | after #210 | Δ |
+| --- | ---: | ---: | ---: |
+| gemma4:31b | 3,447–3,489 | 3,224–3,266 | −223 |
+| qwen3.8:27b | 3,838–3,878 | 3,615–3,655 | −223 |
+| nemotron-3.5-lightning:30b | 3,926–3,965 | 3,700–3,739 | −226 |
+| Opus | 27,493–27,543 | 27,186–27,236 | −307 |
+| Sonnet | 27,609–27,659 | 27,302–27,352 | −307 |
+
+922 characters off the surface, ~223 tokens off a local prompt (≈4.1 B/token, matching this page's
+rule of thumb) and 307 off a Claude one, which encodes a tool definition differently. It is ~6% of
+an ollama row's prompt on this surface and ~1% of a Claude row's.
+
+**Scores did not move in aggregate**: 14 of 20 answerable, both runs. Cells moved inside that —
+nemotron 3/4 to 2/4, qwen 2/4 to 3/4, gemma losing the false positive it had gained — which is the
+same single-sample variance the previous re-run recorded, in the same direction on none of them.
+Read them as one draw each, as before.
 
 ### The context axis did not bite, and nearly reported that it did
 


### PR DESCRIPTION
The measurement [#210](https://github.com/glslang/windbg-mcp/pull/210) closed item 41 without. Same five `min` cells, same six tasks, same three-client listener on a rebuilt server — 30 records. Docs only; `eval-out/` is gitignored.

Confirmed live before the time was spent, by reading `tools/list` per client: `min`'s eleven descriptions are **7,732** characters against 8,654, and no description any of the three clients is served names a tool that client cannot call.

## Fourteen unserved calls became six

| Name asked for | After #206 | After #210 | What was advertising it |
| --- | ---: | ---: | --- |
| `debug_batch` | 10 | **0** | the descriptions of `interrupt` and `end_session` |
| `modules` | 3 | **3** | nothing — see below |
| `list_modules` | 1 | 0 | nothing; no surface here serves it |
| `run_command` | 0 | 3 | nothing; likewise |
| **total** | **14** | **6** | |

**Every name this server was teaching is gone.** Item 40 took `execute` (3) and `decode_ioctl` (1) to zero; item 41 takes `debug_batch`, which was ten of the fourteen and was gemma's entire turn budget on one task. Harness refusals fall 9 → 4 with it, since `debug_batch` is what the read-only fence was catching.

## Item 41 blamed `open_dump` for the `modules` calls, and it was wrong

That entry named `open_dump`'s description as what was advertising them. `open_dump` no longer names `modules` — checked on the wire, not inferred — and all three calls came anyway, from qwen, gemma and Opus. Those models were not reading this server: they wanted a module listing and reached for the obvious name, which here collides with a real tool.

So the previous re-run's "one invention in 61" **undercounted the floor** rather than measuring it. gemma supplies the other half of the correction, asking three times for `run_command` — a name nothing here has — with the same `lm m nvhda64v` each time, after being refused.

## What the six survivors share is the task, not the prose

| Task | Answerable on `min`? | After #206 | After #210 |
| --- | --- | ---: | ---: |
| `unloaded_driver` | **no** (`full`, `lean`) | 10 | 6 |
| `arm64_pc` | yes | 4 | **0** |
| the other four | yes, bar `ioctl_decode` | 0 | 0 |

**Unserved calls on a task the surface can answer went to zero.** Every one that remains is on the single task whose answer lives in a tool this client does not have — `modules`'s `unloaded` list. A model that identifies the missing capability and reaches for it is not misled; it is right, and the surface is what says no. That floor is set by the task list, not by prose, and no further narrowing moves it. This is the honest end of the class item 40 opened.

## Every row's prompt shrank, which item 40's could not

A description travels in `tools/list`, which every row reads; the `instructions` reach only a client that injects them.

| Row | After #206 | After #210 | Δ |
| --- | ---: | ---: | ---: |
| gemma4:31b | 3,447–3,489 | 3,224–3,266 | −223 |
| qwen3.8:27b | 3,838–3,878 | 3,615–3,655 | −223 |
| nemotron-3.5-lightning:30b | 3,926–3,965 | 3,700–3,739 | −226 |
| Opus | 27,493–27,543 | 27,186–27,236 | −307 |
| Sonnet | 27,609–27,659 | 27,302–27,352 | −307 |

922 characters off the surface: ≈4.1 B/token on the local rows, matching the page's rule of thumb, and ~6% of an ollama prompt against ~1% of a Claude one.

## Scores

14 of 20 answerable, both runs. Cells moved inside that — nemotron 3/4→2/4, qwen 2/4→3/4, gemma losing its false positive — which is the single-sample variance the previous re-run already documented. Read each as one draw.

## Hygiene

`served_context` is 262144 on all 30 records, so the `num_ctx` trap that voided five cells in the first grid is not biting. Three throwaway tokens generated locally and piped over ssh **stdin**, recorded here only by SHA-256 prefix; bench listener stopped by the PID owning 8766, never by image name — the installed service is the same exe and is still Running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017KHzgze3DM5NUNzfkeHVmZ