### PR TITLE
Root every output schema at `type: "object"`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Every tool's `outputSchema` is rooted at `type: "object"`, which is what keeps a strict client
+  holding any tools at all** (issue #223). The structured results are internally-tagged enums, and
+  `schemars` renders one as `{ $schema, oneOf, $defs }` — object-ness stated on each branch of the
+  union and nowhere at the root. rmcp passes that through deliberately, because SEP-2106
+  (`2026-07-28`) relaxed the requirement for output schemas. But that relaxation says what a server
+  *may* emit, not what clients accept: every released `@modelcontextprotocol/sdk` 1.x — 1.30.0
+  included — parses `Tool.outputSchema` as `z.object({ type: z.literal("object"), … })` and
+  `tools/list` as `z.array(ToolSchema)`, so the array fails on the first non-conforming tool and the
+  client registers **none** of them. Measured against 1.30.0 on this server's own captured
+  `tools/list`: **0 of 51 tools before, 51 of 51 after**. It reached a real client as zero tools
+  registered, a reconnect loop exhausted and the server deregistered.
+
+  Supplying the keyword is not a concession to old clients — it is *true*, since MCP types
+  `structuredContent` as a JSON object in every revision — and it changes nothing about what
+  validates: each branch of the `oneOf` already carried `"type": "object"`, and `ajv` gives success,
+  failure, a payload missing its required fields and an unknown discriminator the same verdict
+  either way. Emitting the relaxed shape only to peers that negotiated `2026-07-28` was considered
+  and rejected for the same reason: the object-rooted form is legal under both revisions, so the
+  version-aware branch would exist only to send a worse schema to half the population. It costs
+  16 bytes per tool — 528 across the surface, none of it model-visible.
+
 - **A raw `execute` of `g`/`p`/`t` moves the target instead of wedging the session**
   ([#226](https://github.com/glslang/windbg-mcp/issues/226)). `execute` runs a plain
   `IDebugControl::Execute`, and DbgEng's execution-control commands only *set the run state*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,7 +172,7 @@ It checks *same-file* fragments only, so a cross-file `../README.md#some-heading
 verify by hand.
 
 **The pass count does not say which tiers ran.** Each gate is inside its test, so the `mcp_smoke`
-harness reports the same **76 passed** with the debugger tier off as with it on — that harness's own
+harness reports the same **79 passed** with the debugger tier off as with it on — that harness's own
 result line, since a plain `cargo test` runs the crate's several hundred unit tests beside it and
 prints a result line per binary. What differs between the two runs is the runtime (measured on the
 ARM64 bench 2026-08-23: **1.6s against 61s** for `cargo test --test mcp_smoke`) and the `SKIPPED`
@@ -660,7 +660,11 @@ Four rules worth knowing before touching it. **`session` is in every surface** w
 says, because every other tool routes by a `session_id` this server alone issues — so `--tools
 crash` is eleven tools and 11,265 B is the floor. **Output schemas carry no prose at all**
 (`src/schema.rs`): declare one with `schema::constraints_of`, never rmcp's `schema_for_output`, or
-the tool ships every doc comment in its `$defs` closure and the wire ceiling notices. And **a
+the tool ships every doc comment in its `$defs` closure and the wire ceiling notices. That call is
+also what supplies the root `type: "object"` a discriminated union does not generate and rmcp does
+not add — without which every released TypeScript-SDK client rejects the *whole* `tools/list` and
+registers no tools at all, not 50 of 51 (issue #223, measured: 0 of 51 against SDK 1.30.0). Both
+halves are asserted on the wire in `mcp_smoke`, because both come undone the same way. And **a
 surface is per client, not per run** (item 36): `--tools` is the run's *default*, and a listener's
 client may be configured with a spec of its own (`WINDBG_MCP_TOOLS_<NAME>`, or a `tools` field in
 the credential file) that replaces it. So a change to a group is a change to what several

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -154,8 +154,9 @@ suppress it — not ship an advertisement clients will call into a dead end.
 surface as it appears on the wire: JSON Schema dialect, `$defs` usage (`true` since `debug_batch`
 introduced the first nested schema), tool count, and per tool its
 name, title, four behaviour hints, required arguments, each parameter's type/format/enum, and — for
-the tools that declare one — the shape of its `outputSchema`: the dialect, and for each branch of
-the result union its `status` const, the payload type it references, and what that branch requires.
+the tools that declare one — the shape of its `outputSchema`: the dialect, the root `type`, and for
+each branch of the result union its `status` const, the payload type it references, and what that
+branch requires.
 It deliberately excludes descriptions, so prose edits do not churn it while a `schemars` dialect
 switch, an `rmcp` annotation-casing change, a discriminator that stops being emitted, or an
 accidental tool rename all land as a readable line diff.
@@ -165,6 +166,25 @@ descriptions **at all** — 68% of every `outputSchema` byte used to be rustdoc 
 and no validator reads, which is `FOLLOWUPS.md` item 24's first finding. It reads `tools/list` off
 the wire because the way that comes undone is one tool declaring its schema with rmcp's
 `schema_for_output` instead of `schema::constraints_of`, and nothing else would report it.
+
+And beside *that*, `output_schemas_are_object_rooted` asserts every declared `outputSchema` is
+rooted at `type: "object"` — the keyword whose absence costs a strict client not the one tool that
+lacks it but **every tool on the list**. The structured results are internally-tagged enums, which
+`schemars` renders as `{ $schema, oneOf, $defs }` with the object-ness on each branch and none at
+the root, and rmcp passes that through: `schema_for_input` requires a root `object` and refuses
+anything else, while `schema_for_output` deliberately does not, SEP-2106 (`2026-07-28`) having
+relaxed the requirement. That relaxation is what a server may emit, not what clients accept — every
+released `@modelcontextprotocol/sdk` 1.x through 1.30.0 parses `Tool.outputSchema` as
+`z.object({ type: z.literal("object"), … })` and `tools/list` as `z.array(ToolSchema)`, so the array
+fails on the first non-conforming tool. Measured against 1.30.0 on this server's own captured
+`tools/list`: **0 of 51 tools before the fix, 51 of 51 after**, and all 33 schemas compile under
+`ajv`. That is issue #223, which reached a real client as zero tools registered and the server
+deregistered after its reconnect loop. `src/schema.rs` supplies the keyword; this is the assertion
+that it reaches the wire, since the failure is a tool declaring its schema the other way round.
+
+The reason no tier caught it is worth keeping: this harness is a hand-rolled JSON-RPC client, and
+it never validated a tool *definition* — only the results of calling one. The assertion encodes the
+SDK's rule rather than adding a Node client to CI.
 
 Re-record after an *intended* change, and read the diff before committing:
 

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -32,6 +32,11 @@
 //! model context, because `ModuleInfo` is embedded in six output shapes. The same type costs
 //! roughly a seventh of that now: the multiplier is unchanged, but what is being multiplied is a
 //! handful of keywords rather than a paragraph.
+//!
+//! The other thing this module does is **add** one keyword, for the opposite reason: a root
+//! `type: "object"` that `schemars` does not emit for a discriminated union and rmcp does not
+//! supply, without which every released TypeScript-SDK client rejects the whole `tools/list` and
+//! is left with no tools at all. [`object_rooted`] has the measurements.
 
 use std::any::{Any, TypeId};
 use std::collections::HashMap;
@@ -62,14 +67,47 @@ pub fn constraints_of<T: JsonSchema + Any>() -> Arc<JsonObject> {
         return cached.clone();
     }
 
-    let lean = Arc::new(strip_descriptions(
+    let lean = Arc::new(object_rooted(strip_descriptions(
         &rmcp::handler::server::tool::schema_for_output::<T>(),
-    ));
+    )));
     CACHE
         .write()
         .expect("output schema cache poisoned")
         .insert(TypeId::of::<T>(), lean.clone());
     lean
+}
+
+/// The root's `"type": "object"`, supplied where the generator emitted no `type` at all.
+///
+/// Every structured result here is an [`Outcome`](crate::structured::Outcome) — a serde
+/// internally-tagged enum — and `schemars` renders one as `{ $schema, oneOf, $defs }` with the
+/// object-ness stated on each branch and nowhere at the root. rmcp does not fill it in: its
+/// `schema_for_input` requires a root `type: "object"` and refuses anything else, while
+/// `schema_for_output` deliberately does not, because SEP-2106 (`2026-07-28`) relaxed the
+/// requirement for output schemas.
+///
+/// The relaxation is what a *server* may emit, not what clients accept. Every released
+/// `@modelcontextprotocol/sdk` 1.x — through 1.30.0 — parses `Tool.outputSchema` as
+/// `z.object({ type: z.literal("object"), … })`, and `tools/list` as `z.array(ToolSchema)`, so a
+/// single non-conforming tool fails the array and the client is left with **no tools at all** —
+/// not 50 of 51 (issue #223). Such a client negotiates `2025-11-25`, which rmcp knows and echoes,
+/// so the session runs under the revision that requires the keyword anyway.
+///
+/// Supplying it is not a concession to old clients, because the keyword is *true*: MCP types
+/// `structuredContent` as a JSON object in every revision, so a tool result can be nothing else.
+/// Nor does it change what validates — measured, with `ajv` on both shapes: each branch of the
+/// `oneOf` already carries `"type": "object"`, so success, failure, a payload missing its required
+/// fields and an unknown discriminator all get the same verdict either way.
+///
+/// A root that *does* declare a type is left alone rather than corrected. Nothing produces one
+/// today; if something ever does, the type it declares is either `object` already or a bug worth
+/// seeing, and this function runs on every `router()` build — so the invariant is asserted in the
+/// tests below and on the wire in `mcp_smoke`, where a failure can be read rather than crashed on.
+fn object_rooted(mut schema: JsonObject) -> JsonObject {
+    schema
+        .entry("type")
+        .or_insert_with(|| Value::String("object".into()));
+    schema
 }
 
 /// Every `description` in a JSON Schema document, removed.
@@ -290,6 +328,53 @@ mod tests {
             rendered.contains("\"stale_session\""),
             "the ErrorCategory vocabulary is a constraint, not prose: {rendered}"
         );
+    }
+
+    /// The root keyword that decides whether a strict client keeps *any* of this server's tools.
+    ///
+    /// `schemars` states the object-ness of an internally-tagged enum on each branch of the
+    /// `oneOf` and nowhere at the root, and rmcp's `schema_for_output` passes that through. A
+    /// TypeScript-SDK 1.x client parses `tools/list` as an array of tools whose `outputSchema`
+    /// must be root-`object`, so one such schema costs the client the whole list (issue #223).
+    #[test]
+    fn a_declared_output_schema_is_object_rooted() {
+        for schema in [
+            constraints_of::<crate::structured::Outcome<crate::structured::SessionEnded>>(),
+            constraints_of::<crate::structured::OpenOutcome>(),
+        ] {
+            assert_eq!(
+                schema.get("type"),
+                Some(&json!("object")),
+                "an output schema with no root `type: \"object\"` is dropped by every released \
+                 TypeScript-SDK client, and it takes the other fifty tools with it: {schema:?}"
+            );
+        }
+    }
+
+    /// The keyword is supplied, not asserted: the branches already carry it, so what is added at
+    /// the root states what the union could only ever have meant.
+    #[test]
+    fn every_branch_was_already_an_object() {
+        let schema = constraints_of::<crate::structured::OpenOutcome>();
+        let branches = schema["oneOf"].as_array().expect("an outcome is a union");
+        assert!(!branches.is_empty(), "the union has branches: {schema:?}");
+        for branch in branches {
+            assert_eq!(
+                branch["type"], "object",
+                "a branch that is not an object would make the root keyword a lie: {branch}"
+            );
+        }
+    }
+
+    /// A root that already declares a type is left as it is. Nothing generates one today, and a
+    /// future one is either `object` already or a bug — and this runs on every `router()` build,
+    /// so it is the wire assertion in `mcp_smoke` that has to report it, not a panic in a live
+    /// server.
+    #[test]
+    fn a_root_that_declares_a_type_is_left_alone() {
+        let declared = json!({ "type": "array", "items": true });
+        let object = declared.as_object().expect("a schema is an object").clone();
+        assert_eq!(Value::Object(object_rooted(object)), declared);
     }
 
     /// Two calls hand back the same cached document rather than two walks of the same one.

--- a/tests/golden/tool_budget.json
+++ b/tests/golden/tool_budget.json
@@ -6,8 +6,8 @@
       "inputSchema": 904,
       "modelVisible": 2001,
       "name": "attach_kernel",
-      "outputSchema": 3838,
-      "wire": 5993
+      "outputSchema": 3854,
+      "wire": 6009
     },
     {
       "annotations": 122,
@@ -15,8 +15,8 @@
       "inputSchema": 33,
       "modelVisible": 330,
       "name": "attach_kernel_local",
-      "outputSchema": 3838,
-      "wire": 4321
+      "outputSchema": 3854,
+      "wire": 4337
     },
     {
       "annotations": 117,
@@ -24,8 +24,8 @@
       "inputSchema": 204,
       "modelVisible": 499,
       "name": "attach_process",
-      "outputSchema": 3838,
-      "wire": 4485
+      "outputSchema": 3854,
+      "wire": 4501
     },
     {
       "annotations": 68,
@@ -33,8 +33,8 @@
       "inputSchema": 463,
       "modelVisible": 1123,
       "name": "backtrace",
-      "outputSchema": 1501,
-      "wire": 2723
+      "outputSchema": 1517,
+      "wire": 2739
     },
     {
       "annotations": 117,
@@ -42,8 +42,8 @@
       "inputSchema": 1308,
       "modelVisible": 2936,
       "name": "crash_triage",
-      "outputSchema": 2511,
-      "wire": 5595
+      "outputSchema": 2527,
+      "wire": 5611
     },
     {
       "annotations": 134,
@@ -51,8 +51,8 @@
       "inputSchema": 7980,
       "modelVisible": 9746,
       "name": "debug_batch",
-      "outputSchema": 2904,
-      "wire": 12815
+      "outputSchema": 2920,
+      "wire": 12831
     },
     {
       "annotations": 79,
@@ -78,8 +78,8 @@
       "inputSchema": 629,
       "modelVisible": 1471,
       "name": "disassemble",
-      "outputSchema": 1478,
-      "wire": 3044
+      "outputSchema": 1494,
+      "wire": 3060
     },
     {
       "annotations": 74,
@@ -105,8 +105,8 @@
       "inputSchema": 314,
       "modelVisible": 1079,
       "name": "end_session",
-      "outputSchema": 1242,
-      "wire": 2468
+      "outputSchema": 1258,
+      "wire": 2484
     },
     {
       "annotations": 124,
@@ -123,8 +123,8 @@
       "inputSchema": 314,
       "modelVisible": 440,
       "name": "go",
-      "outputSchema": 1232,
-      "wire": 1821
+      "outputSchema": 1248,
+      "wire": 1837
     },
     {
       "annotations": 118,
@@ -141,8 +141,8 @@
       "inputSchema": 1153,
       "modelVisible": 1430,
       "name": "heap_allocations",
-      "outputSchema": 5449,
-      "wire": 7038
+      "outputSchema": 5465,
+      "wire": 7054
     },
     {
       "annotations": 124,
@@ -150,8 +150,8 @@
       "inputSchema": 618,
       "modelVisible": 864,
       "name": "heap_census",
-      "outputSchema": 5283,
-      "wire": 6302
+      "outputSchema": 5299,
+      "wire": 6318
     },
     {
       "annotations": 126,
@@ -159,8 +159,8 @@
       "inputSchema": 493,
       "modelVisible": 900,
       "name": "heap_chunk",
-      "outputSchema": 5639,
-      "wire": 6696
+      "outputSchema": 5655,
+      "wire": 6712
     },
     {
       "annotations": 130,
@@ -168,8 +168,8 @@
       "inputSchema": 762,
       "modelVisible": 1078,
       "name": "heap_diagnostics",
-      "outputSchema": 5115,
-      "wire": 6354
+      "outputSchema": 5131,
+      "wire": 6370
     },
     {
       "annotations": 119,
@@ -177,8 +177,8 @@
       "inputSchema": 465,
       "modelVisible": 821,
       "name": "heap_list",
-      "outputSchema": 4979,
-      "wire": 5950
+      "outputSchema": 4995,
+      "wire": 5966
     },
     {
       "annotations": 120,
@@ -222,8 +222,8 @@
       "inputSchema": 229,
       "modelVisible": 542,
       "name": "launch",
-      "outputSchema": 3838,
-      "wire": 4540
+      "outputSchema": 3854,
+      "wire": 4556
     },
     {
       "annotations": 65,
@@ -231,8 +231,8 @@
       "inputSchema": 1640,
       "modelVisible": 2411,
       "name": "modules",
-      "outputSchema": 3223,
-      "wire": 5730
+      "outputSchema": 3239,
+      "wire": 5746
     },
     {
       "annotations": 128,
@@ -240,8 +240,8 @@
       "inputSchema": 211,
       "modelVisible": 718,
       "name": "open_dump",
-      "outputSchema": 3838,
-      "wire": 4715
+      "outputSchema": 3854,
+      "wire": 4731
     },
     {
       "annotations": 114,
@@ -249,8 +249,8 @@
       "inputSchema": 211,
       "modelVisible": 534,
       "name": "open_trace",
-      "outputSchema": 3838,
-      "wire": 4517
+      "outputSchema": 3854,
+      "wire": 4533
     },
     {
       "annotations": 123,
@@ -258,8 +258,8 @@
       "inputSchema": 602,
       "modelVisible": 1029,
       "name": "pool_census",
-      "outputSchema": 4679,
-      "wire": 5862
+      "outputSchema": 4695,
+      "wire": 5878
     },
     {
       "annotations": 129,
@@ -267,8 +267,8 @@
       "inputSchema": 760,
       "modelVisible": 1752,
       "name": "pool_chunk",
-      "outputSchema": 5447,
-      "wire": 7359
+      "outputSchema": 5463,
+      "wire": 7375
     },
     {
       "annotations": 127,
@@ -276,8 +276,8 @@
       "inputSchema": 831,
       "modelVisible": 1983,
       "name": "pool_diagnostics",
-      "outputSchema": 4616,
-      "wire": 6757
+      "outputSchema": 4632,
+      "wire": 6773
     },
     {
       "annotations": 122,
@@ -285,8 +285,8 @@
       "inputSchema": 1420,
       "modelVisible": 2032,
       "name": "pool_find_tag",
-      "outputSchema": 5499,
-      "wire": 7684
+      "outputSchema": 5515,
+      "wire": 7700
     },
     {
       "annotations": 90,
@@ -321,8 +321,8 @@
       "inputSchema": 630,
       "modelVisible": 1008,
       "name": "registers",
-      "outputSchema": 2097,
-      "wire": 3203
+      "outputSchema": 2113,
+      "wire": 3219
     },
     {
       "annotations": 123,
@@ -330,8 +330,8 @@
       "inputSchema": 314,
       "modelVisible": 451,
       "name": "reverse_go",
-      "outputSchema": 1232,
-      "wire": 1837
+      "outputSchema": 1248,
+      "wire": 1853
     },
     {
       "annotations": 114,
@@ -339,8 +339,8 @@
       "inputSchema": 791,
       "modelVisible": 1320,
       "name": "run_to_address",
-      "outputSchema": 1406,
-      "wire": 2871
+      "outputSchema": 1422,
+      "wire": 2887
     },
     {
       "annotations": 75,
@@ -348,8 +348,8 @@
       "inputSchema": 1608,
       "modelVisible": 2599,
       "name": "server_log",
-      "outputSchema": 1820,
-      "wire": 4525
+      "outputSchema": 1836,
+      "wire": 4541
     },
     {
       "annotations": 73,
@@ -357,8 +357,8 @@
       "inputSchema": 314,
       "modelVisible": 1389,
       "name": "session_status",
-      "outputSchema": 2726,
-      "wire": 4219
+      "outputSchema": 2742,
+      "wire": 4235
     },
     {
       "annotations": 115,
@@ -366,8 +366,8 @@
       "inputSchema": 467,
       "modelVisible": 852,
       "name": "set_breakpoint",
-      "outputSchema": 2236,
-      "wire": 3234
+      "outputSchema": 2252,
+      "wire": 3250
     },
     {
       "annotations": 123,
@@ -384,8 +384,8 @@
       "inputSchema": 314,
       "modelVisible": 438,
       "name": "step_back",
-      "outputSchema": 1232,
-      "wire": 1817
+      "outputSchema": 1248,
+      "wire": 1833
     },
     {
       "annotations": 109,
@@ -393,8 +393,8 @@
       "inputSchema": 314,
       "modelVisible": 398,
       "name": "step_into",
-      "outputSchema": 1232,
-      "wire": 1770
+      "outputSchema": 1248,
+      "wire": 1786
     },
     {
       "annotations": 109,
@@ -402,8 +402,8 @@
       "inputSchema": 314,
       "modelVisible": 410,
       "name": "step_over",
-      "outputSchema": 1232,
-      "wire": 1782
+      "outputSchema": 1248,
+      "wire": 1798
     },
     {
       "annotations": 121,
@@ -411,8 +411,8 @@
       "inputSchema": 314,
       "modelVisible": 441,
       "name": "step_over_back",
-      "outputSchema": 1232,
-      "wire": 1825
+      "outputSchema": 1248,
+      "wire": 1841
     },
     {
       "annotations": 65,
@@ -456,8 +456,8 @@
       "inputSchema": 2713,
       "modelVisible": 4080,
       "name": "walk_memory",
-      "outputSchema": 2954,
-      "wire": 7190
+      "outputSchema": 2970,
+      "wire": 7206
     }
   ],
   "totals": {
@@ -466,10 +466,10 @@
     "inputSchema": 40207,
     "instructions": 1983,
     "modelVisible": 67766,
-    "outputSchema": 103224,
-    "payload": 177850,
+    "outputSchema": 103752,
+    "payload": 178378,
     "tools": 51,
-    "wire": 177732,
+    "wire": 178260,
     "worstTool": "debug_batch",
     "worstToolModelVisible": 9746
   }

