### PR TITLE
Add early-stop pool tag queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   no processor number applies, which every user-mode target is). A position on its own does not
   identify a stop on a multi-threaded target, and the alternative was parsing `~.`, whose text is
   one shape for a thread and another for a processor. Both come from new typed `dbgscope` readers.
+- **`pool_find_tag` can answer existence and bounded-cardinality questions without walking the
+  entire kernel pool** ([#86](https://github.com/glslang/windbg-mcp/issues/86)). Pass the nonzero
+  `stop_after_matches` threshold to stop a newly started walk as soon as that many matching
+  allocated chunks are decoded. The result reports `walk.coverage: "match_limit_reached"` and
+  echoes the threshold in `walk.stop_after_matches`; its counts and byte total are explicitly
+  floors. These deliberately partial snapshots are never cached as exhaustive. A complete cached
+  snapshot is still reused and stays complete, while `limit` remains the independent rendering
+  cap. The `debug_batch` `pool_find_tag` step accepts the same field.
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,7 +164,7 @@ dependencies = [
 [[package]]
 name = "dbgscope"
 version = "0.1.0"
-source = "git+https://github.com/glslang/dbgscope?rev=39c06d5bc12826c55784b3243a8745054013ff55#39c06d5bc12826c55784b3243a8745054013ff55"
+source = "git+https://github.com/glslang/dbgscope?rev=205fb9d30120b429b29c3b27744b628ff2928387#205fb9d30120b429b29c3b27744b628ff2928387"
 dependencies = [
  "hex",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,7 +164,7 @@ dependencies = [
 [[package]]
 name = "dbgscope"
 version = "0.1.0"
-source = "git+https://github.com/glslang/dbgscope?rev=8474b569717b88a32810bbabc8b262aeeebde485#8474b569717b88a32810bbabc8b262aeeebde485"
+source = "git+https://github.com/glslang/dbgscope?rev=39c06d5bc12826c55784b3243a8745054013ff55#39c06d5bc12826c55784b3243a8745054013ff55"
 dependencies = [
  "hex",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/glslang/windbg-mcp"
 license = "MIT"
 
 [dependencies]
-dbgscope = { git = "https://github.com/glslang/dbgscope", rev = "8474b569717b88a32810bbabc8b262aeeebde485" }
+dbgscope = { git = "https://github.com/glslang/dbgscope", rev = "39c06d5bc12826c55784b3243a8745054013ff55" }
 # 3.1.1 is a floor, not a preference: every 3.x before it generates a `tools/list` that omits
 # SEP-2549's required `ttlMs`/`cacheScope`, which a spec-strict `2026-07-28` client rejects
 # outright — the server connects and appears to expose no tools at all (upstream issue #1114).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/glslang/windbg-mcp"
 license = "MIT"
 
 [dependencies]
-dbgscope = { git = "https://github.com/glslang/dbgscope", rev = "39c06d5bc12826c55784b3243a8745054013ff55" }
+dbgscope = { git = "https://github.com/glslang/dbgscope", rev = "205fb9d30120b429b29c3b27744b628ff2928387" }
 # 3.1.1 is a floor, not a preference: every 3.x before it generates a `tools/list` that omits
 # SEP-2549's required `ttlMs`/`cacheScope`, which a spec-strict `2026-07-28` client rejects
 # outright — the server connects and appears to expose no tools at all (upstream issue #1114).

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -24,8 +24,12 @@
   (`WINDBG_MCP_CALL_TIMEOUT_SECS`, less what the query waited its turn on the session), so it can
   neither outlive the call that asked for it nor stop early while that call is still waiting; a walk
   cut short still answers, and every result says how much of the pool it reached. `interrupt` ends
-  one sooner. A query that reaches the engine with no time left to walk in — a call timeout at or
-  under the 15s the reply itself reserves, or a long wait behind other work on the session — is
+  one sooner. `pool_find_tag` can also stop deliberately at a nonzero `stop_after_matches` count;
+  that result reports `match_limit_reached`, is not cached as exhaustive, and keeps its counts as
+  floors. A complete cached snapshot still answers exhaustively. This traversal threshold is
+  independent of `limit`, which caps only the rows rendered. A query that reaches the engine with
+  no time left to walk in — a call timeout at or under the 15s the reply itself reserves, or a
+  long wait behind other work on the session — is
   *refused* rather than run, since a truncated walk is discarded rather than cached; without
   `refresh` it is still answered from the cached snapshot if there is one. Two semantics worth knowing: only *allocated* chunks are indexed by tag (a freed
   chunk's tag is not reliably preserved, so `pool_find_tag` never reports freed memory — ask about a

--- a/docs/messagemanager-walkthrough.md
+++ b/docs/messagemanager-walkthrough.md
@@ -115,6 +115,11 @@ are for:
 pool_find_tag { "tag": "Tgsm" }
 ```
 
+When only existence matters, add `"stop_after_matches": 1`; that stops a new walk at the first
+allocated match and reports `walk.coverage: "match_limit_reached"`. Keep `limit` for the separate
+question of how many found rows to render. Omit `stop_after_matches` when the exhaustive count and
+byte total matter.
+
 ```text
 tag `Tgsm`: 1 allocation(s), 0x68 bytes total
 ffff8c8f`13a02f90  0x68  SpecialNonPagedNx  Allocated

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -1153,9 +1153,10 @@ than measuring a patch that never landed.
 turns the MessageManager challenge into a repeatable live regression fixture. It builds a benign
 mode of `mm_exploit.c`, copies it to the VM over WinRM, and waits until the process has retained real
 `Tgsm` messages. It then runs the ignored Rust test through the shipped stdio MCP transport. The
-test attaches over KDNET, checks that `MessageManager.sys` is loaded, finds the retained allocations
-with `pool_find_tag`, verifies the session still serves a register request, and always attempts
-`end_session` before reporting an assertion failure.
+test attaches over KDNET, checks that `MessageManager.sys` is loaded, asks for one retained
+allocation with `pool_find_tag { "stop_after_matches": 1 }`, verifies the result says
+`match_limit_reached` with that stop condition, verifies the session still serves a register
+request, and always attempts `end_session` before reporting an assertion failure.
 
 Prerequisites are a disposable VM with the challenge driver installed and running, PowerShell
 remoting enabled, a working KDNET connection back to the host, the host MSVC Build Tools path used

--- a/docs/structured-results.md
+++ b/docs/structured-results.md
@@ -33,11 +33,19 @@ Two conventions hold across all of them:
   past 2^53 does not survive a JSON parser that reads numbers as doubles; zero-padded so lexical
   order matches numeric order. The debugger's backtick form (``fffff803`1ab10000``) appears only in
   the text.
-- **An allocator answer says what the walk covered.** `walk.coverage` is `complete`, `deadline_truncated`
-  (the call's budget ran out — more time reaches more of the allocator) or `partial` (unreadable regions
-  or a traversal cap — more time changes nothing). Counts from anything but `complete` are floors,
-  not totals. A walk that failed outright, or was stopped by `interrupt`, is not a coverage state at
-  all: it is the error branch below, with category `debugger` or `interrupted`.
+- **An allocator answer says what the walk covered.** `walk.coverage` is `complete`,
+  `deadline_truncated` (the call's budget ran out — more time reaches more of the allocator),
+  `partial` (unreadable regions or a traversal cap — more time changes nothing), or
+  `match_limit_reached` (`pool_find_tag` deliberately stopped at the nonzero
+  `walk.stop_after_matches` threshold). Counts from anything but `complete` are floors, not totals.
+  A walk that failed outright, or was stopped by `interrupt`, is not a coverage state at all: it is
+  the error branch below, with category `debugger` or `interrupted`.
+
+For `pool_find_tag`, `stop_after_matches` and `limit` answer different questions. The first bounds
+a newly started walk and therefore makes its result intentionally partial; the second only caps
+the `chunks` rendered after the walk and never changes `matches` or `total_bytes`. If the session
+already holds a complete cached snapshot, it is reused and the answer remains exhaustive even when
+`stop_after_matches` was supplied.
 
 One caveat about "also", measured rather than assumed: a client that understands
 `structuredContent` generally forwards **it** to the model and drops the text block, rather than

--- a/skills/windbg-debugging/heap-walking.md
+++ b/skills/windbg-debugging/heap-walking.md
@@ -29,8 +29,13 @@ validated VS family. An unfamiliar or ambiguous family is intentionally refused.
 - The first query walks the pool. Later queries reuse the same session snapshot. Pass
   `refresh: true` after any execution that could change the target; control tools invalidate the
   cache automatically, but explicit refresh makes the intent clear at the final observation.
-- Read both `layout` and `walk`. `deadline_truncated` and `partial` counts are floors, and an
-  uncovered address is not evidence that it was never pool.
+- For an existence or bounded-cardinality question, pass nonzero `stop_after_matches` to
+  `pool_find_tag`. A newly started walk stops when that many matching allocated chunks have been
+  decoded and reports `walk.coverage: match_limit_reached` plus the threshold. Its `matches` and
+  `total_bytes` are floors. A complete cached snapshot is reused instead and stays exhaustive.
+  `limit` is separate: it caps only the rendered `chunks`, never the walk.
+- Read both `layout` and `walk`. `deadline_truncated`, `partial`, and `match_limit_reached` counts
+  are floors, and an uncovered address is not evidence that it was never pool.
 - Query a tag by its `raw_tag`, not by the `tag` a listing prints. The printed form renders every
   unprintable byte as `.` — and a literal `.` the same way — so a tag containing `.` names no
   particular tag, and `pool_find_tag` will read it as four literal `.` bytes and report no

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -33,6 +33,7 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::Write as _;
+use std::num::NonZeroU32;
 use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::time::Duration;
 
@@ -149,7 +150,8 @@ const FAILED_OUTPUT_CHARS: usize = 8_000;
 /// `refresh` is what makes a pool step expensive — it re-walks every committed page — and inside a
 /// batch that walk is bounded by the *step's* share of the budget rather than by dbgscope's own
 /// default, which is longer than most batches. A walk cut short says how much of the pool it
-/// covered, so the answer stays honest; see [`Debuggee::pool`].
+/// covered, so the answer stays honest; `pool_find_tag` may also stop deliberately at its
+/// `stop_after_matches` threshold. See [`Debuggee::pool`].
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(tag = "op", rename_all = "snake_case")]
 pub enum StepAction {
@@ -195,7 +197,7 @@ pub enum StepAction {
         #[serde(default)]
         refresh: Option<bool>,
     },
-    /// Every allocated chunk carrying `tag` — the `pool_find_tag` tool.
+    /// Allocated chunks carrying `tag` — the `pool_find_tag` tool.
     PoolFindTag {
         tag: String,
         /// true = paged only, false = nonpaged only, omitted = both.
@@ -203,6 +205,10 @@ pub enum StepAction {
         paged: Option<bool>,
         #[serde(default)]
         refresh: Option<bool>,
+        /// Stop a newly started walk after this many matches. Must be nonzero. `limit` controls
+        /// only how many rows are printed.
+        #[serde(default)]
+        stop_after_matches: Option<NonZeroU32>,
         #[serde(default)]
         limit: Option<u32>,
     },
@@ -230,7 +236,7 @@ impl StepAction {
             Self::Eval { .. } => &["expr"],
             Self::ReadMemory { .. } => &["address", "size"],
             Self::PoolChunk { .. } => &["address", "refresh"],
-            Self::PoolFindTag { .. } => &["tag", "paged", "refresh", "limit"],
+            Self::PoolFindTag { .. } => &["tag", "paged", "refresh", "stop_after_matches", "limit"],
             Self::PoolCensus { .. } => &["refresh", "limit"],
         };
         key == "op" || fields.contains(&key)
@@ -254,16 +260,22 @@ impl StepAction {
                 tag,
                 paged,
                 refresh,
+                stop_after_matches,
                 ..
-            } => format!(
-                "pool chunks tagged {tag}{}{}",
-                match paged {
-                    Some(true) => " in paged pool",
-                    Some(false) => " in nonpaged pool",
-                    None => "",
-                },
-                walk_kind(*refresh)
-            ),
+            } => {
+                let stop = stop_after_matches.map_or_else(String::new, |matches| {
+                    format!(", stop after {} match(es)", matches.get())
+                });
+                format!(
+                    "pool chunks tagged {tag}{}{stop}{}",
+                    match paged {
+                        Some(true) => " in paged pool",
+                        Some(false) => " in nonpaged pool",
+                        None => "",
+                    },
+                    walk_kind(*refresh)
+                )
+            }
             Self::PoolCensus { refresh, .. } => format!("pool census{}", walk_kind(*refresh)),
         }
     }
@@ -310,11 +322,13 @@ impl StepAction {
                 tag,
                 paged,
                 refresh,
+                stop_after_matches,
                 limit,
             } => Self::PoolFindTag {
                 tag: substitute(tag, resolve)?,
                 paged: *paged,
                 refresh: *refresh,
+                stop_after_matches: *stop_after_matches,
                 limit: *limit,
             },
             Self::PoolCensus { refresh, limit } => Self::PoolCensus {
@@ -1312,9 +1326,10 @@ fn run_step(
             tag,
             paged,
             refresh,
+            stop_after_matches,
             limit,
         } => d.pool(
-            &PoolOp::find_tag(tag.clone(), *paged, *refresh, *limit),
+            &PoolOp::find_tag(tag.clone(), *paged, *refresh, *stop_after_matches, *limit),
             budget_ms,
         ),
         StepAction::PoolCensus { refresh, limit } => {
@@ -3508,6 +3523,7 @@ mod tests {
                 tag: "{{nope}}".to_string(),
                 paged: None,
                 refresh: None,
+                stop_after_matches: None,
                 limit: None,
             },
             StepAction::PoolChunk {
@@ -3539,7 +3555,8 @@ mod tests {
             serde_json::json!({"op": "pool_chunk", "address": "0xffffc00f6ec02f90"}),
             serde_json::json!({"op": "pool_chunk", "address": "{{obj}}", "refresh": true}),
             serde_json::json!({
-                "op": "pool_find_tag", "tag": "Tgsm", "paged": false, "refresh": true, "limit": 32
+                "op": "pool_find_tag", "tag": "Tgsm", "paged": false, "refresh": true,
+                "stop_after_matches": 1, "limit": 32
             }),
             serde_json::json!({"op": "pool_census", "refresh": true, "limit": 200}),
         ] {
@@ -3550,6 +3567,28 @@ mod tests {
                 step.unknown_fields()
             );
         }
+    }
+
+    #[test]
+    fn a_pool_match_threshold_must_be_nonzero() {
+        let json = serde_json::json!({
+            "op": "pool_find_tag", "tag": "Tgsm", "stop_after_matches": 0
+        });
+        assert!(serde_json::from_value::<BatchStep>(json).is_err());
+    }
+
+    #[test]
+    fn a_pool_step_report_names_its_match_threshold() {
+        let action = StepAction::PoolFindTag {
+            tag: "Tgsm".into(),
+            paged: Some(false),
+            refresh: Some(true),
+            stop_after_matches: NonZeroU32::new(2),
+            limit: Some(1),
+        };
+        let rendered = action.rendered();
+        assert!(rendered.contains("stop after 2 match(es)"), "{rendered}");
+        assert!(rendered.contains("fresh walk"), "{rendered}");
     }
 
     /// A batch is a value that crosses a process boundary, so it has to survive its own encoding.

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -24,6 +24,7 @@
 //! property of the plumbing rather than a convention about who prints where — which is what lets
 //! the framing stay line-delimited and cheap.
 
+use std::num::NonZeroU32;
 use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
@@ -425,12 +426,13 @@ pub struct ReachabilityOp {
 /// come to disagree about what `limit` means.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum PoolOp {
-    /// Every *allocated* chunk carrying `tag`.
+    /// Allocated chunks carrying `tag`, optionally stopping a new walk at a match threshold.
     FindTag {
         tag: String,
         /// `Some(true)` paged only, `Some(false)` nonpaged only, `None` both.
         paged: Option<bool>,
         refresh: bool,
+        stop_after_matches: Option<NonZeroU32>,
         limit: usize,
     },
     /// The chunk containing `address`, with its immediate neighbours.
@@ -488,17 +490,19 @@ impl PoolOp {
     const CENSUS_ROWS: u32 = 40;
     const DIAGNOSTIC_LINES: u32 = 60;
 
-    /// Every allocated chunk carrying `tag`.
+    /// Allocated chunks carrying `tag`, optionally stopping a new walk at a match threshold.
     pub fn find_tag(
         tag: String,
         paged: Option<bool>,
         refresh: Option<bool>,
+        stop_after_matches: Option<NonZeroU32>,
         limit: Option<u32>,
     ) -> Self {
         Self::FindTag {
             tag,
             paged,
             refresh: refresh.unwrap_or(false),
+            stop_after_matches,
             limit: clamp_rows(limit, Self::FIND_TAG_ROWS),
         }
     }
@@ -735,7 +739,7 @@ mod tests {
     #[test]
     fn the_slot_the_pump_writes_is_the_one_that_crosses_the_pipe() {
         let mut op = EngineOp::Pool {
-            query: PoolOp::find_tag("Tgsm".into(), None, None, None),
+            query: PoolOp::find_tag("Tgsm".into(), None, None, None, None),
             patience_ms: 0,
         };
         *op.patience_slot().expect("a pool query carries one") = 42_000;
@@ -743,6 +747,23 @@ mod tests {
             unreachable!("still a pool query")
         };
         assert_eq!(patience_ms, 42_000);
+    }
+
+    #[test]
+    fn a_find_tag_match_threshold_does_not_change_its_rendering_limit() {
+        let Some(threshold) = NonZeroU32::new(3) else {
+            unreachable!()
+        };
+        let PoolOp::FindTag {
+            stop_after_matches,
+            limit,
+            ..
+        } = PoolOp::find_tag("Tgsm".into(), None, None, Some(threshold), Some(1))
+        else {
+            unreachable!("still a tag query")
+        };
+        assert_eq!(stop_after_matches.map(NonZeroU32::get), Some(3));
+        assert_eq!(limit, 1);
     }
 
     /// The module listing's cap is the supervisor's to apply, like the allocator ones — so a

--- a/src/server.rs
+++ b/src/server.rs
@@ -6,6 +6,7 @@
 //! returning full text); session-management tools drive the typed `dbgscope` openers.
 
 use std::collections::{HashMap, HashSet, VecDeque};
+use std::num::NonZeroU32;
 use std::time::Duration;
 
 use rmcp::ErrorData;
@@ -1878,6 +1879,11 @@ pub struct PoolFindTagArgs {
     /// after letting the target run, when the cached view describes a target that has moved.
     #[serde(default)]
     pub refresh: Option<bool>,
+    /// Stop a newly started pool walk as soon as this many matching allocated chunks have been
+    /// decoded. Must be nonzero. A complete cached snapshot is still reused, so `matches` and
+    /// `total_bytes` remain exhaustive; `limit` below controls only how many rows are printed.
+    #[serde(default)]
+    pub stop_after_matches: Option<NonZeroU32>,
     /// Maximum rows to print (default 64).
     #[serde(default)]
     pub limit: Option<u32>,
@@ -3117,8 +3123,9 @@ impl WindbgServer {
         engine_result(out)
     }
 
-    /// Find every **allocated** kernel pool chunk carrying a tag, with its size, allocator
-    /// and backend. Needs a broken-in x64 kernel target.
+    /// Find **allocated** kernel pool chunks carrying a tag, with their size, allocator and
+    /// backend. Needs a broken-in x64 kernel target. `stop_after_matches` can make a new walk
+    /// return deliberately early; a complete cached snapshot remains exhaustive.
     /// This walks the pool's own descriptors rather than shelling out to `!poolused`, so the
     /// result is structured.
     /// Only allocated chunks are indexed by tag — a freed chunk's tag is not reliably
@@ -3144,6 +3151,7 @@ impl WindbgServer {
                     args.tag,
                     args.paged,
                     args.refresh,
+                    args.stop_after_matches,
                     args.limit,
                 )),
             )
@@ -5377,6 +5385,16 @@ fn text_of(result: &CallToolResult) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn a_pool_match_threshold_must_be_nonzero() {
+        let zero = serde_json::json!({"tag": "Tgsm", "stop_after_matches": 0});
+        assert!(serde_json::from_value::<PoolFindTagArgs>(zero).is_err());
+
+        let one = serde_json::json!({"tag": "Tgsm", "stop_after_matches": 1});
+        let parsed: PoolFindTagArgs = serde_json::from_value(one).expect("one is nonzero");
+        assert_eq!(parsed.stop_after_matches.map(NonZeroU32::get), Some(1));
+    }
 
     // ---- the instructions a client is served ---------------------------
 

--- a/src/structured.rs
+++ b/src/structured.rs
@@ -1152,9 +1152,9 @@ impl From<&dbgscope::allocator::LayoutProvenance> for AllocatorLayoutInfo {
 /// How much of an allocator the walk behind an answer actually covered.
 ///
 /// Every allocator answer carries this, because every one of them is drawn from a snapshot and a
-/// count taken from a partial snapshot is a floor rather than a total. The three ways of falling
-/// short are separate values because they need different responses; a fourth — the walk failing
-/// outright, or being interrupted — is not a coverage state at all but the `error` branch of
+/// count taken from a partial snapshot is a floor rather than a total. The ways of falling short
+/// are separate values because they need different responses; a walk failing outright, or being
+/// interrupted, is not a coverage state at all but the `error` branch of
 /// [`Outcome`], with category [`ErrorCategory::Debugger`] or [`ErrorCategory::Interrupted`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
@@ -1170,6 +1170,10 @@ pub enum AllocatorCoverage {
     /// mid-chunk, a traversal cap. `pool_diagnostics` says which. Unlike `deadline_truncated`,
     /// more time changes nothing.
     Partial,
+    /// The caller's `stop_after_matches` threshold was reached. This is an intentional partial
+    /// answer rather than a deadline or decoder failure; `walk.stop_after_matches` names the
+    /// threshold that fired.
+    MatchLimitReached,
 }
 
 impl AllocatorCoverage {
@@ -1178,6 +1182,7 @@ impl AllocatorCoverage {
             Self::Complete => "complete",
             Self::DeadlineTruncated => "deadline_truncated",
             Self::Partial => "partial",
+            Self::MatchLimitReached => "match_limit_reached",
         }
     }
 }
@@ -1197,6 +1202,10 @@ impl From<dbgscope::pool::query::WalkCoverage> for AllocatorCoverage {
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct WalkInfo {
     pub coverage: AllocatorCoverage,
+    /// The requested match threshold that intentionally stopped this walk. Absent when the
+    /// threshold was not reached or a complete cached snapshot answered the query.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stop_after_matches: Option<usize>,
     /// Chunks the walk indexed, allocated and free.
     pub chunks_walked: usize,
     pub allocated_chunks: usize,
@@ -1382,11 +1391,14 @@ pub struct PoolTagMatches {
     pub raw_tag: String,
     pub scope: PoolScope,
     /// How many allocated chunks carry the tag. A floor rather than a total unless
-    /// `walk.coverage` is `complete`.
+    /// `walk.coverage` is `complete`; when it is `match_limit_reached`, this is the threshold
+    /// reached by the intentional early stop.
     pub matches: usize,
-    /// Their total size in bytes, over all matches — not only the ones listed.
+    /// Their total size in bytes, over every match the walk found — not only the ones listed.
+    /// This is a floor unless `walk.coverage` is `complete`.
     pub total_bytes: u64,
-    /// The matches themselves, capped by the call's `limit`; `matches` is the full count.
+    /// The matches themselves, capped by the call's rendering `limit`; `matches` is the full
+    /// count from this walk.
     pub chunks: Vec<PoolChunkInfo>,
     pub walk: WalkInfo,
 }
@@ -2459,7 +2471,7 @@ mod tests {
         assert_eq!(finite["value"], 1.5);
     }
 
-    /// The three coverage states stay distinct across the seam: collapsing `deadline_truncated`
+    /// The engine's three coverage states stay distinct across the seam: collapsing `deadline_truncated`
     /// into `partial` would tell a caller that waiting longer cannot help, when it is the one
     /// thing that would.
     #[test]
@@ -2478,6 +2490,12 @@ mod tests {
             assert_eq!(expected.as_str(), wire);
             assert_eq!(serde_json::to_value(expected).unwrap(), wire);
         }
+        let intentional = AllocatorCoverage::MatchLimitReached;
+        assert_eq!(intentional.as_str(), "match_limit_reached");
+        assert_eq!(
+            serde_json::to_value(intentional).unwrap(),
+            "match_limit_reached"
+        );
     }
 
     #[test]
@@ -2538,6 +2556,7 @@ mod tests {
             total_chunks: 0,
             allocated_chunks: 0,
             coverage: dbgscope::pool::query::WalkCoverage::Partial,
+            stopped_after_matches: None,
             diagnostics: dbgscope::pool::PoolDiagnostics::default(),
             stalls,
             refused_chunks,
@@ -2576,6 +2595,7 @@ mod tests {
         // would be a shape change on every healthy pool answer — the ones that are fine.
         let walk = |gaps| WalkInfo {
             coverage: AllocatorCoverage::Partial,
+            stop_after_matches: None,
             chunks_walked: 0,
             allocated_chunks: 0,
             diagnostics_emitted: 0,

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -35,6 +35,7 @@
 
 use std::collections::{BTreeSet, HashSet};
 use std::io::{BufRead, BufReader, PipeReader, PipeWriter, Write};
+use std::num::NonZeroUsize;
 use std::os::windows::io::{AsRawHandle, FromRawHandle, RawHandle};
 use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -4068,6 +4069,14 @@ fn diagnostic_categories(diagnostics: &PoolDiagnostics) -> Vec<&DiagnosticShape>
 /// drawn from what the walk indexed, so under partial coverage a count is a floor. Saying so
 /// is the difference between "there are three of these" and "these are the three I could see".
 fn coverage_caveat(report: &query::PoolSnapshotReport) -> Option<String> {
+    if let Some(matches) = report.stopped_after_matches {
+        return Some(format!(
+            "\n--- pool walk ---\ncoverage: MATCH LIMIT REACHED - stopped after {matches} \
+             matching allocated chunk(s), having walked {} chunk(s). What is listed above is \
+             intentionally partial; omit or raise `stop_after_matches` for more.\n",
+            report.total_chunks
+        ));
+    }
     if report.coverage.complete() {
         return None;
     }
@@ -4098,10 +4107,10 @@ fn render_walk_report(report: &query::PoolSnapshotReport) -> String {
         "\n--- pool walk ---\nchunks walked: {} ({} allocated), coverage: {}\n",
         report.total_chunks,
         report.allocated_chunks,
-        if report.coverage.complete() {
-            "complete"
-        } else {
-            "INCOMPLETE - the walk did not reach everything it set out to"
+        match report.stopped_after_matches {
+            Some(_) => "match_limit_reached - the requested match threshold stopped the walk",
+            None if report.coverage.complete() => "complete",
+            None => "INCOMPLETE - the walk did not reach everything it set out to",
         }
     );
     if report.diagnostics.is_empty() {
@@ -4167,6 +4176,7 @@ fn pool(e: &DebugEngine, args: PoolOp, within: Duration) -> Result<Output, Faile
             tag,
             paged,
             refresh,
+            stop_after_matches,
             limit,
         } => {
             let filter = paged.map(|paged| {
@@ -4176,7 +4186,14 @@ fn pool(e: &DebugEngine, args: PoolOp, within: Duration) -> Result<Output, Faile
                     PoolPageFilter::NonPaged
                 }
             });
-            let answer = query::find_tag(e, &tag, filter, walk(refresh)).map_err(pool_failure)?;
+            let answer = query::find_tag(
+                e,
+                &tag,
+                filter,
+                stop_after_matches.and_then(|matches| NonZeroUsize::new(matches.get() as usize)),
+                walk(refresh),
+            )
+            .map_err(pool_failure)?;
             let spans = &answer.found;
             let mut out = render_find_tag(&tag, filter, spans, limit);
             if spans.is_empty() {
@@ -4728,7 +4745,12 @@ fn heap(e: &DebugEngine, args: HeapOp, within: Duration) -> Result<Output, Faile
 /// answer, from the same snapshot. There is no "could not read the walk" case left to render.
 fn walk_info(report: &query::PoolSnapshotReport) -> structured::WalkInfo {
     structured::WalkInfo {
-        coverage: report.coverage.into(),
+        coverage: if report.stopped_after_matches.is_some() {
+            structured::AllocatorCoverage::MatchLimitReached
+        } else {
+            report.coverage.into()
+        },
+        stop_after_matches: report.stopped_after_matches,
         chunks_walked: report.total_chunks,
         allocated_chunks: report.allocated_chunks,
         diagnostics_emitted: report.diagnostics.emitted(),
@@ -5508,6 +5530,7 @@ mod tests {
             total_chunks: 0,
             allocated_chunks: 0,
             coverage: coverage(true),
+            stopped_after_matches: None,
             diagnostics: PoolDiagnostics::default(),
             stalls: WalkStalls::default(),
             refused_chunks: 0,
@@ -5544,6 +5567,14 @@ mod tests {
             ),
             (2, 0x2000, 0x8000, 7)
         );
+
+        report.stopped_after_matches = Some(2);
+        let intentional = walk_info(&report);
+        assert_eq!(
+            intentional.coverage,
+            structured::AllocatorCoverage::MatchLimitReached
+        );
+        assert_eq!(intentional.stop_after_matches, Some(2));
     }
 
     fn report_with(complete: bool, diagnostics: &[&str]) -> query::PoolSnapshotReport {
@@ -5813,6 +5844,16 @@ mod tests {
         assert!(caveat.contains("4211"), "{caveat}");
         // Not merely "incomplete": the caller has to know which way the number is wrong.
         assert!(caveat.contains("floor"), "{caveat}");
+    }
+
+    #[test]
+    fn an_intentional_match_stop_names_the_condition_instead_of_a_failure() {
+        let mut report = report(false);
+        report.stopped_after_matches = Some(1);
+        let caveat = coverage_caveat(&report).expect("an early stop must be explained");
+        assert!(caveat.contains("MATCH LIMIT REACHED"), "{caveat}");
+        assert!(caveat.contains("stopped after 1"), "{caveat}");
+        assert!(!caveat.contains("INCOMPLETE"), "{caveat}");
     }
 
     /// The other half: a complete walk must not decorate every answer with a warning, or the
@@ -8150,7 +8191,7 @@ mod tests {
     #[test]
     fn only_a_query_that_must_walk_is_refused_for_want_of_time() {
         assert!(PoolOp::census(Some(true), None).refreshes());
-        assert!(PoolOp::find_tag("Tgsm".into(), None, Some(true), None).refreshes());
+        assert!(PoolOp::find_tag("Tgsm".into(), None, Some(true), None, None).refreshes());
         assert!(PoolOp::chunk("0x1000".into(), Some(true)).refreshes());
         assert!(PoolOp::diagnostics(None, Some(true), None).refreshes());
 

--- a/tests/golden/tool_budget.json
+++ b/tests/golden/tool_budget.json
@@ -66,11 +66,11 @@
     {
       "annotations": 134,
       "description": 1714,
-      "inputSchema": 8032,
-      "modelVisible": 9798,
+      "inputSchema": 8255,
+      "modelVisible": 10021,
       "name": "debug_batch",
       "outputSchema": 3176,
-      "wire": 13139
+      "wire": 13362
     },
     {
       "annotations": 79,
@@ -159,8 +159,8 @@
       "inputSchema": 1153,
       "modelVisible": 1430,
       "name": "heap_allocations",
-      "outputSchema": 5508,
-      "wire": 7097
+      "outputSchema": 5556,
+      "wire": 7145
     },
     {
       "annotations": 124,
@@ -168,8 +168,8 @@
       "inputSchema": 618,
       "modelVisible": 864,
       "name": "heap_census",
-      "outputSchema": 5342,
-      "wire": 6361
+      "outputSchema": 5390,
+      "wire": 6409
     },
     {
       "annotations": 126,
@@ -177,8 +177,8 @@
       "inputSchema": 493,
       "modelVisible": 900,
       "name": "heap_chunk",
-      "outputSchema": 5698,
-      "wire": 6755
+      "outputSchema": 5746,
+      "wire": 6803
     },
     {
       "annotations": 130,
@@ -186,8 +186,8 @@
       "inputSchema": 762,
       "modelVisible": 1078,
       "name": "heap_diagnostics",
-      "outputSchema": 5174,
-      "wire": 6413
+      "outputSchema": 5222,
+      "wire": 6461
     },
     {
       "annotations": 119,
@@ -195,8 +195,8 @@
       "inputSchema": 465,
       "modelVisible": 821,
       "name": "heap_list",
-      "outputSchema": 5038,
-      "wire": 6009
+      "outputSchema": 5086,
+      "wire": 6057
     },
     {
       "annotations": 120,
@@ -276,8 +276,8 @@
       "inputSchema": 602,
       "modelVisible": 1029,
       "name": "pool_census",
-      "outputSchema": 4738,
-      "wire": 5921
+      "outputSchema": 4863,
+      "wire": 6046
     },
     {
       "annotations": 129,
@@ -285,8 +285,8 @@
       "inputSchema": 760,
       "modelVisible": 1752,
       "name": "pool_chunk",
-      "outputSchema": 5506,
-      "wire": 7418
+      "outputSchema": 5631,
+      "wire": 7543
     },
     {
       "annotations": 127,
@@ -294,17 +294,17 @@
       "inputSchema": 831,
       "modelVisible": 1983,
       "name": "pool_diagnostics",
-      "outputSchema": 4675,
-      "wire": 6816
+      "outputSchema": 4800,
+      "wire": 6941
     },
     {
       "annotations": 122,
-      "description": 558,
-      "inputSchema": 1420,
-      "modelVisible": 2032,
+      "description": 671,
+      "inputSchema": 1795,
+      "modelVisible": 2520,
       "name": "pool_find_tag",
-      "outputSchema": 5558,
-      "wire": 7743
+      "outputSchema": 5683,
+      "wire": 8356
     },
     {
       "annotations": 90,
@@ -489,15 +489,15 @@
   ],
   "totals": {
     "annotations": 5762,
-    "description": 28561,
-    "inputSchema": 42620,
+    "description": 28674,
+    "inputSchema": 43218,
     "instructions": 1983,
-    "modelVisible": 73996,
-    "outputSchema": 111705,
-    "payload": 192970,
+    "modelVisible": 74707,
+    "outputSchema": 112445,
+    "payload": 194421,
     "tools": 54,
-    "wire": 192849,
+    "wire": 194300,
     "worstTool": "debug_batch",
-    "worstToolModelVisible": 9798
+    "worstToolModelVisible": 10021
   }
 }

--- a/tests/golden/tools_list.json
+++ b/tests/golden/tools_list.json
@@ -1042,6 +1042,7 @@
         "paged: boolean|null",
         "refresh: boolean|null",
         "session_id: string|null",
+        "stop_after_matches: integer|null/uint32",
         "tag: string"
       ],
       "required": [

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -11880,7 +11880,8 @@ fn a_messagemanager_ctf_fixture_is_visible_through_mcp() {
                 "tag": "Tgsm",
                 "paged": false,
                 "refresh": true,
-                "limit": 32,
+                "stop_after_matches": 1,
+                "limit": 1,
                 "session_id": session,
             }),
             POOL_CALL_BUDGET,
@@ -11893,12 +11894,19 @@ fn a_messagemanager_ctf_fixture_is_visible_through_mcp() {
             symbols.transcript
         );
         let matches = call["result"]["structuredContent"].clone();
-        assert!(
-            matches["matches"].as_u64().unwrap_or_default() > 0,
+        assert_eq!(
+            matches["matches"].as_u64(),
+            Some(1),
             "the target fixture retained `Tgsm` messages, but the MCP pool snapshot did not find \
              them. Read the walk's coverage before treating an incomplete walk as an allocator \
              result: {matches}"
         );
+        assert_eq!(
+            matches["walk"]["coverage"], "match_limit_reached",
+            "an existence query must report its deliberate early stop separately from a deadline \
+             or decoder failure: {matches}"
+        );
+        assert_eq!(matches["walk"]["stop_after_matches"], 1, "{matches}");
         // Every chunk it hands back really carries the tag that was asked for, at an address in
         // this server's one representation — the two claims a caller acts on.
         for chunk in matches["chunks"].as_array().into_iter().flatten() {


### PR DESCRIPTION
Adds nonzero stop_after_matches to pool_find_tag and its debug_batch step. Intentional stops return match_limit_reached with the threshold that fired; counts remain floors, limit remains rendering-only, and complete cached snapshots stay exhaustive. Updates the MessageManager CTF regression to stop after its first Tgsm allocation. Uses merged glslang/dbgscope#124 and pins merge commit 205fb9d30120b429b29c3b27744b628ff2928387. Closes #86. Tests: cargo test; cargo clippy --all-targets; cargo fmt --all --check.