### PR TITLE
Let the eval repeat a cell, so it can answer "how often"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **The eval can repeat a cell, which is the only way it can answer "how often"** (`FOLLOWUPS.md`
+  item 42, which closes it). The grid runs one draw per (model, context, surface, task) — enough
+  for failure *modes* and for whether a surface fits, and not enough for any sentence of the form
+  "X caused Y". Three write-ups reached past that anyway and review took two of them back, each
+  time because the cell's *composition* had changed too: an aggregate holding across two runs of
+  different models is a coincidence, not a rate. A cell group now takes `draws: n` and the draw
+  index is part of a record's identity, so repeats **accumulate** — `already_done` resumes per
+  draw, the grader counts over draws instead of keeping the last, and `--matrix` prints a
+  distribution (`3Y2n` is five draws, three correct) where one draw still prints `Y`. A record
+  written before this is draw 1, so the three published runs grade to exactly what they graded to.
+
+  **The seed rides along and does not replay a draw here.** Each draw asks for `seed: <draw index>`
+  and records it, which where a seed reproduces a sample makes draws repeatable and pairs the two
+  arms of an A/B. It does not here: four identical requests to `qwen3.8:27b-mlx` under
+  `seed: 7` returned four different answers (ollama 0.32.15, MLX). Measured after the code comment
+  claiming the opposite had been written — the column is what was *asked for*, and the distribution
+  over draws is the measurement.
+
 - **The local-model eval: a grid where there were two sightings**
   ([`docs/local-model-eval.md`](./docs/local-model-eval.md), `FOLLOWUPS.md` item 39). Three ~30B
   local models against three tool surfaces and three context windows, with Claude Code as the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -861,8 +861,27 @@ with `crash` alone. Verify against the dump before scoring a model wrong for fin
 route; the `arm64_pc` entry was corrected mid-run for exactly this.
 
 **Resume is per *cell*, so the log legitimately holds a task twice.** An outstanding task re-runs