--- a/tests/golden/tools_list.json
+++ b/tests/golden/tools_list.json
@@ -30,7 +30,8 @@
             "status": "error"
           }
         ],
-        "dialect": "https://json-schema.org/draft/2020-12/schema"
+        "dialect": "https://json-schema.org/draft/2020-12/schema",
+        "root": "object"
       },
       "params": [
         "connection: string|null",
@@ -64,7 +65,8 @@
             "status": "error"
           }
         ],
-        "dialect": "https://json-schema.org/draft/2020-12/schema"
+        "dialect": "https://json-schema.org/draft/2020-12/schema",
+        "root": "object"
       },
       "params": [],
       "required": [],
@@ -95,7 +97,8 @@
             "status": "error"
           }
         ],
-        "dialect": "https://json-schema.org/draft/2020-12/schema"
+        "dialect": "https://json-schema.org/draft/2020-12/schema",
+        "root": "object"
       },
       "params": [
         "pid: integer/uint32"
@@ -130,7 +133,8 @@
             "status": "error"
           }
         ],
-        "dialect": "https://json-schema.org/draft/2020-12/schema"
+        "dialect": "https://json-schema.org/draft/2020-12/schema",
+        "root": "object"
       },
       "params": [
         "frames: integer|null/uint32",
@@ -164,7 +168,8 @@
             "status": "error"
           }
         ],
