### PR TITLE
Fix three TTD defects: blank query rows, dropped arguments, a false failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,8 +35,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and a backslash run before a quote halves the way Windows says it does. An **unquoted** path that
   exists exactly as written is still one program: that is what handing the whole string over got
   right, `C:\Program Files\…` is where programs live, and splitting it on whitespace would have
-  taken the case away from callers relying on it without an error to show for it. An empty `target`
-  is refused before the output directory and log are created, beside the existing `env` validation.
+  taken the case away from callers relying on it without an error to show for it. That check asks
+  the directory the *recorder* will run in — `working_dir` when the caller set one, since the
+  recorder resolves a relative program against its own cwd and this process's is a different
+  directory. Asking the wrong one is not a refusal: measured on `TTD.exe` 1.01.11, a target of
+  `.\a program.exe` under a `working_dir` holding that file split into `.\a` and `program.exe` and
+  recorded **`a.exe`** — a different program — into a 29 MB trace reported as a complete recording.
+  An empty `target` is refused before the output directory and log are created, beside the existing
+  `env` validation.
   Measured: `record_trace { "target": "cmd.exe /c dir C:\\Windows\\System32\\ntdll.dll" }` records
   and the recorder's own echo is now `Launching 'cmd.exe /c dir …'` rather than the quoted single
   token it used to be.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,57 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`ttd_calls` and `ttd_memory` return the fields their descriptions promise** (issue #231). Both
+  ran `dx` without a recursion depth, and `dx` renders one level unless told otherwise:
+  `TTD.Calls` and `TTD.Memory` return *containers of records*, so `-r1` was exactly one level short
+  and every result came back as a bare index. The count was right and the payload absent, which
+  reads as "three calls, details unavailable" rather than as a defect — and there was no error to
+  go on. Not a regression: all three query commands are in the initial commit and only `ttd_events`
+  ever carried `-r2`, so two of the three TTD query tools had never returned usable output.
+  Measured after the fix against a trace recorded on this host: `ttd_calls` carries `TimeStart`,
+  `TimeEnd`, `Function`, `FunctionAddress`, `ReturnAddress`, `ReturnValue` and `Parameters`, and
+  `ttd_memory` carries `AccessType`, `IP`, `Address`, `Size` and `Value`. The depth is now one
+  constant the three share rather than three literals, and a test asserts that every TTD query asks
+  for it — what went wrong was one of them being written differently from its siblings, which no
+  test could see while each built its own command line.
+
+- **`record_trace` passes arguments to the target, which its schema always said it could**
+  (issue #232). `target` is documented as "Program (with optional arguments)", and the whole string
+  went to `TTD.exe` as a **single** argv entry — so the recorder looked for a file named
+  `cmd.exe /c dir C:\Windows\System32\ntdll.dll` and answered `0x80004005` with "cannot find the
+  file specified", a message pointing at the program rather than at the quoting. TTD's own help
+  requires the opposite ("`-launch` … must be the last option in the command-line, followed by the
+  program + `<arguments>`"), and `-launch` was already last, so the only thing wrong was that the
+  tail was one token instead of several. It is now split by `CommandLineToArgvW`'s rules — the ones
+  that will parse the line at the other end — so a quoted path holding spaces stays one argument
+  and a backslash run before a quote halves the way Windows says it does. An **unquoted** path that
+  exists exactly as written is still one program: that is what handing the whole string over got
+  right, `C:\Program Files\…` is where programs live, and splitting it on whitespace would have
+  taken the case away from callers relying on it without an error to show for it. An empty `target`
+  is refused before the output directory and log are created, beside the existing `env` validation.
+  Measured: `record_trace { "target": "cmd.exe /c dir C:\\Windows\\System32\\ntdll.dll" }` records
+  and the recorder's own echo is now `Launching 'cmd.exe /c dir …'` rather than the quoted single
+  token it used to be.
+
+- **`record_trace` reports a recording that already finished as a success, naming the trace**
+  (issue #233). The recorder is watched for 2.5s for a fast failure — the un-elevated refusal is
+  what that was built to surface — and **any** exit inside the window was treated as one. A target
+  that runs to completion faster than that exits inside it, so `hostname.exe` produced a 46 MB
+  trace that opened and replayed correctly and was reported as `TTD recording failed to start
+  (exit code: 0)`, with the quoted reason being TTD's `Launching '<target>'` banner: a line that
+  says nothing was wrong. An early exit means the recorder is no longer running, not why, and "the
+  target already finished" is an ordinary reason. The decision is now on the recorder's exit
+  *status* and on what it left behind: a successful exit with a finished `.run` is a **complete
+  recording**, and the message says so and names the trace — which is the more useful of the two
+  success answers, since only one of them has a file ready to open. A successful exit with no trace
+  is still an error, and a distinct one. A non-zero exit takes the path it always did, except that
+  the reason is now read past the launch banner to the line that reports the failure. The trace is
+  identified from the log's own `Full trace dumped to <path>`, falling back to a `.run` in
+  `out_dir` written since the recorder was spawned — restricted that way so a trace an earlier
+  recording left in the same directory cannot be reported as this one's.
+
 ## [0.12.0] - 2026-08-25
 
 ### Changed

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -117,7 +117,9 @@
   **recording** (`record_trace`) needs `TTD.exe` **and** Administrator. `record_trace` captures the
   recorder's startup output to `<out_dir>\ttd_record.log` and watches it briefly, so a fast failure
   (e.g. running un-elevated → `0x80070005 Access is denied`) is reported as an error rather than a
-  false "recording started".
+  false "recording started". A target that *finishes* inside that watch is the other case, and is
+  reported as a **complete** recording naming the finished `.run` — so `record_trace` answers one
+  of two things on success, and only one of them has a trace ready to open.
 - **Control-flow tools (`go`/`step*`/`reverse_*`) wait 60s for a stop, then break the target in.**
   The command is issued and the engine pumped to the next stop; if the target has not reached one
   by then the debugger raises a Ctrl+Break, so the call returns with the target *stopped where it

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -1123,7 +1123,14 @@ before a release, or when a change touches the relevant path. Drivers live in
 - **TTD replay** — needs the WinDbg store engine next to the binary (System32's engine rejects
   `.run` traces with `0x80070057`). Open a trace, then exercise `ttd_calls` / `ttd_memory` /
   `ttd_events` and reverse execution. The worked example is
-  [`docs/flareauthenticator-ttd-walkthrough.md`](flareauthenticator-ttd-walkthrough.md).
-- **TTD recording** — `record_trace` needs elevation and `TTD.exe` on `PATH`.
+  [`docs/flareauthenticator-ttd-walkthrough.md`](flareauthenticator-ttd-walkthrough.md). **Read a
+  row, do not count them**: issue #231 was two of these three tools rendering the right number of
+  rows with nothing in any of them, which a count cannot tell from a query that matched.
+- **TTD recording** — `record_trace` needs elevation and `TTD.exe` on `PATH`. Three targets, not
+  one, because each covers a case that was broken and none of the three has an automated tier: a
+  **short** one (`hostname.exe`) has to report a *complete* recording naming its `.run` rather than
+  a failure (#233), one **with arguments** (`cmd.exe /c dir C:\Windows\System32\ntdll.dll`) has to
+  record at all (#232), and a **missing** program has to still report the failure with the log's
+  own reason rather than TTD's `Launching '<target>'` banner.
 - **Driver IOCTL sweep** — `examples/sweep_ioctls.ps1` plus the target-side
   `examples/send_ioctls_target.ps1`; needs a benign test driver on a KDNET target.

--- a/src/server.rs
+++ b/src/server.rs
@@ -2357,6 +2357,41 @@ fn dx_executes_commands(expression: &str) -> bool {
     expression.to_ascii_lowercase().contains("executecommand")
 }
 
+/// The recursion depth every TTD query has to ask for, and the reason it is not a default.
+///
+/// `dx` renders one level unless told otherwise, and `TTD.Calls` / `TTD.Memory` / `TTD.Events` each
+/// return a *container of records*: at `-r1` the container's elements render as bare indices and
+/// every field the tools promise — the time, the thread, the parameters, the return value, the
+/// access type — is dropped, with the right number of rows and nothing in them. That is not an
+/// error the caller can see, which is what made it survive from the initial commit to
+/// [#231](https://github.com/glslang/windbg-mcp/issues/231): `ttd_events` carried the depth from
+/// the start and the other two never did, so two of the three TTD query tools had never returned
+/// usable output.
+///
+/// One level and no more: `-r3` would expand each record's own children (`Parameters`), multiplying
+/// a result that is already unbounded (`docs/token-budget.md` finding 6) for a caller who can ask
+/// for a specific call's arguments with `dx` when they want them.
+const TTD_QUERY_DEPTH: &str = "-r2";
+
+/// The `dx` behind `ttd_calls`, at [`TTD_QUERY_DEPTH`].
+fn ttd_calls_command(function: &str) -> String {
+    format!("dx {TTD_QUERY_DEPTH} @$cursession.TTD.Calls(\"{function}\")")
+}
+
+/// The `dx` behind `ttd_memory`, at [`TTD_QUERY_DEPTH`].
+///
+/// A blank `mode` is the same request as no mode at all — report every access — rather than a
+/// filter that matches nothing.
+fn ttd_memory_command(start: u64, end: u64, mode: Option<&str>) -> String {
+    match mode {
+        Some(m) if !m.trim().is_empty() => format!(
+            "dx {TTD_QUERY_DEPTH} @$cursession.TTD.Memory(0x{start:x}, 0x{end:x}, \"{}\")",
+            m.trim()
+        ),
+        _ => format!("dx {TTD_QUERY_DEPTH} @$cursession.TTD.Memory(0x{start:x}, 0x{end:x})"),
+    }
+}
+
 /// Does this raw `execute` command replace or release the debug target?
 ///
 /// The typed tools announce their own transitions, but `execute` is an escape hatch: a
@@ -3883,7 +3918,7 @@ impl WindbgServer {
             .run(
                 args.session_id.as_deref(),
                 EngineOp::BoundedCommand {
-                    command: format!("dx @$cursession.TTD.Calls(\"{}\")", args.function),
+                    command: ttd_calls_command(&args.function),
                     patience_ms: 0,
                 },
             )
@@ -3915,13 +3950,7 @@ impl WindbgServer {
             Err(e) => return tool_error(e),
         };
         let end = start.saturating_add(args.size as u64);
-        let cmd = match args.mode.as_deref() {
-            Some(m) if !m.trim().is_empty() => format!(
-                "dx @$cursession.TTD.Memory(0x{start:x}, 0x{end:x}, \"{}\")",
-                m.trim()
-            ),
-            _ => format!("dx @$cursession.TTD.Memory(0x{start:x}, 0x{end:x})"),
-        };
+        let cmd = ttd_memory_command(start, end, args.mode.as_deref());
         let out = self
             .run(
                 args.session_id.as_deref(),
@@ -3950,7 +3979,7 @@ impl WindbgServer {
             .run(
                 args.session_id.as_deref(),
                 EngineOp::BoundedCommand {
-                    command: "dx -r2 @$curprocess.TTD.Events".to_string(),
+                    command: format!("dx {TTD_QUERY_DEPTH} @$curprocess.TTD.Events"),
                     patience_ms: 0,
                 },
             )
@@ -5999,6 +6028,53 @@ mod tests {
                 "`{expression}` is an ordinary query and must keep the handle"
             );
         }
+    }
+
+    /// Every TTD query asks for the depth that renders a record's fields.
+    ///
+    /// The bug was silent in the one direction a caller cannot check (#231): `dx` at its default
+    /// `-r1` renders the right number of rows with nothing in any of them, so `ttd_calls` and
+    /// `ttd_memory` read as "three calls, details unavailable" rather than as a defect, and did so
+    /// from the initial commit. The three commands are asserted together because what went wrong
+    /// was one of them being written differently from the others.
+    #[test]
+    fn every_ttd_query_asks_for_the_fields_it_promises() {
+        let events = format!("dx {TTD_QUERY_DEPTH} @$curprocess.TTD.Events");
+        for command in [
+            ttd_calls_command("kernelbase!CreateFileW"),
+            ttd_memory_command(0x1000, 0x1008, None),
+            ttd_memory_command(0x1000, 0x1008, Some("w")),
+            events,
+        ] {
+            assert!(
+                command.starts_with("dx -r2 "),
+                "`{command}` renders indices without their records"
+            );
+        }
+    }
+
+    /// The rest of each query, so a depth that is present cannot be the whole assertion.
+    #[test]
+    fn a_ttd_query_names_the_object_and_the_range_it_was_asked_for() {
+        assert_eq!(
+            ttd_calls_command("ntdll!Nt*"),
+            "dx -r2 @$cursession.TTD.Calls(\"ntdll!Nt*\")"
+        );
+        assert_eq!(
+            ttd_memory_command(0x7ff7_0715_0000, 0x7ff7_0715_0008, None),
+            "dx -r2 @$cursession.TTD.Memory(0x7ff707150000, 0x7ff707150008)"
+        );
+        assert_eq!(
+            ttd_memory_command(0x1000, 0x1010, Some(" w ")),
+            "dx -r2 @$cursession.TTD.Memory(0x1000, 0x1010, \"w\")",
+            "a mode is trimmed before it is quoted"
+        );
+        // A blank mode is "every access", not a filter matching none — the argument is left off
+        // rather than passed as an empty string the data model would have to interpret.
+        assert_eq!(
+            ttd_memory_command(0x1000, 0x1010, Some("   ")),
+            ttd_memory_command(0x1000, 0x1010, None)
+        );
     }
 
     /// `execute` is the one path that can swap the target without going through a typed

--- a/src/ttd.rs
+++ b/src/ttd.rs
@@ -167,7 +167,7 @@ pub fn record_launch(
     for kv in env {
         parsed_env.push(split_env_entry(kv)?);
     }
-    let argv = split_target(target)?;
+    let argv = split_target(target, working_dir)?;
 
     // Resolve out_dir to an absolute path. When `working_dir` is set, TTD.exe would otherwise
     // resolve a relative `-out` against the *target's* cwd — mismatching where we create the
@@ -321,7 +321,10 @@ fn split_env_entry(entry: &str) -> Result<(&str, &str), String> {
 ///
 /// Refuses an empty target rather than letting `TTD.exe` report it, because at the point this runs
 /// nothing has been created yet — the same reason the environment is validated here.
-fn split_target(target: &str) -> Result<Vec<String>, String> {
+///
+/// `working_dir` is the caller's, and is taken because the probe below has to ask about the
+/// directory the *recorder* will use — see [`names_a_file`].
+fn split_target(target: &str, working_dir: Option<&str>) -> Result<Vec<String>, String> {
     let trimmed = target.trim();
     if trimmed.is_empty() {
         return Err(
@@ -333,7 +336,7 @@ fn split_target(target: &str) -> Result<Vec<String>, String> {
     // string as a single argument got right, and splitting on whitespace would look for
     // `C:\Program`; quoting only becomes necessary once such a path is followed by arguments.
     // Skipped when the caller has quoted anything, since then they have said how it parses.
-    if !trimmed.contains('"') && Path::new(trimmed).is_file() {
+    if !trimmed.contains('"') && names_a_file(trimmed, working_dir) {
         return Ok(vec![trimmed.to_string()]);
     }
     let argv = split_argv(trimmed);
@@ -344,6 +347,32 @@ fn split_target(target: &str) -> Result<Vec<String>, String> {
         _ => Err(format!(
             "`target` names no program to launch (`{target}` parses to no program)"
         )),
+    }
+}
+
+/// Does `candidate` name a file **where `TTD.exe` will look for it**?
+///
+/// Not the same question as [`Path::is_file`], and getting it wrong does not produce an error.
+/// The recorder is spawned with the caller's `working_dir` as its cwd and resolves a relative
+/// program against that, so a probe against *this process's* cwd answers for a directory nothing
+/// in the recording is using — the probe then declines, the target is split on its spaces, and
+/// `TTD.exe` launches whatever the first token resolves to.
+///
+/// Measured on `TTD.exe` 1.01.11 with `target: ".\\a program.exe"` and a `working_dir` holding
+/// that file: the split handed it `.\a` and `program.exe`, and it recorded **`a.exe`** — a
+/// different program — into a 29 MB trace that `record_trace` then reported as a complete
+/// recording. A wrong answer rather than a refusal, which is why this asks the right directory
+/// rather than falling back to both.
+///
+/// Worth knowing for the near miss beside it: TTD does **not** search its own cwd for a *bare*
+/// relative name (`aprogram.exe` in the cwd is not found; `.\aprogram.exe` is). So a bare name is
+/// a target neither this nor the code before it could launch, and keeping it whole is still the
+/// better answer — it fails naming the program the caller asked for.
+fn names_a_file(candidate: &str, working_dir: Option<&str>) -> bool {
+    let path = Path::new(candidate);
+    match working_dir {
+        Some(dir) if path.is_relative() => Path::new(dir).join(path).is_file(),
+        _ => path.is_file(),
     }
 }
 
@@ -572,7 +601,7 @@ mod tests {
     #[test]
     fn a_target_with_arguments_becomes_a_program_and_its_arguments() {
         assert_eq!(
-            split_target("cmd.exe /c dir C:\\Windows\\System32\\ntdll.dll").unwrap(),
+            split_target("cmd.exe /c dir C:\\Windows\\System32\\ntdll.dll", None).unwrap(),
             vec![
                 "cmd.exe",
                 "/c",
@@ -582,14 +611,17 @@ mod tests {
                 "C:\\Windows\\System32\\ntdll.dll"
             ]
         );
-        assert_eq!(split_target("hostname.exe").unwrap(), vec!["hostname.exe"]);
+        assert_eq!(
+            split_target("hostname.exe", None).unwrap(),
+            vec!["hostname.exe"]
+        );
     }
 
     /// A quoted path with spaces is one entry, not three — the case the split exists to respect.
     #[test]
     fn a_quoted_path_holding_spaces_is_one_argument() {
         assert_eq!(
-            split_target("\"C:\\Program Files\\App\\app.exe\" --flag \"a b\"").unwrap(),
+            split_target("\"C:\\Program Files\\App\\app.exe\" --flag \"a b\"", None).unwrap(),
             vec!["C:\\Program Files\\App\\app.exe", "--flag", "a b"]
         );
     }
@@ -608,16 +640,45 @@ mod tests {
         let target = program.to_string_lossy().to_string();
 
         assert_eq!(
-            split_target(&target).unwrap(),
+            split_target(&target, None).unwrap(),
             vec![target.clone()],
             "an existing path is a program, whatever whitespace it holds"
         );
         // Once it is followed by an argument the string is no longer a path, so it parses as the
         // command line it is — and quoting is how the caller keeps the program whole.
         assert_eq!(
-            split_target(&format!("\"{target}\" --flag")).unwrap(),
+            split_target(&format!("\"{target}\" --flag"), None).unwrap(),
             vec![target, "--flag".to_string()]
         );
+    }
+
+    /// A *relative* one is probed against the directory the recorder will run in, not this one.
+    ///
+    /// The two are different directories whenever `working_dir` is set, and the consequence is not
+    /// an error: probing here declines, the target is split on its spaces, and `TTD.exe` launches
+    /// whatever the first token resolves to. Measured on 1.01.11 with `.\a program.exe` — it
+    /// recorded `a.exe`, a different program, into a 29 MB trace reported as a complete recording.
+    #[test]
+    fn a_relative_path_is_probed_where_the_recorder_will_look_for_it() {
+        let dir = scratch("relative-working-dir");
+        std::fs::write(dir.join("a program.exe"), b"not really an exe").expect("write the fixture");
+        let working_dir = dir.to_string_lossy().to_string();
+
+        for target in [".\\a program.exe", "a program.exe"] {
+            assert_eq!(
+                split_target(target, Some(&working_dir)).unwrap(),
+                vec![target],
+                "`{target}` is one program in the recorder's own directory"
+            );
+            // And with no `working_dir` the recorder inherits this process's, where the fixture is
+            // not — so the same string is the command line it looks like. This is the half that
+            // makes the assertion above about the *directory* rather than about the string.
+            assert_eq!(
+                split_target(target, None).unwrap().len(),
+                2,
+                "`{target}` names nothing here, so it parses as a command line"
+            );
+        }
     }
 
     /// Rejected here rather than by `TTD.exe`, which is the difference between an error and an
@@ -625,12 +686,12 @@ mod tests {
     #[test]
     fn an_empty_target_is_refused_before_anything_is_created() {
         for empty in ["", "   ", "\t\n", "\"\"", "\" \""] {
-            let refused = split_target(empty).expect_err("this target names no program");
+            let refused = split_target(empty, None).expect_err("this target names no program");
             assert!(refused.contains("target"), "{refused}");
         }
         // A quoted argument that is *followed* by something is a different case: the empty
         // program is still the problem, and it is still the first entry.
-        assert!(split_target("\"\" --flag").is_err());
+        assert!(split_target("\"\" --flag", None).is_err());
     }
 
     /// The backslash rules, which are the half of Windows argv parsing that is not obvious — and

--- a/src/ttd.rs
+++ b/src/ttd.rs
@@ -6,7 +6,7 @@
 
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime};
 
 /// A recorder's architecture, and the two different names the installers give it.
 ///
@@ -140,12 +140,18 @@ const STARTUP_WATCH: Duration = Duration::from_millis(2500);
 /// Starts recording a TTD trace by launching `target` under `TTD.exe`, writing the
 /// `.run`/`.idx` into `out_dir`.
 ///
-/// Recording is long-lived (it finalizes only when the recorded process exits), so
-/// this is fire-and-forget for the success path. But TTD fails *fast* on common
-/// misconfigurations — most notably "Administrative privileges are required" when the
-/// server isn't elevated — so we capture its startup output to a log file and watch
-/// the recorder briefly: if it dies during [`STARTUP_WATCH`], we surface the real
-/// error instead of falsely reporting success.
+/// Recording is usually long-lived — it finalizes only when the recorded process exits — so the
+/// ordinary success path is fire-and-forget. But TTD fails *fast* on common misconfigurations,
+/// most notably "Administrative privileges are required" when the server isn't elevated, so we
+/// capture its startup output to a log file and watch the recorder for [`STARTUP_WATCH`].
+///
+/// **Exiting inside that window is not itself a failure**, which is what the watch used to assume
+/// ([#233](https://github.com/glslang/windbg-mcp/issues/233)): a short target — `hostname.exe`
+/// finishes in 156ms — runs to completion before the watch elapses, and the recorder then exits
+/// **0** having written a finished trace. So the decision is on the recorder's exit *status* and
+/// on what it left in `out_dir`, and this returns one of three answers: recording underway, a
+/// recording already complete (naming the trace, which is the more useful answer of the two), or
+/// the failure the watch was built to surface.
 ///
 /// Requires Administrator privileges.
 pub fn record_launch(
@@ -155,12 +161,13 @@ pub fn record_launch(
     env: &[String],
     working_dir: Option<&str>,
 ) -> Result<String, String> {
-    // Validate the caller-supplied environment up front — before any filesystem side effect —
-    // so a malformed entry doesn't leave a stray log file behind.
+    // Validate the caller-supplied environment and target up front — before any filesystem side
+    // effect — so a malformed one doesn't leave a stray directory and log file behind.
     let mut parsed_env = Vec::with_capacity(env.len());
     for kv in env {
         parsed_env.push(split_env_entry(kv)?);
     }
+    let argv = split_target(target)?;
 
     // Resolve out_dir to an absolute path. When `working_dir` is set, TTD.exe would otherwise
     // resolve a relative `-out` against the *target's* cwd — mismatching where we create the
@@ -185,8 +192,15 @@ pub fn record_launch(
     cmd.arg("-accepteula")
         .arg("-out")
         .arg(&out_dir)
+        // `-launch` is last, and the program and each of its arguments follow it as separate
+        // entries. TTD.exe's own help requires both — "This must be the last option in the
+        // command-line, followed by the program + <arguments>" — and its example is
+        // `TTD.exe ping.exe msn.com`. Handing the whole line over as one `.arg` made TTD look for
+        // a file literally named `cmd.exe /c dir C:\...`, which it reported as "cannot find the
+        // file specified": a message pointing at the program rather than at the quoting
+        // ([#232](https://github.com/glslang/windbg-mcp/issues/232)).
         .arg("-launch")
-        .arg(target)
+        .args(&argv)
         .stdout(Stdio::from(log))
         .stderr(Stdio::from(log_err));
     // Configured kernel connections do not reach the recorder. TTD.exe launches `target` with
@@ -212,6 +226,10 @@ pub fn record_launch(
     if let Some(dir) = working_dir {
         cmd.current_dir(dir);
     }
+    // Read before the spawn, so a `.run` an *earlier* recording left in this same `out_dir` can
+    // never be mistaken for this one's. See [`finished_trace`].
+    let started = SystemTime::now();
+
     // Under the server's spawn lock, like every other process this server creates. Nothing here
     // wants an inherited handle — but a worker being spawned at this moment has its protocol
     // channel marked inheritable, and marking is process-wide: a recorder started inside that
@@ -226,21 +244,47 @@ pub fn record_launch(
 
     let pid = child.id();
 
-    // Watch for an early exit (a fast failure).
+    // Watch for an early exit — which is a fast failure, or a target that has already finished.
     let deadline = Instant::now() + STARTUP_WATCH;
     loop {
         match child.try_wait() {
             Ok(Some(status)) => {
-                // Exited during startup → recording did not take. Report the captured
-                // reason (e.g. the access-denied message).
                 let log_text = std::fs::read_to_string(&log_path).unwrap_or_default();
-                let detail = first_meaningful_line(&log_text)
-                    .unwrap_or("see log for details")
-                    .to_string();
-                return Err(format!(
-                    "TTD recording failed to start ({status}): {detail}. Full log: {}",
-                    log_path.display()
-                ));
+                if !status.success() {
+                    // The case the watch was built for: the recorder refused. Report the captured
+                    // reason (e.g. the access-denied message).
+                    let detail = failure_detail(&log_text)
+                        .unwrap_or("see log for details")
+                        .to_string();
+                    return Err(format!(
+                        "TTD recording failed to start ({status}): {detail}. Full log: {}",
+                        log_path.display()
+                    ));
+                }
+                // Exited *successfully*: the target ran to completion inside the watch window, so
+                // the recording is not merely underway but done. Say so and name the trace — a
+                // caller told "recording started, finalizes when the target exits" about a target
+                // that has already exited would go looking for a file this function knows the
+                // name of.
+                return match finished_trace(&log_text, &out_dir, started) {
+                    Some(trace) => Ok(format!(
+                        "TTD recording complete (recorder pid {pid} exited successfully): \
+                         `{target}` ran to completion inside the {}ms startup watch, so the whole \
+                         run is recorded. The trace is finished and ready to `open_trace`: `{}`. \
+                         Recorder log: {}",
+                        STARTUP_WATCH.as_millis(),
+                        trace.display(),
+                        log_path.display()
+                    )),
+                    // Exit 0 and nothing on disk is neither of the two answers above, and saying
+                    // "complete" about a trace that is not there would be the same class of
+                    // mistake this arm exists to fix.
+                    None => Err(format!(
+                        "TTD.exe exited successfully but wrote no .run trace to `{}`. Full log: {}",
+                        out_dir.display(),
+                        log_path.display()
+                    )),
+                };
             }
             Ok(None) => {
                 if Instant::now() >= deadline {
@@ -248,7 +292,7 @@ pub fn record_launch(
                     return Ok(format!(
                         "TTD recording started (recorder pid {pid}). Tracing `{target}`; \
                          output (.run/.idx) goes to `{}`. Recording finalizes when the \
-                         target exits. Recorder log: {}",
+                         target exits — there is no trace to open until then. Recorder log: {}",
                         out_dir.display(),
                         log_path.display()
                     ));
@@ -269,6 +313,203 @@ fn split_env_entry(entry: &str) -> Result<(&str, &str), String> {
     }
 }
 
+/// Splits a caller's `target` into the program to launch and its arguments.
+///
+/// `TTD.exe` takes them as separate argv entries and [`Command::arg`] makes exactly one entry per
+/// call, so the whole string in one call was a filename with spaces in it as far as the recorder
+/// was concerned (#232).
+///
+/// Refuses an empty target rather than letting `TTD.exe` report it, because at the point this runs
+/// nothing has been created yet — the same reason the environment is validated here.
+fn split_target(target: &str) -> Result<Vec<String>, String> {
+    let trimmed = target.trim();
+    if trimmed.is_empty() {
+        return Err(
+            "`target` is empty — pass the program to record, with any arguments after it".into(),
+        );
+    }
+    // A path that exists exactly as written is one program, not a command line — even when it
+    // holds spaces, and `C:\Program Files\...` is where they live. This is what passing the whole
+    // string as a single argument got right, and splitting on whitespace would look for
+    // `C:\Program`; quoting only becomes necessary once such a path is followed by arguments.
+    // Skipped when the caller has quoted anything, since then they have said how it parses.
+    if !trimmed.contains('"') && Path::new(trimmed).is_file() {
+        return Ok(vec![trimmed.to_string()]);
+    }
+    let argv = split_argv(trimmed);
+    match argv.first() {
+        Some(program) if !program.trim().is_empty() => Ok(argv),
+        // Reachable from a target that is nothing but quotes: `""` parses to one argument, and
+        // that argument is the empty program.
+        _ => Err(format!(
+            "`target` names no program to launch (`{target}` parses to no program)"
+        )),
+    }
+}
+
+/// Parses a command line into argv the way Windows does.
+///
+/// These are `CommandLineToArgvW`'s rules, and they are the right ones because the string makes a
+/// round trip: this splits it, [`Command::arg`] re-quotes each entry by the matching rules, and
+/// `TTD.exe` — then the recorded target — parse the result back. Whitespace separates (space and
+/// tab only, which is what Windows treats as a separator); double quotes group; a backslash is
+/// literal unless it runs into a quote, where `2n` backslashes are `n` backslashes plus a
+/// delimiter and `2n+1` are `n` plus a literal quote; and `""` inside a quoted argument is a
+/// literal quote that leaves it quoted.
+///
+/// Not a general shell splitter: there is no variable expansion, no globbing and no single-quote
+/// handling, because none of those is what will parse the line at the other end.
+fn split_argv(line: &str) -> Vec<String> {
+    let chars: Vec<char> = line.chars().collect();
+    let mut argv = Vec::new();
+    let mut current = String::new();
+    // Distinct from `current.is_empty()`: `""` is an argument, and an empty one.
+    let mut in_arg = false;
+    let mut in_quotes = false;
+    let mut i = 0;
+    while i < chars.len() {
+        match chars[i] {
+            '\\' => {
+                let mut slashes = 0;
+                while i < chars.len() && chars[i] == '\\' {
+                    slashes += 1;
+                    i += 1;
+                }
+                if i < chars.len() && chars[i] == '"' {
+                    for _ in 0..slashes / 2 {
+                        current.push('\\');
+                    }
+                    if slashes % 2 == 1 {
+                        // The quote is escaped: consume it as a literal.
+                        current.push('"');
+                        i += 1;
+                    }
+                    // An even run leaves the quote for the arm below, where it delimits.
+                } else {
+                    for _ in 0..slashes {
+                        current.push('\\');
+                    }
+                }
+                in_arg = true;
+            }
+            '"' => {
+                i += 1;
+                if in_quotes && i < chars.len() && chars[i] == '"' {
+                    current.push('"');
+                    i += 1;
+                } else {
+                    in_quotes = !in_quotes;
+                }
+                in_arg = true;
+            }
+            ' ' | '\t' if !in_quotes => {
+                if in_arg {
+                    argv.push(std::mem::take(&mut current));
+                    in_arg = false;
+                }
+                i += 1;
+            }
+            c => {
+                current.push(c);
+                in_arg = true;
+                i += 1;
+            }
+        }
+    }
+    if in_arg {
+        argv.push(current);
+    }
+    argv
+}
+
+/// The finished `.run` this recorder wrote, if it wrote one.
+///
+/// Asked only of a recorder that has already exited **successfully**, which is what makes either
+/// answer meaningful: a trace named in the log is complete, and its absence is a real anomaly
+/// rather than a recording still in progress.
+///
+/// The log is the primary source because it names the file exactly. The directory is a fallback
+/// for a recorder whose log does not — the format of that line is TTD's, not ours — and it is
+/// restricted to a file written since the recorder was spawned, so a `.run` an earlier recording
+/// left in the same `out_dir` cannot be reported as this one's.
+fn finished_trace(log: &str, out_dir: &Path, since: SystemTime) -> Option<PathBuf> {
+    if let Some(named) = trace_named_in(log) {
+        let path = PathBuf::from(named);
+        if path.is_file() {
+            return Some(path);
+        }
+    }
+    // Coarse timestamps are a real filesystem (FAT's are two-second), so the window is widened
+    // rather than compared exactly. The cost of being wrong here is bounded: at worst it names a
+    // trace from a recording seconds old, in a directory this recording also wrote to.
+    let floor = since.checked_sub(Duration::from_secs(2)).unwrap_or(since);
+    let mut newest: Option<(SystemTime, PathBuf)> = None;
+    for entry in std::fs::read_dir(out_dir).ok()?.flatten() {
+        let path = entry.path();
+        if !path
+            .extension()
+            .is_some_and(|e| e.eq_ignore_ascii_case("run"))
+        {
+            continue;
+        }
+        let Ok(written) = entry.metadata().and_then(|m| m.modified()) else {
+            continue;
+        };
+        if written >= floor && newest.as_ref().is_none_or(|(seen, _)| written > *seen) {
+            newest = Some((written, path));
+        }
+    }
+    newest.map(|(_, path)| path)
+}
+
+/// The path TTD names as the trace it finished writing.
+///
+/// Several of its lines carry the same path and they mean different things: a real log has
+/// `Initializing the recording of process (PID:N) on trace file: <path>` and
+/// `Recording has started … on trace file: <path>` before the target has run, and
+/// `Full trace dumped to <path>` once it is finished. Only the last of those is matched, so this
+/// cannot name a trace that was begun and never finalised. Read in reverse, so that if a log ever
+/// holds more than one the newest wins.
+fn trace_named_in(log: &str) -> Option<&str> {
+    const DUMPED: &str = "full trace dumped to ";
+    log.lines().rev().find_map(|line| {
+        let line = line.trim();
+        // Matched anywhere in the line rather than at its start: the log interleaves the recorded
+        // target's own stdout, so nothing guarantees this banner begins one.
+        let at = line.to_ascii_lowercase().find(DUMPED)?;
+        // `to_ascii_lowercase` maps ASCII in place, so the byte offset is the same in both.
+        let path = line[at + DUMPED.len()..].trim().trim_end_matches('.');
+        (!path.is_empty()).then_some(path)
+    })
+}
+
+/// The line of a failed recorder's log that says *why*.
+///
+/// [`first_meaningful_line`] skips the banner, which was enough for the not-elevated case it was
+/// written for, where the refusal is the first thing after it. It is not enough in general: TTD
+/// prints `Launching '<target>'` before it tries, so any failure past that point was reported with
+/// a line that says nothing was wrong — the "reason" quoted back for #232 was the banner for the
+/// launch that then failed two lines later.
+fn failure_detail(log: &str) -> Option<&str> {
+    /// Words TTD's own failures use: `Error: Failed starting the guest process ...`,
+    /// `Administrative privileges are required to record a trace.`
+    fn reports_a_failure(line: &str) -> bool {
+        let lower = line.to_ascii_lowercase();
+        ["error", "failed", "failure", "cannot ", "denied", "unable"]
+            .iter()
+            .any(|word| lower.contains(word))
+            || lower.contains("are required")
+    }
+
+    log.lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty())
+        .find(|l| reports_a_failure(l))
+        // A failure that named itself in none of those words still has to report something, and
+        // the first line past the banner is the best guess available.
+        .or_else(|| first_meaningful_line(log))
+}
+
 /// First non-empty, non-banner line of TTD's output — the part that usually carries
 /// the actual error (e.g. the "Administrative privileges are required" line).
 fn first_meaningful_line(log: &str) -> Option<&str> {
@@ -286,7 +527,23 @@ fn first_meaningful_line(log: &str) -> Option<&str> {
 
 #[cfg(test)]
 mod tests {
-    use super::{Arch, first_meaningful_line, probe_order, split_env_entry};
+    use super::{
+        Arch, failure_detail, finished_trace, first_meaningful_line, probe_order, split_argv,
+        split_env_entry, split_target, trace_named_in,
+    };
+    use std::path::PathBuf;
+    use std::time::{Duration, SystemTime};
+
+    /// A directory of this module's own, named per test and per process so two of these can run at
+    /// once, and emptied first so a `.run` left by an earlier run of the same test cannot be
+    /// mistaken for the one under test.
+    fn scratch(name: &str) -> PathBuf {
+        let dir =
+            std::env::temp_dir().join(format!("windbg-mcp-ttd-{}-{name}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("create the scratch directory");
+        dir
+    }
 
     #[test]
     fn split_env_entry_parses_key_value() {
@@ -306,6 +563,216 @@ mod tests {
     fn split_env_entry_rejects_missing_equals_or_empty_key() {
         assert!(split_env_entry("NOEQUALS").is_err());
         assert!(split_env_entry("=value").is_err());
+    }
+
+    // ---- the target's command line (#232) -------------------------------
+
+    /// The bug, in the shape the issue reported it: a program and its arguments are separate
+    /// entries, because that is how `TTD.exe -launch` reads them.
+    #[test]
+    fn a_target_with_arguments_becomes_a_program_and_its_arguments() {
+        assert_eq!(
+            split_target("cmd.exe /c dir C:\\Windows\\System32\\ntdll.dll").unwrap(),
+            vec![
+                "cmd.exe",
+                "/c",
+                "dir",
+                // A backslash run that never reaches a quote is literal, so a Windows path
+                // survives unchanged — which is most of what a target's arguments are.
+                "C:\\Windows\\System32\\ntdll.dll"
+            ]
+        );
+        assert_eq!(split_target("hostname.exe").unwrap(), vec!["hostname.exe"]);
+    }
+
+    /// A quoted path with spaces is one entry, not three — the case the split exists to respect.
+    #[test]
+    fn a_quoted_path_holding_spaces_is_one_argument() {
+        assert_eq!(
+            split_target("\"C:\\Program Files\\App\\app.exe\" --flag \"a b\"").unwrap(),
+            vec!["C:\\Program Files\\App\\app.exe", "--flag", "a b"]
+        );
+    }
+
+    /// And an *unquoted* one still is, when it names a file that exists.
+    ///
+    /// This is what handing the whole string to `TTD.exe` as one argument got right, and it is the
+    /// property a split on whitespace would have taken away silently: `C:\Program Files\...` is
+    /// where programs live, and the caller who was relying on it gets no error, just a recorder
+    /// looking for `C:\Program`.
+    #[test]
+    fn an_unquoted_path_that_exists_is_not_split_on_its_spaces() {
+        let dir = scratch("unquoted-path");
+        let program = dir.join("a program.exe");
+        std::fs::write(&program, b"not really an exe").expect("write the fixture");
+        let target = program.to_string_lossy().to_string();
+
+        assert_eq!(
+            split_target(&target).unwrap(),
+            vec![target.clone()],
+            "an existing path is a program, whatever whitespace it holds"
+        );
+        // Once it is followed by an argument the string is no longer a path, so it parses as the
+        // command line it is — and quoting is how the caller keeps the program whole.
+        assert_eq!(
+            split_target(&format!("\"{target}\" --flag")).unwrap(),
+            vec![target, "--flag".to_string()]
+        );
+    }
+
+    /// Rejected here rather than by `TTD.exe`, which is the difference between an error and an
+    /// error plus an output directory and a log file nobody asked for.
+    #[test]
+    fn an_empty_target_is_refused_before_anything_is_created() {
+        for empty in ["", "   ", "\t\n", "\"\"", "\" \""] {
+            let refused = split_target(empty).expect_err("this target names no program");
+            assert!(refused.contains("target"), "{refused}");
+        }
+        // A quoted argument that is *followed* by something is a different case: the empty
+        // program is still the problem, and it is still the first entry.
+        assert!(split_target("\"\" --flag").is_err());
+    }
+
+    /// The backslash rules, which are the half of Windows argv parsing that is not obvious — and
+    /// they matter here because every path in a target's arguments is full of backslashes.
+    #[test]
+    fn backslashes_are_literal_until_they_reach_a_quote() {
+        // No quote in sight: every backslash is itself, doubled runs included.
+        assert_eq!(split_argv("a\\\\b c"), vec!["a\\\\b", "c"]);
+        // An even run before a quote halves, and the quote delimits.
+        assert_eq!(split_argv("\"a\\\\\" b"), vec!["a\\", "b"]);
+        // An odd run before a quote halves and the quote survives as a character.
+        assert_eq!(split_argv("a\\\"b"), vec!["a\"b"]);
+        // A trailing backslash on a quoted path is the classic one: `"C:\dir\\"` is the directory,
+        // not an unterminated string.
+        assert_eq!(
+            split_argv("\"C:\\dir\\\\\" next"),
+            vec!["C:\\dir\\", "next"]
+        );
+        // `""` inside a quoted argument is a literal quote and leaves it quoted.
+        assert_eq!(split_argv("\"say \"\"hi\"\" now\""), vec!["say \"hi\" now"]);
+        // An empty argument is an argument.
+        assert_eq!(split_argv("a \"\" b"), vec!["a", "", "b"]);
+        // Tabs separate as spaces do, and runs of either collapse.
+        assert_eq!(split_argv("a\t\t b   c"), vec!["a", "b", "c"]);
+    }
+
+    // ---- what an exited recorder wrote (#233) ---------------------------
+
+    /// The success discriminator: the log names the finished trace, and it is on disk.
+    #[test]
+    fn a_completed_recording_is_found_by_the_path_its_log_names() {
+        let dir = scratch("completed");
+        let trace = dir.join("hostname01.run");
+        std::fs::write(&trace, b"trace").expect("write the fixture trace");
+
+        let log = format!(
+            "Microsoft (R) TTD 1.01.11\n\
+             Launching 'hostname.exe'\n\
+             Recording has started of process (PID:5568) on trace file: {}\n\
+             hostname.exe(x64) (PID:5568): Process exited with exit code 0 after 156ms\n\
+             Full trace dumped to {}\n",
+            trace.display(),
+            trace.display()
+        );
+        assert_eq!(
+            finished_trace(&log, &dir, SystemTime::now()).as_deref(),
+            Some(trace.as_path())
+        );
+    }
+
+    /// And by what is in the directory when the log does not say — that line's wording is TTD's,
+    /// so the ground truth is the file.
+    #[test]
+    fn a_completed_recording_is_still_found_without_the_log_line() {
+        let dir = scratch("no-log-line");
+        let trace = dir.join("target01.run");
+        std::fs::write(&trace, b"trace").expect("write the fixture trace");
+        // Beside a file that is not a trace, and one that is only named like the index.
+        std::fs::write(dir.join("ttd_record.log"), b"log").expect("write the log");
+        std::fs::write(dir.join("target01.idx"), b"idx").expect("write the index");
+
+        assert_eq!(
+            finished_trace("nothing useful here\n", &dir, SystemTime::now()).as_deref(),
+            Some(trace.as_path())
+        );
+    }
+
+    /// A `.run` older than this recorder is somebody else's, and reporting it would be the same
+    /// false claim in the other direction — "complete", naming a trace of a different run.
+    #[test]
+    fn a_trace_an_earlier_recording_left_behind_is_not_claimed() {
+        let dir = scratch("stale");
+        std::fs::write(dir.join("older01.run"), b"trace").expect("write the fixture trace");
+
+        // As if the recorder had been spawned an hour after that file was written.
+        let spawned = SystemTime::now() + Duration::from_secs(3600);
+        assert_eq!(finished_trace("", &dir, spawned), None);
+        // Nothing at all is the same answer, and so is a directory that is not there.
+        assert_eq!(
+            finished_trace("", &scratch("empty"), SystemTime::now()),
+            None
+        );
+        assert_eq!(
+            finished_trace("", &dir.join("does-not-exist"), SystemTime::now()),
+            None
+        );
+    }
+
+    /// The started line names a trace that may never be finalised, so only the finished one counts.
+    #[test]
+    fn only_the_finished_line_names_a_trace() {
+        assert_eq!(
+            trace_named_in("Recording has started of process (PID:1) on trace file: C:\\t\\a.run"),
+            None
+        );
+        assert_eq!(
+            trace_named_in("Full trace dumped to C:\\t\\a.run"),
+            Some("C:\\t\\a.run")
+        );
+        // The last one wins: one recorder run can finish several traces.
+        assert_eq!(
+            trace_named_in("Full trace dumped to C:\\t\\a.run\nFull trace dumped to C:\\t\\b.run"),
+            Some("C:\\t\\b.run")
+        );
+        assert_eq!(trace_named_in("Full trace dumped to \n"), None);
+    }
+
+    /// The reported reason has to be the line that says what went wrong.
+    ///
+    /// `Launching '<target>'` is printed *before* the attempt, so it is the first meaningful line
+    /// of every log including the failing ones — which is how #232's failure came to be reported
+    /// with a line saying nothing was wrong.
+    #[test]
+    fn the_reason_for_a_failure_is_read_past_the_launch_banner() {
+        let log = "Microsoft (R) TTD 1.01.11\n\
+                   Launching '\"cmd.exe /c dir C:\\Windows\"'\n\
+                   Error: Failed starting the guest process \"cmd.exe /c dir C:\\Windows\"\n\
+                        : error:(2)The system cannot find the file specified.\n";
+        let detail = failure_detail(log).expect("a failing log has a reason");
+        assert!(detail.starts_with("Error: Failed starting"), "{detail}");
+        assert!(
+            first_meaningful_line(log).is_some_and(|l| l.starts_with("Launching")),
+            "the banner is what the old reading returned, which is why this test exists"
+        );
+    }
+
+    /// And the case the watch was built for still reports the same line it always did.
+    #[test]
+    fn the_not_elevated_refusal_is_still_the_reason() {
+        let log = "Microsoft (R) TTD 1.01.11\n\
+                   Release: 1.11.428.0\n\
+                   Administrative privileges are required to record a trace.\n";
+        assert_eq!(
+            failure_detail(log),
+            Some("Administrative privileges are required to record a trace.")
+        );
+        // A log with no failure word in it still has to say something.
+        assert_eq!(
+            failure_detail("Launching 'x.exe'\n"),
+            Some("Launching 'x.exe'")
+        );
+        assert_eq!(failure_detail(""), None);
     }
 
     #[test]


### PR DESCRIPTION
Three defects on the TTD surface, all pre-existing, all found in the v0.11.x release regression run
of 2026-08-25. Each is verified against the real recorder and a real trace on this host — none of
the three has an automated tier, which is why all three survived.

Closes #231. Closes #232. Closes #233.

## `ttd_calls` and `ttd_memory` rendered every result as a blank row (#231)

`dx` renders one level unless told otherwise, and `TTD.Calls` / `TTD.Memory` return *containers of
records*, so `-r1` was exactly one level short: the count was right and the payload absent. That is
not an error a caller can see — three blank rows read as "three calls, details unavailable" rather
than as a defect — which is how it survived from the initial commit. `ttd_events` carried `-r2`
from the start and is the only reason one of the three worked.

The depth is now a single `TTD_QUERY_DEPTH` that all three format from, rather than three literals
one of which was written differently from its siblings. Two tests: that every query asks for it,
and one pinning the rest of each command so a present `-r2` cannot be the whole assertion.

Measured after the fix, against a trace recorded on this host:

```text
dx -r2 @$cursession.TTD.Calls("kernelbase!CreateFileW")
    [0x0]
        EventType        : 0x0
        ThreadId         : 0x2298
        TimeStart        : A8:394
        TimeEnd          : AA:12E4
        Function         : kernelbase!CreateFileW
        FunctionAddress  : 0x7ffc92237a70
        ReturnAddress    : 0x2101b196f
        ReturnValue      : 0xffffffffffffffff
        Parameters
        ...
```

and `ttd_memory` on an image base returns `AccessType : Read`, `IP`, `Address`, `Size` and
`Value : 0x5a4d` — the `MZ` the loader read.

## `record_trace` could not pass arguments to the target (#232)

Though its schema said it could. The whole `target` string went to `TTD.exe` as one argv entry, so
the recorder looked for a file named `cmd.exe /c dir C:\Windows\System32\ntdll.dll` and answered
`0x80004005` with "cannot find the file specified" — a message pointing at the program rather than
at the quoting. TTD's own help requires the opposite (`-launch` "must be the last option in the
command-line, followed by the program + `<arguments>`"), and `-launch` was already last, so the
only thing wrong was that the tail was one token instead of several.

Split by `CommandLineToArgvW`'s rules, because those are what parse the line at the other end:
`Command::arg` re-quotes each entry by the matching rules, and `TTD.exe` — then the recorded target
— parse the result back.

**One thing beyond what the issue proposed.** An *unquoted* path that exists exactly as written
stays one program. That is what handing the whole string over got right, `C:\Program Files\...` is
where programs live, and a plain whitespace split would have taken the case away from callers
relying on it with no error to show for it — it would have looked for `C:\Program`. Quoting only
becomes necessary once such a path is followed by arguments, and that case now fails naming the
truncated program rather than the whole line.

An empty target is refused before the output directory and log exist, beside the `env` validation
that is already there for that reason. Confirmed: no directory is left behind.

Measured — the recorder's own echo is the tell, compare it with the one in the issue:

```text
Launching 'cmd.exe /c dir C:\Windows\System32\ntdll.dll'
    Recording has started of process (PID:8456) on trace file: ...\cmd01.run
cmd.exe(x64) (PID:8456): Process exited with exit code 0 after 203ms
  Full trace dumped to ...\cmd01.run
```

## `record_trace` reported a finished recording as a startup failure (#233)

The recorder is watched for 2.5s for a fast failure — the un-elevated refusal is what that was
built to surface — and **any** exit inside the window was treated as one. `hostname.exe` finishes
in a fraction of that, so a 46 MB trace that opened and replayed correctly came back as `TTD
recording failed to start (exit code: 0)`, quoting TTD's `Launching '<target>'` banner as the
reason: a line that says nothing was wrong.

An early exit means the recorder is no longer running; it does not say **why**, and "the target
already finished" is an ordinary reason. The decision is now on the recorder's exit status and on
what it left behind:

- exit 0 with a finished `.run` → a **complete recording**, and the message says so and names the
  trace. That is the more useful of the two success answers, since only one of them has a file
  ready to open — the long-target message now says explicitly that there is not.
- exit 0 with no trace → still an error, and a distinct one.
- non-zero → the path it always took, except that the reason is read past the launch banner to the
  line that reports the failure.

The trace is identified from the log's own `Full trace dumped to <path>`, falling back to a `.run`
in `out_dir` written since the recorder was spawned — restricted that way so a trace an earlier
recording left in the same directory cannot be reported as this one's.

Measured:

```text
TTD recording complete (recorder pid 9024 exited successfully): `hostname.exe` ran to completion
inside the 2500ms startup watch, so the whole run is recorded. The trace is finished and ready to
`open_trace`: ...\ttd-short\hostname01.run
```

## What did not change

**No golden moved.** A quoting hint on `target`'s description was written and then dropped: 78 B on
the surface, and five current-state byte figures across the docs to re-derive, to hedge a case the
code now handles and whose failure now names the truncated program it tried.

`failure_detail` deliberately does not rank TTD's error cascade. On a missing program the log holds
six `Error:` lines, the most specific of them last; the first is taken, which is a line that reports
a failure rather than the banner, and the full log path is in the message. Fitting a selector to one
recorder version's output would be a guess the next version invalidates.

## Verification

- `cargo fmt --all --check`, `cargo clippy --all-targets -- -D warnings` — clean.
- 561 unit tests, `mcp_smoke` 79 passed / 12 ignored, goldens unchanged.
- `npx markdownlint-cli2@0.23.2 README.md CHANGELOG.md "docs/**/*.md" "skills/**/*.md"` — 0 issues.
- The behavioural claims above were driven against `TTD.exe` 1.01.11 and traces recorded on this
  host, elevated, through the dev binary over stdio — not reasoned about from the source.

Docs: `CHANGELOG.md` (Unreleased/Fixed), `docs/limitations.md` (the second success answer
`record_trace` can now give), and `docs/smoke-test.md` — which now names the three recording targets
a manual run has to try, and says to *read a row* of a TTD query rather than count them, since a
count cannot tell #231 from a query that matched nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
