### PR TITLE
A rule for the error six review rounds kept finding

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1055,9 +1055,16 @@ verification on [#220](https://github.com/glslang/windbg-mcp/pull/220):
 
 **The tell is that the sentence is about behaviour and the file is not open.** It is the same error
 as the eval task that started that work — answering the question the way it reads rather than the
-way it is keyed — which is worth knowing because at the time it does not feel like guessing. And it
-survives being noticed: the paragraph you are reading claimed "five review rounds" and attributed a
-three-way split to `docs/smoke-test.md`, and both were wrong until counted and re-read.
+way it is keyed — which is worth knowing because at the time it does not feel like guessing.
+
+**And it survives being noticed, which is the last thing this paragraph is for.** Its first draft
+opened "Five review rounds on #221 were all this". Five was neither: it was the *finding* count at
+that moment, written as a *round* count, and there were four rounds — by the time either was
+counted from the API rather than from my own commit subjects (which had numbered my own edits as
+rounds) there were **five rounds and six findings**, the sixth having landed while the paragraph
+was being written. The same draft also credited `docs/smoke-test.md` with the three-way symbol
+split; that file draws a two-way line — target memory against the dump's structure — and the third
+way was mine.
 
 **And this file is not linted.** `CLAUDE.md` and `FOLLOWUPS.md` are absent from CI's markdownlint
 globs (see *Local verification* above). Point the linter at them anyway and it reports ten

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1025,6 +1025,40 @@ has gone wrong here, each of which produced a confident wrong edit or came one s
   five tests gating on those conditions, because the four are the ones opening `NATIVE_SAMPLE` and
   the fifth is deliberately separate — counting `skip` call sites would have "fixed" it wrongly.
 
+**And re-read every mechanism, for the same reason.** A number gets re-derived; a claim about *how
+something works* gets the file opened. What goes wrong is stating it from the shape of the code
+around it, from a field's name, from one backend in front of you, or from what a neighbouring rule
+does — and it is cheap to avoid, because every instance below was one `grep` or one `sed` away.
+**Six findings across five review rounds** on
+[#221](https://github.com/glslang/windbg-mcp/pull/221) were all this, and so was a wrong
+verification on [#220](https://github.com/glslang/windbg-mcp/pull/220):
+
+- **From the neighbours.** A proposed test's module counts and `pc` "need a symbol gate", because
+  the tier around them gates. `docs/smoke-test.md` already draws that line — target memory against
+  the dump's structure — and carries the measurement that settles where a *stack* falls; two rounds
+  to land, and what the entry carries now is a pointer to that file rather than a second copy of it.
+- **From a name.** A drift test was to pin `answer_key`. **Nothing reads `answer_key`** — `grep -rn`
+  finds no consumer in `tools/`, `tests/` or `src/` — because `matches()` grades from each task's
+  `expect`. The test would have stayed green while the facts models are scored against rotted.
+- **From an identifier.** A compare mode was to pair two runs on `(backend, model, ctx, surface,
+  task)` and note any suite difference above the table, while `usable()` in that same file
+  *refuses* a record whose prompt differs. The proposal was laxer than the code beside it.
+- **From one backend.** "Record the model digest on every record", generalised from the ollama
+  driver, which is the only one with an `/api/ps` to ask; `claude_code_drive.py` records a mutable
+  alias and has no equivalent to offer.
+- **From what a field is for.** `expect` was taken as ground truth for a verifier, but it holds only
+  the expected *answers* — a task's dump path lives in its prose `prompt` and `useful_tools` carries
+  no arguments, so nothing structured says what to call.
+- **From the half that agreed.** "Grades unchanged" after rewording a task, checked by running
+  `--grade` and reading the numerators, which did match. The denominators had gone 20 to 15 and
+  every row said `UNCOUNTED x5`.
+
+**The tell is that the sentence is about behaviour and the file is not open.** It is the same error
+as the eval task that started that work — answering the question the way it reads rather than the
+way it is keyed — which is worth knowing because at the time it does not feel like guessing. And it
+survives being noticed: the paragraph you are reading claimed "five review rounds" and attributed a
+three-way split to `docs/smoke-test.md`, and both were wrong until counted and re-read.
+
 **And this file is not linted.** `CLAUDE.md` and `FOLLOWUPS.md` are absent from CI's markdownlint
 globs (see *Local verification* above). Point the linter at them anyway and it reports ten
 pre-existing errors — fence and list spacing, nothing that renders wrongly — so neither a clean run


### PR DESCRIPTION
Adds one rule to `CLAUDE.md`. No code, no behaviour.

## Why

Numbers already have a rule here — *re-derive every number, and distrust the derivation*. Mechanisms did not, and the failure has its own shape: **stating how something works from the code around it, from a field's name, from the one backend in front of you, or from what a neighbouring rule does.**

Six findings across five review rounds on #221 were all this, plus a wrong verification on #220. Every one was a `grep` or a `sed` away from being right:

| asserted from | what it was |
| --- | --- |
| the neighbours | module counts and `pc` "need a symbol gate", because the surrounding tier gates |
| a name | pin `answer_key` — which **nothing reads**; `matches()` grades from `expect` |
| an identifier | pair runs on task id, while `usable()` beside it *refuses* a differing prompt |
| one backend | "record the model digest on every record" — only ollama has an `/api/ps` to ask |
| what a field is for | `expect` as a verifier's ground truth, when it holds no inputs at all |
| the half that agreed | "grades unchanged" — numerators matched, denominators had gone 20 → 15 |

It is placed beside the re-derive block because they are siblings: **a number gets re-derived, a claim about behaviour gets the file opened.** The tell is that the sentence is about behaviour and the file is not open.

## Written by checking rather than asserting, which caught two errors in it

Both are left visible in the rule's last sentence, because a rule about this that shipped containing two instances of it would be worth less than the rule:

- The first draft said **"five review rounds"**. It is *six findings across five rounds* — counted from the API rather than from my own commit subjects, which had numbered my own edits as review rounds.
- It attributed a **three-way** symbol split to `docs/smoke-test.md`. That file draws a **two-way** line — target memory against the dump's structure — and separately carries the measurement that settles where a *stack* falls. The three-way reading was mine, not its.

## Scope

Separate from #221 so a green PR is not held open for this; that PR's review history is the evidence, cited rather than merged into. `CLAUDE.md` is not in CI's markdownlint globs, and the linter reports the same ten pre-existing errors before and after this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017KHzgze3DM5NUNzfkeHVmZ