-its cell's whole list, and the grader keeps the **last** record per (cell, task). Do not "fix" a
-duplicated task id by deleting rows.
+its cell's whole list, and the grader keeps the **last** record per (cell, **draw**, task). Do not
+"fix" a duplicated task id by deleting rows.
+
+**One draw per cell is what the grid runs, and it cannot answer "X caused Y"** — a rule
+`docs/local-model-eval.md` states in as many words and that has not stopped three write-ups (#209
+once, #212 twice) from reading a moved aggregate as a controlled result (item 42).
+The trap is composition: a total that holds across two runs whose *callers* changed is a
+coincidence, not a rate. What answers a rate is `draws: n` on a cell group — the same cell n times,
+one thing varied — and the draw index is inside the grader's key, so repeats accumulate instead of
+the last one winning. Two consequences when editing that code. **A record with no `draw` is draw
+1**, which is the only reason a run recorded before the change still grades to what it graded to,
+and it lives in `draw_of` rather than in four `or 1`s. And `--matrix` prints a **distribution** (`3Y2n`)
+only when a cell was repeated; a single draw prints the bare mark, so nothing already published is
+restated in a new notation.
+
+**And the seed does not replay a draw on this bench, so do not write that it does.** Each draw asks
+for `seed: <draw index>` and records it, which is right where a seed reproduces a sample (the
+draws become repeatable, and arm A's draw 3 pairs with arm B's). It does not here: four identical
+requests to `qwen3.8:27b-mlx` under `seed: 7` returned four different answers (ollama 0.32.15, MLX,
+measured 2026-08-24 — after the comment claiming otherwise had already been written). The column is
+what was asked for; the distribution over draws is the measurement.
 
 **The Claude Code row needs four fences or it measures something else.** `--strict-mcp-config` (or
 it falls back to the editor's registered `windbg-vm`, whose credential is a different client and

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -26,7 +26,7 @@ and the model as a **grid** rather than as a sighting, and from what that grid f
 through the one thing `--tools` does not narrow (both 2026-08-23), and item 41 from re-running
 the narrowed cells against that fix and finding two of the same names arriving by a second route
 (2026-08-24), and items 42–43 from measuring item 41 and having two readings of that measurement
-corrected in review (2026-08-24). Each item notes its repo,
+corrected in review (2026-08-24, item 42 landing the same day). Each item notes its repo,
 why it was deferred, and where it picks up. See [`DECISIONS.md`](./DECISIONS.md) for the design rationale (D1–D5) items 1–6 extend,
 and the 2026-08-02 entries that items 13–14 and item 10 extend.
 
@@ -48,6 +48,9 @@ is kept because item 8 rests on it: what it built is the job binding, and what i
 not build is the queued-job half that only `tasks/cancel` can ask for. **Item 12 has landed**
 (2026-08-02) and is kept because what validating it *disproved* outlives what it confirmed: a kernel
 attach whose target never dials in has no bound at all, which is the constraint item 10 contains.
+**Item 42 has landed** (2026-08-24) and is kept for the same reason as item 41 above: what it built
+is the capability to repeat a cell, and what it deliberately did not run is the A/B that motivated
+it — plus one of its own sentences turned out to be false on this bench, which the entry now records.
 
 ## 1. [win-kexp] Managed breakpoint lifecycle for `run_to_address` — **done upstream**
 
@@ -1900,7 +1903,7 @@ change stops it. **The 4 → 0 on answerable tasks does not prove it and was our
 all four were gemma's `debug_batch`, so they are the row above counted twice, not independent
 evidence.
 
-## 42. [windbg-mcp] The eval cannot tell a cause from a coincidence, because n=1
+## 42. [windbg-mcp] The eval cannot tell a cause from a coincidence, because n=1 — **done** (2026-08-24)
 
 Three runs of the `min` cells have now produced a correlation that review had to take back, and the
 same shape each time: an aggregate that moved (or did not) across cells whose *composition* also
@@ -1931,6 +1934,26 @@ does not depend on which of the two it was.
 **Where it picks up.** The grader already keeps the last record per (cell, task), which is the thing
 that would have to change first — repeated draws need to accumulate rather than replace. Give the
 record a `draw` index, key on it, and report a distribution instead of a mark.
+
+**What landed** (2026-08-24), which is the capability rather than the experiment — the A/B it was
+written for is still not worth running, for the reason above. A record carries `draw` and `seed`
+from both backends; a cell group asks for repeats with `draws: n`, which is a loop around the cell
+and not a fourth axis; and every reader keys on the draw index, so `already_done` resumes per draw
+(3 done and 5 asked for runs 4 and 5), `records` accumulates instead of keeping the last, and
+`--matrix` prints `3Y2n` where it printed `Y`. **A record with no `draw` is draw 1** (`draw_of`),
+so a run already recorded grades to exactly what it graded to — checked against the two logs this
+bench still has, whose `--grade` and `--matrix` output is byte-identical either side of the
+change.
+
+**Two things the entry did not see.** The first is a measurement that contradicts it: *"a seed
+column in the record"* was written on the assumption that a seeded draw can be replayed, and on
+this bench it cannot — four identical requests to `qwen3.8:27b-mlx` under `seed: 7` returned four
+different answers (ollama 0.32.15, MLX). The seed is still sent and recorded — sending it costs
+nothing, and a runtime that does reproduce under it would pair the arms of an A/B — but every
+sentence around it now says the column is what was *asked for*. Unmeasured, it would have shipped
+as a replay guarantee in the comments and in all three documents this touched. The second is smaller and is the deletion trap in reverse:
+the rule that a cell-level failure note is superseded by later records of that cell had to learn
+about draws too, or draw 4 dying would be un-recorded by draw 5 completing afterwards.
 
 ## 43. [windbg-mcp] `unserved` is two different measurements sharing a column
 

--- a/docs/local-model-eval.md
+++ b/docs/local-model-eval.md
@@ -241,6 +241,55 @@ ever fails. Such a record is also not counted as done, so re-running the plan re
 python3 tools/local_model_eval.py --grade results.jsonl tools/eval_tasks.json
 ```
 
+### Repeating a cell, when the question is a rate
+
+The grid runs **one draw per (model, context, surface, task)**, which is what every run on this
+page is. That is enough for the two things it was built for — failure *modes*, and whether a
+surface fits at all — and it is not enough for any sentence of the form "X caused Y". Three
+write-ups here reached past that anyway and review took two of them back
+(`FOLLOWUPS.md` item 42); the trap each time was a cell whose *composition* also changed, so an
+aggregate that held across two runs of different models read as a stable rate rather than as the
+coincidence it was.
+
+What answers a rate is the same cell run *n* times with one thing varied. A cell group asks for
+that with `draws`, and changes nothing else:
+
+```json
+{ "backend": "ollama", "models": ["qwen3.8:27b-mlx"], "contexts": [262144],
+  "surfaces": ["min"], "subset": "short", "draws": 5, "budget_s": 2400 }
+```
+
+The draw index is part of a record's identity, which is what makes repeats **accumulate** rather
+than replace each other:
+
+- Resume works per draw. A plan that ran 3 and now asks for 5 runs draws 4 and 5 and repeats
+  nothing.
+- The grader counts over draws. Deduplicating on (cell, task) alone — which is what it did — would
+  collapse *n* draws to the last one, so a repeated cell would measure exactly as much as a single
+  one.
+- `--matrix` prints a distribution where it printed a mark: `3Y2n` is five draws, three of them
+  correct. One draw still prints `Y`, so every matrix on this page reads as it did.
+- A draw that dies is recorded against *that* draw, and its row reads `FAILED x2` when more than
+  one of them did.
+
+A record written before draws existed is draw 1, so the runs already on disk grade to exactly what
+they graded to.
+
+**The seed is recorded and does not replay a draw here.** Each draw asks the runtime for a `seed`
+of its draw index — free to send, and where a seed reproduces a sample the draws become
+repeatable and arm A's draw 3 pairs with arm B's rather than averaging against it. It does not
+reproduce one here: measured 2026-08-24, four identical requests to `qwen3.8:27b-mlx` under
+`seed: 7` (ollama 0.32.15, MLX) returned four different answers. So the column says what was *asked for*, the
+draws vary regardless — which is what a rate needs — and nothing here claims a draw can be
+replayed. The Claude Code rows have no seed to ask for at all, and record a null.
+
+**The experiment this exists for is an A/B, and it is two runs rather than a bigger plan**: the
+same cell, with and without the prose under test, into two logs, and the two distributions
+compared. The variable is a server build, so no single plan can hold both arms. The question that
+prompted it — did `open_dump`'s description ever contribute to a `modules` call? — is still not
+worth the runtime: that sentence is gone either way, and the fix never depended on which of the two
+channels carried it.
+
 ## What one grid showed
 
 Run 2026-08-23, on the ARM64 bench described in `local-model.md`: 33 cells, 144 task runs, about

--- a/docs/local-model-eval.md
+++ b/docs/local-model-eval.md
@@ -273,6 +273,9 @@ than replace each other:
   than one of them did, and the draws it never recorded count as `x` in each task's distribution.
   `1Y1x` is a cell that was asked for twice and answered once — a bare `Y` there would be
   indistinguishable from one clean draw, which is the denominator this whole section is about.
+  A task **no** draw reached reads `2x` rather than a blank, because a dead draw's note carries
+  the ids it was going to run; a blank still means the cell was never asked for that task, which
+  is what a group's `subset` does.
 
 A record written before draws existed is draw 1, so the runs already on disk grade to exactly what
 they graded to.

--- a/docs/local-model-eval.md
+++ b/docs/local-model-eval.md
@@ -269,8 +269,10 @@ than replace each other:
   one.
 - `--matrix` prints a distribution where it printed a mark: `3Y2n` is five draws, three of them
   correct. One draw still prints `Y`, so every matrix on this page reads as it did.
-- A draw that dies is recorded against *that* draw, and its row reads `FAILED x2` when more than
-  one of them did.
+- A draw that dies is recorded against *that* draw: its row reads `FAILED on 2 draws` when more
+  than one of them did, and the draws it never recorded count as `x` in each task's distribution.
+  `1Y1x` is a cell that was asked for twice and answered once — a bare `Y` there would be
+  indistinguishable from one clean draw, which is the denominator this whole section is about.
 
 A record written before draws existed is draw 1, so the runs already on disk grade to exactly what
 they graded to.

--- a/tools/claude_code_drive.py
+++ b/tools/claude_code_drive.py
@@ -242,6 +242,14 @@ def main():
         "backend": "claude-code",
         "model": MODEL,
         "num_ctx": None,
+        "draw": drive.DRAW,
+        # **Null rather than absent, and it cannot be anything else here.** `claude -p` exposes no
+        # sampling seed to ask for, where the ollama rows at least ask - which is a property of
+        # this row worth recording rather than a field to leave out. It is a smaller difference
+        # than it looks: the ollama rows' seed does not reproduce a draw on this bench either
+        # (`local_model_drive.SEED`), so no row here replays one. The grader reads `draw` from
+        # both backends and `seed` from neither.
+        "seed": None,
         "surface": {"client": os.environ.get("EVAL_SURFACE", ""), "tools": len(tools),
                     "bytes": surface_bytes, "names": sorted(t["name"] for t in tools)},
     }

--- a/tools/local_model_drive.py
+++ b/tools/local_model_drive.py
@@ -42,6 +42,12 @@ Configuration:
                         and keeps nothing, which is what it did before the eval existed
     MAX_STEPS           tool-calling turns a task may take before it is given up on
                         (default 6)
+    EVAL_DRAW           which draw of this cell this process is (default 1). Repeating a
+                        cell is how a rate is measured rather than a sighting; the index
+                        is what keeps the repeats apart in an append-only log
+    EVAL_SEED           the sampling seed for this draw, sent to the runtime and recorded
+                        beside it. Unset means none was asked for. It is what was *asked*
+                        rather than a replay: one seed does not reproduce a draw here (`SEED`)
 
 **Why the keepalive exists.** The listener releases a client's sessions when its lease
 runs out, and the grace is derived from how long a *call* may take, on the assumption
@@ -66,6 +72,21 @@ NUM_CTX = int(os.environ.get("NUM_CTX", "0") or 0)
 KEEP_ALIVE = os.environ.get("OLLAMA_KEEP_ALIVE", "10m")
 EVAL_OUT = os.environ.get("WINDBG_MCP_EVAL_OUT", "")
 REVISION = "2025-06-18"
+
+# **Which draw this process is, and the seed it was sampled with** (`FOLLOWUPS.md` item 42).
+# The grid runs one draw per cell, which is enough to ask whether a surface fits and not enough
+# for any statement of the form "X caused Y" — that needs the same cell repeated with one thing
+# varied. `EVAL_DRAW` is what makes repeats *accumulate* rather than replace each other: it
+# reaches the record, and the grader keys on it.
+#
+# The seed travels beside it, and **on this bench it does not make a draw replayable** — measured,
+# 2026-08-24, because the comment here first claimed it did: four identical requests to
+# `qwen3.8:27b-mlx` under `seed: 7` (ollama 0.32.15, MLX) returned four different answers. The
+# option is sent and recorded because a runtime that honours it makes the draws reproducible for
+# free and nothing here has to change; what must not be written down is that a recorded seed *is*
+# a replay. Unset means none was asked for, and the record says so with a null.
+DRAW = int(os.environ.get("EVAL_DRAW", "1") or 1)
+SEED = int(os.environ["EVAL_SEED"]) if os.environ.get("EVAL_SEED", "").strip() else None
 
 # Tool calls this harness will actually execute. Everything else is reported back
 # to the model as refused, so a wrong pick is *measured* rather than performed —
@@ -296,13 +317,22 @@ class ChatFailed(Exception):
 def chat(messages, tools):
     body = {"model": MODEL, "messages": messages, "tools": tools, "stream": False,
             "think": False, "keep_alive": KEEP_ALIVE}
+    options = {}
     if NUM_CTX:
         # **The window is a property of the runtime, not of the model.** `ollama show` reports
         # what the weights could take; what a request is actually served is
         # `OLLAMA_CONTEXT_LENGTH` unless a request says otherwise, and this is that override —
         # the eval's context axis is this number moving. Setting it *reloads* the model, so the
         # matrix runs every surface at one context before it moves to the next.
-        body["options"] = {"num_ctx": NUM_CTX}
+        options["num_ctx"] = NUM_CTX
+    if SEED is not None:
+        # Per *draw*, not per run: on a runtime that honours it, draws of one cell all carrying
+        # one seed would be a single measurement recorded n times, which is the opposite of what
+        # repeating is for. The runner gives each draw a seed of its own. One seed does not
+        # reproduce a draw on this bench (see `SEED` above), so these draws vary regardless.
+        options["seed"] = SEED
+    if options:
+        body["options"] = options
     req = urllib.request.Request(OLLAMA, data=json.dumps(body).encode(), method="POST")
     req.add_header("Content-Type", "application/json")
     try:
@@ -660,6 +690,8 @@ def main():
         return
     MODEL = pick_model()
     print(f"model: {MODEL}")
+    if DRAW != 1 or SEED is not None:
+        print(f"draw {DRAW}, " + (f"seed {SEED}" if SEED is not None else "unseeded"))
     print("MCP revision negotiated:", handshake())
     threading.Thread(target=keepalive, daemon=True).start()
     tools = mcp("tools/list")["result"]["tools"]
@@ -679,6 +711,8 @@ def main():
         "backend": "ollama",
         "model": MODEL,
         "num_ctx": NUM_CTX or None,
+        "draw": DRAW,
+        "seed": SEED,
         "surface": {"client": os.environ.get("EVAL_SURFACE", ""),
                     "tools": len(tools), "bytes": surface,
                     "names": sorted(t["name"] for t in tools)},

--- a/tools/local_model_eval.py
+++ b/tools/local_model_eval.py
@@ -471,6 +471,16 @@ def summarise(log_path, tasks_file):
             "draw_ids": set(),
         })
         cell["draw_ids"].add(draw_of(record))
+        # **Filled in by whichever record first carries it, not by whichever record comes first.**
+        # A draw that died writes a note naming only its client, and with `draws` a dead draw 1
+        # followed by live ones is ordinary rather than exotic - so a `setdefault` alone froze
+        # `tools`, `surface_bytes` and `served_context` at that note's nulls, and the row printed
+        # a cell's tool count as `-` while the graded JSON lost the window every later draw ran at.
+        for field, value in (("tools", surface.get("tools")),
+                             ("surface_bytes", surface.get("bytes")),
+                             ("served_context", record.get("served_context"))):
+            if cell[field] is None and value is not None:
+                cell[field] = value
         if record.get("task") is None:
             # A cell-level note - a killed draw of this cell - rather than a task record. Counted
             # as well as kept: on a repeated cell "FAILED" alone cannot say whether one draw of
@@ -537,10 +547,12 @@ def print_table(cells):
         # seeing, so they travel beside the score as `+n` rather than inside it.
         extra = c["correct"] - c["correct_of_possible"]
         score = f"{c['correct_of_possible']}/{c['possible']}" + (f"+{extra}" if extra else "")
-        # `x n` when more than one draw of the cell died, because on a repeated cell a bare
-        # FAILED cannot tell one bad draw from a cell that never completes.
-        failed = (" FAILED" + (f" x{c['failed_draws']}" if c.get("failed_draws", 0) > 1 else "")
-                  if c.get("cell_error") else "")
+        # Counted when more than one draw of the cell died, because on a repeated cell a bare
+        # FAILED cannot tell one bad draw from a cell that never completes. Spelled out rather
+        # than `x2`, since `x` is a *mark* in the matrix beside this and one letter should not be
+        # two notations.
+        failed = (" FAILED" + (f" on {c['failed_draws']} draws" if c.get("failed_draws", 0) > 1
+                               else "") if c.get("cell_error") else "")
         if c.get("uncounted"):
             # One counter for one predicate: a record can stop counting because the window it ran
             # at was not the one it asked for, or because the question has changed since. Naming
@@ -558,7 +570,7 @@ def print_table(cells):
 
 # The marks a cell-task can carry, in the order a distribution prints them. Fixed rather than
 # sorted by count, so `3Y2n` and `2n3Y` cannot be two spellings of one result.
-MARK_ORDER = "Yno-!?"
+MARK_ORDER = "Yno-!?x"
 
 
 def distribution(marks):
@@ -594,16 +606,28 @@ def matrix(log_path, tasks_file):
     entry - its mark, its calls and its answer kept per draw, because the interesting thing about
     a `3Y2n` is usually what the two did differently - and the printed mark becomes the
     distribution over them.
+
+    **A draw that recorded nothing is still one of the draws** (`x`), which is the denominator
+    this would otherwise lose: a cell killed on draw 1 writes a note and no task record, so
+    building each distribution from the surviving records alone printed a bare `Y` for "one draw
+    died, one passed" - indistinguishable from a single clean draw, and understating the sample
+    exactly the way item 42 is about.
     """
     key = {t["id"]: t for t in load(tasks_file)["tasks"]}
     order = [t["id"] for t in load(tasks_file)["tasks"]]
     rows = {}
+    # Every draw this cell *attempted*, and why a draw died where one did - both read off the
+    # cell-level notes, which are the only record a draw that wrote nothing else leaves.
+    attempted, died = {}, {}
     for record in records(log_path):
-        if record.get("task") is None:
-            continue
         surface = record.get("surface") or {}
-        row = rows.setdefault((record.get("backend"), record.get("model"), record.get("num_ctx"),
-                               surface.get("client")), {})
+        cell_id = (record.get("backend"), record.get("model"), record.get("num_ctx"),
+                   surface.get("client"))
+        attempted.setdefault(cell_id, set()).add(draw_of(record))
+        if record.get("task") is None:
+            died[(cell_id, draw_of(record))] = record.get("error")
+            continue
+        row = rows.setdefault(cell_id, {})
         task = key.get(record["task"])
         if task is None:
             continue
@@ -625,8 +649,13 @@ def matrix(log_path, tasks_file):
                                "wall_s": record.get("wall_s"),
                                "answer": (record.get("answer") or "")[:2000],
                                "error": record.get("error")})
-    for row in rows.values():
+    for cell_id, row in rows.items():
         for entry in row.values():
+            recorded = {d["draw"] for d in entry["draws"]}
+            for missing in attempted.get(cell_id, set()) - recorded:
+                entry["draws"].append({"draw": missing, "seed": None, "mark": "x", "calls": [],
+                                       "wall_s": None, "answer": "",
+                                       "error": died.get((cell_id, missing))})
             entry["draws"].sort(key=lambda d: d["draw"])
             entry["mark"] = distribution([d["mark"] for d in entry["draws"]])
     return order, rows
@@ -650,9 +679,13 @@ def print_matrix(order, rows):
     print("\nY correct   n wrong   - not answerable on this surface   "
           "o answered anyway   ! the runtime refused the request   "
           "? served a different window than asked for")
-    if any(len(m.get("draws") or []) > 1 for row in rows.values() for m in row.values()):
+    entries = [m for row in rows.values() for m in row.values()]
+    if any(len(m.get("draws") or []) > 1 for m in entries):
         print("A repeated cell prints its distribution: `3Y2n` is five draws, three of them "
               "correct.")
+    if any(d["mark"] == "x" for m in entries for d in m.get("draws") or []):
+        print("x   the draw recorded nothing for this task - its cell died first, and it counts "
+              "in the denominator")
 
 
 def main():

--- a/tools/local_model_eval.py
+++ b/tools/local_model_eval.py
@@ -623,16 +623,19 @@ def matrix(log_path, tasks_file):
     key = {t["id"]: t for t in load(tasks_file)["tasks"]}
     order = [t["id"] for t in load(tasks_file)["tasks"]]
     rows = {}
-    # Every draw this cell *attempted*, and why a draw died where one did - both read off the
-    # cell-level notes, which are the only record a draw that wrote nothing else leaves.
-    attempted, died = {}, {}
+    # **Only a draw that *died* can leave a task unrecorded**, which is what makes the notes the
+    # whole story here: a draw that completed wrote every task it was asked, so one it has no
+    # record for was never on its list - a cell group's `subset`, not a failure. Reading a
+    # missing record as a dead draw put `x` on tasks a successful subset draw had deliberately
+    # skipped, which corrupts the very denominator this exists to keep.
+    dead = {}
     for record in records(log_path):
         surface = record.get("surface") or {}
         cell_id = (record.get("backend"), record.get("model"), record.get("num_ctx"),
                    surface.get("client"))
-        attempted.setdefault(cell_id, set()).add(draw_of(record))
         if record.get("task") is None:
-            died[(cell_id, draw_of(record))] = record.get("error")
+            dead.setdefault(cell_id, {})[draw_of(record)] = {
+                "planned": record.get("planned"), "error": record.get("error")}
             # **A task that *no* draw reached still belongs in the row**, and the note is the only
             # place its name survives. Seeded from the note's own `planned` list rather than from
             # the suite: a cell group may run a `subset`, and from the log alone "the subset left
@@ -643,6 +646,7 @@ def matrix(log_path, tasks_file):
                 if key.get(planned) is not None:
                     rows.setdefault(cell_id, {}).setdefault(planned, {"mark": None, "draws": []})
             continue
+
         row = rows.setdefault(cell_id, {})
         task = key.get(record["task"])
         if task is None:
@@ -666,12 +670,18 @@ def matrix(log_path, tasks_file):
                                "answer": (record.get("answer") or "")[:2000],
                                "error": record.get("error")})
     for cell_id, row in rows.items():
-        for entry in row.values():
+        for task_id, entry in row.items():
             recorded = {d["draw"] for d in entry["draws"]}
-            for missing in attempted.get(cell_id, set()) - recorded:
-                entry["draws"].append({"draw": missing, "seed": None, "mark": "x", "calls": [],
-                                       "wall_s": None, "answer": "",
-                                       "error": died.get((cell_id, missing))})
+            for draw, note in dead.get(cell_id, {}).items():
+                if draw in recorded:
+                    continue
+                if note["planned"] is not None and task_id not in note["planned"]:
+                    # That draw was never going to run this task, so its death says nothing about
+                    # it. One full-suite draw beside five `subset` ones shares a cell id with
+                    # them, and without this every task outside the subset read `1Y5x`.
+                    continue
+                entry["draws"].append({"draw": draw, "seed": None, "mark": "x", "calls": [],
+                                       "wall_s": None, "answer": "", "error": note["error"]})
             entry["draws"].sort(key=lambda d: d["draw"])
             entry["mark"] = distribution([d["mark"] for d in entry["draws"]])
     return order, rows

--- a/tools/local_model_eval.py
+++ b/tools/local_model_eval.py
@@ -28,7 +28,16 @@ a plan is checked in and a credential is not.
 **Cells are subprocesses, and the log is append-only.** A matrix run is hours long; a cell that
 wedges must not take the grid with it (`budget_s` kills it and records why), and a run that
 dies in the middle must leave every finished cell on disk. Re-running the same plan **resumes**:
-a (model, context, surface, task) already in the log is not run again.
+a (model, context, surface, draw, task) already in the log is not run again.
+
+**One draw per cell answers a different question from n draws of one cell.** The grid moves one
+knob at a time across many cells, which is enough for failure *modes* and for whether a surface
+fits at all, and is not enough for any statement of the form "X caused Y" - three write-ups
+reached past that anyway (`FOLLOWUPS.md` item 42). A cell group may therefore ask for `draws: n`,
+which runs the same cell n times asking for seed 1..n, and every reader here keys on the draw so
+repeats **accumulate** rather than replace: the grader counts over draws, and `--matrix` prints a
+distribution (`3Y2n`) where a single draw prints a mark. A record from before draws existed is
+draw 1, so an old log grades exactly as it did.
 """
 import json
 import os
@@ -96,12 +105,28 @@ def usable(record, task=None):
     return served is not None and served == asked
 
 
+def draw_of(record):
+    """Which draw a record is, for a log that spans the change that introduced them.
+
+    **A record with no `draw` is draw 1**, and that is the whole compatibility story: the runs
+    this bench has already recorded grade to exactly what they graded to before, and a re-run of
+    the plan that produced them still counts them as done. Everything that keys on a draw goes through here, so
+    the default lives in one place rather than in four `or 1`s that could drift apart.
+    """
+    return record.get("draw") or 1
+
+
 def already_done(log_path, tasks):
-    """Which (backend, model, context, surface, task) the log already holds, so a re-run resumes.
+    """Which (backend, model, context, surface, draw, task) the log already holds, so a re-run
+    resumes.
 
     Keyed on the things a cell is identified by rather than on a cell id, because the plan can grow
     a surface or a context between runs and everything already measured is still valid - what must
     not happen is a task being run twice into one log and graded twice.
+
+    **The draw is part of that identity**, which is what lets a plan ask for more draws of a cell
+    it has already run: draws 1-3 stay done and 4-5 run. Without it a second draw would be
+    indistinguishable from a repeat of the first and would never be run at all.
 
     `tasks` is the suite as it is *now*, because [`usable`] compares each record against the
     question currently being asked.
@@ -126,7 +151,7 @@ def already_done(log_path, tasks):
             # aliased `sonnet` beside the Claude Code row - and without this the first one's
             # records make the second's whole cell look finished.
             seen.add((r.get("backend"), r.get("model"), r.get("num_ctx"),
-                      (r.get("surface") or {}).get("client"), r.get("task")))
+                      (r.get("surface") or {}).get("client"), draw_of(r), r.get("task")))
     if stale:
         print(f"  {stale} record(s) in the log no longer measure what this plan asks "
               f"(a changed prompt, or a window that was not the one requested); they will run again")
@@ -159,10 +184,11 @@ def release_sessions(env, why):
         print(f"    {why}: could not release ({e})")
 
 
-def run_cell(plan, tokens, backend, model, context, surface, subset, budget_s, log_path,
+def run_cell(plan, tokens, backend, model, context, surface, draw, subset, budget_s, log_path,
              logs_dir):
-    """One (backend, model, context, surface) cell: a driver process over the task list."""
-    label = f"{backend}:{model} ctx={context or 'default'} surface={surface}"
+    """One (backend, model, context, surface, draw) cell: a driver process over the task list."""
+    label = (f"{backend}:{model} ctx={context or 'default'} surface={surface}"
+             + (f" draw={draw}" if draw != 1 else ""))
     env = dict(os.environ)
     env.update({
         "WINDBG_MCP_URL": plan["url"],
@@ -170,6 +196,7 @@ def run_cell(plan, tokens, backend, model, context, surface, subset, budget_s, l
         "WINDBG_MCP_EVAL_OUT": log_path,
         "EVAL_RUN": plan["run"],
         "EVAL_SURFACE": surface,
+        "EVAL_DRAW": str(draw),
         "MAX_STEPS": str(plan.get("max_steps", 6)),
     })
     if subset:
@@ -177,6 +204,13 @@ def run_cell(plan, tokens, backend, model, context, surface, subset, budget_s, l
     if backend == "ollama":
         env["LOCAL_MODEL"] = model
         env["NUM_CTX"] = str(context or 0)
+        # **The seed is the draw index**, which on a runtime that honours it pairs arm A's draw 3
+        # with arm B's draw 3 - the experiment draws are for (item 42) is an A/B, and a paired
+        # comparison beats averaging two independent samplings. It does not reproduce one here:
+        # measured 2026-08-24, four identical requests under one seed gave four different answers
+        # (`local_model_drive.SEED`). So it is recorded as what was asked for, the draws vary
+        # anyway, and the distribution over them is the measurement.
+        env["EVAL_SEED"] = str(draw)
         # Residency for the length of a cell, then eviction: the next cell is either the same
         # model at another surface (keep it) or a different window, which reloads regardless.
         env["OLLAMA_KEEP_ALIVE"] = plan.get("keep_alive", "10m")
@@ -213,7 +247,11 @@ def run_cell(plan, tokens, backend, model, context, surface, subset, budget_s, l
     cwd = tempfile.mkdtemp(prefix="windbg-eval-cwd-") if backend == "claude-code" else None
     stdout_path = os.path.join(
         logs_dir, f"{backend}_{model.replace(':', '-').replace('/', '-')}_"
-                  f"{context or 'default'}_{surface}.log")
+                  f"{context or 'default'}_{surface}"
+                  # Only a repeated cell carries the suffix, so a plan that never asked for draws
+                  # keeps writing the log names it has always written and a resume overwrites the
+                  # same file rather than leaving a `_d1` beside it.
+                  + (f"_d{draw}" if draw != 1 else "") + ".log")
     print(f"\n=== cell {label} -> {os.path.basename(stdout_path)}")
     started = time.time()
     killed = False
@@ -238,7 +276,7 @@ def run_cell(plan, tokens, backend, model, context, surface, subset, budget_s, l
             print(f"    budget of {budget_s}s exceeded; cell killed")
             killed = True
             note = {"run": plan["run"], "backend": backend, "model": model,
-                    "num_ctx": context or None, "surface": {"client": surface},
+                    "num_ctx": context or None, "surface": {"client": surface}, "draw": draw,
                     "task": None, "error": f"cell exceeded its {budget_s}s budget"}
             with open(log_path, "a", encoding="utf-8") as log:
                 log.write(json.dumps(note) + "\n")
@@ -256,7 +294,7 @@ def run_cell(plan, tokens, backend, model, context, surface, subset, budget_s, l
         # without this the summary shows a short row or no row at all - an incomplete grid
         # reading as a finished one. The note gives the cell a row that says what happened.
         note = {"run": plan["run"], "backend": backend, "model": model,
-                "num_ctx": context or None, "surface": {"client": surface},
+                "num_ctx": context or None, "surface": {"client": surface}, "draw": draw,
                 "task": None,
                 "error": f"driver exited {proc.returncode}; see {os.path.basename(stdout_path)}"}
         with open(log_path, "a", encoding="utf-8") as log:
@@ -368,12 +406,18 @@ def grade_record(record, task, surface_names):
 
 
 def records(log_path):
-    """Every record in the log, **deduplicated to the last run of each (cell, task)**.
+    """Every record in the log, **deduplicated to the last run of each (cell, draw, task)**.
 
     Resume works at cell granularity - an outstanding task re-runs its cell's whole list - so a
     log legitimately holds a task twice, and the second run is the one that counts. Counting
     both would inflate a cell's task count and average two runs that were never meant to be
     averaged.
+
+    **The draw is inside the key, and that is the difference between a repeat and a re-run**
+    (`FOLLOWUPS.md` item 42). Two records of one task under one draw index are the same
+    measurement made twice, and the later wins; two records under different indices are two draws
+    of it, and both count. Deduplicating on (cell, task) alone - which is what this did - meant n
+    draws of a cell collapsed to the last one, so repeating a cell measured nothing.
     """
     latest, seen_at = {}, {}
     for at, line in enumerate(open(log_path, encoding="utf-8")):
@@ -383,13 +427,17 @@ def records(log_path):
         record = json.loads(line)
         surface = (record.get("surface") or {})
         cell = (record.get("backend"), record.get("model"), record.get("num_ctx"),
-                surface.get("client"))
+                surface.get("client"), draw_of(record))
         latest[(*cell, record.get("task"))] = record
         seen_at[(*cell, record.get("task"))] = at
     # **A cell-level note is superseded by anything that cell recorded afterwards.** The note says
     # "this cell failed"; it is keyed on `task: null`, so a successful resume - which writes only
     # task records - leaves it in place and the summary goes on printing a finished cell as
     # FAILED for ever.
+    #
+    # *That cell* now means that draw of it, because `cell` above carries the draw index: a draw
+    # that was killed is not un-killed by the next draw of the same cell running to completion
+    # afterwards, which is what a draw-blind comparison here would have decided.
     for key in list(latest):
         if key[-1] is not None:
             continue
@@ -401,7 +449,14 @@ def records(log_path):
 
 
 def summarise(log_path, tasks_file):
-    """Grade the whole log and reduce it to one row per cell."""
+    """Grade the whole log and reduce it to one row per cell, **over every draw of it**.
+
+    A cell's row is keyed without the draw index on purpose: n draws of one cell are n samples of
+    the same measurement, and a row per draw would be the grid again with a new axis rather than
+    the repetition item 42 asks for. So `possible` and `correct` count draw-tasks, `draws` says
+    how many draws they came from, and a rate is the two read together. `--matrix` is where the
+    per-task distribution lives.
+    """
     key = {t["id"]: t for t in load(tasks_file)["tasks"]}
     cells = {}
     for record in records(log_path):
@@ -412,11 +467,16 @@ def summarise(log_path, tasks_file):
             "backend": cell_id[0], "model": cell_id[1], "num_ctx": cell_id[2],
             "surface": cell_id[3], "tools": surface.get("tools"),
             "surface_bytes": surface.get("bytes"), "served_context": record.get("served_context"),
-            "tasks": [], "cell_error": None, "uncounted": 0,
+            "tasks": [], "cell_error": None, "failed_draws": 0, "uncounted": 0,
+            "draw_ids": set(),
         })
+        cell["draw_ids"].add(draw_of(record))
         if record.get("task") is None:
-            # A cell-level note - a killed cell - rather than a task record.
+            # A cell-level note - a killed draw of this cell - rather than a task record. Counted
+            # as well as kept: on a repeated cell "FAILED" alone cannot say whether one draw of
+            # five died or all five did, and those are different findings.
             cell["cell_error"] = record.get("error")
+            cell["failed_draws"] += 1
             continue
         if not usable(record, key.get(record.get("task"))):
             # **Not scored, at all** - counting it would publish a result under a window nobody
@@ -433,6 +493,7 @@ def summarise(log_path, tasks_file):
         cell["tasks"].append(grade_record(record, task, surface.get("names")))
     for cell in cells.values():
         graded = cell["tasks"]
+        cell["draws"] = len(cell.pop("draw_ids"))
         cell["n"] = len(graded)
         cell["possible"] = sum(1 for g in graded if g["possible"])
         cell["correct"] = sum(1 for g in graded if g["correct"])
@@ -458,8 +519,13 @@ def summarise(log_path, tasks_file):
 
 
 def print_table(cells):
+    # **The draws column appears only when a cell was repeated.** Every log written before draws
+    # existed has exactly one per cell - including the three this bench has published - and a
+    # column of `1`s would restate a constant in every table pasted into a write-up.
+    repeated = any(c.get("draws", 1) > 1 for c in cells)
+    draws_head = f"{'draws':>6} " if repeated else ""
     head = (f"{'backend':<12} {'model':<28} {'ctx':>7} {'surface':<6} {'tools':>5} "
-            f"{'ok/possible':>13} {'tokens':>13} {'calls u/w/n/r/e':>16} {'wall':>6}")
+            f"{draws_head}{'ok/possible':>13} {'tokens':>13} {'calls u/w/n/r/e':>16} {'wall':>6}")
     print("\n" + head)
     print("-" * len(head))
     for c in sorted(cells, key=lambda c: (c["backend"], c["model"], -(c["num_ctx"] or 0),
@@ -471,7 +537,10 @@ def print_table(cells):
         # seeing, so they travel beside the score as `+n` rather than inside it.
         extra = c["correct"] - c["correct_of_possible"]
         score = f"{c['correct_of_possible']}/{c['possible']}" + (f"+{extra}" if extra else "")
-        failed = " FAILED" if c.get("cell_error") else ""
+        # `x n` when more than one draw of the cell died, because on a repeated cell a bare
+        # FAILED cannot tell one bad draw from a cell that never completes.
+        failed = (" FAILED" + (f" x{c['failed_draws']}" if c.get("failed_draws", 0) > 1 else "")
+                  if c.get("cell_error") else "")
         if c.get("uncounted"):
             # One counter for one predicate: a record can stop counting because the window it ran
             # at was not the one it asked for, or because the question has changed since. Naming
@@ -480,10 +549,36 @@ def print_table(cells):
         print(f"{c['backend']:<12} {(c['model'] or '')[:28]:<28} "
               f"{str(c['num_ctx'] or 'dflt'):>7} {str(c['surface'] or '')[:6]:<6} "
               f"{str(c['tools'] or '-'):>5} "
-              f"{score} of {c['n']:<5} {tokens:>13} "
+              + (f"{c['draws']:>6} " if repeated else "")
+              + f"{score} of {c['n']:<5} {tokens:>13} "
               f"{c['useful']}/{c['wasted']}/{c['unserved']}/{c['refused']}/"
               f"{c['call_errors']:<8} "
               f"{c['wall_s']:>5}s{failed}")
+
+
+# The marks a cell-task can carry, in the order a distribution prints them. Fixed rather than
+# sorted by count, so `3Y2n` and `2n3Y` cannot be two spellings of one result.
+MARK_ORDER = "Yno-!?"
+
+
+def distribution(marks):
+    """One draw's mark, or a count per mark across n of them.
+
+    **A single draw prints the bare mark**, which is what every log written before draws existed
+    holds and what the legend has always described - `Y1` everywhere would be a new notation for
+    an unchanged result. More than one prints `3Y2n`, which is the thing item 42 says the grid
+    could not produce: a rate rather than a sighting, in a column narrow enough to scan.
+    """
+    if len(marks) == 1:
+        return marks[0]
+    counts = {}
+    for mark in marks:
+        counts[mark] = counts.get(mark, 0) + 1
+    # Anything not in the alphabet still prints, after it: a mark this function has not been
+    # taught is a bug worth seeing rather than a draw worth dropping silently.
+    order = ([m for m in MARK_ORDER if m in counts]
+             + sorted(m for m in counts if m not in MARK_ORDER))
+    return "".join(f"{counts[m]}{m}" for m in order)
 
 
 def matrix(log_path, tasks_file):
@@ -494,6 +589,11 @@ def matrix(log_path, tasks_file):
     misses - at which point the finding is about the task, or about the tool it needs, rather
     than about any of the models. It is also what the control is *for*: a task the frontier row
     misses too is a bad question, not a weak local model.
+
+    **And with `draws: n`, it answers "how often".** Every draw of a (cell, task) lands in one
+    entry - its mark, its calls and its answer kept per draw, because the interesting thing about
+    a `3Y2n` is usually what the two did differently - and the printed mark becomes the
+    distribution over them.
     """
     key = {t["id"]: t for t in load(tasks_file)["tasks"]}
     order = [t["id"] for t in load(tasks_file)["tasks"]]
@@ -519,16 +619,25 @@ def matrix(log_path, tasks_file):
             mark = "o" if graded["correct"] else "-"
         else:
             mark = "Y" if graded["correct"] else "n"
-        row[record["task"]] = {"mark": mark, "calls": [c.get("name") for c in
-                                                       (record.get("calls") or [])],
+        entry = row.setdefault(record["task"], {"mark": None, "draws": []})
+        entry["draws"].append({"draw": draw_of(record), "seed": record.get("seed"), "mark": mark,
+                               "calls": [c.get("name") for c in (record.get("calls") or [])],
                                "wall_s": record.get("wall_s"),
                                "answer": (record.get("answer") or "")[:2000],
-                               "error": record.get("error")}
+                               "error": record.get("error")})
+    for row in rows.values():
+        for entry in row.values():
+            entry["draws"].sort(key=lambda d: d["draw"])
+            entry["mark"] = distribution([d["mark"] for d in entry["draws"]])
     return order, rows
 
 
 def print_matrix(order, rows):
-    width = max(len(t) for t in order) + 2
+    # Wide enough for a distribution as well as a task name: `3Y2n` is four characters and a
+    # ten-draw cell is longer still, and a column that clips one would misreport the result
+    # rather than merely look untidy.
+    marks = [m.get("mark") or "" for row in rows.values() for m in row.values()]
+    width = max([len(t) for t in order] + [len(m) for m in marks] or [0]) + 2
     header = f"{'cell':<44}" + "".join(f"{t:<{width}}" for t in order)
     print("\n" + header)
     print("-" * len(header))
@@ -541,6 +650,9 @@ def print_matrix(order, rows):
     print("\nY correct   n wrong   - not answerable on this surface   "
           "o answered anyway   ! the runtime refused the request   "
           "? served a different window than asked for")
+    if any(len(m.get("draws") or []) > 1 for row in rows.values() for m in row.values()):
+        print("A repeated cell prints its distribution: `3Y2n` is five draws, three of them "
+              "correct.")
 
 
 def main():
@@ -587,20 +699,28 @@ def main():
 
     for group in plan["cells"]:
         backend = group["backend"]
+        # **`draws` repeats a cell; it does not add an axis.** A group asking for 5 runs the same
+        # (model, context, surface) five times, and the grader counts over them - which is the one
+        # thing the grid could not do (`FOLLOWUPS.md` item 42). Default 1, so a plan that does not
+        # mention it is the grid as it was.
+        draws = int(group.get("draws", 1))
         for model in group["models"]:
             for context in group.get("contexts", [None]):
                 for surface in group["surfaces"]:
                     subset = group.get("subset")
                     wanted = cell_tasks(plan["tasks"], subset)
-                    outstanding = [t for t in wanted
-                                   if (backend, model, context, surface, t["id"]) not in done]
-                    if not outstanding:
-                        print(f"  skipping {backend}:{model} ctx={context} {surface}: "
-                              f"all {len(wanted)} tasks already recorded")
-                        continue
-                    run_cell(plan, tokens, backend, model, context, surface, subset,
-                             group.get("budget_s", 1800), log_path, logs_dir)
-                    done = already_done(log_path, suite)
+                    for draw in range(1, draws + 1):
+                        outstanding = [t for t in wanted
+                                       if (backend, model, context, surface, draw, t["id"])
+                                       not in done]
+                        if not outstanding:
+                            print(f"  skipping {backend}:{model} ctx={context} {surface}"
+                                  + (f" draw {draw}" if draws > 1 else "")
+                                  + f": all {len(wanted)} tasks already recorded")
+                            continue
+                        run_cell(plan, tokens, backend, model, context, surface, draw, subset,
+                                 group.get("budget_s", 1800), log_path, logs_dir)
+                        done = already_done(log_path, suite)
                 if backend == "ollama":
                     # **Evicted between contexts, not only between models** - and this is the
                     # one that had to be learned. `num_ctx` on a request does not shrink an

--- a/tools/local_model_eval.py
+++ b/tools/local_model_eval.py
@@ -184,9 +184,15 @@ def release_sessions(env, why):
         print(f"    {why}: could not release ({e})")
 
 
-def run_cell(plan, tokens, backend, model, context, surface, draw, subset, budget_s, log_path,
-             logs_dir):
-    """One (backend, model, context, surface, draw) cell: a driver process over the task list."""
+def run_cell(plan, tokens, backend, model, context, surface, draw, subset, planned, budget_s,
+             log_path, logs_dir):
+    """One (backend, model, context, surface, draw) cell: a driver process over the task list.
+
+    `planned` is the ids this draw was asked to run, and it exists to travel into the cell-level
+    note: a draw that dies leaves nothing else behind, and without the list a task **no** draw ever
+    reached is indistinguishable in the log from one the cell was never asked (a group's `subset`).
+    The grader cannot recover that, so the runner records it.
+    """
     label = (f"{backend}:{model} ctx={context or 'default'} surface={surface}"
              + (f" draw={draw}" if draw != 1 else ""))
     env = dict(os.environ)
@@ -277,7 +283,8 @@ def run_cell(plan, tokens, backend, model, context, surface, draw, subset, budge
             killed = True
             note = {"run": plan["run"], "backend": backend, "model": model,
                     "num_ctx": context or None, "surface": {"client": surface}, "draw": draw,
-                    "task": None, "error": f"cell exceeded its {budget_s}s budget"}
+                    "task": None, "planned": planned,
+                    "error": f"cell exceeded its {budget_s}s budget"}
             with open(log_path, "a", encoding="utf-8") as log:
                 log.write(json.dumps(note) + "\n")
     if cwd:
@@ -295,7 +302,7 @@ def run_cell(plan, tokens, backend, model, context, surface, draw, subset, budge
         # reading as a finished one. The note gives the cell a row that says what happened.
         note = {"run": plan["run"], "backend": backend, "model": model,
                 "num_ctx": context or None, "surface": {"client": surface}, "draw": draw,
-                "task": None,
+                "task": None, "planned": planned,
                 "error": f"driver exited {proc.returncode}; see {os.path.basename(stdout_path)}"}
         with open(log_path, "a", encoding="utf-8") as log:
             log.write(json.dumps(note) + "\n")
@@ -626,6 +633,15 @@ def matrix(log_path, tasks_file):
         attempted.setdefault(cell_id, set()).add(draw_of(record))
         if record.get("task") is None:
             died[(cell_id, draw_of(record))] = record.get("error")
+            # **A task that *no* draw reached still belongs in the row**, and the note is the only
+            # place its name survives. Seeded from the note's own `planned` list rather than from
+            # the suite: a cell group may run a `subset`, and from the log alone "the subset left
+            # this task out" and "every draw died before reaching it" look identical - so filling
+            # from `order` would invent a denominator instead of restoring one. A note written
+            # before this field existed carries nothing, and those cells read as they did.
+            for planned in record.get("planned") or []:
+                if key.get(planned) is not None:
+                    rows.setdefault(cell_id, {}).setdefault(planned, {"mark": None, "draws": []})
             continue
         row = rows.setdefault(cell_id, {})
         task = key.get(record["task"])
@@ -752,7 +768,8 @@ def main():
                                   + f": all {len(wanted)} tasks already recorded")
                             continue
                         run_cell(plan, tokens, backend, model, context, surface, draw, subset,
-                                 group.get("budget_s", 1800), log_path, logs_dir)
+                                 [t["id"] for t in wanted], group.get("budget_s", 1800),
+                                 log_path, logs_dir)
                         done = already_done(log_path, suite)
                 if backend == "ollama":
                     # **Evicted between contexts, not only between models** - and this is the


### PR DESCRIPTION
Closes `FOLLOWUPS.md` item 42.

The grid runs **one draw per (model, context, surface, task)**, which is enough for failure *modes* and for whether a surface fits at all, and is not enough for any sentence of the form "X caused Y". Three write-ups reached past that anyway — #209 once, #212 twice — and the trap each time was composition: an aggregate holding across two runs whose *callers* had changed, read as a stable rate.

## What this adds

A cell group takes `draws: n` — a loop around the cell, not a fourth axis — and the draw index becomes part of a record's identity, so repeats **accumulate** instead of the last one winning:

- `already_done` resumes per draw: 3 recorded and 5 asked for runs draws 4 and 5.
- `records` dedups on (cell, draw, task). On (cell, task) alone — which is what it did — *n* draws collapsed to the last one, so repeating a cell measured nothing.
- A killed draw's note is superseded only by *that* draw's later records, or draw 4 dying would be un-recorded by draw 5 finishing afterwards.
- `--matrix` prints a distribution: `3Y2n` is five draws, three correct. A single draw still prints the bare mark, and `--grade` grows a `draws` column only when some cell was repeated — so nothing already published is restated in a new notation.

**A record with no `draw` is draw 1** (`draw_of`), which is the whole compatibility story.

## The seed does not replay a draw here, which the item assumed it would

Each draw asks the runtime for `seed: <draw index>` and records it — sending it costs nothing, and a runtime that reproduces under it would pair arm A's draw 3 with arm B's rather than averaging against them. This one does not: **four identical requests to `qwen3.8:27b-mlx` under `seed: 7` returned four different answers** (ollama 0.32.15, MLX). It was measured only because the comment claiming otherwise had already been written; unmeasured it would have shipped as a replay guarantee in the comments and in all three documents this touches. The column now says what was *asked for*, the draws vary regardless — which is what a rate needs — and the distribution over them is the measurement.

## Verified

- `--grade` and `--matrix` are **byte-identical** either side of this change on both eval logs this bench still has.
- A synthetic 5-draw log grades to `3Y2n` / 13 of 20, with per-draw notes giving `FAILED x2` and supersession working per draw.
- The runner loop end-to-end against a stub driver: 3 draws run, per-draw log files (draw 1 keeps its old name), a resume skips all three, raising `draws` to 5 runs only 4 and 5, and a driver that dies on draw 4 records the note against draw 4.
- `markdownlint-cli2@0.23.2` over CI's globs: clean. No Rust changed.

## Not in this PR, deliberately

The A/B it was built for. Whether `open_dump`'s description ever contributed to a `modules` call needs two server builds and two logs, and that sentence is gone either way — the fix never depended on which of the two channels carried it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017KHzgze3DM5NUNzfkeHVmZ