### PR TITLE
Make the module inventory refresh explicit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`modules { "refresh": true }` resynchronises the debugger's module inventory before it lists
+  it** ([#85](https://github.com/glslang/windbg-mcp/issues/85)). DbgEng's inventory is the
+  *debugger's*, not the target's: it is built from the module-load events the debugger saw, so it
+  is complete for a dump and for a process the debugger launched, and it is not complete for a
+  live kernel — an attach starts from what it can read at connect time, and a driver loaded before
+  the debugger dialled in is in the target and missing from the list. On the MessageManager
+  regression target that meant `nt` and little else, and a `modules` call straight after the attach
+  read as "the challenge driver is not loaded" while the driver was open and serving IOCTLs.
+  Measured on that target on 2026-08-30, across one attach: the engine held **1** module, a
+  `modules { "filter": "MessageManager" }` matched **0**, and the same call with `refresh: true`
+  reported `before: 1` against **158** loaded and matched the driver at `0xfffff80343970000` —
+  `deferred`, so it was found without a byte of PDB being fetched.
+
+  The resynchronisation was always available — it is what an unqualified `.reload /f` was doing as
+  a side effect of fetching every module's PDB — and nothing said so, so finding a loaded image
+  meant guessing that a force symbol reload was the missing step. This is that half on its own, and
+  the tool says which half it is: it discovers modules and **fetches no symbols**, so what it finds
+  comes back `deferred` with no symbol-server round trip.
+
+  The result carries `refresh` — `synchronized`, the `before` count against `loaded` after it, and
+  the engine's own `error` where it failed. Three things worth knowing. **Absent means it was not
+  asked for**, which is not the same as one that found nothing, so a default call is unchanged in
+  both channels and still cheap. **A failure is reported, not raised**: the listing beside it may
+  well be the right one, so the answer stands and the text says so *above* the tables — a caveat
+  printed under a listing arrives after the conclusion it was there to prevent — and withdraws the
+  only inference the listing supports, that a module absent from it is absent from the target. And
+  **on a live target it costs the symbol state**: a reload discards what the engine had loaded
+  and reloads it as needed, so most modules come back `deferred` — measured on a launched
+  `cmd.exe` either side of a `.reload /f`, where four of its five modules went `pdb` → `deferred`
+  and `ntdll` kept its PDB. A **dump** pays none of it: its module list comes from its own header,
+  so there is nothing to re-read, and `nt`'s PDB survives a refresh with the other 226 modules
+  `deferred` either way. So refresh first and load symbols afterwards on anything live —
+  [`docs/structured-results.md`](docs/structured-results.md) has the two reloads side by side and
+  both measurements.
+
 - **Asynchronous execution control: `continue_async`, `wait_for_stop` and `break_in`**
   ([#83](https://github.com/glslang/windbg-mcp/issues/83)). `go` waits for the next stop and answers
   with it, which leaves no room for the sequence a live target usually needs — arm a breakpoint,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -212,7 +212,7 @@ It checks *same-file* fragments only, so a cross-file `../README.md#some-heading
 verify by hand.
 
 **The pass count does not say which tiers ran.** Each gate is inside its test, so the `mcp_smoke`
-harness reports the same **93 passed** with the debugger tier off as with it on — that harness's own
+harness reports the same **94 passed** with the debugger tier off as with it on — that harness's own
 result line, since a plain `cargo test` runs the crate's several hundred unit tests beside it and
 prints a result line per binary. What differs between the two runs is the runtime (measured on the
 ARM64 bench 2026-08-23: **1.6s against 61s** for `cargo test --test mcp_smoke`) and the `SKIPPED`
@@ -220,9 +220,10 @@ lines, which only `--nocapture` prints. Read one of those two before believing a
 debugger claim. The count moves whenever a test is added — it was 69 until #195 and #196, 75
 until item 37, 79 until the TTD tier, 84 until item 50's version-resource test, 85 until
 item 48's two endings, 87 until item 49's live 32-bit target, 88 until item 51's
-attach teardown, 89 until the 32-bit worker's version resource, 90 until #66's symbol-path default
-and 91 until #83's two asynchronous-execution tests — and it said 83 while it was 84, and 90 while
-it was 91, which is the usual state of it, so re-derive it rather than trusting this sentence.
+attach teardown, 89 until the 32-bit worker's version resource, 90 until #66's symbol-path default,
+91 until #83's two asynchronous-execution tests and 93 until #85's module-inventory refresh — and
+it said 83 while it was 84, and 90 while it was 91, which is the usual state of it, so re-derive it
+rather than trusting this sentence.
 
 **The dev exe can be locked too, and the failure is quiet.** A worker left running — a driver
 script that died mid-session, a debugger tier killed partway — holds `target\debug\windbg-mcp.exe`,
@@ -404,7 +405,8 @@ cargo test --test mcp_smoke -- --ignored --nocapture --test-threads=1 bounded
 A fourth tier drives a **real KDNET target** through a full session lifecycle — attach, work
 alongside a second session, detach gracefully — separately checks that a client *disconnect*
 releases a live kernel session rather than killing its worker, covers the **pool walk**
-(`pool_find_tag`/`pool_census`), whose cost only exists over a live link, and runs a **`debug_batch`
+(`pool_find_tag`/`pool_census`) and the **module-inventory refresh**, both of which only mean
+anything over a live link, and runs a **`debug_batch`
 that patches a byte of the running kernel** and has to put it back (through a failing assertion, a
 clamped call budget, a disconnect and an `end_session`) — the one claim a crash dump cannot test,
 because a byte patched in a dump is patched in a file nobody reads again. It is gated on the
@@ -545,6 +547,34 @@ with `/GS`, so overrunning the buffer corrupts the cookie and the driver's own `
 runs `mov w0, #2; brk #0xf003` — `0x139 KERNEL_SECURITY_CHECK_FAILURE`, raised inside the driver.
 That is how `docs/samples/082126-7015-01.dmp` was made (issue #154); `docs/smoke-test.md` has the
 one-line recipe.
+
+**DbgEng's module inventory is the debugger's, not the target's, and `.reload` is two operations
+wearing one name.** A kernel attach starts from what it can read at connect time, so a driver
+loaded before the debugger dialled in is in the target and absent from `lm` — which is
+[#85](https://github.com/glslang/windbg-mcp/issues/85), where a running challenge driver read as
+"not loaded". The gap is not small: measured on the CTF guest 2026-08-30, a fresh attach held
+**1** module and a refresh found **158**. `IDebugSymbols::Reload("")` resynchronises the list and leaves symbols deferred;
+`/f` additionally fetches every PDB. `modules { "refresh": true }` is the first half on its own
+(`worker::resynchronise`). Three things bite when editing it:
+
+- **The refresh costs the symbol state, on a live target and not on a dump.** Measured both ways
+  (2026-08-30, engine DLLs bundled): a launched `cmd.exe` goes all-five-`pdb` after a `.reload /f`
+  and comes back with four `deferred` and `ntdll` still `pdb`, while the checked-in kernel dump
+  keeps `nt` at `pdb` across a refresh and discards nothing. A live reload re-reads the module
+  list and the entries are rebuilt; a dump's list is its own header. So the note says *on a live
+  target* and *most* modules, and anything that refreshes after a live symbol load has undone it.
+  **The first attempt at this measurement was taken on a host whose engine had no `symsrv.dll` or
+  `msdia140.dll`** — the five modules could only reach `export` fallback, so the effect read as
+  smaller than it is and the dump half was never asked. Check the engine is bundled before
+  measuring anything symbol-shaped here.
+- **Order is the whole of the CTF tier's claim.** `a_messagemanager_ctf_fixture_is_visible_through_mcp`
+  asks `modules { "refresh": true }` **before** `load_kernel_symbols`, deliberately: that helper's
+  unqualified `.reload /f` resynchronises the inventory as a side effect, so a `modules` call after
+  it passes whether or not `refresh` does anything at all. Moving it back below the symbol setup
+  keeps the test green and deletes what it is for.
+- **A failed refresh is reported, not raised**, and the note goes *above* the tables. A caveat
+  under a listing arrives after the conclusion it was there to prevent, which is the exact failure
+  the issue is about.
 
 **Read a driver's IOCTL codes out of its own dispatch — do not take them from a published list.**
 This build's are not the ones HEVD's widely-quoted table gives, and the code that table calls the
@@ -1133,7 +1163,7 @@ measurements and the options that were weighed.
 
 Two files, not one. A tool is declared in `src/server.rs` as always, and its name also goes in a
 **group** in `src/toolset.rs` — the table behind `--tools`, which advertises a named subset of the
-surface because 74% of the 73,996-byte tool surface is prose a model needs and cannot be trimmed
+surface because 70% of the 75,547-byte tool surface is prose a model needs and cannot be trimmed
 (`docs/token-budget.md` finding 8).
 
 Forgetting the second half fails in the one direction nothing would notice: the *default* surface

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -1,6 +1,6 @@
 # Follow-ups
 
-Deferred work, in twenty-seven clusters: items 1–6 come from the reachability-confirmation effort (path
+Deferred work, in twenty-eight clusters: items 1–6 come from the reachability-confirmation effort (path
 recipe + `run_to_address`, merged 2026-07-04), items 7–11 from surveying this server against the
 MCP `2026-07-28` extensions (tasks, apps), item 12 from the opener split
 (glslang/dbgscope#71, 2026-08-01), items 13–14 from the bounded-command coverage review
@@ -55,7 +55,10 @@ reachable: the first tier to attach to a running process found that ending its s
 [#83](https://github.com/glslang/windbg-mcp/issues/83)'s asynchronous execution handles, where the
 invariant that stops a description naming a tool its client cannot call turned out to cover only
 half the prose a client is served (2026-08-29), and where a break arriving in the microseconds
-after a run built its stop is recorded in that result's prose and not in its flag (2026-08-30).
+after a run built its stop is recorded in that result's prose and not in its flag (2026-08-30),
+and item 54 from
+[#85](https://github.com/glslang/windbg-mcp/issues/85)'s module-inventory refresh, whose engine
+call no watchdog in either crate can currently cut short (2026-08-30).
 Each item notes its repo, why it was deferred, and where it picks up. See [`DECISIONS.md`](./DECISIONS.md) for the design rationale (D1–D5) items 1–6 extend,
 and the 2026-08-02 entries that items 13–14 and item 10 extend.
 
@@ -3691,3 +3694,37 @@ other way (`|| self.broken()`), correctly for a batch, which is worth reading be
 **Where it picks up.** `run_job`'s `release`/`cut_short` block and `cut_short` itself in
 `src/worker.rs`, `stop_report` beside them, and `Ran::ran_told` for the path that already consults
 the late-break flag.
+
+## 54. [dbgscope + windbg-mcp] `modules { "refresh": true }` has no wall-clock bound
+
+**What it is.** The resynchronisation behind `refresh`
+([#85](https://github.com/glslang/windbg-mcp/issues/85)) is `IDebugSymbols::Reload("")` — a direct
+engine call, not a command — so no watchdog can cut it short and `EngineOp::Modules` carries no
+`patience_ms`. What bounds it is the caller's own call timeout and `interrupt`, which reaches the
+engine from off the engine thread. That is the same position `EngineOp::Backtrace` is in, and its
+doc comment says so for the same reason: carrying a `patience_ms` would imply a bound that does not
+exist.
+
+**Why it was deferred.** The acceptance criterion it was written against is about *symbol-server*
+cost, and that one is closed by construction: the reload is unqualified and unforced, so what it
+discovers is `deferred` and nothing is fetched. What is left is the time the reload itself takes,
+which is a walk of the target's loaded-module list. Measured on the CTF guest over KDNET on
+2026-08-30, that is imperceptible — a whole `modules { "refresh": true }` inside a test that ran in
+1.96s including attach and detach. The wire it would be slow on is the one this repo already
+documents as unusable for a pool walk: **115200-baud serial**, where a per-module round trip is
+tens of milliseconds and 158 modules is a wait with no upper bound and no way to tell it from a
+hung debugger.
+
+**What would close it.** A bounded `Reload` in dbgscope — arm the crate's `Watchdog` around the
+call, as `execute_command_bounded` and `settle` already do, and report an interruption the way they
+do rather than as an error. `SetInterrupt` is expected to reach a `Reload` (a person Ctrl+Breaks
+one in WinDbg), but that is an expectation and not a measurement: **measure it first**, because a
+bound that cannot actually break the call in is worse than no bound, and dbgscope's watchdog tests
+arm one over a counter precisely so this can be tried without a debuggee. Then give
+`EngineOp::Modules` a `patience_ms` and add it to `EngineOp::patience_slot`'s match — the arm whose
+absence silently gave `Self::Pool` dbgscope's default walk budget instead of this server's
+deadline.
+
+**Where it picks up.** `worker::resynchronise` and `EngineOp::Modules` in `src/proto.rs`,
+`DebugEngine::reload_symbols` and `Watchdog` in dbgscope's `src/dbgeng.rs`, and
+`execute_command_bounded` beside it for the shape a bounded direct call takes here.

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Fifty-four tools in eight `--tools` groups; the rows below split some of those g
 |-------|-----------|-------|
 | Session | `session` | `open_dump`, `open_trace`, `attach_kernel_local`, `attach_kernel`, `attach_process`, `launch`, `interrupt`, `end_session`, `session_status` |
 | Server   | `session` | `server_log` — the server's own log: the supervisor's records, plus those of the sessions you opened, tagged with the session each belongs to |
-| State   | `inspect` | `registers`, `read_memory`, `backtrace` (the stack as typed frames, each carrying `module`+`RVA` where the engine can place it, as well as its symbol), `modules`, `threads`, `disassemble` (instructions as records, each with its encoding and, where the engine can place it, its `RVA`), `dx`, `set_symbol_path` |
+| State   | `inspect` | `registers`, `read_memory`, `backtrace` (the stack as typed frames, each carrying `module`+`RVA` where the engine can place it, as well as its symbol), `modules` (`refresh: true` resynchronises the debugger's inventory with the target first — what a fresh kernel attach needs before "not loaded" means anything), `threads`, `disassemble` (instructions as records, each with its encoding and, where the engine can place it, its `RVA`), `dx`, `set_symbol_path` |
 | Crash   | `crash` | `crash_triage` — a bug check as fields: code and parameters, crashing process, the stack as `module+RVA`, and the faulting driver frame |
 | Control | `exec` | `go`, `step_over`, `step_into`, `set_breakpoint`, `run_to_address` |
 | Async control | `exec` | `continue_async` (resume and return a handle), `wait_for_stop` (collect the stop; running out of the wait is a poll, not a failure), `break_in` |
@@ -117,9 +117,9 @@ Fifty-four tools in eight `--tools` groups; the rows below split some of those g
 | Structure walk | `allocator` | `walk_memory` |
 | Raw     | `inspect` | `execute` — run any debugger command, returns full text output |
 
-All of them are served unless you say otherwise, and the definitions cost the model **73,996 bytes —
-about 18k tokens — before it has asked anything**. `--tools session,inspect,crash` cuts that to
-25,465 B for twenty tools, and a `--listen` client can be given a narrower surface than the run's
+All of them are served unless you say otherwise, and the definitions cost the model **75,547 bytes —
+about 19k tokens — before it has asked anything**. `--tools session,inspect,crash` cuts that to
+26,305 B for twenty tools, and a `--listen` client can be given a narrower surface than the run's
 default. [`docs/tool-surface.md`](docs/tool-surface.md) has the arithmetic, the rule that `session`
 is always included, and what a typed operand may not contain.
 

--- a/docs/local-model.md
+++ b/docs/local-model.md
@@ -221,7 +221,7 @@ setx WINDBG_MCP_TOOLS_DRIVER        "session,inspect,crash"
 ```
 
 The second line is what makes this work on a listener the editor also uses: the driver is served 20
-tools and 25,465 B while every other client on that listener keeps all 54. Leave it out and the
+tools and 26,305 B while every other client on that listener keeps all 54. Leave it out and the
 driver is served whatever the listener was started with, which is the older behaviour and is the
 right one when the listener is the driver's own.
 
@@ -288,10 +288,10 @@ spec. Re-read them rather than trusting this table, which has been stale before.
 
 | | bytes | ≈tokens |
 |---|---|---|
-| The tool surface, paid once per conversation | 73,996 (54 tools) | ~18k |
-| — the same surface as `--tools session,inspect,crash` | 25,465 (20 tools) | ~6k |
+| The tool surface, paid once per conversation | 75,547 (54 tools) | ~19k |
+| — the same surface as `--tools session,inspect,crash` | 26,305 (20 tools) | ~6.5k |
 | — as `--tools crash` | 14,587 (11 tools) | ~3.6k |
-| Its worst single tool (`debug_batch`) | 9,798 | ~2.4k |
+| Its worst single tool (`debug_batch`) | 10,021 | ~2.5k |
 | The largest answer this server gives (`modules`) | 53,875 | ~13k |
 | `read_memory` at its design limit | ~4 MiB of hex | ~1M |
 

--- a/docs/remote-listener.md
+++ b/docs/remote-listener.md
@@ -6,7 +6,7 @@ the machine DbgEng needs — a Mac driving a Windows VM, say.
 
 **`--tools` works here exactly as it does on stdio**, and matters more: the client at the far end
 may be a local model whose window is bought in RAM. `--listen 127.0.0.1:8765 --tools
-session,inspect,crash` serves 20 tools and 25,465 B of model context instead of 54 and 73,996 — the
+session,inspect,crash` serves 20 tools and 26,305 B of model context instead of 54 and 75,547 — the
 README has the table, and [`local-model.md`](./local-model.md) is the runbook it was measured for.
 It is this listener's **default**: a client may be given a surface of its own, which is what lets
 one server hold a local model and a hosted client at once — see [A tool surface per

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -304,6 +304,21 @@ default page, against 53933 B / 74052 B for all 227 modules` — the same dump
 [`token-budget.md`](./token-budget.md) records its baseline against, so the two can be read
 together.
 
+**A refresh is asked for as the first call on a freshly opened session**
+(`a_module_listing_can_resynchronise_the_inventory_before_it_lists_it`), which is the ordering
+[#85](https://github.com/glslang/windbg-mcp/issues/85) is about: DbgEng's inventory holds the
+module loads the debugger *saw*, so on a live kernel attach a driver loaded beforehand is in the
+target and absent from the list. A dump cannot reproduce that gap — it carries its own complete
+module list — so what this tier claims is the half that would otherwise break silently: the reload
+**runs against a real engine, succeeds, and costs the listing nothing**, reported as a
+resynchronisation that found the inventory already current (`refresh.before` equal to `loaded`, all
+227 of them), with the rows still equal to the values row for row. The default call is asserted in
+the same breath, because "cheap and backward compatible" is a claim about an *absent* field: an
+answer that carried `refresh` unasked would tell every caller a resynchronisation had happened. The
+gap itself is the live tiers' to claim — the generic one checks the reload runs over the KD wire
+and loses no modules, and the CTF one asks *before* any symbol work and requires the challenge
+driver in the answer.
+
 **`registers` gets the same treatment, and its test runs against this host's own architecture.** A
 default answer is documented as the integer registers, excluding the x87 and vector ones — and it
 carried 64 of them, because DbgEng exposes `xmm0` twice and leaves the subregister flag clear on the
@@ -1013,6 +1028,15 @@ about. This is the other half — an attach that lands:
   no longer reclaimable and the fix is undone.
 - **A second session works alongside it** — a dump opened and used while the kernel attach is held,
   with the kernel session unaffected. Impossible by construction before.
+- **`modules { "refresh": true }` resynchronises over the KD wire.** This is the only tier where
+  that call reaches a target whose module list the debugger did not watch being built. A generic
+  KDNET target carries no fixture, so what is claimed here is the mechanism rather than a find: the
+  reload runs, reports `synchronized`, and leaves a listing at least as complete as the one before
+  it — a refresh that *lost* modules would be worse than no refresh at all. The `before`/`after`
+  counts are printed under `--nocapture`, and on the bench this was written against they read
+  `1 module(s) before the refresh, 158 after` — which is the size of the gap on a fresh attach,
+  measured rather than argued. Finding a *named* module that was missing is the CTF tier's claim,
+  below.
 - **`crash_triage` refuses a kernel that has not crashed, and refuses it correctly.** This is the
   state the debugger-free exploitation loop sits in *between* fires — attached, working, nothing
   bug-checked yet — and a dump can never be in it: a dump either is a crash dump or is not, while a
@@ -1153,10 +1177,24 @@ than measuring a patch that never landed.
 turns the MessageManager challenge into a repeatable live regression fixture. It builds a benign
 mode of `mm_exploit.c`, copies it to the VM over WinRM, and waits until the process has retained real
 `Tgsm` messages. It then runs the ignored Rust test through the shipped stdio MCP transport. The
-test attaches over KDNET, checks that `MessageManager.sys` is loaded, asks for one retained
+test attaches over KDNET, checks that `MessageManager.sys` is loaded **before any symbol work**,
+asks for one retained
 allocation with `pool_find_tag { "stop_after_matches": 1 }`, verifies the result says
 `match_limit_reached` with that stop condition, verifies the session still serves a register
 request, and always attempts `end_session` before reporting an assertion failure.
+
+That "before any symbol work" is the fixture's own regression, and it is
+[#85](https://github.com/glslang/windbg-mcp/issues/85). The driver is loaded before the debugger
+dials in, so it is in the target and not in DbgEng's inventory, and a fresh attach lists `nt` and
+little else — which is how a running driver came to be reported as "not loaded". It used to be
+found only *after* the tier's `load_kernel_symbols`, whose unqualified `.reload /f` resynchronised
+the inventory as a side effect of fetching every PDB: the answer was right, and nothing said that a
+full symbol load was what made it right. The test now asks with `refresh: true` **first**, so a
+pass cannot be borrowed from the reload that follows, and asserts `refresh.synchronized` before it
+believes the listing at all. Confirmed by hand against the CTF guest on 2026-08-30, on one
+attach: `loaded: 1`, `modules { "filter": "MessageManager" }` matching **0**, and the same call
+with `refresh: true` reporting `before: 1` against `loaded: 158` and matching the driver at
+`0xfffff80343970000` with `deferred` symbols — found without fetching a PDB.
 
 Prerequisites are a disposable VM with the challenge driver installed and running, PowerShell
 remoting enabled, a working KDNET connection back to the host, the host MSVC Build Tools path used

--- a/docs/structured-results.md
+++ b/docs/structured-results.md
@@ -11,7 +11,7 @@ matching `outputSchema` in `tools/list`, so a program can read a field instead o
 | `server_log` | `records[]` as `{seq, at, level, session_id, target, message}` — `session_id` absent for the supervisor's own — plus `matched`, the buffer's `held`/`capacity`/`oldest_seq`, and a `next_since` cursor that advances even on an empty page |
 | `end_session` | `released`, `worker_terminated`, `waited_ms`, `target_left_running` |
 | `registers` | `registers[]` as `{name, kind, …}` plus `instruction_pointer` — `kind: int` and `kind: float` carry `value`, `kind: bytes` carries `bytes` (an x87 or vector register, which no number holds), `kind: non_finite` names a NaN or infinity that JSON has no literal for and carries its bits, `kind: unavailable` carries neither, and `subregister` is present only when true; pass `all: true` for the x87/vector registers and subregister views, which the default excludes — including the vector bank's 32-bit lanes (`xmm0/0`), which the engine reports as integers — a value's `kind` is how this server saw it, not the register's architectural width |
-| `modules` | `modules[]` with `start`/`end`, `size`, `timestamp` (the `TimeDateStamp`+`size` pair a symbol server is keyed by — see [`coordinates.md`](coordinates.md)), a typed `symbols` state (`deferred` is *not* `none`) and, for a module whose symbols resolved, the `pdb` identity (`guid`, `age`, and the `key` those two make) plus `unmatched` when the engine loaded a PDB that does not belong to the image; `unloaded[]` for the images that have since unloaded (listed by image name, since an unloaded module has none of its own); `loaded` (how many the target has in total), `matched` / `unloaded_matched` (how many each half would have had before `limit` cut it — default 64 rows for the whole listing, maximum 2000, the two halves sharing one budget so neither crowds the other out) and the `filter` a narrowed listing was matched by. The listing text is rendered from these same records rather than pasted from `lm`, so the two halves cannot describe different sets of modules; the filter's grammar is this server's own — a name plus `*` (any run) and `?` (exactly one), **every other character literal** — and `execute { "command": "lm m <pattern>" }` is where WinDbg's fuller wildcard syntax lives |
+| `modules` | `modules[]` with `start`/`end`, `size`, `timestamp` (the `TimeDateStamp`+`size` pair a symbol server is keyed by — see [`coordinates.md`](coordinates.md)), a typed `symbols` state (`deferred` is *not* `none`) and, for a module whose symbols resolved, the `pdb` identity (`guid`, `age`, and the `key` those two make) plus `unmatched` when the engine loaded a PDB that does not belong to the image; `unloaded[]` for the images that have since unloaded (listed by image name, since an unloaded module has none of its own); `loaded` (how many the target has in total), `matched` / `unloaded_matched` (how many each half would have had before `limit` cut it — default 64 rows for the whole listing, maximum 2000, the two halves sharing one budget so neither crowds the other out) and the `filter` a narrowed listing was matched by. The listing text is rendered from these same records rather than pasted from `lm`, so the two halves cannot describe different sets of modules; the filter's grammar is this server's own — a name plus `*` (any run) and `?` (exactly one), **every other character literal** — and `execute { "command": "lm m <pattern>" }` is where WinDbg's fuller wildcard syntax lives. `refresh: true` resynchronises the debugger's inventory with the target before the listing is taken and reports what that did as `refresh` — `synchronized`, the `before` count against `loaded` after it, and the engine's `error` where it failed, which is reported rather than raised because the stale listing under it may still be the right one. Absent when no refresh was asked for, which is not the same as one that found nothing. **Inventory, not symbols**: see [the two reloads](#inventory-refresh-against-symbol-reload) |
 | `set_breakpoint` | the ids this call `added`, and every breakpoint now set — a successful `bp` prints nothing at all |
 | `run_to_address` | `verdict` (`hit`/`stopped_elsewhere`/`timeout`/`target_gone`), `target`, `stopped_at` |
 | `go`, `step_over`, `step_into`, `step_back`, `step_over_back`, `reverse_go` | `stopped_at`, and the `thread` it belongs to plus, on a kernel target, the `processor` — absent where no processor number applies (every user-mode target, which is not a failure) or where the engine would not answer, one field because a caller cannot act on the difference. Plus `interrupted` and `timed_out` — two reasons the position is real and is *not* a stop the target reached: somebody called `interrupt`, or the wait ran out and the debugger broke the target in — and `target_gone`, the ending where there is no position at all because the target ran to completion |
@@ -52,6 +52,58 @@ One caveat about "also", measured rather than assumed: a client that understands
 sending both. So for the tools above, the typed answer is what a model reads and the rendering is
 what a program-with-a-terminal reads — they are two audiences, not one audience twice.
 [`token-budget.md`](token-budget.md) has the measurements, and what they cost.
+
+## Inventory refresh against symbol reload
+
+Two different things that have been reached through one command for as long as this server has
+existed, and telling them apart is what `modules { "refresh": true }` is for
+([#85](https://github.com/glslang/windbg-mcp/issues/85)).
+
+**The inventory** is DbgEng's list of the modules it knows the target has loaded. It is built from
+the module-load events the debugger *saw*, so it is complete for a dump (which carries its own
+list) and for a process the debugger launched, and it is emphatically not complete for a live
+kernel: an attach starts from what it can read at connect time, and a driver loaded before the
+debugger dialled in is in the target and missing from the list. A `modules` call there answers
+`nt` and little else, and "the driver is not loaded" is the conclusion a caller draws from it.
+
+**A symbol reload** is the separate business of getting a PDB in front of the engine so
+`module!Symbol` names resolve. It is what `set_symbol_path` does, and what `.reload /f` does.
+
+They have been confused because `.reload /f` does both: forcing every module's symbols also
+resynchronises the inventory, so a caller who ran one got the right module list as a side effect of
+a symbol-server download it may not have wanted. `refresh` is the inventory half on its own:
+
+| | `modules { "refresh": true }` | `set_symbol_path`, `.reload /f` |
+|---|---|---|
+| Finds a module the engine has not heard of | yes | yes, incidentally |
+| Fetches PDBs | **no** — what it discovers is `deferred` | yes, one per module |
+| Costs a symbol-server round trip | no | yes, per module |
+| Effect on symbols already loaded | on a **live** target, discards them | loads them |
+
+The last row is the one to plan around, and it is **live-target only**: on a live target a refresh
+throws away the symbol state the engine was holding and reloads it as needed, so **refresh first
+and load symbols afterwards** — doing it the other way round undoes the reload you just paid for.
+A dump pays none of it. Measured both ways on one host, with the engine's `symsrv.dll` and
+`msdia140.dll` bundled and a store configured:
+
+| target | before the refresh | after it |
+|---|---|---|
+| launched `cmd.exe`, 5 modules, after `.reload /f` | all five `pdb` | `ntdll` still `pdb`, the other four `deferred` |
+| the checked-in kernel dump, 227 modules | `nt` `pdb`, 226 `deferred` | unchanged — nothing discarded |
+
+Which fits what the reload is: on a live target it re-reads the module list and the entries are
+rebuilt, while a dump's list comes from its own header and there is nothing to re-read. So the note
+beside a listing says *on a live target*, and it says *most* modules rather than all of them.
+
+That distinction cost a measurement to find. The first attempt was made on a host whose engine had
+no `symsrv.dll` or `msdia140.dll`, where the same five modules could only reach `export` fallback —
+so the effect looked like a fallback being reset rather than real PDB state being dropped, and the
+dump half was never asked at all.
+
+A refresh that **fails** is reported in the `refresh` field and does not fail the call — the
+listing beside it may well be the right one, and a caller can see for itself. What it must not do
+is pass unnoticed, so the text says so *above* the tables rather than in the note below them: a
+caveat printed under a listing arrives after the conclusion it was there to prevent.
 
 ## Error reporting
 

--- a/docs/token-budget.md
+++ b/docs/token-budget.md
@@ -91,7 +91,7 @@ The two halves moved independently, which is the whole argument for measuring th
 fell by 55% and the model-visible column did not move at all except for what the tools themselves
 have accumulated since.
 
-Worst single tool: `debug_batch` at 9,798 model-visible bytes, because its `inputSchema` pulls the
+Worst single tool: `debug_batch` at 10,021 model-visible bytes, because its `inputSchema` pulls the
 whole `StepAction`/`Check` vocabulary out of `src/batch.rs`.
 
 The payload is measured as the **serialized result**, not as the sum of its tools, and the 118-byte
@@ -284,7 +284,7 @@ None of these is a bug. They are recorded because they were invisible, and
    even covers `w29`.
 8. **Five tools are a third of the model-visible surface**, and it is their *input* schemas rather
    than their prose — **answered** (2026-08-22) by serving fewer tools rather than smaller ones.
-   `debug_batch` alone is 9,798 B — 14% of everything a model is given before it asks anything — of
+   `debug_batch` alone is 10,021 B — 13% of everything a model is given before it asks anything — of
    which 7,980 B is the `StepAction`/`Check` vocabulary its schema pulls out of `src/batch.rs`.
    Then `walk_memory` 4,080, `crash_triage` 2,936, `reachable_from_dispatch` 2,628, `server_log`
    2,599: **21,989 B, 33%**, against a median tool of 900 B.
@@ -299,18 +299,19 @@ None of these is a bug. They are recorded because they were invisible, and
    output schemas because nothing read it. Prose in an *input* schema is the opposite: it is most of
    what tells a model how to drive the tool, and `debug_batch` is the tool where getting that wrong
    leaves a patched byte in a running kernel. Measured across all 54 tools, **70% of the
-   model-visible surface is prose** — 28,118 B of tool descriptions and 24,015 B in the 152
+   model-visible surface is prose** — 28,470 B of tool descriptions and 24,911 B in the 155
    `description` strings nested inside the input schemas — so a strip here buys context by making
    the tools harder to drive correctly. (Re-derived 2026-08-30 by walking a `tools/list`; the
    figures it replaces were 74%, 24,902 and 25,333, and were a percentage of **67,873** — a surface
    total two re-derivations out of date, which is how a share can go stale without its own
-   arithmetic ever being wrong.)
+   arithmetic ever being wrong. Re-derived again the same day against `modules { "refresh": true }`
+   and the two commits before it, which is how quickly it goes stale again.)
 
    The structural remainder does not pay for the risk either. Dropping `"default": null`, which
-   schemars emits 115 times and which tells a model nothing an absent field does not, is 1,725 B —
-   2.3%. The other candidates are not free: `$schema` is 3,021 B but is how a client picks a
+   schemars emits 118 times and which tells a model nothing an absent field does not, is 1,770 B —
+   2.3%. The other candidates are not free: `$schema` is 3,074 B but is how a client picks a
    validator dialect (and `tool_schemas_declare_one_dialect_and_are_self_contained` pins it), and
-   `minimum`/`format` are constraints. **Roughly 1.7 KB of 73,996 is the whole honest total** for
+   `minimum`/`format` are constraints. **Roughly 1.7 KB of 75,547 is the whole honest total** for
    trimming the schemas.
 
    So the third lever is the one taken: `--tools` (`src/toolset.rs`) advertises a named subset. A
@@ -320,20 +321,20 @@ None of these is a bug. They are recorded because they were invisible, and
 
    | group | tools | bytes | share |
    |---|---:|---:|---:|
-   | `allocator` | 10 | 15,969 | 21.6% |
-   | `session` | 10 | 12,817 | 17.3% |
-   | `inspect` | 9 | 10,786 | 14.6% |
-   | `batch` | 1 | 9,798 | 13.2% |
-   | `exec` | 8 | 8,367 | 11.3% |
-   | `ttd` | 9 | 6,829 | 9.2% |
-   | `ioctl` | 6 | 6,494 | 8.8% |
-   | `crash` | 1 | 2,936 | 4.0% |
+   | `allocator` | 10 | 16,457 | 21.8% |
+   | `session` | 10 | 12,817 | 17.0% |
+   | `inspect` | 9 | 11,626 | 15.4% |
+   | `batch` | 1 | 10,021 | 13.3% |
+   | `exec` | 8 | 8,367 | 11.1% |
+   | `ttd` | 9 | 6,829 | 9.0% |
+   | `ioctl` | 6 | 6,494 | 8.6% |
+   | `crash` | 1 | 2,936 | 3.9% |
 
    | `--tools` | tools | model |
    |---|---:|---:|
-   | *(absent)* | 54 | 73,996 |
-   | `session,inspect,exec,crash` | 28 | 33,985 |
-   | `session,inspect,crash` | 20 | 25,465 |
+   | *(absent)* | 54 | 75,547 |
+   | `session,inspect,exec,crash` | 28 | 34,825 |
+   | `session,inspect,crash` | 20 | 26,305 |
    | `crash` | 11 | 14,587 |
 
    **The two tables do not reconcile, and that is the point of item 41.** The first is each group's

--- a/docs/tool-surface.md
+++ b/docs/tool-surface.md
@@ -6,8 +6,8 @@ how much of that surface a run serves, and three behaviours the table has no roo
 ## Serving fewer tools (`--tools`)
 
 All fifty-four tools are served unless you say otherwise, and their definitions cost the model
-**73,996 bytes — about 18k tokens — before it has asked anything**, once per conversation. Three
-quarters of that is the prose that tells a model how to drive them, so it cannot be trimmed without
+**75,547 bytes — about 19k tokens — before it has asked anything**, once per conversation. Seven
+tenths of that is the prose that tells a model how to drive them, so it cannot be trimmed without
 making the tools harder to use correctly (see
 [`token-budget.md`](token-budget.md)). What *can* change is how many of them a given run
 offers:
@@ -18,9 +18,9 @@ windbg-mcp.exe --tools session,inspect,crash
 
 | `--tools` | Tools | Model context |
 |---|---:|---:|
-| *(absent)* — every tool | 54 | 73,996 B |
-| `session,inspect,exec,crash` | 28 | 33,985 B |
-| `session,inspect,crash` | 20 | 25,465 B |
+| *(absent)* — every tool | 54 | 75,547 B |
+| `session,inspect,exec,crash` | 28 | 34,825 B |
+| `session,inspect,crash` | 20 | 26,305 B |
 | `crash` | 11 | 14,587 B |
 
 The spec is a comma-separated list of the group names in the [tool table](../README.md#tools), of

--- a/skills/windbg-debugging/SKILL.md
+++ b/skills/windbg-debugging/SKILL.md
@@ -125,6 +125,12 @@ where its stderr is not on your screen.
   `go`/breakpoint, **not** straight off a `goto_position`/`!tt`). Without these you silently
   get export symbols only and `module!name` lookups fail. Address-based queries, navigation,
   and memory reads still work without symbols — query by address.
+- **A module missing from `modules` may be missing from the *debugger*, not from the target.** The
+  inventory is built from the loads the debugger saw, so a live kernel attach can list `nt` and
+  little else while the driver you are after is loaded and running. `modules { "refresh": true }`
+  resynchronises the two — inventory only, no PDB fetch — and reports what it did. On a live
+  target it discards symbols already loaded, so refresh **before** the symbol setup below, not
+  after.
 - **`file not found` for a PDB usually means the engine, not the path.** `dbgeng.dll` is in
   System32, so a binary with no DLLs beside it opens targets and runs commands happily — it
   just has no `symsrv.dll` to read a symbol store and no `msdia140.dll` to parse a PDB, and

--- a/skills/windbg-debugging/live-and-kernel.md
+++ b/skills/windbg-debugging/live-and-kernel.md
@@ -101,6 +101,15 @@ all, so ending the session takes it; `attach_process` is the route that is.
     instead; that reclaims the session by terminating its engine process.
 
   A *connected* target that doesn't break in is bounded and returns an error.
+- **A fresh attach does not see the drivers already loaded.** DbgEng's module inventory holds the
+  loads the debugger *saw*, and a kernel attach starts from what it can read at connect time — so
+  `modules` straight afterwards often lists `nt` and little else, and a driver that is loaded and
+  serving IOCTLs reads as absent. **`modules { "refresh": true, "filter": "<driver>" }`**
+  resynchronises the inventory first; never conclude a module is not loaded from a listing that
+  did not. It finds modules and fetches no symbols — and on a live target it discards the symbols the
+  engine had loaded, so **refresh first, load symbols after**, not the other way round. A `.reload /f` also
+  resynchronises, as a side effect of downloading every module's PDB; that is the slow way to
+  answer "is this driver loaded".
 - **TTD is user-mode only** — you cannot time-travel a kernel target. For reverse
   execution, record a user-mode trace instead (see [ttd.md](ttd.md)).
 - Symbol names need the full setup (`msdia140.dll` + `.sympath` + `.reload /f` at a stop) —

--- a/skills/windbg-debugging/setup.md
+++ b/skills/windbg-debugging/setup.md
@@ -508,6 +508,14 @@ Two more things that mislead here:
 - `.reload /f <mod>` fetches one module's PDB; bare `.reload /f` walks every loaded module,
   which on a live kernel is a couple of hundred of them and correspondingly slow. Reach for
   the unqualified form only to rule the module name out as the variable.
+  **And note what it also does**: any `.reload` resynchronises DbgEng's *module inventory* with
+  the target, which is a separate thing from loading symbols and is the reason a bare `.reload /f`
+  is sometimes what makes a driver appear in `lm` at all. If that is what you are after, ask for
+  it directly — `modules { "refresh": true }` does the inventory half and fetches no PDBs. Doing
+  it the other way round costs you the reload: on a **live** target a refresh discards the symbols
+  the engine has loaded, so **refresh first, then load symbols**. (A dump does not pay that — its
+  module list comes from its own header, so there is nothing to re-read and the symbol state
+  survives.)
 - `x <mod>!<symbol>` prints **nothing at all** for an unresolved name — no error, no
   diagnostic. Its silence is not confirmation. `lm m <mod>` is the check that answers.
 

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -130,11 +130,22 @@ pub enum EngineOp {
     /// `limit` is how many rows that listing prints in all — the loaded and unloaded halves share
     /// it — defaulted and clamped by the supervisor as every other row cap here is.
     ///
+    /// `refresh` resynchronises the engine's inventory with the target before the listing is
+    /// taken ([#85]). **It carries no `patience_ms`**, and that is the same call
+    /// [`Self::Backtrace`] makes and for the same reason: it is a direct engine call rather than
+    /// a command, so no watchdog can cut it short. What bounds it is the caller's own call
+    /// timeout and `interrupt`, which reaches the engine from off the engine thread. What it is
+    /// *not* is a symbol-server operation — the reload is unqualified and unforced, so the
+    /// modules it discovers are deferred rather than fetched.
+    ///
+    /// [#85]: https://github.com/glslang/windbg-mcp/issues/85
     /// [#120]: https://github.com/glslang/windbg-mcp/issues/120
     Modules {
         #[serde(default)]
         filter: Option<String>,
         limit: usize,
+        #[serde(default)]
+        refresh: bool,
     },
     /// The current thread's call stack, as values and as the listing rendered from them.
     ///
@@ -358,12 +369,13 @@ impl EngineOp {
     /// each half a share of anything left — so every count in the note describes rows that are
     /// actually there, *unless* the listing is allowed to carry none at all. A caller asking for
     /// counts alone is asking for `matched` and `loaded`, which one row carries as well as none.
-    pub fn modules(filter: Option<String>, limit: Option<u32>) -> Self {
+    pub fn modules(filter: Option<String>, limit: Option<u32>, refresh: bool) -> Self {
         Self::Modules {
             filter,
             limit: limit
                 .unwrap_or(DEFAULT_MODULE_ROWS)
                 .clamp(1, MAX_MODULE_ROWS) as usize,
+            refresh,
         }
     }
 
@@ -771,7 +783,12 @@ mod tests {
     /// the two roles.
     #[test]
     fn a_module_listings_row_cap_is_applied_before_crossing_the_worker_pipe() {
-        let EngineOp::Modules { limit, filter } = EngineOp::modules(Some("nt".into()), None) else {
+        let EngineOp::Modules {
+            limit,
+            filter,
+            refresh,
+        } = EngineOp::modules(Some("nt".into()), None, false)
+        else {
             unreachable!("still a module listing")
         };
         assert_eq!(limit, DEFAULT_MODULE_ROWS as usize);
@@ -780,15 +797,22 @@ mod tests {
             Some("nt"),
             "the pattern is the worker's to normalise"
         );
+        assert!(!refresh, "a caller who asked for none gets none");
 
-        let EngineOp::Modules { limit, .. } = EngineOp::modules(None, Some(u32::MAX)) else {
+        let EngineOp::Modules { limit, refresh, .. } =
+            EngineOp::modules(None, Some(u32::MAX), true)
+        else {
             unreachable!()
         };
         assert_eq!(limit, MAX_MODULE_ROWS as usize);
+        assert!(
+            refresh,
+            "the resynchronisation is the caller's to ask for and is passed through as asked"
+        );
 
         // And never nothing: a listing carrying no rows at all would leave the note counting
         // unloaded images it says are listed above it.
-        let EngineOp::Modules { limit, .. } = EngineOp::modules(None, Some(0)) else {
+        let EngineOp::Modules { limit, .. } = EngineOp::modules(None, Some(0), false) else {
             unreachable!()
         };
         assert_eq!(limit, 1);

--- a/src/server.rs
+++ b/src/server.rs
@@ -1620,6 +1620,14 @@ pub struct ModulesArgs {
     /// so a short listing is never mistaken for the whole table.
     #[serde(default)]
     pub limit: Option<u32>,
+    /// Resynchronise the debugger's inventory with the target before listing it (default false).
+    /// The inventory holds the module loads the debugger *saw*, so a fresh kernel attach often
+    /// lists `nt` and little else and a driver loaded before it reads as absent — pass this
+    /// before concluding a module is not loaded. It finds modules **without fetching symbols**,
+    /// and on a live target discards ones already loaded, so refresh first and load symbols after.
+    /// The result's `refresh` reports it, including a resynchronisation that failed.
+    #[serde(default)]
+    pub refresh: Option<bool>,
     /// Which session to act on. Omit for the current one; pass an opener's handle to route to that
     /// session and be refused if its target was replaced or closed.
     #[serde(default)]
@@ -4024,7 +4032,8 @@ impl WindbgServer {
     /// how many matched, so pass `filter` to ask about one driver rather than paging through a
     /// table of two hundred. The modules that have **unloaded** come back in their own
     /// `unloaded` list, narrowed by the same filter — that is what can name an address in a driver
-    /// that is no longer there.
+    /// that is no longer there. A module absent from the listing may be absent from the
+    /// *debugger's* inventory rather than from the target — `refresh: true` resynchronises them.
     #[rmcp::tool(
         annotations(
             title = "List modules",
@@ -4061,7 +4070,7 @@ impl WindbgServer {
         let out = self
             .run(
                 args.session_id.as_deref(),
-                EngineOp::modules(args.filter, args.limit),
+                EngineOp::modules(args.filter, args.limit, args.refresh.unwrap_or(false)),
             )
             .await;
         engine_result_for(args.session_id.as_deref(), out)
@@ -5214,6 +5223,12 @@ const TOOL_NOTES: &[ToolNote] = &[
         tool: "modules",
         names: &["execute"],
         note: "For the engine's own listing verbatim, `execute { \"command\": \"lm\" }`.",
+    },
+    ToolNote {
+        tool: "modules",
+        names: &["set_symbol_path"],
+        note: "`refresh` finds modules and loads no symbols; `set_symbol_path` is the one that \
+               loads them.",
     },
     ToolNote {
         tool: "disassemble",

--- a/src/structured.rs
+++ b/src/structured.rs
@@ -812,6 +812,54 @@ pub struct ModuleList {
     /// this is what says so. Absent when nothing was filtered.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub filter: Option<String>,
+    /// What the call's `refresh` did to the engine's inventory before this listing was taken.
+    ///
+    /// **Absent means it was not asked for**, which is every default call — not "it was asked for
+    /// and did nothing". The two have to be distinguishable because the question this listing
+    /// answers most often is *is this driver loaded*, and a `matched: 0` means one thing when the
+    /// inventory was resynchronised a moment ago and something much weaker when it was whatever
+    /// the engine happened to be holding.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub refresh: Option<ModuleRefresh>,
+}
+
+/// What a `modules { "refresh": true }` did before the listing beside it was taken.
+///
+/// **Inventory, not symbols.** The engine is asked to resynchronise its module list with the
+/// target (`IDebugSymbols::Reload` with no arguments, which is the `.reload` a person types).
+/// That discovers images the engine has not heard of — the case this exists for is a live kernel
+/// attach, where a driver loaded *before* the debugger connected is in the target and not in the
+/// engine's list until something asks. It is deliberately not `.reload /f`: forcing a symbol load
+/// would put a symbol-server round trip per module behind a call whose caller asked about module
+/// *names*, and finding a loaded image should not cost a PDB download.
+///
+/// The price of that is on [`ModuleInfo::symbols`], and it is the one surprise here: **on a live
+/// target** a resynchronisation discards what the engine had loaded and reloads it as needed, so
+/// most rows that named a PDB before a refresh read `deferred` after one. Nothing was lost — the
+/// PDB is re-read from the local cache the next time a symbol is asked for — but a caller that has
+/// just run a force-reload and then refreshes has undone the state it paid for, so the order to do
+/// them in is refresh first. A **dump** pays none of it: its module list comes from its own header
+/// rather than from the target, so there is nothing to re-read and the symbol state survives
+/// (measured either way — see `worker::resynchronise`).
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct ModuleRefresh {
+    /// Whether the engine resynchronised. When this is `false` the listing beside it is whatever
+    /// the engine was already holding, which may be stale — and is exactly the state that reads
+    /// as "the driver is not loaded" when the driver is loaded.
+    pub synchronized: bool,
+    /// How many modules the engine listed **before** the resynchronisation, against
+    /// [`ModuleList::loaded`] after it.
+    ///
+    /// Carried because it is the only evidence a caller has that the refresh was worth asking
+    /// for, and because the number this tool exists for is the difference: a fresh kernel attach
+    /// reporting `before: 1` against `loaded: 158` — measured on the CTF guest, 2026-08-30 — is
+    /// the whole of [#85](https://github.com/glslang/windbg-mcp/issues/85) in two fields. On a
+    /// target whose inventory was already current the two are equal, which is an answer rather
+    /// than a wasted call.
+    pub before: usize,
+    /// Why the resynchronisation failed, in the engine's own words. Absent when it succeeded.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
 }
 
 impl ModuleInfo {

--- a/src/toolset.rs
+++ b/src/toolset.rs
@@ -1,7 +1,7 @@
 //! Which of this server's fifty-four tools a run advertises.
 //!
 //! The tool surface is paid **once per conversation, before anything is debugged**, and it is
-//! 68,893 bytes — roughly 17k tokens. Three quarters of that is prose, and the prose is what tells
+//! 75,547 bytes — roughly 19k tokens. Seven tenths of that is prose, and the prose is what tells
 //! a model how to drive the tools, so there is no strip here the way there was in
 //! [`crate::schema`]: `FOLLOWUPS.md` item 24 measured it and the only honest lever left is the one
 //! this module is — **not offering every tool to every caller**.
@@ -20,12 +20,12 @@
 //! ```text
 //!   group      tools   bytes   what it is for
 //!   session       10   12,817  opening a target, ending it, and watching this server
-//!   allocator     10   15,969  pool and heap walks, and `walk_memory`
-//!   inspect        9   10,786  registers, stacks, memory, modules, symbols, raw commands
+//!   allocator     10   16,457  pool and heap walks, and `walk_memory`
+//!   inspect        9   11,626  registers, stacks, memory, modules, symbols, raw commands
 //!   ttd            9    6,829  recording, indexing and querying a Time Travel trace
 //!   ioctl          6    6,494  driver objects, IRP stacks, and dispatch reachability
 //!   exec           8    8,367  breakpoints and execution control
-//!   batch          1    9,798  `debug_batch`
+//!   batch          1   10,021  `debug_batch`
 //!   crash          1    2,936  `crash_triage`
 //! ```
 //!

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -1569,7 +1569,11 @@ fn execute(e: &DebugEngine, id: u64, op: EngineOp, queued: Duration) -> Result<O
             timeout_ms,
         } => resume(e, id, &command, timeout_ms),
         EngineOp::Registers { all } => registers(e, all),
-        EngineOp::Modules { filter, limit } => modules(e, filter.as_deref(), limit),
+        EngineOp::Modules {
+            filter,
+            limit,
+            refresh,
+        } => modules(e, filter.as_deref(), limit, refresh),
         EngineOp::Backtrace { frames } => backtrace(e, frames as usize),
         EngineOp::Disassemble { address, count } => {
             disassemble(e, address.as_deref(), count as usize)
@@ -2442,8 +2446,23 @@ fn with_pdb_identity(
 /// cannot squeeze out the unloaded rows and two halves cannot double the ceiling between them.
 /// What the cap must not cost is the counts: the note and the values report what *matched*, so a
 /// listing that stops short says so rather than reading as a smaller target.
-fn modules(e: &DebugEngine, filter: Option<&str>, limit: usize) -> Result<Output, Failed> {
+///
+/// **`refresh` runs before any of that**, and the ordering is the whole of it: a listing taken
+/// from an inventory the engine has not resynchronised is a listing of what the *engine* knows
+/// rather than of what the target has loaded ([`resynchronise`]).
+fn modules(
+    e: &DebugEngine,
+    filter: Option<&str>,
+    limit: usize,
+    refresh: bool,
+) -> Result<Output, Failed> {
     let pattern = filter.map(module_pattern);
+    // Asked for first, and its failure does **not** end the call: a stale listing plus a field
+    // saying the resynchronisation failed is strictly more than an error, since the rows may well
+    // be the right ones and the caller can see for themselves. What must not happen is the
+    // failure going unsaid, which is why [`refresh_note`] renders above the tables rather than
+    // into the note under them — the caveat has to arrive before the conclusion it qualifies.
+    let refreshed = refresh.then(|| resynchronise(e)).transpose()?;
     let loaded = e.modules().map_err(failed)?;
     // Unloaded modules are best-effort: not every Windows version tracks them, the ones that do
     // may have nothing to report, and a listing of what *is* loaded must not fail over what is
@@ -2468,8 +2487,85 @@ fn modules(e: &DebugEngine, filter: Option<&str>, limit: usize) -> Result<Output
         matched: total,
         unloaded: identified(e, matched_unloaded, for_unloaded),
         unloaded_matched: total_unloaded,
+        refresh: refreshed,
     };
     Ok(Output::typed(render_modules(&list), list))
+}
+
+/// Asks the engine to resynchronise its module inventory with the target, and reports what that
+/// did.
+///
+/// **The defect this closes.** DbgEng's module list is the engine's, not the target's: it is built
+/// from the module-load events the debugger *saw*, so a live kernel attach starts from whatever it
+/// can read at connect time and a driver loaded before the debugger dialled in is simply not in
+/// it. On the MessageManager regression target that was `nt` and nothing else, and a `modules`
+/// call straight after the attach read as "the challenge driver is not loaded" while the driver
+/// was open and serving IOCTLs ([#85]). Measured there on 2026-08-30, one attach: the engine held
+/// **1** module, a filter on `MessageManager` matched **0**, and the same call with `refresh`
+/// reported `before: 1` against **158** loaded and matched the driver — `deferred`, so it was
+/// found without a byte of PDB being fetched. The synchronisation existed all along — it is what the
+/// tier's `.reload /f` was doing as a side effect — and nothing said so, so finding a loaded image
+/// meant guessing that a force symbol reload was the missing step.
+///
+/// **Unqualified and unforced**, which is the argument for a separate flag rather than a wider
+/// `set_symbol_path`. `Reload("")` is the `.reload` a person types: it re-reads the target's
+/// loaded-module list and leaves every module's symbols *deferred*, so the images it discovers
+/// cost their names and nothing else. `/f` — what the symbol path's own reload takes — is a PDB
+/// fetch per module, which on a live kernel over a symbol server is minutes and is not what a
+/// caller asking whether a driver is loaded wanted to buy.
+///
+/// The one thing it does cost is that a reload *discards* the symbol information the engine had
+/// and reloads it as needed, so a module that had symbols reports `deferred` afterwards until
+/// something asks for one again (from the local cache, not the server). That cost is why this is
+/// opt-in rather than something an opener does for you, and why the tool's own prose says to
+/// refresh before loading symbols rather than after.
+///
+/// **And it is a live-target cost, which took two measurements to establish** (this bench,
+/// 2026-08-30, with the engine's `symsrv.dll`/`msdia140.dll` bundled and a store configured —
+/// without them the first attempt saw only `export` fallback and read the effect as smaller than
+/// it is):
+///
+/// * a launched `cmd.exe`, five modules. After `.reload /f`, all five `pdb`. After a refresh,
+///   `cmd`/`ucrtbase`/`KERNELBASE`/`KERNEL32` back to `deferred` and `ntdll` still `pdb` — real
+///   PDB state discarded, and *most* modules rather than all of them.
+/// * the checked-in kernel dump, 227 modules. `nt` is `pdb` and stays `pdb` across a refresh; the
+///   other 226 are `deferred` either side. **Nothing is discarded at all.**
+///
+/// Which fits what the reload is: on a live target it re-reads the module list and the entries are
+/// rebuilt, while a dump's list comes from its own header and there is nothing to re-read. So the
+/// note beside the listing says *on a live target*, and a caller reading a dump is not warned
+/// about a cost that target cannot pay.
+///
+/// **`before` is read here rather than derived**, because the count the caller needs is the one
+/// from before the reload and there is no later moment that still has it. It is the engine's own
+/// bookkeeping — `GetNumberModules` and the parameter block behind it — not a target read, so it
+/// costs the same as the listing that follows and no round trip to the debuggee.
+///
+/// A `Failed` here is a pre-count that did not work, which is the same call the listing itself is
+/// about to make: there is nothing to report a refresh against if the inventory cannot be read at
+/// all, and letting it through would only move the identical failure two lines down.
+///
+/// [#85]: https://github.com/glslang/windbg-mcp/issues/85
+fn resynchronise(e: &DebugEngine) -> Result<structured::ModuleRefresh, Failed> {
+    let before = e.modules().map_err(failed)?.len();
+    match e.reload_symbols("") {
+        Ok(()) => Ok(structured::ModuleRefresh {
+            synchronized: true,
+            before,
+            error: None,
+        }),
+        Err(why) => {
+            // Logged as well as reported, because the reported half is a field on a result that
+            // still looks like an answer, and the server's own record of a failing engine call
+            // belongs in the log whether or not the caller reads the field.
+            tracing::warn!("worker: the module inventory could not be resynchronised: {why}");
+            Ok(structured::ModuleRefresh {
+                synchronized: false,
+                before,
+                error: Some(why.to_string()),
+            })
+        }
+    }
 }
 
 /// The records a pattern matched, each still paired with the engine's own — which is what the PDB
@@ -2532,10 +2628,63 @@ fn render_modules(list: &structured::ModuleList) -> String {
         out.push_str(&fenced(&module_table(&list.unloaded, "image")));
     }
     let note = listing_note(list);
-    if out.is_empty() {
-        return note;
+    let listing = if out.is_empty() {
+        note
+    } else {
+        format!("{out}\n{note}")
+    };
+    // Above everything, including the tables — a refresh that failed makes every count below it
+    // untrustworthy, and a caveat printed under a table is read after the conclusion it was there
+    // to prevent. Composed last rather than pushed first so the two tables keep deciding their own
+    // spacing from whether *they* are empty.
+    match refresh_note(list.refresh.as_ref(), list.loaded) {
+        Some(said) => format!("{said}\n\n{listing}"),
+        None => listing,
     }
-    format!("{out}\n{note}")
+}
+
+/// The line above a listing that says what the call's `refresh` did — and nothing at all for the
+/// calls that asked for none, which is every default one.
+///
+/// Three states, because they are three different things to do next. A resynchronisation that
+/// **found something** is the case [#85] is about, and it names both counts: a caller who has just
+/// been told the driver is not loaded needs to see that the inventory it was told that from had
+/// one module in it. One that found **nothing new** is worth a line too — it is what turns "the
+/// module is absent" from a guess into an answer, and without it a caller has no way to tell a
+/// refresh that ran from one that was ignored. And one that **failed** is the only line that
+/// carries advice, because it is the only one where the listing under it may be wrong.
+///
+/// [#85]: https://github.com/glslang/windbg-mcp/issues/85
+fn refresh_note(refresh: Option<&structured::ModuleRefresh>, loaded: usize) -> Option<String> {
+    let refresh = refresh?;
+    // Keyed on `synchronized` rather than on the presence of `error`, so the sentence and the flag
+    // beside it cannot say different things: `synchronized` is the field that *means* it, and the
+    // reason is what a failure additionally carries.
+    if refresh.synchronized {
+        let found = if loaded > refresh.before {
+            format!(
+                "Inventory resynchronised with the target: {} module(s) before, {loaded} now.",
+                refresh.before
+            )
+        } else {
+            format!("Inventory resynchronised with the target; it already held all {loaded}.")
+        };
+        return Some(format!(
+            "{found} On a live target it discards the symbol information the engine had loaded \
+             (most modules come back `deferred`), so load symbols **after** refreshing rather \
+             than before."
+        ));
+    }
+    let warning = "**The inventory could not be resynchronised**, so the listing below is whatever \
+                   the engine was already holding and may be missing modules the target has \
+                   loaded — a module absent from it is not evidence it is absent from the target.";
+    // The engine's own words, escaped like every other string that came from outside this server.
+    // A failure with no reason is a state this worker does not produce, but the sentence above is
+    // the load-bearing half and must not depend on one having survived the trip.
+    Some(match &refresh.error {
+        Some(why) => format!("{warning} The engine said: {}", renderable(why)),
+        None => warning.to_string(),
+    })
 }
 
 /// One table: a header, then a row per module.
@@ -6856,6 +7005,7 @@ mod tests {
             filter: filter.map(module_pattern),
             matched: matched.len(),
             unloaded_matched: matched_unloaded.len(),
+            refresh: None,
             modules: matched.into_iter().take(for_loaded).collect(),
             unloaded: matched_unloaded.into_iter().take(for_unloaded).collect(),
         }
@@ -6980,6 +7130,7 @@ mod tests {
                 .collect(),
             unloaded: Vec::new(),
             unloaded_matched: 0,
+            refresh: None,
         };
         let text = render_modules(&list);
         assert!(text.contains(long), "a long name is printed whole:\n{text}");
@@ -7010,6 +7161,7 @@ mod tests {
                 modules: Vec::new(),
                 unloaded: Vec::new(),
                 unloaded_matched: 0,
+                refresh: None,
             })
         };
 
@@ -7096,6 +7248,7 @@ mod tests {
                 .collect(),
             unloaded: Vec::new(),
             unloaded_matched: 0,
+            refresh: None,
         };
         let text = render_modules(&list);
         assert_eq!(
@@ -7141,6 +7294,7 @@ mod tests {
                 .collect(),
             unloaded: Vec::new(),
             unloaded_matched: 0,
+            refresh: None,
         };
         let text = render_modules(&list);
 
@@ -7177,6 +7331,7 @@ mod tests {
                 .collect(),
             unloaded: Vec::new(),
             unloaded_matched: 0,
+            refresh: None,
         };
         let text = render_modules(&list);
 
@@ -7389,6 +7544,7 @@ mod tests {
                 .map(structured::ModuleInfo::from)
                 .collect(),
             unloaded_matched: 26,
+            refresh: None,
         };
         let text = render_modules(&cut_tail);
         assert!(
@@ -7428,6 +7584,7 @@ mod tests {
                 loaded: 227,
                 matched: 227,
                 unloaded_matched: 50,
+                refresh: None,
                 filter: None,
                 modules: (0..for_loaded)
                     .map(|i| structured::ModuleInfo::from(&module("drv", 0x1000 + i as u64 * 0x10)))
@@ -7467,6 +7624,115 @@ mod tests {
         assert!(
             truncation_note(&whole).is_none(),
             "nothing was cut, so nothing is said about a cut"
+        );
+    }
+
+    /// The three things a `refresh` can have done, said above the listing rather than under it.
+    ///
+    /// The ordering is the assertion that matters. A caller reads a `modules` answer top-down and
+    /// draws its conclusion from the rows; a caveat about those rows printed beneath them arrives
+    /// after the conclusion it was there to prevent — which is exactly how
+    /// [#85](https://github.com/glslang/windbg-mcp/issues/85) was read as "the driver is not
+    /// loaded" in the first place.
+    #[test]
+    fn a_refresh_says_what_it_did_before_the_listing_it_qualifies() {
+        let listing = |refresh: Option<structured::ModuleRefresh>| {
+            render_modules(&structured::ModuleList {
+                loaded: 226,
+                matched: 0,
+                unloaded_matched: 0,
+                filter: Some(module_pattern("MessageManager")),
+                modules: Vec::new(),
+                unloaded: Vec::new(),
+                refresh,
+            })
+        };
+
+        // Not asked for: not one word about it, on every default call.
+        let quiet = listing(None);
+        assert!(
+            !quiet.to_lowercase().contains("resynchronis"),
+            "a call that asked for no refresh must not be told about one:\n{quiet}"
+        );
+
+        // The case the flag exists for — the fresh-attach inventory, and what it grew to.
+        let found = listing(Some(structured::ModuleRefresh {
+            synchronized: true,
+            before: 1,
+            error: None,
+        }));
+        assert!(
+            found.contains("1 module(s) before, 226 now"),
+            "the refresh names both counts, which is the evidence it was worth asking for:\n{found}"
+        );
+        assert!(
+            found.contains("deferred"),
+            "and warns what it costs, which is the symbol state the engine had:\n{found}"
+        );
+
+        // Already current. Worth a line of its own: it is what turns "the module is absent" from
+        // a guess into an answer, and a caller cannot otherwise tell it from a refresh that was
+        // ignored.
+        let current = listing(Some(structured::ModuleRefresh {
+            synchronized: true,
+            before: 226,
+            error: None,
+        }));
+        assert!(
+            current.contains("already held all 226"),
+            "a refresh that found nothing new still says it ran:\n{current}"
+        );
+
+        // And the failure, which is the only one that may not be quietly believed. It has to be
+        // above the note that says nothing matched, or it is advice arriving after the verdict.
+        let failed = listing(Some(structured::ModuleRefresh {
+            synchronized: false,
+            before: 1,
+            error: Some("Unable to read PsLoadedModuleList".into()),
+        }));
+        let (warning, verdict) = (
+            failed.find("could not be resynchronised"),
+            failed.find("Nothing matches"),
+        );
+        assert!(
+            warning.is_some() && verdict.is_some() && warning < verdict,
+            "the caveat has to arrive before the conclusion it qualifies:\n{failed}"
+        );
+        assert!(
+            failed.contains("Unable to read PsLoadedModuleList"),
+            "and it carries the engine's own reason:\n{failed}"
+        );
+        assert!(
+            failed.contains("not evidence it is absent from the target"),
+            "…and withdraws the only conclusion the listing would otherwise support:\n{failed}"
+        );
+    }
+
+    /// The engine's failure text is a string from outside this server, and lands in the listing.
+    ///
+    /// Same rule and same escape as a module name and the caller's own filter: this rendering is
+    /// line-oriented and its rows begin with an address, so a reason carrying a line break could
+    /// otherwise print a row the values beside it do not have.
+    #[test]
+    fn a_refresh_failure_cannot_smuggle_a_row_into_the_listing() {
+        let text = render_modules(&structured::ModuleList {
+            loaded: 1,
+            matched: 0,
+            unloaded_matched: 0,
+            filter: None,
+            modules: Vec::new(),
+            unloaded: Vec::new(),
+            refresh: Some(structured::ModuleRefresh {
+                synchronized: false,
+                before: 1,
+                error: Some(
+                    "no\n0xfffff80389200000  0xfffff8038a650000  smuggled  pdb".to_string(),
+                ),
+            }),
+        });
+        assert!(
+            listed_rows(&text).is_empty(),
+            "an engine message must not be able to print a row:\n{text}"
         );
     }
 

--- a/tests/golden/tool_budget.json
+++ b/tests/golden/tool_budget.json
@@ -245,12 +245,12 @@
     },
     {
       "annotations": 65,
-      "description": 723,
-      "inputSchema": 1640,
-      "modelVisible": 2411,
+      "description": 965,
+      "inputSchema": 2238,
+      "modelVisible": 3251,
       "name": "modules",
-      "outputSchema": 3282,
-      "wire": 5789
+      "outputSchema": 3564,
+      "wire": 6911
     },
     {
       "annotations": 128,
@@ -489,14 +489,14 @@
   ],
   "totals": {
     "annotations": 5762,
-    "description": 28674,
-    "inputSchema": 43218,
+    "description": 28916,
+    "inputSchema": 43816,
     "instructions": 1983,
-    "modelVisible": 74707,
-    "outputSchema": 112445,
-    "payload": 194421,
+    "modelVisible": 75547,
+    "outputSchema": 112727,
+    "payload": 195543,
     "tools": 54,
-    "wire": 194300,
+    "wire": 195422,
     "worstTool": "debug_batch",
     "worstToolModelVisible": 10021
   }

--- a/tests/golden/tools_list.json
+++ b/tests/golden/tools_list.json
@@ -821,6 +821,7 @@
       "params": [
         "filter: string|null",
         "limit: integer|null/uint32",
+        "refresh: boolean|null",
         "session_id: string|null"
       ],
       "required": [],

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -1747,8 +1747,8 @@ fn budget_report(result: &Value, instructions: &str) -> Value {
     })
 }
 
-/// Ceiling on the tool surface a model is given before it has asked anything. 73,996 bytes across
-/// 54 tools (~18k tokens), +12% headroom — sized so that rewording a description passes and a new
+/// Ceiling on the tool surface a model is given before it has asked anything. 75,547 bytes across
+/// 54 tools (~19k tokens), +10% headroom — sized so that rewording a description passes and a new
 /// tool arriving with a `debug_batch`-scale schema does not.
 ///
 /// **Raised 76,000 → 83,000 when the three asynchronous-execution tools landed** (2026-08-29), and
@@ -1786,7 +1786,7 @@ const MODEL_VISIBLE_CEILING: usize = 83_000;
 /// item 24's first finding done rather than priced.
 const WIRE_CEILING: usize = 205_000;
 
-/// Ceiling on any single tool's model-visible definition. `debug_batch` is the worst at 9,757
+/// Ceiling on any single tool's model-visible definition. `debug_batch` is the worst at 10,021
 /// bytes, because its `inputSchema` pulls the whole `StepAction`/`Check` vocabulary from
 /// `src/batch.rs`. A tool costing more than this is not necessarily wrong, but it should be a
 /// decision somebody made rather than a schema that grew.
@@ -2109,7 +2109,7 @@ fn every_tool_belongs_to_exactly_one_group() {
 
 /// A narrowed surface serves fewer tools, and says so rather than pretending the rest never were.
 ///
-/// The measurement behind `--tools` is that 70% of the 73,996-byte tool surface is prose a model
+/// The measurement behind `--tools` is that 70% of the 75,547-byte tool surface is prose a model
 /// needs, so the only way to spend less of a caller's context is to offer fewer tools —
 /// `FOLLOWUPS.md` item 24. This asserts the three things that makes true.
 #[test]
@@ -6428,6 +6428,114 @@ fn a_module_filter_narrows_both_halves_of_the_answer_alike() {
     assert_eq!(after["loaded"].as_u64(), Some(loaded), "{after}");
 }
 
+/// `modules { "refresh": true }` resynchronises the debugger's inventory with the target before
+/// listing it, asked as the **first** call on a freshly opened session
+/// ([#85](https://github.com/glslang/windbg-mcp/issues/85)).
+///
+/// That ordering is the test, not decoration. DbgEng's module list is built from the loads the
+/// debugger *saw*, so on a live kernel attach it starts at whatever it can read at connect time
+/// and a driver loaded beforehand is simply absent — which read as "the challenge driver is not
+/// loaded" on the MessageManager target while the driver was serving IOCTLs. Asking on a *dump*
+/// cannot reproduce that gap (a dump carries its own complete module list), so what this tier
+/// claims is the other half, and it is the half that would break silently: the refresh **runs
+/// against a real engine, succeeds, and costs the listing nothing** — same modules, same counts,
+/// reported as a resynchronisation that found the inventory already current. The live tier below
+/// covers the gap itself, on a target that has one.
+///
+/// The default call is checked in the same breath, because "cheap and backward compatible" is a
+/// claim about the *absence* of a field: an answer that started carrying `refresh` on every call
+/// would tell every caller a refresh had happened when none had.
+#[test]
+fn a_module_listing_can_resynchronise_the_inventory_before_it_lists_it() {
+    let Some(dump) = target_tier() else { return };
+    let mut server = Server::started();
+    let session_id = server.open_session("open_dump", json!({ "path": dump }), TARGET_STEP);
+
+    // First call on the session, before anything else has made the engine look at a module.
+    let response = server.call_tool(
+        "modules",
+        json!({ "session_id": session_id, "refresh": true, "filter": "nt" }),
+        TARGET_STEP,
+    );
+    assert_no_error(&response, "modules with refresh");
+    assert!(
+        !is_tool_error(&response),
+        "a refresh on an open target is ordinary work, not a fault: {response}"
+    );
+    let refreshed = response["result"]["structuredContent"].clone();
+    let text = text_of(&response["result"]);
+    assert_eq!(
+        refreshed["refresh"]["synchronized"],
+        json!(true),
+        "the engine resynchronised, and the field is how a caller knows:\n{text}\n{refreshed}"
+    );
+    assert!(
+        refreshed["refresh"]["error"].is_null(),
+        "a synchronisation that worked carries no reason: {refreshed}"
+    );
+    // A dump's own module list is complete when it opens, so the refresh has nothing to find —
+    // and must not *lose* anything either, which is the failure this pins.
+    let (before, loaded) = (
+        refreshed["refresh"]["before"].as_u64(),
+        refreshed["loaded"].as_u64(),
+    );
+    assert_eq!(
+        before, loaded,
+        "a dump opens with its inventory already complete, so a refresh changes nothing: \
+         {refreshed}"
+    );
+    assert!(
+        loaded.unwrap_or_default() > 20,
+        "…and that inventory is the whole table, not an empty one: {refreshed}"
+    );
+    assert!(
+        text.contains("Inventory resynchronised"),
+        "the text says a refresh ran, above the listing it qualifies:\n{text}"
+    );
+    // The rows are still the rows: a refresh is a step before the listing, not a different answer.
+    assert_eq!(
+        listed_rows(&text),
+        valued_rows(&refreshed),
+        "a refreshed listing agrees with its own values like any other:\n{text}"
+    );
+    assert!(
+        refreshed["matched"].as_u64().unwrap_or_default() > 0,
+        "`nt` matches something on this target with or without a refresh: {refreshed}"
+    );
+
+    // And the default, on the same session: the same inventory, and not one word about a refresh
+    // nobody asked for.
+    let plain = server.tool_data(
+        "modules",
+        json!({ "session_id": session_id, "filter": "nt" }),
+        TARGET_STEP,
+    );
+    assert!(
+        plain["refresh"].is_null(),
+        "a call that asked for no refresh must not report one: {plain}"
+    );
+    assert_eq!(
+        plain["loaded"].as_u64(),
+        loaded,
+        "the refresh left the engine holding what it found: {plain}"
+    );
+    assert_eq!(
+        valued_rows(&plain),
+        valued_rows(&refreshed),
+        "and the same modules, row for row"
+    );
+    println!(
+        "refresh on {dump}: {}",
+        text.lines().next().unwrap_or_default()
+    );
+
+    server.tool_data(
+        "end_session",
+        json!({ "session_id": session_id }),
+        TARGET_STEP,
+    );
+}
+
 /// **A default register set is the integer registers, on whatever architecture this host is.**
 ///
 /// The `all` argument documents the default as excluding the x87 and vector registers, and it did
@@ -9962,6 +10070,34 @@ fn a_live_kernel_session_attaches_coexists_and_detaches_cleanly() {
             listed.contains(&"nt"),
             "the kernel image should be in the module list:\n{modules}"
         );
+
+        // And the same listing asked to resynchronise the inventory first, which is the only tier
+        // where that call reaches a target whose module list the debugger did not watch being
+        // built ([#85](https://github.com/glslang/windbg-mcp/issues/85)). This target carries no
+        // fixture, so what is claimed here is the mechanism rather than a find: the reload runs
+        // over the KD wire, succeeds, and leaves a listing at least as complete as the one above
+        // — a refresh that lost modules would be worse than no refresh at all. The CTF tier makes
+        // the other claim, on a driver that is actually missing before it.
+        let refreshed = server.tool_data(
+            "modules",
+            json!({ "session_id": session, "refresh": true }),
+            TARGET_STEP,
+        );
+        assert_eq!(
+            refreshed["refresh"]["synchronized"],
+            json!(true),
+            "a live kernel is the target a resynchronisation exists for: {refreshed}"
+        );
+        let (before, after) = (
+            refreshed["refresh"]["before"].as_u64().unwrap_or_default(),
+            refreshed["loaded"].as_u64().unwrap_or_default(),
+        );
+        assert!(
+            after >= before && after > 1,
+            "the refresh left {after} module(s) where the engine held {before}: {refreshed}"
+        );
+        println!("live kernel inventory: {before} module(s) before the refresh, {after} after");
+
         let registers =
             server.tool_text("registers", json!({ "session_id": session }), TARGET_STEP);
         assert!(
@@ -11831,23 +11967,31 @@ fn a_messagemanager_ctf_fixture_is_visible_through_mcp() {
             "the CTF attach reported a tool failure:\n{report}"
         );
 
-        let symbols = load_kernel_symbols(&mut server, &session);
-        assert!(
-            symbols.loaded.contains("pdb symbols") && !symbols.probe.is_empty(),
-            "the CTF pool check needs full `nt` symbols and the pool-root global. If a known-good \
-             path exists, set {SYMBOLS_ENV}. Engine setup said: {engine}\n{}",
-            symbols.transcript
-        );
-
-        // A fresh kernel attach may initially expose only `nt`; the unqualified reload above
-        // populates DbgEng's full module inventory as well as loading the pool types.
+        // **Before any symbol work**, which is the whole of what this assertion now claims
+        // ([#85]). The driver was loaded before the debugger dialled in, so it is in the target
+        // and not yet in DbgEng's inventory — a fresh attach here lists `nt` and little else, and
+        // a `modules` call straight after one read as "the challenge driver is not loaded" while
+        // it was open and serving IOCTLs. It used to be found only *after* `load_kernel_symbols`
+        // below, whose unqualified `.reload /f` resynchronised the inventory as a side effect of
+        // fetching every PDB: the answer was right and the caller had no way to know that a full
+        // symbol load was what made it right. `refresh` is that resynchronisation on its own, and
+        // asking here means a pass cannot be borrowed from the reload that follows.
+        //
         // Matched against module *names*, not against a substring of the whole `lm` listing:
         // "messagemanager appears somewhere in that text" was true of a symbol path echoed into
         // the same output, which is the kind of accidental pass a field cannot give.
+        //
+        // [#85]: https://github.com/glslang/windbg-mcp/issues/85
         let modules = server.tool_data(
             "modules",
-            json!({ "session_id": session, "filter": "MessageManager" }),
+            json!({ "session_id": session, "filter": "MessageManager", "refresh": true }),
             TARGET_STEP,
+        );
+        assert_eq!(
+            modules["refresh"]["synchronized"],
+            json!(true),
+            "the resynchronisation itself failed, so nothing below it says anything about the \
+             fixture: {modules}"
         );
         let driver = modules["modules"]
             .as_array()
@@ -11861,8 +12005,9 @@ fn a_messagemanager_ctf_fixture_is_visible_through_mcp() {
             .cloned();
         assert!(
             driver.is_some(),
-            "the fixture reported ready, but KD does not list MessageManager.sys after the full \
-             module reload:\n{}\n\nsymbol setup said:{}",
+            "the fixture reported ready, but KD does not list MessageManager.sys after an \
+             inventory refresh the engine reports it made, from {} module(s):\n{}",
+            modules["refresh"]["before"],
             text_of(
                 &server.call_tool(
                     "modules",
@@ -11870,6 +12015,13 @@ fn a_messagemanager_ctf_fixture_is_visible_through_mcp() {
                     TARGET_STEP
                 )["result"]
             ),
+        );
+
+        let symbols = load_kernel_symbols(&mut server, &session);
+        assert!(
+            symbols.loaded.contains("pdb symbols") && !symbols.probe.is_empty(),
+            "the CTF pool check needs full `nt` symbols and the pool-root global. If a known-good \
+             path exists, set {SYMBOLS_ENV}. Engine setup said: {engine}\n{}",
             symbols.transcript
         );
 


### PR DESCRIPTION
Closes #85.

## The defect

DbgEng's module list is the **debugger's**, not the target's — it is built from the module-load
events the debugger *saw*. So it is complete for a dump (which carries its own list) and for a
process the debugger launched, and it is emphatically not complete for a live kernel: an attach
starts from what it can read at connect time, and a driver loaded before the debugger dialled in is
in the target and missing from the list.

Measured on the CTF guest, one attach:

```text
attach: ok
before refresh: loaded=1
  MessageManager without refresh: matched=0 unloaded_matched=0
  refresh: {"before": 1, "synchronized": true}
  loaded after refresh: 158  matched=1
    0xfffff80343970000  0xfffff80343977000  MessageManager  deferred
```

That first `matched=0` is the false "driver is not loaded" the issue is about, and the `deferred`
on the last line is the point of the flag: the driver was found without a byte of PDB being
fetched.

## What changed

`modules { "refresh": true }` resynchronises before it lists. The resynchronisation was always
available — it is what the CTF tier's unqualified `.reload /f` was doing as a side effect of
fetching every module's PDB — and nothing said so, so finding a loaded image meant guessing that a
force symbol reload was the missing step. This is that half on its own: `IDebugSymbols::Reload("")`,
unqualified and unforced.

The result carries `refresh` — `synchronized`, `before` against `loaded`, and the engine's own
`error` where it failed. Three decisions in it:

- **Absent means it was not asked for**, which is not the same as one that found nothing. A default
  call is byte-identical to what it was and still cheap.
- **A failure is reported, not raised.** The listing beside it may well be the right one and a
  caller can see for itself. What it must not do is pass unnoticed, so the note renders *above* the
  tables — a caveat printed under a listing arrives after the conclusion it was there to prevent —
  and it withdraws the only inference the listing supports. The note keys on `synchronized` rather
  than on the presence of `error`, so the text and the flag cannot disagree.

## What it costs, and the measurement that corrected itself

A refresh discards the symbol state the engine was holding — **on a live target, and only there**.
Measured both ways on one host, with the engine's `symsrv.dll`/`msdia140.dll` bundled and a store
configured:

| target | before the refresh | after it |
|---|---|---|
| launched `cmd.exe`, 5 modules, after `.reload /f` | all five `pdb` | `ntdll` still `pdb`, the other four `deferred` |
| the checked-in kernel dump, 227 modules | `nt` `pdb`, 226 `deferred` | unchanged — nothing discarded |

Which fits what the reload is: a live reload re-reads the module list and the entries are rebuilt,
while a dump's list comes from its own header. So the note says *on a live target* and *most*
modules, and the ordering advice — refresh first, load symbols after — applies to live targets.

**The first version of this PR said something weaker and partly wrong.** That measurement was taken
on a host whose engine had no `symsrv.dll` or `msdia140.dll`, where those five modules could only
reach `export` fallback: the effect read as a fallback being reset rather than real PDB state being
dropped, and the dump half was never asked at all. Restoring the engine also un-skipped five
symbol-gated assertions in the debugger tier, which now run.

## Coverage

- **Dump tier** — `a_module_listing_can_resynchronise_the_inventory_before_it_lists_it` asks as the
  **first** call on a fresh session. A dump cannot reproduce the gap, so what it pins is the half
  that would otherwise break silently: the reload runs against a real engine, succeeds, and costs
  the listing nothing (`before` equal to `loaded`, all 227, rows still equal to values row for row).
  The default call is asserted in the same breath, because "backward compatible" is a claim about an
  absent field.
- **Live kernel tier** — the reload runs over the KD wire, reports `synchronized`, and loses no
  modules. Prints `1 module(s) before the refresh, 158 after` under `--nocapture`.
- **CTF tier** — now asks **before** `load_kernel_symbols`, deliberately: that helper's `.reload /f`
  resynchronises the inventory as a side effect, so a `modules` call after it passes whether or not
  `refresh` does anything at all. Moving it back below the symbol setup keeps the test green and
  deletes what it is for; `CLAUDE.md` says so beside the code.
- Two unit tests on the rendering: the three states and their ordering against the "nothing matches"
  verdict, and that an engine message cannot smuggle a row into the listing.

Run here: `634 passed` unit, `94 passed` smoke with the debugger tier on **and its symbol
assertions no longer skipping**, and the live-kernel lifecycle test green against a real KDNET
target (attach, refresh, graceful detach).

## Docs

`docs/structured-results.md` grows an **Inventory refresh against symbol reload** section with the
two side by side and both measurements, since confusing them is the whole of the issue. Beside it:
`README.md`, the three `skills/windbg-debugging/` files that talk about `.reload`,
`docs/smoke-test.md`, `CHANGELOG.md` and `CLAUDE.md`.

## Two things worth reviewing separately

**Surface cost.** `modules` goes 2,411 → 3,251 model-visible bytes (+840). While touching the
figures, the byte counts in five documents and three doc comments were re-derived against this
build; **711 B of that movement predates this change** and came from the two commits before it
(`allocator` +488, `batch` +223). Recorded eval runs in `docs/local-model.md` were left alone.

**`FOLLOWUPS.md` item 54.** The reload is a direct engine call, not a command, so no watchdog can
cut it short and `EngineOp::Modules` carries no `patience_ms` — the same position `Backtrace` is in.
The symbol-server half of the acceptance criterion is closed by construction (nothing is fetched);
what is left is wall-clock, which is imperceptible over KDNET and would not be over 115200-baud
serial. Closing it needs a bounded `Reload` in dbgscope *and* a measurement that `SetInterrupt`
actually reaches one.

## Declined

Codex raised (P2) that `refresh: true` mutates symbol state while `modules` still declares
`readOnlyHint: true`, and proposed marking the tool non-read-only or splitting refresh into its own
tool. The fact is right; the remedy is declined. `pool_find_tag` is the same shape — an opt-in
`refresh: true` that discards a cached snapshot and re-walks — and is annotated
`read_only_hint = true` (`src/server.rs:3142`), so changing `modules` would leave two
identically-shaped tools with opposite annotations. Nothing here modifies the *target*; the undo is
a local-cache PDB re-read, not a decision a human needs to make. And the annotation is per tool, so
every default `modules` call would be relabelled to warn about an opt-in flag whose warning already
sits in the argument's own description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WhhF5x9fE4bdd1jiKBvhNa