-        "dialect": "https://json-schema.org/draft/2020-12/schema"
+        "dialect": "https://json-schema.org/draft/2020-12/schema",
+        "root": "object"
       },
       "params": [
         "analyze: boolean|null",
@@ -199,7 +204,8 @@
             "status": "error"
           }
         ],
-        "dialect": "https://json-schema.org/draft/2020-12/schema"
+        "dialect": "https://json-schema.org/draft/2020-12/schema",
+        "root": "object"
       },
       "params": [
         "always: array<ref(#/$defs/BatchStep)>",
@@ -272,7 +278,8 @@
             "status": "error"
           }
         ],
-        "dialect": "https://json-schema.org/draft/2020-12/schema"
+        "dialect": "https://json-schema.org/draft/2020-12/schema",
+        "root": "object"
       },
       "params": [
         "address: string|null",
@@ -343,7 +350,8 @@
             "status": "error"
           }
         ],
-        "dialect": "https://json-schema.org/draft/2020-12/schema"
+        "dialect": "https://json-schema.org/draft/2020-12/schema",
+        "root": "object"
       },
       "params": [
         "session_id: string|null"
@@ -394,7 +402,8 @@
             "status": "error"
           }
         ],
-        "dialect": "https://json-schema.org/draft/2020-12/schema"
+        "dialect": "https://json-schema.org/draft/2020-12/schema",
+        "root": "object"
       },
       "params": [
         "session_id: string|null"
@@ -445,7 +454,8 @@
             "status": "error"
           }
         ],
