### PR TITLE
The first read of the narrowed surface with every channel closed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -935,9 +935,10 @@ assertable. **The split attributes need, not provenance**: an opener's result ta
 the bench has produced — with the weakness on the *other* side, which is one draw per cell. Two
 things only draws could say: `ioctl_decode` is answered from a frontier model's own knowledge 5/5
 and from a local one's 1/5, and **`arm64_pc` is `5n` in every row**, which is what sent someone to
-look at the task rather than the models. It has never been answered correctly in 35 runs across
-every log (item 44): the key is the literal `pc`, `nt!KeBugCheck2+0x2e8`, and every model gives the
-bug check's parameter 1 instead — the address whose execution faulted. **A task that fails
+look at the task rather than the models. It went unanswered in all 35 runs in the logs still on
+disk, and has been answered right once ever — qwen, in the original grid, reasoning that frame 0
+*is* the `pc` (item 44). The key is the literal `pc`, `nt!KeBugCheck2+0x2e8`; almost every model
+gives the bug check's parameter 1 instead — the address whose execution faulted. **A task that fails
 everywhere is a task to read, not a model to blame.**
 
 **Re-run against item 41** (2026-08-24): unserved calls 14 -> 6, with `debug_batch` going 10 -> 0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -931,8 +931,10 @@ assertable. **The split attributes need, not provenance**: an opener's result ta
 
 **Fourth run, five draws of the five `min` cells** (2026-08-25, against #217): `modules` went from
 3 of 5 cell-draws to **0 of 25**, and what remains is mostly invented (`execute_command`,
-`run_command`). The arms differ by exactly one server change, so this is the cleanest causal read
-the bench has produced — with the weakness on the *other* side, which is one draw per cell. Two
+`run_command`). The arms differ by exactly one server behaviour *these tasks reach* - the opener's
+summary; the other two paths #217 changed were measured as unexercised (0 user-mode refusals in 95
+`crash_triage` calls, 0 post-commit failures) - so this is the cleanest causal read the bench has
+produced — with the weakness on the *other* side, which is one draw per cell. Two
 things only draws could say: `ioctl_decode` is answered from a frontier model's own knowledge 5/5
 and from a local one's 1/5, and **`arm64_pc` is `5n` in every row**, which is what sent someone to
 look at the task rather than the models. It went unanswered in all 35 runs in the logs still on

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -929,6 +929,17 @@ assertable. **The split attributes need, not provenance**: an opener's result ta
 `unloaded_driver` until #217, and that task is one `min` cannot answer, so those calls are
 `wanted`. Lower bound on advertising, upper bound on need.
 
