### PR TITLE
Ask the eval question that has one reading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   — `docs/local-model-eval.md`, three tables over — were graded against the old wording and say so
   now.
 
+- **A run's identity includes the question it asked**, so the suite the published runs used is
+  frozen as `tools/eval_tasks_v1.json` and both checked-in plans name it; the live
+  `tools/eval_tasks.json` is `v2`. `usable()` drops any record whose stored prompt is not the one
+  the suite asks now — right for a resume, and it meant rewording `arm64_pc` in place took that
+  task out of every historical plan: `after-217.jsonl` graded 15 possible per cell instead of 20,
+  with 25 of 150 records `UNCOUNTED`, and a *resumed* plan would have appended new-wording answers
+  under the same `(cell, draw, task)` key as the old ones. Pinned, it grades to 20 again and
+  resume counts 150 of 150 done. The grader now also names that reason under the table when it
+  fires, because it is the one uncounted reason a reader can act on — a served window that was not
+  the one requested is unrecoverable, a changed question is only the wrong suite.
+
 - **The eval's `unserved` column is two numbers, because it was two measurements** (`FOLLOWUPS.md`
   item 43, which closes it). A call naming a tool the client is not served is either `taught` — the
   task *was* answerable on this surface, so nothing about the question required a name off it — or

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **The eval's `arm64_pc` task asks a question with one reading** (`FOLLOWUPS.md` item 44, which
+  closes it). It asked for "the value of the `pc` register at the point of the crash", which reads
+  as the address whose execution faulted — bug check parameter 1 — rather than as the register's
+  value: across the 35 runs of it in the three logs on disk, **none** gave the key and **32** gave
+  parameter 1. Both are defensible on that dump (`pc` is `nt!KeBugCheck2+0x2e8`, inside the
+  bug-check path the machine reached *after* the fault), so the fix is the question and not the
+  key — widening `expect` to accept parameter 1 would let the task pass off `open_dump`'s summary,
+  where the parameters already are, without the route it exists to check being taken at all. The
+  other five prompts were re-read against their keys at the same time and none has the same
+  defect; `driver_blame`'s `0x1654` is the nearest thing and is recorded in that task's `note`
+  rather than changed, since 33 of its 35 runs give the key. **Scores published before this**
+  — `docs/local-model-eval.md`, three tables over — were graded against the old wording and say so
+  now.
+
 - **The eval's `unserved` column is two numbers, because it was two measurements** (`FOLLOWUPS.md`
   item 43, which closes it). A call naming a tool the client is not served is either `taught` — the
   task *was* answerable on this surface, so nothing about the question required a name off it — or

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -29,8 +29,8 @@ the narrowed cells against that fix and finding two of the same names arriving b
 corrected in review (2026-08-24; **both have since landed** — item 42 the same day, item 43 on
 2026-08-25, once #217 had shown that its "`taught` is zero" premise was false), and item 44 from
 the first run those two made possible: five draws of the narrowed cells, where a task failing in
-all twenty-five turned out to be failing at its own wording (2026-08-25). Each item notes its repo,
-why it was deferred, and where it picks up. See [`DECISIONS.md`](./DECISIONS.md) for the design rationale (D1–D5) items 1–6 extend,
+all twenty-five turned out to be failing at its own wording (2026-08-25, **landed** the same day).
+Each item notes its repo, why it was deferred, and where it picks up. See [`DECISIONS.md`](./DECISIONS.md) for the design rationale (D1–D5) items 1–6 extend,
 and the 2026-08-02 entries that items 13–14 and item 10 extend.
 
 Items are roughly ordered by how soon they're worth doing, within each cluster. **Item 10 has
@@ -54,6 +54,9 @@ attach whose target never dials in has no bound at all, which is the constraint 
 **Item 42 has landed** (2026-08-24) and is kept for the same reason as item 41 above: what it built
 is the capability to repeat a cell, and what it deliberately did not run is the A/B that motivated
 it — plus one of its own sentences turned out to be false on this bench, which the entry now records.
+**Item 44 has landed** (2026-08-25) and is kept because its own proposed wording was not the wording
+that shipped: closing the reading it identified needed the prompt to say what the answer is *not*,
+which is a judgement nothing has measured, and the entry now records what would settle it.
 
 ## 1. [win-kexp] Managed breakpoint lifecycle for `run_to_address` — **done upstream**
 
@@ -2127,9 +2130,9 @@ prior exposure cannot be excluded at one draw per cell. Separating memorised-fro
 guessed-by-convention is item 42's machinery (the same cell repeated with that sentence varied),
 not this item's.
 
-## 44. [windbg-mcp] `arm64_pc` is answered the way it reads, not the way it is keyed
+## 44. [windbg-mcp] `arm64_pc` is answered the way it reads, not the way it is keyed — **done** (2026-08-25)
 
-The eval's `arm64_pc` task asks for "the value of the `pc` register at the point of the crash" on
+The eval's `arm64_pc` task asked for "the value of the `pc` register at the point of the crash" on
 the ARM64 sample, and its key is `0xfffff8013c65bca8`. **Across the 35 runs of it in the three logs
 still on disk, no model on any surface gave that answer, and 32 gave `0x0000019e7b820000`** — the
 bug check's first parameter. Five draws of five models on `min` (2026-08-25) is `5n` in every row,
@@ -2157,18 +2160,49 @@ question the way a person would, and the key wants the register's literal value 
 is not the crash. **A task passed once in about fifty attempts is measuring its own wording**, not
 the surface it was written to probe.
 
-**What would close it.** Reword the prompt so one reading survives - "what value does `pc` hold in
-the crash context, as the debugger reports it" - rather than widening `expect` to accept both,
-which is the tempting fix and the wrong one: the task exists to check that a *narrow* surface can
-reach a register value through `crash_triage` frame 0, and accepting parameter 1 would let it pass
-without that route being taken at all. Check the other five tasks for the same defect while there:
-this one was found by five draws agreeing, and nothing says it is the only one.
+**What landed.** The prompt, not the key: it now asks for "what value the pc register holds in the
+crash context the dump saved - the register's own value as the debugger reports it, not an address
+taken from the bug check's parameters". Widening `expect` to accept parameter 1 stayed rejected for
+the reason above, and re-measuring on the dump gave it a second one this entry had not stated:
+`open_dump`'s summary carries all four parameters, so a key accepting parameter 1 would let the
+task pass off the *opener's* result with neither `registers` nor `crash_triage` called - the exact
+route it exists to check would be the one route not taken.
 
-**Why deferred.** It invalidates comparison with every run published so far - the six-task score is
-in `docs/local-model-eval.md` three times over - so it wants doing at the start of the next run
-rather than between two, and the numbers already published want a line saying which task they were
-scored against. Nothing about the server is wrong here, which is why this is not urgent: the grid's
-*server* findings (items 40, 41, 43, and #217) never depended on this task.
+**The entry's own suggested wording was not enough, and that is a judgement rather than a
+measurement.** "In the crash context, as the debugger reports it" removes the phrase that invites
+the faulting-address reading, but it leaves the reading itself available to a model that believes
+the bug check's parameter *is* the `pc` - which is what 32 of the 35 recorded runs believed. So the
+prompt names what the answer is not. That cannot hand the answer over, and it keeps the tool route
+required; what it costs is that the question now mentions the bug check at all. Nobody has measured
+the shorter wording, and what would settle it is item 42's `draws` on one cell with the sentence
+varied - the same A/B this bench keeps deferring.
 
-**Where it picks up.** `tools/eval_tasks.json`, the `arm64_pc` entry - and note its `note` field is
-what argued `possible_on` should include `min`, which is still true and is not what is wrong.
+**Re-verified before rewriting anything**, since the numbers above were the whole argument and
+were inherited rather than measured here. Both dump readings again, and the log breakdown finer
+than "no model gave that answer": of the 35 runs, **0** gave the key, **32** gave parameter 1, and
+the remaining **3** answered nothing at all - two closing the session and reporting that, one
+empty. So the split is not 33 wrong readings and 2 failures; every run that produced an answer
+produced the same wrong one.
+
+**The other five were checked, and none has it - but the corpus only stretches to four.** The three
+logs are `min` cells, so `unloaded_driver` and `ioctl_decode` have no answers in them at all
+(neither is answerable on that surface); those two were checked by reading the prompt against the
+key. The other three grade **33 of 35** correct each, and all six failures between them are
+non-answers or noise - three that closed the session and said so, one empty, one turn that ran out
+mid-narration, one invented module count - rather than a second reading anything agreed on.
+
+**`driver_blame` is the near miss, and it is what sharpened the rule.** It asks "at what offset into
+that driver did it fault", and the key `0x1654` is frame 7: the address `nt!ExFreePoolWithTag`
+returns to, not an instruction that itself faulted. So the prompt is loose in exactly the way
+`arm64_pc` was - and it is *not* the same defect, because no model takes the other reading: 33 of
+35 give the key, and `crash_triage` calls that frame `faulting_frame`, which is the vocabulary the
+question borrowed in the first place. **A wording defect shows up as agreement on a different
+answer, not as imprecision**, which is the check to run rather than re-reading prompts for rigour.
+Recorded in that task's `note` rather than fixed, so its published numbers stay comparable.
+
+**Where the published numbers stand.** `docs/local-model-eval.md` now says, once and above every
+table, that every score in it was graded against the old wording and is not comparable with a run
+against the new one on this task. The suite `note` in `tools/eval_tasks.json` says the same for
+anyone reading the task file first. Nothing about the server was wrong here, so the grid's *server*
+findings (items 40, 41, 43, and #217) are unaffected, and the next run starts against a question
+with one reading.

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -2200,6 +2200,26 @@ question borrowed in the first place. **A wording defect shows up as agreement o
 answer, not as imprecision**, which is the check to run rather than re-reading prompts for rigour.
 Recorded in that task's `note` rather than fixed, so its published numbers stay comparable.
 
+**A reworded task un-grades its own history, which review caught and the first attempt had not**
+([#220](https://github.com/glslang/windbg-mcp/pull/220), Codex). `usable()` drops any record whose
+stored `prompt` differs from the one the suite asks now - deliberate machinery, added when this
+bench reworded `unloaded_driver` mid-flight - so changing the live suite quietly took `arm64_pc`
+out of every checked-in plan. Measured on `after-217.jsonl`: the denominator went **20 to 15** per
+cell and 25 of the 150 records became `UNCOUNTED`. Worse, a *resume* of either checked-in plan
+would re-run the task and append new-wording answers under the same `(cell, draw, task)` key as the
+old ones, where `records()` keeps the later - one log, two experiments, nothing saying so. **A
+run's identity includes the question it asked**, so the old wording is frozen as
+`tools/eval_tasks_v1.json` and both historical plans name it: `after-217.jsonl` grades to 20 again
+and resume counts 150 of 150 done. The live suite is `v2`. And the one uncounted reason a reader
+can *act* on now says so under the table, since a served window that was not the one asked for is
+unrecoverable while a changed question is only the wrong suite - `stale_prompt` is split out of
+`usable` rather than restated inside it, so the predicate keeps one home.
+
+**My own verification of this was wrong, and the way it was wrong is worth keeping.** "Grades
+unchanged" was checked by running `--grade` and reading the numerators, which did match. The
+denominators did not, and the rows said `UNCOUNTED x5` in plain sight. Re-grading proves nothing
+unless the comparison is against the *previous output* rather than against expectations.
+
 **Where the published numbers stand.** `docs/local-model-eval.md` now says, once and above every
 table, that every score in it was graded against the old wording and is not comparable with a run
 against the new one on this task. The suite `note` in `tools/eval_tasks.json` says the same for

--- a/docs/local-model-eval.md
+++ b/docs/local-model-eval.md
@@ -119,6 +119,15 @@ five prompts were re-read against their keys at the same time and none has the s
 the check did find is in each task's `note` in `tools/eval_tasks.json`, and the measurement that
 prompted it is the fourth run below.
 
+**So a run's identity includes the question it asked**, and the old wording is kept as
+[`tools/eval_tasks_v1.json`](../tools/eval_tasks_v1.json) rather than overwritten. The two
+checked-in plans name it, which is what keeps this page re-gradable: `usable()` drops every answer
+to a question the suite no longer asks — correct for a resume, and the reason a reworded task would
+otherwise both shrink these tables' denominators and let a *resumed* plan append new-wording
+answers under the same (cell, draw, task) key as the old ones. Grade a published log against the
+suite its plan names; grading one against the live suite drops those records and says so under the
+table.
+
 ## Grading
 
 Mechanical, and stated so it can be argued with:
@@ -225,7 +234,7 @@ grid is re-runnable rather than described:
 ```json
 {
   "run": "2026-08-23",
-  "tasks": "tools/eval_tasks.json",
+  "tasks": "tools/eval_tasks_v1.json",
   "url": "http://127.0.0.1:8766/",
   "out": "eval-out/results.jsonl",
   "surfaces": [{ "client": "full" }, { "client": "lean" }, { "client": "min" }],
@@ -264,6 +273,11 @@ ever fails. Such a record is also not counted as done, so re-running the plan re
 ```console
 python3 tools/local_model_eval.py --grade results.jsonl tools/eval_tasks.json
 ```
+
+The suite argument is the one the log's **plan** names, not whichever suite is current —
+`tools/eval_tasks_v1.json` for every log this page reports. It defaults to `tools/eval_tasks.json`,
+so a published log graded with the default loses each record whose question has been reworded
+since; the count and what to do about it print under the table.
 
 ### Repeating a cell, when the question is a rate
 

--- a/docs/local-model-eval.md
+++ b/docs/local-model-eval.md
@@ -109,6 +109,16 @@ what the other two measure is what a model does when the tool it wants is not th
 for it anyway, or compute the answer itself — `CTL_CODE` is arithmetic, and a model that knows the
 macro can decode a code with no tool at all.
 
+**One of the six has been reworded since every run on this page** (2026-08-25, `FOLLOWUPS.md`
+item 44). `arm64_pc` used to ask for "the value of the `pc` register at the point of the crash",
+which reads as the address whose execution faulted — bug check parameter 1 — rather than as the
+register's value; it now asks for the register's own value as the debugger reports it, and not for
+an address taken from the bug check's parameters. **Every score below was graded against the old
+wording**, so none of them is comparable with a run against the current one on that task. The other
+five prompts were re-read against their keys at the same time and none has the same defect; what
+the check did find is in each task's `note` in `tools/eval_tasks.json`, and the measurement that
+prompted it is the fourth run below.
+
 ## Grading
 
 Mechanical, and stated so it can be argued with:
@@ -683,9 +693,18 @@ rate; it is the sentence above about fifteen draws. Note also that gemma's twelv
   address, `nt!KeBugCheck2+0x2e8`, so the key is literally right; but that address is inside the
   bug-check path the machine reached *after* the fault, while parameter 1 is the address whose
   execution faulted. A model answering "the pc at the point of the crash" with the faulting address
-  is reading the question the way a person would. `FOLLOWUPS.md` item 44 carries what to do about
-  it; the scores in this document are as-graded, against a task whose wording is what they were
-  measuring.
+  is reading the question the way a person would. **The prompt has since been reworded** (item 44,
+  2026-08-25): it asks for the register's own value as the debugger reports it, and not for an
+  address taken from the bug check's parameters. Widening the key to accept parameter 1 was the
+  tempting fix and the wrong one — `open_dump`'s summary already carries the parameters, so the
+  task would then pass without the route it exists to check, which is a narrow surface reaching a
+  *register* through `crash_triage` frame 0. The scores in this document are as-graded, against
+  the old wording. Re-reading the other five prompts against their keys at the same time found no
+  second instance: `driver_blame` is the only one with any looseness at all — its `0x1654` is the
+  address `nt!ExFreePoolWithTag` returns to rather than one that itself faulted, which is the
+  frame `crash_triage` calls `faulting_frame` — and 33 of its 35 recorded runs give the key, the
+  other two being an empty answer and a closed session. A wording defect shows up as *agreement
+  on a different answer*, and only this task has one.
 
 ## What this does not cover
 

--- a/docs/local-model-eval.md
+++ b/docs/local-model-eval.md
@@ -271,13 +271,14 @@ ever fails. Such a record is also not counted as done, so re-running the plan re
 **Grading, separately**, over the log:
 
 ```console
-python3 tools/local_model_eval.py --grade results.jsonl tools/eval_tasks.json
+python3 tools/local_model_eval.py --grade results.jsonl tools/eval_tasks_v1.json
 ```
 
-The suite argument is the one the log's **plan** names, not whichever suite is current —
-`tools/eval_tasks_v1.json` for every log this page reports. It defaults to `tools/eval_tasks.json`,
-so a published log graded with the default loses each record whose question has been reworded
-since; the count and what to do about it print under the table.
+**The suite argument is the one that log's plan names**, not whichever suite is current — the plan
+above writes `results.jsonl` and names `tools/eval_tasks_v1.json`, as does every log this page
+reports. It is optional and defaults to `tools/eval_tasks.json`, so a published log graded with the
+default silently loses each record whose question has been reworded since; the count and what to do
+about it print under the table.
 
 ### Repeating a cell, when the question is a rate
 

--- a/tools/eval_plan.json
+++ b/tools/eval_plan.json
@@ -1,6 +1,6 @@
 {
   "run": "2026-08-23",
-  "tasks": "tools/eval_tasks.json",
+  "tasks": "tools/eval_tasks_v1.json",
   "url": "http://127.0.0.1:8766/",
   "out": "eval-out/results.jsonl",
   "logs": "eval-out/logs",

--- a/tools/eval_plan_after_217.json
+++ b/tools/eval_plan_after_217.json
@@ -1,7 +1,7 @@
 {
   "run": "2026-08-25 after #217: the five min cells, five draws each",
   "note": "The first read of the min surface with all three advertising channels closed. Items 40 and 41 took the `instructions` string and the tool descriptions; #217 took the opener's *result*, which was still handing `modules` over with its `filter` argument and is why the earlier 'three calls came anyway' reading was confounded. Five draws because one cannot answer 'how often' - see item 42 and the `draws` column - and because the arms it is being compared against are n=1, which is a weakness of the comparison rather than of this run.",
-  "tasks": "tools/eval_tasks.json",
+  "tasks": "tools/eval_tasks_v1.json",
   "url": "http://127.0.0.1:8766/",
   "out": "eval-out/after-217.jsonl",
   "logs": "eval-out/logs-after-217",

--- a/tools/eval_tasks.json
+++ b/tools/eval_tasks.json
@@ -1,6 +1,6 @@
 {
   "suite": "windbg-mcp local-model eval v1",
-  "note": "Six tasks with a mechanical answer key, read off the checked-in sample dumps with this server's own tools before any model saw them (2026-08-23). `needs` names the tool group a task cannot be answered without, which is what makes the surface axis predictive rather than decorative: `session` is in every surface whatever a spec says, `crash` is in all three of these, `inspect` in two of them, and `ioctl` only in the whole one. `expect` is a list of groups, all of which must appear in the final answer, any alternative within a group counting; `bonus` is recorded but never decides pass/fail. `possible_on` names the surfaces on which the answer key is reachable at all, which is what keeps a narrowed surface from being scored as a stupid model: on `min` three of the six tasks have no tool that can answer them. Two tasks are reachable on every surface because `open_dump`'s own summary carries the bug check and the module count - the opener is doing more work than the tool table suggests.",
+  "note": "Six tasks with a mechanical answer key, read off the checked-in sample dumps with this server's own tools before any model saw them (2026-08-23). `needs` names the tool group a task cannot be answered without, which is what makes the surface axis predictive rather than decorative: `session` is in every surface whatever a spec says, `crash` is in all three of these, `inspect` in two of them, and `ioctl` only in the whole one. `expect` is a list of groups, all of which must appear in the final answer, any alternative within a group counting; `bonus` is recorded but never decides pass/fail. `possible_on` names the surfaces on which the answer key is reachable at all, which is what keeps a narrowed surface from being scored as a stupid model: on `min` three of the six tasks have no tool that can answer them. Two tasks are reachable on every surface because `open_dump`'s own summary carries the bug check and the module count - the opener is doing more work than the tool table suggests. Every prompt was re-read against its key on 2026-08-25 (`FOLLOWUPS.md` item 44), after `arm64_pc` turned out to be measuring its own wording rather than the surface: five draws of five models had failed it in all twenty-five. Only that one was reworded - the audit is recorded in the `note` of each task it found anything in - and its scores from before that date are not comparable with later ones.",
   "tasks": [
     {
       "id": "bugcheck",
@@ -53,7 +53,8 @@
         "modules",
         "session_status",
         "end_session"
-      ]
+      ],
+      "note": "Checked against item 44's defect on 2026-08-25 and it is not the same one: 33 of the 35 recorded runs agree with the key and the two that do not are an empty answer and a closed session, so no second reading is one a model actually gives. Worth knowing anyway - `MessageManager+0x1654` is frame 7, the address the call into `nt!ExFreePoolWithTag` returns to, rather than an instruction that itself faulted. `crash_triage` names it `faulting_frame`, which is the vocabulary the question borrows."
     },
     {
       "id": "module_count",
@@ -115,7 +116,7 @@
         "lean",
         "min"
       ],
-      "prompt": "Open the ARM64 kernel crash dump C:\\workspace\\windbg-mcp\\docs\\samples\\121524-4703-01.dmp and tell me the value of the pc register at the point of the crash.",
+      "prompt": "Open the ARM64 kernel crash dump C:\\workspace\\windbg-mcp\\docs\\samples\\121524-4703-01.dmp and tell me what value the pc register holds in the crash context the dump saved - the register's own value as the debugger reports it, not an address taken from the bug check's parameters.",
       "expect": [
         [
           "0xfffff8013c65bca8",
@@ -130,7 +131,7 @@
         "session_status",
         "end_session"
       ],
-      "note": "`registers` is the direct route; `crash_triage` frame 0 carries the same address on this dump, which is why every surface can reach it."
+      "note": "`registers` is the direct route; `crash_triage` frame 0 carries the same address on this dump, which is why every surface can reach it - that half of this note is unchanged and is what argued `possible_on` should include `min`. **The prompt was reworded on 2026-08-25** (`FOLLOWUPS.md` item 44), so scores against it before that date measure a different question. It used to ask for \"the value of the pc register at the point of the crash\", which reads as the address whose execution faulted: bug check parameter 1, `0x0000019e7b820000`, also in `x24`. Thirty-two of the thirty-five recorded runs answered exactly that, and none gave the key. Both readings are defensible on this dump - `pc` is `nt!KeBugCheck2+0x2e8`, inside the bug-check path the machine reached *after* the fault - which is why the fix is the question rather than the key: widening `expect` to accept parameter 1 would let the task pass off `open_dump`'s summary alone, where the parameters already are, and it exists to check that a narrow surface reaches a *register* through `crash_triage` frame 0."
     },
     {
       "id": "ioctl_decode",

--- a/tools/eval_tasks_v1.json
+++ b/tools/eval_tasks_v1.json
@@ -1,6 +1,7 @@
 {
-  "suite": "windbg-mcp local-model eval v2",
-  "note": "Six tasks with a mechanical answer key, read off the checked-in sample dumps with this server's own tools before any model saw them (2026-08-23). `needs` names the tool group a task cannot be answered without, which is what makes the surface axis predictive rather than decorative: `session` is in every surface whatever a spec says, `crash` is in all three of these, `inspect` in two of them, and `ioctl` only in the whole one. `expect` is a list of groups, all of which must appear in the final answer, any alternative within a group counting; `bonus` is recorded but never decides pass/fail. `possible_on` names the surfaces on which the answer key is reachable at all, which is what keeps a narrowed surface from being scored as a stupid model: on `min` three of the six tasks have no tool that can answer them. Two tasks are reachable on every surface because `open_dump`'s own summary carries the bug check and the module count - the opener is doing more work than the tool table suggests. Every prompt was re-read against its key on 2026-08-25 (`FOLLOWUPS.md` item 44), after `arm64_pc` turned out to be measuring its own wording rather than the surface: five draws of five models had failed it in all twenty-five. Only that one was reworded - the audit is recorded in the `note` of each task it found anything in - and its scores from before that date are not comparable with later ones.",
+  "frozen": "The suite as it stood until 2026-08-25, kept because a run's identity includes the question it asked. `tools/eval_plan.json` and `tools/eval_plan_after_217.json` point here, so the runs already published grade to what they graded to and a resume of either cannot append answers to a different question under the same (cell, draw, task) key. `arm64_pc` was reworded in the live suite (`tools/eval_tasks.json`, `FOLLOWUPS.md` item 44); nothing here may be edited - a changed `prompt` is what `usable()` compares, and editing one would silently un-grade the log it belongs to.",
+  "suite": "windbg-mcp local-model eval v1",
+  "note": "Six tasks with a mechanical answer key, read off the checked-in sample dumps with this server's own tools before any model saw them (2026-08-23). `needs` names the tool group a task cannot be answered without, which is what makes the surface axis predictive rather than decorative: `session` is in every surface whatever a spec says, `crash` is in all three of these, `inspect` in two of them, and `ioctl` only in the whole one. `expect` is a list of groups, all of which must appear in the final answer, any alternative within a group counting; `bonus` is recorded but never decides pass/fail. `possible_on` names the surfaces on which the answer key is reachable at all, which is what keeps a narrowed surface from being scored as a stupid model: on `min` three of the six tasks have no tool that can answer them. Two tasks are reachable on every surface because `open_dump`'s own summary carries the bug check and the module count - the opener is doing more work than the tool table suggests.",
   "tasks": [
     {
       "id": "bugcheck",
@@ -53,8 +54,7 @@
         "modules",
         "session_status",
         "end_session"
-      ],
-      "note": "Checked against item 44's defect on 2026-08-25 and it is not the same one: 33 of the 35 recorded runs agree with the key and the two that do not are an empty answer and a closed session, so no second reading is one a model actually gives. Worth knowing anyway - `MessageManager+0x1654` is frame 7, the address the call into `nt!ExFreePoolWithTag` returns to, rather than an instruction that itself faulted. `crash_triage` names it `faulting_frame`, which is the vocabulary the question borrows."
+      ]
     },
     {
       "id": "module_count",
@@ -116,7 +116,7 @@
         "lean",
         "min"
       ],
-      "prompt": "Open the ARM64 kernel crash dump C:\\workspace\\windbg-mcp\\docs\\samples\\121524-4703-01.dmp and tell me what value the pc register holds in the crash context the dump saved - the register's own value as the debugger reports it, not an address taken from the bug check's parameters.",
+      "prompt": "Open the ARM64 kernel crash dump C:\\workspace\\windbg-mcp\\docs\\samples\\121524-4703-01.dmp and tell me the value of the pc register at the point of the crash.",
       "expect": [
         [
           "0xfffff8013c65bca8",
@@ -131,7 +131,7 @@
         "session_status",
         "end_session"
       ],
-      "note": "`registers` is the direct route; `crash_triage` frame 0 carries the same address on this dump, which is why every surface can reach it - that half of this note is unchanged and is what argued `possible_on` should include `min`. **The prompt was reworded on 2026-08-25** (`FOLLOWUPS.md` item 44), so scores against it before that date measure a different question. It used to ask for \"the value of the pc register at the point of the crash\", which reads as the address whose execution faulted: bug check parameter 1, `0x0000019e7b820000`, also in `x24`. Thirty-two of the thirty-five recorded runs answered exactly that, and none gave the key. Both readings are defensible on this dump - `pc` is `nt!KeBugCheck2+0x2e8`, inside the bug-check path the machine reached *after* the fault - which is why the fix is the question rather than the key: widening `expect` to accept parameter 1 would let the task pass off `open_dump`'s summary alone, where the parameters already are, and it exists to check that a narrow surface reaches a *register* through `crash_triage` frame 0."
+      "note": "`registers` is the direct route; `crash_triage` frame 0 carries the same address on this dump, which is why every surface can reach it."
     },
     {
       "id": "ioctl_decode",

--- a/tools/local_model_eval.py
+++ b/tools/local_model_eval.py
@@ -76,6 +76,21 @@ def tokens_for(plan):
     return tokens
 
 
+def stale_prompt(record, task):
+    """Whether this record answers a question the suite no longer asks.
+
+    Split out of [`usable`] rather than restated inside it, so the comparison that decides a
+    record's fate keeps one home *and* the grader can say which of `usable`'s two reasons dropped
+    a record. Rewording a task un-grades every answer to the old wording, which is right for a
+    resume and is a footgun when re-grading a log that was published against it - the denominator
+    shrinks and the row says only `UNCOUNTED`. `tools/eval_tasks_v1.json` is the suite frozen at
+    the wording the logs on disk were run against, and each checked-in plan names the one its own
+    log belongs to.
+    """
+    return bool(task is not None and record.get("prompt")
+                and record["prompt"] != task.get("prompt"))
+
+
 def usable(record, task=None):
     """Whether a record still measures what this run is asking.
 
@@ -92,7 +107,7 @@ def usable(record, task=None):
     resume would otherwise have skipped the task while the grader scored the old answers against
     the new key.
     """
-    if task is not None and record.get("prompt") and record["prompt"] != task.get("prompt"):
+    if stale_prompt(record, task):
         return False
     served, asked = record.get("served_context"), record.get("num_ctx")
     if not asked:
@@ -503,6 +518,7 @@ def summarise(log_path, tasks_file):
             "surface": cell_id[3], "tools": surface.get("tools"),
             "surface_bytes": surface.get("bytes"), "served_context": record.get("served_context"),
             "tasks": [], "cell_error": None, "failed_draws": 0, "uncounted": 0,
+            "stale_prompt": 0,
             "draw_ids": set(),
         })
         cell["draw_ids"].add(draw_of(record))
@@ -528,6 +544,8 @@ def summarise(log_path, tasks_file):
             # asked for, or against a question the suite no longer asks. `--matrix` marks these
             # `?`; the row says how many were dropped.
             cell["uncounted"] = cell.get("uncounted", 0) + 1
+            if stale_prompt(record, key.get(record.get("task"))):
+                cell["stale_prompt"] = cell.get("stale_prompt", 0) + 1
             continue
         task = key.get(record["task"])
         if task is None:
@@ -608,6 +626,16 @@ def print_table(cells):
               f"{c['useful']}/{c['wasted']}/{c['taught']}+{c['wanted']}/{c['refused']}/"
               f"{c['call_errors']:<8} "
               f"{c['wall_s']:>5}s{failed}")
+    stale = sum(c.get("stale_prompt", 0) for c in cells)
+    if stale:
+        # **The one uncounted reason a reader can act on.** A served window that was not the one
+        # asked for is a property of the run and nothing recovers it; a changed question is a
+        # property of *which suite this log is being graded against*, and grading it against the
+        # one it ran on gives every record back.
+        print(f"\n  {stale} record(s) answer a question this suite no longer asks and are "
+              f"uncounted above.\n  Grade a published log against the suite it ran on - each "
+              f"plan in tools/ names its own\n  (tools/eval_tasks_v1.json for the logs this "
+              f"bench has published).")
     print_taught(cells)
 
 


### PR DESCRIPTION
Closes `FOLLOWUPS.md` item 44.

## What was wrong

The eval's `arm64_pc` task asked for *"the value of the `pc` register at the point of the crash"*, which reads as the address whose execution faulted rather than as the register's value. Five draws of five models on `min` was `5n` in every row, frontier rows included, which is what made it visible — at one draw per cell it read as a hard task.

Re-graded across the three logs still on disk, rather than inherited from the item:

| | count |
| --- | ---: |
| runs of `arm64_pc` | 35 |
| gave the key | **0** |
| gave bug check parameter 1 | **32** |
| answered nothing at all | 3 |

Two of those three closed the session and reported that; one was empty. So the split is not "33 wrong readings and 2 failures" — **every run that produced an answer produced the same wrong one**, which is what a task measuring its own wording looks like.

## Both readings are defensible, re-measured on the dump

- `registers` reports `pc = 0xfffff8013c65bca8`, and `crash_triage` frame 0 is that address, `nt!KeBugCheck2+0x2e8`. The key is literally right, and the note claiming `min` reaches it through frame 0 is right too.
- That address is inside the bug-check path the machine reached *after* the fault. The address whose execution faulted is parameter 1, `0x0000019e7b820000`, also sitting in `x24`, with `nt!MiCheckSystemNxFault` two frames up.

## The fix is the question, not the key

The prompt now asks for *"what value the pc register holds in the crash context the dump saved — the register's own value as the debugger reports it, not an address taken from the bug check's parameters."* `expect` is untouched, so **no published grade moves**.

Widening `expect` to accept parameter 1 stayed rejected, and re-measuring gave it a second reason the item had not stated: `open_dump`'s summary carries all four parameters, so a key accepting parameter 1 would let the task pass off the *opener's* result with neither `registers` nor `crash_triage` called — the one route it exists to check would be the only route not taken.

**Item 44's own suggested wording is not what shipped, and that is a judgement rather than a measurement.** "In the crash context, as the debugger reports it" removes the phrase that invites the faulting-address reading, but leaves the reading available to a model that believes the bug check's parameter *is* the `pc` — which is what 32 of the 35 runs believed. So the prompt also names what the answer is not. That cannot hand the answer over and it keeps the tool route required; what it costs is that the question now mentions the bug check at all. Nobody has measured the shorter wording, and the entry records what would settle it: item 42's `draws` on one cell with the sentence varied.

## The other five were checked, and the corpus reaches four

The three logs are `min` cells, so `unloaded_driver` and `ioctl_decode` have no answers in them at all and were checked by reading the prompt against the key. The other three grade **33 of 35** correct each, and all six failures between them are non-answers or noise — three that closed the session and said so, one empty, one turn that ran out mid-narration, one invented module count — rather than a second reading anything agreed on.

`driver_blame` is the near miss and is what sharpened the rule. It asks "at what offset into that driver did it fault", and the key `0x1654` is **frame 7**: the address `nt!ExFreePoolWithTag` returns to, not an instruction that itself faulted. So it is loose in exactly the way `arm64_pc` was — and is still not the same defect, because no model takes the other reading, and `crash_triage` calls that frame `faulting_frame`, which is the vocabulary the question borrowed. **A wording defect shows up as agreement on a different answer, not as imprecision**, which is the check to run rather than re-reading prompts for rigour. Recorded in that task's `note` rather than fixed, so its published numbers stay comparable.

## Where the published numbers stand

`docs/local-model-eval.md` now says once, above every table, that every score in it was graded against the old wording and is not comparable with a run against the new one *on that task*. The suite `note` in `tools/eval_tasks.json` says the same for anyone reading the task file first. Nothing about the server was wrong here, so the grid's server findings (items 40, 41, 43 and #217) are unaffected.

## Verification

- `python3 tools/local_model_eval.py --grade` over `after-206` and `after-217`: every cell grades to what it graded to, since `expect` did not move.
- `npx markdownlint-cli2@0.23.2 README.md CHANGELOG.md "docs/**/*.md" "skills/**/*.md"` — 0 issues.
- Both dump readings re-measured through the server (`registers`, `crash_triage`), and `modules`/`open_dump` re-read for the two module tasks' keys (227 loaded, 26 unload records for `nvhda64v.sys`).
- No Rust changed, so no build or test tier is involved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017KHzgze3DM5NUNzfkeHVmZ
