### PR TITLE
test: the 32-bit worker's version resource is a shipped artefact nothing read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `csc.exe` every stock Windows ships; one test opens the full-memory dump that program writes of
   itself, and the other attaches to it running. `WINDBG_MCP_X86_DUMP` still overrides the made dump
   with a real capture. The tier stands down where there is no 32-bit engine to run it against.
+- **The 32-bit worker's PE version resource is asserted too.** The existing check reads the binary
+  built for the host, so `x86\windbg-mcp.exe` — shipped in both the `.zip` and the `.mcpb` — carried
+  its resource unchecked on every host and in CI. `build.rs` will not fail a build whose resource it
+  could not embed, so a worker that quietly lost one would ship with nothing saying so, and an
+  absent version resource is one of the two causes Microsoft names for the `Bearfoos.B!ml` verdict
+  that motivated the resource in the first place. Its fields are asserted equal to this build's
+  rather than pinned again, because the two binaries are one product from one build.
 
 ### Fixed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -212,15 +212,15 @@ It checks *same-file* fragments only, so a cross-file `../README.md#some-heading
 verify by hand.
 
 **The pass count does not say which tiers ran.** Each gate is inside its test, so the `mcp_smoke`
-harness reports the same **89 passed** with the debugger tier off as with it on — that harness's own
+harness reports the same **90 passed** with the debugger tier off as with it on — that harness's own
 result line, since a plain `cargo test` runs the crate's several hundred unit tests beside it and
 prints a result line per binary. What differs between the two runs is the runtime (measured on the
 ARM64 bench 2026-08-23: **1.6s against 61s** for `cargo test --test mcp_smoke`) and the `SKIPPED`
 lines, which only `--nocapture` prints. Read one of those two before believing a run covered a
 debugger claim. The count moves whenever a test is added — it was 69 until #195 and #196, 75
 until item 37, 79 until the TTD tier, 84 until item 50's version-resource test, 85 until
-item 48's two endings, 87 until item 49's live 32-bit target and 88 until item 51's
-attach teardown — and it said 83 while it was 84,
+item 48's two endings, 87 until item 49's live 32-bit target, 88 until item 51's
+attach teardown and 89 until the 32-bit worker's version resource — and it said 83 while it was 84,
 which is the usual state of it, so re-derive it rather than trusting this sentence.
 
 **The dev exe can be locked too, and the failure is quiet.** A worker left running — a driver

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -139,6 +139,16 @@ Mac has none: the build script warns and carries on, so the only thing standing 
 resource and a release is this assertion, on the one host that can build one. To check that it still
 catches the case it is for, point `RC_PATH` at nothing, touch `build.rs`, and re-run it.
 
+**And the same claim for the 32-bit worker**, which the assertion above does not reach: it reads the
+binary `cargo` built for the *host*, so `x86\windbg-mcp.exe` — shipped in both release artefacts —
+went unchecked on every host and in CI until this. Its fields are asserted **equal to this build's**
+rather than against literals of their own, because the two are one product from one build; pinning
+the strings twice would let the copies drift apart with both tests green. It stands down where there
+is no worker beside the server, and gates on that worker rather than on the 32-bit *engine* the rest
+of the x86 tier gates on — no engine is needed to read a file's resource, and CI builds the worker on
+runners that may carry no x86 engine payload. To check it still catches its case, put any other
+signed binary at that path and re-run: it fails on `CompanyName`.
+
 **Transport.** Every line the server writes to stdout parses as JSON-RPC, and the startup log
 appears on **stderr**. A dependency that prints a banner or a warning to stdout desynchronizes
 every client, and the client-side symptom is an unreadable parse error. Also: closing stdin exits

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -842,23 +842,86 @@ fn the_binary_carries_a_pe_version_resource() {
         ("ProductVersion", stamped_version()),
     ];
     for (field, want) in pinned {
-        assert_eq!(read_version_field(field), want, "{field} in {EXE}");
+        assert_eq!(read_version_field(EXE, field), want, "{field} in {EXE}");
     }
     for field in ["FileDescription", "LegalCopyright", "Comments"] {
         assert!(
-            !read_version_field(field).is_empty(),
+            !read_version_field(EXE, field).is_empty(),
             "{field} must not be empty in {EXE}"
         );
     }
