### PR TITLE
Record what a run ran against, so two of them can be compared

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **The server reports the git revision it was built from**, as semver build metadata on the
-  version it already reported: `0.11.0+g1a2b3c4`, and `-dirty` where the build inputs differ from
-  that commit. It reaches both places that carried the crate version alone and are the two a reader
+  version it already reported: `0.11.0+g1a2b3c4`, and `-dirty.<digest>` where the build inputs
+  differ from that commit — the digest, over the working-tree diff, so that two uncommitted
+  iterations on one `HEAD` are not one identity. It reaches both places that carried the crate version alone and are the two a reader
   reaches for when asking *which* build did something — MCP `serverInfo.version`, and a
   transcript's `start` record. A crate version moves only on release, so every build between two of
   them was indistinguishable, including the pairs that matter most: the behaviour a bug report or a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   that change over time: which model weights answered — `qwen3.8:27b-mlx` is a mutable tag that can
   be re-pulled onto different ones — and which server build was asked. Both facts were already on
   the wire and both were thrown away, so every record now carries `server`, `model_digest`, `suite`
-  and, for the Claude rows that can have no digest, `harness_version`. `--compare` reads two logs
+  and, for the Claude rows that can have no digest, `harness_version`. A surface is fingerprinted
+  by a **digest** of what went over the wire rather than by its byte length, and a field that is
+  deliberately null (`unavailable`) is kept apart from one nobody recorded (`unrecorded`). `--compare` reads two logs
   with two rules that are not one rule: a **changed question blocks** a pairing, and a changed
   build, model or window is **named above the table**. `--series` reduces logs to one row per run
   in `docs/eval-runs.json`. The three runs already recorded read `unrecorded` throughout, which is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **The server reports the git revision it was built from**, as semver build metadata on the
+  version it already reported: `0.11.0+g1a2b3c4`, and `-dirty` where the build inputs differ from
+  that commit. It reaches both places that carried the crate version alone and are the two a reader
+  reaches for when asking *which* build did something — MCP `serverInfo.version`, and a
+  transcript's `start` record. A crate version moves only on release, so every build between two of
+  them was indistinguishable, including the pairs that matter most: the behaviour a bug report or a
+  bench turns on is often a changed *result* rather than a changed API. Absent git, the reported
+  version is the bare crate version, and nothing that compares versions is affected — build
+  metadata is ignored for precedence.
+
+- **The eval records what a run ran against, so two runs can be compared** (`FOLLOWUPS.md` item 46,
+  which closes it). A record identified the question and the surface and neither of the two things
+  that change over time: which model weights answered — `qwen3.8:27b-mlx` is a mutable tag that can
+  be re-pulled onto different ones — and which server build was asked. Both facts were already on
+  the wire and both were thrown away, so every record now carries `server`, `model_digest`, `suite`
+  and, for the Claude rows that can have no digest, `harness_version`. `--compare` reads two logs
+  with two rules that are not one rule: a **changed question blocks** a pairing, and a changed
+  build, model or window is **named above the table**. `--series` reduces logs to one row per run
+  in `docs/eval-runs.json`. The three runs already recorded read `unrecorded` throughout, which is
+  the part of this that expires: a run recorded without identity cannot have it added later.
+
 - **The eval's answer key is re-read off the dumps rather than trusted** (`FOLLOWUPS.md` item 45,
   which closes it). Its six tasks are graded against facts read off the checked-in samples with
   this server's own tools, and nothing re-checked them — so a fact that stopped being what the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -950,7 +950,7 @@ mutable ollama tag), `suite`, and `harness_version` for the Claude rows, which c
 two logs with **two rules that are not one rule**: a *changed question* blocks a pairing (via
 `stale_prompt`, printed at the row), while a changed build, model or window is *named above the
 table* for a reader to weigh - conflating them is how a moved aggregate gets read as a controlled
-result. `--series` reduces logs to one row per run in `docs/eval-runs.json`. Three things bite.
+result. `--series` reduces logs to one row per run in `docs/eval-runs.json`. Five things bite.
 **The server's version now carries its git revision** (`0.11.0+g1a2b3c4`), stamped by `build.rs`,
 so anything asserting on it is a *prefix* check - and the smoke test additionally asserts the
 revision is **there** when built from a checkout, which is the assertion that catches a `build.rs`
@@ -964,7 +964,10 @@ relative to the git dir and not a revision): a `git worktree` checkout has a `.g
 literal `.git/HEAD` is a watched path that does not exist, which Cargo reads as always-changed and
 recompiles the crate on every no-op build. And **the two `/api/ps` facts are one call**
 (`runtime_identity`): asking twice could catch different instances and pair one model's window with
-another's digest.
+another's digest. **A surface is compared by digest, not byte length** - a same-length reword or an
+equal-sized allowlist swap moves neither the count nor the length - and **`unrecorded` (nobody
+recorded it) is kept apart from `unavailable`** (this row has no such answer), or every run with a
+Claude cell reads as a legacy log.
 
 **The key is a snapshot, and `--verify-key` is what re-takes it** (item 45). The six tasks are
 graded against facts read off the checked-in dumps with this server's own tools, so a fact that

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -965,7 +965,8 @@ literal `.git/HEAD` is a watched path that does not exist, which Cargo reads as 
 recompiles the crate on every no-op build. And **the two `/api/ps` facts are one call**
 (`runtime_identity`): asking twice could catch different instances and pair one model's window with
 another's digest. **A surface is compared by digest, not byte length** - a same-length reword or an
-equal-sized allowlist swap moves neither the count nor the length - and **`unrecorded` (nobody
+equal-sized allowlist swap moves neither the count nor the length, though a comparison spanning the
+rollout falls back to what both sides recorded and says `unverifiable` rather than `moved` - and **`unrecorded` (nobody
 recorded it) is kept apart from `unavailable`** (this row has no such answer), or every run with a
 Claude cell reads as a legacy log.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -950,7 +950,7 @@ mutable ollama tag), `suite`, and `harness_version` for the Claude rows, which c
 two logs with **two rules that are not one rule**: a *changed question* blocks a pairing (via
 `stale_prompt`, printed at the row), while a changed build, model or window is *named above the
 table* for a reader to weigh - conflating them is how a moved aggregate gets read as a controlled
-result. `--series` reduces logs to one row per run in `docs/eval-runs.json`. Five things bite.
+result. `--series` reduces logs to one row per run in `docs/eval-runs.json`. Six things bite.
 **The server's version now carries its git revision** (`0.11.0+g1a2b3c4`), stamped by `build.rs`,
 so anything asserting on it is a *prefix* check - and the smoke test additionally asserts the
 revision is **there** when built from a checkout, which is the assertion that catches a `build.rs`
@@ -964,7 +964,12 @@ relative to the git dir and not a revision): a `git worktree` checkout has a `.g
 literal `.git/HEAD` is a watched path that does not exist, which Cargo reads as always-changed and
 recompiles the crate on every no-op build. And **the two `/api/ps` facts are one call**
 (`runtime_identity`): asking twice could catch different instances and pair one model's window with
-another's digest. **A surface is compared by digest, not byte length** - a same-length reword or an
+another's digest. **The surface and the window are per-cell facts; the weights and the build are
+deliberately not** - review asked for both and both were built and then removed, because reaching
+the state they guard needs a model re-pulled mid-run or a run spanning a rebuild, and neither
+happens here. `tools/` is a developer script and the bar for defending it against states its own
+workflow cannot produce is lower than `src/`'s. **A surface is compared by digest, not byte
+length** - a same-length reword or an
 equal-sized allowlist swap moves neither the count nor the length, though a comparison spanning the
 rollout falls back to what both sides recorded and says `unverifiable` rather than `moved` - and **`unrecorded` (nobody
 recorded it) is kept apart from `unavailable`** (this row has no such answer), or every run with a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -956,8 +956,13 @@ so anything asserting on it is a *prefix* check - and the smoke test additionall
 revision is **there** when built from a checkout, which is the assertion that catches a `build.rs`
 that stopped running. **`build.rs`'s watch list and its dirty check are one `INPUTS` const**,
 because emitting any `rerun-if-changed` replaces Cargo's default of watching the whole package, and
-two lists would disagree about what a clean build is; `-dirty` therefore means "the build inputs
-differ from that commit", not "the tree is dirty". And **the two `/api/ps` facts are one call**
+two lists would disagree about what a clean build is; `-dirty.<digest>` therefore means "the build
+inputs differ from that commit", not "the tree is dirty", and the digest is over the diff so two
+uncommitted iterations on one `HEAD` are two identities. Git paths go through
+`rev-parse --git-path` (and the branch ref through `symbolic-ref`, since `--git-path` takes a path
+relative to the git dir and not a revision): a `git worktree` checkout has a `.git` **file**, so a
+literal `.git/HEAD` is a watched path that does not exist, which Cargo reads as always-changed and
+recompiles the crate on every no-op build. And **the two `/api/ps` facts are one call**
 (`runtime_identity`): asking twice could catch different instances and pair one model's window with
 another's digest.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -943,6 +943,24 @@ disk, and has been answered right once ever — qwen, in the original grid, reas
 gives the bug check's parameter 1 instead — the address whose execution faulted. **A task that fails
 everywhere is a task to read, not a model to blame.**
 
+**A run records what it ran against, and that is what makes two of them comparable** (item 46).
+Every record carries `server` (the build that answered), `model_digest` (the weights behind a
+mutable ollama tag), `suite`, and `harness_version` for the Claude rows, which can have no digest -
+`opus` and `sonnet` are aliases resolved inside a client this bench does not own. `--compare` reads
+two logs with **two rules that are not one rule**: a *changed question* blocks a pairing (via
+`stale_prompt`, printed at the row), while a changed build, model or window is *named above the
+table* for a reader to weigh - conflating them is how a moved aggregate gets read as a controlled
+result. `--series` reduces logs to one row per run in `docs/eval-runs.json`. Three things bite.
+**The server's version now carries its git revision** (`0.11.0+g1a2b3c4`), stamped by `build.rs`,
+so anything asserting on it is a *prefix* check - and the smoke test additionally asserts the
+revision is **there** when built from a checkout, which is the assertion that catches a `build.rs`
+that stopped running. **`build.rs`'s watch list and its dirty check are one `INPUTS` const**,
+because emitting any `rerun-if-changed` replaces Cargo's default of watching the whole package, and
+two lists would disagree about what a clean build is; `-dirty` therefore means "the build inputs
+differ from that commit", not "the tree is dirty". And **the two `/api/ps` facts are one call**
+(`runtime_identity`): asking twice could catch different instances and pair one model's window with
+another's digest.
+
 **The key is a snapshot, and `--verify-key` is what re-takes it** (item 45). The six tasks are
 graded against facts read off the checked-in dumps with this server's own tools, so a fact that
 stops being what the server reports leaves the suite grading and every model scoring against

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -2494,7 +2494,9 @@ now stamps the short git revision into the version the server reports, as semver
   `after-210`, a difference those write-ups compared across in silence. And the round after *that*
   caught the mirror image: adopting the digest is not a surface change, so a comparison spanning
   the rollout would have read every cell as moved on a telemetry format. It falls back to what both
-  runs recorded, and reports `unverifiable` rather than agreement where one side has no digest.
+  runs recorded, and reports `unverifiable` rather than agreement where one side has no digest —
+  once beneath the table, rather than per cell, where *neither* side has one, since then it is true
+  of every cell equally and the per-cell wording would be false.
 - **Absent is not the same as deliberately null**, which the same round caught. A Claude row's
   `model_digest` is null *on purpose* - an alias resolved inside a client this bench does not own
   has no content address - and folding that into `unrecorded` labelled every current run containing

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -2496,7 +2496,12 @@ now stamps the short git revision into the version the server reports, as semver
   the rollout would have read every cell as moved on a telemetry format. It falls back to what both
   runs recorded, and reports `unverifiable` rather than agreement where one side has no digest —
   once beneath the table, rather than per cell, where *neither* side has one, since then it is true
-  of every cell equally and the per-cell wording would be false.
+  of every cell equally and the per-cell wording would be false. The **weights** joined those two
+  as a per-cell fact a round later, for the same reason the surface did: the identity line's
+  `weights` is a run-wide set, and two runs assigning the same two digests to opposite cells - one
+  model at two contexts, a tag re-pulled between the runs - compare equal there while pairing
+  results from different weights. And a row label carries its **backend**, since a cell is keyed by
+  one and an ollama tag may be the same string as a Claude alias.
 - **Absent is not the same as deliberately null**, which the same round caught. A Claude row's
   `model_digest` is null *on purpose* - an alias resolved inside a client this bench does not own
   has no content address - and folding that into `unrecorded` labelled every current run containing

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -2491,7 +2491,10 @@ now stamps the short git revision into the version the server reports, as semver
   none reliably, so a same-length reword or an equal-sized allowlist swap said nothing had happened;
   the drivers record a digest of the surface exactly as it went over the wire. Pointed at the two
   published logs it reports one at once: `min` was 15,544 B in `after-206` and 14,606 B in
-  `after-210`, a difference those write-ups compared across in silence.
+  `after-210`, a difference those write-ups compared across in silence. And the round after *that*
+  caught the mirror image: adopting the digest is not a surface change, so a comparison spanning
+  the rollout would have read every cell as moved on a telemetry format. It falls back to what both
+  runs recorded, and reports `unverifiable` rather than agreement where one side has no digest.
 - **Absent is not the same as deliberately null**, which the same round caught. A Claude row's
   `model_digest` is null *on purpose* - an alias resolved inside a client this bench does not own
   has no content address - and folding that into `unrecorded` labelled every current run containing

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -2501,11 +2501,19 @@ now stamps the short git revision into the version the server reports, as semver
   `weights` is a run-wide set, and two runs assigning the same two digests to opposite cells - one
   model at two contexts, a tag re-pulled between the runs - compare equal there while pairing
   results from different weights. And a row label carries its **backend**, since a cell is keyed by
-  one and an ollama tag may be the same string as a Claude alias. The **build** followed the
-  weights a round later, on the identical argument - a log is append-only and a plan resumes, so a
-  run can span a rebuild and two logs holding the same revision *set* with the cells swapped
-  compare equal run-wide - and the series learned to carry all four per cell, since a historical
-  row holding two digests could not otherwise attribute its own numbers.
+  one and an ollama tag may be the same string as a Claude alias.
+
+**Two rounds were declined after being built, which is the more useful record.** Review asked for
+the model weights and then the server build to become per-cell facts beside the surface and the
+window, on a sound argument: a run-wide *set* cannot say which digest or revision answered which
+cell, so two logs assigning the same two to opposite cells compare equal. Both were implemented and
+then taken back out, because the premise is not reachable on this bench - a model cannot be
+re-pulled while a run holds it, and a run that spanned a rebuild of the server is invalid for
+reasons no comparison could repair. A surface and a window are different in kind: the grid varies
+both deliberately, cell by cell, every run. What survives is the one thing a historical row cannot
+recover from the identity line, the surface digest per cell in the series. **`tools/` is a
+developer script, not the server**, and the bar for defending it against states its own workflow
+cannot produce is lower than `src/`'s.
 - **Absent is not the same as deliberately null**, which the same round caught. A Claude row's
   `model_digest` is null *on purpose* - an alias resolved inside a client this bench does not own
   has no content address - and folding that into `unrecorded` labelled every current run containing

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -2486,7 +2486,17 @@ now stamps the short git revision into the version the server reports, as semver
   as a model comparison - the very intervention these runs exist to measure, silently. And a cell
   that asks for no window records `num_ctx: null` while the runtime serves what it likes. Both are
   named per cell beneath the table now, on the same rule as everything else that is not the
-  question: weighable, so named rather than blocking.
+  question: weighable, so named rather than blocking. And the surface is compared **by digest**,
+  not by length - the round after found that a byte count moves for almost any prose edit and for
+  none reliably, so a same-length reword or an equal-sized allowlist swap said nothing had happened;
+  the drivers record a digest of the surface exactly as it went over the wire. Pointed at the two
+  published logs it reports one at once: `min` was 15,544 B in `after-206` and 14,606 B in
+  `after-210`, a difference those write-ups compared across in silence.
+- **Absent is not the same as deliberately null**, which the same round caught. A Claude row's
+  `model_digest` is null *on purpose* - an alias resolved inside a client this bench does not own
+  has no content address - and folding that into `unrecorded` labelled every current run containing
+  a Claude cell as a log predating the field. `unavailable` is the second word, and one predicate
+  reads presence for all four fields rather than four special cases.
 - **A cell-failure note carries no identity and must not contribute one.** `run_cell` writes it
   with the cell's coordinates and nothing else, so counting it put an `unrecorded` beside the real
   server a current run *had* recorded - a partially failed cell reading as a second, unknown

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -2501,7 +2501,11 @@ now stamps the short git revision into the version the server reports, as semver
   `weights` is a run-wide set, and two runs assigning the same two digests to opposite cells - one
   model at two contexts, a tag re-pulled between the runs - compare equal there while pairing
   results from different weights. And a row label carries its **backend**, since a cell is keyed by
-  one and an ollama tag may be the same string as a Claude alias.
+  one and an ollama tag may be the same string as a Claude alias. The **build** followed the
+  weights a round later, on the identical argument - a log is append-only and a plan resumes, so a
+  run can span a rebuild and two logs holding the same revision *set* with the cells swapped
+  compare equal run-wide - and the series learned to carry all four per cell, since a historical
+  row holding two digests could not otherwise attribute its own numbers.
 - **Absent is not the same as deliberately null**, which the same round caught. A Claude row's
   `model_digest` is null *on purpose* - an alias resolved inside a client this bench does not own
   has no content address - and folding that into `unrecorded` labelled every current run containing

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -2443,7 +2443,7 @@ served window and not for the `digest` beside it.
 crate version is a floor, not an identity - it moves on release, so two builds of `0.11.0` were
 indistinguishable, which is the same trap the service-image warning names in `CLAUDE.md`. `build.rs`
 now stamps the short git revision into the version the server reports, as semver build metadata
-(`0.11.0+g1a2b3c4`, `-dirty` where the build inputs differ from that commit), and the transcript's
+(`0.11.0+g1a2b3c4`, `-dirty.<digest>` where the build inputs differ from that commit), and the transcript's
 `start` record carries the same string - it had the same weakness and nothing had noticed.
 
 **Four things it needed that this entry did not anticipate.**
@@ -2453,7 +2453,20 @@ now stamps the short git revision into the version the server reports, as semver
   clean on a tree that is not is worse than no stamp. Both read one `INPUTS` const - what actually
   reaches the binary and its tests - which also gives `-dirty` a meaning that can be stated: the
   build inputs differ from that commit, and an edit under `docs/` does not make a binary a
-  different binary.
+  different binary. **And those git paths must be resolved by git**, which review caught: a
+  `git worktree` checkout has a `.git` *file*, so a literal `.git/HEAD` is a watched path that does
+  not exist - Cargo reads that as perpetually changed and recompiles the whole crate on every
+  otherwise no-op build. `rev-parse --git-path` answers in every layout, with the branch's ref name
+  from `symbolic-ref` first, since `--git-path` takes a path relative to the git directory and not
+  a revision (`--git-path @` answers `.git/@`, which is nothing - checked, after writing it the
+  wrong way).
+- **And `-dirty` alone is not an identity**, which review caught too and which is this item's own
+  argument one level below the commit: the workflow this exists for is edit, rebuild, evaluate, and
+  two iterations on one `HEAD` would stamp the same string while behaving differently. It carries a
+  digest of the working-tree diff now. The hash is hand-rolled FNV-1a rather than `DefaultHasher`
+  for a reason worth writing down - that one is explicitly not stable across Rust releases, so two
+  machines on different toolchains would tag one working tree two ways, relocating the failure
+  rather than removing it.
 - **The two version assertions had to become prefix checks, and that is a weakening** - so the
   smoke test gained one that is not: built from a git checkout, the version *must* carry a
   revision. Without it a `build.rs` that silently stopped running would leave every assertion
