### PR TITLE
Track two things the eval cannot do: re-check its key, and compare two runs

### DIFF
--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -2291,6 +2291,17 @@ and the entry should not pretend one is obvious:
 Deciding between the first two is the work. The assertions are the easy half, and the third option
 is the one that looks easiest and is the item repeating itself.
 
+**And whatever holds the ground truth has to carry the *inputs*, not only the expectations** —
+which review found next and which defeats all three shapes as written. `expect` says what an answer
+must contain; **nothing structured says what to call to get it.** A task's dump path lives only in
+the prose `prompt`, and `useful_tools` names tools with no arguments and no order — so a verifier
+must either parse prose or hard-code the calls, and a task later pointed at a different sample
+would leave it querying the old one and matching expectations that never changed. Green, and
+drifted: this item's own failure mode, one level further down than the `answer_key` version of it.
+So the structured thing is a per-task binding of **`(tool, arguments)` to the value expected back**,
+which the verifier's calls and the task's `expect` both derive from, leaving the prompt's path a
+rendering of that binding rather than its only home.
+
 **And say which corpus is being asserted**, because the two disagree: `082126-7015-01.dmp` is in
 `answer_key` and no task references it, so a test driven off the key covers a dump the eval never
 asks about, while one driven off `tasks` covers less than the key claims. Neither is wrong; a test

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -30,9 +30,10 @@ corrected in review (2026-08-24; **both have since landed** — item 42 the same
 2026-08-25, once #217 had shown that its "`taught` is zero" premise was false), and item 44 from
 the first run those two made possible: five draws of the narrowed cells, where a task failing in
 all twenty-five turned out to be failing at its own wording (2026-08-25, **landed** the same day),
-and item 45 from what closing it exposed: the suite's answer key is a set of facts read off the
-sample dumps that nothing re-checks, so it can rot while every model goes on scoring against it
-(2026-08-25). Each item notes its repo, why it was deferred, and where it picks up. See [`DECISIONS.md`](./DECISIONS.md) for the design rationale (D1–D5) items 1–6 extend,
+and items 45–46 from what closing it opened up: the suite's answer key is a set of facts read off
+the sample dumps that nothing re-checks, so it can rot while every model goes on scoring against
+it, and a run can be graded but not *compared*, because nothing records the model weights or the
+server build it ran against (both 2026-08-25). Each item notes its repo, why it was deferred, and where it picks up. See [`DECISIONS.md`](./DECISIONS.md) for the design rationale (D1–D5) items 1–6 extend,
 and the 2026-08-02 entries that items 13–14 and item 10 extend.
 
 Items are roughly ordered by how soon they're worth doing, within each cluster. **Item 10 has
@@ -2298,3 +2299,67 @@ change, or a new sample replacing an old one, and none is scheduled.
 **Where it picks up.** `tests/mcp_smoke.rs`, beside `DRIVER_CRASHES` and `NATIVE_SAMPLE`, which
 already carry half of this and are the shape the rest wants; and `tools/eval_tasks.json`'s
 `answer_key`, which is the half that has to become readable before a test can honestly consume it.
+
+## 46. [windbg-mcp] A run can be graded but not compared, because nothing records what it ran against
+
+**Re-running a cell is the point, not a hazard.** As models are updated the same question on the
+same surface will be asked again, and what will matter is run N against run N-1 - the frozen suite
+(#220) exists so a *reworded question* cannot silently un-grade its own history, which is a
+different thing from discouraging a rerun. A rerun into a new log with a new plan is exactly what
+this bench is for. What it cannot do today is **compare two of them**.
+
+**A record identifies the question and the surface, and neither of the two things that change over
+time.** It carries `prompt` (the question identity #220 leaned on), `surface` with its client,
+tool count, byte size and names, plus `served_context`, `seed` and `draw`. It does not carry which
+*model weights* answered or which *server build* was asked.
+
+- **The model is a mutable tag.** `qwen3.8:27b-mlx` is a name that can be re-pulled onto different
+  weights, so two runs a month apart can agree on every recorded field and have been different
+  models. This is the axis the whole comparison is about.
+- **The server build is absent entirely.** `surface.bytes` is a real fingerprint of the tool prose
+  and did move when item 41 landed (8,654 -> 7,732 on `min`), but it is a fingerprint of one
+  channel: [#217](https://github.com/glslang/windbg-mcp/pull/217) changed an **opener's result**,
+  which no tool-list byte count can see. So the field that looks like a build identity is silent on
+  exactly the channel the last three findings were about.
+
+**Both facts are already on the wire and already parsed, and both are thrown away** - which is the
+same shape as the `served_context` lesson and should be read the same way:
+
+- `local_model_drive.py:served_context()` calls `/api/ps` and reads `context_length` off the
+  matching entry. That response also carries the model's **`digest`**, which is a content address
+  rather than a name.
+- The handshake at `local_model_drive.py:264` returns `out["result"]["protocolVersion"]` and drops
+  the rest of the `initialize` result - including `serverInfo.version`, which this server does
+  send (`src/server.rs`, `with_server_info(... env!("CARGO_PKG_VERSION") ...)`).
+
+**But the crate version is a floor, not an identity**, and the entry should not pretend otherwise:
+it moves on release, so two builds of one version are indistinguishable - the same trap the
+service-image warning already names in `CLAUDE.md`. Recording it is strictly better than recording
+nothing and is not sufficient; a build SHA would be, and that means deciding whether this server
+reports one. That decision is the item, not the two lines that record what is already there.
+
+**What would close it.** Identity fields on every record - model digest, server version (or SHA),
+suite id - and a **compare mode** over two logs: pair cells by `(backend, model, ctx, surface,
+task)`, print the two distributions side by side, and **name what differs in the run identity
+above the table**. That last clause is the whole value, and it is not a nicety: this repo has three
+times read a moved aggregate as a controlled result (items 42 and 43, and twice in
+[#212](https://github.com/glslang/windbg-mcp/pull/212)), and every one of those was a *composition*
+error - the callers changed and the total held. A comparison that states its own uncontrolled
+variables is the only version of this tool worth having, because the arithmetic is easy and the
+judgement it invites is what keeps going wrong.
+
+**And the reporting is the other half.** `docs/local-model-eval.md` accumulates a prose section per
+run, which reads well and cannot be diffed: the three tables in it measure three different servers,
+which the page says in words and no reader can check. A machine-readable series - one row per run,
+keyed by the identity above - is what makes "comparison with historic data" a query rather than a
+re-reading.
+
+**Why deferred.** Nothing already published is wrong, because each write-up names its own server
+build in prose; what is missing is the ability to *check* that, and to do it for a run nobody has
+written up yet. It wants doing before the next model refresh rather than after, since a run
+recorded without identity cannot have it added later - which is the one part of this that expires.
+
+**Where it picks up.** `tools/local_model_drive.py` - `served_context()` and the handshake, both of
+which already make the call that carries the fact; `tools/local_model_eval.py` for the compare mode
+beside `--grade` and `--matrix`; and `docs/local-model-eval.md` for what a versioned report looks
+like.

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -2277,27 +2277,36 @@ assertions are the easy half.
 asks about, while one driven off `tasks` covers less than the key claims. Neither is wrong; a test
 that has not chosen is.
 
-**Almost none of this needs a symbol gate, and the first draft of this entry said it did** —
-asserted by analogy with the rest of the tier rather than checked against which facts read a
-target, and caught in review on
-[#221](https://github.com/glslang/windbg-mcp/pull/221). `docs/smoke-test.md` already draws the line
-and draws it elsewhere: a host that resolves nothing still reads **the bug check, the module list
-and the stack**, because those come out of the dump's own headers, and fails only the reads
-*behind* them with `0x8007001E`. So the module counts, the 26 unload records, the frame
-attribution, and the `pc` by **either** route — `registers`, or `crash_triage` frame 0 — are all
-checkable on a symbol-poor host. What is not: `walk_memory`, `disassemble`, and the `_EPROCESS`
-read behind `crash_triage`'s `process_name`.
+**Gating splits three ways, and this entry has now been wrong in both directions.** The first
+draft asserted a symbol gate over all of it, by analogy with the rest of the tier rather than from
+which facts read a target; the correction then removed it wholesale. Review was right both times
+([#221](https://github.com/glslang/windbg-mcp/pull/221)) and neither answer is the one the code
+supports:
 
-Getting that backwards is not a harmless over-gate. It would have stood these assertions down on
-precisely the hosts that can still run them — the ARM64 CI runner resolved nothing until item 25
-([#153](https://github.com/glslang/windbg-mcp/pull/153)) — so the drift protection would have gone
-quiet on the machine most likely to drift. **Gate on the tier and the dump, as the rest of that
-file does, and reserve the symbol gate for the fields that walk pointers or types.**
+- **No target at all.** The four `0x22200B` fields — which is why that tier already uses
+  `decode_ioctl` as its pure-tool fixture.
+- **No gate.** The module counts and the 26 unload records come out of the dump's own module list,
+  which `docs/smoke-test.md` says a host resolving nothing still reads and which
+  `tests/mcp_smoke.rs` already asserts with no symbol probe in front of it. Same for `pc` read
+  through `registers`: that is the saved context, not a walk.
+- **Gated on both probes.** `pc` through `crash_triage` **frame 0**, and the
+  `MessageManager+0x1654` attribution. `assert_driver_crash_names_its_driver` stands down unless
+  *both* `engine_reads_target_memory` and `engine_resolves_kernel_symbols` pass, and the
+  measurement behind it is why: with `_NT_SYMBOL_PATH` pointed at an empty directory the ARM64
+  sample "reads nothing at all", while the x64 one "gives up a module base and then walks a stack
+  of the bug check's own parameters — neither is an answer, and only one of them looks like a
+  failure".
 
-Which is a third reason to choose the corpus deliberately: the only symbol-gated fact anywhere near
-this is a **process name**, and `answer_key` carries two (`mm_exploit_v5.exe`, `powershell.exe`)
-while no *task* keys on one. Assert the tasks and no gate is needed at all; assert the key and
-exactly that field needs one.
+**That last clause is what makes the gate non-optional on the stack half.** An ungated frame-0
+assertion on a symbol-poor host does not fail; it compares against a plausible wrong stack. And it
+lands on this suite in particular: `arm64_pc` claims `possible_on: min` *because* frame 0 carries
+the `pc`, a `min` client having no `registers`. So the eval's narrow-surface route to that fact is
+precisely the gated one, and the ungated route is the one `min` cannot take — a test that asserts
+only through `registers` is not checking the route the task depends on.
+
+**And the corpus choice moves with it.** Asserting the tasks still needs the gate for frame 0;
+asserting `answer_key` needs it for the two process names as well (`mm_exploit_v5.exe`,
+`powershell.exe`), which the `_EPROCESS` read is behind and which no task keys on.
 
 **One fragility worth writing down while it is in view.** `arm64_pc` claims `possible_on: min`
 because `crash_triage` frame 0 carries the `pc`. That holds on a **freshly opened** dump, which is
@@ -2343,7 +2352,15 @@ same shape as the `served_context` lesson and should be read the same way:
 
 - `local_model_drive.py:served_context()` calls `/api/ps` and reads `context_length` off the
   matching entry. That response also carries the model's **`digest`**, which is a content address
-  rather than a name.
+  rather than a name. **This is the ollama rows only**, and the entry should not have implied
+  otherwise: `claude_code_drive.py` records `"model": MODEL` — `opus`, `sonnet` — which are
+  mutable aliases resolved inside a client this bench does not own, and there is no `/api/ps` to
+  ask. So the two control rows keep the ambiguity the digest removes from the other three, and
+  what is available to them (the `claude` CLI version, the alias as written) is a floor rather
+  than an identity. That file already has the right habit for this: its `seed` is `None` with a
+  comment saying why the row cannot have one, which is what a null digest should look like beside
+  it rather than an absent field. Naming a real version source for a Claude row is open, and
+  scoping the claim to what can actually be recorded is the minimum.
 - The handshake at `local_model_drive.py:264` returns `out["result"]["protocolVersion"]` and drops
   the rest of the `initialize` result - including `serverInfo.version`, which this server does
   send (`src/server.rs`, `with_server_info(... env!("CARGO_PKG_VERSION") ...)`).

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -2258,20 +2258,38 @@ gave — while nothing in this repo pins the `pc` the task is actually keyed to.
 ambiguity are named in the codebase, in two different files, and the half the eval depends on is
 the unasserted one.
 
-**What would close it.** A table-driven test in the debugger tier over the facts the tasks depend
-on. It is cheap in the way the rest of that tier is not: no model, no ollama, no listener, no
-grid — `open_dump`, `crash_triage`, `registers`, `modules` and `decode_ioctl` against dumps the
-tier already opens, in seconds. The `0x22200B` half is cheaper still and needs no target at all,
-which is why that tier already uses `decode_ioctl` as its pure-tool fixture.
+**What would close it.** A table-driven check over the facts the tasks depend on — `open_dump`,
+`crash_triage`, `registers`, `modules` and `decode_ioctl` against dumps the debugger tier already
+opens. It is cheap in the way the rest of that tier is not: no model, no ollama, no listener, no
+grid, seconds rather than minutes. The `0x22200B` half is cheaper still and needs no target at
+all, which is why that tier already uses `decode_ioctl` as its pure-tool fixture. *Where* it runs
+is not settled — see the next paragraph, which is the part that has to be decided first.
 
-**The design question it must not skip is where the facts live**, because the key is not in a form
-a test can consume. `answer_key` is one prose string per dump ("x64, 0x13a
-KERNEL_MODE_HEAP_CORRUPTION, 158 modules, faulting frame MessageManager+0x1654, …") and `expect` is
-a list of answer alternatives keyed to a *question* rather than to a tool call, so neither can be
-read mechanically. Either the key becomes machine-readable and the test consumes it, or the test
-restates the facts — and restating them creates the second copy this item exists to prevent, with
-the two drifting apart being the failure mode it would then have. Decide that first; the
-assertions are the easy half.
+**Assert against the oracle, and `answer_key` is not it** — a correction this entry needed, because
+its first draft proposed pinning exactly the wrong half. **Nothing in this repo reads
+`answer_key`**: `grep` finds no consumer in `tools/`, `tests/` or `src/`. It is one prose string
+per dump ("x64, 0x13a KERNEL_MODE_HEAP_CORRUPTION, 158 modules, faulting frame
+MessageManager+0x1654, …") and it is documentation. What decides pass or fail is `matches()`, which
+reads a task's **`expect`** groups and nothing else. So a drift test pinned to `answer_key` would
+stay green while the facts models are actually graded against went stale — this item's own failure
+mode, reached through this item's own fix.
+
+**And the oracle is in the wrong language for the tier this proposed putting it in**, which is the
+real constraint. `expect` is answer *alternatives* matched by `present()` — hex-boundary rules,
+leading zeros, separators, all three learned from a wrong verdict — so consuming it faithfully
+means having `present()`. That is Python, beside the grader; `mcp_smoke` is Rust. Three shapes,
+and the entry should not pretend one is obvious:
+
+- **A `--verify-key` mode beside `--grade`**, driving the server and checking each task's `expect`
+  against what the tools answer, through the same `present()` that grades. One oracle, no second
+  copy — and not a `cargo test` gate, since CI runs the Rust tier and not this.
+- **A Rust test whose constants are generated from `tools/eval_tasks.json`.** A CI gate, at the
+  cost of a codegen step and of `present()`'s rules having to hold on the generated side.
+- **A Rust test with the facts written out by hand** — a CI gate today and the second copy this
+  item exists to prevent, with the two drifting apart being the failure it would then have.
+
+Deciding between the first two is the work. The assertions are the easy half, and the third option
+is the one that looks easiest and is the item repeating itself.
 
 **And say which corpus is being asserted**, because the two disagree: `082126-7015-01.dmp` is in
 `answer_key` and no task references it, so a test driven off the key covers a dump the eval never

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -2277,11 +2277,27 @@ assertions are the easy half.
 asks about, while one driven off `tasks` covers less than the key claims. Neither is wrong; a test
 that has not chosen is.
 
-**Gating is the same discipline as the rest of the tier**, and for the same reason. The module
-counts and the `pc` read a *target*, so a host that resolves no symbols cannot check them and must
-`SKIPPED`-and-pass rather than fail — a green tier there is not the same claim as a green tier
-here. The `0x22200B` decode is the exception and needs no target at all, which is why the tier
-already uses `decode_ioctl` as its pure-tool fixture.
+**Almost none of this needs a symbol gate, and the first draft of this entry said it did** —
+asserted by analogy with the rest of the tier rather than checked against which facts read a
+target, and caught in review on
+[#221](https://github.com/glslang/windbg-mcp/pull/221). `docs/smoke-test.md` already draws the line
+and draws it elsewhere: a host that resolves nothing still reads **the bug check, the module list
+and the stack**, because those come out of the dump's own headers, and fails only the reads
+*behind* them with `0x8007001E`. So the module counts, the 26 unload records, the frame
+attribution, and the `pc` by **either** route — `registers`, or `crash_triage` frame 0 — are all
+checkable on a symbol-poor host. What is not: `walk_memory`, `disassemble`, and the `_EPROCESS`
+read behind `crash_triage`'s `process_name`.
+
+Getting that backwards is not a harmless over-gate. It would have stood these assertions down on
+precisely the hosts that can still run them — the ARM64 CI runner resolved nothing until item 25
+([#153](https://github.com/glslang/windbg-mcp/pull/153)) — so the drift protection would have gone
+quiet on the machine most likely to drift. **Gate on the tier and the dump, as the rest of that
+file does, and reserve the symbol gate for the fields that walk pointers or types.**
+
+Which is a third reason to choose the corpus deliberately: the only symbol-gated fact anywhere near
+this is a **process name**, and `answer_key` carries two (`mm_exploit_v5.exe`, `powershell.exe`)
+while no *task* keys on one. Assert the tasks and no gate is needed at all; assert the key and
+exactly that field needs one.
 
 **One fragility worth writing down while it is in view.** `arm64_pc` claims `possible_on: min`
 because `crash_triage` frame 0 carries the `pc`. That holds on a **freshly opened** dump, which is

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -2261,7 +2261,8 @@ the unasserted one.
 **What would close it.** A table-driven test in the debugger tier over the facts the tasks depend
 on. It is cheap in the way the rest of that tier is not: no model, no ollama, no listener, no
 grid — `open_dump`, `crash_triage`, `registers`, `modules` and `decode_ioctl` against dumps the
-tier already opens, in seconds.
+tier already opens, in seconds. The `0x22200B` half is cheaper still and needs no target at all,
+which is why that tier already uses `decode_ioctl` as its pure-tool fixture.
 
 **The design question it must not skip is where the facts live**, because the key is not in a form
 a test can consume. `answer_key` is one prose string per dump ("x64, 0x13a
@@ -2275,46 +2276,28 @@ assertions are the easy half.
 **And say which corpus is being asserted**, because the two disagree: `082126-7015-01.dmp` is in
 `answer_key` and no task references it, so a test driven off the key covers a dump the eval never
 asks about, while one driven off `tasks` covers less than the key claims. Neither is wrong; a test
-that has not chosen is.
+that has not chosen is. It also changes what has to stand down: the key's two process names
+(`mm_exploit_v5.exe`, `powershell.exe`) sit behind the `_EPROCESS` read and no task keys on one.
 
-**Gating splits three ways, and this entry has now been wrong in both directions.** The first
-draft asserted a symbol gate over all of it, by analogy with the rest of the tier rather than from
-which facts read a target; the correction then removed it wholesale. Review was right both times
-([#221](https://github.com/glslang/windbg-mcp/pull/221)) and neither answer is the one the code
-supports:
+**Gating: `docs/smoke-test.md` already draws that line, and this entry deliberately does not draw
+it again.** Which reads survive a host that resolves no symbols, which do not, and the measurement
+behind the distinction all live there. Three review rounds on this entry
+([#221](https://github.com/glslang/windbg-mcp/pull/221)) were corrections to a *second copy* of it
+kept here — first too wide, then too narrow — which is the argument for keeping none. Read it
+there when implementing this, and do not restate it.
 
-- **No target at all.** The four `0x22200B` fields — which is why that tier already uses
-  `decode_ioctl` as its pure-tool fixture.
-- **No gate.** The module counts and the 26 unload records come out of the dump's own module list,
-  which `docs/smoke-test.md` says a host resolving nothing still reads and which
-  `tests/mcp_smoke.rs` already asserts with no symbol probe in front of it. Same for `pc` read
-  through `registers`: that is the saved context, not a walk.
-- **Gated on both probes.** `pc` through `crash_triage` **frame 0**, and the
-  `MessageManager+0x1654` attribution. `assert_driver_crash_names_its_driver` stands down unless
-  *both* `engine_reads_target_memory` and `engine_resolves_kernel_symbols` pass, and the
-  measurement behind it is why: with `_NT_SYMBOL_PATH` pointed at an empty directory the ARM64
-  sample "reads nothing at all", while the x64 one "gives up a module base and then walks a stack
-  of the bug check's own parameters — neither is an answer, and only one of them looks like a
-  failure".
-
-**That last clause is what makes the gate non-optional on the stack half.** An ungated frame-0
-assertion on a symbol-poor host does not fail; it compares against a plausible wrong stack. And it
-lands on this suite in particular: `arm64_pc` claims `possible_on: min` *because* frame 0 carries
-the `pc`, a `min` client having no `registers`. So the eval's narrow-surface route to that fact is
-precisely the gated one, and the ungated route is the one `min` cannot take — a test that asserts
-only through `registers` is not checking the route the task depends on.
-
-**And the corpus choice moves with it.** Asserting the tasks still needs the gate for frame 0;
-asserting `answer_key` needs it for the two process names as well (`mm_exploit_v5.exe`,
-`powershell.exe`), which the `_EPROCESS` read is behind and which no task keys on.
-
-**One fragility worth writing down while it is in view.** `arm64_pc` claims `possible_on: min`
-because `crash_triage` frame 0 carries the `pc`. That holds on a **freshly opened** dump, which is
-what every cell does — but `crash_triage`'s own contract is that its stack is the target's default
-context only when `!analyze` ran to completion, and otherwise whatever the session has selected. So
-the claim is true for the eval and is not true in general, and a test asserting it should open the
-dump rather than inherit a session. Measured 2026-08-25 with `analyze: false` on a fresh open:
-frame 0 is `nt!KeBugCheck2+0x2e8`, the same address `registers` reports.
+**What that file cannot tell you is where its line falls on this suite, and for `arm64_pc` it falls
+awkwardly.** The task claims `possible_on: min` *because* `crash_triage` frame 0 carries the `pc` —
+a `min` client has no `registers`. Frame 0 is on the standing-down side of that file's line and
+`registers` is not, so **a test asserting this fact through `registers` alone would not be checking
+the route the task depends on**, and the route it does depend on is the one that goes quiet on a
+symbol-poor host. Frame 0 carries a second condition besides: it is the crash context only on a
+**freshly opened** dump — what every cell does, but not `crash_triage`'s general contract, whose
+stack is the default context only when `!analyze` ran to completion and otherwise whatever the
+session has selected. So a test here opens the dump rather than inheriting a session, asserts
+through frame 0 as well as `registers`, and takes that file's gate on the frame-0 half. Measured
+2026-08-25 with `analyze: false` on a fresh open: frame 0 is `nt!KeBugCheck2+0x2e8`, the address
+`registers` reports.
 
 **Why deferred.** Nothing is wrong today — all three dumps were re-read on 2026-08-25 and every
 fact the tasks depend on still holds, which is what makes this protection against future drift

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -2354,15 +2354,28 @@ service-image warning already names in `CLAUDE.md`. Recording it is strictly bet
 nothing and is not sufficient; a build SHA would be, and that means deciding whether this server
 reports one. That decision is the item, not the two lines that record what is already there.
 
-**What would close it.** Identity fields on every record - model digest, server version (or SHA),
-suite id - and a **compare mode** over two logs: pair cells by `(backend, model, ctx, surface,
-task)`, print the two distributions side by side, and **name what differs in the run identity
-above the table**. That last clause is the whole value, and it is not a nicety: this repo has three
-times read a moved aggregate as a controlled result (items 42 and 43, and twice in
-[#212](https://github.com/glslang/windbg-mcp/pull/212)), and every one of those was a *composition*
-error - the callers changed and the total held. A comparison that states its own uncontrolled
-variables is the only version of this tool worth having, because the arithmetic is easy and the
-judgement it invites is what keeps going wrong.
+**What would close it.** Identity fields on every record - model digest where one exists, server
+version (or SHA), suite id - and a **compare mode** over two logs, with two rules that are not the
+same rule.
+
+**Pairing refuses at the task, it does not annotate.** A cell pairs on `(backend, model, ctx,
+surface, task)`, but a task id is not the question: `arm64_pc` has the same id in
+`tools/eval_tasks_v1.json` and `tools/eval_tasks.json` and a materially different prompt, so
+pairing on id would put two distributions side by side that #220 established are not comparable -
+and would be *weaker than the grader already is*, since `usable()` refuses such a record outright.
+The predicate for this already exists and has a home: `stale_prompt`, split out of `usable` in
+#220 so the reason could be named rather than restated. A compare mode reuses it and renders that
+row as incomparable with the reason, at the row rather than in a header - which is the same
+principle as the `UNCOUNTED` line beside it. (`expect` can move too; a pairing predicate that
+reads only the prompt is a floor.)
+
+**The run-identity line is for what is left**, and that is its actual job: the uncontrolled
+variables that are *not* the question - model weights, server build, served window. Naming them
+above the table is not a nicety, because this repo has three times read a moved aggregate as a
+controlled result (items 42 and 43, and twice in
+[#212](https://github.com/glslang/windbg-mcp/pull/212)), and every one was a *composition* error -
+the callers changed and the total held. But a note is the right instrument only for a variable a
+reader can weigh. A changed question is not one of those; it blocks the comparison.
 
 **And the reporting is the other half.** `docs/local-model-eval.md` accumulates a prose section per
 run, which reads well and cannot be diffed: the three tables in it measure three different servers,

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -1,6 +1,6 @@
 # Follow-ups
 
-Deferred work, in twenty-one clusters: items 1–6 come from the reachability-confirmation effort (path
+Deferred work, in twenty-three clusters: items 1–6 come from the reachability-confirmation effort (path
 recipe + `run_to_address`, merged 2026-07-04), items 7–11 from surveying this server against the
 MCP `2026-07-28` extensions (tasks, apps), item 12 from the opener split
 (glslang/win-kexp#71, 2026-08-01), items 13–14 from the bounded-command coverage review
@@ -29,8 +29,10 @@ the narrowed cells against that fix and finding two of the same names arriving b
 corrected in review (2026-08-24; **both have since landed** — item 42 the same day, item 43 on
 2026-08-25, once #217 had shown that its "`taught` is zero" premise was false), and item 44 from
 the first run those two made possible: five draws of the narrowed cells, where a task failing in
-all twenty-five turned out to be failing at its own wording (2026-08-25, **landed** the same day).
-Each item notes its repo, why it was deferred, and where it picks up. See [`DECISIONS.md`](./DECISIONS.md) for the design rationale (D1–D5) items 1–6 extend,
+all twenty-five turned out to be failing at its own wording (2026-08-25, **landed** the same day),
+and item 45 from what closing it exposed: the suite's answer key is a set of facts read off the
+sample dumps that nothing re-checks, so it can rot while every model goes on scoring against it
+(2026-08-25). Each item notes its repo, why it was deferred, and where it picks up. See [`DECISIONS.md`](./DECISIONS.md) for the design rationale (D1–D5) items 1–6 extend,
 and the 2026-08-02 entries that items 13–14 and item 10 extend.
 
 Items are roughly ordered by how soon they're worth doing, within each cluster. **Item 10 has
@@ -2226,3 +2228,73 @@ against the new one on this task. The suite `note` in `tools/eval_tasks.json` sa
 anyone reading the task file first. Nothing about the server was wrong here, so the grid's *server*
 findings (items 40, 41, 43, and #217) are unaffected, and the next run starts against a question
 with one reading.
+
+## 45. [windbg-mcp] The eval's answer key is a snapshot, and nothing checks it still holds
+
+The six tasks are graded against facts read off the checked-in dumps **with this server's own
+tools**, before any model saw them. That is what makes the bench mechanical, and it is also the
+whole exposure: if one of those facts stops being what the server reports, the suite keeps grading,
+every model keeps scoring, and the number measures nothing. A key that rots is indistinguishable
+from a model that got worse.
+
+**Part of it is already pinned, in `tests/mcp_smoke.rs`** — the debugger tier reads the same dumps
+and asserts bug check code and name, `Arg1`, the crashing process, and each driver crash's
+`module` + `rva` + kernel frame (`DRIVER_CRASHES`, `NATIVE_SAMPLE`). What is *not* pinned is the
+rest of what the tasks depend on:
+
+| Fact a task is keyed to | Asserted by the tier? |
+| --- | --- |
+| bug check `0x13a` / `0x9f`, and the names | yes |
+| `MessageManager+0x1654` | yes |
+| `nvhda64v.sys` unloaded | yes, as a **relation** — not the **26** records `unloaded_driver` asks for |
+| module counts **227** / **158** / **177** | no |
+| the four `0x22200B` fields | no — the tier exercises `0x70000` |
+| `pc = 0xfffff8013c65bca8` | **no** |
+
+**The last row is the one that makes the case**, and it is exactly item 44 wearing its other face.
+`NATIVE_SAMPLE` pins `first_parameter: "0x0000019e7b820000"` — the address 32 of 35 recorded runs
+gave — while nothing in this repo pins the `pc` the task is actually keyed to. Both halves of the
+ambiguity are named in the codebase, in two different files, and the half the eval depends on is
+the unasserted one.
+
+**What would close it.** A table-driven test in the debugger tier over the facts the tasks depend
+on. It is cheap in the way the rest of that tier is not: no model, no ollama, no listener, no
+grid — `open_dump`, `crash_triage`, `registers`, `modules` and `decode_ioctl` against dumps the
+tier already opens, in seconds.
+
+**The design question it must not skip is where the facts live**, because the key is not in a form
+a test can consume. `answer_key` is one prose string per dump ("x64, 0x13a
+KERNEL_MODE_HEAP_CORRUPTION, 158 modules, faulting frame MessageManager+0x1654, …") and `expect` is
+a list of answer alternatives keyed to a *question* rather than to a tool call, so neither can be
+read mechanically. Either the key becomes machine-readable and the test consumes it, or the test
+restates the facts — and restating them creates the second copy this item exists to prevent, with
+the two drifting apart being the failure mode it would then have. Decide that first; the
+assertions are the easy half.
+
+**And say which corpus is being asserted**, because the two disagree: `082126-7015-01.dmp` is in
+`answer_key` and no task references it, so a test driven off the key covers a dump the eval never
+asks about, while one driven off `tasks` covers less than the key claims. Neither is wrong; a test
+that has not chosen is.
+
+**Gating is the same discipline as the rest of the tier**, and for the same reason. The module
+counts and the `pc` read a *target*, so a host that resolves no symbols cannot check them and must
+`SKIPPED`-and-pass rather than fail — a green tier there is not the same claim as a green tier
+here. The `0x22200B` decode is the exception and needs no target at all, which is why the tier
+already uses `decode_ioctl` as its pure-tool fixture.
+
+**One fragility worth writing down while it is in view.** `arm64_pc` claims `possible_on: min`
+because `crash_triage` frame 0 carries the `pc`. That holds on a **freshly opened** dump, which is
+what every cell does — but `crash_triage`'s own contract is that its stack is the target's default
+context only when `!analyze` ran to completion, and otherwise whatever the session has selected. So
+the claim is true for the eval and is not true in general, and a test asserting it should open the
+dump rather than inherit a session. Measured 2026-08-25 with `analyze: false` on a fresh open:
+frame 0 is `nt!KeBugCheck2+0x2e8`, the same address `registers` reports.
+
+**Why deferred.** Nothing is wrong today — all three dumps were re-read on 2026-08-25 and every
+fact the tasks depend on still holds, which is what makes this protection against future drift
+rather than a bug. The things that would move it are an engine or `win-kexp` bump, a symbol-path
+change, or a new sample replacing an old one, and none is scheduled.
+
+**Where it picks up.** `tests/mcp_smoke.rs`, beside `DRIVER_CRASHES` and `NATIVE_SAMPLE`, which
+already carry half of this and are the shape the rest wants; and `tools/eval_tasks.json`'s
+`answer_key`, which is the half that has to become readable before a test can honestly consume it.


### PR DESCRIPTION
Adds `FOLLOWUPS.md` items 45 and 46 — one cluster, one conversation, no code.

## 45 — the answer key is a snapshot, and nothing checks it still holds

The six tasks are graded against facts read off the checked-in dumps **with this server's own tools**. If one stops being what the server reports, the suite keeps grading, every model keeps scoring, and the number measures nothing. **A key that rots is indistinguishable from a model that got worse.**

Half is already pinned in `tests/mcp_smoke.rs`. The gap:

| Fact a task is keyed to | Asserted by the tier? |
| --- | --- |
| bug check `0x13a` / `0x9f`, and the names | yes |
| `MessageManager+0x1654` | yes |
| `nvhda64v.sys` unloaded | yes, as a **relation** — not the **26** records `unloaded_driver` asks for |
| module counts **227** / **158** / **177** | no |
| the four `0x22200B` fields | no — the tier exercises `0x70000` |
| `pc = 0xfffff8013c65bca8` | **no** |

The last row is #220 wearing its other face: `NATIVE_SAMPLE` pins `first_parameter: "0x0000019e7b820000"` — the address 32 of 35 recorded runs gave — while nothing pins the `pc` the task is keyed to.

The entry does not pretend the assertions are the work. **The key is not in a form a test can consume** (`answer_key` is prose per dump; `expect` is answer alternatives keyed to a question, not a tool call), so either it becomes machine-readable or the test restates the facts — creating the second copy the item exists to prevent. It also says which corpus to assert (`082126-7015-01.dmp` is in the key and no task uses it) and carries the tier's target-gating discipline.

## 46 — a run can be graded but not compared

**Re-running a cell is the point, not a hazard.** The frozen suite exists so a *reworded question* cannot silently un-grade its own history — a different thing from discouraging a rerun. A rerun into a new log with a new plan is what this bench is for. What it cannot do is compare two of them.

A record carries the question and the surface, and neither thing that moves over time:

- **The model is a mutable tag.** `qwen3.8:27b-mlx` can be re-pulled onto different weights, so two runs a month apart can agree on every recorded field and have been different models — the axis the comparison is about.
- **The server build is absent**, and the field that looks like a substitute is not one: `surface.bytes` did move when item 41 landed (8,654 → 7,732 on `min`), but it fingerprints the *tool list*, and #217 changed an opener's **result** — which no tool-list byte count can see.

**Both facts are already on the wire and already parsed, and both are discarded** — the same shape as the `served_context` lesson:

| Fact | Where it already arrives | What is kept |
| --- | --- | --- |
| model `digest` | `/api/ps`, in `served_context()` | `context_length` only |
| `serverInfo.version` | the `initialize` result | `protocolVersion` only |

The entry is explicit that this is not the whole job: `CARGO_PKG_VERSION` moves on release, so two builds of one version are indistinguishable — the trap `CLAUDE.md` already names for the service-image warning. Whether this server should report a build SHA is the decision; the two lines are not.

**The part worth building is a compare mode that names what differs in the run identity above the table.** That clause is the value, not the arithmetic: this repo has three times read a moved aggregate as a controlled result (items 42 and 43, and twice in #212), and every one was a *composition* error — the callers changed and the total held.

## Verification

- Header checked mechanically: **46 headings, 1–46 contiguous, 23 clusters, every heading covered by exactly one cluster.** (The count was already stale before this branch — it claimed twenty-one while enumerating twenty-two, item 44's cluster having been added without bumping it.)
- `npx markdownlint-cli2@0.23.2 README.md CHANGELOG.md "docs/**/*.md" "skills/**/*.md"` — 0 issues. `FOLLOWUPS.md` is not in CI's globs.
- No code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017KHzgze3DM5NUNzfkeHVmZ