+}
+
+/// Every field of that resource, so the test below can assert the 32-bit worker agrees with this
+/// build on all of them rather than on a subset chosen by hand.
+const VERSION_FIELDS: &[&str] = &[
+    "CompanyName",
+    "ProductName",
+    "OriginalFilename",
+    "InternalName",
+    "FileVersion",
+    "ProductVersion",
+    "FileDescription",
+    "LegalCopyright",
+    "Comments",
+];
+
+/// **The 32-bit worker is a shipped binary too, and the test above does not cover it.**
+///
+/// `EXE` is this build — the host's architecture — so until this existed nothing read
+/// `x86\windbg-mcp.exe`'s resource at all, on any host or in CI. That is the same gap the test
+/// above was written to close, one binary along: `build.rs` will not fail a build it could not
+/// embed a resource into, so a 32-bit worker that quietly lost one would ship in the `.zip` and the
+/// `.mcpb` with nothing saying so. An absent version resource is one of the two causes Microsoft
+/// names for the `Bearfoos.B!ml` verdict, and a quarantined worker is a server that silently
+/// degrades to "SOS is unreachable" rather than one that fails.
+///
+/// **Asserted against this build's values rather than against literals**, which is why the pins
+/// live in the test above and not here: the two binaries are one product from one build, so the
+/// claim is that they *agree*. Pinning the strings twice would let the copies drift apart while
+/// both tests passed, and would double the edit a reworded `FileDescription` costs.
+///
+/// **Gated on the worker and not on the 32-bit engine**, unlike [`x86_engine_tier`]. The engine is
+/// what makes a 32-bit *target* openable, and none is needed to read a file's resource — CI builds
+/// the worker on runners that may carry no x86 engine payload, and gating on the engine would skip
+/// this there for a reason that has nothing to do with what it checks.
+#[test]
+fn the_32_bit_worker_carries_the_same_version_resource() {
+    let Some(worker) = std::path::Path::new(EXE)
+        .parent()
+        .map(|dir| dir.join("x86").join("windbg-mcp.exe"))
+        .filter(|p| p.is_file())
+    else {
+        skip(
+            "no `x86\\windbg-mcp.exe` beside the server under test, so there is no 32-bit worker \
+             to read a version resource from — `cargo build --target i686-pc-windows-msvc` and \
+             `skills/windbg-debugging/setup.md` have the copy block",
+        );
+        return;
+    };
+    let worker = worker.to_string_lossy().into_owned();
+
+    for field in VERSION_FIELDS {
+        assert_eq!(
+            read_version_field(&worker, field),
+            read_version_field(EXE, field),
+            "`{field}` must match this build's — the 32-bit worker is the same product from the \
+             same build, and a client cannot tell which architecture served its session"
+        );
+    }
+    ran("the 32-bit worker's version resource matches this build's");
 }
 
 /// One `StringFileInfo` value out of the binary's own version resource, read through the API
 /// Explorer's properties dialog reads it through — rather than by scanning the file for the string,
 /// which would pass on a resource Windows itself refuses to parse.
 ///
