### PR TITLE
docs: ollama drives this server, and nothing said so where a reader looks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   five configurations — an MCP client or ollama, local weights or ollama's cloud, one machine or
   two — then the commands that install **and start** the listener as a service, the ssh forward,
   why the token is not optional, and the one line that points ollama at it. The benchmark follows
-  as its own section, backing those claims instead of standing in for them, and its context-window
+  as its own section, backing those claims instead of standing in for them. The service install is
+  stated with the prerequisite that makes it work: `--install-service` **refuses** an exe outside
+  `%ProgramFiles%`, `%ProgramFiles(x86)%` or `%SystemRoot%`, which a downloaded zip, a Scoop shim
+  and a `target\release` build all are, so the whole deployment moves first — engine DLLs and
+  `x86\` included — and `--allow-unprotected-path` is named as the development install it is. The
+  skill and `docs/mcp-clients.md` both said "elevated" as though elevation were the only
+  requirement, and now do not. Its context-window
   finding now carries the qualifier it always needed: it is a fact about that bench's runtime, and
   `ollama ps` is how a reader learns what theirs serves.
 - **The tool-surface figures were stale in eight files and disagreed with each other in two.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,54 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Documentation
+
+- **Driving this server with ollama was supported in fact and written down nowhere a reader would
+  look.** `skills/windbg-debugging/setup.md` explained at length how to put the server on another
+  machine and never said what could drive it from there; its only mention of a local model was a
+  half-sentence about `--tools` inside the service bullet, and it linked to none of the three
+  documents that carry the subject. It now ends with *What drives the server — there is a choice*:
+  the three arrangements, and the four things that decide whether the ollama route works — a
+  credential of its own, the `tools` capability being necessary and not sufficient, the lease a
+  quiet client loses its sessions to, and the surface being the fixed cost where a single
+  `read_memory` is the variable one. The depth stays in `docs/local-model.md` rather than being
+  copied, so there is one place for each rule to be wrong.
+- **The tool-surface figures were stale in six documents and disagreed with each other in two.**
+  Every current claim now comes from one re-derivation, none of which needs the eval run: the whole
+  surface is `tests/golden/tool_budget.json`'s `modelVisible` total, which `cargo test` re-records
+  (**68,322** — not the 67,766 five documents carried, and not the 67,873 in `README.md` and
+  `CLAUDE.md`); each group's share is that golden summed over `src/toolset.rs`'s membership, which
+  reconciles to the total across all 51 tools; and what a `--tools` spec actually *serves* is the
+  same sum over a `tools/list` from a listener started with it. So `session,inspect,crash` is
+  24,894 rather than 24,445, `crash` 14,587 rather than 14,138, the `session` floor 11,714 rather
+  than 11,265, `debug_batch` 9,798 rather than 9,746, and the gap item 41 opened between a group's
+  share and what a spec serves is 15,542 against 14,587. `docs/local-model.md` also says how to
+  re-derive its own table, because this is the second time these numbers have gone quietly stale.
+  The **historical** figures are deliberately untouched: `token-budget.md`'s `67,076 → 67,766`
+  before-and-after column, `local-model-eval.md`'s statement of the conditions its grid ran under,
+  and this file's earlier entries each record a measured moment and would be falsified by a refresh.
+- **That page described one arrangement as though it were the only one — the bench's.** Where the
+  weights run and where the listener runs are independent choices, and `docs/local-model.md` opened
+  on *the three pieces* with the ssh forward baked in as piece 2, because the bench that produced
+  its numbers had the model on a Mac and the engine on a Windows VM. It now opens on the four
+  arrangements those two choices make, says that only the listener is pinned and why, labels which
+  row each measurement came from, and says outright that on a single machine piece 2 is not a step.
+  The driver is also described for what it is — a batch task runner with six tool-calling turns a
+  task, no interactive mode, and four environment variables that exist only so the grid can be
+  graded — so that a reader stops looking for the conversation it does not have.
+- **`docs/local-model.md` is about ollama, not about local weights.** A cloud tag and a local one
+  are the same route — the same endpoint, the same script, a different model name — so the page
+  says so from its title down, and `ollama launch` is now explicitly not needed rather than merely
+  "not a prerequisite". Three facts measured on 2026-08-28 are new, and a local bench could not
+  have produced any of them. A pulled cloud tag is a registered *name*: `glm-5.3:cloud` declared
+  `capabilities: ['completion', 'thinking', 'tools']`, passed the driver's model gate, and answered
+  the first real call with *"currently being rolled out and is not yet available to you"* — so the
+  gate is necessary and not sufficient, and one token is the probe. `/api/ps` is empty for a cloud
+  model even straight after a successful run, so `served_context` and `model_digest` are recorded
+  null and the served-window rule has no instrument at all — the position `claude_code_drive.py`'s
+  rows are already in. And the keepalive stays on despite turns of 4 to 10 seconds, because what
+  the lease measures is silence, and a queued request is silent the same way a thinking one is.
+
 ## [0.13.1] - 2026-08-28
 
 ### Documentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   quiet client loses its sessions to, and the surface being the fixed cost where a single
   `read_memory` is the variable one. The depth stays in `docs/local-model.md` rather than being
   copied, so there is one place for each rule to be wrong.
+- **`README.md` presented driving this with a local model as a benchmark result rather than as
+  something a reader can do.** Its single section on the subject was the eval — the grid, the
+  axes, the findings — so someone asking whether a local model is supported at all, how the
+  listener is configured, or whether a Mac can drive a Windows host over ssh found none of it, and
+  the answer to all three is yes. That section is now two. *Driving it* leads with a table of the
+  five configurations — an MCP client or ollama, local weights or ollama's cloud, one machine or
+  two — then the commands that install **and start** the listener as a service, the ssh forward,
+  why the token is not optional, and the one line that points ollama at it. The benchmark follows
+  as its own section, backing those claims instead of standing in for them, and its context-window
+  finding now carries the qualifier it always needed: it is a fact about that bench's runtime, and
+  `ollama ps` is how a reader learns what theirs serves.
 - **The tool-surface figures were stale in six documents and disagreed with each other in two.**
   Every current claim now comes from one re-derivation, none of which needs the eval run: the whole
   surface is `tests/golden/tool_budget.json`'s `modelVisible` total, which `cargo test` re-records

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   quiet client loses its sessions to, and the surface being the fixed cost where a single
   `read_memory` is the variable one. The depth stays in `docs/local-model.md` rather than being
   copied, so there is one place for each rule to be wrong.
+- **The benchmark's driver was being offered as the way to use a local model, and it is not.**
+  `tools/local_model_drive.py` ships in no release — the zip is `windbg-mcp.exe`, the `x86\` worker
+  and `LICENSE` — wants a checkout and Python 3, has no interactive mode, and exists to measure a
+  model rather than to debug with one. Driving this server with an ollama model is the **client's**
+  job: an MCP client that drives one holds the listener exactly as an editor does, ollama ships
+  integrations for several of them, and nothing from this repository is involved. `README.md`, the
+  skill and `docs/local-model.md` now say so, and name
+  [`agent-sandbox-vm`](https://github.com/glslang/agent-sandbox-vm) as the environment the grid is
+  actually run in.
 - **`README.md` presented driving this with a local model as a benchmark result rather than as
   something a reader can do.** Its single section on the subject was the eval — the grid, the
   axes, the findings — so someone asking whether a local model is supported at all, how the
@@ -30,7 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   as its own section, backing those claims instead of standing in for them, and its context-window
   finding now carries the qualifier it always needed: it is a fact about that bench's runtime, and
   `ollama ps` is how a reader learns what theirs serves.
-- **The tool-surface figures were stale in six documents and disagreed with each other in two.**
+- **The tool-surface figures were stale in eight files and disagreed with each other in two.**
   Every current claim now comes from one re-derivation, none of which needs the eval run: the whole
   surface is `tests/golden/tool_budget.json`'s `modelVisible` total, which `cargo test` re-records
   (**68,322** — not the 67,766 five documents carried, and not the 67,873 in `README.md` and
@@ -41,6 +50,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   than 11,265, `debug_batch` 9,798 rather than 9,746, and the gap item 41 opened between a group's
   share and what a spec serves is 15,542 against 14,587. `docs/local-model.md` also says how to
   re-derive its own table, because this is the second time these numbers have gone quietly stale.
+  The developer-facing copies moved with them — `src/toolset.rs`'s module table and floor,
+  `tests/mcp_smoke.rs`'s note on why `--tools` exists, and `CLAUDE.md` — since a figure in a doc
+  comment is a current claim like any other.
   The **historical** figures are deliberately untouched: `token-budget.md`'s `67,076 → 67,766`
   before-and-after column, `local-model-eval.md`'s statement of the conditions its grid ran under,
   and this file's earlier entries each record a measured moment and would be falsified by a refresh.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -926,7 +926,7 @@ test, because `Toolset::parse` resolves group names first and would decide it si
 
 Four rules worth knowing before touching it. **`session` is in every surface** whatever the spec
 says, because every other tool routes by a `session_id` this server alone issues — so `--tools
