### PR TITLE
ci: own the CodeQL config, so a test naming a session handle is not a leak

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,22 @@
+# CodeQL analysis config, read by `.github/workflows/codeql.yml`.
+#
+# It exists for one property GitHub's *default* setup cannot express: a path filter. Default setup
+# takes no config file at all, so excluding a directory means owning the workflow — which is the
+# whole reason this repo has an advanced setup. The workflow's header carries that trade.
+
+name: windbg-mcp
+
+paths-ignore:
+  # `tests/mcp_smoke.rs` drives the built binary over stdio, so its assertion messages are full of
+  # session handles, ports and fake credentials — which is what an assertion is *for*, and what a
+  # taint scanner reads as a program logging a secret. Four `rust/cleartext-logging` alerts came
+  # from exactly that shape: an `assert!`/`panic!` naming the `session_id` it failed to find.
+  #
+  # A session handle is not a credential here. `engine::mint_session_id` says so in as many words
+  # — it "exists to name a worker, not to authenticate" — and `Sessions::resolve` reports a handle
+  # whose `owner != caller` as *unknown*, so holding someone else's buys nothing. The rule was
+  # wrong rather than early.
+  #
+  # The cost, stated plainly because nothing else will state it: a genuine finding in the smoke
+  # harness is now unreported. That is judged worth it for a file whose job is to print state.
+  - tests/**

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,72 @@
+name: CodeQL
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  # What default setup ran on, kept: a weekly pass is what catches a query newly shipped in a
+  # CodeQL bundle against code nobody has touched since.
+  schedule:
+    - cron: "17 4 * * 1"
+  workflow_dispatch:
+
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze ${{ matrix.language }}
+    # No build, so no Windows runner — see `build-mode` below. This crate is Windows-only and does
+    # not compile here, which is not a gap: extraction reads source, and `ci.yml` is where a
+    # compile is claimed.
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    permissions:
+      # Writing the results is the point of the job. `packages: read` is what `init` fetches query
+      # packs with; the other two let it read the workflow and the tree.
+      security-events: write
+      packages: read
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        # The three languages default setup was configured for, unchanged. `rust` is the one this
+        # workflow exists for; dropping either of the others would narrow coverage while claiming
+        # only to have moved it.
+        include:
+          - language: actions
+            build-mode: none
+          - language: python
+            build-mode: none
+          - language: rust
+            build-mode: none
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
+        with:
+          languages: ${{ matrix.language }}
+          # `none` is required, not merely cheaper. `paths-ignore` is honoured for a *compiled*
+          # language only when it is analyzed without building; add a build step and the filter
+          # goes silently inert, taking the excluded alerts with it — a failure that looks like
+          # the config never being read.
+          build-mode: ${{ matrix.build-mode }}
+          config-file: ./.github/codeql/codeql-config.yml
+          # No `queries:` — that leaves the `default` suite, which is what default setup ran.
+          # `security-extended` is a deliberate not-yet: it would land a fresh batch of findings in
+          # the same pass as this migration, and the two would be indistinguishable.
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
Six `rust/cleartext-logging` alerts on the security tab, all one claim — *"writes `session_id` to a log file"* — and all six in **test code**, where the "log" is an `assert!`/`panic!` naming the handle it failed to find. Two are on the literal `"sess-1"` handed to `post_commit_failure`.

## Why the rule is wrong here

Its heuristic is the name: in a web app a session id is a bearer cookie. Here it isn't, and the code says so already — `engine::mint_session_id`, *"exists to name a worker, not to authenticate"* — with `Sessions::resolve` reporting a handle whose `owner != caller` as **unknown**. Ownership comes from the authenticated client, never from the handle, so holding someone else's buys nothing.

## What changed

Excluding `tests/**` needs a config file and default setup takes none, so the setup moves into the tree. Same three languages, same `default` suite, same weekly schedule, plus the `push`/`pull_request` triggers a workflow gets for free.

`build-mode: none` is load-bearing rather than an economy: `paths-ignore` is honoured for a compiled language **only** when it's analyzed without building — add a build step and the filter goes silently inert. It's also why this runs on `ubuntu-latest` for a Windows-only crate. Nothing is compiled; `ci.yml` stays where a compile is claimed.

## Deliberately not done

- **The rule is not excluded repo-wide.** This server handles a real secret in the KDNET debug key, and `rust/cleartext-logging` is exactly what would catch `Connection`'s redaction regressing — no `derive(Debug)`, both `Debug` and `Display` render redacted, one `expose()` outside its own module (`worker.rs:1245`, dialling the engine).
- **The suite stays `default`.** `security-extended` would land a fresh batch of findings in the same pass as this migration, and the two would be indistinguishable.

## Follow-up

Default setup is **already disabled** (advanced setup cannot upload while it's on, so this had to precede the merge).

The four alerts in `tests/mcp_smoke.rs` should close once this runs. The two in `src/server.rs` are inside `#[cfg(test)] mod tests`, in a file that has to stay scanned — no path filter reaches them, so they want a dismissal as false positives.

**Cost, since nothing else states it:** a genuine finding in the smoke harness is now unreported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)