### PR TITLE
`!analyze`'s module attribution is the host's fact, not the dump's

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Documentation: `!analyze`'s module attribution is a fact about the debugging host, not about
+  the dump.** Four documents and a smoke-test fixture said the two checked-in driver crashes
+  disagree about it — that `MessageManager` has no PDB so `!analyze` reports `Unknown_Module`,
+  while `HEVD` ships one so `!analyze` blames it by name. Measured on one engine against both
+  dumps, they behave identically, and what decides it is whether `triage\triage.ini` is beside the
+  engine (`skills/windbg-debugging/setup.md` copies it as a step of its own): with it, each crash
+  is attributed to its driver; without it, both report `Unknown_Module`; with no `winext\` either,
+  `!analyze` does not run at all. A missing PDB costs the *function* — both failure buckets end
+  `!unknown_function` whichever way that falls.
+
+  The same correction reaches the `0x9F` walkthrough, where it changes the reading rather than just
+  the wording: with `triage\` bundled that dump is attributed to `pci` —
+  `0x9F_3_ACPI_IMAGE_pci.sys` — which is the **bus driver** the walkthrough's own device-stack walk
+  identifies as *not* the culprit. So the manual walk is required either way, and what a bundled
+  engine changes is whether `!analyze` declines to answer or answers with the wrong layer.
+
+  `a_driver_crash_names_the_driver_frame_an_all_kernel_walk_would_miss` now asks the host
+  (`triage\triage.ini` beside the server) instead of carrying a per-fixture flag, and asserts on
+  both sides of that rather than skipping either. It had never run: `ci.yml` copies no extension
+  directory, so `analysis.ran` is false on both runners and every `!analyze` assertion in that tier
+  is skipped there.
+
 - **A transcript no longer records an interrupt that reached nothing as one that was delivered.**
   `WINDBG_MCP_TRANSCRIPT`'s `interrupt` event took `delivered` from whether the request succeeded,
   and four of the five things an interrupt can do succeed while raising nothing — there was no

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -225,6 +225,23 @@ attach teardown, 89 until the 32-bit worker's version resource, 90 until #66's s
 it said 83 while it was 84, and 90 while it was 91, which is the usual state of it, so re-derive it
 rather than trusting this sentence.
 
+**And a gate can be a *directory beside the exe*, which prints no `SKIPPED` line at all.** The
+debugger tier's `!analyze` assertions are inside `if analysis["ran"] == true`, and `ran` is false
+without `winext\ext.dll` — which `ci.yml` does not copy (it takes `dbghelp.dll` and `symsrv.dll`
+and no extension directory), so **every `!analyze` claim in that tier is vacuous on both CI
+runners** and a green matrix says nothing about any of them. Restoring the extensions on this
+bench on 2026-08-30 immediately failed a fixture that had been passing for want of ever running.
+Its premise was wrong in the instructive direction: the two driver crashes were described as
+disagreeing about `!analyze`'s attribution because `MessageManager` has no PDB and `HEVD` ships
+one. Measured on one engine against both dumps, they do not disagree — what decides it is
+`triage\triage.ini` (present: each names its driver; absent: both `Unknown_Module`; no `winext\`:
+`ran: false`), and the missing PDB costs the *function*, which is not what the test read. So
+`analyze_can_attribute_a_module()` asks the **host** and both branches assert, and
+`docs/smoke-test.md` carries the table. Two rules fall out. A fixture whose expected value differs
+per fixture is worth a second look when the thing being measured is the *engine* — one fixture
+would have been enough to notice. And bundling the engine changes what the tier covers, so re-run
+it after a `setup.md` copy rather than assuming a green run transfers.
+
 **The dev exe can be locked too, and the failure is quiet.** A worker left running — a driver
 script that died mid-session, a debugger tier killed partway — holds `target\debug\windbg-mcp.exe`,
 and `cargo build` then fails at the final replace step with `Access is denied (os error 5)` while

--- a/docs/crash-dump-walkthrough.md
+++ b/docs/crash-dump-walkthrough.md
@@ -3,7 +3,7 @@
 A hands-on tour of the crash-dump tools against two real kernel minidumps:
 [`052126-34312-01.dmp`](samples/052126-34312-01.dmp) (5.8 MB) for §1–§6, and
 [`081226-2187-01.dmp`](samples/081226-2187-01.dmp) in [§7](#7-the-other-shape-of-crash-a-driver-frame-analyze-cant-name),
-where a driver crashes in its own code and `!analyze` cannot name it. It mirrors the skill's
+where a driver crashes in its own code and `!analyze` names no frame inside it. It mirrors the skill's
 [`crash-dump.md`](../skills/windbg-debugging/crash-dump.md) playbook and shows the
 real `windbg` MCP tool calls, their output, and the gotchas — from `crash_triage`'s
 one-call summary through to the culprit driver named by a manual device-stack walk
@@ -157,7 +157,18 @@ FAILURE_BUCKET_ID:  0x9F_3
 ```
 
 `!analyze` already hints at NVIDIA (the timestamp warning) but leaves