-        "dialect": "https://json-schema.org/draft/2020-12/schema"
+        "dialect": "https://json-schema.org/draft/2020-12/schema",
+        "root": "object"
       },
       "params": [
         "backend: enum[\"lfh\"|\"vs\"|\"segment\"|\"large\"]|null",
@@ -485,7 +495,8 @@
             "status": "error"
           }
         ],
-        "dialect": "https://json-schema.org/draft/2020-12/schema"
+        "dialect": "https://json-schema.org/draft/2020-12/schema",
+        "root": "object"
       },
       "params": [
         "heap: string|null",
@@ -521,7 +532,8 @@
             "status": "error"
           }
         ],
-        "dialect": "https://json-schema.org/draft/2020-12/schema"
+        "dialect": "https://json-schema.org/draft/2020-12/schema",
+        "root": "object"
       },
       "params": [
         "address: string",
@@ -558,7 +570,8 @@
             "status": "error"
           }
         ],
-        "dialect": "https://json-schema.org/draft/2020-12/schema"
+        "dialect": "https://json-schema.org/draft/2020-12/schema",
+        "root": "object"
       },
       "params": [
         "filter: string|null",
@@ -595,7 +608,8 @@
             "status": "error"
           }
         ],
-        "dialect": "https://json-schema.org/draft/2020-12/schema"
+        "dialect": "https://json-schema.org/draft/2020-12/schema",
+        "root": "object"
       },
       "params": [
         "refresh: boolean|null",
@@ -693,7 +707,8 @@
             "status": "error"
           }
         ],
