### PR TITLE
Pin dbgscope to its merged commit, not the branch's

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,8 +86,20 @@ update command alone was enough, which silently leaves you building the old code
 **Develop against the feature branch, not a `[patch]`.** Push the dbgscope branch and point
 `Cargo.toml`'s `rev` at that branch commit while iterating: it needs no local checkout on the build
 machine, it works identically on every machine, and it travels through git like everything else.
-Repoint to the merge commit before the dependent PR merges. A `[patch]` section still works for a
-quick local `cargo check` but must never be committed:
+Repoint before the dependent PR merges — and **"the merge commit" may not exist**, which is how
+this was got wrong on 2026-08-27. dbgscope#120 was *rebase*-merged, so its commits landed on `main`
+under new SHAs and the branch head this repo pinned was an ancestor of nothing there. It went on
+building only because the merged branch had not been deleted yet; deleting it — the ordinary tidy —
+would have left `main` unable to resolve its own dependency. So the rule is **repoint at whatever
+`dbgscope`'s `main` now is**, and check rather than assume:
+
+```console
+git -C ../dbgscope merge-base --is-ancestor <pinned-rev> origin/main   # 0, or the pin is dangling
+```
+
+Both PRs merging together is the ordinary case, not a mistake, so the check belongs after the merge
+as well as before it. A `[patch]` section still works for a quick local `cargo check` but must never
+be committed:
 
 ```toml
 [patch.'https://github.com/glslang/dbgscope']

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,7 +164,7 @@ dependencies = [
 [[package]]
 name = "dbgscope"
 version = "0.1.0"
-source = "git+https://github.com/glslang/dbgscope?rev=612323602641085c531fff7ac2361cd2856ad58e#612323602641085c531fff7ac2361cd2856ad58e"
+source = "git+https://github.com/glslang/dbgscope?rev=c4043d098e65be23028d5eba806948e6b12c5ad9#c4043d098e65be23028d5eba806948e6b12c5ad9"
 dependencies = [
  "hex",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/glslang/windbg-mcp"
 license = "MIT"
 
 [dependencies]
-dbgscope = { git = "https://github.com/glslang/dbgscope", rev = "612323602641085c531fff7ac2361cd2856ad58e" }
+dbgscope = { git = "https://github.com/glslang/dbgscope", rev = "c4043d098e65be23028d5eba806948e6b12c5ad9" }
 # 3.1.1 is a floor, not a preference: every 3.x before it generates a `tools/list` that omits
 # SEP-2549's required `ttlMs`/`cacheScope`, which a spec-strict `2026-07-28` client rejects
 # outright — the server connects and appears to expose no tools at all (upstream issue #1114).


### PR DESCRIPTION
`main` currently pins a dbgscope rev that is **not on dbgscope's `main`**, and it builds today only because the merged branch has not been deleted yet.

[dbgscope#120](https://github.com/glslang/dbgscope/pull/120) was rebase-merged, so its three commits are on `main` under new SHAs:

```console
$ git merge-base --is-ancestor 6123236 origin/main; echo $?
1        # not an ancestor
```

`6123236` survives only as the head of `origin/fix/a-target-that-ends-is-not-a-failure`. Delete that branch — the ordinary post-merge tidy — and a clean `cargo fetch` of this repo's `main` cannot resolve the rev.

Repointed to `c4043d0`, dbgscope's `main`. **The trees are identical** — `git diff 6123236 c4043d0` is empty — so this is a no-op in content and a fix to where that content is reachable from.

`CLAUDE.md` says to repoint to the merge commit before the dependent PR merges, and both merged together instead, which is the ordinary thing to do and leaves exactly this behind. A *rebase* merge makes it sharper than that note implies: there is no merge commit to point at, and the branch head is on `main` under no name at all. Worth a line in the handoff notes if this happens again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)