### PR TITLE
Hand the TTD-engine-bundling work over: the WinDbg bundle is a source, not a workaround

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   finishes, the provisional closed reason is refined with whether the target was released, the
   worker was parked, or it was already gone.
 
+### Documentation
+
+- **The WinDbg engine payload has three sources, not one, and the two that need no interactive
+  install are now first-class** (issue
+  [#132](https://github.com/glslang/windbg-mcp/issues/132)). TTD `.run` replay needs a `ttd\`
+  directory beside `windbg-mcp.exe`; System32's `dbgeng.dll` ships none of it, the SDK Debugging
+  Tools do not either, and MSIX registration fails from a non-interactive session
+  (`Add-AppxPackage` → `0x80070005`, even elevated) — so a host reached over SSH could record
+  traces and not replay them. `setup.md` had carried the way through since #133, as an appendix
+  headed *when the store package will not install*; it is now source (b) of three named up front,
+  because the store package's `InstallLocation\<arch>` and the unpacked `.msixbundle`'s `<arch>\`
+  are the **same layout** — so the three sources differ only in how they set `$wd` and the copy
+  after them is one block rather than two. What decided it was that this repository's own TTD smoke
+  tier already runs against an engine bundled that way, so the route the documentation held at
+  arm's length was the one its coverage stood on.
+- **That recipe did not work, and had not since the day it was written** (`8bd98a5`, 2026-08-16).
+  Its first line read the `.appinstaller` with `(Invoke-WebRequest …).Content` and cast it to
+  `[xml]`; under Windows PowerShell 5.1 that property is a `Byte[]` for this content type, so the
+  cast threw and nothing was downloaded at all. It now fetches to a file and reads it back with
+  `Get-Content -Raw`, which is version-proof. Found by running it end to end for the first time, on
+  the ARM64 host the issue was filed from — which also measured what the endorsement rests on: the
+  bundle verifies as `Valid` / `Authenticode` / `CN=Microsoft Corporation`, is 1,188,564,441 bytes,
+  and **all three** payload trees inside it (`amd64\`, `arm64\`, `x86\`) hold the entire copy
+  list, `msdia140.dll` included — plus `ttd\TTD.exe`, so the engine copy already brings the
+  *recorder* and not just the replay engine, which `setup.md` and `docs/install.md` now say. The
+  recipe gains a publisher check before it unpacks anything, and `setup.md` states what that
+  settles (provenance) and what it does not (that an unregistered payload is a supported Microsoft
+  configuration). That bench was then bundled from the payload and **replays**: a 40 MB trace
+  recorded with the bundled `ttd\TTD.exe`, opened by `open_trace` reporting its lifetime rather
+  than the missing-`ttd\` diagnostic, and stepped backward with `step_back`. The issue is closed
+  on the host it was filed from, and `FOLLOWUPS.md` item 47's blocker — TTD replay being
+  unavailable on that bench — goes with it.
+
 ## [0.13.2] - 2026-08-28
 
 ### Documentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,9 +52,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and **all three** payload trees inside it (`amd64\`, `arm64\`, `x86\`) hold the entire copy
   list, `msdia140.dll` included — plus `ttd\TTD.exe`, so the engine copy already brings the
   *recorder* and not just the replay engine, which `setup.md` and `docs/install.md` now say. The
-  recipe gains a publisher check before it unpacks anything, and `setup.md` states what that
-  settles (provenance) and what it does not (that an unregistered payload is a supported Microsoft
-  configuration). That bench was then bundled from the payload and **replays**: a 40 MB trace
+  recipe gains a publisher check before it unpacks anything, `setup.md` states what that settles
+  (provenance) and what it does not (that an unregistered payload is a supported Microsoft
+  configuration), and the update advice now says to clear the four wholesale-copied directories
+  first — `Expand-Archive -Force` and `Copy-Item -Force` overwrite collisions and delete nothing,
+  so re-running merges a new payload into the old one rather than replacing it. That bench was then bundled from the payload and **replays**: a 40 MB trace
   recorded with the bundled `ttd\TTD.exe`, opened by `open_trace` reporting its lifetime rather
   than the missing-`ttd\` diagnostic, and stepped backward with `step_back`. The issue is closed
   on the host it was filed from, and `FOLLOWUPS.md` item 47's blocker — TTD replay being

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`record_trace` finds the recorder the engine copy already delivered.** `setup.md`'s one-time
+  engine bundle takes the whole `ttd\` directory, and that directory carries `TTD.exe` as well as
+  the replay DLLs — but `find_ttd` probed `PATH`, the SDK layout and `WindowsApps` and never its
+  own directory, so the one layout this project's own documentation tells people to create was the
+  one it did not know. A host bundled exactly as documented could replay a trace and not record
+  one, unless the recorder was *also* put on `PATH`. It now probes the bundle beside the
+  executable, ranked below `PATH` so that override still wins
+  ([#131](https://github.com/glslang/windbg-mcp/issues/131)) and above the machine-wide installs,
+  since the payload next to the binary is the pair to the engine the loader actually gives this
+  process.
 - **`end_session` stops accepting work when its teardown reaches the front of the session queue
   ([#64](https://github.com/glslang/windbg-mcp/issues/64)).** The pump now marks the session closed
   immediately before forwarding `EndSession`: calls already ahead of it still run, while calls

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -8,7 +8,9 @@ MCP `2026-07-28` extensions (tasks, apps), item 12 from the opener split
 from transactional batches (#82, 2026-08-09/10 — item 17 is what validating the tool against the CTF
 session's own transcript turned up, and item 18 what reviewing it did), item 19 from
 `walk_memory` (#103, 2026-08-13), items 20–22 from standing the server up on an ARM64 guest
-(#131, #132, #134, 2026-08-16), item 23 from making the listener usable rather than merely
+(#131, #132, #134, 2026-08-16 — **all three have since landed**, item 21 last, on 2026-08-29, once
+the repo's own TTD tier turned out to depend on the route its docs called a fallback), item 23 from
+making the listener usable rather than merely
 working (2026-08-17), items 24, 35 and 36 from measuring what this server costs the model driving
 it — the surface and the results first (2026-08-17), then what a `registers` answer is actually
 made of, and then `--tools` landing server-wide on a listener whose clients are already named
@@ -646,7 +648,7 @@ covered by unit tests rather than a live probe, because the ARM64 host it was fo
 a TTD in either layout — its recorder is the `PATH` copy, which is the workaround this removes the
 need for.
 
-## 21. [windbg-mcp] TTD replay on a host where the store package will not install
+## 21. [windbg-mcp] TTD replay on a host where the store package will not install — **done** (2026-08-29, #132)
 
 `open_trace` needs the replay engine — `TTDReplay*.dll`, `TtdExt.dll`, `TTDAnalyze.dll` — in a
 `ttd\` directory beside `windbg-mcp.exe`. System32's `dbgeng.dll` ships none of it and rejects every
@@ -665,13 +667,84 @@ judgement call rather than a task. `open_trace` now says *why* a trace will not 
 surfacing `0x80070057`, and `setup.md` carries a recipe for unpacking `ttd\` from the
 `.msixbundle`, which is an ordinary zip. So the failure is legible and there is a way through it.
 
-What is undecided is whether unpacking a Microsoft package by hand should be a **supported** path
-in this project's own documentation — it is currently written down as a fallback, not endorsed — or
-whether the answer is to require an interactive install and say so plainly. That is a maintainer's
-call about what this repo is willing to tell people to do, not an engineering problem.
+What was undecided is whether unpacking a Microsoft package by hand should be a **supported** path
+in this project's own documentation — it was written down as a fallback, not endorsed — or whether
+the answer is to require an interactive install and say so plainly. That is a maintainer's call
+about what this repo is willing to tell people to do, not an engineering problem.
 
-Picks up at [`setup.md`](./skills/windbg-debugging/setup.md)'s *When the store package will not
-install*, and [#132](https://github.com/glslang/windbg-mcp/issues/132).
+**Resolved as endorsed**, and the deciding evidence came from somewhere this entry was not looking:
+**item 47**. The TTD tier records a trace, opens it and queries it on the x64 bench, and that
+bench's `ttd\` came from this entry's own unpack recipe — so the path the documentation called a
+fallback was already the one this repository's own coverage stood on. A project cannot hold a route
+at arm's length and depend on it at the same time; that, rather than any argument about what MSIX
+is for, is what settled it.
+
+**Three things the entry did not anticipate**, which is why it is kept rather than deleted.
+
+The first is that endorsing removed a step instead of adding one. The store package's
+`InstallLocation\$arch` and the unpacked `.msix`'s `$arch\` are the **same layout** — same files,
+same subdirectories — so the two sources differ only in how `$wd` is set, and the copy block after
+it is one block rather than two. The old shape had the bundle copying `ttd\` *alone* into a
+payload otherwise taken from the SDK, which is the more complicated arrangement as well as the
+less supported one.
+
+The second is that **the recipe did not work, and had not since the day it was written** —
+`8bd98a5`, 2026-08-16, unchanged for the thirteen days until this. Its first line read the
+`.appinstaller` with `(Invoke-WebRequest …).Content` and cast it to `[xml]`; under Windows
+PowerShell 5.1 that property is a `Byte[]` for this content type, so the cast throws
+*"Cannot convert value \"System.Byte[]\" to type \"System.Xml.XmlDocument\""* and nothing is
+downloaded at all. Whatever it was derived from, nobody had run **that text** start to finish, and
+it read perfectly plausibly for thirteen days. Fetching to a file and reading it back with
+`Get-Content -Raw` is version-proof, and is what it does now. **A documented recipe nobody executes
+is a claim, not a procedure** — which is the general lesson, and the reason the end-to-end run
+below was worth its 1.1 GB.
+
+The third is that the honest verification step was cheap. `Get-AuthenticodeSignature` answers on a
+`.msixbundle` — `Valid`, `SignatureType Authenticode`, `CN=Microsoft Corporation` — so "unpack a
+Microsoft package by hand" could become "verify the publisher, then unpack", which is what makes it
+defensible to write down. It settles provenance and not fitness, and `setup.md` says so in those
+terms rather than letting a green check stand for more than it is.
+
+**What the end-to-end run measured** (ARM64 bench, Windows PowerShell 5.1.26100.1, 2026-08-29):
+the `.appinstaller` resolves to `windbg.download.prss.microsoft.com/.../1-2606-22001-0`; the bundle
+is 1,188,564,441 bytes and verifies as above; it holds `windbg_win-arm64.msix`, `windbg_win-x64.msix`
+and `windbg_win-x86.msix`, so the recipe's guessed name is right; and **all three** payload trees
+inside the ARM64 one — `amd64\`, `arm64\`, `x86\` — carry the entire copy list, `msdia140.dll`
+included, plus `ttd\TTD.exe`, which means the engine copy already brings the *recorder* rather than
+only the replay engine.
+
+**And then the bench was bundled from it, which closed the issue where it was filed.** The ARM64
+payload went beside `target\release\windbg-mcp.exe` and the host that could only record now
+replays: `hostname.exe` recorded to a 40 MB `.run` with the bundled `ttd\TTD.exe`, `open_trace`
+answered with the trace's lifetime (`[E:0, 7F8:EB0]`, 9 modules) rather than the missing-`ttd\`
+diagnostic it gave twenty minutes earlier, and `step_back` reached the start of the trace. So
+"an engine bundled this way replays" is measured on ARM64 as well as on the x64 tier.
+
+Two things that copy turned up, neither of them anticipated:
+
+- **The running server holds `dbgeng.dll` open**, so bundling or updating an engine needs the
+  service *stopped* — having no sessions open is not enough. The supervisor never uses DbgEng, but
+  the DLL is an import-table dependency of the image, so the loader maps it before `main` whatever
+  role the process goes on to play. `Copy-Item` fails with *"being used by another process"*
+  against a supervisor sitting idle with an empty session list. Same mechanism this file already
+  records for the 32-bit worker, which is why an `x86\windbg-mcp.exe` with no engine beside it
+  fails to *start* rather than failing to open a dump.
+- **`find_ttd` does not look beside the executable.** It probes `PATH`, the SDK layout and
+  `WindowsApps`, so the `ttd\TTD.exe` the engine copy just delivered is *not* found by
+  `record_trace` — the recorder has to be put on `PATH` even though it is now sitting next to the
+  server. `setup.md` says so at the point of the copy. Adding `<exe dir>\ttd\TTD.exe` to the probe
+  is a one-line change and is deliberately **not** in this docs-only PR.
+
+Picks up at [`setup.md`](./skills/windbg-debugging/setup.md)'s *WinDbg engine + extensions* — the
+three sources and the one copy — and its *Unpacking the `.msixbundle`* subsection, plus
+[#132](https://github.com/glslang/windbg-mcp/issues/132).
+
+**Left open.** Nothing checks that a bundled `ttd\` matches the binary's architecture:
+`worker::replay_engine_bundled` asks whether the directory is non-empty, deliberately, since the
+alternative is a PE read per file against a layout WinDbg owns. A wrong-architecture copy therefore
+still surfaces as DbgEng's bare `0x80070057`, which is the behaviour without the diagnostic rather
+than a regression from it — and `setup.md` states the rule at the point the copy is made, which is
+the only place it can be acted on.
 
 ## 22. [windbg-mcp] Run the debugger tier on an ARM64 runner — **done** (2026-08-16, #134)
 
@@ -2614,11 +2687,17 @@ and nothing recovers from that, which is the second bug that issue turned out to
 `go` that reaches no stop leaves the session usable, and left it unusable before. Live kernel was
 already on this path and the live-kernel tier exercises it. A dump cannot resume at all, so the wait
 is unreachable there. **TTD replay is the gap**: `go`, `step_back` and the rest of the reverse
-family go through this function, and TTD replay does not work on **that** bench at all
+family go through this function, and TTD replay did not work on **that** bench at all
 (item 21 / [#132](https://github.com/glslang/windbg-mcp/issues/132)), so nothing there could ask
 whether `SetInterrupt` unblocks a replay wait the way it unblocks a live one. (Named explicitly
 because "this host" in an item whose measurements are ARM64's has already been read as the x64
 one.)
+
+**That blocker is gone as of 2026-08-29**, and it is the ARM64 bench that changed: item 21 landed,
+the WinDbg payload was bundled beside its release build, and the host now records a trace, opens it
+and steps backward through it. So the gap here is no longer "no bench can ask" — it is that nobody
+has asked. The measurement this item wants can now be taken where every one of its siblings was
+taken, which removes the "generalised from one backend" caveat it raises against itself below.
 
 **Why it is not alarming, and why it is still open.** The watchdog only ever fires at the bound, so
 for every go/step that stops in time the change is a no-op — which is every TTD navigation anyone
@@ -2647,7 +2726,8 @@ strength of a TTD tier passing there, and the correction is what produced the pa
 
 **What would close it.** Record a trace, `go` past the end of it or `reverse_go` with nothing to
 stop at, and assert the session still answers `registers` afterwards — the same assertion the two
-debugger-tier launch tests make. One test, in the TTD tier, on the x64 bench. **Establish first
+debugger-tier launch tests make. One test, in the TTD tier, on either bench — the ARM64 one is now
+capable and is where this item's other measurements were taken. **Establish first
 that the bound is reachable at all**: a replay target has ends, so a `go` or a `reverse_go` with no
 breakpoint may simply stop at the trace boundary in well under the 60s bound, in which case the
 timeout path is *unreachable* on this target type rather than untested — which closes this item as

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -729,22 +729,31 @@ Two things that copy turned up, neither of them anticipated:
   against a supervisor sitting idle with an empty session list. Same mechanism this file already
   records for the 32-bit worker, which is why an `x86\windbg-mcp.exe` with no engine beside it
   fails to *start* rather than failing to open a dump.
-- **`find_ttd` does not look beside the executable.** It probes `PATH`, the SDK layout and
-  `WindowsApps`, so the `ttd\TTD.exe` the engine copy just delivered is *not* found by
-  `record_trace` — the recorder has to be put on `PATH` even though it is now sitting next to the
-  server. `setup.md` says so at the point of the copy. Adding `<exe dir>\ttd\TTD.exe` to the probe
-  is a one-line change and is deliberately **not** in this docs-only PR.
+- **`find_ttd` did not look beside the executable** — it probed `PATH`, the SDK layout and
+  `WindowsApps`, so the `ttd\TTD.exe` the engine copy delivers was reachable only by *also* putting
+  it on `PATH`. The probe this project's own documentation tells people to create was the one
+  layout it did not know, which meant a host bundled exactly as documented could replay a trace and
+  not record one. Fixed here (`recorder_beside`), ranked below `PATH` so the
+  [#131](https://github.com/glslang/windbg-mcp/issues/131) override still wins and above the
+  machine-wide installs, because the payload beside the executable is the pair to the engine this
+  process actually loads. Note the ARM64 bench cannot *demonstrate* the old failure: `TTD.exe` is
+  on its `PATH`, which is [#132](https://github.com/glslang/windbg-mcp/issues/132)'s own stated
+  workaround — "the recorder is a plain executable and can be extracted to any directory on
+  `PATH`". That is the workaround this removes the need for, and since `PATH` is still probed
+  first the fix changes nothing on a host that took it. The failure is covered by unit test
+  instead, which is also how item 20's ordering is covered and for the same reason.
 
 Picks up at [`setup.md`](./skills/windbg-debugging/setup.md)'s *WinDbg engine + extensions* — the
 three sources and the one copy — and its *Unpacking the `.msixbundle`* subsection, plus
 [#132](https://github.com/glslang/windbg-mcp/issues/132).
 
-**Left open.** Nothing checks that a bundled `ttd\` matches the binary's architecture:
-`worker::replay_engine_bundled` asks whether the directory is non-empty, deliberately, since the
-alternative is a PE read per file against a layout WinDbg owns. A wrong-architecture copy therefore
-still surfaces as DbgEng's bare `0x80070057`, which is the behaviour without the diagnostic rather
-than a regression from it — and `setup.md` states the rule at the point the copy is made, which is
-the only place it can be acted on.
+**Nothing left open, and one thing deliberately not done.** `worker::replay_engine_bundled` asks
+whether `ttd\` is non-empty and *not* whether its contents match the binary's architecture, which
+is a decision rather than a gap: the alternative is a PE read per file against a layout WinDbg owns
+and may change. A wrong-architecture copy therefore still surfaces as DbgEng's bare `0x80070057` —
+the behaviour without the diagnostic rather than a regression from it — and `setup.md` states the
+rule at the point the copy is made, which is the only place it can be acted on. Revisit only if
+someone actually lands a mismatched bundle; nobody has.
 
 ## 22. [windbg-mcp] Run the debugger tier on an ARM64 runner — **done** (2026-08-16, #134)
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -15,8 +15,9 @@
 - **For Time Travel Debugging (`.run`) replay**, the System32 engine is *not* enough — it rejects
   `.run` traces (`0x80070057`). You need the **WinDbg engine** (which bundles the TTD replay
   components) loaded next to the binary — see *Bundling the WinDbg engine* below.
-- `TTD.exe` (the standalone Time Travel Debugging recorder) for `record_trace` — ships with the
-  WinDbg / TTD store packages; put it on `PATH`.
+- `TTD.exe` (the standalone Time Travel Debugging recorder) for `record_trace` — it sits at
+  `ttd\TTD.exe` inside the WinDbg payload, so the engine copy below already brings it; put it on
+  `PATH`.
 - A reachable symbol server (e.g. `srv*https://msdl.microsoft.com/download/symbols`) for symbol-name
   queries like `ttd_calls("ucrtbase!_stdio_common_vfprintf")`. Offline, address-based queries and the
   data model still work; symbol *names* won't resolve.
@@ -111,8 +112,10 @@ the attach itself works on the System32 engine. The last row is that same loader
 exception to it: the 32-bit engine goes *inside* `x86\` because it is the 32-bit worker sitting
 there that has to find it, and dropping it beside the 64-bit one instead breaks both.
 
-**The copy list, what each file buys, and what to do when the store package will not install are in
-the skill's [`setup.md`](../skills/windbg-debugging/setup.md).**
+**The copy list, what each file buys, and the three sources it can come from — an installed store
+package, the same package's `.msixbundle` unpacked without installing it, or the Windows SDK
+Debugging Tools, which ship everything except `msdia140.dll` and `ttd\` — are in the skill's
+[`setup.md`](../skills/windbg-debugging/setup.md).**
 It is one document rather than two so the list cannot drift; it is also where symbols, elevation,
 kernel connection profiles and the differences an ARM64 host brings are written down.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -16,8 +16,8 @@
   `.run` traces (`0x80070057`). You need the **WinDbg engine** (which bundles the TTD replay
   components) loaded next to the binary — see *Bundling the WinDbg engine* below.
 - `TTD.exe` (the standalone Time Travel Debugging recorder) for `record_trace` — it sits at
-  `ttd\TTD.exe` inside the WinDbg payload, so the engine copy below already brings it; put it on
-  `PATH`.
+  `ttd\TTD.exe` inside the WinDbg payload, so the engine copy below already brings it and the
+  server finds it there. A copy on `PATH` still wins, which is how you override the choice.
 - A reachable symbol server (e.g. `srv*https://msdl.microsoft.com/download/symbols`) for symbol-name
   queries like `ttd_calls("ucrtbase!_stdio_common_vfprintf")`. Offline, address-based queries and the
   data model still work; symbol *names* won't resolve.

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -35,7 +35,7 @@ taken a second covered no debugger claim at all.
 | **Bounded command** | `--ignored` | `dbgeng.dll`, the sample dump, ~1 minute | the watchdog wiring, which now spans two processes |
 | **Live kernel** | `--ignored` + `WINDBG_MCP_SMOKE_KERNEL` | a live kernel target you can freeze — KDNET, or serial | that a kernel attach *lands*, coexists, and is let go — by `end_session` and by a disconnect; and that a `debug_batch` which patches a byte of the running kernel puts it back |
 | **MessageManager CTF** | `--ignored` + live-kernel gate + `WINDBG_MCP_SMOKE_CTF=1` | the challenge VM, WinRM, full `nt` symbols | the real driver and retained `Tgsm` pool objects through the shipped MCP transport |
-| **TTD** | `WINDBG_MCP_SMOKE_TTD=1` | `TTD.exe`, **elevation**, and the WinDbg store engine to replay what it records | that `record_trace` records the program it was given and reports a finished recording as one, and that a TTD query returns records rather than bare indices |
+| **TTD** | `WINDBG_MCP_SMOKE_TTD=1` | `TTD.exe`, **elevation**, and a WinDbg engine payload beside the binary to replay what it records — both benches' came from `setup.md`'s unpacked `.msixbundle` rather than from an installed package, the ARM64 one as of 2026-08-29 | that `record_trace` records the program it was given and reports a finished recording as one, and that a TTD query returns records rather than bare indices |
 | **32-bit managed target** | a 32-bit `dbgeng.dll` in an `x86` directory beside the binary under test | that engine, `x86\windbg-mcp.exe` beside it, and the `csc.exe` every stock Windows ships — it compiles and dumps its own fixture | that a 32-bit dump **and** a 32-bit live process are each opened by a worker of *their* architecture, so 32-bit SOS loads — which this server's own engine cannot do at all |
 | **Live (other)** | manual | a test driver on a kernel target | see [Manual checklist](#manual-checklist) |
 
@@ -1177,7 +1177,7 @@ recorder's own refusal — `TTD.exe not found`, `Administrative privileges`, `0x
 print `SKIPPED`. Every *other* failure fails the test, which is the distinction that keeps the tier
 honest: a helper that treated any error as a skip would pass on a machine where recording is
 broken. Replay is a third stand-down, taken separately: a host can record a trace it cannot open, because
-replay needs the WinDbg store engine beside the binary, and by then the recording half has already
+replay needs a WinDbg engine payload beside the binary, and by then the recording half has already
 been asserted. It is keyed on the **server's own diagnostic** — the sentence
 `worker::explain_trace_failure` appends when there is no `ttd\` beside the executable — and not on
 `0x80070057`, which is the engine's "the parameter is incorrect" and can equally come from a trace
@@ -1326,7 +1326,7 @@ does not reach.
   `bp nt!NtCreateFile`, `go` to it, resume, detach. See the KDNET gotchas in `CLAUDE.md` before
   diagnosing a hang.
 - **TTD** — recording and the two queries are the [TTD tier](#the-ttd-tier) now, which is where to
-  start; it needs the WinDbg store engine next to the binary to replay what it records (System32's
+  start; it needs a WinDbg engine payload next to the binary to replay what it records (System32's
   rejects a `.run` with `0x80070057`, and the tier stands that half down rather than failing).
   What is left by hand is what the tier does not reach: **reverse execution** (`reverse_go`,
   `step_back`, `step_over_back`, `goto_position`) on a trace, and `ttd_calls` against **resolved

--- a/skills/windbg-debugging/setup.md
+++ b/skills/windbg-debugging/setup.md
@@ -235,9 +235,10 @@ Copy-Item "$wd\winxp\kdexts.dll" "$dst\winxp" -Force   # !drvobj/!devobj/!irp �
 
 - The `ttd\` subdir provides the `@$cursession.TTD` / `@$curprocess.TTD` data model and the
   `!tt` time-travel commands. It also carries **`TTD.exe`** itself, at `ttd\TTD.exe` — so the copy
-  above brings the recorder `record_trace` needs along with the replay engine. Put it on `PATH`
-  anyway: the server searches `PATH`, the SDK layout and `WindowsApps`, and **not** its own
-  directory, so a recorder sitting right beside it is still not one it will find.
+  above brings the recorder `record_trace` needs along with the replay engine, and the server looks
+  there: it probes `PATH` first, then its own `ttd\` directory, then the SDK and `WindowsApps`
+  layouts. Bundling an engine therefore gets you recording as well as replay, with nothing to put
+  on `PATH`.
 - The `winext\` subdir provides `ext.dll` (which exports `!analyze`) and the other `!`-extensions.
   Required for crash-dump triage — without it `!analyze` returns *"No export analyze found"*.
   Whether the **unqualified `!analyze` then resolves is engine- and Windows-version-dependent**, so

--- a/skills/windbg-debugging/setup.md
+++ b/skills/windbg-debugging/setup.md
@@ -309,9 +309,24 @@ the publisher.
 
 Three limits worth taking on knowingly:
 
-- **There is no update path.** A copied engine is a snapshot and does not follow WinDbg; re-run the
-  copy when you would have taken an update. The `.appinstaller` above always names the *current*
-  bundle, so the recipe needs no version bump — only re-running.
+- **There is no update path, and re-running alone does not give you one.** A copied engine is a
+  snapshot and does not follow WinDbg, so re-run the copy when you would have taken an update; the
+  `.appinstaller` above always names the *current* bundle, so nothing here needs a version bump.
+  But `Expand-Archive -Force` and `Copy-Item -Force` overwrite what collides and delete nothing, so
+  a second run **merges** the new payload into the old one — leaving anything the new package
+  renamed or dropped in place, a stale `TTDReplay*.dll` beside a new `dbgeng.dll` among them. Clear
+  the directories that are copied wholesale first, with the server stopped (see above — a running
+  one holds these open):
+
+  ```pwsh
+  Remove-Item "$w\b","$w\p" -Recurse -Force -ErrorAction SilentlyContinue   # staging
+  Remove-Item "$dst\ttd","$dst\winext","$dst\triage","$dst\winxp" `
+              -Recurse -Force -ErrorAction SilentlyContinue
+  ```
+
+  **Not `$dst` itself**, which holds `windbg-mcp.exe`. The six loose DLLs need no such treatment:
+  they are copied by an explicit list of fixed names, so they have no orphan to leave. The risk is
+  entirely in the four `-Recurse` directory copies.
 - **The layout inside the bundle is Microsoft's to change.** Run on 2026-08-29 the bundle held
   `windbg_win-arm64.msix`, `windbg_win-x64.msix` and `windbg_win-x86.msix`, and the payload inside
   the ARM64 one carried `amd64\`, `arm64\` and `x86\` trees, each complete — `msdia140.dll`
@@ -574,7 +589,7 @@ tell two kernel targets apart. `attach_kernel` with no arguments lists the profi
 | TTD replay (`open_trace`) | No |
 | Live user-mode (`launch` / `attach_process`) | No (unless the target requires it) |
 | Live kernel (`attach_kernel_local` / `attach_kernel`) | **Yes** |
-| TTD recording (`record_trace`) | **Yes** + `TTD.exe` on `PATH` |
+| TTD recording (`record_trace`) | **Yes** + a `TTD.exe` — the bundled `ttd\TTD.exe` will do; `PATH` only overrides it |
 
 `record_trace` captures the recorder's startup output to `<out_dir>\ttd_record.log` and
 watches it briefly, so a fast failure (e.g. un-elevated → `0x80070005 Access is denied`)

--- a/skills/windbg-debugging/setup.md
+++ b/skills/windbg-debugging/setup.md
@@ -43,7 +43,7 @@ of its own architecture, so an x64 binary running under emulation on an ARM64 ho
 **`amd64`** engine and cannot load the `arm64` one — it will fail to initialise the debugger rather
 than fall back. Which you need therefore depends on where the binary came from:
 
-| `windbg-mcp.exe` | Store payload | SDK directory |
+| `windbg-mcp.exe` | Package payload (store or bundle) | SDK directory |
 | --- | --- | --- |
 | Prebuilt release zip (Option A) — **always x64** | `\amd64` | `Debuggers\x64` |
 | Built from source on an ARM64 host (Option B) | `\arm64` | `Debuggers\arm64` |
@@ -52,27 +52,11 @@ The releases this repo publishes are x64 only, so downloading one onto an ARM64 
 for `arm64` DLLs — the intuitive move — is the wrong pairing. `cargo build --release` on the host
 is what gets you a native binary worth pairing with `arm64`.
 
-**The store package is not the only source.** If it will not install, the **Windows SDK Debugging
-Tools** — `winsdksetup.exe /features OptionId.WindowsDesktopDebuggers /quiet /norestart` — land in
-`C:\Program Files (x86)\Windows Kits\10\Debuggers\<arch>` and supply every file in the copy below
-**except `msdia140.dll` and `ttd\`**. So `!analyze` and the driver tools work from it and **TTD
-replay does not** ([#132](https://github.com/glslang/windbg-mcp/issues/132)).
-
-Symbols are the interesting omission. `msdia140.dll` is documented below as required for PDB
-parsing, but on the host tested here full private symbols resolved (`nt!RtlpHpVsSlotFreeList`, not
-an export) with **no `msdia140.dll` anywhere on the machine and none registered** — the SDK's own
-`dbghelp.dll` read the PDBs unaided. Treat that requirement as a property of the `dbghelp.dll` you
-bundle rather than a universal one, and check with `lm m <mod>` (`(pdb symbols)` versus
-`(export symbols)`) rather than assuming either way.
-
-That fallback matters because MSIX registration fails from a **non-interactive** session —
-`Add-AppxPackage` returns `0x80070005` even when the session is elevated, leaving the payload
-staged but unrunnable, since `WindowsApps` denies execute to an unregistered package. Install
-WinDbg from the machine's own console session rather than over SSH or a remote shell; that is also
-what makes `Get-AppxPackage Microsoft.WinDbg` resolve, which the copy below depends on.
-
-For `ttd\` specifically there is a way out that needs no install at all — see
-[*When the store package will not install*](#when-the-store-package-will-not-install) below.
+**Where the payload comes from is a separate question, and not an ARM64 one.** Three sources
+supply it and they differ in what they hold — an installed store package, the same package's
+`.msixbundle` unpacked without installing it, and the Windows SDK Debugging Tools, which ship
+everything except `msdia140.dll` and `ttd\`. See *WinDbg engine + extensions* below, which names
+all three and then runs one copy. The architecture rule above applies whichever you pick.
 
 ## Get the server binary
 
@@ -177,7 +161,7 @@ Either way, run `/reload-plugins` afterwards so Claude Code connects the `windbg
 
 ## WinDbg engine + extensions — for `.run` replay, crash-dump `!analyze`, and the kernel driver tools
 
-Drop the **WinDbg** store-package binaries next to `windbg-mcp.exe` (the `$dst` below — for a
+Drop a **WinDbg engine payload** next to `windbg-mcp.exe` (the `$dst` below — for a
 registry/MCPB install that's the client's extraction directory, **not** `target\release`) for
 three reasons:
 
@@ -190,8 +174,19 @@ three reasons:
   `winxp\` copy below, even though the attach itself works on the System32 engine).
 
 `DebugCreate` binds to whichever `dbgeng.dll` the loader finds first, and the app directory is
-searched before `System32`, so the copied engine wins. One-time, from the installed WinDbg store
-package:
+searched before `System32`, so the copied engine wins.
+
+**Three sources supply that payload**, and what separates them is what they leave out:
+
+| Source | Holds | Costs |
+| --- | --- | --- |
+| The installed **WinDbg store package** | everything below | an interactive install — MSIX will not register over SSH |
+| The same **`.msixbundle`, unpacked** | everything below | a ~1.1 GB download; no install, so it is the one source a remote session can use |
+| The **Windows SDK Debugging Tools** | everything **except `msdia140.dll` and `ttd\`** | no TTD replay and no PDB parser ([#132](https://github.com/glslang/windbg-mcp/issues/132)) |
+
+All three are the **same layout** — a directory with `dbgeng.dll` beside `ttd\`, `winext\`,
+`winxp\` and `triage\` — so they differ only in how you set `$wd`, and the copy below is the same
+copy whichever you take:
 
 ```pwsh
 # Match $arch to windbg-mcp.exe, not to the machine: a process loads DLLs of its
@@ -199,7 +194,30 @@ package:
 # See the table under "ARM64 hosts" — "amd64" is right for every x64 binary,
 # including one running under emulation.
 $arch = "amd64"
-$wd  = (Get-AppxPackage Microsoft.WinDbg).InstallLocation + "\$arch"
+
+# Then pick ONE of these three and leave the other two commented out.
+# (a) the installed store package
+$wd = (Get-AppxPackage Microsoft.WinDbg).InstallLocation + "\$arch"
+# (b) the unpacked .msixbundle — $w comes from "Unpacking the .msixbundle" below
+# $wd = "$w\p\$arch"
+# (c) the SDK Debugging Tools — "arm64" keeps its name here, but amd64 is spelled x64
+# $wd = "C:\Program Files (x86)\Windows Kits\10\Debuggers\x64"
+```
+
+From **(c)**, drop `msdia140.dll` from the file list and skip the `ttd\` line — neither is there.
+`!analyze`, the driver tools and symbol resolution all work from it; TTD replay does not, which is
+the whole of why (b) exists.
+
+Symbols are the interesting omission in (c). `msdia140.dll` is documented below as required for PDB
+parsing, but on the ARM64 host this was tested on full private symbols resolved
+(`nt!RtlpHpVsSlotFreeList`, not an export) with **no `msdia140.dll` anywhere on the machine and none
+registered** — the SDK's own `dbghelp.dll` read the PDBs unaided. Treat that requirement as a
+property of the `dbghelp.dll` you bundle rather than a universal one, and check with `lm m <mod>`
+(`(pdb symbols)` versus `(export symbols)`) rather than assuming either way.
+
+One-time, with `$wd` set from whichever source you took:
+
+```pwsh
 # Set $dst to the folder that actually holds windbg-mcp.exe — pick the one for
 # your install (do not leave it as the placeholder):
 #   plugin / build-from-source layout      -> <plugin dir>\target\release
@@ -216,7 +234,10 @@ Copy-Item "$wd\winxp\kdexts.dll" "$dst\winxp" -Force   # !drvobj/!devobj/!irp �
 ```
 
 - The `ttd\` subdir provides the `@$cursession.TTD` / `@$curprocess.TTD` data model and the
-  `!tt` time-travel commands.
+  `!tt` time-travel commands. It also carries **`TTD.exe`** itself, at `ttd\TTD.exe` — so the copy
+  above brings the recorder `record_trace` needs along with the replay engine. Put it on `PATH`
+  anyway: the server searches `PATH`, the SDK layout and `WindowsApps`, and **not** its own
+  directory, so a recorder sitting right beside it is still not one it will find.
 - The `winext\` subdir provides `ext.dll` (which exports `!analyze`) and the other `!`-extensions.
   Required for crash-dump triage — without it `!analyze` returns *"No export analyze found"*.
   Whether the **unqualified `!analyze` then resolves is engine- and Windows-version-dependent**, so
@@ -236,6 +257,70 @@ Copy-Item "$wd\winxp\kdexts.dll" "$dst\winxp" -Force   # !drvobj/!devobj/!irp �
   `.load kdexts` automatically; without the file those tools return *"No export drvobj found"*.
   (Note it lives in `winxp\`, not `winext\`, and the engine already searches a `WINXP` subdir.)
 - `cargo clean` (when building from source) wipes `target\`, so re-copy after one.
+- **Stop the server before copying over an engine that is already there.** A running
+  `windbg-mcp.exe` holds `dbgeng.dll` open even with no session on it — the engine is an
+  import-table dependency of the image, so the loader maps it before `main` whatever role the
+  process plays — and `Copy-Item` then fails with *"being used by another process"*. An idle
+  supervisor reporting an empty session list is not idle enough; `Stop-Service windbg-mcp` (or
+  closing the client that spawned it) is. A first-time copy into a directory with no engine yet has
+  nothing to overwrite and needs none of this.
+
+### Unpacking the `.msixbundle` — source (b)
+
+A `.msixbundle` is an ordinary zip, and the one Microsoft serves from `aka.ms/windbg/download`
+holds the same `amd64\`, `arm64\` and `x86\` payload trees the installed package does. So the
+engine can be had **without installing anything**, which is the only route open to a host that
+cannot register an MSIX at all — see [*When the store package will not
+install*](#when-the-store-package-will-not-install).
+
+```pwsh
+$ProgressPreference = 'SilentlyContinue'   # or Invoke-WebRequest spends longer rendering than downloading
+$w = "$env:TEMP\wdbg"; New-Item $w -ItemType Directory -Force | Out-Null
+# -OutFile, not .Content: 5.1 hands back a Byte[] here and the [xml] cast fails.
+Invoke-WebRequest 'https://aka.ms/windbg/download' -OutFile "$w\windbg.appinstaller" -UseBasicParsing
+$uri = ([xml](Get-Content "$w\windbg.appinstaller" -Raw)).AppInstaller.MainBundle.Uri
+Invoke-WebRequest $uri -OutFile "$w\windbg.msixbundle" -UseBasicParsing      # ~1.1 GB
+
+# Verify the publisher before unpacking anything.
+$sig = Get-AuthenticodeSignature "$w\windbg.msixbundle"
+if ($sig.Status -ne 'Valid' -or $sig.SignerCertificate.Subject -notlike '*O=Microsoft Corporation*') {
+  throw "unexpected signature: $($sig.Status) / $($sig.SignerCertificate.Subject)"
+}
+
+# Expand-Archive dispatches on the extension, so both hops need a .zip name.
+Copy-Item "$w\windbg.msixbundle" "$w\b.zip" -Force
+Expand-Archive "$w\b.zip" "$w\b" -Force
+# Note the two spellings: the .msix is named x64/arm64, while the payload
+# directory inside it is amd64/arm64.
+$msix = if ($arch -eq "arm64") { "windbg_win-arm64.msix" } else { "windbg_win-x64.msix" }
+Copy-Item "$w\b\$msix" "$w\p.zip" -Force
+Expand-Archive "$w\p.zip" "$w\p" -Force
+```
+
+`$w\p\$arch` is then the payload root: set `$wd` to it and run the copy block above.
+
+**What the signature check settles, and what it does not.** It establishes that the file is the one
+Microsoft signed, unmodified — which is the question that matters for a DLL you are about to load
+into the debugger. It does **not** make an unregistered payload a supported Microsoft
+configuration, and it is not a claim that the engine is fit for anything in particular. Treat it as
+this project's floor for telling you to unpack somebody else's package, not as an endorsement by
+the publisher.
+
+Three limits worth taking on knowingly:
+
+- **There is no update path.** A copied engine is a snapshot and does not follow WinDbg; re-run the
+  copy when you would have taken an update. The `.appinstaller` above always names the *current*
+  bundle, so the recipe needs no version bump — only re-running.
+- **The layout inside the bundle is Microsoft's to change.** Run on 2026-08-29 the bundle held
+  `windbg_win-arm64.msix`, `windbg_win-x64.msix` and `windbg_win-x86.msix`, and the payload inside
+  the ARM64 one carried `amd64\`, `arm64\` and `x86\` trees, each complete — `msdia140.dll`
+  included. If `Expand-Archive` produces something else, list `$w\b` and take the `.msix` matching
+  your architecture rather than editing the guess.
+- **Pick the architecture by `windbg-mcp.exe`**, exactly as the copy block says — not by the host,
+  and not by which `.msix` you happened to unpack. Each bundle carries `amd64\`, `arm64\` and
+  `x86\` (an ARM64 bundle ships all three), so there is no default to fall back on and a copy that
+  takes the first match takes the emulation build. That is the same ordering trap as
+  [#131](https://github.com/glslang/windbg-mcp/issues/131), which is easy to walk into twice.
 
 ### 32-bit .NET targets need a 32-bit server
 
@@ -331,34 +416,11 @@ when elevated — and leaves the payload staged but unrunnable, because `Windows
 to an unregistered package. So the files can be on disk and every one of them refuse to run.
 Installing from the machine's own console session is the fix and the first thing to reach for.
 
-Where that is not available, two sources cover the same files between them.
-
-**The Windows SDK Debugging Tools** — `winsdksetup.exe /features OptionId.WindowsDesktopDebuggers
-/quiet /norestart` — give a plain directory, `C:\Program Files (x86)\Windows Kits\10\Debuggers\<arch>`,
-holding every file in the copy above **except `msdia140.dll` and `ttd\`**. So `!analyze`, the driver
-tools and symbol resolution all work from it, and TTD replay does not.
-
-**The WinDbg `.msixbundle`**, for `ttd\` itself, is an ordinary zip and can be unpacked without
-being installed:
-
-```pwsh
-$w = "$env:TEMP\wdbg"; New-Item $w -ItemType Directory -Force | Out-Null
-$uri = ([xml](Invoke-WebRequest 'https://aka.ms/windbg/download' -UseBasicParsing).Content).AppInstaller.MainBundle.Uri
-Invoke-WebRequest $uri -OutFile "$w\b.zip" -UseBasicParsing      # ~1.1 GB
-Expand-Archive "$w\b.zip" "$w\b" -Force
-# Same $arch as the copy block above. Note the two spellings: the .msix is named
-# x64/arm64, while the payload directory inside it is amd64/arm64.
-$msix = if ($arch -eq "arm64") { "windbg_win-arm64.msix" } else { "windbg_win-x64.msix" }
-Copy-Item "$w\b\$msix" "$w\p.zip" -Force
-Expand-Archive "$w\p.zip" "$w\p" -Force
-Copy-Item "$w\p\$arch\ttd" "$dst\ttd" -Recurse -Force
-```
-
-**Pick the architecture by `windbg-mcp.exe`, exactly as above** — not by the host, and not by which
-`.msix` you happened to unpack. Each package carries `amd64\`, `arm64\` and `x86\` payloads (an
-ARM64 package ships all three), so there is no default to fall back on and a copy that takes the
-first match takes the emulation build. That is the same ordering trap as
-[#131](https://github.com/glslang/windbg-mcp/issues/131), which is easy to walk into twice.
+Where that is not available, **the bundle needs no install at all**: source (b) above, [*Unpacking
+the `.msixbundle`*](#unpacking-the-msixbundle--source-b), is the same payload as an ordinary zip
+download, and it is a supported path here rather than a trick — this repository's own TTD smoke
+tier runs against an engine bundled that way. The SDK Debugging Tools, source (c), are the other
+way through and stop short of TTD: they hold everything **except `msdia140.dll` and `ttd\`**.
 
 [#132](https://github.com/glslang/windbg-mcp/issues/132) is why this is written down rather than
 assumed away. Note that `open_trace` reports a missing `ttd\` explicitly instead of leaving you with

--- a/skills/windbg-debugging/setup.md
+++ b/skills/windbg-debugging/setup.md
@@ -182,7 +182,7 @@ searched before `System32`, so the copied engine wins.
 | --- | --- | --- |
 | The installed **WinDbg store package** | everything below | an interactive install — MSIX will not register over SSH |
 | The same **`.msixbundle`, unpacked** | everything below | a ~1.1 GB download; no install, so it is the one source a remote session can use |
-| The **Windows SDK Debugging Tools** | everything **except `msdia140.dll` and `ttd\`** | no TTD replay and no PDB parser ([#132](https://github.com/glslang/windbg-mcp/issues/132)) |
+| The **Windows SDK Debugging Tools** | everything **except `msdia140.dll` and `ttd\`** | no TTD replay, and PDB parsing left to the `dbghelp.dll` you bundle ([#132](https://github.com/glslang/windbg-mcp/issues/132)) |
 
 All three are the **same layout** — a directory with `dbgeng.dll` beside `ttd\`, `winext\`,
 `winxp\` and `triage\` — so they differ only in how you set `$wd`, and the copy below is the same
@@ -361,13 +361,18 @@ one if you are debugging the thunk layer itself. Nothing is lost on a **dump**, 
 capture never held the 64-bit side to begin with; if you want both halves of a live process, take a
 capture with the 64-bit `procdump64.exe -ma` and open that instead, which routes to the x64 engine.
 
-What it needs beside it is a 32-bit engine. Copy the package's **`x86`** payload into that same
+What it needs beside it is a 32-bit engine. It comes from the **same three sources** as the payload
+above and from the same `x86\` tree inside each — an ARM64 or x64 package carries the 32-bit
+payload as well as its own — so pick the source you already took and copy that tree into the
 `x86\` subdirectory:
 
 ```pwsh
 # $dst is the same folder as the copy block above — the one that holds windbg-mcp.exe.
 $dst = "<folder that holds windbg-mcp.exe>"
-$wd86 = (Get-AppxPackage Microsoft.WinDbg).InstallLocation + "\x86"
+# Same three sources, x86 tree. Pick ONE, as above.
+$wd86 = (Get-AppxPackage Microsoft.WinDbg).InstallLocation + "\x86"   # (a)
+# $wd86 = "$w\p\x86"                                                 # (b) unpacked bundle
+# $wd86 = "C:\Program Files (x86)\Windows Kits\10\Debuggers\x86"      # (c) SDK — no msdia140.dll
 New-Item "$dst\x86" -ItemType Directory -Force | Out-Null
 Copy-Item "$wd86\dbgeng.dll","$wd86\dbghelp.dll","$wd86\dbgcore.dll",`
           "$wd86\dbgmodel.dll","$wd86\symsrv.dll","$wd86\msdia140.dll" "$dst\x86" -Force
@@ -403,10 +408,10 @@ wrong:
   x64 build, and the session reports a `limitation` saying SOS is unreachable — so a half-populated
   `x86\` fails quietly in the sense that everything works except the one thing you came for.
 
-The SDK's *Debugging Tools for Windows* works as a source for the engine payload too
-(`C:\Program Files (x86)\Windows Kits\10\Debuggers\x86`) — unlike the store package it has no
-`msdia140.dll`, which is what parses a PDB, so symbols for the 32-bit target need that file from
-elsewhere.
+From **(c)**, drop `msdia140.dll` from that file list as well — its `x86` tree has none, so the copy
+fails with it left in. If the `dbghelp.dll` you put there cannot then read a PDB unaided, private
+symbols for the 32-bit target need that file from elsewhere: the same caveat, and the same
+dependence on the `dbghelp.dll` you bundle, as the payload above.
 
 ### When the store package will not install
 

--- a/skills/windbg-debugging/ttd.md
+++ b/skills/windbg-debugging/ttd.md
@@ -12,7 +12,8 @@ TTD positions are `major:minor` (a sequencing point and a step within it), not w
 
 ## 1. Get a trace
 
-- **Record** (Administrator, `TTD.exe` on `PATH`):
+- **Record** (Administrator, and a `TTD.exe` — the `ttd\TTD.exe` bundled beside the server is
+  found without `PATH`, which only overrides it):
   `record_trace { "out_dir": "C:\\traces", "target": "C:\\path\\app.exe arg" }`.
   If the target needs a specific environment or working directory to run — a Qt app's
   `QT_QPA_PLATFORM_PLUGIN_PATH`, or an anti-analysis "run me from here" guard — pass

--- a/src/ttd.rs
+++ b/src/ttd.rs
@@ -76,13 +76,21 @@ fn probe_order() -> [Arch; 3] {
     }
 }
 
-/// Best-effort search for `TTD.exe` from an installed Windows debugging toolset.
+/// Best-effort search for `TTD.exe` — from `PATH`, from the engine payload bundled beside this
+/// executable, or from an installed Windows debugging toolset, in that order.
 pub fn find_ttd() -> Option<PathBuf> {
     // 1. Anything already on PATH. First, and so the way to override everything below.
     if let Some(p) = search_path("TTD.exe") {
         return Some(p);
     }
-    // 2. Classic SDK "Debugging Tools for Windows".
+    // 2. The engine payload bundled beside this executable.
+    if let Some(p) = std::env::current_exe()
+        .ok()
+        .and_then(|exe| exe.parent().and_then(recorder_beside))
+    {
+        return Some(p);
+    }
+    // 3. Classic SDK "Debugging Tools for Windows".
     for arch in probe_order() {
         let p = PathBuf::from(format!(
             r"C:\Program Files (x86)\Windows Kits\10\Debuggers\{}\TTD\TTD.exe",
@@ -92,8 +100,29 @@ pub fn find_ttd() -> Option<PathBuf> {
             return Some(p);
         }
     }
-    // 3. Modern WinDbg (MSIX) package layout.
+    // 4. Modern WinDbg (MSIX) package layout.
     find_in_windowsapps()
+}
+
+/// The recorder inside an engine payload copied next to `dir`, if there is one.
+///
+/// `setup.md`'s engine copy takes the whole `ttd\` directory, and that directory carries
+/// **`TTD.exe`** as well as the replay DLLs — so a host that bundled an engine so `open_trace`
+/// would work already has a recorder, of the payload's architecture, which is by construction the
+/// one this binary matches. Until 2026-08-29 the probe knew the two *installed* layouts and not the
+/// one this project's own documentation tells people to create, so that recorder was reachable
+/// only by also putting it on `PATH`.
+///
+/// Ranked below `PATH`, which stays the override
+/// ([#131](https://github.com/glslang/windbg-mcp/issues/131)), and above the machine-wide installs:
+/// the payload beside the executable is the pair to the engine this process actually loads, since
+/// the loader searches the application directory before `System32`.
+///
+/// Takes the directory rather than reading `current_exe` itself so it can be tested against a
+/// layout built in a scratch directory.
+fn recorder_beside(dir: &Path) -> Option<PathBuf> {
+    let candidate = dir.join("ttd").join("TTD.exe");
+    candidate.is_file().then_some(candidate)
 }
 
 fn search_path(exe: &str) -> Option<PathBuf> {
@@ -557,8 +586,8 @@ fn first_meaningful_line(log: &str) -> Option<&str> {
 #[cfg(test)]
 mod tests {
     use super::{
-        Arch, failure_detail, finished_trace, first_meaningful_line, probe_order, split_argv,
-        split_env_entry, split_target, trace_named_in,
+        Arch, failure_detail, finished_trace, first_meaningful_line, probe_order, recorder_beside,
+        split_argv, split_env_entry, split_target, trace_named_in,
     };
     use std::path::PathBuf;
     use std::time::{Duration, SystemTime};
@@ -912,6 +941,40 @@ mod tests {
             };
             assert_eq!(order[0], arch);
         }
+    }
+
+    /// The recorder that arrives with the engine payload is found without also being on `PATH`.
+    ///
+    /// `setup.md`'s engine copy brings `ttd\TTD.exe` along with the replay DLLs, and until this
+    /// existed the probe knew the two *installed* layouts and not the one that copy creates — so a
+    /// host bundled exactly as documented could replay a trace and not record one.
+    #[test]
+    fn the_recorder_bundled_beside_the_binary_is_found() {
+        let dir = scratch("beside");
+        assert_eq!(
+            recorder_beside(&dir),
+            None,
+            "nothing bundled yet, so nothing to find"
+        );
+
+        std::fs::create_dir_all(dir.join("ttd")).expect("create the ttd directory");
+        assert_eq!(
+            recorder_beside(&dir),
+            None,
+            "a `ttd\\` holding replay DLLs but no recorder is the ordinary case for a payload              copied file by file, and is not a recorder"
+        );
+
+        let exe = dir.join("ttd").join("TTD.exe");
+        std::fs::write(&exe, b"MZ").expect("write the recorder");
+        assert_eq!(recorder_beside(&dir), Some(exe));
+    }
+
+    /// A directory named `TTD.exe` is not a recorder, which `is_file` is what separates.
+    #[test]
+    fn a_directory_named_like_the_recorder_is_not_one() {
+        let dir = scratch("beside-dir");
+        std::fs::create_dir_all(dir.join("ttd").join("TTD.exe")).expect("create the decoy");
+        assert_eq!(recorder_beside(&dir), None);
     }
 
     /// The two installers spell x64 differently, and crossing them selects the wrong recorder.


### PR DESCRIPTION
Closes #132, and lands `FOLLOWUPS.md` item 21.

TTD `.run` replay needs a `ttd\` directory beside `windbg-mcp.exe`. System32's `dbgeng.dll` ships none of it, the SDK Debugging Tools do not either, and MSIX registration fails from a non-interactive session (`Add-AppxPackage` → `0x80070005`, even elevated) — so a host reached over SSH could record traces and not replay them.

Both engineering halves landed in #133. What #132 left was a judgement call: whether unpacking a Microsoft package by hand should be a **supported** path in this project's documentation, or whether the answer is to require an interactive install and say so. **Endorsed.**

## What decided it

Not an argument about what MSIX is for. This repository's own TTD smoke tier runs against an engine bundled that way (item 47), so the route the documentation held at arm's length was already the one its coverage stood on.

## The structural payoff

The store package's `InstallLocation\<arch>` and the unpacked `.msixbundle`'s `<arch>\` are the **same layout**. So endorsing removed a step rather than adding one: three sources now set one `$wd` and share one copy block, where before the store package got the copy block and the bundle got an appendix that copied `ttd\` alone into a payload otherwise taken from the SDK.

## The recipe never worked

Running it end to end for the first time — on the ARM64 host the issue was filed from — found that its first line read the `.appinstaller` with `(Invoke-WebRequest …).Content` and cast it to `[xml]`. Under Windows PowerShell 5.1 that property is a `Byte[]` for this content type, so it threw `Cannot convert value "System.Byte[]" to type "System.Xml.XmlDocument"` and nothing downloaded at all. Introduced `8bd98a5` on 2026-08-16, unchanged for thirteen days, and it reads perfectly plausibly. It now fetches to a file and reads it back with `Get-Content -Raw`.

*A documented recipe nobody executes is a claim, not a procedure.*

## Measured (ARM64 bench, PowerShell 5.1.26100.1, 2026-08-29)

- The bundle verifies **`Valid` / `Authenticode` / `CN=Microsoft Corporation`** — so the recipe now checks the publisher before unpacking anything, and `setup.md` states what that settles (provenance) and what it does not (that an unregistered payload is a supported Microsoft configuration).
- 1,188,564,441 bytes; holds the three `.msix` names the recipe guesses.
- **All three** payload trees (`amd64\`, `arm64\`, `x86\`) hold the entire copy list, `msdia140.dll` included — plus `ttd\TTD.exe`, so the engine copy brings the *recorder* and not just the replay engine.
- The bench was then bundled from that payload and **replays**: a 40 MB trace recorded with the bundled `ttd\TTD.exe`, `open_trace` answering with its lifetime (`[E:0, 7F8:EB0]`, 9 modules) instead of the missing-`ttd\` diagnostic, and `step_back` reaching the start of the trace.

That closes #132 on the host it was filed from, and lifts **item 47**'s blocker — TTD replay being unavailable on that bench — so the measurement it wants can now be taken where its sibling measurements were.

## Two findings from the copy, both now in `setup.md`

- **A running server holds `dbgeng.dll` open** even with an empty session list: the engine is an import-table dependency mapped by the loader before `main`, whatever role the process plays. `Copy-Item` fails with *"being used by another process"* against an idle supervisor, so bundling over an existing engine needs the service **stopped**, not merely quiet.
- **`find_ttd` does not look beside the executable** — it probes `PATH`, the SDK layout and `WindowsApps` — so the recorder the copy just delivered still has to be put on `PATH`. Adding `<exe dir>\ttd\TTD.exe` to that probe is a one-line change and is deliberately **not** in this docs-only PR.

## Files

`skills/windbg-debugging/setup.md` (the substance), `docs/install.md` and `docs/smoke-test.md` (sentences calling the store package the only source), `FOLLOWUPS.md` (item 21 done, item 47's blocker lifted), `CHANGELOG.md`.

## Verification

- `npx markdownlint-cli2@0.23.2 README.md CHANGELOG.md "docs/**/*.md" "skills/**/*.md"` — clean. MD051 matters here: this moves content around a linked heading, and `### When the store package will not install` is kept verbatim because `setup.md` links to it.
- Cross-file fragments checked by hand (not linted): the three links to `install.md#bundling-the-windbg-engine`.
- No Rust change, so no test claim is made and `cargo fmt --all --check` is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CZu3mUSEzwtjPod3n88vhD