-        "dialect": "https://json-schema.org/draft/2020-12/schema"
+        "dialect": "https://json-schema.org/draft/2020-12/schema",
+        "root": "object"
       },
       "params": [
         "command_line: string"
@@ -728,7 +743,8 @@
             "status": "error"
           }
         ],
-        "dialect": "https://json-schema.org/draft/2020-12/schema"
+        "dialect": "https://json-schema.org/draft/2020-12/schema",
+        "root": "object"
       },
       "params": [
         "filter: string|null",
@@ -763,7 +779,8 @@
             "status": "error"
           }
         ],
-        "dialect": "https://json-schema.org/draft/2020-12/schema"
+        "dialect": "https://json-schema.org/draft/2020-12/schema",
+        "root": "object"
       },
       "params": [
         "path: string"
@@ -798,7 +815,8 @@
             "status": "error"
           }
         ],
-        "dialect": "https://json-schema.org/draft/2020-12/schema"
+        "dialect": "https://json-schema.org/draft/2020-12/schema",
+        "root": "object"
       },
       "params": [
         "path: string"
@@ -833,7 +851,8 @@
             "status": "error"
           }
         ],
-        "dialect": "https://json-schema.org/draft/2020-12/schema"
+        "dialect": "https://json-schema.org/draft/2020-12/schema",
+        "root": "object"
       },
       "params": [
         "limit: integer|null/uint32",
@@ -868,7 +887,8 @@
             "status": "error"
           }
         ],