+**Fourth run, five draws of the five `min` cells** (2026-08-25, against #217): `modules` went from
+3 of 5 cell-draws to **0 of 25**, and what remains is mostly invented (`execute_command`,
+`run_command`). The arms differ by exactly one server change, so this is the cleanest causal read
+the bench has produced — with the weakness on the *other* side, which is one draw per cell. Two
+things only draws could say: `ioctl_decode` is answered from a frontier model's own knowledge 5/5
+and from a local one's 1/5, and **`arm64_pc` is `5n` in every row**, which is what sent someone to
+look at the task rather than the models. It has never been answered correctly in 35 runs across
+every log (item 44): the key is the literal `pc`, `nt!KeBugCheck2+0x2e8`, and every model gives the
+bug check's parameter 1 instead — the address whose execution faulted. **A task that fails
+everywhere is a task to read, not a model to blame.**
+
 **Re-run against item 41** (2026-08-24): unserved calls 14 -> 6, with `debug_batch` going 10 -> 0
 and every name this server was teaching now gone. What that re-run mostly taught is **how easy it
 is to over-read at n=1, in a file that already says so**. Two claims had to be pulled back after

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -2127,14 +2127,21 @@ prior exposure cannot be excluded at one draw per cell. Separating memorised-fro
 guessed-by-convention is item 42's machinery (the same cell repeated with that sentence varied),
 not this item's.
 
-## 44. [windbg-mcp] `arm64_pc` has never measured what it asks, on any surface
+## 44. [windbg-mcp] `arm64_pc` is answered the way it reads, not the way it is keyed
 
 The eval's `arm64_pc` task asks for "the value of the `pc` register at the point of the crash" on
 the ARM64 sample, and its key is `0xfffff8013c65bca8`. **Across the 35 runs of it in the three logs
-this bench has, no model on any surface has ever given that answer, and 32 gave
-`0x0000019e7b820000`** — the bug check's first parameter. Five draws of five models on `min`
-(2026-08-25) is `5n` in every row, frontier rows included, which is what made it visible: at one
-draw per cell it read as a hard task.
+still on disk, no model on any surface gave that answer, and 32 gave `0x0000019e7b820000`** — the
+bug check's first parameter. Five draws of five models on `min` (2026-08-25) is `5n` in every row,
+frontier rows included, which is what made it visible: at one draw per cell it read as a hard task.
+
+**It has been answered correctly once**, in the original grid — qwen, reasoning that frame 0 of the
+bug-check stack *is* the `pc`, which is exactly the route the key wants and is written up in
+`docs/local-model-eval.md`. That log is no longer on disk, so the honest figure is roughly one in
+fifty rather than none in thirty-five (Codex caught the stronger claim on
+[#219](https://github.com/glslang/windbg-mcp/pull/219), against this repo's own published text).
+It matters in the right direction: the task *is* reachable and the route *does* work, so what is
+wrong is only that almost nobody reads the question that way.
 
 **Both answers are defensible, and the debugger says so.** Measured on the dump:
 
@@ -2147,8 +2154,8 @@ draw per cell it read as a hard task.
 
 So a model answering "the pc at the point of the crash" with the faulting address is reading the
 question the way a person would, and the key wants the register's literal value in a context that
-is not the crash. **A task 35 runs have never passed is measuring its own wording**, not the
-surface it was written to probe.
+is not the crash. **A task passed once in about fifty attempts is measuring its own wording**, not
+the surface it was written to probe.
 
 **What would close it.** Reword the prompt so one reading survives - "what value does `pc` hold in
 the crash context, as the debugger reports it" - rather than widening `expect` to accept both,

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -27,7 +27,9 @@ through the one thing `--tools` does not narrow (both 2026-08-23), and item 41 f
 the narrowed cells against that fix and finding two of the same names arriving by a second route
 (2026-08-24), and items 42–43 from measuring item 41 and having two readings of that measurement
 corrected in review (2026-08-24; **both have since landed** — item 42 the same day, item 43 on
-2026-08-25, once #217 had shown that its "`taught` is zero" premise was false). Each item notes its repo,
+2026-08-25, once #217 had shown that its "`taught` is zero" premise was false), and item 44 from
+the first run those two made possible: five draws of the narrowed cells, where a task failing in
+all twenty-five turned out to be failing at its own wording (2026-08-25). Each item notes its repo,
 why it was deferred, and where it picks up. See [`DECISIONS.md`](./DECISIONS.md) for the design rationale (D1–D5) items 1–6 extend,
 and the 2026-08-02 entries that items 13–14 and item 10 extend.
 
@@ -2124,3 +2126,42 @@ told a module table exists and has to name a tool for it. And this is a public r
 prior exposure cannot be excluded at one draw per cell. Separating memorised-from-GitHub from
 guessed-by-convention is item 42's machinery (the same cell repeated with that sentence varied),
 not this item's.
+
+## 44. [windbg-mcp] `arm64_pc` has never measured what it asks, on any surface
+
+The eval's `arm64_pc` task asks for "the value of the `pc` register at the point of the crash" on
+the ARM64 sample, and its key is `0xfffff8013c65bca8`. **Across the 35 runs of it in the three logs
+this bench has, no model on any surface has ever given that answer, and 32 gave
+`0x0000019e7b820000`** — the bug check's first parameter. Five draws of five models on `min`
+(2026-08-25) is `5n` in every row, frontier rows included, which is what made it visible: at one
+draw per cell it read as a hard task.
+
+**Both answers are defensible, and the debugger says so.** Measured on the dump:
+
+- `registers` reports `pc = 0xfffff8013c65bca8`, and `crash_triage` frame 0 is the same address,
+  `nt!KeBugCheck2+0x2e8`. So the key is literally right and the note claiming `min` can reach it
+  through frame 0 is right too - the route works.
+- That address is inside the **bug-check path**, which the machine reached *after* the fault. The
+  address whose execution faulted is parameter 1, `0x0000019e7b820000` (also in `x24`), and
+  `nt!MiCheckSystemNxFault` two frames up is the handler for exactly that.
+
+So a model answering "the pc at the point of the crash" with the faulting address is reading the
+question the way a person would, and the key wants the register's literal value in a context that
+is not the crash. **A task 35 runs have never passed is measuring its own wording**, not the
+surface it was written to probe.
+
+**What would close it.** Reword the prompt so one reading survives - "what value does `pc` hold in
+the crash context, as the debugger reports it" - rather than widening `expect` to accept both,
+which is the tempting fix and the wrong one: the task exists to check that a *narrow* surface can
+reach a register value through `crash_triage` frame 0, and accepting parameter 1 would let it pass
+without that route being taken at all. Check the other five tasks for the same defect while there:
+this one was found by five draws agreeing, and nothing says it is the only one.
+
+**Why deferred.** It invalidates comparison with every run published so far - the six-task score is
+in `docs/local-model-eval.md` three times over - so it wants doing at the start of the next run
+rather than between two, and the numbers already published want a line saying which task they were
+scored against. Nothing about the server is wrong here, which is why this is not urgent: the grid's
+*server* findings (items 40, 41, 43, and #217) never depended on this task.
+
+**Where it picks up.** `tools/eval_tasks.json`, the `arm64_pc` entry - and note its `note` field is
+what argued `possible_on` should include `min`, which is still true and is not what is wrong.

--- a/docs/local-model-eval.md
+++ b/docs/local-model-eval.md
@@ -627,6 +627,57 @@ Claude's prompt-token column is deliberately absent from these tables. It reads 
 surface, and most of that is Claude Code's own system prompt rather than this server's — see the
 last section.
 
+## Fourth run: the first read with every channel closed (2026-08-25)
+
+The five `min` cells again, this time at **five draws each** — 150 records, 25 cell-draws, ~59
+minutes of cell time — against a server carrying
+[#217](https://github.com/glslang/windbg-mcp/pull/217). That fix closed the **third** advertising
+channel: an opener's *result* was ending with "`modules` lists a page of the table and
+`modules { "filter": "<name>" }` answers for one", built in the worker, which knows nothing of a
+client's surface. So the eleven-tool client's first result had been handing it the exact name and
+its real argument the whole time — which is what made the third run's "three `modules` calls came
+anyway" reading unsafe.
+
+**`modules` is gone.**
+
+| | after #210 (1 draw/cell) | after #217 (5 draws/cell) |
+| --- | --- | --- |
+| cell-draws reaching off-surface | 3/5 | 5/25 |
+| naming `modules` | **3/5** | **0/25** |
+| `taught` | 0 | 0 |
+
+The three models that each named `modules` in their single draw before — gemma, opus and qwen —
+named it in **none of their fifteen draws** after. What remains is gemma reaching in four of its
+five draws and opus once in five; qwen, nemotron and sonnet never do.
+
+**And the composition flipped from a real name to invented ones.** Before: `modules`, which is the
+name that result was handing over. After: `execute_command` (12 calls, gemma, three draws),
+`execute` (3, gemma, one draw — a real tool, not served here), `run_command` (1, opus). Thirteen of
+the sixteen are names this server does not have.
+
+The two arms differ by **exactly one server behaviour change**: everything else merged between them
+was documentation, the grader or the runner. That is as clean as a single variable gets here — and
+the weakness is the other arm, which is one draw per cell. So the claim is not a rate against a
+rate; it is the sentence above about fifteen draws. Note also that gemma's twelve calls are a loop
+(four per draw, three draws), so **draw-level presence is the unit**, not call count.
+
+### Two things five draws bought that one could not
+
+- **`ioctl_decode` splits by tier as a rate.** Opus and sonnet answer it from their own knowledge
+  in all five draws (`5o`); the three local models manage it once in five (`1o4-`). At one draw
+  that is a coin toss reported as a fact.
+- **`arm64_pc` is `5n` in every row** — twenty-five wrong answers from five models, frontier rows
+  included. That is what a *task* defect looks like rather than a model one, and reading it that
+  way found one: **across all 35 runs of that task in every log this bench has, none has ever given
+  the key's answer and 32 gave the bug check's first parameter.** Measured on the dump, both are
+  defensible — `registers` reports `pc = 0xfffff8013c65bca8` and `crash_triage` frame 0 is the same
+  address, `nt!KeBugCheck2+0x2e8`, so the key is literally right; but that address is inside the
+  bug-check path the machine reached *after* the fault, while parameter 1 is the address whose
+  execution faulted. A model answering "the pc at the point of the crash" with the faulting address
+  is reading the question the way a person would. `FOLLOWUPS.md` item 44 carries what to do about
+  it; the scores in this document are as-graded, against a task whose wording is what they were
+  measuring.
+
 ## What this does not cover
 
 The same list `local-model.md` carries, minus what this closed. Still open: a long investigation

--- a/docs/local-model-eval.md
+++ b/docs/local-model-eval.md
@@ -656,8 +656,12 @@ name that result was handing over. After: `execute_command` (12 calls, gemma, th
 `execute` (3, gemma, one draw — a real tool, not served here), `run_command` (1, opus). Thirteen of
 the sixteen are names this server does not have.
 
-The two arms differ by **exactly one server behaviour change**: everything else merged between them
-was documentation, the grader or the runner. That is as clean as a single variable gets here — and
+The two arms differ by **exactly one server behaviour these tasks can reach** — the opener's
+summary. Two other paths changed in the same window and neither was exercised, which is measured
+rather than assumed: the user-mode refusal that stopped naming `backtrace` and `execute` (0 of the
+run's 95 `crash_triage` calls reached it — every task here opens a kernel dump) and the
+post-commit failure's `execute` example (no open failed after commit). Everything else merged
+between the runs was documentation, the grader or the runner. That is as clean as a single variable gets here — and
 the weakness is the other arm, which is one draw per cell. So the claim is not a rate against a
 rate; it is the sentence above about fifteen draws. Note also that gemma's twelve calls are a loop
 (four per draw, three draws), so **draw-level presence is the unit**, not call count.

--- a/docs/local-model-eval.md
+++ b/docs/local-model-eval.md
@@ -257,8 +257,9 @@ python3 tools/local_model_eval.py --grade results.jsonl tools/eval_tasks.json
 
 ### Repeating a cell, when the question is a rate
 
-The grid runs **one draw per (model, context, surface, task)**, which is what every run on this
-page is. That is enough for the two things it was built for — failure *modes*, and whether a
+The grid runs **one draw per (model, context, surface, task)**, which is what the first three runs
+on this page are; the fourth (2026-08-25) repeats each cell five times and is the only one that
+does. That is enough for the two things it was built for — failure *modes*, and whether a
 surface fits at all — and it is not enough for any sentence of the form "X caused Y". Three
 write-ups here reached past that anyway and review took two of them back
 (`FOLLOWUPS.md` item 42); the trap each time was a cell whose *composition* also changed, so an
@@ -668,8 +669,12 @@ rate; it is the sentence above about fifteen draws. Note also that gemma's twelv
   that is a coin toss reported as a fact.
 - **`arm64_pc` is `5n` in every row** — twenty-five wrong answers from five models, frontier rows
   included. That is what a *task* defect looks like rather than a model one, and reading it that
-  way found one: **across all 35 runs of that task in every log this bench has, none has ever given
-  the key's answer and 32 gave the bug check's first parameter.** Measured on the dump, both are
+  way found one: **across the 35 runs of that task in the three logs still on disk, none gave the
+  key's answer and 32 gave the bug check's first parameter.** It has been answered correctly
+  exactly once, in the original grid — qwen, above, reasoning that frame 0 of the bug-check stack
+  *is* the `pc`. That log is no longer on disk, so one correct answer in fifty is the best this can
+  be put; the point survives the arithmetic either way, since a task whose intended reading is
+  reached about 2% of the time is measuring its wording. Measured on the dump, both are
   defensible — `registers` reports `pc = 0xfffff8013c65bca8` and `crash_triage` frame 0 is the same
   address, `nt!KeBugCheck2+0x2e8`, so the key is literally right; but that address is inside the
   bug-check path the machine reached *after* the fault, while parameter 1 is the address whose

--- a/tools/eval_plan_after_217.json
+++ b/tools/eval_plan_after_217.json
@@ -1,0 +1,26 @@
+{
+  "run": "2026-08-25 after #217: the five min cells, five draws each",
+  "note": "The first read of the min surface with all three advertising channels closed. Items 40 and 41 took the `instructions` string and the tool descriptions; #217 took the opener's *result*, which was still handing `modules` over with its `filter` argument and is why the earlier 'three calls came anyway' reading was confounded. Five draws because one cannot answer 'how often' - see item 42 and the `draws` column - and because the arms it is being compared against are n=1, which is a weakness of the comparison rather than of this run.",
+  "tasks": "tools/eval_tasks.json",
+  "url": "http://127.0.0.1:8766/",
+  "out": "eval-out/after-217.jsonl",
+  "logs": "eval-out/logs-after-217",
+  "max_steps": 6,
+  "keep_alive": "10m",
+  "surfaces": [
+    { "client": "min", "spec": "crash", "tools": 11 }
+  ],
+  "cells": [
+    { "backend": "ollama",
+      "models": ["qwen3.8:27b-mlx", "gemma4:31b-mlx", "nemotron-3.5-lightning:30b-mlx"],
+      "contexts": [262144],
+      "surfaces": ["min"],
+      "draws": 5,
+      "budget_s": 2400 },
+    { "backend": "claude-code",
+      "models": ["opus", "sonnet"],
+      "surfaces": ["min"],
+      "draws": 5,
+      "budget_s": 1200 }
+  ]
+}


### PR DESCRIPTION
Five draws of the five `min` cells against #217 — 150 records, 25 cell-draws, ~59 minutes. The first time this bench could ask whether a model still reaches for a module listing when **nothing it reads names one**: items 40 and 41 closed the `instructions` string and the descriptions, but an opener's *result* was still handing `modules` over with its `filter` argument, so the third run's "three calls came anyway" was measuring a channel nobody had found.

## `modules` is gone

| | after #210 (1 draw/cell) | after #217 (5 draws/cell) |
| --- | --- | --- |
| cell-draws reaching off-surface | 3/5 | 5/25 |
| naming `modules` | **3/5** | **0/25** |
| `taught` | 0 | 0 |

The three models that each named `modules` in their single draw — gemma, opus, qwen — name it in **none of their fifteen draws** now. What remains is gemma reaching in four of its five draws and opus once in five; qwen, nemotron and sonnet never.

**The composition flipped from a real name to invented ones**: `execute_command` (12 calls, gemma, three draws), `execute` (3, gemma — real, but not served here), `run_command` (1, opus). Thirteen of sixteen are names this server does not have.

The two arms differ by **exactly one server behaviour these tasks can reach** — the opener's summary. Two other paths changed in the same window and both were *measured* as unexercised rather than assumed: the user-mode refusal (0 of the run's 95 `crash_triage` calls reached it — every task opens a kernel dump) and the post-commit failure's `execute` example (no open failed after commit). Everything else merged between them was docs, grader or runner. The weakness is on the *other* arm, which is one draw per cell, so the claim stays "named in none of fifteen draws" rather than a rate against a rate. And gemma's twelve calls are a loop at four per draw, so **draw-level presence is the unit**, not call count.

## Two findings only draws could produce

- **`ioctl_decode` splits by tier as a rate**: frontier rows answer from their own knowledge 5/5 (`5o`), local rows 1/5 (`1o4-`). At n=1 that is a coin toss reported as a fact.
- **`arm64_pc` is `5n` in every row** — 25 wrong answers from five models, frontier included. That is the shape of a *task* defect, and reading it that way found one.

## `arm64_pc` has never measured what it asks (new item 44)

**Across the 35 runs of that task in the three logs still on disk, none gave the key's answer; 32 gave the bug check's first parameter.** It has been answered correctly exactly once — qwen, in the original grid, reasoning that frame 0 of the bug-check stack *is* the `pc`. That result is written up earlier on this very page, and the first version of this section said "never" in flat contradiction of it (Codex caught it). One in roughly fifty is the honest figure, and it points the same way while proving something the stronger claim could not: the route works and the task is reachable.

Measured on the dump rather than argued:

- `registers` reports `pc = 0xfffff8013c65bca8`, and `crash_triage` frame 0 is the same address, `nt!KeBugCheck2+0x2e8`. So the key is literally right, and the task note claiming `min` can reach it through frame 0 is right too.
- But that address is inside the **bug-check path**, which the machine reached *after* the fault. Parameter 1, `0x0000019e7b820000` (also `x24`), is the address whose execution faulted — and `nt!MiCheckSystemNxFault` two frames up is the handler for exactly that.

So a model answering "the pc at the point of the crash" with the faulting address is reading the question the way a person would. Item 44 says the fix is to reword the prompt, **not** to widen `expect` to accept both — the task exists to check that a narrow surface can reach a register value through frame 0, and accepting parameter 1 would let it pass without that route being taken at all. It is deferred because it invalidates comparison with every published run, so it wants doing at the start of the next one.

## Scope

`docs/local-model-eval.md` (the fourth-run section), `FOLLOWUPS.md` (item 44 and its header line), `CLAUDE.md`, and the plan file so the run is re-runnable rather than described. No server code, no CHANGELOG entry — nothing about the product changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017KHzgze3DM5NUNzfkeHVmZ