-/// Panics rather than returning an `Option`, because there is exactly one caller and every way this
-/// can answer nothing is the same failure: no resource was embedded.
-fn read_version_field(field: &str) -> String {
+/// Panics rather than returning an `Option`, because every way this can answer nothing is the same
+/// failure: no resource was embedded.
+///
+/// Takes the executable rather than reading [`EXE`], because the release ships **two** binaries
+/// that must each carry one — this build and the 32-bit worker beside it.
+fn read_version_field(exe: &str, field: &str) -> String {
     use std::ffi::OsStr;
     use std::os::windows::ffi::OsStrExt;
     use windows_sys::Win32::Storage::FileSystem::{
@@ -904,13 +967,13 @@ fn read_version_field(field: &str) -> String {
 
     let missing = |what: &str| -> ! {
         panic!(
-            "{EXE} carries no `{field}` in a PE version resource ({what}). A Rust binary has none \
+            "{exe} carries no `{field}` in a PE version resource ({what}). A Rust binary has none \
              by default, so this is what a `build.rs` that could not run a resource compiler \
              leaves behind — the build printed a `cargo::warning` saying why."
         )
     };
 
-    let path = wide(EXE);
+    let path = wide(exe);
     // SAFETY: `path` is NUL-terminated and outlives the call. The handle out-parameter is
     // documented as ignorable, and a null pointer is how that is spelled.
     let size = unsafe { GetFileVersionInfoSizeW(path.as_ptr(), std::ptr::null_mut()) };


### PR DESCRIPTION
## What this closes

`the_binary_carries_a_pe_version_resource` reads `CARGO_BIN_EXE_windbg-mcp` — the binary cargo built
for the **host** — so `x86\windbg-mcp.exe` carried its version resource unchecked on every host and
in CI, despite shipping in both release artefacts.

That gap arrived with the 32-bit worker (#234) and was found while verifying the release packaging,
not by a failure. The resource is correct today; nothing was guarding it.

## Why it matters

`build.rs` will not fail a build whose resource it could not embed — it prints a `cargo::warning` and
carries on, deliberately, so that `cargo check` from a Mac with no `rc.exe` still works. That makes
the test the only thing between a missing resource and a release, which is the argument the original
assertion was written from. It now covers the second shipped binary.

An absent version resource is one of the two causes Microsoft names for the `Trojan:Win32/Bearfoos.B!ml`
verdict that motivated embedding one (`FOLLOWUPS.md` item 50). The failure would be quiet twice over:
a quarantined worker degrades a session to "SOS is unreachable" rather than failing it.

## Three choices worth reviewing

- **Asserted equal to this build's fields, not pinned to literals of their own.** The two binaries are
  one product from one build, so the claim is that they *agree*. Pinning twice would let the copies
  drift apart with both tests green.
- **Gated on the worker, not on the 32-bit engine** the rest of the x86 tier gates on. No engine is
  needed to read a file's resource, and CI builds the worker on runners that may carry no x86 engine
  payload — gating on the engine would skip this there for an unrelated reason. Absence of the
  resource needs no gate: `read_version_field` panics on it, which is the primary risk.
- **`read_version_field` now takes the executable** rather than reading `EXE`, and its doc comment no
  longer claims exactly one caller.

## Verification

Both outcomes were exercised rather than inferred from a green run:

| Mutation | Result |
| --- | --- |
| No worker beside the server | `SKIPPED`, passes — the gate works |
| Another signed binary at that path | **fails** on `CompanyName` ("Microsoft Corporation" against "glslang") |

Full local run on this x64 bench, after rebuilding and recopying the 32-bit worker (`tests/` is in
`build.rs`'s `INPUTS`, so the edit moves the build identity):

- `cargo test` — 589 unit, **90** smoke (was 89), 12 ignored
- `WINDBG_MCP_SMOKE_DUMP=1 cargo test` — 90 smoke in 56.8s, so the debugger tier ran
- `cargo fmt --all --check` clean; markdownlint 0 issues across 36 files

The release artefacts were also verified by reproducing the packaging locally: both the `.zip` and the
`.mcpb` carry `x86\windbg-mcp.exe`, PE machine types are `amd64`/`i386`, and both binaries stamp
`0.12.1+g93233f6b` from one commit — which is what makes the worker usable at all, since the
supervisor turns away a 32-bit worker whose build identity differs.

## Docs

`CLAUDE.md`'s count 89 → 90 and its history line, a `docs/smoke-test.md` entry stating the claim and
how to re-check it, and a `CHANGELOG.md` entry under Unreleased.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
