### PR TITLE
Cover the TTD calls with a tier that records its own target

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -652,13 +652,17 @@ was already on the bounded wait; a dump cannot `go`, and no tier launched a proc
 tier now does (`launch_tier`, two tests in `tests/mcp_smoke.rs`). The one target type still
 unmeasured on this path is **TTD replay** — `FOLLOWUPS.md` item 47.
 
-**Its stated blocker is gone, and that sentence was stale rather than wrong when written.** Item 47
-defers on "replay does not work on this host at all"; this bench now has the `ttd\` payload beside
-both `target\debug` and `target\release` (item 21's unpack recipe), and the TTD tier records a trace,
-opens it and queries it. So the prerequisite item 47 was waiting for is satisfied here — what it
-still wants is the *timeout* path, and note before writing that test that a `go` or `reverse_go` on
-a replay target may simply stop at the trace boundary, in which case the bound is unreachable rather
-than untested and that is itself the answer.
+**Its blocker moved rather than lifted, and which host it is about is the whole of the distinction.**
+Item 47 defers on "replay does not work on this host at all", and the sentence before it names the
+**ARM64 bench** — so that is the host, and nothing since has re-checked it. What is new is a
+*different* machine: the **x64 bench** has the `ttd\` payload beside `target\debug` and
+`target\release` (item 21's unpack recipe), and the TTD tier records a trace, opens it and queries
+it there. Item 47's gap is a **target type**, not an architecture, so an x64 measurement would
+answer it — but its sibling measurements were all taken on ARM64, and "generalised from one
+backend" is the mistake item 47's own text cites. Say which bench, in the item, whenever this
+moves. Before writing that test at all, note that a `go` or `reverse_go` on a replay target may
+simply stop at the trace boundary, in which case the bound is unreachable rather than untested and
+that is itself the answer.
 
 **And a live target has a lifetime, which is what makes a launch test different from every other
 one here.** A dump does not go away mid-test; a process does. `go` on `cmd.exe /c ping -n 30` runs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,13 +172,13 @@ It checks *same-file* fragments only, so a cross-file `../README.md#some-heading
 verify by hand.
 
 **The pass count does not say which tiers ran.** Each gate is inside its test, so the `mcp_smoke`
-harness reports the same **79 passed** with the debugger tier off as with it on — that harness's own
+harness reports the same **83 passed** with the debugger tier off as with it on — that harness's own
 result line, since a plain `cargo test` runs the crate's several hundred unit tests beside it and
 prints a result line per binary. What differs between the two runs is the runtime (measured on the
 ARM64 bench 2026-08-23: **1.6s against 61s** for `cargo test --test mcp_smoke`) and the `SKIPPED`
 lines, which only `--nocapture` prints. Read one of those two before believing a run covered a
-debugger claim. The count moves whenever a test is added — it was 69 until #195 and #196, and 75
-until item 37 — so
+debugger claim. The count moves whenever a test is added — it was 69 until #195 and #196, 75
+until item 37, and 79 until the TTD tier — so
 re-derive it rather than trusting this sentence.
 
 **The dev exe can be locked too, and the failure is quiet.** A worker left running — a driver
@@ -394,6 +394,25 @@ of them. Only ask the user for a raw connection when no profile is configured at
 
 `--test-threads=1` is not optional: the filter matches **eight** tests, and the KD transport is
 single-owner, so in parallel the second attach fails and can leave the target halted.
