### PR TITLE
Give a matrix row its backend, through the label the compare table already uses

### DIFF
--- a/docs/local-model-eval.md
+++ b/docs/local-model-eval.md
@@ -499,12 +499,13 @@ python3 tools/local_model_eval.py --compare eval-out/after-206.jsonl eval-out/af
 ```
 
 ```text
-cell                                 bugcheck  driver_blame  module_count  unloaded_driver  arm64_pc  ioctl_decode
-opus   dflt min                      Y -> Y    Y -> Y        Y -> Y        - -> -           n -> n    o -> o
-sonnet   dflt min                    Y -> Y    Y -> Y        Y -> Y        - -> -           n -> n    o -> o
-gemma4:31b-mlx 262144 min            Y -> Y    Y -> Y        Y -> Y        - -> -           n -> n    o -> -
-nemotron-3.5-lightning:3 262144 min  Y -> Y    Y -> Y        Y -> n        - -> -           n -> n    - -> -
-qwen3.8:27b-mlx 262144 min           n -> Y    Y -> Y        Y -> Y        - -> -           n -> n    o -> -
+cell                                                bugcheck         driver_blame     module_count     unloaded_driver  arm64_pc         ioctl_decode
+----------------------------------------------------------------------------------------------------------------------------------------------------------
+claude-code opus   dflt min                         Y -> Y           Y -> Y           Y -> Y           - -> -           n -> n           o -> o
+claude-code sonnet   dflt min                       Y -> Y           Y -> Y           Y -> Y           - -> -           n -> n           o -> o
+ollama gemma4:31b-mlx 262144 min                    Y -> Y           Y -> Y           Y -> Y           - -> -           n -> n           o -> -
+ollama nemotron-3.5-lightning:3 262144 min          Y -> Y           Y -> Y           Y -> n           - -> -           n -> n           - -> -
+ollama qwen3.8:27b-mlx 262144 min                   n -> Y           Y -> Y           Y -> Y           - -> -           n -> n           o -> -
 
 old -> new per cell-task; `(old)`/`(new)` is a cell only one run covered.
 ```
@@ -513,8 +514,8 @@ A per-cell move, when there is one, prints under that legend:
 
 ```text
 cells where something besides the question moved:
-  qwen3.8:27b-mlx 262144 min               surface 11 tools, 14606 B -> 11 tools, 7732 B
-  gemma4:31b-mlx 262144 min                window 262144 -> 32768
+  ollama qwen3.8:27b-mlx 262144 min                    surface 11 tools, 14606 B -> 11 tools, 7732 B
+  ollama gemma4:31b-mlx 262144 min                     window 262144 -> 32768
 ```
 
 Those two runs were recorded before the identity fields existed, so nothing above the table names a

--- a/tools/local_model_eval.py
+++ b/tools/local_model_eval.py
@@ -1438,8 +1438,10 @@ def print_matrix(order, rows):
     print("\n" + header)
     print("-" * len(header))
     for cell, marks in sorted(rows.items(), key=lambda kv: cell_order(kv[0])):
-        backend, model, ctx, surface = cell
-        label = f"{model[:24]} {str(ctx or 'dflt'):>6} {surface}"
+        # Through the shared label, which is where the **backend** is: a cell is keyed by it, and
+        # an ollama tag may be the same string as a Claude Code alias, so the three fields this
+        # wrote by hand rendered two different rows identically with nothing to tell them apart.
+        label = cell_label(cell)
         print(f"{label:<52}" + "".join(f"{marks.get(t, {}).get('mark', ' '):<{width}}"
                                        for t in order))
     print("\nY correct   n wrong   - not answerable on this surface   "


### PR DESCRIPTION
Closes #227.

`matrix()` keys a cell by `(backend, model, num_ctx, surface.client)` and `print_matrix` unpacked
the backend and then dropped it, so two cells differing only by backend rendered the same label
with nothing in the table to tell them apart. It is reachable rather than theoretical: an ollama
tag and a Claude Code alias may be the same string — `sonnet` is the pair this bench can reach, and
`already_done` carries a comment about exactly it, which is why the resume set is keyed by backend
in the first place.

`cell_label` landed with #225 for the comparison table and is the same three fields plus the
backend; the column `print_matrix` feeds was widened to 52 in that PR and the label itself was left
behind. So this is that one line.

Checked on a log of two cells that differ only there:

```text
before                          after
sonnet   dflt min               claude-code sonnet   dflt min
sonnet   dflt min               ollama sonnet   dflt min
```

and `--matrix` over `eval-out/after-217.jsonl` still renders its five cells and its distributions.

## The doc sample went with it

`docs/local-model-eval.md`'s `--compare` block had the same rows without their backends, being
older than `cell_label` — so it was inconsistent with the code before this change and would have
stayed so after it. The two logs behind it are checked in, so what is in the diff is re-run output
rather than a hand edit. The *illustrative* block beneath it comes from a doctored log, as the text
there already says, so only its two labels are re-rendered through `cell_label`.

`markdownlint-cli2@0.23.2` over CI's globs: 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CZu3mUSEzwtjPod3n88vhD