### PR TITLE
Stop a result naming tools the client cannot call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **And no *result* names one either, which was the channel nobody had scanned** (`FOLLOWUPS.md`
+  item 43). Items 40 and 41 below closed the `instructions` string and the descriptions; an
+  opener's summary went on ending with "`modules` lists a page of the table and `modules
+  { \"filter\": \"<name>\" }` answers for one", because `summary_text` runs in the **worker**,
+  which owns one session and has never heard of a client, let alone its surface. `modules` is
+  `inspect`, so on an eleven-tool `crash` surface the first result a client ever saw handed it the
+  exact name together with its real argument — which is where the local-model bench's "invented"
+  `modules` calls were coming from. `crash_triage` rode along the same way, and a post-commit
+  failure sent any caller to `execute`. The summary now crosses the pipe as facts and the pointers
+  are appended where the surface is (`SUMMARY_NOTES`, `annotated_report`), on both halves of the
+  result, since a structured-aware client forwards `structuredContent` and drops the text. Two
+  more sentences went the same way: a post-commit failure keeps its advice on every surface and
+  drops only the `execute` example, and `crash_triage`'s user-mode refusal — which named
+  `backtrace` and `execute` to the one caller that has neither, `crash_triage` being `crash` while
+  both of those are `inspect`.
+
 - **A client is told about the tools it is served, and no others** (`FOLLOWUPS.md` item 40, which
   closes it). `--tools` narrowed the router per client — `tools/list` answers with that client's
   set, and anything else is refused by name — while the `instructions` string sent at `initialize`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -615,6 +615,23 @@ TTD description quotes `dx @$cursession.TTD.Calls(...)`, which is the debugger c
 `dx` tool; the rule is a code span that *is* the name or opens a call with it, plus bare-if-it-has-
 an-underscore, which is what caught `step_back`'s "Reverse of step_into.".
 
+**And the same rule again for a *result*, which is the channel that took longest to find** (item
+43). `SUMMARY_NOTES` beside `TOOL_NOTES`, appended by `annotated_report` rather than `annotate`.
+The reason it is a second table and not a wider first one is where the text is built: an opener's
+summary is assembled by `summary_text` in the **worker**, which owns one session and has never
+heard of a client — so a sentence naming `modules`, with its `filter` argument spelled out, shipped
+to an eleven-tool caller for as long as that sentence existed. The summary crosses the pipe as
+facts; the pointers are added where `self.surface` is. Three things to know before touching it.
+**Annotate above both halves of the result**, because a structured-aware client forwards
+`structuredContent` and drops the text — a pointer added to one half is one half the clients never
+see, and a pointer *removed* from one half is the leak still open on the other. **A note carries a
+predicate**, since a pointer to the bug check on a target that did not bug-check is noise on every
+surface. And **the leak was invisible to the eval that was measuring it**: `local_model_drive.py`
+records `text[:300]` and the sentence sat at the end of a 2,508-character summary, so two rounds of
+"which names is this server teaching" never saw the largest one. What found it was a scan of `src/`
+string literals against the tool table — seconds, no bench and no VM, because what a server prints
+is a static question and was never an eval's to answer.
+
 ## Several clients on one listener (`src/client.rs`)
 
 A `--listen` server holds **one bearer token per client**: `WINDBG_MCP_LISTEN_TOKEN_<NAME>` names

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -1999,7 +1999,44 @@ nothing until it has been shown printing on a known one.*
 one is the model's own request coming back.** Nine are the ollama driver's own refusal — the one
 that names the tool it is refusing, "`debug_batch` is not permitted in this harness" — four are
 Claude Code's "No such tool available: `mcp__windbg__…`", and three are **this server's**
-`-32602`. Nothing is *introduced*: no result names a tool the model had not just asked for.
+`-32602`. Nothing is *introduced* **in the part of a result the log kept** — and the qualifier is
+the whole finding, because outside it something was.
+
+**It was wrong, and the truncation bound is what was hiding it** (2026-08-25, one day later). An
+opener's summary ended with "`modules` lists a page of the table and `modules {"filter":
+"<name>"}` answers for one", built by `summary_text` in the **worker** — which owns one session and
+has never heard of a client, let alone its surface. `modules` is `inspect`, so on the bench's own
+eleven-tool `crash` surface the *first result a client ever saw* handed it the exact name together
+with its real argument. `crash_triage` rode along the same way, and `post_commit_failure` sent any
+caller to `execute`. So `taught` was **not** zero on this channel; it was the largest of the three,
+and it is the one that arrives on every call rather than once a conversation.
+
+Three things about how it stayed hidden, each of which is the real lesson:
+
+- **The scan could not have found it.** The excerpt is 300 characters of a 2,508-character summary,
+  and the sentence is at the end. Codex's round-2 bound was not a hedge about a hypothetical; it was
+  a description of where this was sitting.
+- **What found it took no run at all.** The question is what this server *prints*, not what a model
+  does with it, so it is answerable by reading `src/` — a scan of string literals against the tool
+  table, seconds on a laptop, no bench and no VM. Two channels' worth of eval work had been spent
+  on a question that was static all along.
+- **The eval's `modules` calls have a documented cause now**, so the "a mixture is what guessing
+  looks like" reading above is undercut for `modules` specifically: the name and its `filter`
+  argument were both in front of the model. The invented ones (`list_modules`, `run_command`) still
+  read as guesses, but that is a claim about the survivors, not about the three.
+
+Fixed by `SUMMARY_NOTES` and `WindbgServer::annotated_report` — [`ToolNote`]'s rule one channel
+over, with `no_opener_report_names_a_tool_the_client_cannot_call` as its invariant. The same scan
+found two more: a post-commit failure's `execute` example, and `crash_triage`'s user-mode refusal,
+which pointed at `backtrace` and `execute` — both `inspect`, while `crash_triage` is `crash`, so
+the caller most likely to reach it could act on neither half. A third was left alone as
+unreachable: the "a `debug_batch` is running its rollback" message needs a client served
+`debug_batch` to have started one.
+
+**What is still open here** is the count, not the leak. `unserved` is still one number, and the
+three runs on disk cannot be re-graded into `taught` and `wanted` — but the partition now has a
+known instance on the `taught` side rather than none, which is the evidence the entry above says
+it was missing. The next run against a prose change is where it gets made.
 
 **That is zero within the prefixes the log keeps, and it cannot be stated wider than that**
 (Codex's second round on #216, and correct). `local_model_drive.py` records `text[:300]`, so 96 of

--- a/docs/crash-dump-walkthrough.md
+++ b/docs/crash-dump-walkthrough.md
@@ -30,8 +30,14 @@ Kernel base = 0xfffff803`89200000 PsLoadedModuleList = 0xfffff803`8a0f52d0
 Debug session time: Thu May 21 12:44:54.667 2026 (UTC + 1:00)
 
 Bug check 0x9f DRIVER_POWER_STATE_FAILURE, parameters 0x0000000000000003 …
-227 module(s) loaded, `nt` at 0xfffff80389200000; `modules` lists a page of the table and `modules { "filter": "<name>" }` answers for one.
+227 module(s) loaded, `nt` at 0xfffff80389200000.
+  `crash_triage` reads the bug check as fields, with the crashing stack and the module each frame belongs to.
+  `modules` lists a page of that table and `modules { "filter": "<name>" }` answers for one.
 ```
