### PR TITLE
Check the third channel a client reads, and find the check was empty

### DIFF
--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -1978,14 +1978,49 @@ interesting number by accident. The split is worth making the next time the eval
 prose change, and doing it now would re-grade three runs of records to prove a partition that no
 present data disagrees with.
 
-**A third channel was checked and is clean** (2026-08-24, prompted by the reasonable question of
-how a model on an eleven-tool surface produces the *exact* name `modules` with its real `filter`
-argument). Items 40 and 41 closed the `instructions` string and the tool descriptions; nobody had
-looked at what a **result** says. Every tool result shown to a model on a narrowed surface, across
-both logs this bench still holds, was scanned for the name of any tool that client is not served —
-against a 59-name superset of the surface taken from `tests/golden/tool_budget.json`, so the net is
-wider than the 51 tools rather than narrower. **None.** So `taught` is zero on all three channels a
-client reads, not only the two that were fixed.
+**A third channel was checked, and the checking is worth more than the result** (2026-08-24,
+prompted by the reasonable question of how a model on an eleven-tool surface produces the *exact*
+name `modules` with its real `filter` argument). Items 40 and 41 closed the `instructions` string
+and the tool descriptions; nobody had looked at what a **result** says, which is the third thing a
+model reads and the only one that arrives on every call.
+
+**The first scan reported "none" without having compared anything.** It read each call's `text`,
+and a call record carries `excerpt` — so the loop body never ran, and "none" meant "nothing was
+looked at". The number quoted beside it was audited and the scan behind it was not: a "59-name
+superset" is 51 tool names plus the eight JSON field names (`annotations`, `description`,
+`instructions`, `name`, `payload`, `tools`, `totals`, `wire`) that a recursive walk of
+`tests/golden/tool_budget.json` picks up, which Codex asked about on
+[#216](https://github.com/glslang/windbg-mcp/pull/216) and which is how the empty loop surfaced.
+The rule underneath is the one this repo already writes down twice — *a grep is not an
+enumeration*, and a monitor's *silence is not success*: *a scan that can only print on a hit proves
+nothing until it has been shown printing on a known one.*
+
+**Redone against `excerpt`, sixteen results do name a tool their client is not served — and every
+one is the model's own request coming back.** Nine are the ollama driver's own refusal — the one
+that names the tool it is refusing, "`debug_batch` is not permitted in this harness" — four are
+Claude Code's "No such tool available: `mcp__windbg__…`", and three are **this server's** `-32602`. Nothing is *introduced*: no result names
+a tool the model had not just asked for, so `taught` is zero on this channel too — but by a
+narrower warrant than "clean". The log keeps a **262-character prefix** of each result (96 of the
+114 are truncated; the mean full result is 1,826 characters), so this scans what a result *opens*
+with. And names have to be matched the way
+`no_description_names_a_tool_the_client_cannot_call` matches them — bare if the name has an
+underscore, in call context otherwise — because plain containment scores `execute` eight times
+inside `ATTEMPTED_EXECUTE_OF_NOEXECUTE_MEMORY` and "the attempted execute", and because a
+lookbehind of `[A-Za-z0-9_]` silently drops `mcp__windbg__debug_batch`.
+
+**The one of those three that is ours is not neutral, and the split has no box for it.**
+`Toolset::refusal` (`src/toolset.rs`) answers a narrowed client with "`modules` is a tool this
+server has, but it is not on the surface it serves `min` (11 of 51 tools (session, crash))", and
+then how to widen it. That is deliberate, and the doc comment says why: the reader it is written
+for is an operator who can see neither this server's command line nor its client list. On the
+bench the reader is the model, and what it gets is a **guessed name confirmed as real**, beside the
+surface's group names and the size of the full one. It teaches no name — the model supplied it — so
+it is not `taught`; it is not nothing either. A third count, *a refusal that says yes*, is what
+this channel would contribute to the split. In these logs it changed no behaviour — nobody retried
+a name after being told it was real: gemma went from `modules` to `run_command` three times and
+opus to `list_modules`, while the retries that did happen (`debug_batch` five times, then four)
+follow the *driver's* refusal, which confirms nothing. That is one draw per cell, though, and a
+retry is precisely what the confirmation would buy.
 
 **What the survivors' *shape* says, and where it stops.** The names asked for are a mixture of real
 and invented — `modules` (3) beside `list_modules` (1) before item 41, and `modules` (3) beside

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -2018,8 +2018,23 @@ quotes the tool the caller just asked for, and ours adds only group names — a 
 tool name is refused outright (`src/toolset.rs`) — and, for a partly-held group,
 tools the client *is* served. So the transcript covers the bodies, which is where an introduction
 could hide; the eval log covers the refusals, which are echoes by construction; a scan wanting the
-model's whole view reads both. What no route reaches is *these* two runs: nothing kept the bytes
-the driver discarded, so this one cannot be answered backwards.
+model's whole view reads both.
+
+**And a transcript scan can only over-count, which is why a null from it still means something**
+(fourth round, same reviewer). The transcript holds *both* halves of a result, and a client that
+understands structured results forwards `structuredContent` and drops the rendering — a forwarding
+policy, not protocol, which `tool_results_stay_within_their_budget` exists to keep both sides of and
+which applies to the 31 tools that have an output schema. So a name living only in the half the
+client discarded was never read by the model, and a transcript hit is a *candidate* rather than a
+sighting. It bites the two Claude Code rows and not the three ollama ones, whose driver appends the
+result's text verbatim as the tool message. The consequence is one-directional and worth stating in
+the entry that plans the scan: a **null** result from the transcript is sound, since neither half
+named anything; a **positive** has to be checked against which half that client forwarded, and
+capturing the whole `tool_result` in `claude_code_drive.py` is what would settle it without
+reproducing a policy that can change under us.
+
+What no route reaches is *these* two runs: nothing kept the bytes the driver discarded, so this one
+cannot be answered backwards.
 
 Names have to be matched the way
 `no_description_names_a_tool_the_client_cannot_call` matches them — bare if the name has an

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -2004,12 +2004,22 @@ Claude Code's "No such tool available: `mcp__windbg__…`", and three are **this
 **That is zero within the prefixes the log keeps, and it cannot be stated wider than that**
 (Codex's second round on #216, and correct). `local_model_drive.py` records `text[:300]`, so 96 of
 the 114 results are truncated and 29,946 characters of a 208,266-character corpus were compared: a
-name mentioned late in a long module listing is invisible to this scan by construction. The
-whole-result version needs **no new code and no re-grade** — `Recorder::tool_result` writes each
-result's text into the server transcript, scrubbed then capped, and
-`WINDBG_MCP_TRANSCRIPT_MAX_FIELD=0` lifts the cap — so setting `WINDBG_MCP_TRANSCRIPT` on the bench
-listener answers it outright on the next run. It cannot be answered backwards: nothing kept the
-bytes these two runs discarded.
+name mentioned late in a long module listing is invisible to this scan by construction.
+
+**The whole-result version needs no new code, and it is not the same corpus** — the third round of
+the same review, also correct. `Recorder::tool_result` writes each result's text into the server
+transcript, scrubbed then capped, and `WINDBG_MCP_TRANSCRIPT_MAX_FIELD=0` lifts the cap, so
+`WINDBG_MCP_TRANSCRIPT` on the bench listener records every *served* call's result whole. It
+records none of the sixteen: an off-surface call is refused at the top of `WindbgServer::dispatch`
+(`src/server.rs`) and returns before `rec.tool_request` runs, and the other two refusals are the
+ollama driver's and Claude Code's, which never reach this server at all. That is not a gap in the
+answer, because those three classes are exactly the ones that **cannot** introduce a name: each
+quotes the tool the caller just asked for, and ours adds only group names — a group that is also a
+tool name is refused outright (`src/toolset.rs`) — and, for a partly-held group,
+tools the client *is* served. So the transcript covers the bodies, which is where an introduction
+could hide; the eval log covers the refusals, which are echoes by construction; a scan wanting the
+model's whole view reads both. What no route reaches is *these* two runs: nothing kept the bytes
+the driver discarded, so this one cannot be answered backwards.
 
 Names have to be matched the way
 `no_description_names_a_tool_the_client_cannot_call` matches them — bare if the name has an

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -1977,3 +1977,25 @@ the column into `taught` and `wanted`, and let a regression test assert only the
 interesting number by accident. The split is worth making the next time the eval runs against a
 prose change, and doing it now would re-grade three runs of records to prove a partition that no
 present data disagrees with.
+
+**A third channel was checked and is clean** (2026-08-24, prompted by the reasonable question of
+how a model on an eleven-tool surface produces the *exact* name `modules` with its real `filter`
+argument). Items 40 and 41 closed the `instructions` string and the tool descriptions; nobody had
+looked at what a **result** says. Every tool result shown to a model on a narrowed surface, across
+both logs this bench still holds, was scanned for the name of any tool that client is not served —
+against a 59-name superset of the surface taken from `tests/golden/tool_budget.json`, so the net is
+wider than the 51 tools rather than narrower. **None.** So `taught` is zero on all three channels a
+client reads, not only the two that were fixed.
+
+**What the survivors' *shape* says, and where it stops.** The names asked for are a mixture of real
+and invented — `modules` (3) beside `list_modules` (1) before item 41, and `modules` (3) beside
+`run_command` (3) after it, the latter carrying `{"command": "lm m nvhda64v"}`, which is the right
+idea under a name this server does not have. A model copying an advertisement produces exact names
+only; a mixture is what guessing looks like, which is evidence for the `wanted` reading of the
+remainder. Two things keep it from being proof. The *concept* is still on the narrow surface even
+though the name is not — `open_dump` ends "…module count and the bug check a crash dump stopped on
+— not its module table", and the task prompt says "how many **modules** are loaded" — so a model is
+told a module table exists and has to name a tool for it. And this is a public repository, so
+prior exposure cannot be excluded at one draw per cell. Separating memorised-from-GitHub from
+guessed-by-convention is item 42's machinery (the same cell repeated with that sentence varied),
+not this item's.

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -1998,11 +1998,20 @@ nothing until it has been shown printing on a known one.*
 **Redone against `excerpt`, sixteen results do name a tool their client is not served — and every
 one is the model's own request coming back.** Nine are the ollama driver's own refusal — the one
 that names the tool it is refusing, "`debug_batch` is not permitted in this harness" — four are
-Claude Code's "No such tool available: `mcp__windbg__…`", and three are **this server's** `-32602`. Nothing is *introduced*: no result names
-a tool the model had not just asked for, so `taught` is zero on this channel too — but by a
-narrower warrant than "clean". The log keeps a **262-character prefix** of each result (96 of the
-114 are truncated; the mean full result is 1,826 characters), so this scans what a result *opens*
-with. And names have to be matched the way
+Claude Code's "No such tool available: `mcp__windbg__…`", and three are **this server's**
+`-32602`. Nothing is *introduced*: no result names a tool the model had not just asked for.
+
+**That is zero within the prefixes the log keeps, and it cannot be stated wider than that**
+(Codex's second round on #216, and correct). `local_model_drive.py` records `text[:300]`, so 96 of
+the 114 results are truncated and 29,946 characters of a 208,266-character corpus were compared: a
+name mentioned late in a long module listing is invisible to this scan by construction. The
+whole-result version needs **no new code and no re-grade** — `Recorder::tool_result` writes each
+result's text into the server transcript, scrubbed then capped, and
+`WINDBG_MCP_TRANSCRIPT_MAX_FIELD=0` lifts the cap — so setting `WINDBG_MCP_TRANSCRIPT` on the bench
+listener answers it outright on the next run. It cannot be answered backwards: nothing kept the
+bytes these two runs discarded.
+
+Names have to be matched the way
 `no_description_names_a_tool_the_client_cannot_call` matches them — bare if the name has an
 underscore, in call context otherwise — because plain containment scores `execute` eight times
 inside `ATTEMPTED_EXECUTE_OF_NOEXECUTE_MEMORY` and "the attempted execute", and because a


### PR DESCRIPTION
Items 40 and 41 stopped this server advertising tools a narrowed client cannot call — the `instructions` string, then the tool descriptions. Neither looked at what a **result** says, which is the third thing a model reads and the only one that arrives on every call.

The prompt for looking was the obvious question about the leftovers: how does a model on an eleven-tool surface produce the *exact* name `modules`, with its real `filter` argument, if nothing served to it says that name?

## The first version of this PR checked nothing

It scanned each call's `text` for tool names. A call record carries **`excerpt`**, so the loop body never ran and its "none" meant "nothing was compared". The only auditable thing about it was the number beside it — a "59-name superset" of `tests/golden/tool_budget.json`, which Codex correctly noted holds 51 names. The other eight are JSON field names (`annotations`, `description`, `instructions`, `name`, `payload`, `tools`, `totals`, `wire`) that a recursive walk picks up. Chasing the eight is what surfaced the empty loop.

The rule this repo already writes down twice — *a grep is not an enumeration*, and a monitor's *silence is not success* — has a third form: **a scan that can only print on a hit proves nothing until it has been shown printing on a known one.**

## Redone, against the field that exists

**Sixteen results do name a tool their client is not served, and every one is the model's own request coming back**: nine from the ollama driver's own refusal, four from Claude Code's `No such tool available: mcp__windbg__…`, three from **this server's** `-32602`. **Nothing is introduced** — no result names a tool the model had not just asked for.

That is bounded, and the entry bounds it where the claim is made (Codex's second round, also correct): `local_model_drive.py` keeps `text[:300]`, so 96 of 114 results are truncated and **29,946 characters of a 208,266-character corpus** were compared. A name mentioned late in a long module listing is invisible to this scan by construction.

The whole-result version needs **no new code**, and it is a *different corpus* rather than a wider one (Codex's third round, also correct). `Recorder::tool_result` writes each result's text into the server transcript, scrubbed then capped, and `WINDBG_MCP_TRANSCRIPT_MAX_FIELD=0` lifts the cap — so `WINDBG_MCP_TRANSCRIPT` on the bench listener records every *served* call's result whole. It records **none of the sixteen**: an off-surface call is refused at the top of `WindbgServer::dispatch` and returns before `rec.tool_request` runs, and the other two refusals are the ollama driver's and Claude Code's, which never reach this server. That is not a gap in the answer — those three classes are exactly the ones that **cannot** introduce a name, since each quotes the tool just asked for, and ours adds only group names (a group that is also a tool name is refused outright) plus, for a partly-held group, tools the client *is* served. So: transcript for bodies, where an introduction could hide; eval log for refusals, which are echoes by construction. What no route reaches is *these* two runs — nothing kept the bytes the driver discarded.

## Two things the redo turned up

- **The matcher rule from `no_description_names_a_tool_the_client_cannot_call` applies here too.** Plain containment scores `execute` eight times inside `ATTEMPTED_EXECUTE_OF_NOEXECUTE_MEMORY` and "the attempted execute"; and a lookbehind of `[A-Za-z0-9_]` silently drops `mcp__windbg__debug_batch`.
- **`Toolset::refusal` is the one of the three sources that is ours, and it is not neutral.** It answers with "`modules` is a tool this server has, but it is not on the surface it serves `min` (11 of 51 tools (session, crash))" plus how to widen it. That is deliberate and the doc comment says why — the intended reader is an operator who can see neither the command line nor the client list. On the bench the reader is a model, and a **guessed name confirmed as real** is a category the `taught`/`wanted` split has no box for. It bought no retry in these logs (gemma moved on to `run_command`, opus to `list_modules`), at one draw per cell.

## What the survivors' shape says, and where it stops

Unchanged from the first version, since it bears on the split: the names asked for are a **mixture of real and invented**, which is what guessing looks like rather than copying. Two limits stated in the entry — the *concept* is still on the narrow surface (`open_dump` ends "not its module table"; the prompt asks "how many **modules** are loaded"), and this repository is public, so prior exposure cannot be excluded at one draw per cell.

## Scope

`FOLLOWUPS.md` only, item 43. No code, no behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017KHzgze3DM5NUNzfkeHVmZ
