### PR TITLE
Charge the result budget per channel, not per client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   snapshot is still reused and stays complete, while `limit` remains the independent rendering
   cap. The `debug_batch` `pool_find_tag` step accepts the same field.
 
+- **The per-call result budget is charged against every channel a result carries, not only the
+  half this client forwards** ([#150](https://github.com/glslang/windbg-mcp/issues/150)).
+  `tool_results_stay_within_their_budget` now asserts a tool's model ceiling against
+  `content[].text` and against `structuredContent` separately, so a typed tool is checked twice
+  and the failure names which channel moved; the `wire` ceiling that landed with #149 still covers
+  the result taken together. The printed table gains a `worst` column — the larger of the two
+  halves — beside the ceiling it is compared against.
+
+  This closes the half of #150 that was deferred for want of a second client to measure. The
+  deferral had the wrong shape: a second client would say what one more implementation happens to
+  do, which is a sample and not a rule, and inferring a server's budget from a client's forwarding
+  policy is the same step that left the rendering unwatched in the first place. The text-forwarding
+  client was also already in this repo's own compatibility matrix — `structuredContent` arrived
+  with `2025-06-18`, this server serves `2025-03-26` and `2024-11-05` beneath it, and the channel
+  is not gated on the negotiated revision, so for those two the rendering is not the half a client
+  happens to forward but the only half it can read.
+
+  No ceiling moved. `session_status` is the one budgeted typed tool whose rendering is larger than
+  its typed answer (420 B against 297 B), so it is the only row now measured against a number the
+  old assertion never saw; elsewhere the typed half is the larger one and the new check restates
+  the old. Which is what a floor under a channel nothing has yet grown looks like.
+
 ### Fixed
 
 - **Documentation: `!analyze`'s module attribution is a fact about the debugging host, not about

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -916,6 +916,14 @@ result that grows within its ceiling leaves no diff anywhere and is only visible
 table. Adjusting one is an edit to that slice, not a re-record. See
 [`token-budget.md`](./token-budget.md) for the baseline, the ceilings and how to raise one.
 
+Each row carries two numbers and the first is charged **per channel**: the model ceiling holds for
+`content[].text` and for `structuredContent` separately, not only for the half this client
+forwards, so a typed tool is asserted against it twice and the failure names which channel moved.
+The `wire` ceiling then covers the result taken together. Raising the model number is therefore a
+decision about every client rather than about ours — the tool's own doc comment and
+[`token-budget.md`](./token-budget.md) carry why
+([#150](https://github.com/glslang/windbg-mcp/issues/150)).
+
 ## When to run it
 
 ### A dependency moved

--- a/docs/token-budget.md
+++ b/docs/token-budget.md
@@ -445,7 +445,8 @@ One rule is asserted rather than a number: a tool's `structuredContent` may not 
 rendering by more than 20x. A typed answer is meant to be the facts behind a rendering, so a large
 multiple means it is carrying scaffolding instead. `registers` was at 15.9x — the case the rule was
 written around — and is 5.6x since finding 7 was fixed; the rule is there to catch the next one. Being a ratio, it is only safe to read
-alongside the `wire` ceiling below: on its own, a rendering that grows satisfies it *more*.
+alongside the byte ceilings below — the `wire` one, and the model one now that a rendering is
+charged against it too: on its own, a rendering that grows satisfies it *more*.
 
 ### Why each call has two ceilings
 
@@ -465,7 +466,46 @@ client's policy affects. It is measured rather than derived from `text + structu
 result object also carries content-block scaffolding and JSON escaping — a rendered table's
 newlines cost two bytes there and one in `text`.
 
-What is still missing is per-*channel* ceilings, which would say which half moved. That needs a
-decision about which forwarding policies this server intends to be good under, and that wants
-measurements from a second client rather than a guess about one —
-[#150](https://github.com/glslang/windbg-mcp/issues/150).
+### And why the model ceiling is charged per channel
+
+`wire` closes the hole; it does not say which half opened it. A result that grows fails one
+assertion whether the rendering doubled or the typed answer did, and the two want opposite fixes.
+
+The per-channel rule ([#150](https://github.com/glslang/windbg-mcp/issues/150)) is that a tool's
+**model ceiling applies to every channel its result carries**, not only to the half this client
+forwards. A typed tool is asserted twice — once on `text`, once on `structuredContent` — and a
+text-only one once, and the failure names the channel.
+
+That is also the decision the second half of #150 was waiting on, and the wait had the wrong
+shape. It was framed as needing measurements from a second client, to settle which forwarding
+policies this server intends to be good under. But a second client would say what one more
+implementation happens to do, which is a sample and not a rule — and reasoning from what a client
+does to what the server budgets is the same inference that left the rendering unwatched in the
+first place. What a server can budget is what it *emits*, and it emits both channels.
+
+**And the text-forwarding client is not hypothetical: it is in this repo's own compatibility
+matrix.** `structuredContent` arrived with the `2025-06-18` revision, and this server serves
+`2025-03-26` and `2024-11-05` as well — both promised in
+[`docs/architecture.md`](./architecture.md), both asserted in the protocol tier
+(`SUPPORTED_REVISIONS`). The channel is not gated on the negotiated revision (`structured_result` is one function and
+does not ask), so a client on either of those is sent a field its revision does not define, must
+ignore it, and reads the rendering. For those two the rendering is not the half a client *happens*
+to forward; it is the only half it can read. So the answer is every policy, and settling it needed
+a look at the revision list rather than a second client.
+
+The table under `--nocapture` carries a **`worst`** column beside `ceiling` for the same reason:
+`model` is what this client is charged and `worst` is what the most expensive one would be. They
+differ only where a rendering is the bigger half.
+
+Which today is one row: `session_status`, the only *typed* tool here whose rendering is larger
+than its typed answer (420 B against 297 B, the 0.7x in the table above). On every other typed row
+`worst` is the typed half, and on a text-only one like `execute` there is only the one channel — so
+everywhere else the new assertion restates the one that was already there and the column reads the
+same as `model`.
+
+What it does **not** say is which ceiling a growing rendering trips first. That depends on the room
+each row has left in each, and the margins are small: growing text alone, `session_status` reaches
+its model ceiling 197 B before `wire` and `crash_triage` 1,026 B before, while `open_dump` reaches
+it 263 B after and `backtrace` 56 B after — and those last two are figures measured against a
+different dump on a different architecture, which is well inside 56 B of noise. The rule is a floor
+under a channel, not a prediction about which assertion speaks first.

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -6005,10 +6005,32 @@ fn an_open_summarises_the_target_instead_of_listing_its_modules() {
 /// was the one that would have waved it through. Take `registers` from 618 B of text to 6,180 B and
 /// 15.9x becomes 1.59x, and every assertion here passed greener than before.
 ///
-/// Per-*channel* ceilings would say which half moved, and are not here: that needs a decision about
-/// which forwarding policies this server intends to be good under, which wants measurements from a
-/// second client rather than a guess about one
-/// ([#150](https://github.com/glslang/windbg-mcp/issues/150)).
+/// **The model ceiling is charged per channel, not per client**
+/// ([#150](https://github.com/glslang/windbg-mcp/issues/150)). `model` above is the half *this*
+/// client forwards; a client with no support for structured results forwards the other one, and
+/// spends its whole context window on it. Both are therefore a model-visible half somewhere, so
+/// the tool's budget is asserted against each channel the result carries rather than against
+/// whichever one a chosen client reads.
+///
+/// That is also the answer to the question this was deferred on — which forwarding policies the
+/// server intends to be good under — and the deferral had the wrong shape. Measuring a second
+/// client would say what one more implementation happens to do, which is a sample and not a rule;
+/// it is the same inference from client behaviour to server budget that left the text half
+/// unwatched in the first place. What a server can budget is what it *emits*, and it emits both.
+///
+/// The second client was also already here. `structuredContent` arrived with `2025-06-18`, and
+/// [`SUPPORTED_REVISIONS`] carries `2025-03-26` and `2024-11-05` beneath it — and the channel is
+/// not gated on the negotiated revision, since `structured_result` is one function and does not
+/// ask. So a client on either of those is sent a field its revision does not define, ignores it,
+/// and reads the rendering: for them the text is not the half a client happens to forward but the
+/// only half it can read. That was settled by reading the revision list, not by measuring anyone.
+///
+/// It changes what one row is measured against. `session_status` is the only typed tool here
+/// whose rendering is larger than its typed answer (420 B against 297 B when this was measured),
+/// so it is the only place the ceiling now reads a number the old assertion never saw; on every
+/// other typed row the typed half is the larger one, and a text-only tool has the one channel
+/// either way. That is what a rule stated as a floor looks like while nothing has broken it — the
+/// ratio rule beneath is the same shape, and `registers` is the row it was written for.
 #[test]
 fn tool_results_stay_within_their_budget() {
     let Some(dump) = target_tier() else { return };
@@ -6028,6 +6050,12 @@ fn tool_results_stay_within_their_budget() {
     // `wire` is not `model` plus the text: it is the whole `result` object, so it also carries the
     // content-block scaffolding and JSON escaping — a rendered table's newlines cost two bytes each
     // there and one in `text`. It is measured rather than derived for exactly that reason.
+    //
+    // The model ceiling is charged against **each** channel a result carries, so it has to be
+    // sized for the larger of the two rather than for the half this client reads. It moved no
+    // number here — `session_status` is the one row whose rendering is the bigger half, and its
+    // 600 already covers the 420 B measured — but it is why raising one of these is a decision
+    // about every client rather than about ours, and why that row is the one to watch.
     //
     // Only calls that succeed on a *kernel* dump are listed. `threads` is deliberately absent: `~`
     // is a user-mode question and answers with a tool error here, which would measure the size of
@@ -6069,25 +6097,41 @@ fn tool_results_stay_within_their_budget() {
         let model = structured.unwrap_or(text);
         rows.push((*tool, model, wire, text, structured, *model_ceiling));
 
-        assert!(
-            model <= *model_ceiling,
-            "`{tool}` answered with {model} B of model context, over its {model_ceiling} B \
-             budget. Either it started returning more than it used to, or the budget needs \
-             raising with a reason recorded in docs/token-budget.md."
-        );
+        // Once per channel the result carries, against the one budget. A tool with an output
+        // schema is asserted twice here and a text-only one once, which is the whole difference
+        // between the two kinds — not a policy about which half is read. The channel is named
+        // because that is what a failure has to say: `wire` alone reports that a result grew and
+        // cannot report which half did.
+        for (channel, bytes) in [("text", Some(text)), ("structuredContent", structured)] {
+            let Some(bytes) = bytes else { continue };
+            assert!(
+                bytes <= *model_ceiling,
+                "`{tool}`'s {channel} is {bytes} B, over its {model_ceiling} B budget for one \
+                 call. A client that forwards that channel spends every byte of it on context, \
+                 whichever half this one happens to read. Either the tool started returning more \
+                 than it used to, or the budget needs raising with a reason recorded in \
+                 docs/token-budget.md."
+            );
+        }
         assert!(
             wire <= *wire_ceiling,
-            "`{tool}` put {wire} B on the wire, over its {wire_ceiling} B budget, while its \
-             model-visible half ({model} B) is inside its own. So the half this client drops \
-             grew — which costs every client that does *not* drop it, and is the case the \
-             model-visible budget alone cannot see. See docs/token-budget.md."
+            "`{tool}` put {wire} B on the wire, over its {wire_ceiling} B budget, while each of \
+             its channels is inside the {model_ceiling} B one on its own ({text} B of text). So \
+             what grew is the result taken together — both halves at once, or the scaffolding \
+             around them — which costs every client whatever it forwards, and is the case a \
+             per-channel budget cannot see. See docs/token-budget.md."
         );
     }
 
     // The table is the deliverable when this passes — the assertions only speak up once something
     // has already gone wrong. Unlike the surface budget, this one *is* visible in CI, because the
     // debugger tier's job passes `--nocapture`; without it libtest would swallow the table.
-    eprintln!("\n  model     wire     text  struct  ratio  ceiling  tool");
+    //
+    // `worst` is the larger channel, and it sits beside `ceiling` because that is the pair the
+    // assertion above compares: `model` says what this client is charged, `worst` what the most
+    // expensive client would be. They differ on exactly the rows where a rendering is the bigger
+    // half, which is the movement the whole per-channel rule exists to make visible.
+    eprintln!("\n  model     wire     text  struct  ratio   worst  ceiling  tool");
     for (tool, model, wire, text, structured, ceiling) in &rows {
         let (shown, ratio) = match structured {
             Some(bytes) if *text > 0 => (
@@ -6097,7 +6141,10 @@ fn tool_results_stay_within_their_budget() {
             Some(bytes) => (bytes.to_string(), "-".to_string()),
             None => ("-".to_string(), "-".to_string()),
         };
-        eprintln!("{model:7} {wire:8} {text:8} {shown:>7} {ratio:>6} {ceiling:8}  {tool}");
+        let worst = (*text).max(structured.unwrap_or(0));
+        eprintln!(
+            "{model:7} {wire:8} {text:8} {shown:>7} {ratio:>6} {worst:>7} {ceiling:8}  {tool}"
+        );
     }
 
     // A rule rather than a number, and the one regression class the byte budgets cannot state: a
@@ -6106,8 +6153,9 @@ fn tool_results_stay_within_their_budget() {
     // `"subregister":false` on every row. `registers` is ~16x today and is named in
     // docs/token-budget.md rather than fixed here; this catches the *next* one, not that one.
     //
-    // It is a ratio, so it is only safe to read alongside the `wire` ceiling above: on its own, a
-    // rendering that grows satisfies it *more*. That is why the wire budget is not optional.
+    // It is a ratio, so it is only safe to read alongside the byte ceilings above — the `wire`
+    // one, and the model one now that the rendering is charged against it too: on its own, a
+    // rendering that grows satisfies it *more*. That is why neither of those is optional.
     const WORST_STRUCTURED_RATIO: f64 = 20.0;
     for (tool, _, _, text, structured, _) in &rows {
         let (Some(bytes), true) = (structured, *text > 0) else {


### PR DESCRIPTION
Closes #150 — the half of it that was left after #149.

## What was left

`tool_results_stay_within_their_budget` reduced each result to one number before asserting
(`structured.unwrap_or(text)`). That is right for the client it was measured against and is a
*forwarding policy* rather than protocol. #149 closed the self-concealing part with a **`wire`**
ceiling, which no client's policy affects. Item 2 — per-channel ceilings, so the harness says
*which* half moved — was deferred for want of a second client to measure.

## The deferral had the wrong shape

A second client says what one more implementation happens to do, which is a sample and not a rule.
And inferring a server's budget from a client's forwarding policy is the same step that left the
rendering unwatched in the first place. What a server can budget is what it **emits**, and it emits
both channels.

**The text-forwarding client was already in this repo's own compatibility matrix.**
`structuredContent` arrived with `2025-06-18`, and `SUPPORTED_REVISIONS` carries `2025-03-26` and
`2024-11-05` beneath it, both promised in `docs/architecture.md` and asserted in the protocol tier.
The channel is not gated on the negotiated revision — `structured_result` is one function and does
not ask — so a client on either is sent a field its revision does not define, ignores it, and reads
the rendering. For those two the text is not the half a client *happens* to forward; it is the only
half it can read. Settled by reading the revision list, not by measuring anyone.

## The change

The model ceiling now holds for `content[].text` and for `structuredContent` **separately**: a typed
tool is asserted against it twice, a text-only one once, and the failure names the channel. `wire`
still covers the result taken together, and is still reachable — two halves each inside `modules`'
24,000 B budget blow its 32,000 B wire one.

**No ceiling moved.** `session_status` is the one budgeted typed tool whose rendering is larger than
its typed answer (420 B against 297 B, the 0.7x row in `docs/token-budget.md`), so it is the only
row now measured against a number the old assertion never saw — and 600 B already covers it.
Elsewhere the typed half is the larger one and the new check restates the old.

The `--nocapture` table gains a **`worst`** column beside `ceiling`: `model` is what this client is
charged, `worst` what the most expensive one would be.

## One claim I had to withdraw

An early draft of the docs said the rule binds on `session_status` alone and `wire` catches the
rest. Checked against the baseline, that is false. Growing text alone:

| tool | reaches the model ceiling |
| --- | --- |
| `session_status` | 197 B before `wire` |
| `crash_triage` | 1,026 B before `wire` |
| `open_dump` | 263 B after `wire` |
| `backtrace` | 56 B after `wire` |

— and the last two are figures taken against a different dump on a different architecture, which is
well inside 56 B of noise. The rule is a floor under a channel, not a prediction about which
assertion speaks first; the docs now give the margins rather than an order.

## Verification, and its gap

Run here: `cargo fmt --all --check`, `cargo clippy --target x86_64-pc-windows-msvc --all-targets`
(clean bar the expected `rc.exe` warning) and CI's markdownlint at its pinned version — all green.

**The debugger tier was not run**: it needs Windows and a real engine, so the new assertions are
unverified against live bytes. The headroom above is arithmetic from the recorded baseline, and
`session_status` — ~420 B against a 600 B ceiling, cross-checked by counting `describe_session`'s
format strings and by back-solving from the wire ceiling — is the row to watch on the first real
run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CZu3mUSEzwtjPod3n88vhD