+
+Those last two lines are **the surface's, not the target's**: each is appended only where the
+client is served the tool it names, so a caller restricted to `crash` reads the `crash_triage`
+line and not the `modules` one. The summary above them is the same on every surface.
 
 The same fields come back as `structuredContent.summary`. The **table** is `modules`, and it is
 worth a call here because it tells a story — but read it deliberately: 227 rows is the largest

--- a/src/server.rs
+++ b/src/server.rs
@@ -2237,13 +2237,21 @@ pub(crate) fn reject_command_breakers(
 /// that split bought — this text must be unreachable for a failure that created nothing,
 /// because telling a caller "your session exists" when it does not strands them exactly as
 /// badly as the advice it replaced.
-fn post_commit_failure(err: &str, session_id: &str) -> String {
+fn post_commit_failure(err: &str, session_id: &str, can_execute: bool) -> String {
     format!(
         "{err}\n\nsession_id: {session_id}\nThis failure came *after* the target was opened, \
          so the handle above names a session that exists — what failed is the wait for it to \
          become ready. Do not open again to recover: for launch or attach, doing so would \
-         start a second process or attach a second time. Inspect it (`execute \
-         {{ \"command\": \"vertarget\" }}`) or `end_session` first."
+         start a second process or attach a second time. Inspect it{} or `end_session` first.",
+        // The advice is sound on every surface; the example is not. `execute` is `inspect`, so a
+        // `crash` client told to run one is told to call a tool it will be refused — the same
+        // defect [`SUMMARY_NOTES`] exists for, in the arm that carries a caller through a failure.
+        // `end_session` needs no such guard: it is in [`crate::toolset::ALWAYS`].
+        if can_execute {
+            " (`execute { \"command\": \"vertarget\" }`)"
+        } else {
+            ""
+        }
     )
 }
 
@@ -2442,20 +2450,27 @@ impl WindbgServer {
                 id,
                 report,
                 summary,
-            }) => outcome_result(
-                format!(
-                    "{report}\n\nsession_id: {id}\nPass this as `session_id` on later calls \
-                         to route them to this session and to fail loudly rather than act on a \
-                         different target."
-                ),
-                structured::OpenOutcome::Ok(structured::OpenedSession {
-                    session_id: id,
-                    kind: kind.into(),
-                    target,
-                    report,
-                    summary,
-                }),
-            ),
+            }) => {
+                // Annotated once, above both halves, because a structured-aware client forwards
+                // `structuredContent` and drops the text: a pointer added to only one of them is
+                // a pointer half the clients never see, and a pointer *removed* from only one is
+                // the leak still open on the other.
+                let report = self.annotated_report(report, &summary);
+                outcome_result(
+                    format!(
+                        "{report}\n\nsession_id: {id}\nPass this as `session_id` on later \
+                         calls to route them to this session and to fail loudly rather than act \
+                         on a different target."
+                    ),
+                    structured::OpenOutcome::Ok(structured::OpenedSession {
+                        session_id: id,
+                        kind: kind.into(),
+                        target,
+                        report,
+                        summary,
+                    }),
+                )
+            }
             // No worker, so no session — and no argument the model can change fixes that.
             Err(OpenError::Unavailable(m)) => Err(ErrorData::internal_error(m, None)),
             Err(OpenError::NoRoom(m)) => {
@@ -2476,7 +2491,7 @@ impl WindbgServer {
                          report failed, so the handle above is valid and usable."
                     )
                 } else {
-                    post_commit_failure(&message, &id)
+                    post_commit_failure(&message, &id, self.surface.includes("execute"))
                 },
                 Some(id),
                 // Both halves of this branch created a target; that is what "post commit" means,
