### PR TITLE
docs: the release procedure was three files short and lived in my head

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -54,10 +54,29 @@ protection" if you stop there.
    file unreferenced, and **Documentation lint fails on MD053** — the one gate that catches release
    prep, and it catches it after the push. Add the new `[X.Y.Z]:` definition beside it and repoint
    `[Unreleased]:` at the new tag. That section *is* the GitHub release body.
-3. **Dry-run both guards locally**, with the workflow's own regexes rather than by eye — they are
-   twenty lines into [`release.yml`](../.github/workflows/release.yml) and take a second to run in
-   `pwsh`. One compares the tag against all three manifest versions, the other requires a
-   `## [X.Y.Z]` heading in the CHANGELOG. Dry-run the lint too:
+3. **Dry-run both guards locally**, rather than by eye. They are twenty lines into
+   [`release.yml`](../.github/workflows/release.yml) and take a second in `pwsh` — but copy them
+   with one change, or the dry-run is worse than not running it. The workflow reads the tag from
+   `$env:GITHUB_REF_NAME`, which Actions supplies and your shell does not, so a **verbatim** copy
+   compares all three manifests against an empty string and reports a mismatch on a correct tree.
+   Set `$tag` yourself. The second guard needs no tag at all: like the workflow, it takes the
+   version from `Cargo.toml`, which the first guard has just pinned to the tag.
+
+   ```pwsh
+   $tag    = '0.13.1'   # the version about to be released, without the leading v
+   $cargo  = [regex]::Match((Get-Content Cargo.toml -Raw), '(?ms)^\[package\].*?^version\s*=\s*"([^"]+)"').Groups[1].Value
+   $plugin = (Get-Content .claude-plugin/plugin.json -Raw | ConvertFrom-Json).version
+   $readme = [regex]::Match((Get-Content README.md -Raw), 'img\.shields\.io/badge/release-v([^-]+)-').Groups[1].Value
+   if ($cargo -ne $tag -or $plugin -ne $tag -or $readme -ne $tag) {
+     throw "Version mismatch: tag v$tag, Cargo.toml $cargo, plugin.json $plugin, README badge $readme"
+   }
+   if ((Get-Content CHANGELOG.md -Raw) -notmatch "(?m)^## \[$([regex]::Escape($cargo))\]") {
+     throw "CHANGELOG.md has no '## [$cargo]' section"
+   }
+   "guards pass: $tag"
+   ```
+
+   Dry-run the lint too, with CI's own globs:
    `npx markdownlint-cli2@0.23.2 README.md CHANGELOG.md "docs/**/*.md" "skills/**/*.md"`.
 4. **`claude plugin validate . --strict`** — worth running, but know what it answers. In this repo
    it validates `.claude-plugin/marketplace.json` and says so in its output; it is **not** a check

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -2,11 +2,16 @@
 
 The plugin sets an explicit `version` in
 [`.claude-plugin/plugin.json`](../.claude-plugin/plugin.json), so users only receive an update
-when that version changes — pushing commits alone does not trigger one. To cut a release, bump
+when that version changes — pushing commits alone does not trigger one. **That is also the answer to
+"is a documentation change worth a release?"**: the `skills/` a plugin installs come with it, so a
+skill fix merged to `main` reaches GitHub and nobody's machine until the version moves. 0.13.1 was
+exactly that and nothing else.
+
+To cut a release, bump
 `version` in `plugin.json` and `Cargo.toml`, bump the release badge near the top of [`README.md`](../README.md),
 add a matching entry to