-        "dialect": "https://json-schema.org/draft/2020-12/schema"
+        "dialect": "https://json-schema.org/draft/2020-12/schema",
+        "root": "object"
       },
       "params": [
         "address: string",
@@ -905,7 +925,8 @@
             "status": "error"
           }
         ],
-        "dialect": "https://json-schema.org/draft/2020-12/schema"
+        "dialect": "https://json-schema.org/draft/2020-12/schema",
+        "root": "object"
       },
       "params": [
         "filter: string|null",
@@ -941,7 +962,8 @@
             "status": "error"
           }
         ],
-        "dialect": "https://json-schema.org/draft/2020-12/schema"
+        "dialect": "https://json-schema.org/draft/2020-12/schema",
+        "root": "object"
       },
       "params": [
         "limit: integer|null/uint32",
@@ -1045,7 +1067,8 @@
             "status": "error"
           }
         ],
-        "dialect": "https://json-schema.org/draft/2020-12/schema"
+        "dialect": "https://json-schema.org/draft/2020-12/schema",
+        "root": "object"
       },
       "params": [
         "all: boolean|null",
@@ -1079,7 +1102,8 @@
             "status": "error"
           }
         ],
-        "dialect": "https://json-schema.org/draft/2020-12/schema"
+        "dialect": "https://json-schema.org/draft/2020-12/schema",
+        "root": "object"
       },
       "params": [
         "session_id: string|null"
@@ -1112,7 +1136,8 @@
             "status": "error"
           }
         ],
-        "dialect": "https://json-schema.org/draft/2020-12/schema"
+        "dialect": "https://json-schema.org/draft/2020-12/schema",
+        "root": "object"
       },
       "params": [
         "address: string",
@@ -1149,7 +1174,8 @@
             "status": "error"
           }
         ],
-        "dialect": "https://json-schema.org/draft/2020-12/schema"
+        "dialect": "https://json-schema.org/draft/2020-12/schema",
+        "root": "object"
       },
       "params": [
         "level: enum[\"error\"|\"warn\"|\"info\"|\"debug\"|\"trace\"]|null",
@@ -1185,7 +1211,8 @@
             "status": "error"
           }
         ],