@@ -2613,6 +2628,29 @@ impl WindbgServer {
                 None => (*note).into(),
             });
         }
+    }
+
+    /// An opener's report with the pointers this client can act on appended.
+    ///
+    /// The counterpart of [`Self::annotate`] for results rather than descriptions, and it runs on
+    /// every open rather than once per router, which is why it is a walk of two notes and not a
+    /// rebuild of anything.
+    fn annotated_report(&self, mut report: String, summary: &structured::TargetSummary) -> String {
+        for SummaryNote {
+            applies,
+            names,
+            note,
+        } in SUMMARY_NOTES
+        {
+            if !applies(summary) || !names.iter().all(|named| self.surface.includes(named)) {
+                continue;
+            }
+            if !report.is_empty() {
+                report.push_str("\n  ");
+            }
+            report.push_str(note);
+        }
+        report
     }
 
     /// Open a crash dump (.dmp) or a Time Travel Debugging trace (.run) and wait for it to load.
@@ -4561,6 +4599,45 @@ struct ToolNote {
     note: &'static str,
 }
 
+/// A cross-reference an **opener's summary** makes, appended only where the surface serves the
+/// tool it names.
+///
+/// [`ToolNote`]'s rule, one channel over. The description channel was closed by item 41 and the
+/// `instructions` one by item 40; this is the third thing a client reads, and the only one that
+/// arrives on every call. It was open until the eval's own question — how does a model on an
+/// eleven-tool surface produce the exact name `modules`, with its real `filter` argument — was
+/// traced back to the sentence an opener's summary ended with.
+///
+/// Why the sentence cannot simply live where it used to: `summary_text` runs in the **worker**,
+/// which owns one session and has never heard of a client, let alone its surface. So the summary
+/// crosses the pipe as facts, and the pointers are added here, where `self.surface` is.
+struct SummaryNote {
+    /// Whether this summary holds the thing the sentence points at. A pointer to the bug check on
+    /// a target that did not bug-check is noise, whoever is served.
+    applies: fn(&structured::TargetSummary) -> bool,
+    /// Every tool the sentence names; it ships only when the surface has all of them — the same
+    /// all-of rule as [`ToolNote`], because a spec may select part of a group.
+    names: &'static [&'static str],
+    /// The sentence, appended to the report on a line of its own.
+    note: &'static str,
+}
+
+/// Every cross-reference an opener's summary makes, in the order they are appended.
+const SUMMARY_NOTES: &[SummaryNote] = &[
+    SummaryNote {
+        applies: |summary| summary.bug_check.is_some(),
+        names: &["crash_triage"],
+        note: "`crash_triage` reads the bug check as fields, with the crashing stack and the \
+               module each frame belongs to.",
+    },
+    SummaryNote {
+        applies: |summary| summary.modules_loaded.is_some(),
+        names: &["modules"],
+        note: "`modules` lists a page of that table and `modules { \"filter\": \"<name>\" }` \
+               answers for one.",
+    },
+];
+
 /// Every cross-reference this server's descriptions make, in the order they are appended.
 ///
 /// `no_description_names_a_tool_the_client_cannot_call` is what keeps this complete: it walks the