@@ -2463,7 +2476,21 @@ now stamps the short git revision into the version the server reports, as semver
   different instances - a record pairing one model's window with another's digest would be worse
   than either field missing. `served_context()` became `runtime_identity()`.
 - **`--compare` needed the *wording* kept per cell-task**, which `matrix()` did not carry. A task
-  id is not the question, and the record is the only place the wording survives.
+  id is not the question, and the record is the only place the wording survives. Two rounds on that
+  one: the placeholder a dead draw writes already carries `prompt: None`, so a `setdefault` froze
+  the null and `comparable()` then read "no prompt recorded" as "comparable" - pairing two
+  different questions rather than blocking them.
+- **A surface and a served window are per cell, not per run**, so the identity line could not hold
+  them and the first cut simply omitted both. `surface.client` is a *label*: `min` was 11 tools and
+  8,654 B before item 41 and 7,732 B after, so pairing on the label alone presented a surface change
+  as a model comparison - the very intervention these runs exist to measure, silently. And a cell
+  that asks for no window records `num_ctx: null` while the runtime serves what it likes. Both are
+  named per cell beneath the table now, on the same rule as everything else that is not the
+  question: weighable, so named rather than blocking.
+- **A cell-failure note carries no identity and must not contribute one.** `run_cell` writes it
+  with the cell's coordinates and nothing else, so counting it put an `unrecorded` beside the real
+  server a current run *had* recorded - a partially failed cell reading as a second, unknown
+  build.
 
 **Pairing refuses at the task, it does not annotate.** A cell pairs on `(backend, model, ctx,
 surface, task)`, but `arm64_pc` has the same id in `tools/eval_tasks_v1.json` and
@@ -2496,7 +2523,7 @@ yet.
 
 **Verified rather than described.** `/api/ps` carries `digest` beside `context_length`, measured
 against a loaded model rather than read off a document; the live listener's `serverInfo` is
