### PR TITLE
Handshake inside the cleanup, in every driver path that mints a session id

### DIFF
--- a/tools/claude_code_drive.py
+++ b/tools/claude_code_drive.py
@@ -248,47 +248,55 @@ def release_new_sessions(before):
 
 def main():
     print(f"model: claude-code/{MODEL}")
-    print("MCP revision negotiated:", drive.handshake())
-    tools = drive.mcp("tools/list")["result"]["tools"]
-    offered = drive.as_ollama(tools)
-    wire = json.dumps(offered, separators=(",", ":"))
-    surface_bytes = len(wire)
-    print(f"tools offered: {len(tools)} ({surface_bytes} B, measured as the ollama rows are)")
-
     scratch = os.environ.get("EVAL_SCRATCH", "")
     owned = not scratch
     if owned:
         scratch = tempfile.mkdtemp(prefix="windbg-eval-")
     config_path = mcp_config(scratch)
-    tasks = drive.load_tasks(sys.argv[1]) if len(sys.argv) > 1 else []
-    cell = {
-        "run": os.environ.get("EVAL_RUN", time.strftime("%Y%m%dT%H%M%S")),
-        "backend": "claude-code",
-        "model": MODEL,
-        "num_ctx": None,
-        "draw": drive.DRAW,
-        # **Null rather than absent, and it cannot be anything else here.** `claude -p` exposes no
-        # sampling seed to ask for, where the ollama rows at least ask - which is a property of
-        # this row worth recording rather than a field to leave out. It is a smaller difference
-        # than it looks: the ollama rows' seed does not reproduce a draw on this bench either
-        # (`local_model_drive.SEED`), so no row here replays one. The grader reads `draw` from
-        # both backends and `seed` from neither.
-        "seed": None,
-        # **Null rather than absent here too, and for the same kind of reason.** The ollama rows
-        # record the digest of the weights that answered; an alias resolved inside `claude` has no
-        # such address to offer, and leaving the field out would make this row's ambiguity look
-        # like a field nobody thought to record. `harness_version` is what this row *can* say.
-        "model_digest": None,
-        "harness_version": harness_version(),
-        "server": dict(drive.SERVER_INFO) or None,
-        "suite": dict(drive.SUITE) or None,
-        "surface": {"client": os.environ.get("EVAL_SURFACE", ""), "tools": len(tools),
-                    "bytes": surface_bytes, "names": sorted(t["name"] for t in tools),
-                    # Measured as the ollama rows measure it, through the same helper, so the two
-                    # backends' surfaces are comparable rather than merely similar.
-                    "digest": drive.surface_digest(wire)},
-    }
+
     try:
+        # **Inside the cleanup, because the handshake is two requests.** `initialize` mints
+        # the `Mcp-Session-Id` the server then records and `notifications/initialized`
+        # follows it, so a failure between them left an id nothing would ever `DELETE` - and
+        # a matrix run is dozens of these processes. The scratch directory and its config are
+        # made *above* this, because the same `finally` removes them: widening the block over
+        # their assignments instead would leave that cleanup meeting an unbound name and
+        # losing the exception it was raised on.
+        print("MCP revision negotiated:", drive.handshake())
+        tools = drive.mcp("tools/list")["result"]["tools"]
+        offered = drive.as_ollama(tools)
+        wire = json.dumps(offered, separators=(",", ":"))
+        surface_bytes = len(wire)
+        print(f"tools offered: {len(tools)} ({surface_bytes} B, measured as the ollama rows are)")
+
+        tasks = drive.load_tasks(sys.argv[1]) if len(sys.argv) > 1 else []
+        cell = {
+            "run": os.environ.get("EVAL_RUN", time.strftime("%Y%m%dT%H%M%S")),
+            "backend": "claude-code",
+            "model": MODEL,
+            "num_ctx": None,
+            "draw": drive.DRAW,
+            # **Null rather than absent, and it cannot be anything else here.** `claude -p`
+            # exposes no sampling seed to ask for, where the ollama rows at least ask - a
+            # property worth recording rather than a field to leave out. It is a smaller difference
+            # than it looks: the ollama rows' seed does not reproduce a draw on this bench either
+            # (`local_model_drive.SEED`), so no row here replays one. The grader reads `draw` from
+            # both backends and `seed` from neither.
+            "seed": None,
+            # **Null rather than absent here too, and for the same kind of reason.** The ollama
+            # rows record the digest of the weights that answered; an alias resolved inside
+            # `claude` has no such address to offer, and leaving the field out would make it look
+            # like a field nobody thought to record. `harness_version` is what this row *can* say.
+            "model_digest": None,
+            "harness_version": harness_version(),
+            "server": dict(drive.SERVER_INFO) or None,
+            "suite": dict(drive.SUITE) or None,
+            "surface": {"client": os.environ.get("EVAL_SURFACE", ""), "tools": len(tools),
+                        "bytes": surface_bytes, "names": sorted(t["name"] for t in tools),
+                        # Measured as the ollama rows measure it, through the same helper, so
+                        # the two backends' surfaces are comparable rather than merely similar.
+                        "digest": drive.surface_digest(wire)},
+        }
         for i, task in enumerate(tasks, 1):
             prompt = task["prompt"] if isinstance(task, dict) else task
             print(f"\n=== task {i}: {prompt[:110]}")

