### PR TITLE
docs: the 32-bit worker had a setup page and no route to it

### DIFF
--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -3107,6 +3107,18 @@ closes it a second way, by having no transport.)
 3. **Say it in the operator documentation, which today says nothing.** Neither *32-bit .NET dumps
    need an x86 engine host* in `skills/windbg-debugging/setup.md` nor `docs/remote-listener.md`
    mentions the pipe, let alone who can reach it. Owed regardless of which of the rest happens.
+   **Paid on 2026-08-28, and only ever half a debt by then.** The pipe half went with the transport
+   — there is no pipe for `docs/remote-listener.md` to disclose. The other half outlived option 5
+   exactly as *"regardless of which of the rest happens"* predicted, and outlived the fix as well:
+   `setup.md` gained its *32-bit .NET targets need a 32-bit server* section with the implementation
+   on 2026-08-27, and every route to it stayed silent. `SKILL.md` said nothing at all, so its
+   routing table gave a model holding a 32-bit dump no reason to open `setup.md` and nothing warned
+   it that a fallback answers with a `limitation` rather than an error; `docs/install.md`'s *Wanted
+   / Needs* table — the index of what fails quietly without which files — had no row for it;
+   `docs/limitations.md` recorded neither the fallback nor what such a session loses; and
+   `README.md` did not mention the second worker image at all. All four now do. **The lesson is the
+   shape, not the four files:** a feature whose own setup page is written the day it lands still has
+   no reader, because nothing that *routes* to that page moved with it.
 4. **Drive `x86\cdb.exe` as a plain text child over inherited anonymous pipes** instead of using
    DbgEng's remote transport at all. It removes the named pipe and with it every finding above, and
    it needs no new build target. **Rejected on function rather than effort**, and recorded here so

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This file is the map. Each topic is one document, and each document is the whole
 
 | | |
 |---|---|
-| [Install and engine setup](docs/install.md) | Requirements, prebuilt binaries, Scoop, and the one-time WinDbg engine copy that TTD replay, `!analyze` and the driver tools need |
+| [Install and engine setup](docs/install.md) | Requirements, prebuilt binaries, Scoop, and the one-time WinDbg engine copy that TTD replay, `!analyze`, the driver tools and 32-bit .NET SOS need |
 | [Use with an MCP client](docs/mcp-clients.md) | Client config, running the server on another machine (`--listen`), the Claude Code plugin, the MCP registry |
 | [Architecture](docs/architecture.md) | Why a supervisor process and one engine worker per session, what each source file owns, and which MCP revisions are served |
 | [The tool surface](docs/tool-surface.md) | Serving fewer tools with `--tools`, what a typed operand may contain, and how the control-flow and TTD tools behave |
@@ -84,6 +84,14 @@ Every tool that touches a target takes the `session_id` an opener returned, and 
 the call. Omit it and the call goes to the current session. [`docs/architecture.md`](docs/architecture.md)
 has the process model and the file-by-file breakdown; [`docs/sessions.md`](docs/sessions.md) has the
 handle rules, the cap, and what to do when a session is stuck.
+
+**A 32-bit target gets a 32-bit worker.** An extension DLL is loaded into the debugger's own
+process, so .NET's SOS on a 32-bit target is reachable only from a 32-bit host — which a process
+cannot become after its image has loaded. So the release ships a second build of this same server
+at `x86\windbg-mcp.exe`, and a 32-bit dump or a WoW64 `attach_process` is opened by that worker
+instead of by a re-execution of the x64 one. A client cannot tell: one server, one handle, one tool
+surface. Where that worker or its 32-bit engine is absent the target still opens on the x64 build —
+native analysis of it works and always has — and says so in the opener's `limitation`.
 
 ## Tools
 
@@ -165,10 +173,14 @@ did and did not buy.
 ## Limitations
 
 The full list, with what each one means for a workflow, is in
-[`docs/limitations.md`](docs/limitations.md). The three that catch people first:
+[`docs/limitations.md`](docs/limitations.md). The four that catch people first:
 
 - **TTD is user-mode only** — a Microsoft limitation, so a kernel target cannot be time-travelled.
 - **One command at a time per session.** Sessions run concurrently, but each is one engine running
   operations serially: await each result before sending the next call against that session.
 - **Symbol *names* need setup on the debugger host** — `msdia140.dll` beside the binary, a symbol
   path, and (for TTD) a reload at a stopped position. Without them, address-based queries still work.