-crash` is eleven tools and 11,265 B is the floor. **Output schemas carry no prose at all**
+crash` is eleven tools and 11,714 B is the floor. **Output schemas carry no prose at all**
 (`src/schema.rs`): declare one with `schema::constraints_of`, never rmcp's `schema_for_output`, or
 the tool ships every doc comment in its `$defs` closure and the wire ceiling notices. That call is
 also what supplies the root `type: "object"` a discriminated union does not generate and rmcp does

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -914,7 +914,7 @@ measurements and the options that were weighed.
 
 Two files, not one. A tool is declared in `src/server.rs` as always, and its name also goes in a
 **group** in `src/toolset.rs` — the table behind `--tools`, which advertises a named subset of the
-surface because 74% of the 67,873-byte tool surface is prose a model needs and cannot be trimmed
+surface because 74% of the 68,322-byte tool surface is prose a model needs and cannot be trimmed
 (`docs/token-budget.md` finding 8).
 
 Forgetting the second half fails in the one direction nothing would notice: the *default* surface
@@ -947,8 +947,8 @@ tool but the always-served ones, and `no_description_names_a_tool_the_client_can
 build if a new tool's prose points at one its own single-tool spec does not serve. Three
 consequences when you add one. The invariant is checked on `--tools <that tool>` and nowhere else,
 because that is the tightest surface it can be served on and every wider one is covered by
-construction. **Group bytes no longer add up to a surface's**: `crash` is 14,138 B against the
-15,093 its two groups sum to in `docs/token-budget.md`, since narrowing shortens what stays as well
+construction. **Group bytes no longer add up to a surface's**: `crash` is 14,587 B against the
+15,542 its two groups sum to in `docs/token-budget.md`, since narrowing shortens what stays as well
 as dropping what goes. And the check for "names a tool" is deliberately not word containment — this
 prose says frames are "attributed to modules" and that a stuck session "does not let go", while a
 TTD description quotes `dx @$cursession.TTD.Calls(...)`, which is the debugger command and not the

--- a/README.md
+++ b/README.md
@@ -66,8 +66,9 @@ Then point a client at the binary:
 ```
 
 The client and the model do not have to run where DbgEng does: `--listen <addr>` serves the same
