### PR TITLE
Split the eval's `unserved` column, since it was two measurements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **The eval's `unserved` column is two numbers, because it was two measurements** (`FOLLOWUPS.md`
+  item 43, which closes it). A call naming a tool the client is not served is either `taught` — the
+  task *was* answerable on this surface, so nothing about the question required a name off it — or
+  `wanted`, where it was not and the model reached for the capability that would answer it. Summed,
+  they hide each other: re-graded over the two logs on disk, item 41's fix is **4+10 -> 0+6**, an
+  elimination of the half it was aimed at rather than a 57% improvement in a total. `taught` prints
+  its offenders by name and `--grade --assert-no-taught` exits non-zero on one; `wanted` is not
+  assertable, being a property of the task list rather than of this server.
+
 ### Fixed
 
 - **And no *result* names one either, which was the channel nobody had scanned** (`FOLLOWUPS.md`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -920,6 +920,15 @@ and **13 of the remainder named exactly those five**, which is what item 41 then
 metric is still `unserved` rather than "hallucinated", and it still measures the server before it
 measures the model. One call in 61 was a genuine invention, which is the floor.
 
+**It is now two columns, `taught+wanted`** (item 43), split by the task's own `possible_on`: a
+reach off the surface on a task this surface *can* answer against one on a task it cannot. Summed
+they hide each other, which is the whole argument — re-graded, item 41's fix is `4+10 -> 0+6`, an
+elimination of the half it was aimed at rather than a 57% improvement in a total.
+`--grade --assert-no-taught` exits non-zero on a taught call and `wanted` is deliberately not
+assertable. **The split attributes need, not provenance**: an opener's result taught `modules` on
+`unloaded_driver` until #217, and that task is one `min` cannot answer, so those calls are
+`wanted`. Lower bound on advertising, upper bound on need.
+
 **Re-run against item 41** (2026-08-24): unserved calls 14 -> 6, with `debug_batch` going 10 -> 0
 and every name this server was teaching now gone. What that re-run mostly taught is **how easy it
 is to over-read at n=1, in a file that already says so**. Two claims had to be pulled back after

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -26,7 +26,8 @@ and the model as a **grid** rather than as a sighting, and from what that grid f
 through the one thing `--tools` does not narrow (both 2026-08-23), and item 41 from re-running
 the narrowed cells against that fix and finding two of the same names arriving by a second route
 (2026-08-24), and items 42–43 from measuring item 41 and having two readings of that measurement
-corrected in review (2026-08-24, item 42 landing the same day). Each item notes its repo,
+corrected in review (2026-08-24; **both have since landed** — item 42 the same day, item 43 on
+2026-08-25, once #217 had shown that its "`taught` is zero" premise was false). Each item notes its repo,
 why it was deferred, and where it picks up. See [`DECISIONS.md`](./DECISIONS.md) for the design rationale (D1–D5) items 1–6 extend,
 and the 2026-08-02 entries that items 13–14 and item 10 extend.
 
@@ -1955,7 +1956,7 @@ as a replay guarantee in the comments and in all three documents this touched. T
 the rule that a cell-level failure note is superseded by later records of that cell had to learn
 about draws too, or draw 4 dying would be un-recorded by draw 5 completing afterwards.
 
-## 43. [windbg-mcp] `unserved` is two different measurements sharing a column
+## 43. [windbg-mcp] `unserved` is two different measurements sharing a column — **done** (2026-08-25)
 
 The metric was renamed from `hallucinated` when the first grid found that a model asking for a tool
 it could not call was usually reading this server's own advertising. Items 40 and 41 removed that
@@ -1973,10 +1974,28 @@ elimination, and the second could grow without anything being wrong. The task's 
 already carries what separates them, so this is a grader change and not a new measurement — split
 the column into `taught` and `wanted`, and let a regression test assert only the first.
 
-**Why deferred.** Nothing is currently wrong: `taught` is zero, so the sum happens to be the
-interesting number by accident. The split is worth making the next time the eval runs against a
-prose change, and doing it now would re-grade three runs of records to prove a partition that no
-present data disagrees with.
+**Why it was deferred, and what changed.** The argument was that `taught` was zero, so the sum
+happened to be the interesting number by accident, and the split would re-grade runs to prove a
+partition no present data disagreed with. Both halves of that turned out to be wrong: `taught` was
+not zero (the paragraphs below), and the re-grade is what *demonstrates* the partition rather than
+what costs it — the two logs on disk split **4+10** and **0+6**, so item 41's fix reads as an
+elimination of the half it was aimed at rather than a 57% improvement in a total.
+
+**What landed.** `possible` already said whether the answer key was reachable on this surface, so
+the split is that predicate and no new measurement: `taught` when the task *was* answerable here
+and the model still reached off-surface, `wanted` when it was not. The table prints `t+n` in the
+slot that held one number, so the sum stays readable and the halves stop hiding each other.
+`--grade --assert-no-taught` exits non-zero on a taught call, which is the regression this item
+asked for; `wanted` is deliberately not assertable, being a property of the task list and the
+surface rather than of this server. And `taught` prints its offenders by name — "`debug_batch` on
+`arm64_pc`" is checkable, where "taught: 4" is a number to argue about.
+
+**What the split does not do**, stated here because the entry that proposed it did not know yet:
+it attributes by **need, not provenance**. This server taught `modules` through an opener's result
+until [#217](https://github.com/glslang/windbg-mcp/pull/217), on `unloaded_driver`, which is also a
+task `min` cannot answer — so those calls are `wanted`. `taught` is a lower bound on advertising
+and `wanted` an upper bound on need. Separating them properly needs one cell repeated with the
+sentence varied, which is item 42's `draws` and not a fourth column.
 
 **A third channel was checked, and the checking is worth more than the result** (2026-08-24,
 prompted by the reasonable question of how a model on an eleven-tool surface produces the *exact*

--- a/docs/local-model-eval.md
+++ b/docs/local-model-eval.md
@@ -121,9 +121,23 @@ Mechanical, and stated so it can be argued with:
   `useful` (a tool the task needs, and it worked), `wasted` (worked, but nothing to do with the
   question), `off_surface` (the server refused it — on a narrowed surface, the tool is not served),
   `refused` (the harness's read-only fence), and `errored`.
-- **`unserved`** — a call naming a tool this client is not served. It was called `hallucinated`
-  until the run was read properly; see below, because the server is where all but one of those
-  names came from.
+- **`unserved`** — a call naming a tool this client is not served, printed as **`taught+wanted`**
+  because it is two measurements that hide each other:
+  - **`taught`** — the task *was* answerable on this surface, so nothing about the question
+    required a name off it. The model got that name somewhere, and this server is the likeliest
+    somewhere. A regression here is a defect in the server, and `--grade --assert-no-taught`
+    exits non-zero on one.
+  - **`wanted`** — the task is *not* answerable here and the model reached for the capability that
+    would answer it. That is the model being right and the surface saying no. It can grow without
+    anything being wrong, so nothing asserts on it.
+
+  It was called `hallucinated` until the first run was read properly; see below, because the server
+  is where all but one of those names came from. **What the split attributes is need, not
+  provenance**: this server taught `modules` through an opener's *result* until
+  [#217](https://github.com/glslang/windbg-mcp/pull/217), on a task `min` cannot answer, so those
+  calls land in `wanted`. Read `taught` as a lower bound on advertising and `wanted` as an upper
+  bound on need; separating them properly is one cell repeated with the sentence varied, which is
+  what `draws` is for.
 
 Nothing is graded by a model. A substring check accepts an answer a reader would not in exactly one
 direction — a model that lists every bug check code including the right one — and every cell's raw
@@ -496,6 +510,12 @@ clients is served names a tool that client cannot call.
 | `list_modules` | 1 | 0 | nothing; no surface here serves it |
 | `run_command` | 0 | 3 | nothing; likewise |
 | **total** | **14** | **6** | |
+
+**Split by whether the task needed the reach** (the `taught`/`wanted` columns, added later and
+re-graded over both logs): **4+10 became 0+6**. That is the argument for splitting the column at
+all — summed, item 41 reads as a 57% improvement; split, the half it was aimed at is *eliminated*
+and the half it was never aimed at is unchanged. All four were gemma's `debug_batch` on
+`arm64_pc`, a task `min` can answer, so nothing about the question required a name off the surface.
 
 **Every name this server was teaching is now gone.** Item 40 took `execute` (3) and `decode_ioctl`
 (1) to zero and they stayed there; item 41 takes `debug_batch`, which was ten of the fourteen and

--- a/tools/local_model_eval.py
+++ b/tools/local_model_eval.py
@@ -366,7 +366,8 @@ def grade_record(record, task, surface_names):
     calls = record.get("calls") or []
     useful = set(task.get("useful_tools", []))
     verdicts = {"useful": 0, "wasted": 0, "off_surface": 0, "refused": 0, "errored": 0,
-                "unserved": 0, "harness_tool": 0}
+                "unserved": 0, "taught": 0, "wanted": 0, "harness_tool": 0}
+    taught_tools = []
     for call in calls:
         name = call.get("name")
         verdict = call.get("verdict")
@@ -381,8 +382,34 @@ def grade_record(record, task, surface_names):
         # served them. A model asking for one of those was told about it by this server. The
         # count is still worth having - it measures a real cost in wasted turns - but it is a
         # measure of the server's advertising, not of the model's imagination.
+        #
+        # **And it is two measurements, split here by whether the task needed the reach**
+        # (item 43). `possible` says the answer key is reachable on this surface, so:
+        #
+        # - `wanted`: the task is *not* answerable here and the model reached for the capability
+        #   that would answer it. That is the model being right and the surface saying no; it can
+        #   grow without anything being wrong, and a floor of it is a property of the task list.
+        # - `taught`: the task *was* answerable here, so nothing about the question required a
+        #   name off this surface - the model got it from somewhere, and this server is the
+        #   likeliest somewhere. A regression here is a defect in the server.
+        #
+        # Summed they hide each other, which is what item 43 was written about: the first fix
+        # taking `taught` to zero read as a 57% improvement rather than an elimination.
+        #
+        # **What the split attributes is need, not provenance**, and #217 is why that has to be
+        # said. This server taught `modules` through an opener's *result* for as long as the
+        # summary named it - on `unloaded_driver`, which is also a task `min` cannot answer, so
+        # those calls land in `wanted`. `taught` is therefore a lower bound on advertising and
+        # `wanted` an upper bound on need. What separates them properly is one cell repeated with
+        # the sentence varied, which is the `draws` machinery beside this and not a column.
         if surface_names and name not in surface_names:
             verdicts["unserved"] += 1
+            verdicts["taught" if possible else "wanted"] += 1
+            if possible:
+                # The names, not just the count: "taught 3" is a number to argue about, while
+                # "`modules` on `bugcheck_code`" is a sentence somebody can go and check against
+                # the surface that client was served.
+                taught_tools.append(name)
         if verdict == "ok":
             verdicts["useful" if name in useful else "wasted"] += 1
         elif verdict == "refused_by_harness":
@@ -408,6 +435,7 @@ def grade_record(record, task, surface_names):
         "result_chars": sum(c.get("chars") or 0 for c in calls),
         "first_prompt_tokens": record.get("first_prompt_tokens"),
         "wall_s": record.get("wall_s"),
+        "taught_tools": sorted(set(taught_tools)),
         **verdicts,
     }
 
@@ -525,6 +553,10 @@ def summarise(log_path, tasks_file):
         cell["refused"] = sum(g["refused"] for g in graded)
         cell["off_surface"] = sum(g["off_surface"] for g in graded)
         cell["unserved"] = sum(g["unserved"] for g in graded)
+        cell["taught"] = sum(g["taught"] for g in graded)
+        cell["wanted"] = sum(g["wanted"] for g in graded)
+        cell["taught_detail"] = sorted({(g["task"], tool) for g in graded
+                                        for tool in g["taught_tools"]})
         cell["harness_tool"] = sum(g["harness_tool"] for g in graded)
         cell["wasted"] = sum(g["wasted"] for g in graded)
         cell["useful"] = sum(g["useful"] for g in graded)
@@ -542,7 +574,8 @@ def print_table(cells):
     repeated = any(c.get("draws", 1) > 1 for c in cells)
     draws_head = f"{'draws':>6} " if repeated else ""
     head = (f"{'backend':<12} {'model':<28} {'ctx':>7} {'surface':<6} {'tools':>5} "
-            f"{draws_head}{'ok/possible':>13} {'tokens':>13} {'calls u/w/n/r/e':>16} {'wall':>6}")
+            f"{draws_head}{'ok/possible':>13} {'tokens':>13} {'calls u/w/t+n/r/e':>18} "
+            f"{'wall':>6}")
     print("\n" + head)
     print("-" * len(head))
     for c in sorted(cells, key=lambda c: (c["backend"], c["model"], -(c["num_ctx"] or 0),
@@ -570,9 +603,31 @@ def print_table(cells):
               f"{str(c['tools'] or '-'):>5} "
               + (f"{c['draws']:>6} " if repeated else "")
               + f"{score} of {c['n']:<5} {tokens:>13} "
-              f"{c['useful']}/{c['wasted']}/{c['unserved']}/{c['refused']}/"
+              # `t+n` in the slot that used to hold one number: the sum is still readable at a
+              # glance, and the halves no longer hide each other (item 43).
+              f"{c['useful']}/{c['wasted']}/{c['taught']}+{c['wanted']}/{c['refused']}/"
               f"{c['call_errors']:<8} "
               f"{c['wall_s']:>5}s{failed}")
+    print_taught(cells)
+
+
+def print_taught(cells):
+    """The `taught` half, named rather than counted - and its absence stated rather than implied.
+
+    A column of zeroes is indistinguishable from a column nobody looked at, which is the failure
+    this whole item came out of: the scan that reported a clean result had compared nothing. So
+    this line prints either the offenders or the sentence that says there were none.
+    """
+    offenders = [(cell, task, tool) for cell in cells
+                 for task, tool in cell.get("taught_detail", [])]
+    if not offenders:
+        print("\ntaught: none - every off-surface call was on a task this surface cannot answer")
+        return
+    print(f"\ntaught: {sum(c['taught'] for c in cells)} call(s) naming a tool off the surface on "
+          f"a task that surface *can* answer -")
+    for cell, task, tool in offenders:
+        print(f"  {(cell['surface'] or '?'):<6} {(cell['model'] or '?')[:28]:<28} "
+              f"{task:<18} {tool}")
 
 
 # The marks a cell-task can carry, in the order a distribution prints them. Fixed rather than
@@ -729,10 +784,20 @@ def main():
         print(f"\nwrote {out}")
         return
     if sys.argv[1:2] == ["--grade"]:
-        log_path = sys.argv[2]
-        tasks_file = sys.argv[3] if len(sys.argv) > 3 else os.path.join(HERE, "eval_tasks.json")
+        # **The flag is filtered out before the positionals are read**, since the tasks file is
+        # argv[3] and a flag sitting there would be opened as one.
+        rest = [a for a in sys.argv[2:] if not a.startswith("--")]
+        strict = "--assert-no-taught" in sys.argv[2:]
+        log_path = rest[0]
+        tasks_file = rest[1] if len(rest) > 1 else os.path.join(HERE, "eval_tasks.json")
         cells = summarise(log_path, tasks_file)
         print_table(cells)
+        # The regression item 43 asked for, opt-in so an ordinary grading run still just prints.
+        # `wanted` is deliberately not assertable: it is a property of the task list and the
+        # surface, and a floor of it is what a narrowed surface *is*.
+        if strict and any(c["taught"] for c in cells):
+            print("\nFAILED: this server named a tool the client could not call")
+            sys.exit(1)
         out = os.path.splitext(log_path)[0] + ".graded.json"
         with open(out, "w", encoding="utf-8") as f:
             json.dump(cells, f, indent=2)


### PR DESCRIPTION
`FOLLOWUPS.md` item 43, which this closes. A call naming a tool the client is not served is two different findings sharing a column:

- **`taught`** — the task *was* answerable on this surface, so nothing about the question required a name off it. The model got that name somewhere, and this server is the likeliest somewhere. A regression here is a defect in the server.
- **`wanted`** — the task is *not* answerable here and the model reached for the capability that would answer it. That is the model being right and the surface saying no. It can grow without anything being wrong.

No new measurement: `possible` already carried the predicate, so this is the grader reading something it already computed. The table prints `t+n` in the slot that used to hold one number, so the sum stays readable and the halves stop hiding each other.

## The re-grade is the argument, not the cost

The item deferred itself partly to avoid re-grading old runs. That was backwards — the re-grade is what demonstrates the partition:

| log | `unserved` | split |
| --- | --- | --- |
| `after-206` (item 40 only) | 14 | **4+10** |
| `after-210` (item 41) | 6 | **0+6** |

**Item 41's fix is an elimination of the half it was aimed at**, not the 57% improvement in a total that the summed column reported — and the half it was never aimed at is unchanged. All four taught calls were gemma's `debug_batch` on `arm64_pc`, a task `min` can answer.

Both totals match what `docs/local-model-eval.md` published, and both matrices re-grade byte-identically.

## The regression hook

`--grade --assert-no-taught` exits non-zero on a taught call (verified: 1 on `after-206`, 0 on `after-210`). `wanted` is deliberately *not* assertable — it is a property of the task list and the surface rather than of this server.

`taught` prints its offenders **by name**, because "`debug_batch` on `arm64_pc`" is checkable where "taught: 4" is a number to argue about. And it prints `none` explicitly rather than leaving a blank, since a column of zeroes is indistinguishable from a column nobody looked at — which is exactly the failure this item's own investigation produced two days ago on #216.

## What the split does not do

**It attributes need, not provenance**, and the entry that proposed it did not know that yet. This server taught `modules` through an opener's *result* until #217 — on `unloaded_driver`, which is also a task `min` cannot answer, so those calls land in `wanted`. So `taught` is a **lower bound on advertising** and `wanted` an **upper bound on need**. Separating them properly needs one cell repeated with the sentence varied: item 42's `draws`, not a fourth column. The docs and the entry both say so rather than leaving the column to be over-read.

## Scope

`tools/local_model_eval.py`, plus the three handoff places and `docs/local-model-eval.md` (the metric definition, and the `4+10 -> 0+6` line beside the published table). No server code. `docs/smoke-test.md` untouched — no tier moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017KHzgze3DM5NUNzfkeHVmZ