+- **The pool and heap walkers need a stopped x64 target.** They decode x64 allocator structures, so
+  a 32-bit target has no `heap_*` tools whichever worker holds it — SOS's own `!dumpheap`/`!eeheap`
+  are the managed equivalent, and reaching those is what the 32-bit worker and its `x86\` engine
+  payload ([`docs/install.md`](docs/install.md)) are for.

--- a/docs/install.md
+++ b/docs/install.md
@@ -102,11 +102,14 @@ and each needs files that engine does not ship:
 | Crash-dump `!analyze` | `winext\` for the extension, `triage\` for its module attribution |
 | `driver_object` / `device_object` / `irp_stack` | `winxp\kdexts.dll` |
 | `module!name` symbols anywhere | `msdia140.dll` + `symsrv.dll`, plus a symbol path |
+| SOS on a 32-bit .NET target | an `x86\` subdirectory holding a 32-bit engine **and** `x86\windbg-mcp.exe` — an extension loads into the debugger's own process, so only a 32-bit host can load a 32-bit `sos.dll` |
 
 The fix is a one-time file copy: `DebugCreate` binds to whichever `dbgeng.dll` the loader finds
 first and the app directory is searched before `System32`, so a WinDbg engine copied next to
 `windbg-mcp.exe` wins. Note the kernel row — a live-kernel-only user needs this too, even though
-the attach itself works on the System32 engine.
+the attach itself works on the System32 engine. The last row is that same loader rule rather than an
+exception to it: the 32-bit engine goes *inside* `x86\` because it is the 32-bit worker sitting
+there that has to find it, and dropping it beside the 64-bit one instead breaks both.
 
 **The copy list, what each file buys, and what to do when the store package will not install are in
 the skill's [`setup.md`](../skills/windbg-debugging/setup.md).**

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -50,6 +50,27 @@
   investigating freed memory, pass `state: reusable_free` or `state: cached_free` explicitly. Read
   `layout`, `scope`, and `walk` before treating an absent allocation as evidence. The agent workflow is in
   [`skills/windbg-debugging/heap-walking.md`](../skills/windbg-debugging/heap-walking.md).
+- **A 32-bit user-mode target is opened by a worker of its own architecture, and what that buys and
+  costs is worth knowing before you reach for either.** An extension DLL is loaded into the
+  debugger's own process, so SOS on a 32-bit .NET target is reachable only from a 32-bit host: the
+  32-bit `sos.dll` will not load into an x64 engine (`Win32 error 0n193`) and the 64-bit one loads
+  and then refuses the target (`Failed to load data access DLL, 0x80004005`), the CLR data access
+  DLL being paired to the target's architecture as well as the host's. So a 32-bit dump, and an
+  `attach_process` on a WoW64 process, are routed to an `x86\windbg-mcp.exe` worker. Nothing about
+  that is visible to a client — one server, one handle, one tool surface — and where the worker or
+  its 32-bit engine is absent the target **still opens**, on the x64 build, with an opener
+  `limitation` saying SOS is unreachable rather than a failure: native analysis of such a target
+  works and always has. Two things such a session does not have, and only one of them is about the
+  worker. The `heap_*` tools refuse any non-x64 *target* (*"heap walking supports x64 targets
+  only"*), so they are gone whichever worker holds it — SOS's own `!dumpheap`/`!eeheap` are the
+  managed equivalent. The other **is** the 32-bit worker's own trade: a live WoW64 `attach_process`
+  there sees only the 32-bit half of the process. The emulation layer above 4 GiB (`wow64.dll`,
+  `wow64cpu.dll`, `wow64win.dll` and the 64-bit `ntdll`) is what the x64 engine reaches with
+  `!wow64exts.sw` and this one cannot — measured on one process, 36 modules against 30. That is the
+  right trade when you are here for SOS and the wrong one for debugging the thunk layer itself; for
+  both halves, take a `procdump64.exe -ma` capture and open that, which routes to the x64 engine. A
+  dump loses nothing, a 32-bit capture never having held the 64-bit side. The engine payload to copy
+  is in [`setup.md`](../skills/windbg-debugging/setup.md).
 - **`crash_triage` reads a bug check two ways, and keeps them apart.** The code and its parameters
   (`ReadBugCheckData`), the stack, each frame's module, and the crashing process (out of the current
   `_EPROCESS`'s audit name — the full image name, not the 15-byte `ImageFileName` that turns

--- a/skills/windbg-debugging/SKILL.md
+++ b/skills/windbg-debugging/SKILL.md
@@ -17,7 +17,7 @@ session of a workflow you haven't run yet in this environment.
 
 | Task | Playbook |
 |------|----------|
-| Build / engine bundling / symbols / elevation | [setup.md](setup.md) |
+| Build / engine bundling / symbols / elevation / 32-bit .NET | [setup.md](setup.md) |
 | Triage a `.dmp` crash dump | [crash-dump.md](crash-dump.md) |
 | Launch/attach a process, or debug the kernel | [live-and-kernel.md](live-and-kernel.md) |
 | Walk kernel pools or user Segment Heaps | [heap-walking.md](heap-walking.md) |
@@ -142,6 +142,21 @@ where its stderr is not on your screen.
   ([setup.md](setup.md)) **and** the module-qualified form: use `!ext.analyze -v`, not bare
   `!analyze` (which this engine resolves to *"No export analyze found"* even after `.load ext`).
   `open_dump` runs `.load ext` for you.
+- **SOS on a 32-bit .NET target needs a 32-bit engine host, and the opener tells you when it has
+  not got one.** An extension is loaded into the debugger's own process, so a 32-bit `sos.dll`
+  cannot be loaded by an x64 engine at all and the 64-bit one refuses a 32-bit CLR. The server
+  routes a 32-bit dump, or an `attach_process` on a WoW64 process, to an `x86\windbg-mcp.exe`
+  worker instead — invisibly: same handle, same tools. Where that worker or its engine is missing
+  the target still opens on the x64 build, native analysis and all, and the summary's `limitation`
+  says SOS is unreachable and what to copy — read it rather than concluding SOS is broken
+  ([setup.md](setup.md) has the copy block). Two things such a session does not have. The `heap_*`
+  tools refuse any non-x64 *target*, so they are gone whichever worker holds it — `!dumpheap` and
+  `!eeheap` are the managed equivalent and do work. And a live WoW64 attach **on the 32-bit
+  worker** sees only the 32-bit half of the process: the emulation layer above 4 GiB is what the
+  x64 engine reaches with `!wow64exts.sw`, so if you are there for the thunk layer rather than for
+  SOS, open a `procdump64.exe -ma` capture instead — that routes to the x64 engine. And qualify the
+  extension: bare `!threads` resolves to `ext.dll`'s own native thread table and answers on *any*
+  engine, so ask `!sos.threads`.
 - **`read_memory` takes a numeric/`0x`-hex address only.** For a register/symbol
   expression use `execute` with `db`/`dd` (e.g. `db @rip`).
 - **Never walk a list with a MASM `.for` loop — use `walk_memory`.** One unmapped `poi` aborts


### PR DESCRIPTION
The 32-bit .NET / SOS work (#234, released in 0.13.0) is documented, thoroughly, in
`skills/windbg-debugging/setup.md` — both measured failure codes, the `x86\` copy block, the build
line, the three ways to get the layout wrong, the two caveats. That section was written the day the
feature landed. Nothing that *routes* a reader to it moved with it.

## What was missing

| File | Was |
| --- | --- |
| `skills/windbg-debugging/SKILL.md` | Nothing at all — `grep -niE "sos\|32.bit\|x86\|\.net\|managed\|wow64\|clr"` exited 1. The routing row read *"Build / engine bundling / symbols / elevation"*, so a model holding a 32-bit dump had no reason to open `setup.md`, and nothing told it a missing worker answers with a summary `limitation` rather than an error |
| `docs/install.md` | The *Wanted / Needs* table — the index of what fails quietly without which files, which is this failure's exact shape — had four rows and none for SOS |
| `docs/limitations.md` | Neither the fallback nor what such a session loses. Its only WoW64 mention was the heap walker's V1 note |
| `README.md` | No mention of the second worker image |

## What this does

- **`SKILL.md`** — routing row names 32-bit .NET, and a cross-cutting gotcha carries the routing,
  the `limitation` fallback, the two losses, and the `!sos.threads` qualification (a bare
  `!threads` resolves to `ext.dll`'s own native thread table and answers on *any* engine — the same
  trap as `!analyze` versus `!ext.analyze -v`).
- **`docs/install.md`** — a fifth *Wanted / Needs* row, plus why the engine goes *inside* `x86\`:
  that is the same loader rule the section already states, not an exception to it.
- **`docs/limitations.md`** — the full entry.
- **`README.md`** — *How it works* gains **"A 32-bit target gets a 32-bit worker"**, which is where
  the process-per-session model is stated and where this follows from it; §Limitations goes three
  to four.
- **`FOLLOWUPS.md`** — item 49's option 3 marked paid. It predicted this in as many words: *"Owed
  regardless of which of the rest happens"*.

## Two things worth a reviewer's attention

**Item 49 itself needed nothing.** It is already **done (2026-08-26 to 27)** in both its heading
and the file header. What was live was option 3 inside the retained *"What to do about the
transport, priced"* analysis. Its pipe half died with the `cdb -server` transport — there is no
pipe for `docs/remote-listener.md` to disclose — and its documentation half outlived both option 5
and the fix. The header's *"landed in full, on 2026-08-27"* is left alone: option 3 was scoped
outside the implementation by its own wording.

**Two claims were corrected against the source rather than the prose.** Both drafts said the two
losses apply "whichever worker holds it". That is true of `heap_*` — the refusal is on the
*target's* effective processor type (`dbgscope/src/heap.rs:211`, `validate_target` at `:695`) — and
false of the WoW64 module visibility, which is the 32-bit worker's own trade; on the x64 fallback
both halves are visible. Both files now separate them.

## Verification

`markdownlint-cli2@0.23.2` over CI's own globs (`README.md`, `CHANGELOG.md`, `docs/**/*.md`,
`skills/**/*.md`): **0 issues in 0 files**, 36 files linted. No code changed, so no build or test
tier is implicated. Behavioural claims were checked against `dbgscope/src/heap.rs` and
`src/engine.rs:2466` (`x86_worker_image`) rather than taken from the surrounding prose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