-captured by the driver; the stamp reads the branch head's short revision, and gains `-dirty` after a one-line
+captured by the driver; the stamp reads the branch head's short revision, and gains `-dirty.<digest>` after a one-line
 edit under `src/` — which exercises the rerun trigger and the dirty check together; and `--compare`'s
 blocked-pairing and one-sided-cell paths were run against a doctored log. `cargo test` on the ARM64
 bench: 540 unit tests and 76 smoke tests, no new clippy warning.

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -33,7 +33,7 @@ all twenty-five turned out to be failing at its own wording (2026-08-25, **lande
 and items 45–46 from what closing it opened up: the suite's answer key is a set of facts read off
 the sample dumps that nothing re-checks, so it can rot while every model goes on scoring against
 it, and a run can be graded but not *compared*, because nothing records the model weights or the
-server build it ran against (both 2026-08-25; **item 45 has since landed**, the same day). Each item notes its repo, why it was deferred, and where it picks up. See [`DECISIONS.md`](./DECISIONS.md) for the design rationale (D1–D5) items 1–6 extend,
+server build it ran against (both 2026-08-25, and **both have since landed**, the same day). Each item notes its repo, why it was deferred, and where it picks up. See [`DECISIONS.md`](./DECISIONS.md) for the design rationale (D1–D5) items 1–6 extend,
 and the 2026-08-02 entries that items 13–14 and item 10 extend.
 
 Items are roughly ordered by how soon they're worth doing, within each cluster. **Item 10 has
@@ -64,6 +64,10 @@ which is a judgement nothing has measured, and the entry now records what would 
 that proposed it: `expect` turned out not to be *derivable* from a binding — two of one task's
 groups are phrasings of a relation rather than strings the server prints — a tool with no
 structured half needed a second verb, and the ratchet is the coverage rule rather than any pin.
+**Item 46 has landed** (2026-08-25) and is kept for the decision it deferred and the entry now
+records: this server *does* report a build revision, stamped by a `build.rs` whose watch list and
+dirty check have to be one list or they disagree — which is the sort of thing an entry proposing
+"record a build SHA" cannot see from where it is written.
 
 ## 1. [win-kexp] Managed breakpoint lifecycle for `run_to_address` — **done upstream**
 
@@ -2407,87 +2411,102 @@ deliberately carries **no** binding — it is the wording published logs were gr
 mode refuses it by name rather than skipping it quietly.
 
 
-## 46. [windbg-mcp] A run can be graded but not compared, because nothing records what it ran against
+## 46. [windbg-mcp] A run can be graded but not compared, because nothing records what it ran against — **done** (2026-08-25)
 
 **Re-running a cell is the point, not a hazard.** As models are updated the same question on the
 same surface will be asked again, and what will matter is run N against run N-1 - the frozen suite
 (#220) exists so a *reworded question* cannot silently un-grade its own history, which is a
 different thing from discouraging a rerun. A rerun into a new log with a new plan is exactly what
-this bench is for. What it cannot do today is **compare two of them**.
+this bench is for. What it could not do was **compare two of them**.
 
-**A record identifies the question and the surface, and neither of the two things that change over
-time.** It carries `prompt` (the question identity #220 leaned on), `surface` with its client,
-tool count, byte size and names, plus `served_context`, `seed` and `draw`. It does not carry which
+**A record identified the question and the surface, and neither of the two things that change over
+time.** It carried `prompt` (the question identity #220 leaned on), `surface` with its client, tool
+count, byte size and names, plus `served_context`, `seed` and `draw`. It did not carry which
 *model weights* answered or which *server build* was asked.
 
 - **The model is a mutable tag.** `qwen3.8:27b-mlx` is a name that can be re-pulled onto different
   weights, so two runs a month apart can agree on every recorded field and have been different
   models. This is the axis the whole comparison is about.
-- **The server build is absent entirely.** `surface.bytes` is a real fingerprint of the tool prose
+- **The server build was absent entirely.** `surface.bytes` is a real fingerprint of the tool prose
   and did move when item 41 landed (8,654 -> 7,732 on `min`), but it is a fingerprint of one
   channel: [#217](https://github.com/glslang/windbg-mcp/pull/217) changed an **opener's result**,
-  which no tool-list byte count can see. So the field that looks like a build identity is silent on
-  exactly the channel the last three findings were about.
+  which no tool-list byte count can see. So the field that looked like a build identity was silent
+  on exactly the channel the last three findings were about.
 
-**Both facts are already on the wire and already parsed, and both are thrown away** - which is the
-same shape as the `served_context` lesson and should be read the same way:
+**What closed it.** Identity fields on every record - `server`, `model_digest`, `suite`, and
+`harness_version` for the row that can have no digest - plus `--compare` over two logs and
+`--series` over any number of them. Both facts were already on the wire and both were being thrown
+away: the handshake kept `protocolVersion` and dropped `serverInfo`, and `/api/ps` was read for the
+served window and not for the `digest` beside it.
 
-- `local_model_drive.py:served_context()` calls `/api/ps` and reads `context_length` off the
-  matching entry. That response also carries the model's **`digest`**, which is a content address
-  rather than a name. **This is the ollama rows only**, and the entry should not have implied
-  otherwise: `claude_code_drive.py` records `"model": MODEL` — `opus`, `sonnet` — which are
-  mutable aliases resolved inside a client this bench does not own, and there is no `/api/ps` to
-  ask. So the two control rows keep the ambiguity the digest removes from the other three, and
-  what is available to them (the `claude` CLI version, the alias as written) is a floor rather
-  than an identity. That file already has the right habit for this: its `seed` is `None` with a
-  comment saying why the row cannot have one, which is what a null digest should look like beside
-  it rather than an absent field. Naming a real version source for a Claude row is open, and
-  scoping the claim to what can actually be recorded is the minimum.
-- The handshake at `local_model_drive.py:264` returns `out["result"]["protocolVersion"]` and drops
-  the rest of the `initialize` result - including `serverInfo.version`, which this server does
-  send (`src/server.rs`, `with_server_info(... env!("CARGO_PKG_VERSION") ...)`).
+**And the decision this entry said *was* the item: yes, this server reports a build revision.** A
+crate version is a floor, not an identity - it moves on release, so two builds of `0.11.0` were
+indistinguishable, which is the same trap the service-image warning names in `CLAUDE.md`. `build.rs`
+now stamps the short git revision into the version the server reports, as semver build metadata
+(`0.11.0+g1a2b3c4`, `-dirty` where the build inputs differ from that commit), and the transcript's
+`start` record carries the same string - it had the same weakness and nothing had noticed.
 
-**But the crate version is a floor, not an identity**, and the entry should not pretend otherwise:
-it moves on release, so two builds of one version are indistinguishable - the same trap the
-service-image warning already names in `CLAUDE.md`. Recording it is strictly better than recording
-nothing and is not sufficient; a build SHA would be, and that means deciding whether this server
-reports one. That decision is the item, not the two lines that record what is already there.
+**Four things it needed that this entry did not anticipate.**
 
-**What would close it.** Identity fields on every record - model digest where one exists, server
-version (or SHA), suite id - and a **compare mode** over two logs, with two rules that are not the
-same rule.
+- **A build script that names git files loses Cargo's default of watching the whole package**, so
+  the watch list and the dirty check have to be *the same list* or they disagree: a stamp saying
+  clean on a tree that is not is worse than no stamp. Both read one `INPUTS` const - what actually
+  reaches the binary and its tests - which also gives `-dirty` a meaning that can be stated: the
+  build inputs differ from that commit, and an edit under `docs/` does not make a binary a
+  different binary.
+- **The two version assertions had to become prefix checks, and that is a weakening** - so the
+  smoke test gained one that is not: built from a git checkout, the version *must* carry a
+  revision. Without it a `build.rs` that silently stopped running would leave every assertion
+  passing on the bare crate version, which is the legitimate tarball answer.
+- **The two `/api/ps` facts are one call, not two.** This entry treated the digest as a second
+  field to read; it is the same question about the same live state, and two calls could catch
+  different instances - a record pairing one model's window with another's digest would be worse
+  than either field missing. `served_context()` became `runtime_identity()`.
+- **`--compare` needed the *wording* kept per cell-task**, which `matrix()` did not carry. A task
+  id is not the question, and the record is the only place the wording survives.
 
 **Pairing refuses at the task, it does not annotate.** A cell pairs on `(backend, model, ctx,
-surface, task)`, but a task id is not the question: `arm64_pc` has the same id in
-`tools/eval_tasks_v1.json` and `tools/eval_tasks.json` and a materially different prompt, so
-pairing on id would put two distributions side by side that #220 established are not comparable -
-and would be *weaker than the grader already is*, since `usable()` refuses such a record outright.
-The predicate for this already exists and has a home: `stale_prompt`, split out of `usable` in
-#220 so the reason could be named rather than restated. A compare mode reuses it and renders that
-row as incomparable with the reason, at the row rather than in a header - which is the same
-principle as the `UNCOUNTED` line beside it. (`expect` can move too; a pairing predicate that
-reads only the prompt is a floor.)
+surface, task)`, but `arm64_pc` has the same id in `tools/eval_tasks_v1.json` and
+`tools/eval_tasks.json` and a materially different prompt, so pairing on the id would put two
+distributions side by side that #220 established are not comparable - and would be *weaker than the
+grader already is*, since `usable()` refuses such a record outright. It reuses `stale_prompt`, the
+predicate split out of `usable` in #220 so the reason could be named, and renders the row as `--`
+with that reason beneath the table - the same principle as the `UNCOUNTED` line beside it. It is a
+floor: `expect` can move too, and a pairing predicate that reads only the prompt does not see that.
 
 **The run-identity line is for what is left**, and that is its actual job: the uncontrolled
-variables that are *not* the question - model weights, server build, served window. Naming them
+variables that are *not* the question - model weights, server build, harness, suite. Naming them
 above the table is not a nicety, because this repo has three times read a moved aggregate as a
 controlled result (items 42 and 43, and twice in
 [#212](https://github.com/glslang/windbg-mcp/pull/212)), and every one was a *composition* error -
 the callers changed and the total held. But a note is the right instrument only for a variable a
-reader can weigh. A changed question is not one of those; it blocks the comparison.
+reader can weigh; a changed question is not one of those, which is why the two rules are separate.
 
 **And the reporting is the other half.** `docs/local-model-eval.md` accumulates a prose section per
-run, which reads well and cannot be diffed: the three tables in it measure three different servers,
-which the page says in words and no reader can check. A machine-readable series - one row per run,
-keyed by the identity above - is what makes "comparison with historic data" a query rather than a
-re-reading.
+run, which reads well and cannot be diffed: the tables in it measure different servers, which the
+page says in words and no reader can check. `docs/eval-runs.json` is the machine-readable series,
+one row per run keyed by the identity above, regenerated rather than appended to so a log re-graded
+under a corrected key updates its own row.
 
-**Why deferred.** Nothing already published is wrong, because each write-up names its own server
-build in prose; what is missing is the ability to *check* that, and to do it for a run nobody has
-written up yet. It wants doing before the next model refresh rather than after, since a run
-recorded without identity cannot have it added later - which is the one part of this that expires.
+**The three runs already in that series read `unrecorded` for every identity field**, which is the
+part of this that expires rather than an omission: a run recorded without identity cannot have it
+added later. Nothing already published is wrong - each write-up names its own server build in prose
+- and what was missing is the ability to *check* that, and to do it for a run nobody has written up
+yet.
 
-**Where it picks up.** `tools/local_model_drive.py` - `served_context()` and the handshake, both of
-which already make the call that carries the fact; `tools/local_model_eval.py` for the compare mode
-beside `--grade` and `--matrix`; and `docs/local-model-eval.md` for what a versioned report looks
-like.
+**Verified rather than described.** `/api/ps` carries `digest` beside `context_length`, measured
+against a loaded model rather than read off a document; the live listener's `serverInfo` is
+captured by the driver; the stamp reads the branch head's short revision, and gains `-dirty` after a one-line
+edit under `src/` — which exercises the rerun trigger and the dirty check together; and `--compare`'s
+blocked-pairing and one-sided-cell paths were run against a doctored log. `cargo test` on the ARM64
+bench: 540 unit tests and 76 smoke tests, no new clippy warning.
+
+**Left open.** Naming a real version source for a Claude row. `harness_version` is `claude
+--version`, which moves when the client does and says nothing about the weights behind `opus` or
+`sonnet` - a floor, recorded as one, exactly as the crate version was before `build.rs`.
+
+**Where it picks up.** `build.rs` and `src/main.rs`'s `BUILD_VERSION`;
+`tools/local_model_drive.py` (`handshake`, `runtime_identity`, `load_tasks`) and
+`tools/claude_code_drive.py`; `tools/local_model_eval.py` for `identity`, `--compare` and
+`--series`; and `docs/local-model-eval.md` beside `docs/eval-runs.json`.
+

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,81 @@
+//! Stamps the revision this binary was built from into the version it reports.
+//!
+//! **Why a crate version is not an identity.** `serverInfo.version` and the transcript's `Start`
+//! record both carried `CARGO_PKG_VERSION` and nothing else, so every build between two releases
+//! called itself the same thing — and the changes that matter most to somebody reading a recording
+//! or a bench log are exactly the ones that do not move it.
+//! [#217](https://github.com/glslang/windbg-mcp/pull/217) changed what an *opener's result* says,
+//! which no version, no tool count and no surface byte count can see (`FOLLOWUPS.md` item 46).
+//! A short git revision is a content address for the source, and answers it.
+//!
+//! **The suffix is semver build metadata** (`0.11.0+g1a2b3c4`), which is ignored for precedence, so
+//! nothing that compares versions is affected by its presence — a consumer that wants the release
+//! reads up to the `+`.
+//!
+//! **`-dirty` is scoped to the same paths this asks Cargo to watch, and that is deliberate.** A
+//! build script cannot re-run on "any file changed" and also name the git files it needs, because
+//! emitting one `rerun-if-changed` replaces Cargo's default of watching the whole package. So both
+//! the watch list and the dirty check are the inputs that actually reach the binary and its tests;
+//! an edit to `docs/` leaves the stamp clean, which is true of the *code* this build is, rather
+//! than a staleness bug. The alternative — watching the whole tree — reruns this on every prose
+//! commit for a distinction nothing can act on.
+//!
+//! Absent git, an unpacked tarball, or a `git` that fails for any reason: the variable is empty and
+//! the reported version is the bare crate version. A build must never fail over telemetry.
+
+use std::path::Path;
+use std::process::Command;
+
+/// The build inputs: what goes into the binary or the tests, and nothing else. Both the watch list
+/// and the dirty check read this, so the two cannot disagree about what a clean build is.
+const INPUTS: [&str; 5] = ["src", "tests", "build.rs", "Cargo.toml", "Cargo.lock"];
+
+fn main() {
+    for input in INPUTS {
+        println!("cargo::rerun-if-changed={input}");
+    }
+    // `HEAD` moves on a commit and on a checkout; the ref it names moves when the branch does, which
+    // is what a `git commit` on the current branch changes without touching `HEAD` itself. Watching
+    // only the first would keep a stale revision through every commit made on one branch.
+    println!("cargo::rerun-if-changed=.git/HEAD");
+    if let Some(head_ref) = head_ref() {
+        println!("cargo::rerun-if-changed=.git/{head_ref}");
+    }
+    println!(
+        "cargo::rustc-env=WINDBG_MCP_BUILD={}",
+        revision().unwrap_or_default()
+    );
+}
+
+/// The ref `HEAD` points at, or `None` on a detached head — where there is no second file to watch
+/// and `HEAD` itself already holds the revision.
+fn head_ref() -> Option<String> {
+    let head = std::fs::read_to_string(".git/HEAD").ok()?;
+    let named = head.trim().strip_prefix("ref: ")?.to_string();
+    // A packed ref has no file of its own, so watching it would name a path that does not exist.
+    Path::new(".git").join(&named).exists().then_some(named)
+}
+
+/// `g<short sha>`, plus `-dirty` when the build inputs differ from it.
+///
+/// The `g` prefix is `git describe`'s own convention for "the thing after this is a git revision",
+/// and it keeps the suffix from being read as a number by anything scanning a version string.
+fn revision() -> Option<String> {
+    let short = git(&["rev-parse", "--short=8", "HEAD"])?;
+    // Scoped to [`INPUTS`] rather than to the whole tree — see the module comment. `--porcelain`
+    // prints one line per changed path and nothing at all when there are none, which is the only
+    // thing this needs to know.
+    let mut status = vec!["status", "--porcelain", "--"];
+    status.extend(INPUTS);
+    let dirty = git(&status).is_some_and(|out| !out.is_empty());
+    Some(format!("g{short}{}", if dirty { "-dirty" } else { "" }))
+}
+
+/// One git invocation, or `None` if git is missing, this is not a repository, or it failed. Never
+/// an error: a build that cannot describe itself still builds.
+fn git(args: &[&str]) -> Option<String> {
+    let out = Command::new("git").args(args).output().ok()?;
+    out.status
+        .success()
+        .then(|| String::from_utf8_lossy(&out.stdout).trim().to_string())
+}

--- a/build.rs
+++ b/build.rs
@@ -20,26 +20,41 @@
 //! than a staleness bug. The alternative — watching the whole tree — reruns this on every prose
 //! commit for a distinction nothing can act on.
 //!
+//! **And a dirty build carries a digest of what makes it dirty**, because `-dirty` alone is not an
+//! identity: the workflow this exists for is edit, rebuild, evaluate, and two iterations on one
+//! `HEAD` would otherwise stamp the same string while behaving differently — the exact confusion
+//! the whole item is about, one level below the commit. The digest is over `git diff HEAD` for
+//! those same inputs, so it is stable for a given working tree and different for any other.
+//!
 //! Absent git, an unpacked tarball, or a `git` that fails for any reason: the variable is empty and
 //! the reported version is the bare crate version. A build must never fail over telemetry.
 
-use std::path::Path;
 use std::process::Command;
 
-/// The build inputs: what goes into the binary or the tests, and nothing else. Both the watch list
-/// and the dirty check read this, so the two cannot disagree about what a clean build is.
+/// The build inputs: what goes into the binary or the tests, and nothing else. The watch list, the
+/// dirty check and the dirty digest all read this, so they cannot disagree about what a build is.
 const INPUTS: [&str; 5] = ["src", "tests", "build.rs", "Cargo.toml", "Cargo.lock"];
 
 fn main() {
     for input in INPUTS {
         println!("cargo::rerun-if-changed={input}");
     }
-    // `HEAD` moves on a commit and on a checkout; the ref it names moves when the branch does, which
-    // is what a `git commit` on the current branch changes without touching `HEAD` itself. Watching
-    // only the first would keep a stale revision through every commit made on one branch.
-    println!("cargo::rerun-if-changed=.git/HEAD");
-    if let Some(head_ref) = head_ref() {
-        println!("cargo::rerun-if-changed=.git/{head_ref}");
+    // `HEAD` moves on a commit and on a checkout; the ref it names moves when the branch does,
+    // which is what a `git commit` on the current branch changes without touching `HEAD` itself.
+    // Watching only the first would keep a stale revision through every commit made on one branch.
+    //
+    // **Resolved through git rather than assembled from `.git/`**, because `.git` is not always a
+    // directory: a `git worktree` checkout has a *file* there pointing at the real git directory,
+    // so a literal `.git/HEAD` names a path that does not exist — and Cargo treats a watched path
+    // that is missing as changed, re-running this script and recompiling the crate on every
+    // otherwise no-op build. `--git-path` answers with the real location in every layout.
+    let head_ref = git(&["symbolic-ref", "-q", "HEAD"]);
+    for path in ["HEAD"]
+        .into_iter()
+        .chain(head_ref.as_deref())
+        .filter_map(git_path)
+    {
+        println!("cargo::rerun-if-changed={path}");
     }
     println!(
         "cargo::rustc-env=WINDBG_MCP_BUILD={}",
@@ -47,28 +62,56 @@ fn main() {
     );
 }
 
-/// The ref `HEAD` points at, or `None` on a detached head — where there is no second file to watch
-/// and `HEAD` itself already holds the revision.
-fn head_ref() -> Option<String> {
-    let head = std::fs::read_to_string(".git/HEAD").ok()?;
-    let named = head.trim().strip_prefix("ref: ")?.to_string();
-    // A packed ref has no file of its own, so watching it would name a path that does not exist.
-    Path::new(".git").join(&named).exists().then_some(named)
+/// Where git keeps one of its own files, if that file exists.
+///
+/// The argument is a path **relative to the git directory**, not a revision — `--git-path @`
+/// answers `.git/@`, which is nothing, so the branch's own file is found by asking
+/// `symbolic-ref` for the ref name first. A detached head has no such ref (and `symbolic-ref -q`
+/// says so by failing), and a branch whose ref is *packed* has no file: `--git-path` answers with
+/// a path either way, and the `exists` check is what keeps a nonexistent one out of the watch
+/// list, where Cargo would read it as perpetually changed.
+fn git_path(spec: &str) -> Option<String> {
+    let path = git(&["rev-parse", "--git-path", spec])?;
+    std::path::Path::new(&path).exists().then_some(path)
 }
 
-/// `g<short sha>`, plus `-dirty` when the build inputs differ from it.
+/// `g<short sha>`, plus `-dirty.<digest>` when the build inputs differ from it.
 ///
 /// The `g` prefix is `git describe`'s own convention for "the thing after this is a git revision",
 /// and it keeps the suffix from being read as a number by anything scanning a version string.
 fn revision() -> Option<String> {
     let short = git(&["rev-parse", "--short=8", "HEAD"])?;
-    // Scoped to [`INPUTS`] rather than to the whole tree — see the module comment. `--porcelain`
-    // prints one line per changed path and nothing at all when there are none, which is the only
-    // thing this needs to know.
-    let mut status = vec!["status", "--porcelain", "--"];
-    status.extend(INPUTS);
-    let dirty = git(&status).is_some_and(|out| !out.is_empty());
-    Some(format!("g{short}{}", if dirty { "-dirty" } else { "" }))
+    // Scoped to [`INPUTS`] rather than to the whole tree — see the module comment. The diff is
+    // asked for directly rather than `status --porcelain` first: empty output is the same answer
+    // to "is anything different", and a non-empty one is what the digest is taken over.
+    let mut diff = vec!["diff", "HEAD", "--"];
+    diff.extend(INPUTS);
+    Some(match git(&diff) {
+        // Clean: this build *is* that commit, and says so with nothing after it.
+        Some(changes) if changes.is_empty() => format!("g{short}"),
+        Some(changes) => format!("g{short}-dirty.{:08x}", fingerprint(&changes)),
+        // The diff itself failed, which `rev-parse` succeeding makes exotic — but "could not tell"
+        // must not be spelled the same way as "clean", since the bare form is a claim that this
+        // build is exactly that commit.
+        None => format!("g{short}-unknown"),
+    })
+}
+
+/// A 32-bit FNV-1a of the working-tree diff — an identity tag, not a digest anybody should trust
+/// against an adversary.
+///
+/// Hand-rolled because this crate has no build dependencies and a build script is the wrong place
+/// to gain one for eight lines. `DefaultHasher` would have been the obvious alternative and is
+/// wrong here for a reason worth writing down: its output is explicitly not stable across Rust
+/// releases, so two machines on different toolchains would tag one working tree two ways — which
+/// is the failure this is meant to remove rather than relocate.
+fn fingerprint(text: &str) -> u32 {
+    let mut hash: u32 = 0x811c_9dc5;
+    for byte in text.as_bytes() {
+        hash ^= u32::from(*byte);
+        hash = hash.wrapping_mul(0x0100_0193);
+    }
+    hash
 }
 
 /// One git invocation, or `None` if git is missing, this is not a repository, or it failed. Never

--- a/docs/eval-runs.json
+++ b/docs/eval-runs.json
@@ -45,9 +45,7 @@
         "possible": 4,
         "taught": 0,
         "wanted": 3,
-        "window": [],
-        "weights": [],
-        "server": [],
+        "served_context": null,
         "surface_digest": []
       },
       {
@@ -61,9 +59,7 @@
         "possible": 4,
         "taught": 0,
         "wanted": 1,
-        "window": [],
-        "weights": [],
-        "server": [],
+        "served_context": null,
         "surface_digest": []
       },
       {
@@ -77,11 +73,7 @@
         "possible": 4,
         "taught": 4,
         "wanted": 5,
-        "window": [
-          "262144"
-        ],
-        "weights": [],
-        "server": [],
+        "served_context": 262144,
         "surface_digest": []
       },
       {
@@ -95,11 +87,7 @@
         "possible": 4,
         "taught": 0,
         "wanted": 1,
-        "window": [
-          "262144"
-        ],
-        "weights": [],
-        "server": [],
+        "served_context": 262144,
         "surface_digest": []
       },
       {
@@ -113,11 +101,7 @@
         "possible": 4,
         "taught": 0,
         "wanted": 0,
-        "window": [
-          "262144"
-        ],
-        "weights": [],
-        "server": [],
+        "served_context": 262144,
         "surface_digest": []
       }
     ]
@@ -168,9 +152,7 @@
         "possible": 4,
         "taught": 0,
         "wanted": 1,
-        "window": [],
-        "weights": [],
-        "server": [],
+        "served_context": null,
         "surface_digest": []
       },
       {
@@ -184,9 +166,7 @@
         "possible": 4,
         "taught": 0,
         "wanted": 0,
-        "window": [],
-        "weights": [],
-        "server": [],
+        "served_context": null,
         "surface_digest": []
       },
       {
@@ -200,11 +180,7 @@
         "possible": 4,
         "taught": 0,
         "wanted": 4,
-        "window": [
-          "262144"
-        ],
-        "weights": [],
-        "server": [],
+        "served_context": 262144,
         "surface_digest": []
       },
       {
@@ -218,11 +194,7 @@
         "possible": 4,
         "taught": 0,
         "wanted": 0,
-        "window": [
-          "262144"
-        ],
-        "weights": [],
-        "server": [],
+        "served_context": 262144,
         "surface_digest": []
       },
       {
@@ -236,11 +208,7 @@
         "possible": 4,
         "taught": 0,
         "wanted": 1,
-        "window": [
-          "262144"
-        ],
-        "weights": [],
-        "server": [],
+        "served_context": 262144,
         "surface_digest": []
       }
     ]
@@ -291,9 +259,7 @@
         "possible": 20,
         "taught": 0,
         "wanted": 1,
-        "window": [],
-        "weights": [],
-        "server": [],
+        "served_context": null,
         "surface_digest": []
       },
       {
@@ -307,9 +273,7 @@
         "possible": 20,
         "taught": 0,
         "wanted": 0,
-        "window": [],
-        "weights": [],
-        "server": [],
+        "served_context": null,
         "surface_digest": []
       },
       {
@@ -323,11 +287,7 @@
         "possible": 20,
         "taught": 0,
         "wanted": 15,
-        "window": [
-          "262144"
-        ],
-        "weights": [],
-        "server": [],
+        "served_context": 262144,
         "surface_digest": []
       },
       {
@@ -341,11 +301,7 @@
         "possible": 20,
         "taught": 0,
         "wanted": 0,
-        "window": [
-          "262144"
-        ],
-        "weights": [],
-        "server": [],
+        "served_context": 262144,
         "surface_digest": []
       },
       {
@@ -359,11 +315,7 @@
         "possible": 20,
         "taught": 0,
         "wanted": 0,
-        "window": [
-          "262144"
-        ],
-        "weights": [],
-        "server": [],
+        "served_context": 262144,
         "surface_digest": []
       }
     ]

--- a/docs/eval-runs.json
+++ b/docs/eval-runs.json
@@ -45,7 +45,10 @@
         "possible": 4,
         "taught": 0,
         "wanted": 3,
-        "served_context": null
+        "window": [],
+        "weights": [],
+        "server": [],
+        "surface_digest": []
       },
       {
         "backend": "claude-code",
@@ -58,7 +61,10 @@
         "possible": 4,
         "taught": 0,
         "wanted": 1,
-        "served_context": null
+        "window": [],
+        "weights": [],
+        "server": [],
+        "surface_digest": []
       },
       {
         "backend": "ollama",
@@ -71,7 +77,12 @@
         "possible": 4,
         "taught": 4,
         "wanted": 5,
-        "served_context": 262144
+        "window": [
+          "262144"
+        ],
+        "weights": [],
+        "server": [],
+        "surface_digest": []
       },
       {
         "backend": "ollama",
@@ -84,7 +95,12 @@
         "possible": 4,
         "taught": 0,
         "wanted": 1,
-        "served_context": 262144
+        "window": [
+          "262144"
+        ],
+        "weights": [],
+        "server": [],
+        "surface_digest": []
       },
       {
         "backend": "ollama",
@@ -97,7 +113,12 @@
         "possible": 4,
         "taught": 0,
         "wanted": 0,
-        "served_context": 262144
+        "window": [
+          "262144"
+        ],
+        "weights": [],
+        "server": [],
+        "surface_digest": []
       }
     ]
   },
@@ -147,7 +168,10 @@
         "possible": 4,
         "taught": 0,
         "wanted": 1,
-        "served_context": null
+        "window": [],
+        "weights": [],
+        "server": [],
+        "surface_digest": []
       },
       {
         "backend": "claude-code",
@@ -160,7 +184,10 @@
         "possible": 4,
         "taught": 0,
         "wanted": 0,
-        "served_context": null
+        "window": [],
+        "weights": [],
+        "server": [],
+        "surface_digest": []
       },
       {
         "backend": "ollama",
@@ -173,7 +200,12 @@
         "possible": 4,
         "taught": 0,
         "wanted": 4,
-        "served_context": 262144
+        "window": [
+          "262144"
+        ],
+        "weights": [],
+        "server": [],
+        "surface_digest": []
       },
       {
         "backend": "ollama",
@@ -186,7 +218,12 @@
         "possible": 4,
         "taught": 0,
         "wanted": 0,
-        "served_context": 262144
+        "window": [
+          "262144"
+        ],
+        "weights": [],
+        "server": [],
+        "surface_digest": []
       },
       {
         "backend": "ollama",
@@ -199,7 +236,12 @@
         "possible": 4,
         "taught": 0,
         "wanted": 1,
-        "served_context": 262144
+        "window": [
+          "262144"
+        ],
+        "weights": [],
+        "server": [],
+        "surface_digest": []
       }
     ]
   },
@@ -249,7 +291,10 @@
         "possible": 20,
         "taught": 0,
         "wanted": 1,
-        "served_context": null
+        "window": [],
+        "weights": [],
+        "server": [],
+        "surface_digest": []
       },
       {
         "backend": "claude-code",
@@ -262,7 +307,10 @@
         "possible": 20,
         "taught": 0,
         "wanted": 0,
-        "served_context": null
+        "window": [],
+        "weights": [],
+        "server": [],
+        "surface_digest": []
       },
       {
         "backend": "ollama",
@@ -275,7 +323,12 @@
         "possible": 20,
         "taught": 0,
         "wanted": 15,
-        "served_context": 262144
+        "window": [
+          "262144"
+        ],
+        "weights": [],
+        "server": [],
+        "surface_digest": []
       },
       {
         "backend": "ollama",
@@ -288,7 +341,12 @@
         "possible": 20,
         "taught": 0,
         "wanted": 0,
-        "served_context": 262144
+        "window": [
+          "262144"
+        ],
+        "weights": [],
+        "server": [],
+        "surface_digest": []
       },
       {
         "backend": "ollama",
@@ -301,7 +359,12 @@
         "possible": 20,
         "taught": 0,
         "wanted": 0,
-        "served_context": 262144
+        "window": [
+          "262144"
+        ],
+        "weights": [],
+        "server": [],
+        "surface_digest": []
       }
     ]
   }

--- a/docs/eval-runs.json
+++ b/docs/eval-runs.json
@@ -1,0 +1,308 @@
+[
+  {
+    "log": "after-206.jsonl",
+    "identity": {
+      "run": [
+        "2026-08-24-after-206"
+      ],
+      "suite": [
+        "unrecorded"
+      ],
+      "server": [
+        "unrecorded"
+      ],
+      "harness": [
+        "unrecorded"
+      ],
+      "weights": {
+        "gemma4:31b-mlx": [
+          "unrecorded"
+        ],
+        "nemotron-3.5-lightning:30b-mlx": [
+          "unrecorded"
+        ],
+        "opus": [
+          "unrecorded"
+        ],
+        "qwen3.8:27b-mlx": [
+          "unrecorded"
+        ],
+        "sonnet": [
+          "unrecorded"
+        ]
+      }
+    },
+    "graded_against": "eval_tasks_v1.json",
+    "cells": [
+      {
+        "backend": "claude-code",
+        "model": "opus",
+        "num_ctx": null,
+        "surface": "min",
+        "tools": 11,
+        "draws": 1,
+        "correct_of_possible": 3,
+        "possible": 4,
+        "taught": 0,
+        "wanted": 3,
+        "served_context": null
+      },
+      {
+        "backend": "claude-code",
+        "model": "sonnet",
+        "num_ctx": null,
+        "surface": "min",
+        "tools": 11,
+        "draws": 1,
+        "correct_of_possible": 3,
+        "possible": 4,
+        "taught": 0,
+        "wanted": 1,
+        "served_context": null
+      },
+      {
+        "backend": "ollama",
+        "model": "gemma4:31b-mlx",
+        "num_ctx": 262144,
+        "surface": "min",
+        "tools": 11,
+        "draws": 1,
+        "correct_of_possible": 3,
+        "possible": 4,
+        "taught": 4,
+        "wanted": 5,
+        "served_context": 262144
+      },
+      {
+        "backend": "ollama",
+        "model": "nemotron-3.5-lightning:30b-mlx",
+        "num_ctx": 262144,
+        "surface": "min",
+        "tools": 11,
+        "draws": 1,
+        "correct_of_possible": 3,
+        "possible": 4,
+        "taught": 0,
+        "wanted": 1,
+        "served_context": 262144
+      },
+      {
+        "backend": "ollama",
+        "model": "qwen3.8:27b-mlx",
+        "num_ctx": 262144,
+        "surface": "min",
+        "tools": 11,
+        "draws": 1,
+        "correct_of_possible": 2,
+        "possible": 4,
+        "taught": 0,
+        "wanted": 0,
+        "served_context": 262144
+      }
+    ]
+  },
+  {
+    "log": "after-210.jsonl",
+    "identity": {
+      "run": [
+        "2026-08-24-after-210"
+      ],
+      "suite": [
+        "unrecorded"
+      ],
+      "server": [
+        "unrecorded"
+      ],
+      "harness": [
+        "unrecorded"
+      ],
+      "weights": {
+        "gemma4:31b-mlx": [
+          "unrecorded"
+        ],
+        "nemotron-3.5-lightning:30b-mlx": [
+          "unrecorded"
+        ],
+        "opus": [
+          "unrecorded"
+        ],
+        "qwen3.8:27b-mlx": [
+          "unrecorded"
+        ],
+        "sonnet": [
+          "unrecorded"
+        ]
+      }
+    },
+    "graded_against": "eval_tasks_v1.json",
+    "cells": [
+      {
+        "backend": "claude-code",
+        "model": "opus",
+        "num_ctx": null,
+        "surface": "min",
+        "tools": 11,
+        "draws": 1,
+        "correct_of_possible": 3,
+        "possible": 4,
+        "taught": 0,
+        "wanted": 1,
+        "served_context": null
+      },
+      {
+        "backend": "claude-code",
+        "model": "sonnet",
+        "num_ctx": null,
+        "surface": "min",
+        "tools": 11,
+        "draws": 1,
+        "correct_of_possible": 3,
+        "possible": 4,
+        "taught": 0,
+        "wanted": 0,
+        "served_context": null
+      },
+      {
+        "backend": "ollama",
+        "model": "gemma4:31b-mlx",
+        "num_ctx": 262144,
+        "surface": "min",
+        "tools": 11,
+        "draws": 1,
+        "correct_of_possible": 3,
+        "possible": 4,
+        "taught": 0,
+        "wanted": 4,
+        "served_context": 262144
+      },
+      {
+        "backend": "ollama",
+        "model": "nemotron-3.5-lightning:30b-mlx",
+        "num_ctx": 262144,
+        "surface": "min",
+        "tools": 11,
+        "draws": 1,
+        "correct_of_possible": 2,
+        "possible": 4,
+        "taught": 0,
+        "wanted": 0,
+        "served_context": 262144
+      },
+      {
+        "backend": "ollama",
+        "model": "qwen3.8:27b-mlx",
+        "num_ctx": 262144,
+        "surface": "min",
+        "tools": 11,
+        "draws": 1,
+        "correct_of_possible": 3,
+        "possible": 4,
+        "taught": 0,
+        "wanted": 1,
+        "served_context": 262144
+      }
+    ]
+  },
+  {
+    "log": "after-217.jsonl",
+    "identity": {
+      "run": [
+        "2026-08-25 after #217: the five min cells, five draws each"
+      ],
+      "suite": [
+        "unrecorded"
+      ],
+      "server": [
+        "unrecorded"
+      ],
+      "harness": [
+        "unrecorded"
+      ],
+      "weights": {
+        "gemma4:31b-mlx": [
+          "unrecorded"
+        ],
+        "nemotron-3.5-lightning:30b-mlx": [
+          "unrecorded"
+        ],
+        "opus": [
+          "unrecorded"
+        ],
+        "qwen3.8:27b-mlx": [
+          "unrecorded"
+        ],
+        "sonnet": [
+          "unrecorded"
+        ]
+      }
+    },
+    "graded_against": "eval_tasks_v1.json",
+    "cells": [
+      {
+        "backend": "claude-code",
+        "model": "opus",
+        "num_ctx": null,
+        "surface": "min",
+        "tools": 11,
+        "draws": 5,
+        "correct_of_possible": 14,
+        "possible": 20,
+        "taught": 0,
+        "wanted": 1,
+        "served_context": null
+      },
+      {
+        "backend": "claude-code",
+        "model": "sonnet",
+        "num_ctx": null,
+        "surface": "min",
+        "tools": 11,
+        "draws": 5,
+        "correct_of_possible": 15,
+        "possible": 20,
+        "taught": 0,
+        "wanted": 0,
+        "served_context": null
+      },
+      {
+        "backend": "ollama",
+        "model": "gemma4:31b-mlx",
+        "num_ctx": 262144,
+        "surface": "min",
+        "tools": 11,
+        "draws": 5,
+        "correct_of_possible": 15,
+        "possible": 20,
+        "taught": 0,
+        "wanted": 15,
+        "served_context": 262144
+      },
+      {
+        "backend": "ollama",
+        "model": "nemotron-3.5-lightning:30b-mlx",
+        "num_ctx": 262144,
+        "surface": "min",
+        "tools": 11,
+        "draws": 5,
+        "correct_of_possible": 13,
+        "possible": 20,
+        "taught": 0,
+        "wanted": 0,
+        "served_context": 262144
+      },
+      {
+        "backend": "ollama",
+        "model": "qwen3.8:27b-mlx",
+        "num_ctx": 262144,
+        "surface": "min",
+        "tools": 11,
+        "draws": 5,
+        "correct_of_possible": 14,
+        "possible": 20,
+        "taught": 0,
+        "wanted": 0,
+        "served_context": 262144
+      }
+    ]
+  }
+]

--- a/docs/local-model-eval.md
+++ b/docs/local-model-eval.md
@@ -537,13 +537,13 @@ lines that appear when something did move were checked against a log doctored to
   follows. It is a floor: `expect` can move too, and a pairing predicate reading only the prompt
   catches the change the frozen suite was about and not every change there could be.
 - **Everything else is named.** The build, the weights, the harness and the suite go *above* the
-  table, being run-wide; the **surface fingerprint, the served window and the weights** go
-  *beneath* it, being per cell — the identity block's `weights` line is a run-wide set, and a set
-  cannot say which digest answered which cell, so two runs assigning the same two digests to
-  opposite cells compare equal there. The **build** is per cell for the same reason: a log is
-  append-only and a plan resumes, so a run can legitimately span a rebuild. Those per-cell
-  conditions travel into the series too, beside each cell's score, or a historical row holding two
-  digests could not attribute its own numbers. `surface.client` is a label — `min` was 11 tools and 8,654 B before item 41 and 7,732 B
+  table, being run-wide; the **surface fingerprint and the served window** go *beneath* it, being
+  per cell — the grid varies both deliberately, cell by cell, every run. The weights and the build
+  stay run-wide on purpose: a set cannot say which digest answered which cell, but reaching that
+  state needs a model re-pulled while a run holds it, or a run spanning a rebuild of the server,
+  and neither happens here — the second would invalidate the run outright. The identity line
+  already reports a model answering under two digests, which is the form that would actually
+  take. `surface.client` is a label — `min` was 11 tools and 8,654 B before item 41 and 7,732 B
   after — so pairing on the label alone would present a surface change as a model comparison, which
   is the very intervention a rerun exists to measure. The fingerprint is a **digest of the surface
   as it went over the wire**, not its length: a byte count moves for almost any prose edit and for

--- a/docs/local-model-eval.md
+++ b/docs/local-model-eval.md
@@ -546,7 +546,8 @@ lines that appear when something did move were checked against a log doctored to
   nothing had happened. Adopting the digest is not itself a change, so a comparison across that
   rollout falls back to what both runs recorded and reports the surface as **unverifiable** rather
   than as moved — a match on count and length with no digest on one side cannot rule out the very
-  edit the digest exists to see. Naming them is not a nicety: this repo has three times read a moved
+  edit the digest exists to see. Where *neither* side has one, that is true of every cell equally
+  and is said once beneath the table rather than on every row. Naming them is not a nicety: this repo has three times read a moved
   aggregate as a controlled result, and every one was a **composition** error, where the callers
   changed and the total held.
 

--- a/docs/local-model-eval.md
+++ b/docs/local-model-eval.md
@@ -540,9 +540,16 @@ lines that appear when something did move were checked against a log doctored to
   table, being run-wide; the **surface fingerprint and the served window** go *beneath* it, being
   per cell. `surface.client` is a label — `min` was 11 tools and 8,654 B before item 41 and 7,732 B
   after — so pairing on the label alone would present a surface change as a model comparison, which
-  is the very intervention a rerun exists to measure. Naming them is not a nicety: this repo has
-  three times read a moved aggregate as a controlled result, and every one was a **composition**
-  error, where the callers changed and the total held.
+  is the very intervention a rerun exists to measure. The fingerprint is a **digest of the surface
+  as it went over the wire**, not its length: a byte count moves for almost any prose edit and for
+  none reliably, so a same-length reword or an equal-sized allowlist swap would leave it saying
+  nothing had happened. Naming them is not a nicety: this repo has three times read a moved
+  aggregate as a controlled result, and every one was a **composition** error, where the callers
+  changed and the total held.
+
+  Run against the two published logs it reports one immediately — `min` was 15,544 B in
+  `after-206` and 14,606 B in `after-210` — which is a difference those two write-ups compared
+  across without either of them saying so.
 
 **And a series, so history is a query rather than a re-reading.** This page accumulates a prose
 section per run, which reads well and cannot be diffed — the tables in it measure different
@@ -555,8 +562,14 @@ python3 tools/local_model_eval.py --series eval-out/*.jsonl tools/eval_tasks_v1.
   -o docs/eval-runs.json
 ```
 
-The three runs already in it read `unrecorded` for every identity field, and that is the point
-rather than an omission: **a run recorded without identity cannot have it added later.** Each of
+`unrecorded` and `unavailable` are kept apart, which matters more than it looks: the first means
+nobody recorded the field and now nobody can, while the second is a row that has no such answer to
+give — a Claude cell's `model_digest`, since `opus` is an alias resolved inside a client this bench
+does not own. Folding them together would label every current run containing a Claude cell as a
+legacy log.
+
+The three runs already in the series read `unrecorded` for every identity field, and that is the
+point rather than an omission: **a run recorded without identity cannot have it added later.** Each of
 those write-ups names its own server build in prose, which is why nothing published is wrong; what
 was missing was any way to *check* it, and to do it for a run nobody has written up yet.
 

--- a/docs/local-model-eval.md
+++ b/docs/local-model-eval.md
@@ -540,7 +540,10 @@ lines that appear when something did move were checked against a log doctored to
   table, being run-wide; the **surface fingerprint, the served window and the weights** go
   *beneath* it, being per cell — the identity block's `weights` line is a run-wide set, and a set
   cannot say which digest answered which cell, so two runs assigning the same two digests to
-  opposite cells compare equal there. `surface.client` is a label — `min` was 11 tools and 8,654 B before item 41 and 7,732 B
+  opposite cells compare equal there. The **build** is per cell for the same reason: a log is
+  append-only and a plan resumes, so a run can legitimately span a rebuild. Those per-cell
+  conditions travel into the series too, beside each cell's score, or a historical row holding two
+  digests could not attribute its own numbers. `surface.client` is a label — `min` was 11 tools and 8,654 B before item 41 and 7,732 B
   after — so pairing on the label alone would present a surface change as a model comparison, which
   is the very intervention a rerun exists to measure. The fingerprint is a **digest of the surface
   as it went over the wire**, not its length: a byte count moves for almost any prose edit and for

--- a/docs/local-model-eval.md
+++ b/docs/local-model-eval.md
@@ -471,7 +471,7 @@ time. So every record now also carries:
 
 | Field | What it settles | Where it comes from |
 | --- | --- | --- |
-| `server` | which **build** answered — `windbg-mcp 0.11.0+g1a2b3c4` | the `initialize` result, which the handshake used to discard |
+| `server` | which **build** answered — `windbg-mcp 0.11.0+g1a2b3c4`, with `-dirty.<digest>` telling two uncommitted iterations apart | the `initialize` result, which the handshake used to discard |
 | `model_digest` | which **weights** answered, behind a mutable tag | `/api/ps`, beside the window it already reported |
 | `harness_version` | the Claude row's floor: what resolved the alias | `claude --version` |
 | `suite` | which task list the questions came from | the file the driver loaded |
@@ -509,6 +509,14 @@ qwen3.8:27b-mlx 262144 min           n -> Y    Y -> Y        Y -> Y        - -> 
 old -> new per cell-task; `(old)`/`(new)` is a cell only one run covered.
 ```
 
+A per-cell move, when there is one, prints under that legend:
+
+```text
+cells where something besides the question moved:
+  qwen3.8:27b-mlx 262144 min               surface 11 tools, 14606 B -> 11 tools, 7732 B
+  gemma4:31b-mlx 262144 min                window 262144 -> 32768
+```
+
 Those two runs were recorded before the identity fields existed, so nothing above the table names a
 moved variable — which is exactly what a pair of logs written today would not look like. The two
 lines that appear when something did move were checked against a log doctored to move them:
@@ -528,9 +536,12 @@ lines that appear when something did move were checked against a log doctored to
   printed at the **row** with its reason, which is the principle the `UNCOUNTED` line beside it
   follows. It is a floor: `expect` can move too, and a pairing predicate reading only the prompt
   catches the change the frozen suite was about and not every change there could be.
-- **Everything else is named above the table.** The build, the weights, the harness, the suite —
-  the uncontrolled variables that are *not* the question. Naming them is not a nicety: this repo
-  has three times read a moved aggregate as a controlled result, and every one was a **composition**
+- **Everything else is named.** The build, the weights, the harness and the suite go *above* the
+  table, being run-wide; the **surface fingerprint and the served window** go *beneath* it, being
+  per cell. `surface.client` is a label — `min` was 11 tools and 8,654 B before item 41 and 7,732 B
+  after — so pairing on the label alone would present a surface change as a model comparison, which
+  is the very intervention a rerun exists to measure. Naming them is not a nicety: this repo has
+  three times read a moved aggregate as a controlled result, and every one was a **composition**
   error, where the callers changed and the total held.
 
 **And a series, so history is a query rather than a re-reading.** This page accumulates a prose

--- a/docs/local-model-eval.md
+++ b/docs/local-model-eval.md
@@ -543,7 +543,10 @@ lines that appear when something did move were checked against a log doctored to
   is the very intervention a rerun exists to measure. The fingerprint is a **digest of the surface
   as it went over the wire**, not its length: a byte count moves for almost any prose edit and for
   none reliably, so a same-length reword or an equal-sized allowlist swap would leave it saying
-  nothing had happened. Naming them is not a nicety: this repo has three times read a moved
+  nothing had happened. Adopting the digest is not itself a change, so a comparison across that
+  rollout falls back to what both runs recorded and reports the surface as **unverifiable** rather
+  than as moved — a match on count and length with no digest on one side cannot rule out the very
+  edit the digest exists to see. Naming them is not a nicety: this repo has three times read a moved
   aggregate as a controlled result, and every one was a **composition** error, where the callers
   changed and the total held.
 

--- a/docs/local-model-eval.md
+++ b/docs/local-model-eval.md
@@ -537,8 +537,10 @@ lines that appear when something did move were checked against a log doctored to
   follows. It is a floor: `expect` can move too, and a pairing predicate reading only the prompt
   catches the change the frozen suite was about and not every change there could be.
 - **Everything else is named.** The build, the weights, the harness and the suite go *above* the
-  table, being run-wide; the **surface fingerprint and the served window** go *beneath* it, being
-  per cell. `surface.client` is a label — `min` was 11 tools and 8,654 B before item 41 and 7,732 B
+  table, being run-wide; the **surface fingerprint, the served window and the weights** go
+  *beneath* it, being per cell — the identity block's `weights` line is a run-wide set, and a set
+  cannot say which digest answered which cell, so two runs assigning the same two digests to
+  opposite cells compare equal there. `surface.client` is a label — `min` was 11 tools and 8,654 B before item 41 and 7,732 B
   after — so pairing on the label alone would present a surface change as a model comparison, which
   is the very intervention a rerun exists to measure. The fingerprint is a **digest of the surface
   as it went over the wire**, not its length: a byte count moves for almost any prose edit and for

--- a/docs/local-model-eval.md
+++ b/docs/local-model-eval.md
@@ -459,6 +459,96 @@ prompted it — did `open_dump`'s description ever contribute to a `modules` cal
 worth the runtime: that sentence is gone either way, and the fix never depended on which of the two
 channels carried it.
 
+### Comparing two runs, which needs a run to say what it ran against
+
+**Re-running a cell is the point, not a hazard.** As models are updated the same question on the
+same surface will be asked again, and what will matter is run N against run N-1. The frozen suite
+exists so a *reworded question* cannot silently un-grade its own history — a different thing from
+discouraging a rerun. What this bench could not do until now was **compare two of them**.
+
+A record identified the question and the surface, and neither of the two things that change over
+time. So every record now also carries:
+
+| Field | What it settles | Where it comes from |
+| --- | --- | --- |
+| `server` | which **build** answered — `windbg-mcp 0.11.0+g1a2b3c4` | the `initialize` result, which the handshake used to discard |
+| `model_digest` | which **weights** answered, behind a mutable tag | `/api/ps`, beside the window it already reported |
+| `harness_version` | the Claude row's floor: what resolved the alias | `claude --version` |
+| `suite` | which task list the questions came from | the file the driver loaded |
+
+**The build is the one that had to be added on the server side.** `surface.bytes` is a real
+fingerprint of the tool prose and moved when item 41 landed — and it is a fingerprint of *one
+channel*, silent on exactly the one the last three findings were about, since
+[#217](https://github.com/glslang/windbg-mcp/pull/217) changed an **opener's result**. And a crate
+version is a floor rather than an identity, since it moves only on release: two builds of `0.11.0`
+were indistinguishable. So `build.rs` now stamps the git revision into the version this server
+reports, and the same string goes into a transcript's `start` record.
+
+**`qwen3.8:27b-mlx` is a name, not a model.** It can be re-pulled onto different weights, so two
+runs a month apart can agree on every other recorded field and have been different models — the
+axis the whole comparison is about. The digest is a content address and settles it. **The two
+control rows cannot have one**: `opus` and `sonnet` are aliases resolved inside a client this bench
+does not own, and there is no `/api/ps` to ask, so they record `model_digest: null` beside the
+harness version, which is a floor. Naming a real version source for a Claude row is open.
+
+Then:
+
+```console
+python3 tools/local_model_eval.py --compare eval-out/after-206.jsonl eval-out/after-210.jsonl \
+  tools/eval_tasks_v1.json
+```
+
+```text
+cell                                 bugcheck  driver_blame  module_count  unloaded_driver  arm64_pc  ioctl_decode
+opus   dflt min                      Y -> Y    Y -> Y        Y -> Y        - -> -           n -> n    o -> o
+sonnet   dflt min                    Y -> Y    Y -> Y        Y -> Y        - -> -           n -> n    o -> o
+gemma4:31b-mlx 262144 min            Y -> Y    Y -> Y        Y -> Y        - -> -           n -> n    o -> -
+nemotron-3.5-lightning:3 262144 min  Y -> Y    Y -> Y        Y -> n        - -> -           n -> n    - -> -
+qwen3.8:27b-mlx 262144 min           n -> Y    Y -> Y        Y -> Y        - -> -           n -> n    o -> -
+
+old -> new per cell-task; `(old)`/`(new)` is a cell only one run covered.
+```
+
+Those two runs were recorded before the identity fields existed, so nothing above the table names a
+moved variable — which is exactly what a pair of logs written today would not look like. The two
+lines that appear when something did move were checked against a log doctored to move them:
+
+```text
+  moved between these runs, besides the question: suite, server, harness, weights
+--  not compared for arm64_pc: the question changed between these runs
+```
+
+**Two rules, and they are not the same rule.**
+
+- **A changed question blocks a pairing.** It does not annotate one. `arm64_pc` has the same id in
+  `eval_tasks_v1.json` and `eval_tasks.json` and a materially different prompt, so pairing on the
+  id would put two distributions side by side that the frozen suite established are not comparable
+  — and would be *laxer than the grader already is*, since `usable()` refuses such a record
+  outright. The predicate is `stale_prompt`, the same one the grader uses, and the refusal is
+  printed at the **row** with its reason, which is the principle the `UNCOUNTED` line beside it
+  follows. It is a floor: `expect` can move too, and a pairing predicate reading only the prompt
+  catches the change the frozen suite was about and not every change there could be.
+- **Everything else is named above the table.** The build, the weights, the harness, the suite —
+  the uncontrolled variables that are *not* the question. Naming them is not a nicety: this repo
+  has three times read a moved aggregate as a controlled result, and every one was a **composition**
+  error, where the callers changed and the total held.
+
+**And a series, so history is a query rather than a re-reading.** This page accumulates a prose
+section per run, which reads well and cannot be diffed — the tables in it measure different
+servers, which the page says in words and no reader can check.
+[`eval-runs.json`](./eval-runs.json) is the machine-readable half, one row per run keyed by the
+identity above:
+
+```console
+python3 tools/local_model_eval.py --series eval-out/*.jsonl tools/eval_tasks_v1.json \
+  -o docs/eval-runs.json
+```
+
+The three runs already in it read `unrecorded` for every identity field, and that is the point
+rather than an omission: **a run recorded without identity cannot have it added later.** Each of
+those write-ups names its own server build in prose, which is why nothing published is wrong; what
+was missing was any way to *check* it, and to do it for a run nobody has written up yet.
+
 ## What one grid showed
 
 Run 2026-08-23, on the ARM64 bench described in `local-model.md`: 33 cells, 144 task runs, about

--- a/docs/transcripts.md
+++ b/docs/transcripts.md
@@ -16,7 +16,8 @@ $env:WINDBG_MCP_TRANSCRIPT = "$env:USERPROFILE\.windbg-mcp\session.jsonl"
 Every record carries the format version, the run that wrote it, a sequence number, a wall clock
 and a monotonic offset. A run opens with a `start` record whose own `version` is **the build that
 wrote the file** — the crate version with the git revision it was built from appended
-(`0.11.0+g1a2b3c4`, and `-dirty` where the build inputs differed from that commit). Two builds of
+(`0.11.0+g1a2b3c4`, and `-dirty.<digest>` where the build inputs differed from that commit, the
+digest telling two uncommitted iterations apart). Two builds of
 one release are otherwise indistinguishable, which is what makes a recording hard to place months
 later; a build with no git beside it reports the bare crate version.
 The events are the tool call and its result; a session opening, changing state and being released;

--- a/docs/transcripts.md
+++ b/docs/transcripts.md
@@ -14,7 +14,11 @@ $env:WINDBG_MCP_TRANSCRIPT = "$env:USERPROFILE\.windbg-mcp\session.jsonl"
 ```
 
 Every record carries the format version, the run that wrote it, a sequence number, a wall clock
-and a monotonic offset.
+and a monotonic offset. A run opens with a `start` record whose own `version` is **the build that
+wrote the file** — the crate version with the git revision it was built from appended
+(`0.11.0+g1a2b3c4`, and `-dirty` where the build inputs differed from that commit). Two builds of
+one release are otherwise indistinguishable, which is what makes a recording hard to place months
+later; a build with no git beside it reports the bare crate version.
 The events are the tool call and its result; a session opening, changing state and being released;
 a wait abandoned, an `interrupt`, a worker process dying; and — derived from each result's *typed*
 half, never scraped from the text beside it — where execution stopped, what a `run_to_address`

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,6 +42,27 @@ use tracing_subscriber::EnvFilter;
 use crate::engine::Sessions;
 use crate::server::WindbgServer;
 
+/// What this build calls itself: the crate version, plus the git revision it was built from.
+///
+/// `0.11.0+g1a2b3c4`, or `0.11.0+g1a2b3c4-dirty`, or a bare `0.11.0` where `build.rs` could not ask
+/// git. Reported in two places that had the crate version alone and are the two a reader reaches
+/// for when asking *which* build did something: MCP `serverInfo.version`, and the `Start` record of
+/// a transcript.
+///
+/// **The suffix is what makes it an identity rather than a floor.** A crate version moves on
+/// release, so every build between two of them is indistinguishable — including the pairs that
+/// matter most, since the behaviour a bench or a bug report turns on is often a changed *result*
+/// rather than a changed API. `FOLLOWUPS.md` item 46 is the case that forced it: #217 changed what
+/// an opener's summary says, which no version, tool count or surface byte count can see.
+///
+/// It is semver build metadata, ignored for precedence, so a consumer comparing versions reads up
+/// to the `+` and is unaffected.
+pub const BUILD_VERSION: &str = if env!("WINDBG_MCP_BUILD").is_empty() {
+    env!("CARGO_PKG_VERSION")
+} else {
+    concat!(env!("CARGO_PKG_VERSION"), "+", env!("WINDBG_MCP_BUILD"))
+};
+
 /// Upper bound for any single debugger operation before the tool call reports a timeout.
 const ENGINE_CALL_TIMEOUT: Duration = Duration::from_secs(300);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,8 +44,8 @@ use crate::server::WindbgServer;
 
 /// What this build calls itself: the crate version, plus the git revision it was built from.
 ///
-/// `0.11.0+g1a2b3c4`, or `0.11.0+g1a2b3c4-dirty`, or a bare `0.11.0` where `build.rs` could not ask
-/// git. Reported in two places that had the crate version alone and are the two a reader reaches
+/// `0.11.0+g1a2b3c4`, or `0.11.0+g1a2b3c4-dirty.5f2a91c0` where the build inputs differ from that
+/// commit, or a bare `0.11.0` where `build.rs` could not ask git. Reported in two places that had the crate version alone and are the two a reader reaches
 /// for when asking *which* build did something: MCP `serverInfo.version`, and the `Start` record of
 /// a transcript.
 ///

--- a/src/record.rs
+++ b/src/record.rs
@@ -190,7 +190,7 @@ impl Recorder {
             request: AtomicU64::new(0),
         })));
         recorder.write(Event::Start {
-            version: env!("CARGO_PKG_VERSION").to_string(),
+            version: crate::BUILD_VERSION.to_string(),
             pid: std::process::id(),
             field_limit: limit,
             schema: SCHEMA,

--- a/src/server.rs
+++ b/src/server.rs
@@ -4800,7 +4800,7 @@ impl rmcp::ServerHandler for WindbgServer {
         )
         .with_server_info(rmcp::model::Implementation::new(
             "windbg-mcp",
-            env!("CARGO_PKG_VERSION"),
+            crate::BUILD_VERSION,
         ))
         .with_instructions(self.instructions())
     }
@@ -5522,10 +5522,18 @@ mod tests {
             server_info["name"], "windbg-mcp",
             "the server must not report the SDK's identity as its own: {line}"
         );
-        assert_eq!(
-            server_info["version"],
-            env!("CARGO_PKG_VERSION"),
+        // **Starts with** the crate version rather than equalling it: `build.rs` appends the git
+        // revision as semver build metadata, so an equality here would fail on every build that
+        // has a `.git` beside it and pass only on the tarball case nobody runs.
+        let reported = server_info["version"].as_str().unwrap_or_default();
+        assert!(
+            reported.starts_with(env!("CARGO_PKG_VERSION")),
             "the reported version must track this crate, not the SDK: {line}"
+        );
+        assert_eq!(
+            reported,
+            crate::BUILD_VERSION,
+            "the reported version must be the one this build stamped: {line}"
         );
 
         service.cancel().await.expect("shut the service down");

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -786,11 +786,33 @@ fn every_documented_protocol_revision_is_served() {
         // The server has to introduce itself as itself on every revision — left to the SDK's
         // default this reads `rmcp` at the SDK's version.
         assert_eq!(result["serverInfo"]["name"], "windbg-mcp", "on {revision}");
-        assert_eq!(
-            result["serverInfo"]["version"],
-            env!("CARGO_PKG_VERSION"),
-            "the reported version must track this crate, not the SDK (on {revision})"
+        // **A prefix, not an equality.** `build.rs` appends the git revision this binary was built
+        // from as semver build metadata (`0.11.0+g1a2b3c4`), so the whole string is not a constant
+        // this test can name — and the part that must not drift to the SDK's is the release.
+        let reported = result["serverInfo"]["version"]
+            .as_str()
+            .unwrap_or_else(|| panic!("serverInfo.version must be a string on {revision}"));
+        assert!(
+            reported.starts_with(env!("CARGO_PKG_VERSION")),
+            "the reported version must track this crate, not the SDK (on {revision}): {reported}"
         );
+        // And the suffix is not decoration: a build that could not describe itself reports the bare
+        // crate version, which is legitimate, but a build under a git checkout that reports one is
+        // a `build.rs` that has stopped running. Only the shape is asserted, since the revision
+        // itself moves with every commit.
+        if std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join(".git")
+            .exists()
+        {
+            let stamp = reported
+                .strip_prefix(env!("CARGO_PKG_VERSION"))
+                .unwrap_or_default();
+            assert!(
+                stamp.starts_with("+g"),
+                "built from a git checkout, so the version must carry its revision (on \
+                 {revision}): {reported}"
+            );
+        }
 
         // Tools must be reachable on every revision, not just the newest.
         let tools = server.request("tools/list", json!({}), STEP);

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -796,23 +796,23 @@ fn every_documented_protocol_revision_is_served() {
             reported.starts_with(env!("CARGO_PKG_VERSION")),
             "the reported version must track this crate, not the SDK (on {revision}): {reported}"
         );
-        // And the suffix is not decoration: a build that could not describe itself reports the bare
-        // crate version, which is legitimate, but a build under a git checkout that reports one is
-        // a `build.rs` that has stopped running. Only the shape is asserted, since the revision
-        // itself moves with every commit.
-        if std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
-            .join(".git")
-            .exists()
-        {
-            let stamp = reported
-                .strip_prefix(env!("CARGO_PKG_VERSION"))
-                .unwrap_or_default();
-            assert!(
-                stamp.starts_with("+g"),
-                "built from a git checkout, so the version must carry its revision (on \
-                 {revision}): {reported}"
-            );
-        }
+        // And the suffix is checked against **what this build actually stamped**, rather than
+        // against whether a `.git` is lying about. `build.rs` falls back to the bare crate version
+        // whenever git is unavailable or refuses — a minimal builder, or git's own safe-directory
+        // check — which is deliberate and would fail a `.git`-exists proxy on a perfectly good
+        // build. `WINDBG_MCP_BUILD` is the build script's own answer, so this asserts the served
+        // version *is* the one it produced — and a `build.rs` that stopped running fails to
+        // compile this rather than passing it.
+        let stamp = env!("WINDBG_MCP_BUILD");
+        let expected = if stamp.is_empty() {
+            env!("CARGO_PKG_VERSION").to_string()
+        } else {
+            format!("{}+{}", env!("CARGO_PKG_VERSION"), stamp)
+        };
+        assert_eq!(
+            reported, expected,
+            "the served version must be the one this build stamped (on {revision})"
+        );
 
         // Tools must be reachable on every revision, not just the newest.
         let tools = server.request("tools/list", json!({}), STEP);

--- a/tools/claude_code_drive.py
+++ b/tools/claude_code_drive.py
@@ -251,7 +251,8 @@ def main():
     print("MCP revision negotiated:", drive.handshake())
     tools = drive.mcp("tools/list")["result"]["tools"]
     offered = drive.as_ollama(tools)
-    surface_bytes = len(json.dumps(offered, separators=(",", ":")))
+    wire = json.dumps(offered, separators=(",", ":"))
+    surface_bytes = len(wire)
     print(f"tools offered: {len(tools)} ({surface_bytes} B, measured as the ollama rows are)")
 
     scratch = os.environ.get("EVAL_SCRATCH", "")
@@ -282,7 +283,10 @@ def main():
         "server": dict(drive.SERVER_INFO) or None,
         "suite": dict(drive.SUITE) or None,
         "surface": {"client": os.environ.get("EVAL_SURFACE", ""), "tools": len(tools),
-                    "bytes": surface_bytes, "names": sorted(t["name"] for t in tools)},
+                    "bytes": surface_bytes, "names": sorted(t["name"] for t in tools),
+                    # Measured as the ollama rows measure it, through the same helper, so the two
+                    # backends' surfaces are comparable rather than merely similar.
+                    "digest": drive.surface_digest(wire)},
     }
     try:
         for i, task in enumerate(tasks, 1):

--- a/tools/claude_code_drive.py
+++ b/tools/claude_code_drive.py
@@ -201,6 +201,28 @@ def one_task(task, config_path):
     return report
 
 
+def harness_version():
+    """What `claude --version` says — a **floor**, not an identity, and recorded as one.
+
+    The ollama rows get a content digest of the weights that answered (`local_model_drive`'s
+    `runtime_identity`). This row cannot: `opus` and `sonnet` are mutable aliases resolved inside a
+    client this bench does not own, and there is no `/api/ps` to ask. What *is* available is the
+    version of the harness doing the resolving, which moves when the client does and says nothing
+    about the weights behind the alias. Recording it is strictly better than recording nothing and
+    is not sufficient — the same shape as the server's crate version before `build.rs` stamped a
+    revision beside it (`FOLLOWUPS.md` item 46).
+
+    Best effort: a client that will not answer leaves the field null rather than failing the row.
+    """
+    try:
+        out = subprocess.run(["claude", "--version"], capture_output=True, text=True, timeout=60)
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if out.returncode != 0:
+        return None
+    return out.stdout.strip() or None
+
+
 def release_new_sessions(before):
     """End every session this credential gained while the task ran.
 
@@ -237,6 +259,7 @@ def main():
     if owned:
         scratch = tempfile.mkdtemp(prefix="windbg-eval-")
     config_path = mcp_config(scratch)
+    tasks = drive.load_tasks(sys.argv[1]) if len(sys.argv) > 1 else []
     cell = {
         "run": os.environ.get("EVAL_RUN", time.strftime("%Y%m%dT%H%M%S")),
         "backend": "claude-code",
@@ -250,10 +273,17 @@ def main():
         # (`local_model_drive.SEED`), so no row here replays one. The grader reads `draw` from
         # both backends and `seed` from neither.
         "seed": None,
+        # **Null rather than absent here too, and for the same kind of reason.** The ollama rows
+        # record the digest of the weights that answered; an alias resolved inside `claude` has no
+        # such address to offer, and leaving the field out would make this row's ambiguity look
+        # like a field nobody thought to record. `harness_version` is what this row *can* say.
+        "model_digest": None,
+        "harness_version": harness_version(),
+        "server": dict(drive.SERVER_INFO) or None,
+        "suite": dict(drive.SUITE) or None,
         "surface": {"client": os.environ.get("EVAL_SURFACE", ""), "tools": len(tools),
                     "bytes": surface_bytes, "names": sorted(t["name"] for t in tools)},
     }
-    tasks = drive.load_tasks(sys.argv[1]) if len(sys.argv) > 1 else []
     try:
         for i, task in enumerate(tasks, 1):
             prompt = task["prompt"] if isinstance(task, dict) else task

--- a/tools/local_model_drive.py
+++ b/tools/local_model_drive.py
@@ -165,6 +165,17 @@ AUTH = bearer()
 SCENARIO = bool(os.environ.get("WINDBG_MCP_SCENARIO"))
 SESSION = None
 
+# **What this run was asked against, kept rather than discarded.** A record used to identify the
+# question and the surface and neither of the two things that change over *time* - which weights
+# answered, and which build was asked (`FOLLOWUPS.md` item 46). Both were already on the wire and
+# both were thrown away: the `initialize` result carries `serverInfo`, and `/api/ps` carries the
+# model's content digest beside the window it reports. A run recorded without them cannot have them
+# added later, which is the one part of this that expires.
+#
+# Dicts rather than scalars, filled in place, so the readers below need no `global`.
+SERVER_INFO = {}
+SUITE = {}
+
 # One request at a time on this MCP session: the keepalive below runs on its own thread,
 # and two requests sharing `SESSION` would race over the header it may hand back.
 WIRE = threading.Lock()
@@ -255,13 +266,26 @@ def keepalive():
 
 
 def handshake():
+    """Open the MCP session, and **keep the half of the answer this used to drop**.
+
+    The negotiated revision was all this returned; `serverInfo` went in the bin with the rest of the
+    result. That is the server's own identity - `windbg-mcp` at `0.11.0+g1a2b3c4` since the version
+    carries the git revision it was built from - and it is the field a comparison of two runs needs
+    most, because the behaviour that moves between them is often a changed *result* rather than a
+    changed API: no tool count and no surface byte count can see one.
+
+    Both drivers reach it through this function, so the two rows record the server the same way.
+    """
     out = mcp("initialize", {
         "protocolVersion": REVISION,
         "capabilities": {},
         "clientInfo": {"name": "local-model-drive", "version": "1"},
     })
     mcp("notifications/initialized", notify=True)
-    return out["result"]["protocolVersion"]
+    result = out["result"]
+    SERVER_INFO.clear()
+    SERVER_INFO.update(result.get("serverInfo") or {})
+    return result["protocolVersion"]
 
 
 def ollama(path, body=None):
@@ -628,8 +652,12 @@ def load_tasks(path):
     """
     with open(path, encoding="utf-8") as f:
         loaded = json.load(f)
+    SUITE.clear()
     if isinstance(loaded, list):
+        # A bare list has no identity to record, and saying so is not the same as saying nothing:
+        # a record whose `suite` is null ran against a task list that never had a name.
         return loaded
+    SUITE.update({"name": loaded.get("suite"), "file": os.path.basename(path)})
     tasks = loaded["tasks"]
     subset = os.environ.get("EVAL_SUBSET", "")
     if subset:
@@ -640,21 +668,35 @@ def load_tasks(path):
     return tasks
 
 
-def served_context():
-    """What the runtime is actually serving this model, which is not what it could serve.
+def runtime_identity():
+    """What the runtime is serving this model, and **which weights** are serving it.
 
-    Asked rather than assumed for the reason `docs/local-model.md` gives: the default
-    `OLLAMA_CONTEXT_LENGTH` picks 4k, 32k or 256k from the box's memory, so a model whose
-    card says 262144 is routinely served far less. Best effort — a runtime that does not
-    report it leaves the field null rather than failing a run over telemetry.
+    Two facts off one `/api/ps`, because they are one question asked of one live state: a second
+    call could catch a different instance, and a record pairing one model's window with another's
+    digest would be worse than either field missing.
+
+    - `served_context` is not what the model *could* serve. `docs/local-model.md` has the reason:
+      the default `OLLAMA_CONTEXT_LENGTH` picks 4k, 32k or 256k from the box's memory, so a model
+      whose card says 262144 is routinely served far less - and a request's `num_ctx` does not
+      shrink an instance the runtime already holds, which is the contamination this field caught.
+    - `model_digest` is the content address of the weights. `qwen3.8:27b-mlx` is a *mutable tag*:
+      it can be re-pulled onto different weights, so two runs a month apart can agree on every
+      other recorded field and have been different models - which is the axis a comparison of two
+      runs is entirely about. This is the ollama rows only; `claude_code_drive.py` records a
+      mutable alias and has no `/api/ps` to ask (`FOLLOWUPS.md` item 46).
+
+    Best effort - a runtime that does not report either leaves the field null rather than failing a
+    run over telemetry.
     """
+    blank = {"served_context": None, "model_digest": None}
     try:
         for loaded in ollama("/api/ps").get("models", []):
             if loaded.get("name") == MODEL or loaded.get("model") == MODEL:
-                return loaded.get("context_length")
+                return {"served_context": loaded.get("context_length"),
+                        "model_digest": loaded.get("digest")}
     except Exception:  # noqa: BLE001 - a missing figure must not end a run
-        return None
-    return None
+        return blank
+    return blank
 
 
 def write_record(record):
@@ -730,6 +772,11 @@ def main():
         "num_ctx": NUM_CTX or None,
         "draw": DRAW,
         "seed": SEED,
+        # The two identity fields that are constant for a cell: which build was asked, and which
+        # task list it was asked from. The third - which weights answered - is read per task, since
+        # it is a property of the instance the runtime happened to have loaded.
+        "server": dict(SERVER_INFO) or None,
+        "suite": dict(SUITE) or None,
         "surface": {"client": os.environ.get("EVAL_SURFACE", ""),
                     "tools": len(tools), "bytes": surface,
                     "names": sorted(t["name"] for t in tools)},
@@ -742,7 +789,7 @@ def main():
             transcript, report = run(task, offered, transcript)
             # Read *after* the first turn: nothing is loaded before one, so asking earlier
             # reports the previous model's window or nothing at all.
-            record = dict(cell, served_context=served_context(), **report)
+            record = dict(cell, **runtime_identity(), **report)
             if NUM_CTX and record["served_context"] and record["served_context"] != NUM_CTX:
                 # Loudly, because it is invisible otherwise and it invalidates the cell: a
                 # request's `num_ctx` does not shrink an instance the runtime already holds.

--- a/tools/local_model_drive.py
+++ b/tools/local_model_drive.py
@@ -57,6 +57,7 @@ model thinking, with no request in flight, and one measured here took **440s aga
 came back `404 Session not found`, which reads exactly like a broken server. A ping
 during a long turn costs nothing and removes the whole class.
 """
+import hashlib
 import json
 import os
 import sys
@@ -699,6 +700,17 @@ def runtime_identity():
     return blank
 
 
+def surface_digest(wire):
+    """A short content address for the tool surface exactly as it was served.
+
+    Twelve hex characters of SHA-256 over the minified JSON — enough that two surfaces differing at
+    all differ here, short enough to print beside a cell. It is the only field that can tell a
+    same-length description edit from no edit at all, which is what `--compare` needs before it can
+    say a score moved because of the *model* (`FOLLOWUPS.md` item 46).
+    """
+    return hashlib.sha256(wire.encode("utf-8")).hexdigest()[:12]
+
+
 def write_record(record):
     """Append one task's record to the eval log, if this run is part of an eval.
 
@@ -755,7 +767,8 @@ def main():
     threading.Thread(target=keepalive, daemon=True).start()
     tools = mcp("tools/list")["result"]["tools"]
     offered = as_ollama(tools)
-    surface = len(json.dumps(offered, separators=(",", ":")))
+    wire = json.dumps(offered, separators=(",", ":"))
+    surface = len(wire)
     print(f"tools offered: {len(tools)} ({surface} B of minified JSON)")
     if NUM_CTX:
         print(f"context requested: {NUM_CTX}")
@@ -779,7 +792,13 @@ def main():
         "suite": dict(SUITE) or None,
         "surface": {"client": os.environ.get("EVAL_SURFACE", ""),
                     "tools": len(tools), "bytes": surface,
-                    "names": sorted(t["name"] for t in tools)},
+                    "names": sorted(t["name"] for t in tools),
+                    # **The fingerprint, rather than its length.** A byte count moves for almost
+                    # any prose change and for none reliably: a same-length reword, or an
+                    # allowlist swap of equal size, leaves both the count and the length alone
+                    # while the model is handed different tools. This is the surface as it went
+                    # over the wire, which is the thing a comparison is actually about.
+                    "digest": surface_digest(wire)},
     }
     transcript = None
     try:

--- a/tools/local_model_eval.py
+++ b/tools/local_model_eval.py
@@ -1437,8 +1437,7 @@ def print_matrix(order, rows):
     header = f"{'cell':<44}" + "".join(f"{t:<{width}}" for t in order)
     print("\n" + header)
     print("-" * len(header))
-    for cell, marks in sorted(rows.items(), key=lambda kv: (kv[0][0], kv[0][1],
-                                                            -(kv[0][2] or 0), kv[0][3] or "")):
+    for cell, marks in sorted(rows.items(), key=lambda kv: cell_order(kv[0])):
         backend, model, ctx, surface = cell
         label = f"{model[:24]} {str(ctx or 'dflt'):>6} {surface}"
         print(f"{label:<44}" + "".join(f"{marks.get(t, {}).get('mark', ' '):<{width}}"
@@ -1561,6 +1560,18 @@ def print_identity(ident, indent="  ", header=True):
               f"filled in afterwards; {UNAVAILABLE} is a row that has no such answer to give)")
 
 
+def cell_order(cell):
+    """How a `(backend, model, num_ctx, client)` key sorts — **never the raw tuple**.
+
+    A raw sort compares `num_ctx` values directly, and `None` against an integer raises in Python 3:
+    a plan may omit `contexts`, so one run recording `null` beside another recording `262144` for
+    the same model crashed `--compare` before it printed anything. Spelled once here rather than as
+    the third copy of a lambda two other sorts already carried.
+    """
+    backend, model, context, client = cell
+    return (backend or "", model or "", -(context or 0), client or "")
+
+
 def cell_facts(log_records):
     """Per cell, the two variables a run-wide identity line cannot hold.
 
@@ -1621,27 +1632,33 @@ def moved_cells(old_facts, new_facts):
     reported as *unverifiable* rather than as agreement: a byte count cannot see a same-length
     reword, which is the whole reason the digest exists.
     """
-    moved = {}
-    for cell in sorted(set(old_facts) | set(new_facts)):
+    moved, undigested = {}, set()
+    for cell in sorted(set(old_facts) | set(new_facts), key=cell_order):
         before, after = old_facts.get(cell, {}), new_facts.get(cell, {})
         was, now = before.get("surface") or set(), after.get("surface") or set()
         if was and now:
             # Only when both runs recorded one: a log with nothing to say about a field cannot
             # have moved in it, and reporting that as a move would be an invention.
-            both_digested = all(f[2] for f in was | now)
-            comparable_was = was if both_digested else {(f[0], f[1]) for f in was}
-            comparable_now = now if both_digested else {(f[0], f[1]) for f in now}
+            digested = all(f[2] for f in was), all(f[2] for f in now)
+            comparable_was = was if all(digested) else {(f[0], f[1]) for f in was}
+            comparable_now = now if all(digested) else {(f[0], f[1]) for f in now}
             if comparable_was != comparable_now:
                 moved.setdefault(cell, []).append(
                     ("surface", surface_text(was), surface_text(now), "moved"))
-            elif not both_digested:
+            elif digested[0] != digested[1]:
+                # **Only when the two sides disagree about having a digest** — the rollout, which
+                # is transient and worth naming per cell. When *neither* has one the whole
+                # comparison is equally unverifiable, and saying so on every row would be noise
+                # with a wrong reason attached; that is one line under the table instead.
                 moved.setdefault(cell, []).append(
                     ("surface", surface_text(was), surface_text(now), "unverifiable"))
+            elif not any(digested):
+                undigested.add(cell)
         was, now = sorted(before.get("window") or []), sorted(after.get("window") or [])
         if was and now and was != now:
             moved.setdefault(cell, []).append(
                 ("window", ", ".join(was), ", ".join(now), "moved"))
-    return moved
+    return moved, undigested
 
 
 def comparable(old_entry, new_entry):
@@ -1677,8 +1694,7 @@ def compare(old_path, new_path, tasks_file):
     new_order, new_rows = matrix(new_path, tasks_file)
     order = old_order if old_order == new_order else sorted(set(old_order) | set(new_order))
     rows = {}
-    for cell in sorted(set(old_rows) | set(new_rows), key=lambda c: (c[0], c[1], -(c[2] or 0),
-                                                                    c[3] or "")):
+    for cell in sorted(set(old_rows) | set(new_rows), key=cell_order):
         old_row, new_row = old_rows.get(cell, {}), new_rows.get(cell, {})
         rows[cell] = {}
         for task in order:
@@ -1693,11 +1709,12 @@ def compare(old_path, new_path, tasks_file):
                                 "blocked": comparable(old_entry, new_entry)}
     old_records, new_records = records(old_path), records(new_path)
     identities = (identity(old_records), identity(new_records))
-    moved = moved_cells(cell_facts(old_records), cell_facts(new_records))
-    return order, rows, identities, moved
+    moved, undigested = moved_cells(cell_facts(old_records), cell_facts(new_records))
+    return order, rows, identities, (moved, undigested)
 
 
-def print_compare(order, rows, identities, moved_by_cell, old_path, new_path):
+def print_compare(order, rows, identities, surfaces, old_path, new_path):
+    moved_by_cell, undigested = surfaces
     old_ident, new_ident = identities
     print(f"\ncomparing {old_path} -> {new_path}")
     print("\nrun identity — the uncontrolled variables, which are not the question or the surface:")
@@ -1757,6 +1774,10 @@ def print_compare(order, rows, identities, moved_by_cell, old_path, new_path):
                           f"ruled out)")
                 else:
                     print(f"  {label:<40} {name} {was} -> {now}")
+    if undigested:
+        print(f"\n{len(undigested)} cell(s) agree on tool count and byte length with **no surface "
+              f"digest on either side**, so a same-length edit cannot be ruled out for them. Both "
+              f"logs predate that field.")
 
 
 def series(log_paths, tasks_file, out_path):

--- a/tools/local_model_eval.py
+++ b/tools/local_model_eval.py
@@ -1586,7 +1586,7 @@ def cell_order(cell):
 
 
 def cell_facts(log_records):
-    """Per cell, the three variables a run-wide identity line cannot hold.
+    """Per cell, the four variables a run-wide identity line cannot hold.
 
     **A surface and a served window belong to a cell, not to a log.** The grid varies both on
     purpose, so listing them run-wide says nothing: two runs both covering `min` at three windows
@@ -1614,7 +1614,8 @@ def cell_facts(log_records):
         surface = record.get("surface") or {}
         cell_id = (record.get("backend"), record.get("model"), record.get("num_ctx"),
                    surface.get("client"))
-        entry = facts.setdefault(cell_id, {"surface": set(), "window": set(), "weights": set()})
+        entry = facts.setdefault(cell_id, {"surface": set(), "window": set(), "weights": set(),
+                                           "server": set()})
         # **The weights per cell, not only per run.** The identity block's `weights` line is a
         # run-wide set, and a set loses which digest answered which cell: two runs whose *same two*
         # digests are assigned to opposite cells - a tag re-pulled between them - compare equal
@@ -1622,6 +1623,13 @@ def cell_facts(log_records):
         # the surface and the window already get.
         if record.get("model_digest"):
             entry["weights"].add(record["model_digest"][:12])
+        # **And the build, for exactly the same reason.** A log is append-only and a plan resumes,
+        # so a run can legitimately span a rebuild: two logs holding the same *set* of revisions
+        # with the cells swapped compare equal on the run-wide line and pair results from different
+        # builds. Run-wide is the overview; per cell is the comparison.
+        server = record.get("server") or {}
+        if server.get("version"):
+            entry["server"].add(str(server["version"]))
         if surface.get("tools") is not None or surface.get("bytes") is not None:
             # **Kept as its parts, not as a rendered string.** A cell-failure note carries the
             # client and nothing else, so it contributes nothing rather than an `unrecorded`
@@ -1674,7 +1682,7 @@ def moved_cells(old_facts, new_facts):
                     ("surface", surface_text(was), surface_text(now), "unverifiable"))
             elif not any(digested):
                 undigested.add(cell)
-        for name in ("window", "weights"):
+        for name in ("window", "weights", "server"):
             was, now = sorted(before.get(name) or []), sorted(after.get(name) or [])
             if was and now and was != now:
                 moved.setdefault(cell, []).append(
@@ -1811,7 +1819,13 @@ def series(log_paths, tasks_file, out_path):
     rows = []
     for log_path in log_paths:
         cells = summarise(log_path, tasks_file)
-        ident = identity(records(log_path))
+        log_records = records(log_path)
+        ident = identity(log_records)
+        # **The per-cell conditions travel with the per-cell scores.** The identity above keeps a
+        # run-wide *set* of digests and revisions, which cannot say which of them produced which
+        # cell - so a historical row holding two of either could not attribute its own numbers.
+        # Read through the same [`cell_facts`] a comparison uses, rather than a second projection.
+        facts = cell_facts(log_records)
         rows.append({
             "log": os.path.basename(log_path),
             "identity": ident,
@@ -1820,7 +1834,16 @@ def series(log_paths, tasks_file, out_path):
                        "surface": c["surface"], "tools": c["tools"], "draws": c.get("draws", 1),
                        "correct_of_possible": c["correct_of_possible"], "possible": c["possible"],
                        "taught": c["taught"], "wanted": c["wanted"],
-                       "served_context": c["served_context"]}
+                       # `window` rather than the cell's `served_context`, which is the *first*
+                       # non-null one: a cell whose draws were served two different windows is
+                       # exactly the condition a historical row has to be able to state.
+                       **{name: sorted(values) for name, values in
+                          (facts.get((c["backend"], c["model"], c["num_ctx"], c["surface"]))
+                           or {}).items() if name != "surface"},
+                       "surface_digest": sorted(
+                           {f[2] for f in (facts.get((c["backend"], c["model"], c["num_ctx"],
+                                                      c["surface"])) or {}).get("surface", set())
+                            if f[2]})}
                       for c in sorted(cells, key=lambda c: (c["backend"], c["model"] or "",
                                                             c["surface"] or ""))],
         })

--- a/tools/local_model_eval.py
+++ b/tools/local_model_eval.py
@@ -1400,7 +1400,11 @@ def matrix(log_path, tasks_file):
         # on it: a task id is not the question (`arm64_pc` has the same id under two
         # materially different wordings), and the record is the only place the wording
         # survives.
-        entry.setdefault("prompt", record.get("prompt"))
+        # **Assigned, not `setdefault`.** A draw that died writes a placeholder for every task it
+        # planned, and that placeholder already carries `prompt: None` - so a `setdefault` here
+        # kept the null and `comparable()` then read "no prompt recorded" as "comparable", pairing
+        # two different questions instead of blocking them.
+        entry["prompt"] = entry.get("prompt") or record.get("prompt")
         entry["draws"].append({"draw": draw_of(record), "seed": record.get("seed"), "mark": mark,
                                "calls": [c.get("name") for c in (record.get("calls") or [])],
                                "wall_s": record.get("wall_s"),
@@ -1490,6 +1494,14 @@ def identity(log_records):
     fields = {"run": set(), "suite": set(), "server": set(), "harness": set()}
     weights = {}
     for record in log_records:
+        if record.get("task") is None:
+            # **A cell-failure note is not a measurement and carries no identity.** `run_cell`
+            # writes it with the cell's coordinates and nothing else, so counting it here put an
+            # `unrecorded` beside the real server a current run *did* record - a partially failed
+            # cell then reading as a second, unknown build, and the whole log as one written
+            # before these fields existed.
+            fields["run"].add(record.get("run") or UNRECORDED)
+            continue
         fields["run"].add(record.get("run") or UNRECORDED)
         suite = record.get("suite") or {}
         fields["suite"].add(f"{suite.get('name')} ({suite.get('file')})" if suite else UNRECORDED)
@@ -1529,6 +1541,53 @@ def print_identity(ident, indent="  ", header=True):
             any(UNRECORDED in d for d in ident["weights"].values()):
         print(f"{indent}({UNRECORDED} is a log written before a field existed — it cannot be "
               f"filled in afterwards)")
+
+
+def cell_facts(log_records):
+    """Per cell, the two variables a run-wide identity line cannot hold.
+
+    **A surface and a served window belong to a cell, not to a log.** The grid varies both on
+    purpose, so listing them run-wide says nothing: two runs both covering `min` at three windows
+    agree at that level while a single cell moved underneath. What a comparison needs is whether
+    *this* cell got the same one twice.
+
+    Both were missing, and both had already happened here. `surface.client` is a **label**: `min`
+    was 11 tools and 8,654 B before item 41 and 11 tools and 7,732 B after, so pairing on the label
+    alone presented a surface change as a model or build comparison. And a cell that asks for no
+    window records `num_ctx: null` while the runtime serves whatever it likes, so two runs can pair
+    a 4K result against a 32K one with nothing said.
+
+    Named rather than blocked, which is the split the rest of this follows: a changed *question* is
+    not comparable at all, while a changed surface is often the very intervention a rerun exists to
+    measure — items 40, 41 and #217 each changed one and were read across two runs.
+    """
+    facts = {}
+    for record in log_records:
+        surface = record.get("surface") or {}
+        cell_id = (record.get("backend"), record.get("model"), record.get("num_ctx"),
+                   surface.get("client"))
+        entry = facts.setdefault(cell_id, {"surface": set(), "window": set()})
+        if surface.get("tools") is not None or surface.get("bytes") is not None:
+            # A cell-failure note carries the client and nothing else, so it contributes no
+            # fingerprint rather than an `unrecorded` one.
+            entry["surface"].add(f"{surface.get('tools')} tools, {surface.get('bytes')} B")
+        if record.get("served_context") is not None:
+            entry["window"].add(str(record["served_context"]))
+    return facts
+
+
+def moved_cells(old_facts, new_facts):
+    """Per cell, which of [`cell_facts`] differ between two runs — `{cell: {name: (old, new)}}`."""
+    moved = {}
+    for cell in sorted(set(old_facts) | set(new_facts)):
+        before, after = old_facts.get(cell, {}), new_facts.get(cell, {})
+        for name in ("surface", "window"):
+            was, now = sorted(before.get(name) or []), sorted(after.get(name) or [])
+            if was and now and was != now:
+                # Only when both runs recorded one: a log written before a field existed has
+                # nothing to say about it, and reporting that as a move would be an invention.
+                moved.setdefault(cell, {})[name] = (", ".join(was), ", ".join(now))
+    return moved
 
 
 def comparable(old_entry, new_entry):
@@ -1578,11 +1637,13 @@ def compare(old_path, new_path, tasks_file):
                 continue
             rows[cell][task] = {"old": old_entry["mark"], "new": new_entry["mark"],
                                 "blocked": comparable(old_entry, new_entry)}
-    identities = (identity(records(old_path)), identity(records(new_path)))
-    return order, rows, identities
+    old_records, new_records = records(old_path), records(new_path)
+    identities = (identity(old_records), identity(new_records))
+    moved = moved_cells(cell_facts(old_records), cell_facts(new_records))
+    return order, rows, identities, moved
 
 
-def print_compare(order, rows, identities, old_path, new_path):
+def print_compare(order, rows, identities, moved_by_cell, old_path, new_path):
     old_ident, new_ident = identities
     print(f"\ncomparing {old_path} -> {new_path}")
     print("\nrun identity — the uncontrolled variables, which are not the question or the surface:")
@@ -1629,6 +1690,14 @@ def print_compare(order, rows, identities, old_path, new_path):
         # At the row rather than in a header, which is the same principle as the `UNCOUNTED` line
         # beside it: a blocked pairing is a fact about those tasks, not about the comparison.
         print(f"--  not compared for {', '.join(sorted(set(tasks)))}: {reason}")
+    if moved_by_cell:
+        # Beneath the table rather than above it, because these are per cell where the identity
+        # block is per run - and named rather than blocking, for the reason `cell_facts` gives.
+        print("\ncells where something besides the question moved:")
+        for cell, moved in moved_by_cell.items():
+            label = f"{(cell[1] or '?')[:24]} {str(cell[2] or 'dflt'):>6} {cell[3] or '?'}"
+            for name, (was, now) in sorted(moved.items()):
+                print(f"  {label:<40} {name} {was} -> {now}")
 
 
 def series(log_paths, tasks_file, out_path):
@@ -1676,8 +1745,8 @@ def main():
         if len(rest) < 2:
             raise SystemExit("--compare needs two logs: the earlier one first")
         tasks_file = rest[2] if len(rest) > 2 else os.path.join(HERE, "eval_tasks.json")
-        order, rows, identities = compare(rest[0], rest[1], tasks_file)
-        print_compare(order, rows, identities, rest[0], rest[1])
+        order, rows, identities, moved = compare(rest[0], rest[1], tasks_file)
+        print_compare(order, rows, identities, moved, rest[0], rest[1])
         return
     if sys.argv[1:2] == ["--series"]:
         # `-o` names the output, because a series is a file somebody keeps rather than a sibling

--- a/tools/local_model_eval.py
+++ b/tools/local_model_eval.py
@@ -1586,7 +1586,7 @@ def cell_order(cell):
 
 
 def cell_facts(log_records):
-    """Per cell, the four variables a run-wide identity line cannot hold.
+    """Per cell, the two variables a run-wide identity line cannot hold.
 
     **A surface and a served window belong to a cell, not to a log.** The grid varies both on
     purpose, so listing them run-wide says nothing: two runs both covering `min` at three windows
@@ -1614,22 +1614,16 @@ def cell_facts(log_records):
         surface = record.get("surface") or {}
         cell_id = (record.get("backend"), record.get("model"), record.get("num_ctx"),
                    surface.get("client"))
-        entry = facts.setdefault(cell_id, {"surface": set(), "window": set(), "weights": set(),
-                                           "server": set()})
-        # **The weights per cell, not only per run.** The identity block's `weights` line is a
-        # run-wide set, and a set loses which digest answered which cell: two runs whose *same two*
-        # digests are assigned to opposite cells - a tag re-pulled between them - compare equal
-        # there and pair results produced by different weights. This is the same per-cell reading
-        # the surface and the window already get.
-        if record.get("model_digest"):
-            entry["weights"].add(record["model_digest"][:12])
-        # **And the build, for exactly the same reason.** A log is append-only and a plan resumes,
-        # so a run can legitimately span a rebuild: two logs holding the same *set* of revisions
-        # with the cells swapped compare equal on the run-wide line and pair results from different
-        # builds. Run-wide is the overview; per cell is the comparison.
-        server = record.get("server") or {}
-        if server.get("version"):
-            entry["server"].add(str(server["version"]))
+        entry = facts.setdefault(cell_id, {"surface": set(), "window": set()})
+        # **The weights and the build are *not* here, and that is a decision rather than an
+        # oversight.** Review asked for both on one argument: a run-wide set cannot say which
+        # digest, or which revision, answered which cell, so two logs assigning the same two to
+        # opposite cells compare equal. The argument is sound and its premise is not reachable on
+        # this bench - a model cannot be re-pulled while a run holds it, and a run that spanned a
+        # rebuild of the server would be invalid for reasons no comparison could repair. The
+        # run-wide identity line already reports a model answering under two digests, which is the
+        # form that premise would actually take. A surface and a window are different: the grid
+        # varies both deliberately, cell by cell, every run.
         if surface.get("tools") is not None or surface.get("bytes") is not None:
             # **Kept as its parts, not as a rendered string.** A cell-failure note carries the
             # client and nothing else, so it contributes nothing rather than an `unrecorded`
@@ -1682,7 +1676,7 @@ def moved_cells(old_facts, new_facts):
                     ("surface", surface_text(was), surface_text(now), "unverifiable"))
             elif not any(digested):
                 undigested.add(cell)
-        for name in ("window", "weights", "server"):
+        for name in ("window",):
             was, now = sorted(before.get(name) or []), sorted(after.get(name) or [])
             if was and now and was != now:
                 moved.setdefault(cell, []).append(
@@ -1834,12 +1828,10 @@ def series(log_paths, tasks_file, out_path):
                        "surface": c["surface"], "tools": c["tools"], "draws": c.get("draws", 1),
                        "correct_of_possible": c["correct_of_possible"], "possible": c["possible"],
                        "taught": c["taught"], "wanted": c["wanted"],
-                       # `window` rather than the cell's `served_context`, which is the *first*
-                       # non-null one: a cell whose draws were served two different windows is
-                       # exactly the condition a historical row has to be able to state.
-                       **{name: sorted(values) for name, values in
-                          (facts.get((c["backend"], c["model"], c["num_ctx"], c["surface"]))
-                           or {}).items() if name != "surface"},
+                       "served_context": c["served_context"],
+                       # The surface the cell was served, which is the one per-cell condition a
+                       # historical row cannot recover from the identity line: the digest names it
+                       # exactly, where the client is only a label.
                        "surface_digest": sorted(
                            {f[2] for f in (facts.get((c["backend"], c["model"], c["num_ctx"],
                                                       c["surface"])) or {}).get("surface", set())

--- a/tools/local_model_eval.py
+++ b/tools/local_model_eval.py
@@ -10,6 +10,8 @@ what comes back against the answer key in `tools/eval_tasks.json`, so the questi
     python3 tools/local_model_eval.py --grade  <results.jsonl> [tasks.json]
     python3 tools/local_model_eval.py --matrix <results.jsonl> [tasks.json]
     WINDBG_MCP_TOKEN=<token> python3 tools/local_model_eval.py --verify-key [tasks.json]
+    python3 tools/local_model_eval.py --compare <old.jsonl> <new.jsonl> [tasks.json]
+    python3 tools/local_model_eval.py --series <results.jsonl>... [tasks.json] -o <series.json>
 
 **Three axes, and they are not independent.** The tool surface is bytes of prose in every
 turn; the context is what the runtime will hold; the model is what can pick a tool out of
@@ -30,6 +32,15 @@ a plan is checked in and a credential is not.
 wedges must not take the grid with it (`budget_s` kills it and records why), and a run that
 dies in the middle must leave every finished cell on disk. Re-running the same plan **resumes**:
 a (model, context, surface, draw, task) already in the log is not run again.
+
+**A run is identified by what it ran against, not only by what it asked.** Every record carries
+the server build that answered (`serverInfo.version`, which since `build.rs` carries the git
+revision), the digest of the model weights where the runtime has one, and the suite the questions
+came from - the two things that change over *time* and used to be recorded nowhere. `--compare`
+reads two logs against each other with two rules that are not one rule: a **changed question blocks
+a pairing**, and a changed build, model or window is **named above the table** for a reader to
+weigh (`FOLLOWUPS.md` item 46). `--series` reduces logs to one row per run, which is what makes
+comparison with historic data a query rather than a re-reading.
 
 **The key is a snapshot, and `--verify-key` is what re-takes it.** The six tasks are graded
 against facts read off the checked-in dumps with this server's own tools, so a fact that stops
@@ -1364,7 +1375,8 @@ def matrix(log_path, tasks_file):
             # before this field existed carries nothing, and those cells read as they did.
             for planned in record.get("planned") or []:
                 if key.get(planned) is not None:
-                    rows.setdefault(cell_id, {}).setdefault(planned, {"mark": None, "draws": []})
+                    rows.setdefault(cell_id, {}).setdefault(
+                        planned, {"mark": None, "draws": [], "prompt": None})
             continue
 
         row = rows.setdefault(cell_id, {})
@@ -1384,6 +1396,11 @@ def matrix(log_path, tasks_file):
         else:
             mark = "Y" if graded["correct"] else "n"
         entry = row.setdefault(record["task"], {"mark": None, "draws": []})
+        # **The question this draw was asked**, kept on the entry because `--compare` pairs
+        # on it: a task id is not the question (`arm64_pc` has the same id under two
+        # materially different wordings), and the record is the only place the wording
+        # survives.
+        entry.setdefault("prompt", record.get("prompt"))
         entry["draws"].append({"draw": draw_of(record), "seed": record.get("seed"), "mark": mark,
                                "calls": [c.get("name") for c in (record.get("calls") or [])],
                                "wall_s": record.get("wall_s"),
@@ -1434,6 +1451,217 @@ def print_matrix(order, rows):
               "in the denominator")
 
 
+# --------------------------------------------------------------------------------------------
+# Run identity, `--compare` and `--series`: what a log has to carry before two of them can be
+# read against each other (`FOLLOWUPS.md` item 46).
+#
+# **Re-running a cell is the point, not a hazard.** As models are updated the same question on the
+# same surface will be asked again, and what matters is run N against run N-1 — the frozen suite
+# (#220) exists so a *reworded question* cannot silently un-grade its own history, which is a
+# different thing from discouraging a rerun. What this bench could not do was compare two of them.
+#
+# A record identified the question and the surface and neither of the two things that change over
+# time: which **model weights** answered, and which **server build** was asked. `surface.bytes` is a
+# real fingerprint of the tool prose and moved when item 41 landed — and it is a fingerprint of one
+# channel, silent on the one the last three findings were about, since #217 changed an *opener's
+# result*. Both facts were already on the wire and both were thrown away; the drivers now keep them.
+#
+# **Two rules here, and they are not the same rule.** A changed question **blocks** a pairing: it
+# does not annotate one. A changed model, build or served window is **named above the table**,
+# because those a reader can weigh. Conflating them is how this repo has three times read a moved
+# aggregate as a controlled result (items 42 and 43, and twice in #212) — every one a *composition*
+# error, where the callers changed and the total held.
+# --------------------------------------------------------------------------------------------
+
+# What a log does not say, printed rather than left blank. A run recorded before these fields
+# existed cannot have them added later, and a column of empty cells reads as "nothing changed"
+# where the truth is "nobody knows" — which is the whole argument for recording them now.
+UNRECORDED = "unrecorded"
+
+
+def identity(log_records):
+    """The uncontrolled variables of a run: what is neither the question nor the surface.
+
+    Deliberately *not* the tool count or the surface bytes, which a cell already carries and which
+    the grid varies on purpose. These are the ones nothing controls — the build that answered, the
+    weights behind a mutable tag, the harness resolving an alias, and the task list the questions
+    came from.
+    """
+    fields = {"run": set(), "suite": set(), "server": set(), "harness": set()}
+    weights = {}
+    for record in log_records:
+        fields["run"].add(record.get("run") or UNRECORDED)
+        suite = record.get("suite") or {}
+        fields["suite"].add(f"{suite.get('name')} ({suite.get('file')})" if suite else UNRECORDED)
+        server = record.get("server") or {}
+        fields["server"].add(f"{server.get('name')} {server.get('version')}"
+                             if server else UNRECORDED)
+        if record.get("backend") == "claude-code":
+            fields["harness"].add(record.get("harness_version") or UNRECORDED)
+        model = record.get("model")
+        if model:
+            weights.setdefault(model, set()).add(record.get("model_digest") or UNRECORDED)
+    return {name: sorted(values) for name, values in fields.items()} | {
+        "weights": {model: sorted(digests) for model, digests in sorted(weights.items())}}
+
+
+def print_identity(ident, indent="  ", header=True):
+    """The identity block, above whatever table follows it.
+
+    Printed on every `--grade`, not only on a comparison, because the value of a run's identity is
+    that it is recorded *at the time*: a table pasted into a write-up with this above it can be
+    placed months later, and one without it cannot be placed at all.
+    """
+    if header:
+        print("\nrun identity — the uncontrolled variables, which are not the question or the "
+              "surface:")
+    for name in ("run", "suite", "server", "harness"):
+        if ident[name]:
+            print(f"{indent}{name:<8} {', '.join(ident[name])}")
+    for model, digests in ident["weights"].items():
+        # A model answering under two digests inside one log is a re-pull mid-run, which is worth
+        # seeing loudly: the cells before it and the cells after it are different models.
+        # Twelve characters, which is what `ollama list` prints in its `ID` column — so a digest
+        # here can be matched against the machine's own listing by eye, and the full value is in
+        # the record for anything that needs to be exact.
+        print(f"{indent}{'weights':<8} {model} {' '.join(d[:12] for d in digests)}")
+    if any(UNRECORDED in ident[name] for name in ("suite", "server")) or \
+            any(UNRECORDED in d for d in ident["weights"].values()):
+        print(f"{indent}({UNRECORDED} is a log written before a field existed — it cannot be "
+              f"filled in afterwards)")
+
+
+def comparable(old_entry, new_entry):
+    """Why these two cannot be paired, or `None` if they can.
+
+    **A changed question blocks the pairing** rather than annotating it: `arm64_pc` has the same id
+    in `eval_tasks_v1.json` and `eval_tasks.json` and a materially different prompt, so pairing on
+    the id alone would put two distributions side by side that #220 established are not comparable
+    — and would be laxer than the grader already is, since [`usable`] refuses such a record
+    outright. So this reuses [`stale_prompt`], the predicate split out of `usable` for exactly this
+    naming, with one log's record standing in for the other's task.
+
+    It is a **floor**: `expect` can move too, and a log records the question it asked but not the
+    key it was graded against. A pairing predicate that reads only the prompt catches the change
+    #220 was about and not every change there could be.
+    """
+    old_prompt, new_prompt = old_entry.get("prompt"), new_entry.get("prompt")
+    if not old_prompt or not new_prompt:
+        return None
+    if stale_prompt({"prompt": new_prompt}, {"prompt": old_prompt}):
+        return "the question changed between these runs"
+    return None
+
+
+def compare(old_path, new_path, tasks_file):
+    """Two logs, cell by cell and task by task. Returns `(order, rows, identities)`.
+
+    Pairs on `(backend, model, num_ctx, surface, task)` — the cell a grid varies, plus the task —
+    and a side present in one log and not the other is shown as such rather than dropped, since a
+    run that stopped covering a cell is a finding about the comparison.
+    """
+    old_order, old_rows = matrix(old_path, tasks_file)
+    new_order, new_rows = matrix(new_path, tasks_file)
+    order = old_order if old_order == new_order else sorted(set(old_order) | set(new_order))
+    rows = {}
+    for cell in sorted(set(old_rows) | set(new_rows), key=lambda c: (c[0], c[1], -(c[2] or 0),
+                                                                    c[3] or "")):
+        old_row, new_row = old_rows.get(cell, {}), new_rows.get(cell, {})
+        rows[cell] = {}
+        for task in order:
+            old_entry, new_entry = old_row.get(task), new_row.get(task)
+            if old_entry is None and new_entry is None:
+                continue
+            if old_entry is None or new_entry is None:
+                rows[cell][task] = {"mark": (new_entry or old_entry)["mark"],
+                                    "only": "new" if old_entry is None else "old"}
+                continue
+            rows[cell][task] = {"old": old_entry["mark"], "new": new_entry["mark"],
+                                "blocked": comparable(old_entry, new_entry)}
+    identities = (identity(records(old_path)), identity(records(new_path)))
+    return order, rows, identities
+
+
+def print_compare(order, rows, identities, old_path, new_path):
+    old_ident, new_ident = identities
+    print(f"\ncomparing {old_path} -> {new_path}")
+    print("\nrun identity — the uncontrolled variables, which are not the question or the surface:")
+    print_identity(old_ident, indent="  old  ", header=False)
+    print_identity(new_ident, indent="  new  ", header=False)
+    moved = [name for name in ("suite", "server", "harness")
+             if old_ident[name] != new_ident[name]]
+    if old_ident["weights"] != new_ident["weights"]:
+        moved.append("weights")
+    if moved:
+        # Named, not scored. These are the variables a reader has to weigh against any movement in
+        # the table below, and the failure this prevents is the composition error: an aggregate
+        # that holds across two runs whose callers changed is a coincidence, not a rate.
+        print(f"\n  moved between these runs, besides the question: {', '.join(moved)}")
+
+    # **Spaces around the arrow, which is not cosmetic.** `-` is the mark for a task this surface
+    # cannot answer, so an unspaced arrow renders "unanswerable both times" as `-->-`, which reads
+    # as one long arrow and hides a mark on each side.
+    width = max([len(t) for t in order]
+                + [len(f"{m.get('old', '')} -> {m.get('new', '')}")
+                   for row in rows.values() for m in row.values()] or [0]) + 2
+    header = f"{'cell':<44}" + "".join(f"{t:<{width}}" for t in order)
+    print("\n" + header)
+    print("-" * len(header))
+    blocked = {}
+    for cell, marks in rows.items():
+        backend, model, ctx, surface = cell
+        label = f"{model[:24]} {str(ctx or 'dflt'):>6} {surface}"
+        rendered_row = []
+        for task in order:
+            mark = marks.get(task)
+            if mark is None:
+                rendered_row.append("")
+            elif mark.get("only"):
+                rendered_row.append(f"{mark['mark']}({mark['only']})")
+            elif mark.get("blocked"):
+                blocked.setdefault(mark["blocked"], []).append(task)
+                rendered_row.append("--")
+            else:
+                rendered_row.append(f"{mark['old']} -> {mark['new']}")
+        print(f"{label:<44}" + "".join(f"{r:<{width}}" for r in rendered_row))
+    print("\nold -> new per cell-task; `(old)`/`(new)` is a cell only one run covered.")
+    for reason, tasks in blocked.items():
+        # At the row rather than in a header, which is the same principle as the `UNCOUNTED` line
+        # beside it: a blocked pairing is a fact about those tasks, not about the comparison.
+        print(f"--  not compared for {', '.join(sorted(set(tasks)))}: {reason}")
+
+
+def series(log_paths, tasks_file, out_path):
+    """One row per run, keyed by its identity — the thing that makes history a query.
+
+    `docs/local-model-eval.md` accumulates a prose section per run, which reads well and cannot be
+    diffed: its tables measure different servers, which the page says in words and no reader can
+    check. This is the machine-readable half. It is regenerated rather than appended to, so a log
+    re-graded under a corrected key updates its own row instead of growing a second one.
+    """
+    rows = []
+    for log_path in log_paths:
+        cells = summarise(log_path, tasks_file)
+        ident = identity(records(log_path))
+        rows.append({
+            "log": os.path.basename(log_path),
+            "identity": ident,
+            "graded_against": os.path.basename(tasks_file),
+            "cells": [{"backend": c["backend"], "model": c["model"], "num_ctx": c["num_ctx"],
+                       "surface": c["surface"], "tools": c["tools"], "draws": c.get("draws", 1),
+                       "correct_of_possible": c["correct_of_possible"], "possible": c["possible"],
+                       "taught": c["taught"], "wanted": c["wanted"],
+                       "served_context": c["served_context"]}
+                      for c in sorted(cells, key=lambda c: (c["backend"], c["model"] or "",
+                                                            c["surface"] or ""))],
+        })
+    with open(out_path, "w", encoding="utf-8") as f:
+        json.dump(rows, f, indent=2)
+        f.write("\n")
+    print(f"\nwrote {out_path}: {len(rows)} run(s)")
+    return rows
+
+
 def main():
     if sys.argv[1:2] == ["--verify-key"]:
         # No log to read: this mode asks the *server*, not a run of it. The tasks file is the
@@ -1443,6 +1671,29 @@ def main():
         rest = [a for a in sys.argv[2:] if not a.startswith("--")]
         tasks_file = rest[0] if rest else os.path.join(HERE, "eval_tasks.json")
         sys.exit(verify_key(tasks_file))
+    if sys.argv[1:2] == ["--compare"]:
+        rest = [a for a in sys.argv[2:] if not a.startswith("--")]
+        if len(rest) < 2:
+            raise SystemExit("--compare needs two logs: the earlier one first")
+        tasks_file = rest[2] if len(rest) > 2 else os.path.join(HERE, "eval_tasks.json")
+        order, rows, identities = compare(rest[0], rest[1], tasks_file)
+        print_compare(order, rows, identities, rest[0], rest[1])
+        return
+    if sys.argv[1:2] == ["--series"]:
+        # `-o` names the output, because a series is a file somebody keeps rather than a sibling
+        # of whichever log happened to be listed first.
+        args = sys.argv[2:]
+        if args[-1:] == ["-o"]:
+            raise SystemExit("-o needs a path to write the series to")
+        out = args[args.index("-o") + 1] if "-o" in args else "eval-runs.json"
+        rest = [a for a in args if not a.startswith("-") and a != out]
+        logs = [a for a in rest if a.endswith(".jsonl")]
+        tasks_file = next((a for a in rest if a.endswith(".json")),
+                          os.path.join(HERE, "eval_tasks.json"))
+        if not logs:
+            raise SystemExit("--series needs at least one .jsonl log")
+        series(logs, tasks_file, out)
+        return
     if sys.argv[1:2] == ["--matrix"]:
         log_path = sys.argv[2]
         tasks_file = sys.argv[3] if len(sys.argv) > 3 else os.path.join(HERE, "eval_tasks.json")
@@ -1464,6 +1715,8 @@ def main():
         log_path = rest[0]
         tasks_file = rest[1] if len(rest) > 1 else os.path.join(HERE, "eval_tasks.json")
         cells = summarise(log_path, tasks_file)
+        ident = identity(records(log_path))
+        print_identity(ident)
         print_table(cells)
         # The regression item 43 asked for, opt-in so an ordinary grading run still just prints.
         # `wanted` is deliberately not assertable: it is a property of the task list and the
@@ -1473,7 +1726,10 @@ def main():
             sys.exit(1)
         out = os.path.splitext(log_path)[0] + ".graded.json"
         with open(out, "w", encoding="utf-8") as f:
-            json.dump(cells, f, indent=2)
+            # **The identity travels with the table, not beside it.** A graded file pasted into a
+            # write-up months later is placeable only if it says what it ran against; one that
+            # carries cells alone is the thing item 46 was written about.
+            json.dump({"identity": ident, "cells": cells}, f, indent=2)
         print(f"\nwrote {out}")
         return
 
@@ -1540,9 +1796,11 @@ def main():
                               f"    cells at the next context may be served this one's window")
 
     cells = summarise(log_path, plan["tasks"])
+    ident = identity(records(log_path))
+    print_identity(ident)
     print_table(cells)
     with open(os.path.splitext(log_path)[0] + ".graded.json", "w", encoding="utf-8") as f:
-        json.dump(cells, f, indent=2)
+        json.dump({"identity": ident, "cells": cells}, f, indent=2)
 
 
 if __name__ == "__main__":

--- a/tools/local_model_eval.py
+++ b/tools/local_model_eval.py
@@ -1591,33 +1591,56 @@ def cell_facts(log_records):
         cell_id = (record.get("backend"), record.get("model"), record.get("num_ctx"),
                    surface.get("client"))
         entry = facts.setdefault(cell_id, {"surface": set(), "window": set()})
-        if surface.get("digest"):
-            # **The digest when there is one**, because a count and a byte length are not a
-            # fingerprint: a same-length reword, or an allowlist swap of equal size, leaves both
-            # unchanged while the model is handed different tools. Older logs have no digest, and
-            # for those the count and length are what there is - a floor, said as one.
-            entry["surface"].add(f"{surface.get('tools')} tools, {surface['digest']}")
-        elif surface.get("tools") is not None or surface.get("bytes") is not None:
-            # A cell-failure note carries the client and nothing else, so it contributes no
-            # fingerprint rather than an `unrecorded` one.
-            entry["surface"].add(f"{surface.get('tools')} tools, {surface.get('bytes')} B "
-                                 f"(no digest recorded)")
+        if surface.get("tools") is not None or surface.get("bytes") is not None:
+            # **Kept as its parts, not as a rendered string.** A cell-failure note carries the
+            # client and nothing else, so it contributes nothing rather than an `unrecorded`
+            # fingerprint - and the comparison below has to be able to fall back to the count and
+            # the length when one side predates the digest, which a pre-rendered string forbids.
+            entry["surface"].add((surface.get("tools"), surface.get("bytes"),
+                                  surface.get("digest")))
         if record.get("served_context") is not None:
             entry["window"].add(str(record["served_context"]))
     return facts
 
 
+def surface_text(fingerprints):
+    """A cell's surface as a line — the digest where there is one, the length where there is not."""
+    return ", ".join(f"{tools} tools, {digest or f'{size} B'}"
+                     for tools, size, digest in sorted(fingerprints, key=str))
+
+
 def moved_cells(old_facts, new_facts):
-    """Per cell, which of [`cell_facts`] differ between two runs — `{cell: {name: (old, new)}}`."""
+    """Per cell, what differs between two runs — `{cell: [(name, old, new, kind)]}`.
+
+    `kind` is `moved` or `unverifiable`, and the second exists because **adopting the digest is not
+    a surface change**. A log written before that field carries a tool count and a byte length; one
+    written after carries a digest as well. Comparing whatever each side happens to have would make
+    every cell of the first post-digest comparison read as moved, on nothing but a telemetry format
+    — the same false-positive class as the sentence in [`cell_facts`], pointed the other way. So
+    the two are compared on what they share, and a match there with a digest missing on one side is
+    reported as *unverifiable* rather than as agreement: a byte count cannot see a same-length
+    reword, which is the whole reason the digest exists.
+    """
     moved = {}
     for cell in sorted(set(old_facts) | set(new_facts)):
         before, after = old_facts.get(cell, {}), new_facts.get(cell, {})
-        for name in ("surface", "window"):
-            was, now = sorted(before.get(name) or []), sorted(after.get(name) or [])
-            if was and now and was != now:
-                # Only when both runs recorded one: a log written before a field existed has
-                # nothing to say about it, and reporting that as a move would be an invention.
-                moved.setdefault(cell, {})[name] = (", ".join(was), ", ".join(now))
+        was, now = before.get("surface") or set(), after.get("surface") or set()
+        if was and now:
+            # Only when both runs recorded one: a log with nothing to say about a field cannot
+            # have moved in it, and reporting that as a move would be an invention.
+            both_digested = all(f[2] for f in was | now)
+            comparable_was = was if both_digested else {(f[0], f[1]) for f in was}
+            comparable_now = now if both_digested else {(f[0], f[1]) for f in now}
+            if comparable_was != comparable_now:
+                moved.setdefault(cell, []).append(
+                    ("surface", surface_text(was), surface_text(now), "moved"))
+            elif not both_digested:
+                moved.setdefault(cell, []).append(
+                    ("surface", surface_text(was), surface_text(now), "unverifiable"))
+        was, now = sorted(before.get("window") or []), sorted(after.get("window") or [])
+        if was and now and was != now:
+            moved.setdefault(cell, []).append(
+                ("window", ", ".join(was), ", ".join(now), "moved"))
     return moved
 
 
@@ -1727,8 +1750,13 @@ def print_compare(order, rows, identities, moved_by_cell, old_path, new_path):
         print("\ncells where something besides the question moved:")
         for cell, moved in moved_by_cell.items():
             label = f"{(cell[1] or '?')[:24]} {str(cell[2] or 'dflt'):>6} {cell[3] or '?'}"
-            for name, (was, now) in sorted(moved.items()):
-                print(f"  {label:<40} {name} {was} -> {now}")
+            for name, was, now, kind in moved:
+                if kind == "unverifiable":
+                    print(f"  {label:<40} {name} {was} -> {now} (same on what both runs "
+                          f"recorded; only one has a digest, so a same-length edit cannot be "
+                          f"ruled out)")
+                else:
+                    print(f"  {label:<40} {name} {was} -> {now}")
 
 
 def series(log_paths, tasks_file, out_path):

--- a/tools/local_model_eval.py
+++ b/tools/local_model_eval.py
@@ -1482,6 +1482,12 @@ def print_matrix(order, rows):
 # where the truth is "nobody knows" — which is the whole argument for recording them now.
 UNRECORDED = "unrecorded"
 
+# And what a log *did* record as having no answer. A Claude row's `model_digest` is deliberately
+# null - an alias resolved inside a client this bench does not own has no content address - and
+# spelling that the same way as "nobody recorded it" made every current run with a Claude cell
+# read as a legacy log.
+UNAVAILABLE = "unavailable"
+
 
 def identity(log_records):
     """The uncontrolled variables of a run: what is neither the question nor the surface.
@@ -1491,6 +1497,20 @@ def identity(log_records):
     weights behind a mutable tag, the harness resolving an alias, and the task list the questions
     came from.
     """
+    def stated(record, name, render=str):
+        """One identity field, with **absent and null kept apart**.
+
+        A driver writes `model_digest: null` *deliberately* on a Claude row - an alias resolved
+        inside a client this bench does not own has no content address to offer - so folding that
+        into `unrecorded` labelled every current run containing a Claude cell as a log predating
+        the field. Absent means nobody recorded it and never can; null means this row cannot have
+        one. The series has to tell those apart or it cannot compare anything against history.
+        """
+        if name not in record:
+            return UNRECORDED
+        value = record[name]
+        return render(value) if value else UNAVAILABLE
+
     fields = {"run": set(), "suite": set(), "server": set(), "harness": set()}
     weights = {}
     for record in log_records:
@@ -1503,16 +1523,14 @@ def identity(log_records):
             fields["run"].add(record.get("run") or UNRECORDED)
             continue
         fields["run"].add(record.get("run") or UNRECORDED)
-        suite = record.get("suite") or {}
-        fields["suite"].add(f"{suite.get('name')} ({suite.get('file')})" if suite else UNRECORDED)
-        server = record.get("server") or {}
-        fields["server"].add(f"{server.get('name')} {server.get('version')}"
-                             if server else UNRECORDED)
+        fields["suite"].add(stated(record, "suite", lambda s: f"{s.get('name')} ({s.get('file')})"))
+        fields["server"].add(stated(record, "server",
+                                    lambda s: f"{s.get('name')} {s.get('version')}"))
         if record.get("backend") == "claude-code":
-            fields["harness"].add(record.get("harness_version") or UNRECORDED)
+            fields["harness"].add(stated(record, "harness_version"))
         model = record.get("model")
         if model:
-            weights.setdefault(model, set()).add(record.get("model_digest") or UNRECORDED)
+            weights.setdefault(model, set()).add(stated(record, "model_digest"))
     return {name: sorted(values) for name, values in fields.items()} | {
         "weights": {model: sorted(digests) for model, digests in sorted(weights.items())}}
 
@@ -1537,10 +1555,10 @@ def print_identity(ident, indent="  ", header=True):
         # here can be matched against the machine's own listing by eye, and the full value is in
         # the record for anything that needs to be exact.
         print(f"{indent}{'weights':<8} {model} {' '.join(d[:12] for d in digests)}")
-    if any(UNRECORDED in ident[name] for name in ("suite", "server")) or \
+    if any(UNRECORDED in ident[name] for name in ("suite", "server", "harness")) or \
             any(UNRECORDED in d for d in ident["weights"].values()):
         print(f"{indent}({UNRECORDED} is a log written before a field existed — it cannot be "
-              f"filled in afterwards)")
+              f"filled in afterwards; {UNAVAILABLE} is a row that has no such answer to give)")
 
 
 def cell_facts(log_records):
@@ -1557,6 +1575,12 @@ def cell_facts(log_records):
     window records `num_ctx: null` while the runtime serves whatever it likes, so two runs can pair
     a 4K result against a 32K one with nothing said.
 
+    **The surface is compared by digest, not by length**, which is the same distinction one level
+    down: a byte count moves for almost any prose edit and for none reliably, so a same-length
+    reword or an equal-sized allowlist swap would leave it saying nothing moved. The drivers record
+    a digest of the surface exactly as it went over the wire; a log written before that field
+    existed falls back to the count and the length, and says so.
+
     Named rather than blocked, which is the split the rest of this follows: a changed *question* is
     not comparable at all, while a changed surface is often the very intervention a rerun exists to
     measure — items 40, 41 and #217 each changed one and were read across two runs.
@@ -1567,10 +1591,17 @@ def cell_facts(log_records):
         cell_id = (record.get("backend"), record.get("model"), record.get("num_ctx"),
                    surface.get("client"))
         entry = facts.setdefault(cell_id, {"surface": set(), "window": set()})
-        if surface.get("tools") is not None or surface.get("bytes") is not None:
+        if surface.get("digest"):
+            # **The digest when there is one**, because a count and a byte length are not a
+            # fingerprint: a same-length reword, or an allowlist swap of equal size, leaves both
+            # unchanged while the model is handed different tools. Older logs have no digest, and
+            # for those the count and length are what there is - a floor, said as one.
+            entry["surface"].add(f"{surface.get('tools')} tools, {surface['digest']}")
+        elif surface.get("tools") is not None or surface.get("bytes") is not None:
             # A cell-failure note carries the client and nothing else, so it contributes no
             # fingerprint rather than an `unrecorded` one.
-            entry["surface"].add(f"{surface.get('tools')} tools, {surface.get('bytes')} B")
+            entry["surface"].add(f"{surface.get('tools')} tools, {surface.get('bytes')} B "
+                                 f"(no digest recorded)")
         if record.get("served_context") is not None:
             entry["window"].add(str(record["served_context"]))
     return facts

--- a/tools/local_model_eval.py
+++ b/tools/local_model_eval.py
@@ -1434,13 +1434,13 @@ def print_matrix(order, rows):
     # rather than merely look untidy.
     marks = [m.get("mark") or "" for row in rows.values() for m in row.values()]
     width = max([len(t) for t in order] + [len(m) for m in marks] or [0]) + 2
-    header = f"{'cell':<44}" + "".join(f"{t:<{width}}" for t in order)
+    header = f"{'cell':<52}" + "".join(f"{t:<{width}}" for t in order)
     print("\n" + header)
     print("-" * len(header))
     for cell, marks in sorted(rows.items(), key=lambda kv: cell_order(kv[0])):
         backend, model, ctx, surface = cell
         label = f"{model[:24]} {str(ctx or 'dflt'):>6} {surface}"
-        print(f"{label:<44}" + "".join(f"{marks.get(t, {}).get('mark', ' '):<{width}}"
+        print(f"{label:<52}" + "".join(f"{marks.get(t, {}).get('mark', ' '):<{width}}"
                                        for t in order))
     print("\nY correct   n wrong   - not answerable on this surface   "
           "o answered anyway   ! the runtime refused the request   "
@@ -1560,6 +1560,19 @@ def print_identity(ident, indent="  ", header=True):
               f"filled in afterwards; {UNAVAILABLE} is a row that has no such answer to give)")
 
 
+def cell_label(cell):
+    """A cell as a row heading — **backend included**, since a cell is keyed by it.
+
+    An ollama tag and a Claude Code alias may be the same string (`sonnet` is the example this bench
+    could reach), and two rows rendering identically leave a reader no way to tell which movement
+    note belongs to which backend. The summary table has a `backend` column; these rows are one
+    line, so it goes in the label.
+    """
+    backend, model, context, client = cell
+    return (f"{(backend or '?')[:11]} {(model or '?')[:24]} "
+            f"{str(context or 'dflt'):>6} {client or '?'}")
+
+
 def cell_order(cell):
     """How a `(backend, model, num_ctx, client)` key sorts — **never the raw tuple**.
 
@@ -1573,7 +1586,7 @@ def cell_order(cell):
 
 
 def cell_facts(log_records):
-    """Per cell, the two variables a run-wide identity line cannot hold.
+    """Per cell, the three variables a run-wide identity line cannot hold.
 
     **A surface and a served window belong to a cell, not to a log.** The grid varies both on
     purpose, so listing them run-wide says nothing: two runs both covering `min` at three windows
@@ -1601,7 +1614,14 @@ def cell_facts(log_records):
         surface = record.get("surface") or {}
         cell_id = (record.get("backend"), record.get("model"), record.get("num_ctx"),
                    surface.get("client"))
-        entry = facts.setdefault(cell_id, {"surface": set(), "window": set()})
+        entry = facts.setdefault(cell_id, {"surface": set(), "window": set(), "weights": set()})
+        # **The weights per cell, not only per run.** The identity block's `weights` line is a
+        # run-wide set, and a set loses which digest answered which cell: two runs whose *same two*
+        # digests are assigned to opposite cells - a tag re-pulled between them - compare equal
+        # there and pair results produced by different weights. This is the same per-cell reading
+        # the surface and the window already get.
+        if record.get("model_digest"):
+            entry["weights"].add(record["model_digest"][:12])
         if surface.get("tools") is not None or surface.get("bytes") is not None:
             # **Kept as its parts, not as a rendered string.** A cell-failure note carries the
             # client and nothing else, so it contributes nothing rather than an `unrecorded`
@@ -1654,10 +1674,11 @@ def moved_cells(old_facts, new_facts):
                     ("surface", surface_text(was), surface_text(now), "unverifiable"))
             elif not any(digested):
                 undigested.add(cell)
-        was, now = sorted(before.get("window") or []), sorted(after.get("window") or [])
-        if was and now and was != now:
-            moved.setdefault(cell, []).append(
-                ("window", ", ".join(was), ", ".join(now), "moved"))
+        for name in ("window", "weights"):
+            was, now = sorted(before.get(name) or []), sorted(after.get(name) or [])
+            if was and now and was != now:
+                moved.setdefault(cell, []).append(
+                    (name, ", ".join(was), ", ".join(now), "moved"))
     return moved, undigested
 
 
@@ -1736,13 +1757,12 @@ def print_compare(order, rows, identities, surfaces, old_path, new_path):
     width = max([len(t) for t in order]
                 + [len(f"{m.get('old', '')} -> {m.get('new', '')}")
                    for row in rows.values() for m in row.values()] or [0]) + 2
-    header = f"{'cell':<44}" + "".join(f"{t:<{width}}" for t in order)
+    header = f"{'cell':<52}" + "".join(f"{t:<{width}}" for t in order)
     print("\n" + header)
     print("-" * len(header))
     blocked = {}
     for cell, marks in rows.items():
-        backend, model, ctx, surface = cell
-        label = f"{model[:24]} {str(ctx or 'dflt'):>6} {surface}"
+        label = cell_label(cell)
         rendered_row = []
         for task in order:
             mark = marks.get(task)
@@ -1755,7 +1775,7 @@ def print_compare(order, rows, identities, surfaces, old_path, new_path):
                 rendered_row.append("--")
             else:
                 rendered_row.append(f"{mark['old']} -> {mark['new']}")
-        print(f"{label:<44}" + "".join(f"{r:<{width}}" for r in rendered_row))
+        print(f"{label:<52}" + "".join(f"{r:<{width}}" for r in rendered_row))
     print("\nold -> new per cell-task; `(old)`/`(new)` is a cell only one run covered.")
     for reason, tasks in blocked.items():
         # At the row rather than in a header, which is the same principle as the `UNCOUNTED` line
@@ -1766,14 +1786,14 @@ def print_compare(order, rows, identities, surfaces, old_path, new_path):
         # block is per run - and named rather than blocking, for the reason `cell_facts` gives.
         print("\ncells where something besides the question moved:")
         for cell, moved in moved_by_cell.items():
-            label = f"{(cell[1] or '?')[:24]} {str(cell[2] or 'dflt'):>6} {cell[3] or '?'}"
+            label = cell_label(cell)
             for name, was, now, kind in moved:
                 if kind == "unverifiable":
-                    print(f"  {label:<40} {name} {was} -> {now} (same on what both runs "
+                    print(f"  {label:<52} {name} {was} -> {now} (same on what both runs "
                           f"recorded; only one has a digest, so a same-length edit cannot be "
                           f"ruled out)")
                 else:
-                    print(f"  {label:<40} {name} {was} -> {now}")
+                    print(f"  {label:<52} {name} {was} -> {now}")
     if undigested:
         print(f"\n{len(undigested)} cell(s) agree on tool count and byte length with **no surface "
               f"digest on either side**, so a same-length edit cannot be ruled out for them. Both "


### PR DESCRIPTION
Closes `FOLLOWUPS.md` item 46. **Stacked on #224** (item 45) — review that one first; this branch
contains it.

Re-running a cell is the point: as models are updated the same question on the same surface will be
asked again, and what matters is run N against run N-1. A record identified the question and the
surface, and **neither of the two things that change over time** — which model weights answered,
and which server build was asked.

Both facts were already on the wire and both were being thrown away. The handshake kept
`protocolVersion` and dropped `serverInfo`; `/api/ps` was read for the served window and not for the
`digest` beside it.

## The decision the entry deferred: yes, this server reports a build revision

A crate version is a **floor**, not an identity — it moves only on release, so two builds of
`0.11.0` were indistinguishable. And the field that *looked* like a build identity, `surface.bytes`,
is a fingerprint of one channel and silent on exactly the one the last three findings were about:
[#217](https://github.com/glslang/windbg-mcp/pull/217) changed an **opener's result**.

So `build.rs` stamps the short git revision into the version this server reports, as semver build
metadata — `0.11.0+g1a2b3c4`, and `-dirty` where the build inputs differ from that commit. The
transcript's `start` record carries the same string; it had the same weakness and nothing had
noticed. Build metadata is ignored for precedence, so nothing comparing versions is affected, and a
build with no git reports the bare crate version.

Two consequences worth reviewing:

- **Both version assertions become prefix checks**, which is a weakening — so the smoke test gains
  one that is not: built from a git checkout, the version *must* carry a revision. Without it a
  `build.rs` that silently stopped running would leave every assertion passing on the bare crate
  version, which is the legitimate tarball answer.
- **`build.rs`'s watch list and its dirty check are one `INPUTS` const.** Emitting any
  `rerun-if-changed` replaces Cargo's default of watching the whole package, so two lists would
  disagree about what a clean build is. `-dirty` therefore means "the build inputs differ from that
  commit" — an edit under `docs/` does not make a binary a different binary.

## `--compare`, with two rules that are not one rule

- **A changed question blocks a pairing.** `arm64_pc` has one id and two materially different
  wordings; pairing on the id would be *laxer than `usable()` already is*. It reuses
  `stale_prompt` — the predicate split out of `usable` in #220 so the reason could be named — and
  prints the refusal at the row.
- **Everything else is named above the table**: build, weights, harness, suite. Those a reader can
  weigh, and this repo has three times read a moved aggregate as a controlled result — every one a
  *composition* error where the callers changed and the total held.

`--series` reduces logs to one row per run in `docs/eval-runs.json`, so history is a query rather
than a re-reading of prose sections that measure three different servers. The three runs already in
it read `unrecorded` throughout, which is the part of this that expires rather than an omission: a
run recorded without identity cannot have it added later.

## Verification

Checked rather than described:

- `/api/ps` carries `digest` beside `context_length` — **measured against a loaded model**, not read
  off a document.
- The live listener's `serverInfo` is captured by the driver (`{'name': 'windbg-mcp', 'version':
  '0.11.0'}` from the unstamped release build, which is the correct fallback answer).
- The stamp reads the branch head's short revision, and gains `-dirty` after a one-line edit under
  `src/` — exercising the rerun trigger and the dirty check together.
- `--compare`'s **blocked-pairing** and **one-sided-cell** paths were run against a doctored log
  rather than described; the real `after-206 -> after-210` output in the docs is captured, not
  assembled.
- ARM64 bench: `cargo fmt --all --check`, **540** unit tests and **76** smoke tests green, no new
  clippy warning (`every_tool` is pre-existing on `main`).

## Left open

Naming a real version source for a Claude row. `harness_version` is `claude --version`, which moves
when the client does and says nothing about the weights behind `opus` or `sonnet` — a floor,
recorded as one, exactly as the crate version was before `build.rs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017KHzgze3DM5NUNzfkeHVmZ