### PR TITLE
Give the binary a PE version resource, so Defender has something to read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **The binary carries a PE version resource** — `FileVersion`, `ProductVersion`, `CompanyName`,
+  `ProductName`, `FileDescription`, `LegalCopyright`, `OriginalFilename`, `InternalName` and
+  `Comments`, where a Rust binary carries none of them by default. Explorer's properties dialog is
+  the visible half; the reason is the other one. Windows Defender quarantined a freshly built
+  `windbg-mcp.exe` as `Trojan:Win32/Bearfoos.B!ml`, and an absent version resource is one of the two
+  causes Microsoft names for that same detection on its own shipped binaries — an `!ml` verdict is a
+  machine-learning score rather than a signature match, so a binary with no metadata is scored on
+  what little there is. `ProductVersion` carries the git-stamped identity (`0.12.1+g1a2b3c4`) while
+  `FileVersion` stays the bare release, so the dialog answers the same question `serverInfo.version`
+  does. This does not make the binary signed, and signing is what the reputation systems above
+  Defender actually read: [`FOLLOWUPS.md`](./FOLLOWUPS.md) item 50 is what remains.
 - **A 32-bit .NET dump is opened by an engine that can load its SOS** (issue #234). An extension DLL
   is loaded into the debugger's own process, so its architecture is the *host's*: the 32-bit
   `sos.dll` will not load into this server's x64 engine (`Win32 error 0n193`) and the 64-bit one

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,6 +126,20 @@ split this way caught a `windows` feature trimmed by module path (`IMAGE_NT_HEAD
 behind `Win32_System_SystemInformation`, not the `Debug` feature its path suggests) that would
 otherwise have been a red VM build.
 
+**One warning from that check is expected and is not a break.** `build.rs` compiles the binary's PE
+version resource (item 50 — an empty `FileVersion`/`CompanyName`/`ProductName` is half of why
+Defender scored this project's own exe as `Bearfoos.B!ml`), and that needs `rc.exe`, which no Mac
+has. The script prints `cargo::warning=no PE version resource was embedded: …` and carries on,
+because failing there would cost this whole workflow for the sake of metadata. Which means the
+warning is the *only* thing between a Windows build that quietly lost its resource and a release, so
+the assertion is a test instead — `mcp_smoke::the_binary_carries_a_pe_version_resource`, which reads
+the resource back through `GetFileVersionInfoW` on the one host that can build one. To check that
+test still catches what it is for, break the compiler rather than the code:
+`$env:RC_PATH = "C:\nope\rc.exe"`, touch `build.rs`, re-run it, then unset and touch again. And note
+the resource is composed **in `build.rs`** from `CARGO_PKG_*` and literals for a reason: an `.rc`
+template or an icon file would be a new build input, and `INPUTS` is one const precisely so the
+watch list and the dirty check cannot disagree about what a clean build is.
+
 **A `[patch]` cannot verify against a repo that does not exist yet.** Cargo resolves the original
 source *before* applying the patch, so pointing one at a local checkout still fetches the git URL
 and fails on a repo not yet created or renamed — which is exactly the middle of a rename. Swap the
@@ -186,14 +200,15 @@ It checks *same-file* fragments only, so a cross-file `../README.md#some-heading
 verify by hand.
 
 **The pass count does not say which tiers ran.** Each gate is inside its test, so the `mcp_smoke`
-harness reports the same **83 passed** with the debugger tier off as with it on — that harness's own
+harness reports the same **85 passed** with the debugger tier off as with it on — that harness's own
 result line, since a plain `cargo test` runs the crate's several hundred unit tests beside it and
 prints a result line per binary. What differs between the two runs is the runtime (measured on the
 ARM64 bench 2026-08-23: **1.6s against 61s** for `cargo test --test mcp_smoke`) and the `SKIPPED`
 lines, which only `--nocapture` prints. Read one of those two before believing a run covered a
 debugger claim. The count moves whenever a test is added — it was 69 until #195 and #196, 75
-until item 37, and 79 until the TTD tier — so
-re-derive it rather than trusting this sentence.
+until item 37, 79 until the TTD tier and 84 until item 50's version-resource test — and it
+said 83 while it was 84, which is the usual state of it, so re-derive it rather than trusting this
+sentence.
 
 **The dev exe can be locked too, and the failure is quiet.** A worker left running — a driver
 script that died mid-session, a debugger tier killed partway — holds `target\debug\windbg-mcp.exe`,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -999,6 +999,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1074,6 +1080,7 @@ dependencies = [
  "tracing-subscriber",
  "windows-service",
  "windows-sys",
+ "winresource",
 ]
 
 [[package]]
@@ -1204,6 +1211,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "winresource"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0986a8b1d586b7d3e4fe3d9ea39fb451ae22869dcea4aa109d287a374d866087"
+dependencies = [
+ "version_check",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,12 @@
 name = "windbg-mcp"
 version = "0.12.1"
 edition = "2024"
+# Not published to crates.io — these are here because `build.rs` stamps them into the binary's PE
+# version resource, which is what Explorer's properties dialog and Defender's ML scoring read
+# (`FOLLOWUPS.md` item 50). The description is the short one, from `server.json`.
+description = "WinDbg/DbgEng over MCP: crash dumps, live user & kernel, driver IOCTLs, and TTD."
+repository = "https://github.com/glslang/windbg-mcp"
+license = "MIT"
 
 [dependencies]
 dbgscope = { git = "https://github.com/glslang/dbgscope", rev = "19a87d80768b3c236f873898e47762696d8498ae" }
@@ -55,7 +61,20 @@ windows-sys = { version = "0.61", features = [
 # left frozen. Small and focused — it pulls in no framework behind it.
 windows-service = "0.8"
 
+[build-dependencies]
+# The PE version resource (`build.rs`), which is item 50's cheap half: a Rust binary carries none by
+# default, and an empty `FileVersion`/`CompanyName`/`ProductName` is one of the two causes Microsoft
+# names for the `Bearfoos.B!ml` verdict this binary has drawn. Default features off drops its `toml`
+# dependency, whose only job is reading a `[package.metadata.winresource]` table — the fields are
+# set from `build.rs` instead, because one of them is the git revision only that script computes.
+winresource = { version = "0.1", default-features = false }
+
 [dev-dependencies]
+# `Win32_Storage_FileSystem` for `GetFileVersionInfoW`, so `mcp_smoke` can read the PE version
+# resource back off the exe it just built. A dev-dependency rather than a feature on the entry
+# above: the edition-2024 resolver does not unify these into a normal build, so the shipped
+# binary's `windows-sys` surface is unchanged by a test wanting to check the metadata.
+windows-sys = { version = "0.61", features = ["Win32_Storage_FileSystem"] }
 # `test-util` only, and only for the tests: `src/progress.rs` asserts on a heartbeat measured in
 # tens of seconds, and the alternative — real sleeps shrunk to milliseconds — is a test that fails
 # on a loaded runner for reasons that have nothing to do with the code. A paused clock makes the

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -2820,14 +2820,28 @@ question `serverInfo.version` does. Four things that entry did not see:
   detection goes away — Microsoft's own issue files signing under a later tier than the metadata —
   and it is not a prerequisite for the submission above; what it buys is a *stable identity for
   reputation to attach to*, so the submission stops starting from nothing each release, plus the fix
-  for SmartScreen's "unknown publisher" prompt, which nothing else addresses. And **it need not be
-  expensive**, which is the assumption worth checking before deferring it again: SignPath's
-  Foundation programme signs open-source projects for free and is the obvious first ask here; Azure
-  Trusted Signing is the CI-friendly route at roughly ten dollars a month, gated on an identity
-  check rather than on price; Certum's open-source certificates are around a hundred euros for
-  several years. Only **EV** — the one that earns SmartScreen reputation immediately rather than
-  accumulating it — is genuinely a few hundred a year. Prices move; treat these as the shape of the
-  choice, not as quotes. Note also what the release *does* carry and why it does not help here:
+  for SmartScreen's "unknown publisher" prompt, which nothing else addresses. And **price is not
+  what is blocking it — eligibility is**, which is the distinction to get right before deferring it
+  again on the wrong ground:
+
+  - **Azure Trusted Signing** is the CI-friendly route and is the obvious suggestion, at roughly ten
+    dollars a month. It is **not available here**: individual subscribers must be legally based in
+    the United States or Canada, and this project's maintainer is not. Cross it off rather than
+    re-proposing it.
+  - **An EV certificate** is the only thing that earns SmartScreen reputation *immediately* rather
+    than accumulating it, and it is also the one a solo maintainer cannot buy: EV issuance requires
+    a registered legal entity, so it is a company-formation decision before it is a few hundred a
+    year.
+  - **SignPath's Foundation programme** signs open-source projects for free and has no such
+    geographic or entity bar, which makes it the first ask.
+  - **Certum's open-source code-signing certificates** are the paid fallback — aimed at EU
+    individual developers, around a hundred euros for several years, on a token or their cloud
+    signing.
+
+  So the reachable options are both OV-class, and reputation accumulates rather than arriving — which
+  is an argument for doing the per-release submission above *regardless* of what gets signed, not
+  for treating signing as the thing that makes it unnecessary. Prices and programme terms move;
+  treat these as the shape of the choice, not as quotes. Note also what the release *does* carry and why it does not help here:
   `release.yml` produces a Sigstore build-provenance attestation, which is a supply-chain claim a
   user verifies deliberately with `gh attestation verify`. Nothing on the machine reads it, and it
   establishes provenance rather than benignity — a compromised dependency or runner would be

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -75,7 +75,10 @@ structured half needed a second verb, and the ratchet is the coverage rule rathe
 **Item 46 has landed** (2026-08-25) and is kept for the decision it deferred and the entry now
 records: this server *does* report a build revision, stamped by a `build.rs` whose watch list and
 dirty check have to be one list or they disagree — which is the sort of thing an entry proposing
-"record a build SHA" cannot see from where it is written.
+"record a build SHA" cannot see from where it is written. **Item 50 has half landed** (2026-08-26):
+the PE version resource is in, and what is left is the half the entry always said needed a decision
+rather than a patch — a signing certificate — so the entry now records what building the first half
+taught and is otherwise narrowed to the second.
 
 ## 1. [dbgscope] Managed breakpoint lifecycle for `run_to_address` — **done upstream**
 
@@ -2764,7 +2767,7 @@ cannot exercise them — and the user-mode heap walker, which is in scope for x8
 operator half is *32-bit .NET dumps need an x86 engine host* in
 `skills/windbg-debugging/setup.md`.
 
-## 50. [windbg-mcp] The released binary is unsigned and carries no PE metadata, and Defender acts on that
+## 50. [windbg-mcp] The released binary is unsigned — the metadata half has landed
 
 **What happened.** On 2026-08-26 Windows Defender quarantined a freshly built
 `target\debug\windbg-mcp.exe` as `Trojan:Win32/Bearfoos.B!ml`, blocking every smoke test that
@@ -2775,37 +2778,51 @@ it is a machine-learning score with a cloud lookup behind it, not a signature ma
 source can land either side of the line.
 
 **Why this is not a local curiosity.** The released binary has the same profile as the one that was
-quarantined, so a user downloading the release zip can hit it, and nothing in the project mitigates
-it today. `microsoft/apm#487` is the **same detection name on Microsoft's own shipped binary**, and
-the causes it lists that apply here are both true of this project:
+quarantined, so a user downloading the release zip can hit it. `microsoft/apm#487` is the **same
+detection name on Microsoft's own shipped binary**, and two of the causes it lists applied here.
+(Its other two — UPX compression and a stock PyInstaller bootloader — do not.)
 
-- **No PE version resource at all** — measured: `FileVersion`, `CompanyName` and `ProductName` are
-  all empty on both the debug and release binaries. Rust embeds none by default.
-- **Unsigned.** `release.yml` produces a Sigstore build-provenance attestation, which is a supply
-  chain claim a user verifies deliberately with `gh attestation verify`. It is not Authenticode, and
-  nothing on the machine reads it — so it does nothing for Defender or for SmartScreen's "unknown
-  publisher" prompt.
+**What has landed.** The **PE version resource**, via a `winresource` build-dependency in
+`build.rs`: `FileVersion`, `CompanyName` and `ProductName` were all empty, measured, on both the
+debug and the release binary, because Rust embeds none by default. They are now filled in, along
+with `FileDescription`, `LegalCopyright`, `OriginalFilename`, `InternalName` and `Comments`, and
+`ProductVersion` carries the git-stamped identity so Explorer's properties dialog answers the same
+question `serverInfo.version` does. Four things that entry did not see:
 
-(Its other two causes — UPX compression and a stock PyInstaller bootloader — do not apply.)
+- **`INPUTS` needed no change, because the resource has no file.** The warning this entry carried
+  was about adding a resource input to the watch list and not to the dirty check; the way to not
+  have that problem is to compose the resource in `build.rs` from `CARGO_PKG_*` and literals, with
+  no `.rc` template and no icon beside it. An icon *would* be a new input, and is the thing to think
+  about `INPUTS` for if one is ever added.
+- **`[package]` gained `description`, `repository` and `license`**, which it had never carried. The
+  resource is what wanted them; nothing else in this repo did, and the crate is not published.
+- **The build must not fail when there is no resource compiler**, because `cargo check --target
+  x86_64-pc-windows-msvc` from the Mac has neither `rc.exe` nor `llvm-rc`, and that is a documented
+  routine workflow. So `build.rs` warns and carries on — which means the assertion has to live
+  somewhere that only runs where a resource *can* be built:
+  `mcp_smoke::the_binary_carries_a_pe_version_resource` reads it back through
+  `GetFileVersionInfoW`. Point `RC_PATH` at nothing and touch `build.rs` to check that test still
+  catches the case it is for; it was verified that way rather than by assuming.
+- **Reading it back is not the same as finding the string in the file.** The test asks the API
+  Explorer and the reputation systems ask, so a resource Windows itself refuses to parse fails it.
 
-**What would close it**, cheapest first:
+**What is left, and it needs a decision rather than a patch:**
 
-- **A PE version resource**, via a `winresource` build-dependency in `build.rs`. Free, immediate,
-  and it also makes Explorer's properties dialog useful. **Careful with `INPUTS`**: `build.rs`'s
-  watch list and its dirty check are deliberately one const, because emitting any `rerun-if-changed`
-  replaces Cargo's default of watching the whole package — a resource input added to one and not the
-  other makes clean builds disagree about what is dirty.
-- **Submit the current release for false-positive review** at Microsoft's file submission portal.
-  Free, and it is what `microsoft/apm#487` does between releases.
-- **Authenticode signing** in `release.yml`. This is the part that needs a decision rather than a
-  patch, because it needs a certificate: Azure Trusted Signing is the CI-friendly route and
-  SignPath has a free tier for open source; an EV certificate earns SmartScreen reputation at once
-  where an OV one accumulates it. Worth stating plainly that signing **does not guarantee** an `!ml`
-  detection goes away — Microsoft's own issue files it under a later tier than the metadata — but
-  it is what the reputation systems above Defender actually read, and it is the fix for the
-  SmartScreen prompt regardless.
+- **Authenticode signing** in `release.yml`, which needs a certificate. Azure Trusted Signing is the
+  CI-friendly route and SignPath has a free tier for open source; an EV certificate earns SmartScreen
+  reputation at once where an OV one accumulates it. Worth stating plainly that signing **does not
+  guarantee** an `!ml` detection goes away — Microsoft's own issue files it under a later tier than
+  the metadata — but it is what the reputation systems above Defender actually read, and it is the
+  fix for the SmartScreen "unknown publisher" prompt regardless. Note what the release *does* carry
+  and why it does not help here: `release.yml` produces a Sigstore build-provenance attestation,
+  which is a supply-chain claim a user verifies deliberately with `gh attestation verify`. Nothing
+  on the machine reads it.
+- **Submitting the current release for false-positive review** at Microsoft's file submission
+  portal. Free, and it is what `microsoft/apm#487` does between releases — but it is a per-release
+  human action with an account behind it, so it belongs in the release checklist rather than in a
+  workflow. `skills/windbg-debugging/setup.md` now tells a user who hits this what to verify first
+  and points at the same portal.
 
-**Where it picks up.** `build.rs` (and its `INPUTS` const), the *Build & publish binary* job in
-`.github/workflows/release.yml`, and `skills/windbg-debugging/setup.md`, whose Option A download
-block already tells a user to `Unblock-File` the zip and would be where any "if Defender quarantines
-it" note belongs.
+**Where it picks up.** The *Build & publish binary* job in `.github/workflows/release.yml`, and
+[`docs/releasing.md`](./docs/releasing.md) if the submission becomes a step.
+

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -2808,20 +2808,31 @@ question `serverInfo.version` does. Four things that entry did not see:
 
 **What is left, and it needs a decision rather than a patch:**
 
-- **Authenticode signing** in `release.yml`, which needs a certificate. Azure Trusted Signing is the
-  CI-friendly route and SignPath has a free tier for open source; an EV certificate earns SmartScreen
-  reputation at once where an OV one accumulates it. Worth stating plainly that signing **does not
-  guarantee** an `!ml` detection goes away — Microsoft's own issue files it under a later tier than
-  the metadata — but it is what the reputation systems above Defender actually read, and it is the
-  fix for the SmartScreen "unknown publisher" prompt regardless. Note what the release *does* carry
-  and why it does not help here: `release.yml` produces a Sigstore build-provenance attestation,
-  which is a supply-chain claim a user verifies deliberately with `gh attestation verify`. Nothing
-  on the machine reads it.
-- **Submitting the current release for false-positive review** at Microsoft's file submission
-  portal. Free, and it is what `microsoft/apm#487` does between releases — but it is a per-release
-  human action with an account behind it, so it belongs in the release checklist rather than in a
-  workflow. `skills/windbg-debugging/setup.md` now tells a user who hits this what to verify first
-  and points at the same portal.
+- **A per-release developer submission** to Microsoft's file submission portal, which is what to do
+  *now* because it needs no certificate and costs nothing. Submitting as a **software developer**
+  rather than as a customer runs automated analysis and clears a clean file for every machine rather
+  than for the one that reported it. It is per artifact — the previous release having been cleared
+  says nothing about the next, since an `!ml` verdict is scored on the file in front of it — and it
+  is a human action with an account behind it, so it belongs in `docs/releasing.md` (where it now
+  is) rather than in a workflow.
+- **Authenticode signing** in `release.yml`, which is the standing fix and the part that needs a
+  decision. Two things about it are easy to get backwards. It **does not guarantee** an `!ml`
+  detection goes away — Microsoft's own issue files signing under a later tier than the metadata —
+  and it is not a prerequisite for the submission above; what it buys is a *stable identity for
+  reputation to attach to*, so the submission stops starting from nothing each release, plus the fix
+  for SmartScreen's "unknown publisher" prompt, which nothing else addresses. And **it need not be
+  expensive**, which is the assumption worth checking before deferring it again: SignPath's
+  Foundation programme signs open-source projects for free and is the obvious first ask here; Azure
+  Trusted Signing is the CI-friendly route at roughly ten dollars a month, gated on an identity
+  check rather than on price; Certum's open-source certificates are around a hundred euros for
+  several years. Only **EV** — the one that earns SmartScreen reputation immediately rather than
+  accumulating it — is genuinely a few hundred a year. Prices move; treat these as the shape of the
+  choice, not as quotes. Note also what the release *does* carry and why it does not help here:
+  `release.yml` produces a Sigstore build-provenance attestation, which is a supply-chain claim a
+  user verifies deliberately with `gh attestation verify`. Nothing on the machine reads it, and it
+  establishes provenance rather than benignity — a compromised dependency or runner would be
+  attested just as faithfully, which is why `skills/windbg-debugging/setup.md` no longer treats a
+  verified attestation as grounds to restore a quarantined file.
 
 **Where it picks up.** The *Build & publish binary* job in `.github/workflows/release.yml`, and
 [`docs/releasing.md`](./docs/releasing.md) if the submission becomes a step.

--- a/build.rs
+++ b/build.rs
@@ -28,6 +28,29 @@
 //!
 //! Absent git, an unpacked tarball, or a `git` that fails for any reason: the variable is empty and
 //! the reported version is the bare crate version. A build must never fail over telemetry.
+//!
+//! # And stamps the PE version resource
+//!
+//! Rust embeds none by default, so `FileVersion`, `CompanyName` and `ProductName` were all empty on
+//! every binary this project has ever shipped — which is one of the two causes
+//! [`microsoft/apm#487`](https://github.com/microsoft/apm/issues/487) lists for the
+//! `Trojan:Win32/Bearfoos.B!ml` verdict Defender handed a freshly built `windbg-mcp.exe` on
+//! 2026-08-26 (`FOLLOWUPS.md` item 50). An `!ml` verdict is a machine-learning score rather than a
+//! signature match, so a binary with no metadata at all is scored on what little there is; filling
+//! the resource in is the free half of the fix, and the half that also makes Explorer's properties
+//! dialog answer *which build is this*.
+//!
+//! **No new build input.** The resource is composed here from `CARGO_PKG_*` and literals, with no
+//! `.rc` template and no icon file beside it, so [`INPUTS`] is unchanged and still names every file
+//! that reaches the binary. A resource input added to the watch list and not to the dirty check (or
+//! the reverse) would make two builds of one tree disagree about whether it is clean — the two are
+//! one const precisely so they cannot.
+//!
+//! **A missing resource compiler warns rather than fails**, for the same reason the git stamp falls
+//! back: `cargo check --target x86_64-pc-windows-msvc` from a Mac has no `rc.exe` and no `llvm-rc`,
+//! and that check is a routine workflow here. What keeps the warning from being a silent release is
+//! that the assertion lives where it can run — `mcp_smoke::the_binary_carries_a_pe_version_resource`
+//! reads the resource back off the built exe, on Windows, which is the only host that builds one.
 
 use std::process::Command;
 
@@ -56,10 +79,56 @@ fn main() {
     {
         println!("cargo::rerun-if-changed={path}");
     }
-    println!(
-        "cargo::rustc-env=WINDBG_MCP_BUILD={}",
-        revision().unwrap_or_default()
-    );
+    let revision = revision().unwrap_or_default();
+    println!("cargo::rustc-env=WINDBG_MCP_BUILD={revision}");
+    version_resource(&revision);
+}
+
+/// Compose and compile the `VS_VERSION_INFO` resource — see the module comment for why.
+///
+/// The numeric `FILEVERSION`/`PRODUCTVERSION` and the `FileVersion`/`ProductName` strings come free
+/// from `CARGO_PKG_*`; what is set here is the rest, and one override. **`ProductVersion` carries
+/// the stamped identity** (`0.12.1+g1a2b3c4`) where `FileVersion` stays the bare release, which is
+/// semver's own split between a release and the build metadata under it — so the properties dialog
+/// answers the same question `serverInfo.version` does, and the field anything numeric compares is
+/// left alone. **`FileDescription` is deliberately short**: Windows uses it as the application name
+/// in Task Manager and in dialogs, where the package description would not fit; that goes in
+/// `Comments`.
+fn version_resource(revision: &str) {
+    // Not `cfg!(windows)`: this is a question about the artefact, and a Mac cross-checking a
+    // Windows target should take this path and report what it finds, not skip it silently.
+    if std::env::var("CARGO_CFG_TARGET_OS").as_deref() != Ok("windows") {
+        return;
+    }
+    let version = std::env::var("CARGO_PKG_VERSION").unwrap_or_default();
+    let product_version = if revision.is_empty() {
+        version
+    } else {
+        format!("{version}+{revision}")
+    };
+
+    let mut resource = winresource::WindowsResource::new();
+    resource
+        // The repo owner, which is also the registry namespace (`io.github.glslang/windbg-mcp`)
+        // and the account an `Authenticode` certificate would eventually name — so a reader has
+        // one identity to check rather than two that have to be reconciled.
+        .set("CompanyName", "glslang")
+        .set("FileDescription", "WinDbg MCP server")
+        // Tracks `LICENSE`, which is where the year and the holder are authoritative.
+        .set(
+            "LegalCopyright",
+            "Copyright (c) 2026 Gonçalo Carvalho. MIT.",
+        )
+        .set("OriginalFilename", "windbg-mcp.exe")
+        .set("InternalName", "windbg-mcp.exe")
+        .set("ProductVersion", &product_version);
+    if let Ok(description) = std::env::var("CARGO_PKG_DESCRIPTION") {
+        resource.set("Comments", &description);
+    }
+    if let Err(err) = resource.compile() {
+        // Never fatal — see the module comment. The test is what makes this loud where it matters.
+        println!("cargo::warning=no PE version resource was embedded: {err}");
+    }
 }
 
 /// Where git keeps one of its own files, if that file exists.
@@ -100,11 +169,12 @@ fn revision() -> Option<String> {
 /// A 32-bit FNV-1a of the working-tree diff — an identity tag, not a digest anybody should trust
 /// against an adversary.
 ///
-/// Hand-rolled because this crate has no build dependencies and a build script is the wrong place
-/// to gain one for eight lines. `DefaultHasher` would have been the obvious alternative and is
-/// wrong here for a reason worth writing down: its output is explicitly not stable across Rust
-/// releases, so two machines on different toolchains would tag one working tree two ways — which
-/// is the failure this is meant to remove rather than relocate.
+/// Hand-rolled because a build script is the wrong place to gain a dependency for eight lines —
+/// which the `winresource` above does not change, since that one buys a resource compiler rather
+/// than arithmetic. `DefaultHasher` would have been the obvious alternative and is wrong here for a
+/// reason worth writing down: its output is explicitly not stable across Rust releases, so two
+/// machines on different toolchains would tag one working tree two ways — which is the failure this
+/// is meant to remove rather than relocate.
 fn fingerprint(text: &str) -> u32 {
     let mut hash: u32 = 0x811c_9dc5;
     for byte in text.as_bytes() {

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -39,8 +39,18 @@ binary does carry a full PE version resource, which is the other cause Microsoft
 detection on its own binaries, but the metadata is the cheap half rather than the fix
 ([`FOLLOWUPS.md`](../FOLLOWUPS.md) item 50 is the certificate decision that remains).
 
-So if a release is reported as quarantined, the two things to do are to point the reporter at
-[`skills/windbg-debugging/setup.md`](../skills/windbg-debugging/setup.md)'s note — verify the
-SHA-256 and the attestation *first*, since those answer a question the verdict does not — and to
-submit the artifact to [Microsoft's file submission portal](https://www.microsoft.com/wdsi/filesubmission)
-as a false positive. That submission is per artifact, so a new release needs a new one.
+So if a release is reported as quarantined, the fix is a **developer submission**, and it is the
+maintainer's to make rather than the reporter's. At
+[Microsoft's file submission portal](https://www.microsoft.com/wdsi/filesubmission), submit the
+artifact as a **software developer** rather than as a customer: that route runs automated analysis
+against the file and, for a clean one, clears the detection for every machine rather than for the
+one that reported it — usually within hours, though nothing promises a turnaround. Point the
+reporter at [`skills/windbg-debugging/setup.md`](../skills/windbg-debugging/setup.md)'s note
+meanwhile: verify the SHA-256 and the attestation, and leave the file in quarantine until the
+submission is answered.
+
+Two things about that. It is **per artifact**, so every release needs its own — and the release
+before it having been cleared says nothing, since an `!ml` verdict is scored on the file in front of
+it. And it is the step that gets *shorter* once the binary is signed: a signature is a stable
+identity for the reputation to attach to, where an unsigned build starts from nothing each time.
+Worth doing pre-emptively on a release rather than waiting for the first report.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -27,3 +27,20 @@ gh attestation verify <zip> --repo glslang/windbg-mcp `
 
 (`--repo` alone only proves the attestation came from *some* workflow in this repo;
 `--signer-workflow` pins it to the release workflow.)
+
+## What the release is not
+
+**It is not Authenticode signed**, so SmartScreen shows an "unknown publisher" prompt and Defender
+may quarantine it — `Trojan:Win32/Bearfoos.B!ml` is the verdict this project has actually drawn, on
+a locally built binary. That suffix marks a machine-learning score rather than a signature match, so
+the same file lands either side of the line on different days. The attestation above does not help:
+it is a supply-chain claim a user verifies deliberately, and nothing on the machine reads it. The
+binary does carry a full PE version resource, which is the other cause Microsoft names for that
+detection on its own binaries, but the metadata is the cheap half rather than the fix
+([`FOLLOWUPS.md`](../FOLLOWUPS.md) item 50 is the certificate decision that remains).
+
+So if a release is reported as quarantined, the two things to do are to point the reporter at
+[`skills/windbg-debugging/setup.md`](../skills/windbg-debugging/setup.md)'s note — verify the
+SHA-256 and the attestation *first*, since those answer a question the verdict does not — and to
+submit the artifact to [Microsoft's file submission portal](https://www.microsoft.com/wdsi/filesubmission)
+as a false positive. That submission is per artifact, so a new release needs a new one.

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -19,11 +19,12 @@ adding the debugger tier takes it to ~50s, almost all of it two tests waiting ou
 lease grace, and a call staying silent long enough to have to report that it is still running.
 
 **The pass count is the same either way**, because each gate is inside its own test: `cargo test
---test mcp_smoke` reports 69 passed with the tier off and 69 passed with it on. (A plain `cargo test`
-runs the unit tests beside it and prints a result line per binary, so it is this harness's own line
-to read.) The runtime is what tells the two runs apart, and `--nocapture` is what prints the
-`SKIPPED` reason — a run that reports 69 green having taken a second covered no debugger claim at
-all.
+--test mcp_smoke` reports the same number passed with the tier off as with it on — 85 on 2026-08-26,
+against ~2s and ~57s respectively, but it moves whenever a test is added, so re-derive it rather
+than reading it here. (A plain `cargo test` runs the unit tests beside it and prints a result line
+per binary, so it is this harness's own line to read.) The runtime is what tells the two runs apart,
+and `--nocapture` is what prints the `SKIPPED` reason — a run that reports every test green having
+taken a second covered no debugger claim at all.
 
 ### Tiers
 
@@ -126,6 +127,17 @@ minutes, the other touches another machine; see below. Neither is automated, and
 live checklist is not either: no runner has a kernel target, a TTD engine, or elevation.
 
 ## What it asserts, and why each one is a dependency tripwire
+
+**The artefact, before it runs.** The exe carries a PE version resource, with `CompanyName`,
+`ProductName`, `OriginalFilename`, `InternalName` and `FileVersion` pinned to their values and
+`ProductVersion` pinned to the identity `build.rs` stamped — the same string `serverInfo.version`
+reports. It is read back through `GetFileVersionInfoW`, the API Explorer and the reputation systems
+read it through, rather than by scanning the file for the string, which would pass on a resource
+Windows itself refuses to parse. This is a test rather than a hard failure in `build.rs` because the
+resource needs `rc.exe` and the `cargo check --target x86_64-pc-windows-msvc` this repo runs from a
+Mac has none: the build script warns and carries on, so the only thing standing between a missing
+resource and a release is this assertion, on the one host that can build one. To check that it still
+catches the case it is for, point `RC_PATH` at nothing, touch `build.rs`, and re-run it.
 
 **Transport.** Every line the server writes to stdout parses as JSON-RPC, and the startup log
 appears on **stderr**. A dependency that prints a banner or a warning to stdout desynchronizes

--- a/skills/windbg-debugging/setup.md
+++ b/skills/windbg-debugging/setup.md
@@ -138,11 +138,17 @@ a machine-learning score rather than a signature match, so the same file lands e
 line on different days, and it is a known shape for a small unsigned Windows executable —
 Microsoft's own shipped binaries have drawn the same verdict. The release is **not** Authenticode
 signed today; what it does carry is a SHA-256 published beside it and the Sigstore build-provenance
-attestation the block above verifies, which together say the file is the one this repo's workflow
-built. Verify those first — they answer a question a scanner's verdict does not — then restore the
-file from Defender's *Protection history* and add an exclusion for the directory you extracted it
-into, or [submit it to Microsoft](https://www.microsoft.com/wdsi/filesubmission) as a false
-positive. Do not simply disable Defender.
+attestation the block above verifies.
+
+Verify both — but be clear about what they settle. They establish **provenance**: that this file is
+the one this repo's release workflow built, unmodified. They do **not** establish that it is benign,
+because a compromised dependency, workflow or runner would be attested exactly as faithfully. So a
+verdict that survives them is not thereby a false positive, and the right next step is to have it
+adjudicated rather than to wave it through:
+[submit the file to Microsoft](https://www.microsoft.com/wdsi/filesubmission) and leave it in
+quarantine until they answer, or inspect it yourself. Restoring it and excluding the directory you
+extracted it into would run the flagged file on the strength of a check that does not cover this,
+and leave that directory unscanned for everything written there afterwards. Do not disable Defender.
 
 ### Option B — build from source
 

--- a/skills/windbg-debugging/setup.md
+++ b/skills/windbg-debugging/setup.md
@@ -133,6 +133,17 @@ gh attestation verify $zip --repo glslang/windbg-mcp `
    --signer-workflow glslang/windbg-mcp/.github/workflows/release.yml
 ```
 
+**If Defender quarantines the exe**, most likely as `Trojan:Win32/Bearfoos.B!ml`: that suffix marks
+a machine-learning score rather than a signature match, so the same file lands either side of the
+line on different days, and it is a known shape for a small unsigned Windows executable —
+Microsoft's own shipped binaries have drawn the same verdict. The release is **not** Authenticode
+signed today; what it does carry is a SHA-256 published beside it and the Sigstore build-provenance
+attestation the block above verifies, which together say the file is the one this repo's workflow
+built. Verify those first — they answer a question a scanner's verdict does not — then restore the
+file from Defender's *Protection history* and add an exclusion for the directory you extracted it
+into, or [submit it to Microsoft](https://www.microsoft.com/wdsi/filesubmission) as a false
+positive. Do not simply disable Defender.
+
 ### Option B — build from source
 
 ```pwsh

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -846,18 +846,34 @@ fn read_version_field(field: &str) -> String {
             .collect()
     }
 
-    /// One sub-block of a version-info block, or `None` where it holds no such key.
-    fn query(block: &[u8], sub: &str) -> Option<(*const u16, u32)> {
+    /// One sub-block of a version-info block, as the UTF-16 units it holds — `None` where the block
+    /// has no such key.
+    ///
+    /// **Borrowed from `block`**, so the compiler enforces what a raw pointer out of
+    /// `VerQueryValueW` cannot say for itself. Returning the pointer instead put a value with no
+    /// lifetime across a function boundary, and nothing but a comment then stopped a later edit
+    /// reading it after `block` had gone; CodeQL was right to call that an invalid dereference.
+    ///
+    /// **`unit_bytes` is what `VerQueryValueW` reports the length *in*, and it is not one answer:**
+    /// `\VarFileInfo\Translation` comes back as a **byte** count and a string value as a
+    /// **character** count. That asymmetry is documented, and it is exactly what a helper that
+    /// picked one unit would turn into a slice running off the end of the block — so the caller
+    /// names it.
+    fn query<'a>(block: &'a [u8], sub: &str, unit_bytes: u32) -> Option<&'a [u16]> {
         let sub = wide(sub);
         let mut value: *mut core::ffi::c_void = std::ptr::null_mut();
         let mut len: u32 = 0;
-        // SAFETY: `block` holds a version-info block written by `GetFileVersionInfoW`, and `sub`
-        // is NUL-terminated. `value` and `len` are written only on success. The pointer handed back
-        // points *into* `block` and carries no lifetime saying so, which is the one thing a caller
-        // has to honour: both callers here read it before `block` goes out of scope.
+        // SAFETY: `block` holds a version-info block written by `GetFileVersionInfoW`, and `sub` is
+        // NUL-terminated. `value` and `len` are written only on success.
         let found =
             unsafe { VerQueryValueW(block.as_ptr().cast(), sub.as_ptr(), &mut value, &mut len) };
-        (found != 0 && len > 0).then(|| (value.cast::<u16>().cast_const(), len))
+        let units = (len as usize * unit_bytes as usize) / size_of::<u16>();
+        (found != 0 && units > 0).then(|| {
+            // SAFETY: on success the value lies inside `block` and spans `units` UTF-16 units, so
+            // the slice is in bounds — and the returned lifetime is `block`'s, which is what makes
+            // that hold for every read of it rather than only for the ones written today.
+            unsafe { std::slice::from_raw_parts(value.cast::<u16>().cast_const(), units) }
+        })
     }
 
     let missing = |what: &str| -> ! {
@@ -884,22 +900,19 @@ fn read_version_field(field: &str) -> String {
     // A value's key is qualified by language and codepage, and the block says which pair it wrote:
     // `winresource` emits the *language-neutral* `000004b0`, so the `040904b0` a hard-coded key
     // would name reads nothing at all.
-    let Some((translation, len)) = query(&block, r"\VarFileInfo\Translation") else {
+    let Some(translation) = query(&block, r"\VarFileInfo\Translation", 1) else {
         missing("its version resource declares no translation");
     };
-    if len < 4 {
+    // A `Translation` value is a run of (language, codepage) pairs; the first is the one to use.
+    if translation.len() < 2 {
         missing("its translation table is shorter than one language/codepage pair");
     }
-    // SAFETY: a `Translation` value is a run of (language, codepage) `u16` pairs, and `len` has
-    // just been checked to cover the first of them.
-    let (language, codepage) = unsafe { (*translation, *translation.add(1)) };
+    let (language, codepage) = (translation[0], translation[1]);
 
     let key = format!(r"\StringFileInfo\{language:04x}{codepage:04x}\{field}");
-    let Some((text, len)) = query(&block, &key) else {
+    let Some(text) = query(&block, &key, size_of::<u16>() as u32) else {
         missing("its version resource carries no such field");
     };
-    // SAFETY: the value is `len` UTF-16 code units, its NUL terminator included.
-    let text = unsafe { std::slice::from_raw_parts(text, len as usize) };
     String::from_utf16_lossy(text)
         .trim_end_matches('\0')
         .to_string()

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -767,6 +767,144 @@ fn a_malformed_line_does_not_kill_the_server() {
     );
 }
 
+// ---- tier 1: the artefact itself ----------------------------------------------
+
+/// What this build calls itself, exactly as `main::BUILD_VERSION` composes it: the crate version,
+/// plus the git revision `build.rs` stamped when there was one to stamp.
+///
+/// Read from `WINDBG_MCP_BUILD` — the build script's own answer — rather than from whether a `.git`
+/// is present, because the fallback to a bare crate version is deliberate and a `.git`-exists proxy
+/// would fail a perfectly good build that git declined to describe. It also means a `build.rs` that
+/// stopped running fails to compile this rather than passing it.
+fn stamped_version() -> String {
+    let stamp = env!("WINDBG_MCP_BUILD");
+    if stamp.is_empty() {
+        env!("CARGO_PKG_VERSION").to_string()
+    } else {
+        format!("{}+{}", env!("CARGO_PKG_VERSION"), stamp)
+    }
+}
+
+/// The binary has to carry a PE version resource, and `build.rs` will not fail the build if it
+/// cannot produce one — so this is the only place that says whether it did.
+///
+/// **Why the resource matters at all.** Defender quarantined a freshly built `windbg-mcp.exe` as
+/// `Trojan:Win32/Bearfoos.B!ml` on 2026-08-26, blocking every test that spawns the server. That is
+/// a machine-learning verdict rather than a signature match — the same source lands either side of
+/// the line on different days — and an empty `FileVersion`/`CompanyName`/`ProductName` is one of
+/// the two causes Microsoft names for exactly that detection on its own shipped binaries
+/// (`microsoft/apm#487`, `FOLLOWUPS.md` item 50). A Rust binary carries none by default.
+///
+/// **Why it is a test and not a hard failure in `build.rs`.** The resource needs `rc.exe`, and the
+/// `cargo check --target x86_64-pc-windows-msvc` this repo runs from a Mac has none — a workflow
+/// `CLAUDE.md` documents and that must not start failing over metadata. So the build script warns
+/// and carries on, and the check moves here, where it only ever runs on the host that can build one.
+///
+/// The split in what is pinned is deliberate: the fields a *checker* compares are pinned to their
+/// values, and the ones a human reads are asserted non-empty, so rewording the prose is not a test
+/// edit while renaming the product is.
+#[test]
+fn the_binary_carries_a_pe_version_resource() {
+    let pinned = [
+        ("CompanyName", "glslang".to_string()),
+        ("ProductName", "windbg-mcp".to_string()),
+        ("OriginalFilename", "windbg-mcp.exe".to_string()),
+        ("InternalName", "windbg-mcp.exe".to_string()),
+        // The release, and — separately — the build under it, which is semver's own split and
+        // makes the properties dialog answer the question `serverInfo.version` answers.
+        ("FileVersion", env!("CARGO_PKG_VERSION").to_string()),
+        ("ProductVersion", stamped_version()),
+    ];
+    for (field, want) in pinned {
+        assert_eq!(read_version_field(field), want, "{field} in {EXE}");
+    }
+    for field in ["FileDescription", "LegalCopyright", "Comments"] {
+        assert!(
+            !read_version_field(field).is_empty(),
+            "{field} must not be empty in {EXE}"
+        );
+    }
+}
+
+/// One `StringFileInfo` value out of the binary's own version resource, read through the API
+/// Explorer's properties dialog reads it through — rather than by scanning the file for the string,
+/// which would pass on a resource Windows itself refuses to parse.
+///
+/// Panics rather than returning an `Option`, because there is exactly one caller and every way this
+/// can answer nothing is the same failure: no resource was embedded.
+fn read_version_field(field: &str) -> String {
+    use std::ffi::OsStr;
+    use std::os::windows::ffi::OsStrExt;
+    use windows_sys::Win32::Storage::FileSystem::{
+        GetFileVersionInfoSizeW, GetFileVersionInfoW, VerQueryValueW,
+    };
+
+    fn wide(text: &str) -> Vec<u16> {
+        OsStr::new(text)
+            .encode_wide()
+            .chain(std::iter::once(0))
+            .collect()
+    }
+
+    /// One sub-block of a version-info block, or `None` where it holds no such key.
+    fn query(block: &[u8], sub: &str) -> Option<(*const u16, u32)> {
+        let sub = wide(sub);
+        let mut value: *mut core::ffi::c_void = std::ptr::null_mut();
+        let mut len: u32 = 0;
+        // SAFETY: `block` holds a version-info block written by `GetFileVersionInfoW`, and `sub`
+        // is NUL-terminated. `value` and `len` are written only on success. The pointer handed back
+        // points *into* `block` and carries no lifetime saying so, which is the one thing a caller
+        // has to honour: both callers here read it before `block` goes out of scope.
+        let found =
+            unsafe { VerQueryValueW(block.as_ptr().cast(), sub.as_ptr(), &mut value, &mut len) };
+        (found != 0 && len > 0).then(|| (value.cast::<u16>().cast_const(), len))
+    }
+
+    let missing = |what: &str| -> ! {
+        panic!(
+            "{EXE} carries no `{field}` in a PE version resource ({what}). A Rust binary has none \
+             by default, so this is what a `build.rs` that could not run a resource compiler \
+             leaves behind — the build printed a `cargo::warning` saying why."
+        )
+    };
+
+    let path = wide(EXE);
+    // SAFETY: `path` is NUL-terminated and outlives the call. The handle out-parameter is
+    // documented as ignorable, and a null pointer is how that is spelled.
+    let size = unsafe { GetFileVersionInfoSizeW(path.as_ptr(), std::ptr::null_mut()) };
+    if size == 0 {
+        missing("the file has no version resource at all");
+    }
+    let mut block = vec![0u8; size as usize];
+    // SAFETY: `block` is exactly the `size` bytes the call above asked for.
+    if unsafe { GetFileVersionInfoW(path.as_ptr(), 0, size, block.as_mut_ptr().cast()) } == 0 {
+        missing("its version resource would not load");
+    }
+
+    // A value's key is qualified by language and codepage, and the block says which pair it wrote:
+    // `winresource` emits the *language-neutral* `000004b0`, so the `040904b0` a hard-coded key
+    // would name reads nothing at all.
+    let Some((translation, len)) = query(&block, r"\VarFileInfo\Translation") else {
+        missing("its version resource declares no translation");
+    };
+    if len < 4 {
+        missing("its translation table is shorter than one language/codepage pair");
+    }
+    // SAFETY: a `Translation` value is a run of (language, codepage) `u16` pairs, and `len` has
+    // just been checked to cover the first of them.
+    let (language, codepage) = unsafe { (*translation, *translation.add(1)) };
+
+    let key = format!(r"\StringFileInfo\{language:04x}{codepage:04x}\{field}");
+    let Some((text, len)) = query(&block, &key) else {
+        missing("its version resource carries no such field");
+    };
+    // SAFETY: the value is `len` UTF-16 code units, its NUL terminator included.
+    let text = unsafe { std::slice::from_raw_parts(text, len as usize) };
+    String::from_utf16_lossy(text)
+        .trim_end_matches('\0')
+        .to_string()
+}
+
 // ---- tier 1: protocol revisions -----------------------------------------------
 
 /// `docs/architecture.md` names the revisions this server speaks. When the spec revs, this is the
@@ -809,14 +947,9 @@ fn every_documented_protocol_revision_is_served() {
         // build. `WINDBG_MCP_BUILD` is the build script's own answer, so this asserts the served
         // version *is* the one it produced — and a `build.rs` that stopped running fails to
         // compile this rather than passing it.
-        let stamp = env!("WINDBG_MCP_BUILD");
-        let expected = if stamp.is_empty() {
-            env!("CARGO_PKG_VERSION").to_string()
-        } else {
-            format!("{}+{}", env!("CARGO_PKG_VERSION"), stamp)
-        };
         assert_eq!(
-            reported, expected,
+            reported,
+            stamped_version(),
             "the served version must be the one this build stamped (on {revision})"
         );
 


### PR DESCRIPTION
Closes the metadata half of `FOLLOWUPS.md` item 50.

## Why

Windows Defender quarantined a freshly built `windbg-mcp.exe` as `Trojan:Win32/Bearfoos.B!ml` on
2026-08-26, blocking every smoke test that spawns the server. That suffix marks a machine-learning
score rather than a signature match — it stopped reproducing on the next rebuild with no change to
the code — and an empty `FileVersion`/`CompanyName`/`ProductName` is one of the two causes
[`microsoft/apm#487`](https://github.com/microsoft/apm/issues/487) lists for that same detection on
Microsoft's own shipped binaries. Measured: all three were empty on both the debug and the release
binary, because Rust embeds no version resource by default.

## What this does

`build.rs` compiles one, via a `winresource` build-dependency (`default-features = false`, so the
lock gains `winresource` and `version_check` and nothing else). On the built exe:

| Field | Value |
| --- | --- |
| `FileVersion` | `0.12.1` |
| `ProductVersion` | `0.12.1+g2fc88231` |
| `CompanyName` | `glslang` |
| `ProductName` | `windbg-mcp` |
| `FileDescription` | `WinDbg MCP server` |
| `LegalCopyright` | `Copyright (c) 2026 Gonçalo Carvalho. MIT.` |
| `OriginalFilename` / `InternalName` | `windbg-mcp.exe` |
| `Comments` | the package description |

`ProductVersion` carries the git-stamped identity where `FileVersion` stays the bare release, which
is semver's own split — so the properties dialog answers the question `serverInfo.version` answers,
and the field anything numeric compares is left alone.

## Three things the item did not see

**`INPUTS` needs no change, because the resource has no file.** The item's warning was about a
resource input added to the watch list and not to the dirty check; the way to not have that problem
is to compose the resource in `build.rs` from `CARGO_PKG_*` and literals, with no `.rc` template and
no icon beside it. An icon *would* reopen it, and is the thing to think about `INPUTS` for if one is
ever added.

**`[package]` gained `description`, `repository` and `license`**, which it had never carried. The
resource is what wanted them; nothing else in this repo did, and the crate is not published. The
release tag guard's regex still reads `0.12.1` — checked, not assumed.

**The build must not fail when there is no resource compiler.** `cargo check --target
x86_64-pc-windows-msvc` from a Mac has neither `rc.exe` nor `llvm-rc`, and that is a documented
routine workflow here. So `build.rs` warns and carries on — which makes that warning the only thing
between a Windows build that quietly lost its resource and a release. The assertion therefore lives
where it only ever runs on a host that can build one: `the_binary_carries_a_pe_version_resource`
reads the resource back through `GetFileVersionInfoW`, rather than scanning the file for the string,
which would pass on a resource Windows itself refuses to parse.

## Verification

- The test catches what it is for, checked rather than assumed: `RC_PATH` pointed at nothing, touch
  `build.rs` — the build warns, the build **succeeds**, and the test fails naming the warning.
- `cargo fmt --all --check` clean; `cargo clippy --all-targets` adds no warning (one pre-existing
  `chunks_exact` lint in `src/dump.rs`, untouched).
- 577 unit tests and **85** `mcp_smoke` green; debugger tier (`WINDBG_MCP_SMOKE_DUMP=1`) also 85, in
  57s against 2s, with no target-read `SKIPPED` lines on this host.
- `markdownlint-cli2@0.23.2` clean over CI's globs.
- `cargo check --release --locked --all-targets` clean, so the release job's `--locked` build
  resolves.

## What is left, and it needs a decision rather than a patch

Item 50 is narrowed to **Authenticode signing**, which needs a certificate — Azure Trusted Signing
or SignPath's OSS tier; EV earns SmartScreen reputation at once where OV accumulates it. Worth
stating plainly that signing does not *guarantee* an `!ml` detection goes away, but it is what the
reputation systems above Defender actually read, and it fixes the "unknown publisher" prompt
regardless. The Sigstore build-provenance attestation the release already carries does not help
here: nothing on the machine reads it.

Beside it, the per-release false-positive submission to Microsoft's portal — a human action with an
account behind it, so `docs/releasing.md` carries it as a step rather than a workflow, under a new
*What the release is not* section. `skills/windbg-debugging/setup.md` tells a user who hits this to
verify the SHA-256 and the attestation **first**, since those answer a question a scanner's verdict
does not, and not to disable Defender.

## Counts re-derived while here

The `mcp_smoke` pass count said 83 in `CLAUDE.md` while it was 84, and 69 in `docs/smoke-test.md`.
Both now say to re-derive it, and `docs/smoke-test.md` states the property (same count either way)
with a dated datum rather than three bare numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
