### PR TITLE
Track what #212's review found, and link the grid write-up

### DIFF
--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -1,6 +1,6 @@
 # Follow-ups
 
-Deferred work, in twenty clusters: items 1–6 come from the reachability-confirmation effort (path
+Deferred work, in twenty-one clusters: items 1–6 come from the reachability-confirmation effort (path
 recipe + `run_to_address`, merged 2026-07-04), items 7–11 from surveying this server against the
 MCP `2026-07-28` extensions (tasks, apps), item 12 from the opener split
 (glslang/win-kexp#71, 2026-08-01), items 13–14 from the bounded-command coverage review
@@ -25,7 +25,8 @@ says against a real service (both 2026-08-23), and items 39–40 from running th
 and the model as a **grid** rather than as a sighting, and from what that grid found leaking
 through the one thing `--tools` does not narrow (both 2026-08-23), and item 41 from re-running
 the narrowed cells against that fix and finding two of the same names arriving by a second route
-(2026-08-24). Each item notes its repo,
+(2026-08-24), and items 42–43 from measuring item 41 and having two readings of that measurement
+corrected in review (2026-08-24). Each item notes its repo,
 why it was deferred, and where it picks up. See [`DECISIONS.md`](./DECISIONS.md) for the design rationale (D1–D5) items 1–6 extend,
 and the 2026-08-02 entries that items 13–14 and item 10 extend.
 
@@ -1898,3 +1899,58 @@ cannot answer the question, so a model that spots the missing capability is righ
 change stops it. **The 4 → 0 on answerable tasks does not prove it and was our own double count**:
 all four were gemma's `debug_batch`, so they are the row above counted twice, not independent
 evidence.
+
+## 42. [windbg-mcp] The eval cannot tell a cause from a coincidence, because n=1
+
+Three runs of the `min` cells have now produced a correlation that review had to take back, and the
+same shape each time: an aggregate that moved (or did not) across cells whose *composition* also
+changed, read as though the surface were the only thing varying.
+
+- **#209**: the re-run's cleanest correlation stated as a controlled test, which at one sample per
+  cell it cannot be.
+- **#212**, twice. `modules` held at 3 → 3 and was read as proving `open_dump`'s description had
+  never caused it — but the callers went nemotron/Opus/Sonnet → qwen/gemma/Opus, only Opus
+  repeating, so a steady total is composition rather than a rate. And "unserved on answerable tasks
+  went 4 → 0" was a **double count**: all four were gemma's `debug_batch`, already counted in the
+  row above it.
+
+**What the grid can and cannot answer.** It runs one draw per (model, context, surface, task), which
+is enough for what it was built for — failure *modes*, and whether a surface fits at all — and is
+not enough for any statement of the form "X caused Y". `docs/local-model-eval.md` says so in as many
+words ("one sample per cell is one draw") and that has not stopped three write-ups, mine included,
+from reaching past it. The rule is not missing; the grid's shape is what makes it easy to ignore.
+
+**What would close it**, and why it is a different experiment rather than a bigger one: *n* draws of
+**one** cell with one thing varied, rather than more cells. The question that actually needs it —
+did a description ever contribute to a `modules` call? — is a single A/B: the same model, the same
+task, the same surface, with and without the sentence, repeated enough times to see a rate. That is
+`local_model_drive.py` in a loop and a seed column in the record, not a change to the matrix runner.
+It is deferred because the answer is worth little now: the sentence is gone either way, and the fix
+does not depend on which of the two it was.
+
+**Where it picks up.** The grader already keeps the last record per (cell, task), which is the thing
+that would have to change first — repeated draws need to accumulate rather than replace. Give the
+record a `draw` index, key on it, and report a distribution instead of a mark.
+
+## 43. [windbg-mcp] `unserved` is two different measurements sharing a column
+
+The metric was renamed from `hallucinated` when the first grid found that a model asking for a tool
+it could not call was usually reading this server's own advertising. Items 40 and 41 removed that
+advertising, and the number that remains is no longer measuring the same thing:
+
+- **Names this server taught.** `execute`, `decode_ioctl` (item 40), `debug_batch` (item 41). Now
+  **zero**, and a regression here is a defect in this server.
+- **Capabilities the surface does not have.** The six survivors, all on `unloaded_driver`, whose
+  answer lives in `modules`'s `unloaded` list — three asking for `modules` and three for
+  `run_command`, which does not exist. A model that spots a missing capability and reaches for it is
+  *right*; the surface is what says no.
+
+Summed, they hide each other: the first going to zero looks like a 57% improvement rather than an
+elimination, and the second could grow without anything being wrong. The task's own `possible_on`
+already carries what separates them, so this is a grader change and not a new measurement — split
+the column into `taught` and `wanted`, and let a regression test assert only the first.
+
+**Why deferred.** Nothing is currently wrong: `taught` is zero, so the sum happens to be the
+interesting number by accident. The split is worth making the next time the eval runs against a
+prose change, and doing it now would re-grade three runs of records to prove a partition that no
+present data disagrees with.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,14 @@ Operator and reference material: [remote listener](docs/remote-listener.md),
 [disassembler coordinates](docs/coordinates.md), [smoke test](docs/smoke-test.md),
 [token budget](docs/token-budget.md), [releasing](docs/releasing.md).
 
+The eval also has a visual write-up of the original grid —
+[**The Tool Surface Grid**](https://claude.ai/code/artifact/aad9956d-47f3-450a-a436-1d2b29939a39),
+33 cells of three ~30B local models against three tool surfaces and three context windows, with
+Claude Code as the control. It is a snapshot of **2026-08-23** and is not kept in step with the
+server: its "narrowing the surface leaks tools" finding is one this server no longer has, closed by
+`FOLLOWUPS.md` items 40 and 41. [`docs/local-model-eval.md`](docs/local-model-eval.md) is the
+current account, including the two re-runs that measured those fixes.
+
 ## Quick start
 
 Windows x64, with `dbgeng.dll` from `System32` — enough for live user-mode, kernel and crash-dump


### PR DESCRIPTION
Two `FOLLOWUPS.md` items from measuring item 41, and the README link for the eval's visual write-up.

## Item 42 — the eval cannot tell a cause from a coincidence, because n=1

The one worth having. Three runs of the `min` cells have now produced a correlation review had to take back, with the same shape each time: an aggregate read as though the surface were the only thing varying, across cells whose *composition* also changed.

- **#209** stated the re-run's cleanest correlation as a controlled test.
- **#212**, twice — `modules` holding at 3 → 3 read as proving a description never caused it, when the callers went nemotron/Opus/Sonnet → qwen/gemma/Opus with only Opus repeating; and "unserved on answerable tasks went 4 → 0", which re-counted its own numerator (all four were gemma's `debug_batch`).

`docs/local-model-eval.md` already says one sample per cell is one draw, and that hasn't stopped three write-ups from reaching past it. The entry records what would actually close the open question — *n* draws of **one** cell with one thing varied, which is a different experiment rather than a bigger grid — and why it isn't worth running now: the sentence is gone either way, and the fix never depended on which channel it came from.

## Item 43 — `unserved` is two measurements sharing a column

It now sums two things that moved in opposite directions and hide each other:

- **names this server taught** — `execute`, `decode_ioctl`, `debug_batch` — now zero, where a regression is a defect in this server;
- **capabilities the surface lacks** — the six survivors on `unloaded_driver`, where a model reaching for the missing tool is right.

Summed, the first going to zero reads as a 57% improvement rather than an elimination. `possible_on` already carries the partition, so it's a grader change, deferred because nothing is presently wrong.

## The README link

Adds [**The Tool Surface Grid**](https://claude.ai/code/artifact/aad9956d-47f3-450a-a436-1d2b29939a39) beside the eval doc, with the two things a reader needs next to it: it's a **2026-08-23 snapshot**, and its "narrowing the surface leaks tools" finding is one this server no longer has — items 40 and 41 closed both channels. A link to a page contradicting current behaviour is worse than no link, so the sentence sends the reader to `docs/local-model-eval.md` for the current account.

**The artifact is currently private**, so that link 404s for anyone but its owner until it's shared. Nothing in this PR can change that — sharing is a UI action on the artifact itself. Worth doing before this merges, or the README ships a dead link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017KHzgze3DM5NUNzfkeHVmZ