-`MODULE_NAME: Unknown_Module` — it didn't auto-attribute the bug to a driver. The
+`MODULE_NAME: Unknown_Module` — it didn't auto-attribute the bug to a driver.
+
+> **That `Unknown_Module` is this host's, not this dump's.** `!analyze` attributes a module from
+> `triage\triage.ini`, which is a separate copy step in
+> [`setup.md`](../skills/windbg-debugging/setup.md) and was not beside the engine when this
+> session was recorded. Bundle it and the same dump answers
+> `MODULE_NAME: pci`, `FAILURE_BUCKET_ID: 0x9F_3_ACPI_IMAGE_pci.sys` (measured 2026-08-30) —
+> which is the **bus driver**, the one §4 below identifies as *not* the culprit. So the manual
+> walk is needed either way; what changes is whether `!analyze` declines to answer or answers with
+> the wrong layer.
+
+The
 faulting stack is the watchdog firing from a timer DPC on an idle CPU (normal for `0x9F`;
 the blame is on whoever holds the IRP, not this stack):
 
@@ -173,9 +184,9 @@ nt!KiIdleLoop
 
 ## 4. Name the culprit by walking the device stack
 
-`!analyze` left the module unknown, so resolve it from the bug-check arguments by hand.
-Arg2 is the **PDO** and Arg4 is the **blocked IRP** — these address-based reads work even
-on this partial minidump:
+`!analyze` left the module unknown — or, on a host with `triage\` bundled, named the bus driver —
+so resolve it from the bug-check arguments by hand. Arg2 is the **PDO** and Arg4 is the **blocked
+IRP** — these address-based reads work even on this partial minidump:
 
 ```jsonc
 // PDO's owning driver — the bus driver, not the culprit
@@ -289,10 +300,14 @@ STACK (11 frames):
 
 Four things to read off this, none of which the `0x9F` can show:
 
-- **`!analyze` says `Unknown_Module`; the frame says `MessageManager+0x1654`.** The driver has
-  no PDB, which is the case `!analyze`'s attribution handles worst and the case `module+RVA`
-  handles fine — the engine knows which image holds the address and where it is loaded, and the
-  offset falls out. Frame 07 is six frames below the top, under a stack of kernel allocator
+- **`!analyze` says `Unknown_Module`; the frame says `MessageManager+0x1654`.** The two answers
+  are computed differently, which is why one is here and the other is not: `module+RVA` comes off
+  the load base, so the engine needs only to know which image holds the address, while
+  `!analyze`'s attribution is table-driven and reads `triage\triage.ini` — absent here, as it is
+  on any host that bundled the engine's DLLs without the `triage\` directory beside them
+  ([`setup.md`](../skills/windbg-debugging/setup.md) copies it as its own step). Bundle it and this
+  line reads `MODULE_NAME: MessageManager`; the frame below is unchanged either way, which is the
+  argument for reading it. Frame 07 is six frames below the top, under a stack of kernel allocator
   internals that a "blame frame 0" rule would have named instead.
 - **`0x1654` is the whole point of an RVA.** Five dumps from the same crash/reboot loop reported
   that frame at five *different* addresses — `0xfffff8020a5e1654`, `0xfffff80561281654`,

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -82,8 +82,10 @@
   failure bucket, the blamed module and the per-parameter explanations exist nowhere but `!analyze`'s
   own output, so they are extracted from it and confined to the `analysis` object. **Prefer
   `faulting_frame` to `analysis.module_name`**: the frame's `module+RVA` is computed from the load
