### PR TITLE
Remember symbol paths for future sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#131](https://github.com/glslang/windbg-mcp/issues/131)) and above the machine-wide installs,
   since the payload next to the binary is the pair to the engine the loader actually gives this
   process.
+- **A symbol path can now seed later sessions without coupling running workers
+  ([#66](https://github.com/glslang/windbg-mcp/issues/66)).** `set_symbol_path` accepts
+  `for_new_sessions`: `true` remembers the successful `path`/`append` setting for this client's
+  future opens, `false` clears it, and omission keeps the existing session-only behavior. The
+  supervisor applies that starting state on the new worker's engine thread before its opener; it
+  never broadcasts a reload or path mutation to sessions already running, and listener clients
+  cannot inherit one another's host paths.
 - **`end_session` stops accepting work when its teardown reaches the front of the session queue
   ([#64](https://github.com/glslang/windbg-mcp/issues/64)).** The pump now marks the session closed
   immediately before forwarding `EndSession`: calls already ahead of it still run, while calls

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -914,7 +914,7 @@ measurements and the options that were weighed.
 
 Two files, not one. A tool is declared in `src/server.rs` as always, and its name also goes in a
 **group** in `src/toolset.rs` — the table behind `--tools`, which advertises a named subset of the
-surface because 74% of the 68,322-byte tool surface is prose a model needs and cannot be trimmed
+surface because 74% of the 68,893-byte tool surface is prose a model needs and cannot be trimmed
 (`docs/token-budget.md` finding 8).
 
 Forgetting the second half fails in the one direction nothing would notice: the *default* surface

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -327,11 +327,11 @@ What moved, for anyone picking up the items that referenced this:
   supervisor never touches a `DebugEngine` at all, which is a stronger position than the one that
   claim was written for.
 
-Not done, and no longer blocking anything: **per-worker symbol state** —
-[#66](https://github.com/glslang/windbg-mcp/issues/66). Each worker has its own `.sympath` and symbol
-cache, which is correct (sessions are independent) but means a `set_symbol_path` does not carry to a
-session opened later. The fix is a supervisor-held default applied at worker startup, not shared
-state between running workers.
+Fixed since: **per-worker symbol state** —
+[#66](https://github.com/glslang/windbg-mcp/issues/66). Each worker still owns its own `.sympath`
+and symbol cache, but `set_symbol_path { "for_new_sessions": true, … }` records a client-scoped
+starting mutation in the supervisor and applies it before that client's later workers open their
+targets. Session-only overrides remain the default, and no update is pushed into a running worker.
 
 Fixed since, from the same review: [#67](https://github.com/glslang/windbg-mcp/issues/67) — workers
 were spawned with `kill_on_drop`, so a worker shutdown missed was terminated with its target still

--- a/README.md
+++ b/README.md
@@ -116,9 +116,9 @@ Fifty-one tools in eight `--tools` groups; the rows below split some of those gr
 | Structure walk | `allocator` | `walk_memory` |
 | Raw     | `inspect` | `execute` — run any debugger command, returns full text output |
 
-All of them are served unless you say otherwise, and the definitions cost the model **68,322 bytes —
+All of them are served unless you say otherwise, and the definitions cost the model **68,893 bytes —
 about 17k tokens — before it has asked anything**. `--tools session,inspect,crash` cuts that to
-24,894 B for twenty tools, and a `--listen` client can be given a narrower surface than the run's
+25,465 B for twenty tools, and a `--listen` client can be given a narrower surface than the run's
 default. [`docs/tool-surface.md`](docs/tool-surface.md) has the arithmetic, the rule that `session`
 is always included, and what a typed operand may not contain.
 

--- a/docs/hevd-ioctl-walkthrough.md
+++ b/docs/hevd-ioctl-walkthrough.md
@@ -75,9 +75,12 @@ over the KD wire. Ask the user for the folder, then apply it with the `set_symbo
 the DbgEng `AppendSymbolPath` API, so it's immune to the `.sympath` line-eating quirk below):
 
 ```jsonc
-set_symbol_path { "path": "C:\\HEVD\\bin", "reload": "/f HEVD.sys" }
+set_symbol_path { "path": "C:\\HEVD\\bin", "reload": "/f HEVD.sys", "for_new_sessions": true }
 //   → HEVD (private pdb symbols)  c:\hevd\bin\HEVD.pdb
 ```
+
+`for_new_sessions` records the successful path for this client's later opens; it does not change
+workers that are already running. Omit it when the PDB folder belongs only to this session.
 
 > **Gotcha:** the raw `.sympath` / `.sympath+` commands swallow the *rest of the line* — they ignore
 > `;`, so anything chained after (`; .reload …`) is parsed as path text. Use `set_symbol_path`, or

--- a/docs/local-model.md
+++ b/docs/local-model.md
@@ -221,7 +221,7 @@ setx WINDBG_MCP_TOOLS_DRIVER        "session,inspect,crash"
 ```
 
 The second line is what makes this work on a listener the editor also uses: the driver is served 20
-tools and 24,894 B while every other client on that listener keeps all 51. Leave it out and the
+tools and 25,465 B while every other client on that listener keeps all 51. Leave it out and the
 driver is served whatever the listener was started with, which is the older behaviour and is the
 right one when the listener is the driver's own.
 
@@ -288,8 +288,8 @@ spec. Re-read them rather than trusting this table, which has been stale before.
 
 | | bytes | ≈tokens |
 |---|---|---|
-| The tool surface, paid once per conversation | 68,322 (51 tools) | ~17k |
-| — the same surface as `--tools session,inspect,crash` | 24,894 (20 tools) | ~6k |
+| The tool surface, paid once per conversation | 68,893 (51 tools) | ~17k |
+| — the same surface as `--tools session,inspect,crash` | 25,465 (20 tools) | ~6k |
 | — as `--tools crash` | 14,587 (11 tools) | ~3.6k |
 | Its worst single tool (`debug_batch`) | 9,798 | ~2.4k |
 | The largest answer this server gives (`modules`) | 53,875 | ~13k |
@@ -462,8 +462,8 @@ budget, a text-or-data content switch. **Two of the three now exist, and neither
 client-side.**
 
 - **The tool-surface profile is `--tools`** (2026-08-22). Start the listener with
-  `--tools session,inspect,crash` and the surface is 20 tools and 24,894 B instead of 51 and
-  68,322 — `--tools crash` is 11 and 14,587 B, which is the difference between "roughly twice an 8k
+  `--tools session,inspect,crash` and the surface is 20 tools and 25,465 B instead of 51 and
+  68,893 — `--tools crash` is 11 and 14,587 B, which is the difference between "roughly twice an 8k
   window" and "half of one". The tools that remain are the tools they were, less the sentences
   pointing at ones that went (item 41).
   The whole table is in [`token-budget.md`](./token-budget.md) under finding 8, and the README has

--- a/docs/remote-listener.md
+++ b/docs/remote-listener.md
@@ -6,7 +6,7 @@ the machine DbgEng needs — a Mac driving a Windows VM, say.
 
 **`--tools` works here exactly as it does on stdio**, and matters more: the client at the far end
 may be a local model whose window is bought in RAM. `--listen 127.0.0.1:8765 --tools
-session,inspect,crash` serves 20 tools and 24,894 B of model context instead of 51 and 68,322 — the
+session,inspect,crash` serves 20 tools and 25,465 B of model context instead of 51 and 68,893 — the
 README has the table, and [`local-model.md`](./local-model.md) is the runbook it was measured for.
 It is this listener's **default**: a client may be given a surface of its own, which is what lets
 one server hold a local model and a hosted client at once — see [A tool surface per

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -457,6 +457,11 @@ processes, so they need real ones:
 
 - *Two sessions coexist.* Two dumps open at once, and the first handle still works after the second
   open landed. Under the single-engine design this was impossible by construction.
+- *A symbol path can seed later sessions without becoming shared worker state.* Two workers are
+  open before `set_symbol_path` remembers a unique local directory: the other existing worker must
+  stay unchanged, the next open must inherit it, and a session-only override must not replace it.
+  Clearing the remembered setting then sends a final open back to its ambient DbgEng path. Empty
+  temporary directories prove the routing with no symbol server, matching PDB, or network.
 - *A kernel attach that never connects costs one session.* An `attach_kernel` at a dead port parks
   exactly as a guest that is not in debug mode would; the test then opens a dump **while it is
   parked** (the regression test for [#61](https://github.com/glslang/windbg-mcp/issues/61)) and

--- a/docs/token-budget.md
+++ b/docs/token-budget.md
@@ -302,7 +302,7 @@ None of these is a bug. They are recorded because they were invisible, and
    schemars emits 109 times and which tells a model nothing an absent field does not, is 1,744 B —
    2.6%. The other candidates are not free: `$schema` is 2,850 B but is how a client picks a
    validator dialect (and `tool_schemas_declare_one_dialect_and_are_self_contained` pins it), and
-   `minimum`/`format` are constraints. **Roughly 1.7 KB of 68,322 is the whole honest total** for
+   `minimum`/`format` are constraints. **Roughly 1.7 KB of 68,893 is the whole honest total** for
    trimming the schemas.
 
    So the third lever is the one taken: `--tools` (`src/toolset.rs`) advertises a named subset. A
@@ -312,20 +312,20 @@ None of these is a bug. They are recorded because they were invisible, and
 
    | group | tools | bytes | share |
    |---|---:|---:|---:|
-   | `allocator` | 10 | 15,969 | 23.4% |
-   | `session` | 10 | 12,606 | 18.5% |
-   | `inspect` | 9 | 10,215 | 15.0% |
-   | `batch` | 1 | 9,798 | 14.3% |
-   | `ttd` | 9 | 6,829 | 10.0% |
-   | `ioctl` | 6 | 6,494 | 9.5% |
-   | `exec` | 5 | 3,475 | 5.1% |
+   | `allocator` | 10 | 15,969 | 23.2% |
+   | `session` | 10 | 12,606 | 18.3% |
+   | `inspect` | 9 | 10,786 | 15.7% |
+   | `batch` | 1 | 9,798 | 14.2% |
+   | `ttd` | 9 | 6,829 | 9.9% |
+   | `ioctl` | 6 | 6,494 | 9.4% |
+   | `exec` | 5 | 3,475 | 5.0% |
    | `crash` | 1 | 2,936 | 4.3% |
 
    | `--tools` | tools | model |
    |---|---:|---:|
-   | *(absent)* | 51 | 68,322 |
-   | `session,inspect,exec,crash` | 25 | 28,311 |
-   | `session,inspect,crash` | 20 | 24,894 |
+   | *(absent)* | 51 | 68,893 |
+   | `session,inspect,exec,crash` | 25 | 28,882 |
+   | `session,inspect,crash` | 20 | 25,465 |
    | `crash` | 11 | 14,587 |
 
    **The two tables do not reconcile, and that is the point of item 41.** The first is each group's

--- a/docs/tool-surface.md
+++ b/docs/tool-surface.md
@@ -6,7 +6,7 @@ how much of that surface a run serves, and three behaviours the table has no roo
 ## Serving fewer tools (`--tools`)
 
 All fifty-one tools are served unless you say otherwise, and their definitions cost the model
-**68,322 bytes — about 17k tokens — before it has asked anything**, once per conversation. Three
+**68,893 bytes — about 17k tokens — before it has asked anything**, once per conversation. Three
 quarters of that is the prose that tells a model how to drive them, so it cannot be trimmed without
 making the tools harder to use correctly (see
 [`token-budget.md`](token-budget.md)). What *can* change is how many of them a given run
@@ -18,9 +18,9 @@ windbg-mcp.exe --tools session,inspect,crash
 
 | `--tools` | Tools | Model context |
 |---|---:|---:|
-| *(absent)* — every tool | 51 | 68,322 B |
-| `session,inspect,exec,crash` | 25 | 28,311 B |
-| `session,inspect,crash` | 20 | 24,894 B |
+| *(absent)* — every tool | 51 | 68,893 B |
+| `session,inspect,exec,crash` | 25 | 28,882 B |
+| `session,inspect,crash` | 20 | 25,465 B |
 | `crash` | 11 | 14,587 B |
 
 The spec is a comma-separated list of the group names in the [tool table](../README.md#tools), of

--- a/skills/windbg-debugging/SKILL.md
+++ b/skills/windbg-debugging/SKILL.md
@@ -118,7 +118,8 @@ where its stderr is not on your screen.
 - **Symbol *names* (`module!func`) need three things together:** (a) `msdia140.dll` and
   `symsrv.dll` bundled next to the binary, (b) a symbol path — set it with the
   **`set_symbol_path`** tool (`srv*C:\ProgramData\Dbg\sym*https://msdl.microsoft.com/download/symbols`,
-  `append: true`), which goes through the DbgEng API and so avoids `.sympath` swallowing the
+  `append: true`, `for_new_sessions: true` when later sessions should inherit it), which goes
+  through the DbgEng API and so avoids `.sympath` swallowing the
   rest of the command line — and (c) a module-qualified `.reload /f <mod>` at a *stopped*
   position (bare `.reload /f` walks every loaded module, which on a live kernel is slow) (after a
   `go`/breakpoint, **not** straight off a `goto_position`/`!tt`). Without these you silently

--- a/skills/windbg-debugging/driver-ioctl.md
+++ b/skills/windbg-debugging/driver-ioctl.md
@@ -70,7 +70,9 @@ reads.
 > the engine wants with `execute { "command": "!sym noisy; .reload /f <driver>.sys" }` (it prints
 > `<pdb>\<GUID>\…`), then **ask the user for the folder holding that PDB** — it must be on *this*
 > debugger host (symbols are never pulled from the target over the KD wire) — and apply it with
-> `set_symbol_path { "path": "<folder>", "reload": "/f <driver>.sys" }`. Names like
+> `set_symbol_path { "path": "<folder>", "reload": "/f <driver>.sys", "for_new_sessions": true }`
+> when later sessions should start with the same folder; omit `for_new_sessions` for an override
+> confined to this session. Names like
 > `HEVD!IrpDeviceIoCtlHandler` / `HEVD!ArbitraryWriteIoctlHandler` then resolve.
 
 ## Static reachability — dispatch → handler (`reachable_from_dispatch`)

--- a/skills/windbg-debugging/setup.md
+++ b/skills/windbg-debugging/setup.md
@@ -458,7 +458,9 @@ Symbol *names* fail silently without all three of:
    read a symbol-store cache.
 2. **A symbol path:** use the **`set_symbol_path`** tool with
    `srv*C:\ProgramData\Dbg\sym*https://msdl.microsoft.com/download/symbols` and
-   `append: true`. It goes through DbgEng's `Append/SetSymbolPath`, so it avoids
+   `append: true`; add `for_new_sessions: true` when later sessions opened by this client should
+   start with the same setting. Omit it for a session-only override. The tool goes through DbgEng's
+   `Append/SetSymbolPath`, so it avoids
    `.sympath`'s habit of swallowing the rest of the command line. Naming the cache
    explicitly is *recommended*, not required — `.symfix` with no argument uses the `sym`
    subdirectory of the debugger's installation directory — but an explicit path is

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -38,7 +38,7 @@ use tokio::sync::{mpsc, oneshot};
 use windows_sys::Win32::Foundation::{HANDLE_FLAG_INHERIT, SetHandleInformation};
 
 use crate::kdconn;
-use crate::proto::{EngineOp, Output, WorkerMessage, WorkerRequest};
+use crate::proto::{EngineOp, Output, SymbolPathSetting, WorkerMessage, WorkerRequest};
 use crate::worker::{MESSAGES_FLAG, REQUESTS_FLAG, TARGET_FLAG, WORKER_FLAG};
 
 /// How many sessions may be open at once.
@@ -711,6 +711,7 @@ impl Session {
 struct Job {
     id: u64,
     op: EngineOp,
+    startup_symbol_path: Option<SymbolPathSetting>,
     submitted: Instant,
     gate: Gate,
 }
@@ -775,6 +776,7 @@ enum Wait {
 /// A call to run against a session.
 pub struct Call {
     op: EngineOp,
+    startup_symbol_path: Option<SymbolPathSetting>,
     gate: Gate,
 }
 
@@ -783,6 +785,7 @@ impl Call {
     pub fn new(op: EngineOp) -> Self {
         Self {
             op,
+            startup_symbol_path: None,
             gate: Gate {
                 on: On::Default,
                 retires: None,
@@ -804,6 +807,13 @@ impl Call {
         self
     }
 
+    /// Carries supervisor-held starting state on an opener's first worker request.
+    fn starting_with_symbols(mut self, setting: Option<SymbolPathSetting>) -> Self {
+        debug_assert!(self.op.is_opener(), "startup symbols belong on an opener");
+        self.startup_symbol_path = setting;
+        self
+    }
+
     /// Marks this call as the point where its session stops accepting work.
     fn closing(mut self, why: impl Into<String>) -> Self {
         self.gate.closes = Some(why.into());
@@ -814,6 +824,7 @@ impl Call {
     fn supervisor(op: EngineOp) -> Self {
         Self {
             op,
+            startup_symbol_path: None,
             gate: Gate {
                 on: On::Supervisor,
                 retires: None,
@@ -933,6 +944,11 @@ struct Registry {
     /// Credentials that have been **revoked**, whose sessions must stop growing for the same
     /// reason `closing` exists — see [`Sessions::revoke`].
     revoked: std::collections::HashSet<crate::client::Client>,
+    /// The symbol-path mutation each client explicitly asked future workers to start with.
+    ///
+    /// This is client state for the same reason sessions are: a listener credential is an
+    /// isolation boundary, and one caller's host paths must not change another caller's opens.
+    symbol_paths: HashMap<crate::client::Client, SymbolPathSetting>,
 }
 
 impl Registry {
@@ -1065,6 +1081,30 @@ impl Sessions {
         self.rec.clone()
     }
 
+    /// Sets or clears the calling client's starting symbol path for workers opened later.
+    ///
+    /// The tool calls this only after the same mutation succeeded in its current session, so a
+    /// path DbgEng refused can never become startup state. Existing workers are deliberately not
+    /// visited: this is a starting point, not shared engine state.
+    pub fn set_startup_symbol_path(&self, setting: Option<SymbolPathSetting>) {
+        let owner = crate::client::current();
+        let mut registry = self.registry();
+        match setting {
+            Some(setting) => {
+                registry.symbol_paths.insert(owner, setting);
+            }
+            None => {
+                registry.symbol_paths.remove(&owner);
+            }
+        }
+    }
+
+    /// Snapshots the calling client's starting symbol path for one open.
+    fn startup_symbol_path(&self) -> Option<SymbolPathSetting> {
+        let owner = crate::client::current();
+        self.registry().symbol_paths.get(&owner).cloned()
+    }
+
     fn registry(&self) -> std::sync::MutexGuard<'_, Registry> {
         self.inner.lock().unwrap_or_else(|e| e.into_inner())
     }
@@ -1163,7 +1203,9 @@ impl Sessions {
     /// lived there. What it leaves behind is a name and a `u64` per revocation, for the life of the
     /// process.
     pub fn revoke(&self, owner: &crate::client::Client) {
-        self.registry().revoked.insert(owner.clone());
+        let mut registry = self.registry();
+        registry.revoked.insert(owner.clone());
+        registry.symbol_paths.remove(owner);
     }
 
     pub fn snapshot(&self) -> Vec<SessionSnapshot> {
@@ -1251,6 +1293,7 @@ impl Sessions {
         let queued = session.tx.send(Job {
             id,
             op: call.op,
+            startup_symbol_path: call.startup_symbol_path,
             submitted: Instant::now(),
             gate: call.gate,
         });
@@ -1329,6 +1372,9 @@ impl Sessions {
         op: EngineOp,
     ) -> Result<OpenReport, OpenError> {
         debug_assert!(op.is_opener(), "open() needs an opener op");
+        // A default belongs to the moment an open starts. One changed while this worker is being
+        // selected or spawned affects the next open, not a request already in flight.
+        let startup_symbol_path = self.startup_symbol_path();
         // Take a slot before doing anything expensive, but do **not** reclaim anything yet — see
         // `take_slot` and `reconcile_capacity` for why those are separate.
         let slot = self.take_slot().map_err(OpenError::NoRoom)?;
@@ -1391,7 +1437,7 @@ impl Sessions {
         let out = self
             .call_as(
                 &session,
-                Call::new(op),
+                Call::new(op).starting_with_symbols(startup_symbol_path),
                 self.call_timeout,
                 OPENER_JOB,
                 Wait::Fixed,
@@ -3003,7 +3049,11 @@ fn pump(
         if let Some(patience_ms) = op.patience_slot() {
             *patience_ms = remaining_patience_ms(call_timeout, job.submitted);
         }
-        let request = WorkerRequest { id: job.id, op };
+        let request = WorkerRequest {
+            id: job.id,
+            op,
+            startup_symbol_path: job.startup_symbol_path,
+        };
         let Ok(mut line) = serde_json::to_string(&request) else {
             answer(Err(EngineError::Debugger(
                 "could not encode this operation for the engine worker".to_string(),
@@ -3581,6 +3631,66 @@ mod tests {
         .await;
     }
 
+    /// A remembered symbol path is client state, not server state. Rotation keeps the same typed
+    /// identity and therefore the setting; revocation removes it, and a later holder of the same
+    /// visible name starts from nothing.
+    #[tokio::test]
+    async fn startup_symbol_paths_follow_client_identity_and_revocation() {
+        let sessions = Sessions::new(Duration::from_secs(1));
+        let original = crate::client::Client::incarnate("ci", 1);
+        let replacement = crate::client::Client::incarnate("ci", 2);
+        let other = crate::client::Client::incarnate("other", 3);
+        let first = SymbolPathSetting {
+            path: r"C:\symbols\first".to_string(),
+            append: true,
+        };
+        let second = SymbolPathSetting {
+            path: r"D:\symbols\second".to_string(),
+            append: false,
+        };
+
+        crate::client::as_client(original.clone(), async {
+            assert_eq!(sessions.startup_symbol_path(), None);
+            sessions.set_startup_symbol_path(Some(first.clone()));
+            assert_eq!(sessions.startup_symbol_path(), Some(first.clone()));
+            // The latest explicit setting replaces the earlier starting mutation.
+            sessions.set_startup_symbol_path(Some(second.clone()));
+            assert_eq!(sessions.startup_symbol_path(), Some(second.clone()));
+            sessions.set_startup_symbol_path(None);
+            assert_eq!(sessions.startup_symbol_path(), None);
+            sessions.set_startup_symbol_path(Some(second.clone()));
+        })
+        .await;
+
+        crate::client::as_client(other, async {
+            assert_eq!(
+                sessions.startup_symbol_path(),
+                None,
+                "one client inherited another client's host path"
+            );
+        })
+        .await;
+
+        // A token rotation supplies this same identity, so it still sees the setting.
+        crate::client::as_client(original.clone(), async {
+            assert_eq!(sessions.startup_symbol_path(), Some(second));
+        })
+        .await;
+        sessions.revoke(&original);
+        crate::client::as_client(original, async {
+            assert_eq!(sessions.startup_symbol_path(), None);
+        })
+        .await;
+        crate::client::as_client(replacement, async {
+            assert_eq!(
+                sessions.startup_symbol_path(),
+                None,
+                "a name given back inherited the revoked incarnation's setting"
+            );
+        })
+        .await;
+    }
+
     /// And it is not listed either. Reporting another client's sessions would hand over handles it
     /// cannot use, and say how many clients this server has and what they are debugging.
     #[tokio::test]
@@ -3816,6 +3926,51 @@ mod tests {
         (Arc::new(Session { tx, ..session }), rx)
     }
 
+    /// The starting path travels on the opener's request itself. Sending a standalone setup job
+    /// would make the worker briefly routable between setup and open, and would let another call
+    /// occupy that gap.
+    #[test]
+    fn an_opener_carries_its_starting_symbol_path_on_the_same_request() {
+        let (session, rx) = queued("sess-1", SessionState::Opening);
+        let waiters = Arc::clone(&session.waiters);
+        let (requests, worker) = std::io::pipe().expect("a pipe to stand in for the worker's");
+        let setting = SymbolPathSetting {
+            path: r"C:\symbols\driver".to_string(),
+            append: true,
+        };
+        let call = Call::new(EngineOp::OpenDump {
+            path: r"C:\dumps\sample.dmp".to_string(),
+        })
+        .starting_with_symbols(Some(setting.clone()));
+        session
+            .tx
+            .send(Job {
+                id: OPENER_JOB,
+                op: call.op,
+                startup_symbol_path: call.startup_symbol_path,
+                submitted: Instant::now(),
+                gate: call.gate,
+            })
+            .expect("the pump's queue is open");
+
+        let pumping = std::thread::spawn({
+            let session = Arc::downgrade(&session);
+            move || pump(session, rx, worker, waiters, Duration::from_secs(30))
+        });
+        let mut requests = std::io::BufReader::new(requests);
+        let mut line = String::new();
+        requests
+            .read_line(&mut line)
+            .expect("read the opener request");
+        let request: WorkerRequest =
+            serde_json::from_str(&line).expect("the worker request is JSON");
+        assert!(request.op.is_opener());
+        assert_eq!(request.startup_symbol_path, Some(setting));
+
+        drop(session);
+        pumping.join().expect("the pump stops with its session");
+    }
+
     /// Closing is a queue operation, not a caller-side state change. Work already ahead of an
     /// `EndSession` must reach the worker, while work queued behind it must be refused even though
     /// it was submitted while the session still looked open.
@@ -3848,6 +4003,7 @@ mod tests {
                     .send(Job {
                         id,
                         op: call.op,
+                        startup_symbol_path: call.startup_symbol_path,
                         submitted: Instant::now(),
                         gate: call.gate,
                     })

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -176,8 +176,7 @@ pub enum EngineOp {
     /// [`Self::BoundedCommand`]'s is.
     Walk(WalkOp),
     SymbolPath {
-        path: String,
-        append: bool,
+        setting: SymbolPathSetting,
         reload: String,
     },
     RunToAddress {
@@ -280,6 +279,19 @@ pub enum EngineOp {
     /// boundary. Interrupting the engine itself is a different mechanism (`SetInterrupt`, bound to
     /// job identity) and is not this.
     EndSession,
+}
+
+/// A symbol-path mutation that can be applied to either one session or a worker before it opens
+/// its target.
+///
+/// `reload` is deliberately not part of this value. It belongs to the session the caller changed:
+/// replaying a module-qualified reload in an unrelated future target could fail its open for a
+/// module it does not even contain. A worker given this as startup state applies it before the
+/// target is opened, so that target loads against the configured path without a replayed reload.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SymbolPathSetting {
+    pub path: String,
+    pub append: bool,
 }
 
 impl EngineOp {
@@ -752,6 +764,9 @@ mod tests {
 pub struct WorkerRequest {
     pub id: u64,
     pub op: EngineOp,
+    /// Supervisor-held starting state for an opener. Absent on every ordinary request.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub startup_symbol_path: Option<SymbolPathSetting>,
 }
 
 /// A message up the worker's stdout.

--- a/src/server.rs
+++ b/src/server.rs
@@ -22,6 +22,7 @@ use crate::engine::{
 use crate::kdconn;
 use crate::proto::{
     EngineOp, HeapBackendFilter, HeapOp, HeapStateFilter, Output, PoolOp, ReachabilityOp,
+    SymbolPathSetting,
 };
 use crate::schema::constraints_of;
 use crate::structured::{self, ErrorCategory, Outcome, TargetCreated};
@@ -1780,6 +1781,12 @@ pub struct SymbolPathArgs {
     /// force-load one module's symbols. Omit to reload all deferred modules.
     #[serde(default)]
     pub reload: Option<String>,
+    /// Whether this client's subsequently opened sessions should start with this path setting.
+    /// Omit to change only this session (the existing behavior), true to remember this `path` and
+    /// `append` pair, or false to clear a setting remembered earlier. The current session must
+    /// accept the change before either update takes effect. `reload` is always session-only.
+    #[serde(default)]
+    pub for_new_sessions: Option<bool>,
     /// Which session to act on. Omit for the current one; pass an opener's handle to route to that
     /// session and be refused if its target was replaced or closed.
     #[serde(default)]
@@ -2837,7 +2844,9 @@ impl WindbgServer {
 
     /// Set or extend the symbol search path, then reload symbols, so `module!Symbol`
     /// names resolve. Use it when a driver's PDB isn't on the default path: ask the user
-    /// for the folder holding the matching PDB (by GUID) and apply it here. The path must
+    /// for the folder holding the matching PDB (by GUID) and apply it here. Set
+    /// `for_new_sessions: true` when this client should also start later sessions with the same
+    /// path; omit it for a per-session override. The path must
     /// be reachable from THIS (debugger) host — symbols are not fetched from the target
     /// over the KD wire. Goes through the DbgEng API, so it avoids the `.sympath` command
     /// quirk of swallowing the rest of the command line.
@@ -2852,16 +2861,45 @@ impl WindbgServer {
         &self,
         Parameters(args): Parameters<SymbolPathArgs>,
     ) -> Result<CallToolResult, ErrorData> {
-        let out = self
+        let setting = SymbolPathSetting {
+            path: args.path,
+            append: args.append.unwrap_or(true),
+        };
+        let startup = args.for_new_sessions;
+        let mut out = self
             .run(
                 args.session_id.as_deref(),
                 EngineOp::SymbolPath {
-                    path: args.path,
-                    append: args.append.unwrap_or(true),
+                    setting: setting.clone(),
                     reload: args.reload.unwrap_or_default(),
                 },
             )
             .await;
+        if let Ok(output) = &mut out {
+            let note = match startup {
+                Some(true) => {
+                    self.sessions.set_startup_symbol_path(Some(setting));
+                    Some(
+                        "New sessions opened by this client will start with this symbol-path \
+                         setting. Existing sessions were not changed.",
+                    )
+                }
+                Some(false) => {
+                    self.sessions.set_startup_symbol_path(None);
+                    Some(
+                        "The remembered symbol-path setting for this client's new sessions was \
+                         cleared. Existing sessions were not changed.",
+                    )
+                }
+                None => None,
+            };
+            if let Some(note) = note {
+                if !output.text.trim().is_empty() {
+                    output.text.push_str("\n\n");
+                }
+                output.text.push_str(note);
+            }
+        }
         engine_result(out)
     }
 

--- a/src/toolset.rs
+++ b/src/toolset.rs
@@ -1,7 +1,7 @@
 //! Which of this server's fifty-one tools a run advertises.
 //!
 //! The tool surface is paid **once per conversation, before anything is debugged**, and it is
-//! 68,322 bytes — roughly 17k tokens. Three quarters of that is prose, and the prose is what tells
+//! 68,893 bytes — roughly 17k tokens. Three quarters of that is prose, and the prose is what tells
 //! a model how to drive the tools, so there is no strip here the way there was in
 //! [`crate::schema`]: `FOLLOWUPS.md` item 24 measured it and the only honest lever left is the one
 //! this module is — **not offering every tool to every caller**.
@@ -21,7 +21,7 @@
 //!   group      tools   bytes   what it is for
 //!   session       10   12,606  opening a target, ending it, and watching this server
 //!   allocator     10   15,969  pool and heap walks, and `walk_memory`
-//!   inspect        9   10,215  registers, stacks, memory, modules, symbols, raw commands
+//!   inspect        9   10,786  registers, stacks, memory, modules, symbols, raw commands
 //!   ttd            9    6,829  recording, indexing and querying a Time Travel trace
 //!   ioctl          6    6,494  driver objects, IRP stacks, and dispatch reachability
 //!   exec           5    3,475  breakpoints and execution control

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -54,7 +54,7 @@ use windows_sys::Win32::Foundation::{HANDLE_FLAG_INHERIT, SetHandleInformation};
 use crate::batch::{self, BatchOp, Debuggee, Ran};
 use crate::proto::{
     EngineOp, Failed, HeapBackendFilter, HeapOp, HeapStateFilter, MAX_MODULE_ROWS, Output, PoolOp,
-    ReachabilityOp, WorkerMessage, WorkerRequest,
+    ReachabilityOp, SymbolPathSetting, WorkerMessage, WorkerRequest,
 };
 use crate::server::{
     EXEC_WAIT_MS, fmt_addr, format_recipe, format_report, hexdump, matches_module_pattern,
@@ -868,6 +868,14 @@ fn engine_thread(rx: mpsc::Receiver<Job>, target: Option<Opening>) {
         // surface it as an error for this one op. The engine survives, so this stays a
         // debugger-level failure the model can work around by trying something else.
         let result = catch_unwind(AssertUnwindSafe(|| {
+            if let Some(setting) = request.startup_symbol_path {
+                if !request.op.is_opener() {
+                    return Err(Failed::from(
+                        "startup symbol state was attached to a request that is not an opener",
+                    ));
+                }
+                apply_symbol_path(&engine, &setting).map_err(Failed::from)?;
+            }
             execute(&engine, id, request.op, queued)
         }))
         .unwrap_or_else(|_| Err(Failed::from("debugger operation panicked")));
@@ -1123,6 +1131,18 @@ fn refuse_when_the_target_is_gone(e: &DebugEngine, op: &EngineOp) -> Option<Fail
     }
 }
 
+/// Applies one symbol-path mutation through DbgEng's typed API.
+///
+/// Shared by the ordinary tool and an opener's supervisor-held starting state so the two cannot
+/// drift into different interpretations of `append`.
+fn apply_symbol_path(e: &DebugEngine, setting: &SymbolPathSetting) -> Result<(), String> {
+    if setting.append {
+        e.append_symbol_path(&setting.path).map_err(es)
+    } else {
+        e.set_symbol_path(&setting.path).map_err(es)
+    }
+}
+
 /// Runs one op against this worker's engine. `queued` is how long it waited its turn here, which
 /// only the bounded-command path cares about.
 fn execute(e: &DebugEngine, id: u64, op: EngineOp, queued: Duration) -> Result<Output, Failed> {
@@ -1349,16 +1369,8 @@ fn execute(e: &DebugEngine, id: u64, op: EngineOp, queued: Duration) -> Result<O
                 )),
             }
         }
-        EngineOp::SymbolPath {
-            path,
-            append,
-            reload,
-        } => {
-            if append {
-                e.append_symbol_path(&path).map_err(es)?;
-            } else {
-                e.set_symbol_path(&path).map_err(es)?;
-            }
+        EngineOp::SymbolPath { setting, reload } => {
+            apply_symbol_path(e, &setting).map_err(Failed::from)?;
             // Reload so the new path takes effect (default: all deferred modules).
             e.reload_symbols(&reload).map_err(es)?;
             // Echo the effective path so the caller can confirm what resolved.

--- a/tests/golden/tool_budget.json
+++ b/tests/golden/tool_budget.json
@@ -371,12 +371,12 @@
     },
     {
       "annotations": 123,
-      "description": 465,
-      "inputSchema": 1125,
-      "modelVisible": 1646,
+      "description": 602,
+      "inputSchema": 1559,
+      "modelVisible": 2217,
       "name": "set_symbol_path",
       "outputSchema": 0,
-      "wire": 1784
+      "wire": 2355
     },
     {
       "annotations": 116,
@@ -462,14 +462,14 @@
   ],
   "totals": {
     "annotations": 5449,
-    "description": 25406,
-    "inputSchema": 40259,
+    "description": 25543,
+    "inputSchema": 40693,
     "instructions": 1983,
-    "modelVisible": 68322,
+    "modelVisible": 68893,
     "outputSchema": 104589,
-    "payload": 179771,
+    "payload": 180342,
     "tools": 51,
-    "wire": 179653,
+    "wire": 180224,
     "worstTool": "debug_batch",
     "worstToolModelVisible": 9798
   }

--- a/tests/golden/tools_list.json
+++ b/tests/golden/tools_list.json
@@ -1268,6 +1268,7 @@
       "output": null,
       "params": [
         "append: boolean|null",
+        "for_new_sessions: boolean|null",
         "path: string",
         "reload: string|null",
         "session_id: string|null"

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -2095,7 +2095,7 @@ fn every_tool_belongs_to_exactly_one_group() {
 
 /// A narrowed surface serves fewer tools, and says so rather than pretending the rest never were.
 ///
-/// The measurement behind `--tools` is that three quarters of the 68,322-byte tool surface is
+/// The measurement behind `--tools` is that three quarters of the 68,893-byte tool surface is
 /// prose a model needs, so the only way to spend less of a caller's context is to offer fewer
 /// tools — `FOLLOWUPS.md` item 24. This asserts the three things that makes true.
 #[test]
@@ -7837,6 +7837,128 @@ fn two_sessions_coexist_and_do_not_disturb_each_other() {
     );
 
     server.tool_text("end_session", json!({ "session_id": first }), TARGET_STEP);
+}
+
+/// Issue #66: a caller may make one symbol-path setting the starting point for sessions it opens
+/// later, without turning independent workers into shared mutable engine state.
+///
+/// Unique empty directories are enough to prove the path plumbing and need no symbol server or
+/// matching PDB. The contrast carries the claim: a worker that already existed is unchanged, a
+/// later worker inherits, a per-session override does not replace the remembered setting, and an
+/// explicit clear sends the following worker back to its ambient DbgEng path.
+#[test]
+fn a_symbol_path_can_seed_future_sessions_without_broadcasting_to_existing_ones() {
+    let Some(dump) = target_tier() else { return };
+    let remembered = marker_path("remembered-symbols");
+    let override_only = marker_path("session-only-symbols");
+    std::fs::create_dir_all(&remembered).expect("create the remembered symbol directory");
+    std::fs::create_dir_all(&override_only).expect("create the session-only symbol directory");
+    let remembered_text = remembered.to_string_lossy().to_string();
+    let override_text = override_only.to_string_lossy().to_string();
+    let contains_path = |output: &str, path: &str| {
+        output
+            .to_ascii_lowercase()
+            .contains(&path.to_ascii_lowercase())
+    };
+
+    let mut server = Server::started();
+    let first = server.open_session("open_dump", json!({ "path": dump }), TARGET_STEP);
+    let existing = server.open_session("open_dump", json!({ "path": dump }), TARGET_STEP);
+
+    let remembered_result = server.tool_text(
+        "set_symbol_path",
+        json!({
+            "session_id": first,
+            "path": remembered_text,
+            "append": false,
+            "for_new_sessions": true,
+        }),
+        TARGET_STEP,
+    );
+    assert!(
+        remembered_result.contains("New sessions opened by this client"),
+        "the caller was not told the future-session default changed:\n{remembered_result}"
+    );
+    let existing_path = server.tool_text(
+        "execute",
+        json!({ "session_id": existing, "command": ".sympath" }),
+        TARGET_STEP,
+    );
+    assert!(
+        !contains_path(&existing_path, &remembered_text),
+        "the setting was broadcast into a worker that was already running:\n{existing_path}"
+    );
+
+    let inherited = server.open_session("open_dump", json!({ "path": dump }), TARGET_STEP);
+    let inherited_path = server.tool_text(
+        "execute",
+        json!({ "session_id": inherited, "command": ".sympath" }),
+        TARGET_STEP,
+    );
+    assert!(
+        contains_path(&inherited_path, &remembered_text),
+        "a newly opened worker did not inherit the remembered path:\n{inherited_path}"
+    );
+
+    server.tool_text(
+        "set_symbol_path",
+        json!({
+            "session_id": inherited,
+            "path": override_text,
+            "append": false,
+        }),
+        TARGET_STEP,
+    );
+    let later = server.open_session("open_dump", json!({ "path": dump }), TARGET_STEP);
+    let later_path = server.tool_text(
+        "execute",
+        json!({ "session_id": later, "command": ".sympath" }),
+        TARGET_STEP,
+    );
+    assert!(
+        contains_path(&later_path, &remembered_text),
+        "a session-only override replaced the remembered starting path:\n{later_path}"
+    );
+    assert!(
+        !contains_path(&later_path, &override_text),
+        "a session-only override leaked into another worker:\n{later_path}"
+    );
+
+    let cleared = server.tool_text(
+        "set_symbol_path",
+        json!({
+            "session_id": inherited,
+            "path": override_text,
+            "append": false,
+            "for_new_sessions": false,
+        }),
+        TARGET_STEP,
+    );
+    assert!(
+        cleared.contains("remembered symbol-path setting") && cleared.contains("cleared"),
+        "the caller was not told the future-session default was cleared:\n{cleared}"
+    );
+    server.tool_text(
+        "end_session",
+        json!({ "session_id": existing }),
+        TARGET_STEP,
+    );
+    let after_clear = server.open_session("open_dump", json!({ "path": dump }), TARGET_STEP);
+    let ambient = server.tool_text(
+        "execute",
+        json!({ "session_id": after_clear, "command": ".sympath" }),
+        TARGET_STEP,
+    );
+    assert!(
+        !contains_path(&ambient, &remembered_text) && !contains_path(&ambient, &override_text),
+        "clearing the default did not restore ambient startup behavior:\n{ambient}"
+    );
+
+    for session in [first, inherited, later, after_clear] {
+        server.tool_text("end_session", json!({ "session_id": session }), TARGET_STEP);
+    }
+    let _ = std::fs::remove_dir(&remembered);
+    let _ = std::fs::remove_dir(&override_only);
 }
 
 /// A stateless client can work while one of its own calls is parked — the same property as the


### PR DESCRIPTION
Closes #66

## Summary

- extend `set_symbol_path` with an optional, client-scoped setting for future sessions
- apply remembered symbol paths on each new worker's engine thread before its target opens
- keep reloads and running workers session-local, and clear remembered state on client revocation
- add supervisor lifecycle coverage, a real-DbgEng smoke test, and updated user documentation and tool-surface goldens

## Testing

- `cargo fmt --all --check`
- `cargo test` (595 unit tests and 91 smoke tests passed; 12 opt-in tests ignored)
- `cargo clippy --all-targets -- -D warnings`