-[`CHANGELOG.md`](../CHANGELOG.md), and tag the commit `vX.Y.Z`. Run
-`claude plugin validate . --strict` before publishing. Pushing the tag runs
+[`CHANGELOG.md`](../CHANGELOG.md), and tag the commit `vX.Y.Z`. The checklist below is the whole of
+it, in order, with the three things that are not in that sentence. Pushing the tag runs
 [`release.yml`](../.github/workflows/release.yml), which verifies the tag matches both manifest
 versions and the README badge, builds `windbg-mcp.exe`, and attaches the zip + SHA256 checksum to the GitHub release.
 It also builds an [MCPB](https://github.com/anthropics/mcpb) bundle
@@ -27,6 +32,44 @@ gh attestation verify <zip> --repo glslang/windbg-mcp `
 
 (`--repo` alone only proves the attestation came from *some* workflow in this repo;
 `--signer-workflow` pins it to the release workflow.)
+
+## The checklist
+
+**Release prep goes straight to `main`.** It bypasses the repo's *Main Branch* ruleset (a PR plus
+`Build & test` and `Documentation lint`) on admin privilege, and that is sanctioned for this and
+nothing else: version bumps and a CHANGELOG section its own author wrote carry no review value, the
+bypass is logged by GitHub either way, and the required checks still run on the pushed commit.
+**Every other change — features, fixes, documentation, the examples — takes a PR.** Read the
+ruleset with `gh api repos/glslang/windbg-mcp/rules/branches/main`; the branch-protection endpoint
+404s here, because protection is a ruleset rather than branch protection, which reads as "no
+protection" if you stop there.
+
+1. **Bump four files, not three.** `Cargo.toml`, `.claude-plugin/plugin.json`, the `README.md`
+   badge — and **`Cargo.lock`**, which holds this crate's own version. `cargo update -p windbg-mcp
+   --offline` does it. The workflow builds `--locked`, so a stale lock fails the release build
+   after the guards have passed, which is the expensive place to find out. Leave `server.json` and
+   `packaging/mcpb/manifest.json` alone: CI stamps both.
+2. **Add the CHANGELOG section, and keep an empty `## [Unreleased]` above it.** *Renaming*
+   `## [Unreleased]` to `## [X.Y.Z]` leaves the `[Unreleased]:` link definition at the foot of the
+   file unreferenced, and **Documentation lint fails on MD053** — the one gate that catches release
+   prep, and it catches it after the push. Add the new `[X.Y.Z]:` definition beside it and repoint
+   `[Unreleased]:` at the new tag. That section *is* the GitHub release body.
+3. **Dry-run both guards locally**, with the workflow's own regexes rather than by eye — they are
+   twenty lines into [`release.yml`](../.github/workflows/release.yml) and take a second to run in
+   `pwsh`. One compares the tag against all three manifest versions, the other requires a
+   `## [X.Y.Z]` heading in the CHANGELOG. Dry-run the lint too:
+   `npx markdownlint-cli2@0.23.2 README.md CHANGELOG.md "docs/**/*.md" "skills/**/*.md"`.
+4. **`claude plugin validate . --strict`** — worth running, but know what it answers. In this repo
+   it validates `.claude-plugin/marketplace.json` and says so in its output; it is **not** a check
+   that the version bump is consistent, and it passes just as happily before the bump as after.
+   The version agreement is release.yml's guard and nothing else's.
+5. **Commit, push, and wait for `main`'s CI to go green *before* tagging.** Then tag annotated —
+   `git tag -a vX.Y.Z -m "Release X.Y.Z"` — and push the tag.
+
+**Tagging is the irreversible step**, which is why it is last and why the wait is not optional: the
+tag push publishes to the official MCP Registry, and a version number there is spent. A failed
+build can be re-run; a published `io.github.glslang/windbg-mcp` version cannot be taken back and
+reused.
 
 ## What the release is not
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -45,10 +45,20 @@ ruleset with `gh api repos/glslang/windbg-mcp/rules/branches/main`; the branch-p
 protection" if you stop there.
 
 1. **Bump four files, not three.** `Cargo.toml`, `.claude-plugin/plugin.json`, the `README.md`
-   badge — and **`Cargo.lock`**, which holds this crate's own version. `cargo update -p windbg-mcp
-   --offline` does it. The workflow builds `--locked`, so a stale lock fails the release build
-   after the guards have passed, which is the expensive place to find out. Leave `server.json` and
+   badge — and **`Cargo.lock`**, which holds this crate's own version. `cargo update -p windbg-mcp`
+   does it. The workflow builds `--locked`, so a stale lock fails the release build after the
+   guards have passed, which is the expensive place to find out. Leave `server.json` and
    `packaging/mcpb/manifest.json` alone: CI stamps both.
+
+   **Not `--offline`, and not `--locked` either** — both fail here, for opposite reasons, and the
+   flag that looks like the safe one is the one that breaks. `--offline` cannot check out the
+   pinned `dbgscope` revision on a cache that has not already got it, so on a fresh clone it exits
+   101 without touching the lock. A `cargo fetch --locked` to populate that cache first is worse:
+   at this point in the checklist `Cargo.toml` is *ahead* of `Cargo.lock` by construction — that is
+   the whole point of the step — so `--locked` refuses with *"cannot update the lock file … because
+   --locked was passed"*. What confines the update is **`-p`**, not either flag: measured on this
+   crate, the bare command reports *"45 unchanged dependencies behind latest"* and moves one line.
+   `git diff Cargo.lock` is the check, and it should show exactly that line.
 2. **Add the CHANGELOG section, and keep an empty `## [Unreleased]` above it.** *Renaming*
    `## [Unreleased]` to `## [X.Y.Z]` leaves the `[Unreleased]:` link definition at the foot of the
    file unreferenced, and **Documentation lint fails on MD053** — the one gate that catches release


### PR DESCRIPTION
`docs/releasing.md` described cutting a release as *"bump `plugin.json` and `Cargo.toml`, bump the
badge, add a CHANGELOG entry, and tag"*. Every clause of that is true, and it is not enough to cut
one with. The rest lived in an assistant memory — the wrong place for it twice over: nobody else can
read it, and it drifts against `release.yml` with nothing to catch the drift.

## What the old sentence left out

| | Why it bites |
| --- | --- |
| **`Cargo.lock` is a fourth file** | It holds this crate's own version, and `release.yml` builds `--locked`. A stale lock fails the build *after* both version guards have passed — the expensive place to find out |
| **Keep an empty `## [Unreleased]`** | *Renaming* it to `## [X.Y.Z]` orphans the `[Unreleased]:` link definition and **Documentation lint fails on MD053**. That is the one gate that catches release prep, and it catches it after the push |
| **Wait for `main`'s CI before tagging** | The tag push publishes to the MCP Registry, where a version number is spent. A failed build re-runs; a published `io.github.glslang/windbg-mcp` version cannot be taken back |

## What else it now records

- **The flow.** Release prep goes straight to `main` on the admin ruleset bypass — sanctioned for
  that and nothing else; every other change takes a PR. Read the ruleset with
  `gh api repos/glslang/windbg-mcp/rules/branches/main`: the branch-protection endpoint 404s here,
  because protection is a *ruleset*, which reads as "no protection" if you stop there.
- **Dry-run the guards** with the workflow's own regexes rather than by eye — twenty lines into
  `release.yml`, a second to run in `pwsh` — and the lint with CI's own globs.

## One claim corrected by measuring it

The old text put `claude plugin validate . --strict` next to the version bumps, which reads as a
check on them. Run in this repo it validates `.claude-plugin/marketplace.json` and names only that
in its output, and it passes identically before and after a bump — it never sees a tag. The version
agreement is `release.yml`'s guard and nothing else's, and the doc now says which is which. Still
worth running; it just answers a different question than its placement implied.

## Provenance

Everything here was executed in cutting **0.13.1** (`97c1078`) rather than recalled: the four bumps,
the CHANGELOG link-definition edit, both guard dry-runs, and the lint. The bypass rule and its
release-only scope are the user's own, confirmed 2026-08-08 and 2026-08-15.

## Verification

`markdownlint-cli2@0.23.2` over CI's globs: **0 issues in 0 files**, 36 files linted. Documentation
only — no code, no manifest, no workflow touched, so nothing here affects the 0.13.1 release already
in flight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