--- a/tools/local_model_drive.py
+++ b/tools/local_model_drive.py
@@ -738,14 +738,21 @@ def release_everything():
     credential belongs to this run alone (`docs/local-model-eval.md`). Pointed at a shared token it
     would end somebody's sessions, which is the same reason the script refuses to borrow one.
     """
-    handshake()
     try:
-        sessions = live_sessions()
-    except Exception as e:  # noqa: BLE001 - cleanup is best effort by construction
-        print(f"  could not list sessions to release: {e}")
-        sessions = []
-    kept = end_sessions(sessions)
-    close_transport_session()
+        # **Inside the cleanup, for the reason `main` gives.** The handshake is two requests and
+        # the first of them mints the id, so a failure in the second leaves one nothing will
+        # `DELETE` - on the one path whose whole job is to leave this credential's namespace
+        # clean. A `finally` rather than `verify_key`'s `except BaseException`, because that shape
+        # exists to *read* the outcome of the `DELETE` and this caller ignores it.
+        handshake()
+        try:
+            sessions = live_sessions()
+        except Exception as e:  # noqa: BLE001 - cleanup is best effort by construction
+            print(f"  could not list sessions to release: {e}")
+            sessions = []
+        kept = end_sessions(sessions)
+    finally:
+        close_transport_session()
     if kept:
         # **The one caller reads this.** A preflight that cannot clear the namespace has not made
         # the cell that follows it clean, and saying so is the whole difference between a
@@ -763,45 +770,52 @@ def main():
     print(f"model: {MODEL}")
     if DRAW != 1 or SEED is not None:
         print(f"draw {DRAW}, " + (f"seed {SEED}" if SEED is not None else "unseeded"))
-    print("MCP revision negotiated:", handshake())
-    threading.Thread(target=keepalive, daemon=True).start()
-    tools = mcp("tools/list")["result"]["tools"]
-    offered = as_ollama(tools)
-    wire = json.dumps(offered, separators=(",", ":"))
-    surface = len(wire)
-    print(f"tools offered: {len(tools)} ({surface} B of minified JSON)")
-    if NUM_CTX:
-        print(f"context requested: {NUM_CTX}")
-    if SCENARIO:
-        print("scenario: sessions are kept between tasks")
-    snapshot_existing()
-    tasks = load_tasks(sys.argv[1]) if len(sys.argv) > 1 else [
-        "What debug sessions do I currently have open on this server?"
-    ]
-    cell = {
-        "run": os.environ.get("EVAL_RUN", time.strftime("%Y%m%dT%H%M%S")),
-        "backend": "ollama",
-        "model": MODEL,
-        "num_ctx": NUM_CTX or None,
-        "draw": DRAW,
-        "seed": SEED,
-        # The two identity fields that are constant for a cell: which build was asked, and which
-        # task list it was asked from. The third - which weights answered - is read per task, since
-        # it is a property of the instance the runtime happened to have loaded.
-        "server": dict(SERVER_INFO) or None,
-        "suite": dict(SUITE) or None,
-        "surface": {"client": os.environ.get("EVAL_SURFACE", ""),
-                    "tools": len(tools), "bytes": surface,
-                    "names": sorted(t["name"] for t in tools),
-                    # **The fingerprint, rather than its length.** A byte count moves for almost
-                    # any prose change and for none reliably: a same-length reword, or an
-                    # allowlist swap of equal size, leaves both the count and the length alone
-                    # while the model is handed different tools. This is the surface as it went
-                    # over the wire, which is the thing a comparison is actually about.
-                    "digest": surface_digest(wire)},
-    }
-    transcript = None
     try:
+        # **Inside the cleanup, because the handshake is two requests.** `initialize` mints
+        # the `Mcp-Session-Id` the server then records, and `notifications/initialized`
+        # follows it - so a failure between them (a dropped connection, a listener restarted)
+        # left an id already minted that nothing would ever `DELETE`, and a matrix run is
+        # dozens of these processes. Everything after the handshake is in here for the same
+        # reason rather than for its own: `tools/list` and `load_tasks` - which exits over a
+        # subset the suite does not have - both run after the id exists.
+        print("MCP revision negotiated:", handshake())
+        threading.Thread(target=keepalive, daemon=True).start()
+        tools = mcp("tools/list")["result"]["tools"]
+        offered = as_ollama(tools)
+        wire = json.dumps(offered, separators=(",", ":"))
+        surface = len(wire)
+        print(f"tools offered: {len(tools)} ({surface} B of minified JSON)")
+        if NUM_CTX:
+            print(f"context requested: {NUM_CTX}")
+        if SCENARIO:
+            print("scenario: sessions are kept between tasks")
+        snapshot_existing()
+        tasks = load_tasks(sys.argv[1]) if len(sys.argv) > 1 else [
+            "What debug sessions do I currently have open on this server?"
+        ]
+        cell = {
+            "run": os.environ.get("EVAL_RUN", time.strftime("%Y%m%dT%H%M%S")),
+            "backend": "ollama",
+            "model": MODEL,
+            "num_ctx": NUM_CTX or None,
+            "draw": DRAW,
+            "seed": SEED,
+            # The two identity fields that are constant for a cell: which build was asked, and
+            # which task list it was asked from. The third - which weights answered - is read per
+            # task, since it is a property of the instance the runtime happened to have loaded.
+            "server": dict(SERVER_INFO) or None,
+            "suite": dict(SUITE) or None,
+            "surface": {"client": os.environ.get("EVAL_SURFACE", ""),
+                        "tools": len(tools), "bytes": surface,
+                        "names": sorted(t["name"] for t in tools),
+                        # **The fingerprint, rather than its length.** A byte count moves for
+                        # almost any prose change and for none reliably: a same-length reword, or
+                        # an allowlist swap of equal size, leaves both the count and the length
+                        # alone while the model is handed different tools. This is the surface as
+                        # it went over the wire, which is what a comparison is actually about.
+                        "digest": surface_digest(wire)},
+        }
+        transcript = None
         for i, task in enumerate(tasks, 1):
             prompt = task["prompt"] if isinstance(task, dict) else task
             print(f"\n=== task {i}: {prompt[:110]}")


### PR DESCRIPTION
Closes #228.

`handshake()` is two requests: `initialize` mints the `Mcp-Session-Id` the server records, and
`notifications/initialized` follows it. Both drivers called it **before** the `try` whose `finally`
sends the `DELETE`, so a failure in the second request left an id nothing would ever delete. The
server keeps one resident until a whole lease grace passes with no traffic and rmcp spawns a session
worker task per id, so a matrix run of dozens of driver processes piles them up. #224 hit this in
`--verify-key` and fixed it there; the drivers were left alone in that PR and in #225.

## Three paths, not two

`release_everything` — the `--release` preflight, one function above `main` in
`local_model_drive.py` — mints an id the same way and closed it only on its normal path.

And each block is widened *past* the handshake rather than wrapped around it, because the id exists
for everything after it too: `tools/list`, and `load_tasks`, which exits over a subset the suite
does not have, both leaked it identically.

## How it was checked

`urlopen` stubbed to mint `SID-1` on `initialize` and then fail on a named request, asking only
whether a `DELETE` for that id still goes out on the way past. Five paths, all five leaking before
and none after:

```text
LEAK -> ok  local_model_drive.main       dies on notifications/initialized
LEAK -> ok  local_model_drive.main       dies on tools/list
LEAK -> ok  local_model_drive --release  dies on notifications/initialized
LEAK -> ok  claude_code_drive.main       dies on notifications/initialized
LEAK -> ok  claude_code_drive.main       dies on tools/list
```

The ordinary path is unchanged and was re-checked the same way: both drivers run a task, write
their record, leave no scratch directory behind, and the log grades.

## Two shapes, for a reason

A `finally` here rather than `verify_key`'s `except BaseException`, because that shape exists to
*read* the outcome of the `DELETE` and these callers ignore it — which the issue leaves as theirs
to go on doing, since a failed `DELETE` costs a driver a session where it costs a verification its
verdict. The comment beside it says so, so the next reader does not "fix" one into the other.

And in `claude_code_drive.main` the scratch directory and its config file move **above** the `try`:
the same `finally` removes them, so widening the block over their assignments would leave that
cleanup meeting an unbound name and losing the exception it was raised on.

Best read with whitespace hidden (`?w=1`) — most of the diff is the indent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CZu3mUSEzwtjPod3n88vhD