-        "dialect": "https://json-schema.org/draft/2020-12/schema"
+        "dialect": "https://json-schema.org/draft/2020-12/schema",
+        "root": "object"
       },
       "params": [
         "session_id: string|null"
@@ -1218,7 +1245,8 @@
             "status": "error"
           }
         ],
-        "dialect": "https://json-schema.org/draft/2020-12/schema"
+        "dialect": "https://json-schema.org/draft/2020-12/schema",
+        "root": "object"
       },
       "params": [
         "expression: string",
@@ -1274,7 +1302,8 @@
             "status": "error"
           }
         ],
-        "dialect": "https://json-schema.org/draft/2020-12/schema"
+        "dialect": "https://json-schema.org/draft/2020-12/schema",
+        "root": "object"
       },
       "params": [
         "session_id: string|null"
@@ -1307,7 +1336,8 @@
             "status": "error"
           }
         ],
-        "dialect": "https://json-schema.org/draft/2020-12/schema"
+        "dialect": "https://json-schema.org/draft/2020-12/schema",
+        "root": "object"
       },
       "params": [
         "session_id: string|null"
@@ -1340,7 +1370,8 @@
             "status": "error"
           }
         ],
-        "dialect": "https://json-schema.org/draft/2020-12/schema"
+        "dialect": "https://json-schema.org/draft/2020-12/schema",
+        "root": "object"
       },
       "params": [
         "session_id: string|null"
@@ -1373,7 +1404,8 @@
             "status": "error"
           }
         ],
-        "dialect": "https://json-schema.org/draft/2020-12/schema"
+        "dialect": "https://json-schema.org/draft/2020-12/schema",
+        "root": "object"
       },
       "params": [
         "session_id: string|null"
@@ -1475,7 +1507,8 @@
             "status": "error"
           }
         ],