@@ -4920,6 +4997,83 @@ mod tests {
                 );
             }
         }
+    }
+
+    // ---- the pointers a client is served in a result -------------------
+
+    /// The opener's report for one surface, as [`WindbgServer::opened`] would build it.
+    fn report_for(spec: &str, summary: &structured::TargetSummary) -> String {
+        let surface = crate::toolset::Toolset::parse(spec)
+            .unwrap_or_else(|e| panic!("`{spec}` should be a valid spec: {e}"));
+        WindbgServer::new(Sessions::new(Duration::from_secs(1)))
+            .with_tools(surface, crate::toolset::Chosen::ForTheRun)
+            .annotated_report("Windows 10 Kernel Version 26100 MP".to_string(), summary)
+    }
+
+    /// A summary carrying both things the notes point at.
+    fn summary_with_everything() -> structured::TargetSummary {
+        structured::TargetSummary {
+            modules_loaded: Some(233),
+            bug_check: Some(crate::triage::bug_check_info(&win_kexp::dbgeng::BugCheck {
+                code: 0x9f,
+                parameters: [3, 0xffffe284ffe59060, 0, 0],
+            })),
+            ..Default::default()
+        }
+    }
+
+    /// The defect this table exists for: an opener's *result* naming a tool the caller will be
+    /// refused. It is the third channel, after item 40's `instructions` and item 41's
+    /// descriptions, and it was the one the eval's own models were reading `modules` out of —
+    /// the sentence arrived with `filter` spelled out, on an eleven-tool surface.
+    ///
+    /// Asserted on `crash` rather than on a single tool, because that is the surface the bench
+    /// serves and the one the leak was measured on. `crash_triage` is *in* it, so the two notes
+    /// answer differently on the same report — which is the property a per-note rule has and a
+    /// per-result one does not.
+    #[test]
+    fn no_opener_report_names_a_tool_the_client_cannot_call() {
+        let summary = summary_with_everything();
+
+        let narrow = report_for("crash", &summary);
+        assert!(
+            !narrow.contains("`modules`"),
+            "`modules` is `inspect`; a `crash` client is refused it: {narrow}"
+        );
+        assert!(
+            !narrow.contains("filter"),
+            "the argument travelled with the name, which is what made it usable: {narrow}"
+        );
+        assert!(
+            narrow.contains("`crash_triage`"),
+            "and the pointer it *can* act on still ships: {narrow}"
+        );
+
+        let session_only = report_for("session", &summary);
+        assert!(
+            !session_only.contains("crash_triage") && !session_only.contains("modules"),
+            "neither is served here: {session_only}"
+        );
+        assert!(
+            session_only.contains("Windows 10 Kernel Version 26100 MP"),
+            "the report itself is not what the notes gate: {session_only}"
+        );
+
+        let full = report_for("all", &summary);
+        assert!(
+            full.contains("`modules`") && full.contains("`crash_triage`"),
+            "a full surface loses nothing: {full}"
+        );
+    }
+
+    /// A pointer to something this target does not have is noise on every surface.
+    #[test]
+    fn a_note_needs_the_thing_it_points_at() {
+        let bare = report_for("all", &structured::TargetSummary::default());
+        assert!(
+            !bare.contains("crash_triage") && !bare.contains("modules"),
+            "no bug check and no module count, so neither sentence has a subject: {bare}"
+        );
     }
 
     // ---- the descriptions a client is served ---------------------------