-  base and is right for a driver with no PDB, which is exactly where `!analyze`'s attribution goes
-  wrong. **Which frame is the culprit is still a guess, though — only the offset is computed.**
+  base, so it names the driver on any host that can read the dump, while `!analyze`'s attribution
+  additionally needs `triage\triage.ini` beside the engine and reports `Unknown_Module` without it
+  (`skills/windbg-debugging/setup.md` has the copy step). A missing PDB costs the *function* on
+  both — neither answer names one. **Which frame is the culprit is still a guess, though — only the offset is computed.**
   `faulting_frame` is the innermost frame that *could* be a kernel driver: not `nt`/`hal`, not the
   framework layers that sit on a stack on somebody else's behalf (KMDF's `Wdf01000`, Driver
   Verifier), and not a user-mode module — a kernel stack that unwinds past the system call boundary

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -454,10 +454,25 @@ dispatch walk in `CLAUDE.md` are how to redo it against another build.
 this suite deliberately does not pair. An engine that resolves symbols reads either dump either way
 round, so pairing them would mean an ARM64 runner stopped reading the x64 crash it reads today:
 trading one architecture's coverage for the other's rather than adding it. What the pair covers
-that neither does alone is `!analyze`. `MessageManager` has no PDB, so `!analyze` calls the crash
-`Unknown_Module` and the computed frame is the only thing that names the driver. `HEVD` ships a
-PDB, so `!analyze` blames it by name and the computed frame is checked against an independent
-answer instead.
+that neither does alone is the attribution arithmetic against a second architecture's stack.
+
+**`!analyze`'s own attribution beside it is a fact about the host, not about either dump**, and
+this file said otherwise until 2026-08-30 — that `MessageManager` has no PDB so `!analyze` calls
+it `Unknown_Module`, and that `HEVD` ships one so `!analyze` blames it by name. Measured on one
+engine against both dumps, they behave identically, and what decides it is whether
+`triage\triage.ini` is beside the engine:
+
+| beside the server | `analysis.ran` | `analysis.module_name` |
+| --- | --- | --- |
+| `winext\` and `triage\` | `true` | the driver's name |
+| `winext\`, no `triage\` | `true` | `Unknown_Module` |
+| neither | `false` | absent |
+
+The last row is **what CI has** — `ci.yml` copies `dbghelp.dll` and `symsrv.dll` and no extension
+directory at all — so every `!analyze` assertion in this tier is skipped there, and a green CI run
+says nothing about any of them. Run the tier on a host with a bundled engine before believing an
+`analysis` claim is covered. The missing PDB does cost something, but not the module: both
+buckets end `!unknown_function` whichever way the table above falls.
 
 Those checks are made against **typed fields** wherever a tool has them (issue #84): the handle is
 read from `structuredContent`, not from a `session_id:` line; `nt` and `hal` are matched as module

--- a/docs/walkthroughs.md
+++ b/docs/walkthroughs.md
@@ -9,8 +9,9 @@
   `0x9F DRIVER_POWER_STATE_FAILURE` traced to `nvlddmkm.sys` — `crash_triage` for the bug check as
   fields, then `!ext.analyze -v` and a manual device-stack walk for the culprit it cannot name, with
   the real outputs and the partial-minidump (`0x80040205`) gotcha. Ends on a second sample, a
-  `0x13A` in a **PDB-less driver**, where `!analyze` says `Unknown_Module` and the frame says
-  `MessageManager+0x1654` — the same offset in five dumps that loaded the driver at five addresses.
+  `0x13A` in a third-party driver, recorded on a host with no `triage\` beside the engine, where
+  `!analyze` says `Unknown_Module` and the frame says `MessageManager+0x1654` — the same offset in
+  five dumps that loaded the driver at five addresses.
 - [`ttd-walkthrough.md`](ttd-walkthrough.md) — a hands-on tour of the TTD tools against the
   [`xusheng6/TTD_lab`](https://github.com/xusheng6/TTD_lab) `helloworld` sample: opening a `.run`,
   surveying events/threads, forward/reverse navigation, memory analysis, and counting `printf` calls

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -179,14 +179,6 @@ struct DriverCrashSample {
     /// A symbolised `nt` frame the same walk has to carry, which is what makes the point that one
     /// stack holds both kinds of frame - the mix every real driver crash has.
     kernel_frame: &'static str,
-    /// Whether `!analyze` names [`Self::module`] itself.
-    ///
-    /// The two fixtures disagree, and the disagreement is the coverage. `MessageManager` has **no
-    /// PDB**, so `!analyze` calls the crash `Unknown_Module` and the computed frame is the only
-    /// thing that names the driver - which is why the frame is computed rather than taken from the
-    /// analysis. `HEVD` ships a PDB, so `!analyze` does name it, and the computed frame is checked
-    /// against an independent answer instead.
-    analyze_names_the_module: bool,
     /// Whether `!analyze` reports a freed-pool tag, which only a few bug checks produce.
     carries_a_pool_tag: bool,
     /// Whether the crashing process's name is longer than the 15 bytes
@@ -212,7 +204,6 @@ const DRIVER_CRASHES: &[DriverCrashSample] = &[
         module: "MessageManager",
         rva: "0x1654",
         kernel_frame: "nt!ExFreePoolWithTag",
-        analyze_names_the_module: false,
         carries_a_pool_tag: true,
         process_name_needs_the_audit_name: true,
     },
@@ -227,11 +218,36 @@ const DRIVER_CRASHES: &[DriverCrashSample] = &[
         // `__report_gsfailure`.
         rva: "0x10dc",
         kernel_frame: "nt!KeBugCheckEx",
-        analyze_names_the_module: true,
         carries_a_pool_tag: false,
         process_name_needs_the_audit_name: false,
     },
 ];
+
+/// Whether `!analyze` on this host can attribute a crash to a **module** at all.
+///
+/// It is a fact about the engine beside the server, not about the dump, and that is the whole
+/// reason this function exists rather than a flag on [`DriverCrashSample`]. `triage\triage.ini`
+/// is what `!analyze` reads to turn a faulting address into a module, and `setup.md` copies it as
+/// a separate step from the extension that supplies `!analyze` itself — so a host has three
+/// states, and both checked-in crashes behave the same way in each (measured 2026-08-30 on the
+/// x64 bench, both dumps, one engine, three configurations):
+///
+/// | beside the server | `analysis.ran` | `analysis.module_name` |
+/// | --- | --- | --- |
+/// | `winext\` and `triage\` | `true` | the driver's name |
+/// | `winext\`, no `triage\` | `true` | `Unknown_Module` |
+/// | neither — **which is what CI has** | `false` | absent |
+///
+/// The pair used to be described as disagreeing because `MessageManager` has no PDB and `HEVD`
+/// ships one. They do not disagree: with `triage\` bundled `!analyze` names them both, and with
+/// it absent it names neither — and the bucket id says `!unknown_function` for both either way,
+/// since this host has a PDB for neither. What the missing PDB costs is the *function*, which is
+/// not what this test reads.
+fn analyze_can_attribute_a_module() -> bool {
+    std::path::Path::new(EXE)
+        .parent()
+        .is_some_and(|dir| dir.join("triage").join("triage.ini").exists())
+}
 
 /// A checked-in kernel dump and the facts about *that crash* a test asserts, so one test body can
 /// be pointed at either real crash rather than naming one file.
@@ -7213,8 +7229,8 @@ fn a_bug_check_is_triaged_into_its_fields() {
 ///   and the reason a second fixture was captured: until
 ///   [#154](https://github.com/glslang/windbg-mcp/issues/154) it had only ever run against x64
 ///   frames;
-/// * `!analyze`'s own attribution beside it, which the two fixtures disagree about on purpose
-///   (see [`DriverCrashSample::analyze_names_the_module`]).
+/// * `!analyze`'s own attribution beside it, which the two fixtures agree about and this *host*
+///   decides (see [`analyze_can_attribute_a_module`]).
 #[test]
 fn a_driver_crash_names_the_driver_frame_an_all_kernel_walk_would_miss() {
     if target_tier().is_none() {
@@ -7314,21 +7330,23 @@ fn assert_driver_crash_names_its_driver(sample: &DriverCrashSample) {
 
     let analysis = &triage["analysis"];
     if analysis["ran"] == true {
-        if sample.analyze_names_the_module {
-            // Here the computed frame is checked against an independent answer: this driver ships
-            // a PDB, so `!analyze` blames it too and the two have to agree.
+        if analyze_can_attribute_a_module() {
+            // The computed frame checked against an independent answer: `triage.ini` is beside
+            // the engine, so `!analyze` blames a module of its own and the two have to agree.
             assert_eq!(
                 analysis["module_name"], sample.module,
                 "`!analyze` and the computed frame disagree about which driver crashed: {triage}"
             );
         } else {
-            // And here it is the *only* answer — no PDB, so `!analyze` cannot name the driver,
-            // which is precisely why the frame is computed from the load base instead of taken
-            // from the analysis.
-            assert_ne!(
-                analysis["module_name"], sample.module,
-                "if `!analyze` learns to attribute a PDB-less driver, this test's premise is stale \
-                 and the docs claiming otherwise need revisiting: {triage}"
+            // And here the computed frame is the *only* answer, which is the case that argues for
+            // computing it at all. Asserted rather than skipped: `Unknown_Module` is what a host
+            // with no `triage\` reports, so a run that started naming the driver here would mean
+            // the attribution had moved somewhere this test does not model.
+            assert_eq!(
+                analysis["module_name"], "Unknown_Module",
+                "with no `triage\\triage.ini` beside the engine `!analyze` has nothing to \
+                 attribute a module with, so anything but `Unknown_Module` means the host gained \
+                 one mid-run or the attribution moved: {triage}"
             );
         }
         // Only where the analysis got that far: a truncated run may have been cut off before


### PR DESCRIPTION
Restoring the engine's extension directories on this bench (`winext\`, `ttd\`, `winxp\`, `triage\`, per `setup.md`) immediately failed a debugger-tier fixture that had been green for want of ever running.

## Why it had never run

`ci.yml` copies `dbghelp.dll` and `symsrv.dll` and **no extension directory**, so `!analyze` does not resolve on either runner, `analysis.ran` is `false`, and every `!analyze` assertion in that tier is skipped. A green matrix says nothing about any of them.

## The premise was wrong

The two checked-in driver crashes were described as disagreeing about `!analyze`'s attribution — `MessageManager` has no PDB so it reports `Unknown_Module`, `HEVD` ships one so `!analyze` blames it by name — and that explanation had spread to four documents. Measured on one engine against both dumps, they behave **identically**, and what decides it is `triage\triage.ini`:

| beside the server | `analysis.ran` | `analysis.module_name` |
| --- | --- | --- |
| `winext\` and `triage\` | `true` | the driver's name |
| `winext\`, no `triage\` | `true` | `Unknown_Module` |
| neither — **what CI has** | `false` | absent |

The missing PDB costs the *function*, which is not what the test read: both failure buckets end `!unknown_function` whichever way that table falls.

## What changed

- `DriverCrashSample::analyze_names_the_module` (a per-fixture flag) → `analyze_can_attribute_a_module()` (a per-host probe), with **both** sides asserting rather than one skipping. Verified green in all three configurations above.
- `docs/smoke-test.md`, `docs/limitations.md`, `docs/walkthroughs.md`, `docs/crash-dump-walkthrough.md` corrected; `CLAUDE.md` gains the rule that a gate can be a directory beside the exe and prints no `SKIPPED` line.

## It changes a reading, not just wording

With `triage\` bundled, the `0x9F` walkthrough's dump is attributed to `pci` — `0x9F_3_ACPI_IMAGE_pci.sys` — which is the **bus driver that same walkthrough's device-stack walk identifies as *not* the culprit**. So the manual walk is required either way; what a bundled engine changes is whether `!analyze` declines to answer or answers with the wrong layer.

## Verification

- `cargo test --test mcp_smoke` with `WINDBG_MCP_SMOKE_DUMP=1`: **94 passed, 0 failed**
- the changed fixture, green in all three engine configurations (both bundled / no `triage\` / neither)
- `cargo fmt --all --check`, `cargo clippy --all-targets`, markdownlint-cli2 0.23.2 — clean
- TTD tier (`WINDBG_MCP_SMOKE_TTD=1`): 4 passed; ablated to confirm it depends on the restored `ttd\` (without it: records but cannot replay, `0x80070057`)
- `winxp\kdexts.dll` confirmed against the live `ctf-vm` kernel target — `driver_object` answered, session detached cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WhhF5x9fE4bdd1jiKBvhNa