-        "dialect": "https://json-schema.org/draft/2020-12/schema"
+        "dialect": "https://json-schema.org/draft/2020-12/schema",
+        "root": "object"
       },
       "params": [
         "addresses: array<string>",

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -1132,6 +1132,13 @@ fn digest_tool(tool: &Value) -> Value {
 /// is emitted would otherwise land silently on every consumer. The digest keeps the branch shape
 /// rather than the whole schema — the point is that the discriminator and its branches survive,
 /// not the wording of every field's description.
+///
+/// The root `type` is in it for the same reason and one sharper one: it is the keyword whose
+/// absence costs a strict client every tool on the list rather than the one tool that lacks it
+/// (issue #223), and it is supplied by `src/schema.rs` rather than by the generator — so a
+/// `schemars` release that started emitting one, or a change that stopped supplying it, is a line
+/// of this diff either way. [`output_schemas_are_object_rooted`] is the assertion; this is the
+/// record.
 fn digest_output_schema(schema: &Value) -> Value {
     if schema.is_null() {
         return Value::Null;
@@ -1166,6 +1173,7 @@ fn digest_output_schema(schema: &Value) -> Value {
         .unwrap_or_default();
     json!({
         "dialect": schema["$schema"],
+        "root": schema["type"],
         "branches": branches,
     })
 }
@@ -1738,6 +1746,64 @@ fn output_schemas_carry_constraints_not_prose() {
         input_prose > 100,
         "input schemas carry only {input_prose} descriptions: the strip has reached the half a \
          model actually reads"
+    );
+}
+
+/// Every declared `outputSchema` is rooted at `type: "object"`, which is what keeps a strict
+/// client holding **any** of this server's tools.
+///
+/// The structured results are serde internally-tagged enums, and `schemars` renders one as
+/// `{ $schema, oneOf, $defs }` — object-ness stated on each branch of the union and nowhere at the
+/// root. rmcp passes that through: `schema_for_input` requires a root `type: "object"` and refuses
+/// anything else, while `schema_for_output` deliberately does not, SEP-2106 (`2026-07-28`) having
+/// relaxed the requirement for output schemas.
+///
+/// What that relaxation does not do is reach the clients. Every released
+/// `@modelcontextprotocol/sdk` 1.x — 1.30.0 included — parses `Tool.outputSchema` as
+/// `z.object({ type: z.literal("object"), … })` and `tools/list` as `z.array(ToolSchema)`, so the
+/// array fails on the first non-conforming tool and the client registers **none** of them.
+/// Measured against 1.30.0 on the shape this server emitted: 17 conforming tools plus one
+/// `oneOf`-rooted schema parses to zero tools, not 17. That is issue #223 — windbg-mcp v0.11.0
+/// behind a 1.29.0 client: no tools registered, reconnect loop exhausted, server deregistered.
+///
+/// It is asserted here rather than in `src/schema.rs` alone because the unit test knows what
+/// `constraints_of` returns and this knows what a client is *sent* — and the way the fix comes
+/// undone is a tool declaring its schema with rmcp's `schema_for_output` instead, which only the
+/// wire would show. The sibling check is
+/// [`output_schemas_carry_constraints_not_prose`], which fails the same way for the same reason.
+#[test]
+fn output_schemas_are_object_rooted() {
+    let mut server = Server::started();
+    let response = server.request("tools/list", json!({}), STEP);
+    assert_no_error(&response, "tools/list");
+    let tools = response["result"]["tools"]
+        .as_array()
+        .expect("tools/list returns an array")
+        .clone();
+
+    let mut with_schema = 0;
+    for tool in &tools {
+        let name = tool["name"].as_str().unwrap_or("<unnamed>");
+        let Some(schema) = tool.get("outputSchema").filter(|s| !s.is_null()) else {
+            continue;
+        };
+        with_schema += 1;
+        assert_eq!(
+            schema["type"],
+            json!("object"),
+            "`{name}` declares an outputSchema with no root `type: \"object\"`. A strict client \
+             rejects the whole `tools/list` on it and registers none of the {} tools this server \
+             serves — not {} of them. Declare it with `schema::constraints_of`, not rmcp's \
+             `schema_for_output`.",
+            tools.len(),
+            tools.len() - 1
+        );
+    }
+
+    assert!(
+        with_schema > 20,
+        "only {with_schema} tools declare an output schema — this test has stopped covering the \
+         surface it is about"
     );
 }
 


### PR DESCRIPTION
Closes #223.

## The bug

Every typed tool's `outputSchema` is generated from an internally-tagged enum (`Outcome<T>` /
`OpenOutcome`), and `schemars` renders one as `{ $schema, oneOf, $defs }` — object-ness stated on
each branch of the union and nowhere at the root. rmcp passes that through deliberately:
`schema_for_input` requires a root `type: "object"` and refuses anything else, while
`schema_for_output` explicitly does not, SEP-2106 (`2026-07-28`) having relaxed the requirement.

That relaxation says what a server *may* emit, not what clients accept. Every released
`@modelcontextprotocol/sdk` 1.x — 1.30.0 included — parses `Tool.outputSchema` as
`z.object({ type: z.literal("object"), … })` and `tools/list` as `z.array(ToolSchema)`, so the array
fails on the **first** non-conforming tool and the client registers none of them. All 33 tools that
declare a schema were non-conforming, so the client got zero tools, not 50 of 51.

## Measured, not reasoned about

The decisive check captures the real `tools/list` from the built binary and parses it with the
actual SDK, against a reconstruction of the pre-fix surface:

```
negotiated protocol: 2025-11-25
tools on the wire:   51

v0.11.0 (pre-fix)          parsed=0/51   rejected at ["tools",0,"outputSchema","type"]
this build (post-fix)      parsed=51/51

ajv compiled 33 output schemas, 0 failed
```

The capture also settles the premise: a client asking for `2025-11-25` gets it echoed (rmcp knows
that version — it is that crate's `LATEST`), so the session runs under the revision that requires
the keyword anyway.

**The keyword is true, not a shim.** MCP types `structuredContent` as a JSON object in every
revision, so one of these results can be nothing else. **And it changes nothing about what
validates** — each branch of the `oneOf` already carried `"type": "object"`; compiling both shapes
with `ajv` gives success, failure, a payload missing its required fields and an unknown
discriminator the same verdict either way.

## Why not the version-aware alternative

#223 offers emitting the relaxed shape only to peers that negotiated `2026-07-28`. Rejected: the
object-rooted form is legal under **both** revisions, so that branch would exist only to send a
worse schema to half the population — and it would cost a two-key schema cache plus a hand-written
`list_tools` to reach a negotiated version the `#[tool_handler]` macro currently hides.

One sub-claim of the issue does not hold, and it argues the same way: nothing in rmcp's schema path
is version-aware. `schema_for_input` is *unconditionally* strict; `schema_for_output` is
unconditionally permissive. Matching the input side means being unconditionally object-rooted.

## The change

`constraints_of` is the choke point all 33 go through, so `object_rooted` sits there. A root that
*does* declare a type is left alone rather than corrected — nothing produces one today, and this
runs on every `router()` build, so a future non-object root should fail a test rather than panic a
live server.

What lets the fix come back is a tool declaring its schema with rmcp's `schema_for_output` instead,
which only the wire shows — so `output_schemas_are_object_rooted` reads `tools/list` off the socket,
beside the prose assertion that fails for the same reason. The golden digest records the root `type`
too, so a `schemars` release that starts emitting one, or a change that stops supplying it, is a
line of diff either way.

**Why no tier caught it:** this harness is a hand-rolled JSON-RPC client and has never validated a
tool *definition*, only the results of calling one. The new assertion encodes the SDK's rule rather
than adding a Node client to CI.

## Cost

16 bytes per tool, 528 across the surface, and **none of it model-visible** — `modelVisible` stays
at 67,766, payload goes 177,850 → 178,378 against a 205,000 ceiling. Both goldens re-recorded;
`tools_list.json` gained exactly 33 `"root": "object"` lines and nothing else.

## Verification

ARM64 bench: 548 unit tests and 79 smoke tests green, the debugger tier run separately (63.7s, no
`SKIPPED` lines). `cargo fmt --all --check` and CI's markdownlint clean.

`cargo clippy --all-targets -- -D warnings` fails on `Toolset::every_tool is never used` — confirmed
pre-existing on `main` by stashing, and CI runs clippy without `-D warnings`, so it is not a gate.
Left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017KHzgze3DM5NUNzfkeHVmZ