@@ -5820,7 +5974,7 @@ mod tests {
     /// clean slate and had to hedge on every attach and launch; now it knows which it is.
     #[test]
     fn a_post_commit_failure_returns_the_handle_and_warns_against_reopening() {
-        let msg = post_commit_failure("the target never broke in", "sess-1");
+        let msg = post_commit_failure("the target never broke in", "sess-1", true);
         assert!(
             msg.contains("the target never broke in"),
             "must keep the underlying error"
@@ -5834,6 +5988,18 @@ mod tests {
             "must name the cost of re-running blindly, for launch and attach alike"
         );
         assert!(msg.contains("vertarget"), "must say how to inspect it");
+
+        // The advice survives the surface that cannot take the example, which is the half worth
+        // asserting: a caller with no `execute` still has to be told not to open again.
+        let narrow = post_commit_failure("the target never broke in", "sess-1", false);
+        assert!(
+            !narrow.contains("execute") && !narrow.contains("vertarget"),
+            "a `crash` client is refused `execute`, so it must not be sent there: {narrow}"
+        );
+        assert!(
+            narrow.contains("end_session") && narrow.contains("second process"),
+            "the advice is the point and it is served on every surface: {narrow}"
+        );
     }
 
     // ---- Error reporting -----------------------------------------------

--- a/src/server.rs
+++ b/src/server.rs
@@ -2653,6 +2653,29 @@ impl WindbgServer {
         report
     }
 
+    /// [`structured::USER_MODE_NO_BUG_CHECK`] with the pointer this client can act on.
+    ///
+    /// The third site of the same rule, and the one that shows why the worker cannot hold it: the
+    /// tools worth naming here are `inspect`'s, while the tool being refused is `crash`'s, so the
+    /// caller most likely to reach this message is exactly the one that cannot take its advice.
+    fn triage_refusal(&self, message: String) -> String {
+        if message != structured::USER_MODE_NO_BUG_CHECK {
+            return message;
+        }
+        // All of them or none, as everywhere else: half the pointer is worse than no pointer,
+        // since it reads as the whole answer.
+        if !["backtrace", "execute"]
+            .iter()
+            .all(|named| self.surface.includes(named))
+        {
+            return message;
+        }
+        format!(
+            "{message} For a user-mode crash use `backtrace` for the stack and \
+             `execute {{\"command\": \"!analyze -v\"}}` for the exception."
+        )
+    }
+
     /// Open a crash dump (.dmp) or a Time Travel Debugging trace (.run) and wait for it to load.
     /// Opens a new session in its own engine process — sessions already open are left alone —
     /// and returns a `session_id` that routes later calls to it. End it with `end_session`.
@@ -3169,6 +3192,12 @@ impl WindbgServer {
                 },
             )
             .await;
+        let out = match out {
+            Err(EngineError::Debugger(message)) => {
+                Err(EngineError::Debugger(self.triage_refusal(message)))
+            }
+            other => other,
+        };
         engine_result_for(args.session_id.as_deref(), out)
     }
 