+
+A fifth tier **records its own target** rather than opening a checked-in one, which is what no other
+tier does and why the three TTD defects of 2026-08-25 (#231, #232, #233) all shipped: a `.run` is
+tens of MB, none is in the repo, and recording needs `TTD.exe` and elevation.
+
+```pwsh
+$env:WINDBG_MCP_SMOKE_TTD = "1"; cargo test --test mcp_smoke -- --nocapture ttd
+```
+
+Gated on the variable **alone** — no `#[ignore]` beside it, unlike the two tiers above — because a
+stale variable here costs a few tens of MB in `%TEMP%` rather than a wedged VM, and against that the
+rule that matters is that a gate nothing sets is a gap that stays open. Two things to know before
+editing it. The host's reasons to stand down (no recorder, not elevated, a trace it cannot replay)
+are read off the **recorder's own refusal** rather than probed for, because probing would put a
+second copy of `ttd::find_ttd`'s search in a file that cannot call it; every *other* failure fails
+the test, and that split is what stops the tier passing on a machine where recording is broken. And
+its assertions read **which program was recorded**, from the trace's file name — TTD names a trace
+after the program it launched — because the defect that survived review was a recording that
+succeeded against the *wrong* program.
 
 **The transport does not have to be KDNET, and the target does not have to be x64.** The variable is
 a DbgEng connection string, passed through untouched, so `com:port=COM1,baud=115200` is as valid as
@@ -631,8 +650,15 @@ Two consequences worth carrying:
 **Why nothing caught any of it.** Every tier that drives execution was the live-kernel one, which
 was already on the bounded wait; a dump cannot `go`, and no tier launched a process. The debugger
 tier now does (`launch_tier`, two tests in `tests/mcp_smoke.rs`). The one target type still
-unmeasured on this path is **TTD replay**, because replay does not work on this host at all —
-`FOLLOWUPS.md` item 47.
+unmeasured on this path is **TTD replay** — `FOLLOWUPS.md` item 47.
+
+**Its stated blocker is gone, and that sentence was stale rather than wrong when written.** Item 47
+defers on "replay does not work on this host at all"; this bench now has the `ttd\` payload beside
+both `target\debug` and `target\release` (item 21's unpack recipe), and the TTD tier records a trace,
+opens it and queries it. So the prerequisite item 47 was waiting for is satisfied here — what it
+still wants is the *timeout* path, and note before writing that test that a `go` or `reverse_go` on
+a replay target may simply stop at the trace boundary, in which case the bound is unreachable rather
+than untested and that is itself the answer.
 
 **And a live target has a lifetime, which is what makes a launch test different from every other
 one here.** A dump does not go away mid-test; a process does. `go` on `cmd.exe /c ping -n 30` runs

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -2588,7 +2588,7 @@ and nothing recovers from that, which is the second bug that issue turned out to
 `go` that reaches no stop leaves the session usable, and left it unusable before. Live kernel was
 already on this path and the live-kernel tier exercises it. A dump cannot resume at all, so the wait
 is unreachable there. **TTD replay is the gap**: `go`, `step_back` and the rest of the reverse
-family go through this function, and TTD replay does not work on this host at all
+family go through this function, and TTD replay did not work on the bench at all
 (item 21 / [#132](https://github.com/glslang/windbg-mcp/issues/132)), so nothing here could ask
 whether `SetInterrupt` unblocks a replay wait the way it unblocks a live one.
 
@@ -2601,10 +2601,20 @@ documents it as working everywhere, but that is a doc comment rather than a meas
 "generalised from one backend" is a mistake this repo has made before (`CLAUDE.md`, *Handing the
 work over*).
 
-**What would close it.** Record a trace on a host where replay works, `go` past the end of it or
-`reverse_go` with nothing to stop at, and assert the session still answers `registers` afterwards —
-the same assertion the two new debugger-tier tests make. One test, in the tier that already needs a
-recorder.
+**The blocker is gone, and the tier it wanted now exists** (2026-08-26). The bench has the `ttd\`
+payload beside `target\debug` and `target\release` — item 21's unpack recipe — so replay works here:
+the **TTD tier** records a trace, opens it, and queries it, which is the prerequisite this item was
+deferred on. What is still unmeasured is the same thing as before, the *timeout* path, and the tier
+is now the obvious place to put it.
+
+**What would close it.** Record a trace, `go` past the end of it or `reverse_go` with nothing to
+stop at, and assert the session still answers `registers` afterwards — the same assertion the two
+debugger-tier launch tests make. One test, in the TTD tier. **Establish first that the bound is
+reachable at all**: a replay target has ends, so a `go` or a `reverse_go` with no breakpoint may
+simply stop at the trace boundary in well under the 60s bound, in which case the timeout path is
+*unreachable* on this target type rather than untested — which closes this item as an answer rather
+than as a test, and is worth writing down either way. Deciding that costs one measurement and is
+what the next person should do before writing anything.
 
 **Where it picks up.** `win-kexp`'s `DebugEngine::execute_and_wait` and `wait_for_event_bounded`
 (`src/dbgeng.rs`); `worker::resumed`; and the pair

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -2588,9 +2588,11 @@ and nothing recovers from that, which is the second bug that issue turned out to
 `go` that reaches no stop leaves the session usable, and left it unusable before. Live kernel was
 already on this path and the live-kernel tier exercises it. A dump cannot resume at all, so the wait
 is unreachable there. **TTD replay is the gap**: `go`, `step_back` and the rest of the reverse
-family go through this function, and TTD replay did not work on the bench at all
-(item 21 / [#132](https://github.com/glslang/windbg-mcp/issues/132)), so nothing here could ask
-whether `SetInterrupt` unblocks a replay wait the way it unblocks a live one.
+family go through this function, and TTD replay does not work on **that** bench at all
+(item 21 / [#132](https://github.com/glslang/windbg-mcp/issues/132)), so nothing there could ask
+whether `SetInterrupt` unblocks a replay wait the way it unblocks a live one. (Named explicitly
+because "this host" in an item whose measurements are ARM64's has already been read as the x64
+one.)
 
 **Why it is not alarming, and why it is still open.** The watchdog only ever fires at the bound, so
 for every go/step that stops in time the change is a no-op — which is every TTD navigation anyone
@@ -2601,20 +2603,30 @@ documents it as working everywhere, but that is a doc comment rather than a meas
 "generalised from one backend" is a mistake this repo has made before (`CLAUDE.md`, *Handing the
 work over*).
 
-**The blocker is gone, and the tier it wanted now exists** (2026-08-26). The bench has the `ttd\`
-payload beside `target\debug` and `target\release` — item 21's unpack recipe — so replay works here:
-the **TTD tier** records a trace, opens it, and queries it, which is the prerequisite this item was
-deferred on. What is still unmeasured is the same thing as before, the *timeout* path, and the tier
-is now the obvious place to put it.
+**The blocker moved to a different host rather than lifting, and the tier it wanted now exists**
+(2026-08-26). The deferral above is about the **ARM64 bench**, and nothing since has re-checked it.
+What changed is the **x64 bench**: it has the `ttd\` payload beside `target\debug` and
+`target\release` — item 21's unpack recipe — so replay works *there*, and the **TTD tier** records
+a trace, opens it and queries it.
+
+So the prerequisite is satisfied on a machine, just not the one this item was written on. That is
+probably enough, because the gap here is a **target type** and not an architecture — but every
+sibling measurement in this item was taken on ARM64, and an x64 answer inherits the caveat this
+item already cites against itself: "generalised from one backend" is a mistake this repo has made
+before. Whoever closes it should say which bench, and think for a moment about whether the other
+one would answer differently.
+
+(Written down because it was got wrong once already: "this host" was read as the x64 bench, on the
+strength of a TTD tier passing there, and the correction is what produced the paragraph above.)
 
 **What would close it.** Record a trace, `go` past the end of it or `reverse_go` with nothing to
 stop at, and assert the session still answers `registers` afterwards — the same assertion the two
-debugger-tier launch tests make. One test, in the TTD tier. **Establish first that the bound is
-reachable at all**: a replay target has ends, so a `go` or a `reverse_go` with no breakpoint may
-simply stop at the trace boundary in well under the 60s bound, in which case the timeout path is
-*unreachable* on this target type rather than untested — which closes this item as an answer rather
-than as a test, and is worth writing down either way. Deciding that costs one measurement and is
-what the next person should do before writing anything.
+debugger-tier launch tests make. One test, in the TTD tier, on the x64 bench. **Establish first
+that the bound is reachable at all**: a replay target has ends, so a `go` or a `reverse_go` with no
+breakpoint may simply stop at the trace boundary in well under the 60s bound, in which case the
+timeout path is *unreachable* on this target type rather than untested — which closes this item as
+an answer rather than as a test, and is worth writing down either way. Deciding that costs one
+measurement and is what the next person should do before writing anything.
 
 **Where it picks up.** `win-kexp`'s `DebugEngine::execute_and_wait` and `wait_for_event_bounded`
 (`src/dbgeng.rs`); `worker::resumed`; and the pair

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -1113,9 +1113,14 @@ open.
 recorder's own refusal — `TTD.exe not found`, `Administrative privileges`, `0x80070005` — and
 print `SKIPPED`. Every *other* failure fails the test, which is the distinction that keeps the tier
 honest: a helper that treated any error as a skip would pass on a machine where recording is
-broken. Replay is a third stand-down, taken separately: a host can record a trace it cannot open,
-because replay needs the WinDbg store engine beside the binary, and by then the recording half has
-already been asserted.
+broken. Replay is a third stand-down, taken separately: a host can record a trace it cannot open, because
+replay needs the WinDbg store engine beside the binary, and by then the recording half has already
+been asserted. It is keyed on the **server's own diagnostic** — the sentence
+`worker::explain_trace_failure` appends when there is no `ttd\` beside the executable — and not on
+`0x80070057`, which is the engine's "the parameter is incorrect" and can equally come from a trace
+that failed to load for some other reason. Every other `open_trace` failure fails the test. A
+`ttd\` of the *wrong architecture* is deliberately not excused: it gets the engine's error with no
+such sentence, and a misconfigured bundle should be loud.
 
 | Test | Claim | How it is read |
 | --- | --- | --- |

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -10,6 +10,7 @@ crate compiles against stays identical — so the unit tests keep passing and cl
 ```pwsh
 cargo test --test mcp_smoke              # protocol tier (default)
 $env:WINDBG_MCP_SMOKE_DUMP = "1"; cargo test --test mcp_smoke   # + the debugger tier
+$env:WINDBG_MCP_SMOKE_TTD  = "1"; cargo test --test mcp_smoke   # + the TTD tier (elevated)
 ```
 
 It builds and runs against `target/debug`, so it never touches the `target/release` exe a
@@ -33,7 +34,8 @@ all.
 | **Bounded command** | `--ignored` | `dbgeng.dll`, the sample dump, ~1 minute | the watchdog wiring, which now spans two processes |
 | **Live kernel** | `--ignored` + `WINDBG_MCP_SMOKE_KERNEL` | a live kernel target you can freeze — KDNET, or serial | that a kernel attach *lands*, coexists, and is let go — by `end_session` and by a disconnect; and that a `debug_batch` which patches a byte of the running kernel puts it back |
 | **MessageManager CTF** | `--ignored` + live-kernel gate + `WINDBG_MCP_SMOKE_CTF=1` | the challenge VM, WinRM, full `nt` symbols | the real driver and retained `Tgsm` pool objects through the shipped MCP transport |
-| **Live (other)** | manual | TTD engine, elevation, a test driver | see [Manual checklist](#manual-checklist) |
+| **TTD** | `WINDBG_MCP_SMOKE_TTD=1` | `TTD.exe`, **elevation**, and the WinDbg store engine to replay what it records | that `record_trace` records the program it was given and reports a finished recording as one, and that a TTD query returns records rather than bare indices |
+| **Live (other)** | manual | a test driver on a kernel target | see [Manual checklist](#manual-checklist) |
 
 The protocol tier rides `cargo test`, so CI already runs it. The debugger tier is opt-in
 *locally* but runs on every push and PR in CI, as the **Smoke test (debugger tier)** job — it is
@@ -1088,11 +1090,59 @@ are removed by default. If the target is halted or has crashed, cleanup cannot r
 VM, remove the named remote directory if necessary, and treat the transcript's detach warning as
 the primary failure before rerunning.
 
+## The TTD tier
+
+```pwsh
+$env:WINDBG_MCP_SMOKE_TTD = "1"; cargo test --test mcp_smoke -- --nocapture ttd
+```
+
+Four tests, and the tier they belong to exists because **all three of the defects it covers
+shipped** — `ttd_calls` and `ttd_memory` had returned blank rows since the initial commit, and
+`record_trace` could neither pass an argument nor report a short recording as anything but a
+failure. Nothing caught any of it, for a reason that is structural rather than an oversight: a
+`.run` is tens of megabytes, none is checked in, and recording one needs elevation and `TTD.exe`.
+So this is the only tier that **creates its own target** instead of opening a checked-in one.
+
+Gated on `WINDBG_MCP_SMOKE_TTD=1` and deliberately **not** `#[ignore]`d as well, unlike the two
+tiers above it. Those are double-gated because a stale variable costs a wedged VM or a run measured
+in minutes; the worst this does is leave a few tens of MB in the temp directory, and against that
+the rule that matters is the one `launch_tier` states — a gate nothing sets is a gap that stays
+open.
+
+**Elevation and a recorder are the host's business, not the gate's.** Both are read off the
+recorder's own refusal — `TTD.exe not found`, `Administrative privileges`, `0x80070005` — and
+print `SKIPPED`. Every *other* failure fails the test, which is the distinction that keeps the tier
+honest: a helper that treated any error as a skip would pass on a machine where recording is
+broken. Replay is a third stand-down, taken separately: a host can record a trace it cannot open,
+because replay needs the WinDbg store engine beside the binary, and by then the recording half has
+already been asserted.
+
+| Test | Claim | How it is read |
+| --- | --- | --- |
+| `ttd_records_a_target_that_finishes_inside_the_startup_watch_as_complete` | #233 — `hostname.exe` finishes in ~150ms against a 2.5s watch, so it exits *inside* the window, and that is a complete recording rather than a failed start | the message says "recording complete", **and** a non-empty `.run` is in the output directory — two sources for the one fact, because the old bug was a message that contradicted the disk |
+| `ttd_records_the_program_a_target_with_arguments_names` | #232 — `cmd.exe /c dir …` records, instead of TTD looking for a file with that whole name | recording at all (the old behaviour could not), plus the trace being named `cmd*`, since TTD names a trace after the program it launched |
+| `ttd_resolves_a_relative_target_against_the_recorders_working_directory` | the [#235](https://github.com/glslang/windbg-mcp/pull/235) review finding — a relative target is probed where the *recorder* runs, not where the server does | a fixture copied to `<work_dir>\a program.exe` and recorded as `.\a program.exe`; the trace must be named `a program*`, because the defect recorded **`a.exe`** and reported success |
+| `ttd_queries_answer_with_the_fields_they_promise` | #231 — a query returns records, not a column of bare indices | `ttd_events` and `ttd_memory` must render field names (`ModuleLoaded`, `AccessType`, `Value`); the address is a module base, read every time an image is mapped |
+
+**The queries are the two that need no symbols**, on purpose: the fields are then a property of the
+query rather than of what the host can resolve, so the tier does not stand down on a machine with
+no symbol server. That leaves `ttd_calls` — the tool the issue was reported against — asserted
+only by `src/server.rs`'s unit tests on the command it builds, and by hand. It is the deliberate
+gap in this tier, and the [manual checklist](#manual-checklist) carries it.
+
+**Each of the four was checked by putting its defect back**, which is the only evidence that a
+green tier means anything: `-r1` for the depth (both queries blank, and `ttd_events` is the
+assertion that fires), the unconditional early-exit failure, `.arg(target)` for the whole command
+line, and the probe against this process's directory — which fails with `` `a01.run` is not a
+recording of `a program.exe` ``, the wrong-program recording exactly as it was first measured.
+
 ## Manual checklist
 
 Not automated: no runner has a kernel target, a TTD-capable engine, or elevation. Run these by hand
 before a release, or when a change touches the relevant path. Drivers live in
-[`examples/`](../examples/README.md) and need `cargo build --release` first.
+[`examples/`](../examples/README.md) and need `cargo build --release` first. The TTD entry is the
+one that shrank — most of it is now [a tier](#the-ttd-tier), and what stays here is what that tier
+does not reach.
 
 - **Live user-mode** — `examples/test_usermode.ps1`: launch `cmd.exe` under the debugger, break in,
   read registers/modules, set a breakpoint.
@@ -1120,17 +1170,15 @@ before a release, or when a change touches the relevant path. Drivers live in
   `examples/drive_kernel_test.ps1 -Connection "net:port=<n>,key=<w.x.y.z>"`: attach,
   `bp nt!NtCreateFile`, `go` to it, resume, detach. See the KDNET gotchas in `CLAUDE.md` before
   diagnosing a hang.
-- **TTD replay** — needs the WinDbg store engine next to the binary (System32's engine rejects
-  `.run` traces with `0x80070057`). Open a trace, then exercise `ttd_calls` / `ttd_memory` /
-  `ttd_events` and reverse execution. The worked example is
+- **TTD** — recording and the two queries are the [TTD tier](#the-ttd-tier) now, which is where to
+  start; it needs the WinDbg store engine next to the binary to replay what it records (System32's
+  rejects a `.run` with `0x80070057`, and the tier stands that half down rather than failing).
+  What is left by hand is what the tier does not reach: **reverse execution** (`reverse_go`,
+  `step_back`, `step_over_back`, `goto_position`) on a trace, and `ttd_calls` against **resolved
+  symbols** — which the tier avoids deliberately, so that it does not stand down on a host with no
+  symbol server. The worked example is
   [`docs/flareauthenticator-ttd-walkthrough.md`](flareauthenticator-ttd-walkthrough.md). **Read a
-  row, do not count them**: issue #231 was two of these three tools rendering the right number of
-  rows with nothing in any of them, which a count cannot tell from a query that matched.
-- **TTD recording** — `record_trace` needs elevation and `TTD.exe` on `PATH`. Three targets, not
-  one, because each covers a case that was broken and none of the three has an automated tier: a
-  **short** one (`hostname.exe`) has to report a *complete* recording naming its `.run` rather than
-  a failure (#233), one **with arguments** (`cmd.exe /c dir C:\Windows\System32\ntdll.dll`) has to
-  record at all (#232), and a **missing** program has to still report the failure with the log's
-  own reason rather than TTD's `Launching '<target>'` banner.
+  row, do not count them**: issue #231 was two of these tools rendering the right number of rows
+  with nothing in any of them, which a count cannot tell from a query that matched.
 - **Driver IOCTL sweep** — `examples/sweep_ioctls.ps1` plus the target-side
   `examples/send_ioctls_target.ps1`; needs a benign test driver on a KDNET target.

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -10,7 +10,7 @@
 //! * **The MCP spec revved.** New revision, new required field, a capability the SDK now
 //!   advertises on our behalf that this server does not actually implement.
 //!
-//! Five tiers, so the cheap one can ride `cargo test` everywhere:
+//! Six tiers, so the cheap one can ride `cargo test` everywhere:
 //!
 //! * **Protocol** (default) — spawns the server, speaks JSON-RPC. No debugger target, no
 //!   symbols, no network. This tier also drives the **listener** (`--listen`) over real HTTP on a
@@ -46,6 +46,12 @@
 //!   — deploys a benign allocation fixture over WinRM, then verifies that the real driver and its
 //!   pool objects are visible through the structured MCP tools. The PowerShell orchestrator owns
 //!   the second gate so an ordinary live-kernel run never assumes this challenge is installed.
+//! * **TTD** (`WINDBG_MCP_SMOKE_TTD=1`) — records a trace with `TTD.exe` and reads it back, so it
+//!   needs the recorder and **elevation**. The only tier that creates its own target rather than
+//!   opening a checked-in one, because a `.run` is tens of MB and none is in the repo — which is
+//!   why nothing covered these calls, and why #231, #232 and #233 all shipped. Gated on the
+//!   variable alone rather than `#[ignore]`d as well: a stale variable here costs a few tens of MB
+//!   in the temp directory, not a wedged VM.
 //!
 //! See `docs/smoke-test.md` for the runbook.
 
@@ -11086,4 +11092,316 @@ fn ungraceful_detach(ended: &Value, text: &str) -> Option<String> {
         ));
     }
     None
+}
+
+// ---- tier 5: recording a TTD trace, and reading it back -----------------------
+
+/// Gate for the tier that drives the **TTD recorder** and replays what it wrote.
+///
+/// One environment variable and no `#[ignore]`, unlike the two tiers above it. Those are
+/// double-gated because a stale variable there costs something real — a wedged VM, a run measured
+/// in minutes — where the worst this does is leave a few tens of MB in the temp directory. Against
+/// that, [`launch_tier`]'s rule applies with full force: a gate nothing sets is a gap that stays
+/// open, and this tier exists because three defects shipped with nothing exercising these calls
+/// (#231, #232, #233).
+///
+/// The **host's** two reasons to stand down are deliberately not this gate's: a machine with no
+/// recorder, and a server that is not elevated, are read off the recorder's own refusal in
+/// [`recorded`]. Probing for them here would mean a second copy of `ttd::find_ttd`'s search in a
+/// file that cannot call it, which is the kind of duplicate that goes quietly out of date.
+fn ttd_tier() -> bool {
+    if std::env::var_os("WINDBG_MCP_SMOKE_TTD").is_none() {
+        skip("set WINDBG_MCP_SMOKE_TTD=1 to run the TTD recording tier");
+        return false;
+    }
+    true
+}
+
+/// A recording is generous with its clock: `TTD.exe` is located on disk, spawned, and watched for
+/// its whole startup window before the call can answer at all.
+const RECORD_STEP: Duration = Duration::from_secs(120);
+
+/// An empty directory of this tier's own to record into.
+///
+/// Per test and per process, and emptied first, because [`recorded_trace`] identifies a recording
+/// by what is in the directory — a `.run` left by an earlier run of the same test would be read as
+/// this one's, and the assertion would be about the wrong file.
+fn recording_dir(what: &str) -> std::path::PathBuf {
+    let dir = std::env::temp_dir().join(format!(
+        "windbg-mcp-smoke-ttd-{what}-{}",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).expect("create the recording directory");
+    dir
+}
+
+/// Runs one `record_trace`, standing the tier down for the two reasons that are the **host's**
+/// rather than this server's.
+///
+/// Returns the success text, or `None` having printed a `SKIPPED` line. Every other failure fails
+/// the test, and that separation is the point: "not elevated" and "recording is broken" are
+/// indistinguishable to a helper that treats any error as a skip, which is how a tier comes to
+/// pass while covering nothing.
+fn recorded(server: &mut Server, out_dir: &std::path::Path, args: Value) -> Option<String> {
+    let mut arguments = args;
+    arguments["out_dir"] = json!(out_dir.to_string_lossy());
+    let response = server.call_tool("record_trace", arguments.clone(), RECORD_STEP);
+    assert_no_error(&response, "tools/call record_trace");
+    let text = text_of(&response["result"]);
+    if is_tool_error(&response) {
+        let lower = text.to_ascii_lowercase();
+        // No recorder installed, and not elevated — the two states a developer's machine is
+        // legitimately in. `0x80070005` is the code the un-elevated refusal carries.
+        if lower.contains("ttd.exe not found")
+            || lower.contains("administrative privileges")
+            || lower.contains("access is denied")
+            || lower.contains("0x80070005")
+        {
+            skip(&format!("this host cannot record a TTD trace: {text}"));
+            return None;
+        }
+        panic!("`record_trace {arguments}` failed for a reason that is not the host's:\n{text}");
+    }
+    Some(text)
+}
+
+/// The `.run` a recording left behind, read off the directory rather than out of the message.
+///
+/// Deliberately not parsed from `record_trace`'s prose, though the prose names it: the claim under
+/// test is that a finished recording *exists*, and a test that took the path from the sentence
+/// asserting it would be checking that sentence against itself.
+fn recorded_trace(out_dir: &std::path::Path) -> std::path::PathBuf {
+    let mut traces: Vec<std::path::PathBuf> = std::fs::read_dir(out_dir)
+        .expect("read the recording directory")
+        .flatten()
+        .map(|entry| entry.path())
+        .filter(|p| p.extension().is_some_and(|e| e.eq_ignore_ascii_case("run")))
+        .collect();
+    traces.sort();
+    assert_eq!(
+        traces.len(),
+        1,
+        "one recording should leave exactly one trace in {}, found {traces:?}",
+        out_dir.display()
+    );
+    let trace = traces.remove(0);
+    let size = std::fs::metadata(&trace).expect("stat the trace").len();
+    assert!(size > 0, "`{}` is an empty trace", trace.display());
+    trace
+}
+
+/// The lower-cased file name of a trace, which is how this tier reads *which program* was
+/// recorded: `TTD.exe` names a trace after the program it launched, so `cmd01.run` is evidence
+/// about the process that ran and not merely about the call returning.
+fn trace_name(trace: &std::path::Path) -> String {
+    trace
+        .file_name()
+        .map(|n| n.to_string_lossy().to_ascii_lowercase())
+        .unwrap_or_default()
+}
+
+/// Issue #233: a target that finishes inside the startup watch is a **complete recording**, not a
+/// failed one.
+///
+/// `hostname.exe` runs in about 150ms against a 2.5s watch, so it exits while the recorder is
+/// still being watched for a fast failure — and every exit in that window used to be reported as
+/// one, quoting TTD's `Launching '<target>'` banner as the reason. The trace was on disk and
+/// replayed correctly the whole time, which is what makes this the worst shape of the three: the
+/// tool said the opposite of what had happened.
+#[test]
+fn ttd_records_a_target_that_finishes_inside_the_startup_watch_as_complete() {
+    if !ttd_tier() {
+        return;
+    }
+    let out_dir = recording_dir("short");
+    let mut server = Server::started();
+    let Some(text) = recorded(&mut server, &out_dir, json!({ "target": "hostname.exe" })) else {
+        return;
+    };
+
+    // The claim, and then the file — deliberately two different sources for the one fact.
+    assert!(
+        text.contains("recording complete"),
+        "a target that has already exited should be reported as complete, not as started:\n{text}"
+    );
+    let trace = recorded_trace(&out_dir);
+    assert!(
+        text.contains(trace.to_string_lossy().as_ref()),
+        "the message should name the trace it left, so a caller need not go looking for it:\n{text}"
+    );
+
+    let _ = std::fs::remove_dir_all(&out_dir);
+}
+
+/// Issue #232: the arguments in `target` reach the program instead of becoming part of its name.
+///
+/// The whole string went to `TTD.exe` as one argv entry, so the recorder looked for a file called
+/// `cmd.exe /c dir …` and answered `0x80004005` — "cannot find the file specified", a message
+/// about the program when the fault was in the quoting. Recording at all is most of the claim,
+/// since the old behaviour could not; the trace's **name** is the rest, and is what would catch a
+/// split that succeeded while resolving the first token to something else.
+#[test]
+fn ttd_records_the_program_a_target_with_arguments_names() {
+    if !ttd_tier() {
+        return;
+    }
+    let out_dir = recording_dir("arguments");
+    let mut server = Server::started();
+    let target = "cmd.exe /c dir C:\\Windows\\System32\\ntdll.dll";
+    let Some(text) = recorded(&mut server, &out_dir, json!({ "target": target })) else {
+        return;
+    };
+    assert!(text.contains("recording complete"), "{text}");
+
+    let name = trace_name(&recorded_trace(&out_dir));
+    assert!(
+        name.starts_with("cmd"),
+        "`{name}` should be named after `cmd.exe`; a trace named after anything else means the \
+         first token resolved to a different program"
+    );
+
+    let _ = std::fs::remove_dir_all(&out_dir);
+}
+
+/// A relative `target` is resolved where the **recorder** runs, not where this server does.
+///
+/// The review finding on [#235](https://github.com/glslang/windbg-mcp/pull/235), and the one
+/// failure in this area that was not an error. `record_trace` probes whether `target` names an
+/// existing file before deciding it is a program rather than a command line, and that probe used
+/// this process's working directory while `TTD.exe` is given the caller's. With `working_dir`
+/// holding `a program.exe` the probe declined, the target was split on its space, and TTD recorded
+/// **`a.exe`** — a different program — into a trace reported as a complete recording.
+///
+/// The fixture is a copy of a real system binary rather than a stub, because the claim is about
+/// which program was *recorded*, and TTD has to be able to launch it.
+#[test]
+fn ttd_resolves_a_relative_target_against_the_recorders_working_directory() {
+    if !ttd_tier() {
+        return;
+    }
+    let work_dir = recording_dir("relative-work");
+    let out_dir = recording_dir("relative-out");
+    let fixture = work_dir.join("a program.exe");
+    let system = std::path::PathBuf::from(std::env::var("SystemRoot").unwrap_or_default())
+        .join("System32")
+        .join("hostname.exe");
+    if std::fs::copy(&system, &fixture).is_err() {
+        skip(&format!(
+            "could not copy {} to build the spaced-name fixture",
+            system.display()
+        ));
+        return;
+    }
+
+    let mut server = Server::started();
+    // Path-qualified, because TTD does not search its own cwd for a *bare* relative name —
+    // measured on 1.01.11, where `-launch aprogram.exe` fails and `-launch ./aprogram.exe`
+    // records. So this is the form that has to work, and the form that recorded the wrong program.
+    let Some(text) = recorded(
+        &mut server,
+        &out_dir,
+        json!({
+            "target": ".\\a program.exe",
+            "working_dir": work_dir.to_string_lossy(),
+        }),
+    ) else {
+        return;
+    };
+    assert!(text.contains("recording complete"), "{text}");
+
+    let name = trace_name(&recorded_trace(&out_dir));
+    assert!(
+        name.starts_with("a program"),
+        "`{name}` is not a recording of `a program.exe` — the target resolved to some other \
+         program and the recording succeeded anyway, which is the shape of the defect"
+    );
+
+    let _ = std::fs::remove_dir_all(&work_dir);
+    let _ = std::fs::remove_dir_all(&out_dir);
+}
+
+/// Issue #231: a TTD query answers with **records**, not with a column of bare indices.
+///
+/// `dx` renders one level unless asked for more, and these queries return containers of records,
+/// so the tools answered with the right number of rows and nothing in any of them. There is no
+/// error in that — three blank rows read as "three calls, details unavailable" — which is why it
+/// survived from the initial commit in two of the three query tools.
+///
+/// Driven through `ttd_memory` and `ttd_events`, the two that need **no symbols**: the fields are
+/// then a property of the query rather than of what this host can resolve, so the tier does not
+/// stand down on a machine with no symbol server. `ttd_events` is not redundant beside it — it is
+/// the one of the three that always carried the depth, which makes the pair diagnostic. Measured
+/// by putting each defect back: setting the shared `TTD_QUERY_DEPTH` to `-r1` blanks **both**, and
+/// this assertion is the one that fires; `ttd_memory` alone going blank is instead the original
+/// #231 shape, one query written differently from its siblings and off the constant they share.
+#[test]
+fn ttd_queries_answer_with_the_fields_they_promise() {
+    if !ttd_tier() {
+        return;
+    }
+    let out_dir = recording_dir("replay");
+    let mut server = Server::started();
+    if recorded(&mut server, &out_dir, json!({ "target": "hostname.exe" })).is_none() {
+        return;
+    }
+    let trace = recorded_trace(&out_dir);
+
+    let response = server.call_tool(
+        "open_trace",
+        json!({ "path": trace.to_string_lossy() }),
+        TARGET_STEP,
+    );
+    assert_no_error(&response, "tools/call open_trace");
+    if is_tool_error(&response) {
+        // Replay needs the WinDbg store engine beside the binary; System32's rejects a `.run`
+        // outright with `0x80070057`. A host that can record but not replay stands this half down
+        // rather than failing — the recording half has already run in the tests above.
+        skip(&format!(
+            "this host recorded a trace it cannot replay: {}",
+            text_of(&response["result"])
+        ));
+        let _ = std::fs::remove_dir_all(&out_dir);
+        return;
+    }
+    let session = maybe_session_id(&response["result"])
+        .unwrap_or_else(|| panic!("`open_trace` opened without minting a handle: {response}"));
+
+    // Events first. Module loads are in every trace, and this is the query that always rendered
+    // its fields, so a failure here is about the trace rather than about the depth.
+    let events = server.tool_text("ttd_events", json!({ "session_id": session }), TARGET_STEP);
+    assert!(
+        events.contains("ModuleLoaded") && events.contains("Position"),
+        "`ttd_events` should render each event's own fields:\n{events}"
+    );
+
+    // And then the one the issue was about. An image base is read every time it is mapped — the
+    // `MZ` of the PE header — so it is an address certain to have been accessed, and naming it
+    // needs no symbol.
+    let modules = server.tool_data(
+        "modules",
+        json!({ "session_id": session, "limit": 2000 }),
+        TARGET_STEP,
+    );
+    let base = modules["modules"]
+        .as_array()
+        .into_iter()
+        .flatten()
+        .map(|m| address_of(&m["start"]))
+        .find(|&start| start != 0)
+        .unwrap_or_else(|| panic!("the trace should have a module with a base: {modules}"));
+
+    let memory = server.tool_text(
+        "ttd_memory",
+        json!({ "session_id": session, "address": format!("0x{base:x}"), "size": 8 }),
+        TARGET_STEP,
+    );
+    assert!(
+        memory.contains("AccessType") && memory.contains("Value"),
+        "`ttd_memory` should render each access as a record — the defect was a column of bare \
+         indices with the right count and no payload:\n{memory}"
+    );
+
+    server.tool_text("end_session", json!({ "session_id": session }), TARGET_STEP);
+    let _ = std::fs::remove_dir_all(&out_dir);
 }

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -11354,15 +11354,26 @@ fn ttd_queries_answer_with_the_fields_they_promise() {
     );
     assert_no_error(&response, "tools/call open_trace");
     if is_tool_error(&response) {
-        // Replay needs the WinDbg store engine beside the binary; System32's rejects a `.run`
-        // outright with `0x80070057`. A host that can record but not replay stands this half down
-        // rather than failing — the recording half has already run in the tests above.
-        skip(&format!(
-            "this host recorded a trace it cannot replay: {}",
-            text_of(&response["result"])
-        ));
-        let _ = std::fs::remove_dir_all(&out_dir);
-        return;
+        let text = text_of(&response["result"]);
+        // Stand down for the **one** reason that is the host's: no replay engine beside the
+        // binary. Any other `open_trace` failure — a regression, a trace that will not load — has
+        // to fail, or this test passes having exercised neither query, which is the shape
+        // [`recorded`] exists to avoid one function above.
+        //
+        // Keyed on the server's own diagnostic, not on `0x80070057`. That code is the engine's
+        // "the parameter is incorrect" and a trace that failed to load for some other reason can
+        // carry it too; the sentence below is appended by `worker::explain_trace_failure` only
+        // when `replay_engine_bundled()` is false, which is exactly the condition being excused.
+        // A `ttd\` of the wrong architecture is deliberately *not* excused — it gets the engine's
+        // error with no such sentence, and a misconfigured bundle should be loud.
+        if text.to_ascii_lowercase().contains("cannot replay") {
+            skip(&format!(
+                "this host recorded a trace it cannot replay: {text}"
+            ));
+            let _ = std::fs::remove_dir_all(&out_dir);
+            return;
+        }
+        panic!("`open_trace` failed for a reason that is not the host's:\n{text}");
     }
     let session = maybe_session_id(&response["result"])
         .unwrap_or_else(|| panic!("`open_trace` opened without minting a handle: {response}"));


### PR DESCRIPTION
Follow-up to #235. Three defects shipped in v0.11.x — `ttd_calls` and `ttd_memory` returning blank
rows since the initial commit, `record_trace` unable to pass an argument or to report a short
recording as anything but a failure — and **nothing in the suite touched any of those calls**. That
gap was structural rather than an oversight: a `.run` is tens of megabytes, none is checked in, and
recording one needs `TTD.exe` and elevation. So this tier is the first that **creates its own
target** instead of opening a checked-in one, which is what makes covering them possible at all.

```pwsh
$env:WINDBG_MCP_SMOKE_TTD = "1"; cargo test --test mcp_smoke -- --nocapture ttd
```

## What it asserts

| Test | Claim | How it is read |
| --- | --- | --- |
| `ttd_records_a_target_that_finishes_inside_the_startup_watch_as_complete` | #233 | the message says "recording complete", **and** a non-empty `.run` is in the output directory — two sources, because the defect was a message that contradicted the disk |
| `ttd_records_the_program_a_target_with_arguments_names` | #232 | recording at all (the old behaviour could not), plus the trace being named `cmd*` — TTD names a trace after the program it launched |
| `ttd_resolves_a_relative_target_against_the_recorders_working_directory` | the #235 review finding | a fixture at `<work_dir>\a program.exe` recorded as `.\a program.exe`; the trace must be named `a program*`, because that defect recorded **`a.exe`** and reported success |
| `ttd_queries_answer_with_the_fields_they_promise` | #231 | `ttd_events` and `ttd_memory` must render field names; the address is a module base, read every time an image is mapped |

## Three decisions worth reviewing

**Gated on the variable alone, no `#[ignore]` beside it** — unlike the bounded and live-kernel
tiers. Those are double-gated because a stale variable costs a wedged VM or a run measured in
minutes. The worst this does is leave a few tens of MB in `%TEMP%`, and against that `launch_tier`'s
rule applies with full force: a gate nothing sets is a gap that stays open.

**The host's reasons to stand down are read off the recorder's own refusal** — no `TTD.exe`, not
elevated, a trace it cannot replay — rather than probed for, which would put a second copy of
`ttd::find_ttd`'s search in a file that cannot call it. Every *other* failure fails the test. That
split is deliberate: a helper that treats any error as a skip is exactly how a tier comes to pass
while covering nothing.

**The two queries asserted are the ones that need no symbols**, so the fields are a property of the
query rather than of what the host can resolve, and the tier does not stand down on a machine with
no symbol server. That leaves `ttd_calls` — the tool #231 was filed against — covered by unit tests
on the command it builds, and by hand. It is the deliberate gap in this tier and
`docs/smoke-test.md` carries it in the manual checklist, alongside reverse execution.

## Evidence the tier bites

Each test was checked by **putting its defect back**, since a passing test is not by itself evidence
of anything:

| Mutation | Result |
| --- | --- |
| `TTD_QUERY_DEPTH` → `-r1` | `ttd_queries_answer_with_the_fields_they_promise` FAILED |
| the early-exit arm made unconditional again | `ttd_records_a_target_that_finishes_inside_the_startup_watch_as_complete` FAILED |
| `.args(&argv)` → `.arg(target)` | `ttd_records_the_program_a_target_with_arguments_names` FAILED |
| the probe back to `Path::new(trimmed).is_file()` | `ttd_resolves_…` FAILED with ``a01.run` is not a recording of `a program.exe`` — the wrong-program recording, exactly as first measured |

That exercise also **corrected a doc comment I had written**: putting the depth back blanks *both*
queries and `ttd_events` is the assertion that fires, where the comment claimed both going blank
meant something below these tools. It now says what the mutation showed.

## Two stale facts fixed while here

Re-derived rather than trusted, per `CLAUDE.md`'s own rule:

- the smoke-test **pass count** was recorded as 79 and is **83**.
- `CLAUDE.md` and `FOLLOWUPS.md` item 47 both state that TTD replay "does not work on this host at
  all". **That pronoun is the ARM64 bench** — the sentence before it names it — and I first read it
  as this machine, which is `x86_64-pc-windows-msvc`. Corrected in `d3688a4`.

  What is true is narrower: the *x64* bench has the `ttd\` payload beside `target\debug` and
  `target\release` (item 21's unpack recipe), which is what lets the fourth test open what it
  records. So item 47's prerequisite is satisfied on **a** machine — just not the one the item was
  written on, and nothing here has re-checked that one. That is probably enough to close it, since
  its gap is a *target type* and not an architecture; but every sibling measurement in the item was
  taken on ARM64, and an x64 answer inherits the caveat the item already cites against itself
  ("generalised from one backend"). Both files now disambiguate the host instead of leaving a
  pronoun whose antecedent is two sentences up, and the item records that it was misread once,
  since the next reader faces the same pronoun.

  Still **not closed**: what it wants is the *timeout* path, and the note now says to establish
  first whether the bound is reachable on a replay target at all — a trace has ends, so a `go` with
  no breakpoint may stop at one well inside the 60s bound, which would close the item as an answer
  rather than as a test. Happy to take that on separately.

## Verification

- `cargo fmt --all --check`, `cargo clippy --all-targets -- -D warnings` — clean.
- 562 unit tests; `mcp_smoke` **83 passed / 12 ignored** with the gate off *and* on, which is this
  harness's contract (each gate is inside its own test) — the `SKIPPED` lines and the runtime are
  what tell the two runs apart.
- The tier itself: 4 passed, run repeatedly for stability, since the four recordings run in parallel
  with the rest of the harness.
- `npx markdownlint-cli2@0.23.2 …` — 0 issues.

One thing found late and worth flagging as a review lesson: the first draft's test names shared no
substring, so the `-- ttd` filter I had just documented ran **one** of the four. They are named
`ttd_*` now and the filter selects all four — checked, not assumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