-tools over HTTP, one bearer token per client, so a Mac can drive a Windows VM — see
-[`docs/mcp-clients.md`](docs/mcp-clients.md) and [`docs/remote-listener.md`](docs/remote-listener.md).
+tools over HTTP, one bearer token per client, so a Mac can drive a Windows VM — and the model
+itself can be a local one. [Driving it](#driving-it--hosted-or-local-here-or-on-another-machine)
+below has the configurations.
 
 `cargo test` covers the unit tests plus an end-to-end smoke test that drives the built binary over
 stdio; run it after a dependency bump or an MCP spec revision — [`docs/smoke-test.md`](docs/smoke-test.md).
@@ -144,7 +145,58 @@ Worked sessions with the real outputs and the gotchas — the long form is in
 - [Disassembler coordinates](docs/coordinates.md) — joining a `crash_triage` frame to a function in
   an image fetched on another machine.
 
-## Driving it with a local model
+## Driving it — hosted or local, here or on another machine
+
+Anything that speaks MCP can hold this server, and **DbgEng is the only part pinned to Windows**.
+So the model may be a hosted one inside an editor, a local one in ollama, or an ollama cloud model,
+and it does not have to run on the machine being debugged.
+
+| What drives it | Where that runs | The server | Reached over |
+|---|---|---|---|
+| An MCP client — Claude Code, Cursor, Claude Desktop | the Windows machine | launched by the client | stdio |
+| An MCP client | a Mac, or any other machine | a Windows host, `--listen`, usually as a service | HTTP through an ssh forward |
+| A model in **ollama** | the Windows machine | the same machine, `--listen` on loopback | HTTP on loopback |
+| A model in **ollama** | a Mac | a Windows host, `--listen` as a service | HTTP through an ssh forward |
+| A model in **ollama's cloud** | wherever ollama runs | either of the above | unchanged — the tag is all that differs |
+
+**One machine needs no configuration at all**: the client launches the binary and talks to it over
+stdio, which is the Quick start above.
+
+**Two machines need a listener, and installing one is not starting it.** On the Windows host,
+elevated:
+
+```pwsh
+$env:WINDBG_MCP_LISTEN_TOKEN = "<a long random string>"
+windbg-mcp.exe --install-service --listen 127.0.0.1:8765
+Start-Service windbg-mcp          # --install-service only *registers* it
+```
+
+Then, from the machine you are actually working on, for as long as you want the link:
+
+```console
+ssh -N -L 8765:127.0.0.1:8765 <windows-host>
+```
+
+The listener **refuses to start without a token**, because it serves `execute`, `launch` and
+`debug_batch` — an open port here is arbitrary code on the host holding your kernel debugger. Bind
+loopback and forward over ssh rather than exposing it. Each client authenticates as itself, and can
+be served a narrower `--tools` surface than the run's default, which is how a local model and an
+editor share one listener without sharing sessions.
+[`docs/remote-listener.md`](docs/remote-listener.md) is the operator's reference.
+
+**Pointing ollama at it** needs nothing installed on either side. The repo's driver speaks MCP to
+the listener and hands the tool surface to ollama's `POST /api/chat`:
+
+```console
+WINDBG_MCP_TOKEN="<that client's own token>" python3 tools/local_model_drive.py tasks.json
+```
+
+It is a batch task runner rather than a chat client, and a local tag and a cloud tag are one route
+— the model name is the only difference. [`docs/local-model.md`](docs/local-model.md) is the
+runbook: the four arrangements, choosing a model that can actually run, and what a cloud tag can no
+longer tell you about its own run.
+
+## Whether a local model copes — the benchmark
 
 The tool surface is paid on every turn, so *"can a model that runs on a laptop actually drive
 this?"* is a question about **this server** as much as about the model. The repo ships the
@@ -154,10 +206,11 @@ three separately-budgeted clients, and the answer key is read off the checked-in
 this server's own tools before any model sees them. Claude is in the grid as the control, not as a
 competitor. [`docs/local-model-eval.md`](docs/local-model-eval.md) is the write-up.
 
-- **The context window was not the binding constraint.** A 17,300-token surface answered all six
-  tasks at a *served* 8,192-token window — multi-turn ones carrying 10,000 characters of tool
-  output included. The arithmetic that predicted otherwise is in `docs/local-model.md`, and it was
-  wrong.
+- **The context window was not the binding constraint** — on that bench's runtime, which is the
+  qualifier that matters. A 17,300-token surface answered all six tasks at a *served* 8,192-token
+  window, multi-turn ones carrying 10,000 characters of tool output included. The arithmetic that
+  predicted otherwise is in `docs/local-model.md`, and it was wrong; ask `ollama ps` what your own
+  runtime serves rather than generalising either result.
 - **Cutting 51 tools to 11 costs two of six answers.** Most facts here are reachable by more than
   one route, so a narrow surface keeps the ones that matter.
 - **It measures this server before it measures the model.** Every off-surface tool call the first

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ This file is the map. Each topic is one document, and each document is the whole
 | [The local-model eval](docs/local-model-eval.md) | A grid of model × tool surface × context window against a verified answer key: what a laptop-sized model can drive, and the two defects it found in this server |
 
 Operator and reference material: [remote listener](docs/remote-listener.md),
-[local model](docs/local-model.md), [disassembler coordinates](docs/coordinates.md),
+[driving it with ollama](docs/local-model.md), [disassembler coordinates](docs/coordinates.md),
 [smoke test](docs/smoke-test.md), [token budget](docs/token-budget.md),
 [releasing](docs/releasing.md).
 
@@ -115,9 +115,9 @@ Fifty-one tools in eight `--tools` groups; the rows below split some of those gr
 | Structure walk | `allocator` | `walk_memory` |
 | Raw     | `inspect` | `execute` — run any debugger command, returns full text output |
 
-All of them are served unless you say otherwise, and the definitions cost the model **67,873 bytes —
+All of them are served unless you say otherwise, and the definitions cost the model **68,322 bytes —
 about 17k tokens — before it has asked anything**. `--tools session,inspect,crash` cuts that to
-24,445 B for twenty tools, and a `--listen` client can be given a narrower surface than the run's
+24,894 B for twenty tools, and a `--listen` client can be given a narrower surface than the run's
 default. [`docs/tool-surface.md`](docs/tool-surface.md) has the arithmetic, the rule that `session`
 is always included, and what a typed operand may not contain.
 

--- a/README.md
+++ b/README.md
@@ -162,16 +162,31 @@ and it does not have to run on the machine being debugged.
 **One machine needs no configuration at all**: the client launches the binary and talks to it over
 stdio, which is the Quick start above.
 
-**Two machines need a listener, and installing one is not starting it.** On the Windows host,
-elevated:
+**Two machines need a listener.** For a session you are driving anyway, run it in the foreground on
+the Windows host — this works wherever the binary happens to live:
 
 ```pwsh
-$env:WINDBG_MCP_LISTEN_TOKEN = "<a long random string>"
-windbg-mcp.exe --install-service --listen 127.0.0.1:8765
+$env:WINDBG_MCP_LISTEN_TOKEN = "<a long random string>"   # this shell only
+windbg-mcp.exe --listen 127.0.0.1:8765
+```
+
+**For anything longer-lived, install it as a service — from a protected directory.** The SCM stores
+that exact path for a `LocalSystem` auto-start service, so whoever can write the directory, or drop
+an engine DLL beside the exe, gets their code run as SYSTEM at the next start.
+`--install-service` therefore refuses an exe outside `%ProgramFiles%`, `%ProgramFiles(x86)%` or
+`%SystemRoot%` — which a downloaded zip, a Scoop shim or a `target\release` build all are — so move
+the **whole** deployment first: the exe, the engine DLLs beside it, and `x86\`. Then, elevated:
+
+```pwsh
+$env:WINDBG_MCP_LISTEN_TOKEN = "<a long random string>"   # this shell only
+& "$env:ProgramFiles\windbg-mcp\windbg-mcp.exe" --install-service --listen 127.0.0.1:8765
 Start-Service windbg-mcp          # --install-service only *registers* it
 ```
 
-Then, from the machine you are actually working on, for as long as you want the link:
+On a machine that is entirely yours, `--allow-unprotected-path` says so out loud and installs in
+place; that is a development install, not a deployment.
+
+Either way, from the machine you are actually working on, for as long as you want the link:
 
 ```console
 ssh -N -L 8765:127.0.0.1:8765 <windows-host>

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ those clients; `ollama launch` lists them, and `ollama launch claude --model <ta
 tag and an ollama **cloud** tag are the same route, differing only in the model name.
 
 [`docs/local-model.md`](docs/local-model.md) is the runbook: the arrangements, choosing a model that
-can actually run, the lease a quiet model loses its sessions to, and what a cloud tag can no longer
+can actually run, which of two clocks a quiet model loses its sessions to, and what a cloud tag can no longer
 tell you about its own run.
 
 ## Whether a local model copes — the benchmark

--- a/README.md
+++ b/README.md
@@ -184,17 +184,15 @@ be served a narrower `--tools` surface than the run's default, which is how a lo
 editor share one listener without sharing sessions.
 [`docs/remote-listener.md`](docs/remote-listener.md) is the operator's reference.
 
-**Pointing ollama at it** needs nothing installed on either side. The repo's driver speaks MCP to
-the listener and hands the tool surface to ollama's `POST /api/chat`:
+**Pointing ollama at it is the client's job, not this server's.** An MCP client that drives an
+ollama model holds the listener exactly as an editor does — nothing here has to be installed, and
+this server never learns which kind of model answered. ollama ships integrations for a number of
+those clients; `ollama launch` lists them, and `ollama launch claude --model <tag>` is one. A local
+tag and an ollama **cloud** tag are the same route, differing only in the model name.
 
-```console
-WINDBG_MCP_TOKEN="<that client's own token>" python3 tools/local_model_drive.py tasks.json
-```
-
-It is a batch task runner rather than a chat client, and a local tag and a cloud tag are one route
-— the model name is the only difference. [`docs/local-model.md`](docs/local-model.md) is the
-runbook: the four arrangements, choosing a model that can actually run, and what a cloud tag can no
-longer tell you about its own run.
+[`docs/local-model.md`](docs/local-model.md) is the runbook: the arrangements, choosing a model that
+can actually run, the lease a quiet model loses its sessions to, and what a cloud tag can no longer
+tell you about its own run.
 
 ## Whether a local model copes — the benchmark
 
@@ -205,6 +203,14 @@ surface × context window, `tools/bench_listener.ps1` serves all three surfaces 
 three separately-budgeted clients, and the answer key is read off the checked-in crash dumps with
 this server's own tools before any model sees them. Claude is in the grid as the control, not as a
 competitor. [`docs/local-model-eval.md`](docs/local-model-eval.md) is the write-up.
+
+Running the grid yourself needs a **development environment rather than a release**: the release
+zip is `windbg-mcp.exe`, the `x86\` worker and `LICENSE`, so `tools/` comes from a checkout, and the
+driver and grader are Python 3. Nothing above this section needs either — driving the server with a
+local model is a client's job, and the driver here exists to *measure* that, one task list at a
+time, with no interactive mode.
+[`agent-sandbox-vm`](https://github.com/glslang/agent-sandbox-vm) is the Hyper-V / Parallels VM
+setup this project is developed and benchmarked in.
 
 - **The context window was not the binding constraint** — on that bench's runtime, which is the
   qualifier that matters. A 17,300-token surface answered all six tasks at a *served* 8,192-token

--- a/docs/local-model.md
+++ b/docs/local-model.md
@@ -39,7 +39,17 @@ on a Windows VM — and the cloud sighting comes from the third. Neither is *the
 saying which one produced a number is why they are labelled.
 
 The three pieces below assume the widest row, a listener on another machine. On one machine piece 2
-is not a step at all: leave the listener on `127.0.0.1` and skip the forward.
+loses the *forward* but not the *listener* — the ssh line there is what starts the server as well as
+tunnelling to it, so on a single box start it yourself:
+
+```pwsh
+$env:WINDBG_MCP_LISTEN_TOKEN = "<a long random string>"
+windbg-mcp.exe --listen 127.0.0.1:8765
+```
+
+`$env:` rather than piece 1's `setx`, which sets the variable for the *next* shell and not the one
+you are in — a listener started in that shell refuses to come up, and a client pointed at the port
+gets a connection refusal that looks like a server fault.
 
 ## The three pieces
 
@@ -75,14 +85,20 @@ claude mcp add windbg-vm --scope local --transport http http://127.0.0.1:8765/ \
   --header "Authorization: Bearer <the same string>"
 ```
 
-Then drive a local model against it **through ollama's server API**. No second harness is involved
-and nothing has to be launched: a session you already have runs the script, which is how every number
-further down this page was produced.
+**Which model answers is then the client's business, not this server's.** An MCP client that drives
+an ollama model holds that endpoint exactly as an editor does, and ollama ships integrations for
+several of them — `ollama launch` lists them, `ollama launch claude --model <tag>` being one. That
+is the ordinary way to do this, it needs nothing from this repository, and everything below about
+credentials, model choice and the lease applies to it unchanged.
 
+The rest of this page is the **other** way, which exists to *measure* rather than to debug.
 [`tools/local_model_drive.py`](../tools/local_model_drive.py) speaks MCP over HTTP to the listener,
 hands the whole tool surface to `POST /api/chat`, executes the tool calls that come back and feeds
-the results in. It needs a bearer token **of its own** — an environment variable rather than an
-argument, the same rule the listener's own token follows:
+the results in. It is not in a release — the zip is `windbg-mcp.exe`, the `x86\` worker and
+`LICENSE` — so it wants a checkout and Python 3 on whichever machine runs it, which for this project
+is [`agent-sandbox-vm`](https://github.com/glslang/agent-sandbox-vm). It needs a bearer token **of
+its own** — an environment variable rather than an argument, the same rule the listener's own token
+follows:
 
 ```console
 WINDBG_MCP_TOKEN="<the driver's token>" python3 tools/local_model_drive.py [tasks.json]

--- a/docs/local-model.md
+++ b/docs/local-model.md
@@ -89,7 +89,9 @@ claude mcp add windbg-vm --scope local --transport http http://127.0.0.1:8765/ \
 an ollama model holds that endpoint exactly as an editor does, and ollama ships integrations for
 several of them — `ollama launch` lists them, `ollama launch claude --model <tag>` being one. That
 is the ordinary way to do this, it needs nothing from this repository, and everything below about
-credentials, model choice and the lease applies to it unchanged.
+credentials and model choice applies to it unchanged. The **lease** is the one thing that does not:
+which clock reclaims an idle target depends on the revision a client negotiates, and the keepalive
+section says which is which.
 
 The rest of this page is the **other** way, which exists to *measure* rather than to debug.
 [`tools/local_model_drive.py`](../tools/local_model_drive.py) speaks MCP over HTTP to the listener,
@@ -423,6 +425,14 @@ whole tasks in 4 to 10 seconds, two orders off the 440.6s that produced this —
 measures is *silence*, and a queued or rate-limited request is silent in exactly the same way a
 thinking one is. Nothing here has been throttled yet, so that is a prediction rather than a
 measurement; the keepalive costs nothing either way, which is why it stays on by default.
+
+**And it is the driver's answer, not everyone's.** This whole failure is a *lease* failure, and the
+driver is leased because it negotiates `2025-06-18`. A client on `2026-07-28` is never leased at
+all: its targets are reclaimed by the 30-minute per-session idle release instead, which a ping
+cannot refresh — only a call that reaches that session's engine counts, so `session_status` polling
+does not either. A keepalive fitted to such a client keeps nothing alive.
+[`remote-listener.md`](./remote-listener.md) has both clocks, and
+`WINDBG_MCP_SESSION_IDLE_SECS` is the one that moves the second.
 
 ## What to measure
 

--- a/docs/local-model.md
+++ b/docs/local-model.md
@@ -1,8 +1,14 @@
-# Driving this server with a local model
+# Driving this server with ollama
 
-The last plane of the split-plane arrangement: the **model** on your own machine, DbgEng where it
+The last plane of the split-plane arrangement: the **model** wherever you want it, DbgEng where it
 has to live. Nothing here is a feature of this server — it is a runbook, because the pieces are a
-listener you already have, a tunnel, and a client that happens to be pointed at a local model.
+listener you already have, a link to it, and a client that happens to be pointed at ollama.
+
+**Local weights and ollama's cloud are one route, not two.** Both answer at `POST /api/chat` on
+`localhost:11434`, so a cloud tag changes the model name and nothing else — no second harness, no
+integration, and nothing to launch beyond the ollama server itself. Where the two differ is in what
+you can *ask about the run*, which is [its own section](#a-cloud-tag-changes-what-you-can-ask-about-the-run)
+below.
 
 Read [`remote-listener.md`](./remote-listener.md) first for the listener itself; this page is only
 what is different when the thing driving it is not a hosted model.
@@ -15,6 +21,26 @@ clearest case is the arithmetic under *What this server costs a model* below, wh
 the 51-tool surface cannot fit an 8k window, and the grid answers all six tasks at a served 8,192
 anyway.
 
+## Pick an arrangement first
+
+Two choices, independent of one another, and nothing in the driver can tell which you made:
+
+| Where the weights run | Where the listener runs | What links the two |
+| --- | --- | --- |
+| a local ollama instance | this machine | nothing — both are on loopback |
+| a local ollama instance | another machine | an ssh forward |
+| ollama's cloud | this machine | nothing — ollama's own uplink |
+| ollama's cloud | another machine | an ssh forward |
+
+**Only the listener is pinned.** DbgEng is Windows-only and holds one debuggee per process, so the
+Windows machine is wherever the debugging has to happen; everything on the other side of that is a
+preference. The measurements further down come from the second row — the model on a Mac, the engine
+on a Windows VM — and the cloud sighting comes from the third. Neither is *the* arrangement, and
+saying which one produced a number is why they are labelled.
+
+The three pieces below assume the widest row, a listener on another machine. On one machine piece 2
+is not a step at all: leave the listener on `127.0.0.1` and skip the forward.
+
 ## The three pieces
 
 **1 — the engine plane.** The Windows machine runs the listener, bound to loopback, with its token
@@ -24,8 +50,9 @@ in the environment rather than on a command line:
 setx WINDBG_MCP_LISTEN_TOKEN "<a long random string>"
 ```
 
-**2 — the link.** For a session you are driving anyway, one ssh channel both forwards the port and
-runs the listener, so the server lives exactly as long as the tunnel and nothing is left behind:
+**2 — the link, in the two rows that need one.** For a session you are driving anyway, one ssh
+channel both forwards the port and runs the listener, so the server lives exactly as long as the
+tunnel and nothing is left behind:
 
 ```console
 ssh -L 8765:127.0.0.1:8765 <vm> 'windbg-mcp.exe --listen 127.0.0.1:8765'
@@ -60,6 +87,69 @@ argument, the same rule the listener's own token follows:
 ```console
 WINDBG_MCP_TOKEN="<the driver's token>" python3 tools/local_model_drive.py [tasks.json]
 ```
+
+### What that driver is, and is not
+
+A **batch task runner**, and knowing so saves you hunting for what is not there. It takes a list of
+questions, gives each its own conversation and its own targets, allows `MAX_STEPS` tool-calling
+turns apiece (six by default), and prints what happened. There is no interactive mode and no way to
+follow up on an answer — for a session you talk to, you want an MCP client that speaks ollama, which
+`ollama launch claude` is one of and this script is not.
+
+It also carries the bench's knobs, and outside the bench you can ignore them: `WINDBG_MCP_EVAL_OUT`,
+`EVAL_DRAW`, `EVAL_SEED` and `EVAL_SUBSET` exist so `local_model_eval.py` can grade a grid, and with
+`WINDBG_MCP_EVAL_OUT` unset the script keeps nothing at all. The one worth knowing anyway is
+`WINDBG_MCP_SCENARIO`, below.
+
+### Pick a model, and check that it runs
+
+`LOCAL_MODEL` names the tag; with none set the driver takes the first installed model that declares
+the **`tools`** capability, because one without it fails at the first `/api/chat` with an error
+about something else entirely.
+
+**That gate is necessary and not sufficient, and a cloud tag is how you find out.** Pulling a cloud
+model registers a *name* — `ollama ls` shows it with `SIZE -`, since no weights are local — and the
+entitlement is resolved at inference instead. Measured 2026-08-28: `glm-5.3:cloud` reported
+`capabilities: ['completion', 'thinking', 'tools']` and so passed `pick_model` cleanly, and the
+first real call answered *"This model is currently being rolled out and is not yet available to
+you"*. One token settles it before a run does:
+
+```console
+curl -s localhost:11434/api/generate \
+  -d '{"model":"<tag>","prompt":"hi","stream":false,"options":{"num_predict":1}}'
+```
+
+Note also that the driver sends `"think": false`. A model whose card is written around a reasoning
+pass is being asked for something its defaults do not describe, which is worth knowing before
+reading its answers as that model's best.
+
+### A cloud tag changes what you can ask about the run
+
+Everything above this line is identical for local weights and for ollama's cloud. What is not is
+`/api/ps`, which reports the **loaded instance** — and a cloud model has none on this machine.
+Measured on `minimax-m3:cloud` immediately after a successful run: `{"models":[]}`. So
+`runtime_identity()` records `served_context: null` and `model_digest: null`, which puts a cloud row
+where `claude_code_drive.py`'s rows already are — unable to say what it was served or which weights
+answered ([`FOLLOWUPS.md`](../FOLLOWUPS.md) item 46). Two consequences:
+
+- **The served-window rule below has no instrument here**
+  ([The context your runtime serves…](#the-context-your-runtime-serves-is-not-the-models-maximum)).
+  `ollama show` still gives
+  the model's ceiling — 524,288 for that tag, against a ~16k prompt — but there is nothing to
+  confirm what the request was actually served at, so "record what was served" becomes "record that
+  nothing reported it". Do not silently substitute the advertised number for it.
+- **Nothing detects the weights moving under a mutable tag**, which is the axis a comparison of two
+  runs is entirely about. Two cloud runs a month apart can agree on every recorded field and have
+  been different models.
+
+**One sighting, for grounding rather than as a benchmark** (2026-08-28, x64 bench, all 51 tools —
+70,219 B in the function-calling shape `as_ollama` hands the runtime, which is a different
+composition from the `modelVisible` figure tabled below and not comparable with it):
+`minimax-m3:cloud` opened both checked-in x64 kernel dumps and answered
+correctly — `0x13A KERNEL_MODE_HEAP_CORRUPTION` blamed on `MessageManager.sys` at
+`MessageManager+0x1654`, and 227 loaded modules — in 10.0s and 4.2s. It reached the module count
+from `open_dump`'s own summary without calling `modules`, which is the eval's "facts here are
+reachable by more than one route" holding on a runtime it never ran on.
 
 ### Give the run its own listener, not a share of yours
 
@@ -113,7 +203,7 @@ setx WINDBG_MCP_TOOLS_DRIVER        "session,inspect,crash"
 ```
 
 The second line is what makes this work on a listener the editor also uses: the driver is served 20
-tools and 24,445 B while every other client on that listener keeps all 51. Leave it out and the
+tools and 24,894 B while every other client on that listener keeps all 51. Leave it out and the
 driver is served whatever the listener was started with, which is the older behaviour and is the
 right one when the listener is the driver's own.
 
@@ -165,19 +255,25 @@ printed for each task is the transcript growing, and scenario mode is what makes
 or newer) makes the local model *the agent* — it drives the harness itself, with these tools as its
 tools, rather than being called through the API by something else. That is the end state the
 split-plane plan is aimed at, and it is worth knowing about; it is not how anything on this page was
-measured, and it is not needed to measure it.
+measured, and **nothing on this page needs it**. The route above wants the ollama server running and
+nothing else — no integration, and no harness of the model's own.
 
 ## What this server costs a model, measured
 
 [`token-budget.md`](./token-budget.md) has the method and the golden; these are the numbers that
-decide whether a local model can hold this surface at all. Bytes of minified JSON, ≈4 B/token.
+decide whether a model can hold this surface at all. Bytes of minified JSON, ≈4 B/token.
+
+The three surface rows are re-derivable without running anything here: the full one is
+`tests/golden/tool_budget.json`'s `modelVisible` total, which `cargo test` re-records, and a
+narrowed one is the same sum over a `tools/list` served by a listener started with that `--tools`
+spec. Re-read them rather than trusting this table, which has been stale before.
 
 | | bytes | ≈tokens |
 |---|---|---|
-| The tool surface, paid once per conversation | 67,766 (51 tools) | ~17k |
-| — the same surface as `--tools session,inspect,crash` | 24,445 (20 tools) | ~6k |
-| — as `--tools crash` | 14,138 (11 tools) | ~3.5k |
-| Its worst single tool (`debug_batch`) | 9,746 | ~2.4k |
+| The tool surface, paid once per conversation | 68,322 (51 tools) | ~17k |
+| — the same surface as `--tools session,inspect,crash` | 24,894 (20 tools) | ~6k |
+| — as `--tools crash` | 14,587 (11 tools) | ~3.6k |
+| Its worst single tool (`debug_batch`) | 9,798 | ~2.4k |
 | The largest answer this server gives (`modules`) | 53,875 | ~13k |
 | `read_memory` at its design limit | ~4 MiB of hex | ~1M |
 
@@ -199,6 +295,11 @@ ollama ps                        # what the *loaded* instance is serving, under 
 so send it one prompt first — `curl -s localhost:11434/api/generate -d
 '{"model":"<tag>","prompt":"hi","stream":false,"options":{"num_predict":1}}'` is enough. Pin it with
 `OLLAMA_CONTEXT_LENGTH` if two machines have to agree.
+
+**Both lines assume a local instance**, and this whole section is about one. A cloud tag has no
+instance here, so `ollama ps` stays empty even straight after a call and the second question has no
+answer at all — not a large one, and not the number `ollama show` prints. See
+[A cloud tag changes what you can ask about the run](#a-cloud-tag-changes-what-you-can-ask-about-the-run).
 
 Worked example, measured on the bench this page was written on: `ollama show` reports
 `context length 262144` for a 27.8B nvfp4 build, and `ollama ps` reports `CONTEXT 262144` with
@@ -301,6 +402,12 @@ the re-run, and every session was released cleanly at the end. Whether the *list
 be more patient with a client whose MCP session is still connected is
 [`FOLLOWUPS.md`](../FOLLOWUPS.md) item 33.
 
+**A fast model does not retire the hazard, it just stops meeting it.** The cloud tag above answered
+whole tasks in 4 to 10 seconds, two orders off the 440.6s that produced this — but what the grace
+measures is *silence*, and a queued or rate-limited request is silent in exactly the same way a
+thinking one is. Nothing here has been throttled yet, so that is a prediction rather than a
+measurement; the keepalive costs nothing either way, which is why it stays on by default.
+
 ## What to measure
 
 The claims worth testing are about the *client's* budget, not this server's correctness, and the
@@ -329,8 +436,8 @@ budget, a text-or-data content switch. **Two of the three now exist, and neither
 client-side.**
 
 - **The tool-surface profile is `--tools`** (2026-08-22). Start the listener with
-  `--tools session,inspect,crash` and the surface is 20 tools and 24,445 B instead of 51 and
-  67,766 — `--tools crash` is 11 and 14,138 B, which is the difference between "roughly twice an 8k
+  `--tools session,inspect,crash` and the surface is 20 tools and 24,894 B instead of 51 and
+  68,322 — `--tools crash` is 11 and 14,587 B, which is the difference between "roughly twice an 8k
   window" and "half of one". The tools that remain are the tools they were, less the sentences
   pointing at ones that went (item 41).
   The whole table is in [`token-budget.md`](./token-budget.md) under finding 8, and the README has
@@ -352,7 +459,9 @@ here — only the choice to offer fewer tools.
 Four checks, in the order that fails fastest:
 
 ```console
-ollama list                                   # is the model still there
+ollama list                                   # is the model still there (a cloud tag being
+                                              # listed is not the same as being runnable —
+                                              # send it one token, above)
 claude mcp list                               # windbg-vm: connected, or ConnectionRefused?
 ssh <vm> 'powershell -c "(Get-NetTCPConnection -State Listen -LocalPort 8765).Count"'
 ssh <vm> 'powershell -c "[bool][Environment]::GetEnvironmentVariable(\"WINDBG_MCP_LISTEN_TOKEN\",\"User\")"'

--- a/docs/mcp-clients.md
+++ b/docs/mcp-clients.md
@@ -28,7 +28,9 @@ claude mcp add windbg-vm --transport http http://127.0.0.1:8765/ \
   --header "Authorization: Bearer <the same string>"
 ```
 
-Install it as a **Windows service** (`--install-service --listen <addr>`, elevated) and it survives
+Install it as a **Windows service** (`--install-service --listen <addr>`, elevated, and from a
+directory Windows protects — see [Run it as a Windows
+service](remote-listener.md#run-it-as-a-windows-service)) and it survives
 logout, starts at boot, and gets a defined `PATH` and working directory — which is what decides
 whether the engine DLLs beside the exe are the ones that load. `Stop-Service` releases every debug
 target before exiting, because a live kernel that is merely killed is left frozen. Its clients are

--- a/docs/remote-listener.md
+++ b/docs/remote-listener.md
@@ -6,7 +6,7 @@ the machine DbgEng needs — a Mac driving a Windows VM, say.
 
 **`--tools` works here exactly as it does on stdio**, and matters more: the client at the far end
 may be a local model whose window is bought in RAM. `--listen 127.0.0.1:8765 --tools
-session,inspect,crash` serves 20 tools and 24,445 B of model context instead of 51 and 67,766 — the
+session,inspect,crash` serves 20 tools and 24,894 B of model context instead of 51 and 68,322 — the
 README has the table, and [`local-model.md`](./local-model.md) is the runbook it was measured for.
 It is this listener's **default**: a client may be given a surface of its own, which is what lets
 one server hold a local model and a hosted client at once — see [A tool surface per

--- a/docs/token-budget.md
+++ b/docs/token-budget.md
@@ -87,7 +87,7 @@ The two halves moved independently, which is the whole argument for measuring th
 fell by 55% and the model-visible column did not move at all except for what the tools themselves
 have accumulated since.
 
-Worst single tool: `debug_batch` at 9,746 model-visible bytes, because its `inputSchema` pulls the
+Worst single tool: `debug_batch` at 9,798 model-visible bytes, because its `inputSchema` pulls the
 whole `StepAction`/`Check` vocabulary out of `src/batch.rs`.
 
 The payload is measured as the **serialized result**, not as the sum of its tools, and the 118-byte
@@ -280,7 +280,7 @@ None of these is a bug. They are recorded because they were invisible, and
    even covers `w29`.
 8. **Five tools are a third of the model-visible surface**, and it is their *input* schemas rather
    than their prose — **answered** (2026-08-22) by serving fewer tools rather than smaller ones.
-   `debug_batch` alone is 9,746 B — 14% of everything a model is given before it asks anything — of
+   `debug_batch` alone is 9,798 B — 14% of everything a model is given before it asks anything — of
    which 7,980 B is the `StepAction`/`Check` vocabulary its schema pulls out of `src/batch.rs`.
    Then `walk_memory` 4,080, `crash_triage` 2,936, `reachable_from_dispatch` 2,628, `server_log`
    2,599: **21,989 B, 33%**, against a median tool of 900 B.
@@ -302,7 +302,7 @@ None of these is a bug. They are recorded because they were invisible, and
    schemars emits 109 times and which tells a model nothing an absent field does not, is 1,744 B —
    2.6%. The other candidates are not free: `$schema` is 2,850 B but is how a client picks a
    validator dialect (and `tool_schemas_declare_one_dialect_and_are_self_contained` pins it), and
-   `minimum`/`format` are constraints. **Roughly 1.7 KB of 67,766 is the whole honest total** for
+   `minimum`/`format` are constraints. **Roughly 1.7 KB of 68,322 is the whole honest total** for
    trimming the schemas.
 
    So the third lever is the one taken: `--tools` (`src/toolset.rs`) advertises a named subset. A
@@ -312,29 +312,29 @@ None of these is a bug. They are recorded because they were invisible, and
 
    | group | tools | bytes | share |
    |---|---:|---:|---:|
-   | `allocator` | 10 | 15,969 | 23.6% |
-   | `session` | 10 | 12,157 | 17.9% |
-   | `inspect` | 9 | 10,215 | 15.1% |
-   | `batch` | 1 | 9,746 | 14.4% |
-   | `ttd` | 9 | 6,829 | 10.1% |
-   | `ioctl` | 6 | 6,494 | 9.6% |
-   | `exec` | 5 | 3,420 | 5.0% |
+   | `allocator` | 10 | 15,969 | 23.4% |
+   | `session` | 10 | 12,606 | 18.5% |
+   | `inspect` | 9 | 10,215 | 15.0% |
+   | `batch` | 1 | 9,798 | 14.3% |
+   | `ttd` | 9 | 6,829 | 10.0% |
+   | `ioctl` | 6 | 6,494 | 9.5% |
+   | `exec` | 5 | 3,475 | 5.1% |
    | `crash` | 1 | 2,936 | 4.3% |
 
    | `--tools` | tools | model |
    |---|---:|---:|
-   | *(absent)* | 51 | 67,766 |
-   | `session,inspect,exec,crash` | 25 | 27,807 |
-   | `session,inspect,crash` | 20 | 24,445 |
-   | `crash` | 11 | 14,138 |
+   | *(absent)* | 51 | 68,322 |
+   | `session,inspect,exec,crash` | 25 | 28,311 |
+   | `session,inspect,crash` | 20 | 24,894 |
+   | `crash` | 11 | 14,587 |
 
    **The two tables do not reconcile, and that is the point of item 41.** The first is each group's
    share of the whole surface; the second is what a spec actually serves, which is less — `crash`
-   is 14,138 rather than the 15,093 its two rows sum to, because five cross-references leave with
+   is 14,587 rather than the 15,542 its two rows sum to, because five cross-references leave with
    the tools they name.
 
    `session` is in every surface because every other tool routes by a `session_id` this server is
-   the only issuer of — 11,265 B is the floor, and `crash` is eleven tools rather than one. The
+   the only issuer of — 11,714 B is the floor, and `crash` is eleven tools rather than one. The
    flag is a **run's** choice, and on a listener it is the *default*: a named client may be
    configured with a spec of its own (`WINDBG_MCP_TOOLS_<NAME>`), so the figures above are per
    client rather than per server — which is what lets a local model and a hosted client share one
@@ -359,7 +359,7 @@ put in a group would vanish from every narrowed surface without a word — the d
 still carry it, so nothing else would notice. And
 `a_narrowed_tool_surface_serves_only_what_it_was_asked_for` starts a server with `--tools crash` and
 checks the three things that makes true: eleven tools, a refusal by name for a tool that exists and
-is not served, and a figure under half the whole surface (it prints 14,138 B).
+is not served, and a figure under half the whole surface (it prints 14,587 B).
 
 Beside them, `output_schemas_carry_constraints_not_prose` is the
 assertion that finding 1 stays fixed. It reads `tools/list` off the wire, so it catches the way that

--- a/docs/tool-surface.md
+++ b/docs/tool-surface.md
@@ -6,7 +6,7 @@ how much of that surface a run serves, and three behaviours the table has no roo
 ## Serving fewer tools (`--tools`)
 
 All fifty-one tools are served unless you say otherwise, and their definitions cost the model
-**67,766 bytes — about 17k tokens — before it has asked anything**, once per conversation. Three
+**68,322 bytes — about 17k tokens — before it has asked anything**, once per conversation. Three
 quarters of that is the prose that tells a model how to drive them, so it cannot be trimmed without
 making the tools harder to use correctly (see
 [`token-budget.md`](token-budget.md)). What *can* change is how many of them a given run
@@ -18,10 +18,10 @@ windbg-mcp.exe --tools session,inspect,crash
 
 | `--tools` | Tools | Model context |
 |---|---:|---:|
-| *(absent)* — every tool | 51 | 67,766 B |
-| `session,inspect,exec,crash` | 25 | 27,807 B |
-| `session,inspect,crash` | 20 | 24,445 B |
-| `crash` | 11 | 14,138 B |
+| *(absent)* — every tool | 51 | 68,322 B |
+| `session,inspect,exec,crash` | 25 | 28,311 B |
+| `session,inspect,crash` | 20 | 24,894 B |
+| `crash` | 11 | 14,587 B |
 
 The spec is a comma-separated list of the group names in the [tool table](../README.md#tools), of
 individual tool names, or `all`.

--- a/skills/windbg-debugging/setup.md
+++ b/skills/windbg-debugging/setup.md
@@ -592,3 +592,46 @@ request carried.
 `docs/remote-listener.md` in the repository is the operator's reference for the rest — the grace
 and how to change it, what a `409` means, running behind a service, and adding, revoking or
 rotating a client while it runs.
+
+## What drives the server — there is a choice
+
+Everything above assumes an MCP client with a hosted model, over stdio or the listener. That is one
+of three arrangements, and the other two need nothing added to this server: a listener is an HTTP
+MCP endpoint, and anything that speaks MCP can hold one.
+
+- **An MCP client with a hosted model** — Claude Code, an editor. The default; nothing else in this
+  file changes.
+- **A model in ollama.** The repository's `tools/local_model_drive.py` speaks MCP to the listener,
+  hands it the tool surface, and executes the tool calls that come back from `POST /api/chat` on
+  `localhost:11434`. Nothing has to be installed on either side and nothing has to be launched
+  beyond the ollama server itself — `ollama launch claude` is a *different* arrangement, not a
+  prerequisite for this one.
+- **A model in ollama's cloud.** The same endpoint and the same script; a cloud tag changes the
+  model name and nothing else.
+
+Four things decide whether the ollama route works, and none of them is about the debugger:
+
+- **Give it a credential of its own**, never the one your editor is registered with. Two tokens are
+  two namespaces, so a run on a shared one can see, route to, and at the four-session cap cause the
+  reclamation of, the targets you are working in. `--add-listen-client <name>` mints one, and
+  `--tools <spec>` beside it serves that client a surface of its own.
+- **A `tools` capability is necessary and not sufficient.** The driver picks the first installed
+  model that declares one, because a model without it fails at the first call with an error about
+  something else. A *cloud* tag can declare it and still not be runnable — it is a registered name
+  with no local weights, and the entitlement is resolved at inference — so send it one token first
+  (`/api/generate` with `num_predict: 1`) rather than discovering it mid-run.
+- **A model that goes quiet loses its sessions**, and it reads as a broken server. A client whose
+  revision mints an `Mcp-Session-Id` holds the lease described above, and its grace is derived from
+  how long a *call* may take — on the assumption that the server is the slow party. A model
+  thinking, or a cloud request being queued, is silence with nothing in flight: past the grace the
+  sweep releases that credential's sessions and every later call answers `404`. The driver pings
+  during a long turn; anything else driving the listener needs its own equivalent.
+- **The surface is the fixed cost and a single answer is the variable one.** All 51 tools are about
+  70 kB of JSON, paid once per conversation and narrowable per client with `--tools`; one careless
+  `read_memory` is up to ~4 MiB, paid on the spot. Narrowing costs fewer *answers* than it does
+  tools — most facts here are reachable by more than one route — so it is a real option rather than
+  a mutilation.
+
+`docs/local-model.md` in the repository is the runbook for that route: the listener, the link, the
+credential, choosing a tag, and what a cloud tag can no longer tell you about its own run.
+`docs/local-model-eval.md` is the graded grid behind the claim about narrowing.

--- a/skills/windbg-debugging/setup.md
+++ b/skills/windbg-debugging/setup.md
@@ -543,10 +543,16 @@ Four things decide whether that works, and each fails in a way that reads as som
   over the link from the client, and never over the KD wire from the target. A client with symbols
   configured and a server without resolves nothing.
 - **For anything longer than one session, install it as a service** (`--install-service --listen
-  <addr>`, elevated) — and then **start it**. Installing only *registers* it; "starts
-  automatically" means from the next boot, so `Start-Service windbg-mcp` is what gets you an
-  endpoint in this one. Skip that and everything keeps working until the foreground listener stops,
-  and there is nothing listening after it. Once running it survives logout, comes back at boot, and
+  <addr>`, elevated, **from a directory Windows protects**) — and then **start it**. Installing only
+  *registers* it; "starts automatically" means from the next boot, so `Start-Service windbg-mcp` is
+  what gets you an endpoint in this one. Skip that and everything keeps working until the foreground
+  listener stops, and there is nothing listening after it. The **directory** is a refusal rather
+  than advice: the SCM stores that exact path for a `LocalSystem` auto-start service, so
+  `--install-service` rejects an exe outside `%ProgramFiles%`, `%ProgramFiles(x86)%` or
+  `%SystemRoot%` — which a downloaded zip, a Scoop shim and a `target\release` build all are. Move
+  the whole deployment there first, engine DLLs and `x86\` included; `--allow-unprotected-path`
+  installs in place, and is a development install rather than a deployment.
+  Once running it survives logout, comes back at boot, and
   has a defined working directory — which is what decides whether the engine DLLs beside the exe
   are the ones that load. Note `LocalSystem` does not read *your* `%USERPROFILE%`, so kernel
   profiles have to be configured machine-wide for a service to see them. Giving it a **second

--- a/skills/windbg-debugging/setup.md
+++ b/skills/windbg-debugging/setup.md
@@ -620,12 +620,18 @@ Four things decide whether the ollama route works, and none of them is about the
   something else. A *cloud* tag can declare it and still not be runnable — it is a registered name
   with no local weights, and the entitlement is resolved at inference — so send it one token first
   (`/api/generate` with `num_predict: 1`) rather than discovering it mid-run.
-- **A model that goes quiet loses its sessions**, and it reads as a broken server. A client whose
-  revision mints an `Mcp-Session-Id` holds the lease described above, and its grace is derived from
-  how long a *call* may take — on the assumption that the server is the slow party. A model
-  thinking, or a cloud request being queued, is silence with nothing in flight: past the grace the
-  sweep releases that credential's sessions and every later call answers `404`. The driver pings
-  during a long turn; anything else driving the listener needs its own equivalent.
+- **A model that goes quiet can lose its sessions, and which of the two clocks above takes them
+  depends on the revision its client negotiated** — so the remedy is not the same one. A client
+  still minting an `Mcp-Session-Id` holds the **lease**, whose grace is derived from how long a
+  *call* may take, on the assumption that the server is the slow party; a thinking model or a queued
+  cloud request is silence with nothing in flight, and *any* admitted request renews it, which is
+  why the benchmark's driver simply pings. A client on `2026-07-28` — most of them now — is never
+  leased, and what reclaims its targets is the 30-minute **idle release** instead, which a ping
+  cannot refresh: only a call that reaches that session's engine counts, which is the same rule that
+  makes `session_status` polling useless above. So do not fit a keepalive to a stateless client. It
+  needs real work, a longer `WINDBG_MCP_SESSION_IDLE_SECS`, or nothing at all — thirty minutes of
+  thinking is a much rarer thing than the lease's grace, and a session with a call still outstanding
+  is spared either way.
 - **The surface is the fixed cost and a single answer is the variable one.** All 51 tools are about
   70 kB of JSON, paid once per conversation and narrowable per client with `--tools`; one careless
   `read_memory` is up to ~4 MiB, paid on the spot. Narrowing costs fewer *answers* than it does

--- a/skills/windbg-debugging/setup.md
+++ b/skills/windbg-debugging/setup.md
@@ -601,11 +601,11 @@ MCP endpoint, and anything that speaks MCP can hold one.
 
 - **An MCP client with a hosted model** — Claude Code, an editor. The default; nothing else in this
   file changes.
-- **A model in ollama.** The repository's `tools/local_model_drive.py` speaks MCP to the listener,
-  hands it the tool surface, and executes the tool calls that come back from `POST /api/chat` on
-  `localhost:11434`. Nothing has to be installed on either side and nothing has to be launched
-  beyond the ollama server itself — `ollama launch claude` is a *different* arrangement, not a
-  prerequisite for this one.
+- **A model in ollama.** An MCP client that drives an ollama model holds the listener exactly as an
+  editor does — ollama ships integrations for several of them (`ollama launch` lists them), nothing
+  here has to be installed, and this server never learns which kind of model answered. The
+  repository's `tools/local_model_drive.py` is **not** that route: it is the benchmark's batch
+  driver, it wants a checkout and Python, and it ships in no release.
 - **A model in ollama's cloud.** The same endpoint and the same script; a cloud tag changes the
   model name and nothing else.
 

--- a/src/toolset.rs
+++ b/src/toolset.rs
@@ -1,7 +1,7 @@
 //! Which of this server's fifty-one tools a run advertises.
 //!
 //! The tool surface is paid **once per conversation, before anything is debugged**, and it is
-//! 67,873 bytes — roughly 17k tokens. Three quarters of that is prose, and the prose is what tells
+//! 68,322 bytes — roughly 17k tokens. Three quarters of that is prose, and the prose is what tells
 //! a model how to drive the tools, so there is no strip here the way there was in
 //! [`crate::schema`]: `FOLLOWUPS.md` item 24 measured it and the only honest lever left is the one
 //! this module is — **not offering every tool to every caller**.
@@ -19,7 +19,7 @@
 //!
 //! ```text
 //!   group      tools   bytes   what it is for
-//!   session       10   12,157  opening a target, ending it, and watching this server
+//!   session       10   12,606  opening a target, ending it, and watching this server
 //!   allocator     10   15,969  pool and heap walks, and `walk_memory`
 //!   inspect        9   10,215  registers, stacks, memory, modules, symbols, raw commands
 //!   ttd            9    6,829  recording, indexing and querying a Time Travel trace
@@ -30,7 +30,7 @@
 //! ```
 //!
 //! **Those are shares of the whole surface, and they do not sum to a narrowed one.** `crash` reads
-//! 14,138 bytes, not the 15,093 its two rows add to, because the eleven tools it keeps also stop
+//! 14,587 bytes, not the 15,542 its two rows add to, because the eleven tools it keeps also stop
 //! carrying the five sentences that pointed at `modules`, `debug_batch`, `go` and `backtrace`. A
 //! spec is always cheaper than its rows suggest, never dearer.
 //!
@@ -38,7 +38,7 @@
 //!
 //! Not a convenience: every other tool here routes by a `session_id`, and this server is the only
 //! thing that can issue one. A surface with `registers` and no opener cannot be used at all, so a
-//! spec that leaves one out is asking for something that does not exist. On its own it is 11,265
+//! spec that leaves one out is asking for something that does not exist. On its own it is 11,714
 //! bytes, and that is the floor of any usable surface — `--tools crash` is eleven tools, not one,
 //! and the startup line says so rather than leaving the addition to be discovered.
 //!

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -2095,7 +2095,7 @@ fn every_tool_belongs_to_exactly_one_group() {
 
 /// A narrowed surface serves fewer tools, and says so rather than pretending the rest never were.
 ///
-/// The measurement behind `--tools` is that three quarters of the 67,873-byte tool surface is
+/// The measurement behind `--tools` is that three quarters of the 68,322-byte tool surface is
 /// prose a model needs, so the only way to spend less of a caller's context is to offer fewer
 /// tools — `FOLLOWUPS.md` item 24. This asserts the three things that makes true.
 #[test]


### PR DESCRIPTION
## What this is

`ollama` has been a working way to drive this server for as long as a listener has existed, and
nothing said so anywhere a reader would look. The skill's only mention of a local model was half a
sentence inside the `--install-service` bullet, and it linked to none of the three documents that
carry the subject.

## Driving it is the client's job

The correction that shaped this PR: **`tools/local_model_drive.py` is not how anyone uses this.**
It ships in no release — the zip is `windbg-mcp.exe`, the `x86\` worker and `LICENSE` — wants a
checkout and Python 3, and has no interactive mode. It exists to *measure* a model, not to debug
with one.

Driving this server with an ollama model is the client's job: an MCP client that drives one holds
the listener exactly as an editor does, ollama ships integrations for several of them
(`ollama launch` lists them), and nothing from this repository is involved. `README.md`, the skill
and `docs/local-model.md` say that now, and the driver sits beside the grid it exists to run, with
its checkout-and-Python prerequisite stated and
[`agent-sandbox-vm`](https://github.com/glslang/agent-sandbox-vm) named as the environment that has
one.

## `README.md`

Its single section on the subject was the eval — the grid, the axes, the findings — so someone
asking whether a local model is supported at all, how the listener is configured, or whether a Mac
can drive a Windows host over ssh found none of it. The answer to all three is yes.

It is two sections now. **Driving it** opens on a table of the five configurations:

| What drives it | Where that runs | The server | Reached over |
|---|---|---|---|
| An MCP client — Claude Code, Cursor, Claude Desktop | the Windows machine | launched by the client | stdio |
| An MCP client | a Mac, or any other machine | a Windows host, `--listen`, usually as a service | HTTP through an ssh forward |
| A model in **ollama** | the Windows machine | the same machine, `--listen` on loopback | HTTP on loopback |
| A model in **ollama** | a Mac | a Windows host, `--listen` as a service | HTTP through an ssh forward |
| A model in **ollama's cloud** | wherever ollama runs | either of the above | unchanged — the tag is all that differs |

Then the commands that install **and start** the listener as a service, the ssh forward, and why
the token is not optional — this endpoint serves `execute`, `launch` and `debug_batch`. The
benchmark follows as its own section, backing those claims instead of standing in for them.

## The skill

`skills/windbg-debugging/setup.md` gains a closing section, *What drives the server — there is a
choice*: the three arrangements, then the four things that decide whether the ollama route works —
a credential of its own, the `tools` capability being necessary and not sufficient, the lease a
quiet client loses its sessions to, and the surface as the fixed cost against `read_memory` as the
variable one. The depth stays in `docs/local-model.md` rather than being copied.

## `docs/local-model.md`

It was the bench wearing a runbook's title, opening on *the three pieces* with an ssh forward baked
in as piece 2, because the grid that produced its numbers had the model on a Mac and the engine on a
Windows VM. Where the weights run and where the listener runs are independent choices, so it now
opens on the four arrangements they make, says only the listener is pinned and why, and labels which
row each measurement came from. The single-machine path carries its own listener command, since the
ssh line is what *starts* the server as well as tunnelling to it.

## Three cloud findings, measured 2026-08-28

Verified against `glm-5.3:cloud` and `minimax-m3:cloud`; a local bench could not have produced any
of them.

- **A pulled cloud tag is a registered name, not a runnable model.** `glm-5.3:cloud` reported
  `capabilities: ['completion', 'thinking', 'tools']`, passed the driver's model gate cleanly, and
  answered the first real call with *"This model is currently being rolled out and is not yet
  available to you"*. The gate is necessary and not sufficient; a one-token `/api/generate` is the
  probe.
- **`/api/ps` is empty for a cloud model** even straight after a successful run, so
  `served_context` and `model_digest` record null — the served-window rule has no instrument, and
  nothing detects weights moving under a mutable tag. That is the position `claude_code_drive.py`'s
  rows are already in.
- **The keepalive stays on** despite whole tasks answering in 4–10s, because what the lease measures
  is silence, and a queued request is silent the same way a 440s thinking turn is.

Grounding sighting, labelled as one: `minimax-m3:cloud` opened both checked-in x64 kernel dumps and
answered correctly — `0x13A KERNEL_MODE_HEAP_CORRUPTION` on `MessageManager.sys` at
`MessageManager+0x1654`, and 227 loaded modules — reaching the module count from `open_dump`'s own
summary without calling `modules`.

## The surface figures

Stale in eight files and disagreeing with each other in two. Re-derived from checked-in artefacts,
none of which needs the eval run:

| | was | is |
|---|---:|---:|
| whole surface (51 tools) | 67,766 / 67,873 | **68,322** |
| `session,inspect,exec,crash` (25) | 27,807 | **28,311** |
| `session,inspect,crash` (20) | 24,445 | **24,894** |
| `crash` (11) | 14,138 | **14,587** |
| `session` floor (10) | 11,265 | **11,714** |
| `debug_batch` | 9,746 | **9,798** |

The whole surface is `tests/golden/tool_budget.json`'s `modelVisible` total, which `cargo test`
re-records; each group's share is that golden summed over `src/toolset.rs`'s membership, which
reconciles to the total across all 51 tools; what a `--tools` spec *serves* is the same sum over a
`tools/list` from a listener started with it. The method was validated by reproducing the golden's
68,322 exactly before any narrowed surface was trusted. The developer-facing copies moved too —
`src/toolset.rs`'s module table and floor, `tests/mcp_smoke.rs`'s note on why `--tools` exists, and
`CLAUDE.md` — since a figure in a doc comment is a current claim like any other.

**Historical figures are deliberately untouched** — `token-budget.md`'s `67,076 → 67,766`
before-and-after column, `FOLLOWUPS.md` item 41, `local-model-eval.md`'s statement of the conditions
its grid ran under, and `CHANGELOG.md`'s earlier entries each record a measured moment and would be
falsified by a refresh.

## Not in this change

- The eval and its numbers. `docs/local-model-eval.md` is untouched; no benchmark was re-run.
- `docs/token-budget.md`'s "74% of the surface is prose" — carried over with the corrected byte
  figure, but the percentage itself was not re-derived.
- A plugin version bump. A skill edit reaches an installed plugin only when
  `.claude-plugin/plugin.json` moves, so this lands on GitHub and on nobody's machine until a
  release.

## Verification

`npx markdownlint-cli2@0.23.2 README.md CHANGELOG.md "docs/**/*.md" "skills/**/*.md"` — clean, which
covers MD051 for the new in-file fragment links. `cargo fmt --all --check` and
`cargo check --all-targets` are clean: the only changes under `src/` and `tests/` are doc comments
carrying surface figures, so no behaviour moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