@@ -5064,6 +5093,49 @@ mod tests {
             full.contains("`modules`") && full.contains("`crash_triage`"),
             "a full surface loses nothing: {full}"
         );
+    }
+
+    /// The same rule on an error, where the tool being refused and the tools worth naming are in
+    /// different groups — so the caller that reaches this message is the one least able to act on
+    /// the pointer it used to carry.
+    #[test]
+    fn a_user_mode_refusal_points_only_where_the_client_can_go() {
+        let refusal = |spec: &str| {
+            let surface = crate::toolset::Toolset::parse(spec)
+                .unwrap_or_else(|e| panic!("`{spec}` should be a valid spec: {e}"));
+            WindbgServer::new(Sessions::new(Duration::from_secs(1)))
+                .with_tools(surface, crate::toolset::Chosen::ForTheRun)
+                .triage_refusal(structured::USER_MODE_NO_BUG_CHECK.to_string())
+        };
+
+        let narrow = refusal("crash");
+        assert!(
+            narrow.contains("no bug check"),
+            "the fact is the answer and is served on every surface: {narrow}"
+        );
+        assert!(
+            !narrow.contains("`backtrace`") && !narrow.contains("`execute`"),
+            "both are `inspect`; this client has neither: {narrow}"
+        );
+
+        let full = refusal("all");
+        assert!(
+            full.contains("`backtrace`") && full.contains("!analyze -v"),
+            "a full surface keeps the pointer: {full}"
+        );
+
+        // Half a pointer reads as the whole answer, so a surface with one of the two gets neither.
+        let half = refusal("crash,backtrace");
+        assert!(
+            !half.contains("!analyze -v"),
+            "`execute` is not served here, so the sentence does not ship: {half}"
+        );
+
+        // Anything else passes through untouched — this is an equality against one constant, not
+        // a rewrite of every debugger error.
+        let untouched = WindbgServer::new(Sessions::new(Duration::from_secs(1)))
+            .triage_refusal("no such symbol".to_string());
+        assert_eq!(untouched, "no such symbol");
     }
 
     /// A pointer to something this target does not have is noise on every surface.

--- a/src/structured.rs
+++ b/src/structured.rs
@@ -110,6 +110,17 @@ pub struct FailureDetail {
     pub session_id: Option<String>,
 }
 
+/// `crash_triage`'s refusal on a user-mode session, without the pointer to what to read instead.
+///
+/// Shared so the server can recognise this exact message and append that pointer only where the
+/// surface serves the tools it names ([`crate::server::WindbgServer`]'s `crash_triage`) — an
+/// equality against one constant rather than a sniff at prose. The worker cannot append it
+/// itself: it owns one session and has never heard of the client's surface, which is the same
+/// reason an opener's summary crosses the pipe as facts. See `SUMMARY_NOTES`.
+pub const USER_MODE_NO_BUG_CHECK: &str = "this is a user-mode session, which has no bug check: \
+     `crash_triage` reads the kernel bug check data a crash dump or a bug-checked live kernel \
+     carries.";
+
 /// Why a tool call failed, as a value a caller can branch on.
 ///
 /// Deliberately coarse. These are the distinctions that change what a caller *does* next, and

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -1927,11 +1927,11 @@ fn crash_triage(
             return Err(Failed::categorised(
                 structured::ErrorCategory::Debugger,
                 if user_mode {
-                    "this is a user-mode session, which has no bug check: `crash_triage` reads \
-                     the kernel bug check data a crash dump or a bug-checked live kernel carries. \
-                     For a user-mode crash use `backtrace` for the stack and \
-                     `execute {\"command\": \"!analyze -v\"}` for the exception."
-                        .to_string()
+                    // The pointer that used to end this sentence named `backtrace` and
+                    // `execute`, both `inspect`, while `crash_triage` is `crash` — so on an
+                    // eleven-tool surface it sent a caller to two tools it would be refused. The
+                    // server appends it, where the surface is.
+                    structured::USER_MODE_NO_BUG_CHECK.to_string()
                 } else {
                     format!("the target's bug check data could not be read: {why}")
                 },

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -4218,15 +4218,20 @@ fn primary_module(
 /// The opener's diagnostic with the summary rendered under it.
 ///
 /// Three lines at most, and each is there because it answers a question its reader would otherwise
-/// spend a whole tool call on: which bug check this dump is (and that `crash_triage` reads the rest
-/// of it), and where the target's own image is loaded — with the pointer to `modules` for the table
-/// that used to arrive here unasked.
+/// spend a whole tool call on: which bug check this dump is, and where the target's own image is
+/// loaded.
+///
+/// **The pointers to the tools that read the rest are not here**, though they used to be: a worker
+/// serves one session and knows nothing of the client's surface, so a sentence naming `modules`
+/// reached an eleven-tool caller that cannot call it — the same defect items 40 and 41 removed from
+/// the instructions and the descriptions, surviving in the one channel nobody had scanned. They are
+/// appended by [`crate::server::WindbgServer::annotated_report`], from this same summary, and only
+/// where the surface serves the tool named.
 fn summary_text(diagnostic: &str, summary: &structured::TargetSummary) -> String {
     let mut lines: Vec<String> = Vec::new();
     if let Some(bug_check) = &summary.bug_check {
         lines.push(format!(
-            "Bug check {}{}, parameters {}.\n  `crash_triage` reads it as fields, with the \
-             crashing stack and the module each frame belongs to.",
+            "Bug check {}{}, parameters {}.",
             bug_check.code,
             bug_check
                 .name
@@ -4246,15 +4251,11 @@ fn summary_text(diagnostic: &str, summary: &structured::TargetSummary) -> String
             // closes one. The table solves the same problem with a fence; a sentence cannot carry
             // a fence, so it carries the span instead.
             Some(module) => format!(
-                "{loaded} module(s) loaded, `{}` at {}; `modules` lists a page of the table and \
-                 `modules {{ \"filter\": \"<name>\" }}` answers for one.",
+                "{loaded} module(s) loaded, `{}` at {}.",
                 renderable(&module.name),
                 module.start
             ),
-            None => format!(
-                "{loaded} module(s) loaded; `modules` lists a page of the table and \
-                 `modules {{ \"filter\": \"<name>\" }}` answers for one."
-            ),
+            None => format!("{loaded} module(s) loaded."),
         });
     }
     let diagnostic = diagnostic.trim_end();
@@ -6837,9 +6838,11 @@ mod tests {
         assert!(text.contains("233 module(s) loaded"), "{text}");
         // Quoted, because the name is the target's: see `a_primary_module_cannot_rename_itself`.
         assert!(text.contains("`nt` at 0xfffff80312000000"), "{text}");
+        // The pointer to `modules` is the *server's* to add, and only for a surface that serves
+        // it: see `SUMMARY_NOTES`. What the worker owes is the count, which is the fact.
         assert!(
-            text.contains("`modules`"),
-            "the table has to be nameable on demand: {text}"
+            !text.contains("`modules`"),
+            "a worker knows no surface, so it names no tool: {text}"
         );
     }
 
@@ -6895,8 +6898,8 @@ mod tests {
             "the parameters are the half a caller reads first: {text}"
         );
         assert!(
-            text.contains("crash_triage"),
-            "two lines here, the whole crash one call away: {text}"
+            !text.contains("crash_triage"),
+            "the pointer to it is the server's, which alone knows the surface: {text}"
         );
     }
 


### PR DESCRIPTION
Items 40 and 41 closed the two channels that advertised a narrowed client tools it would be refused: the `instructions` string, then the tool descriptions. **The third was open the whole time, and it is the one that arrives on every call.**

An opener's summary ended with:

```text
233 module(s) loaded, `nt` at 0xfffff80312000000; `modules` lists a page of the table
and `modules { "filter": "<name>" }` answers for one.
```

`summary_text` runs in the **worker**, which owns one session and has never heard of a client, let alone its surface. `modules` is `inspect`, so on the bench's own eleven-tool `crash` surface **the first result a client ever saw handed it the exact name together with its real argument** — which is where `docs/local-model-eval.md`'s "invented" `modules` calls were coming from. `crash_triage` rode along the same way.

## The fix is `TOOL_NOTES`' rule, one channel over

The summary crosses the pipe as **facts**; the pointers are appended where `self.surface` is, by `SUMMARY_NOTES` and `annotated_report`. Same all-of-the-names rule, since a spec may select part of a group.

Two things worth knowing:

- **Annotated above both halves of the result.** A structured-aware client forwards `structuredContent` and drops the text, so a pointer added to one half is one half the clients never see — and a pointer *removed* from one half is the leak still open on the other.
- **A note carries a predicate**, because a pointer to the bug check on a target that did not bug-check is noise on every surface.

## Two more sites the same scan found

- **`post_commit_failure`** told any caller to inspect with `execute { "command": "vertarget" }`. The advice survives on every surface; only the example is gated. `end_session` beside it needs no guard — it is always served.
- **`crash_triage`'s user-mode refusal** pointed at `backtrace` and `execute`, both `inspect`, while `crash_triage` is `crash` — so the caller most likely to reach it could act on neither half. An error is a string rather than a structure, so the fact half is a shared constant (`structured::USER_MODE_NO_BUG_CHECK`) and the server appends the pointer on an **equality against it**, not a sniff at prose.

One was left alone as unreachable: the "a `debug_batch` is running its rollback" message needs a client served `debug_batch` to have started one.

## Tests

- `no_opener_report_names_a_tool_the_client_cannot_call` — on `crash`, where the two notes answer *differently* on one report (`crash_triage` ships, `modules` does not, and neither does the word `filter`); on `session`, where neither ships; on `all`, which loses nothing.
- `a_note_needs_the_thing_it_points_at` — no bug check, no sentence about one.
- `a_user_mode_refusal_points_only_where_the_client_can_go` — including a surface with `backtrace` and no `execute`, which gets neither, and an unrelated error passing through untouched.
- The worker's own two tests now assert the **absence** of both names, which is the property that made the leak possible.

Verified on the ARM64 VM: **540 unit tests**, **76 smoke** with `WINDBG_MCP_SMOKE_DUMP=1` (52s, so the debugger tier really ran, no `SKIPPED`). `cargo fmt` and markdownlint clean. `cargo clippy --all-targets -- -D warnings` reports one error, `every_tool` is never used — **pre-existing on `main`**, verified by running it there.

## Handoff

`CLAUDE.md` (the rule beside the two it already states, and why it is a second table), `FOLLOWUPS.md` item 43 (which said `taught` was zero on this channel — it was the largest of the three), `CHANGELOG.md`, and `docs/crash-dump-walkthrough.md` for the new rendering. `docs/smoke-test.md` is deliberately untouched: unit tests only, no tier moved, the harness still reports 76.

**Two things about how this stayed hidden are the actual lesson**, and item 43 now records them. The prefix bound Codex argued for on #216 was not a hedge about a hypothetical — the sentence sat at the end of a 2,508-character summary and the eval log keeps 300 characters, so the scan could not have found it. And what did find it took no run at all: what a server prints is a static question, answerable by scanning `src/` string literals against the tool table in seconds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017KHzgze3DM5NUNzfkeHVmZ