### PR TITLE
Replace the budget margins with what CI measured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,9 +112,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   happens to forward but the only half it can read.
 
   No ceiling moved. `session_status` is the one budgeted typed tool whose rendering is larger than
-  its typed answer (420 B against 297 B), so it is the only row now measured against a number the
-  old assertion never saw; elsewhere the typed half is the larger one and the new check restates
-  the old. Which is what a floor under a channel nothing has yet grown looks like.
+  its typed answer (423 B against 301 B, identical on both CI runners), so it is the only row now
+  measured against a number the old assertion never saw; elsewhere the typed half is the larger one
+  and the new check restates the old. Which is what a floor under a channel nothing has yet grown
+  looks like.
 
 ### Fixed
 

--- a/docs/token-budget.md
+++ b/docs/token-budget.md
@@ -498,14 +498,30 @@ The table under `--nocapture` carries a **`worst`** column beside `ceiling` for 
 differ only where a rendering is the bigger half.
 
 Which today is one row: `session_status`, the only *typed* tool here whose rendering is larger
-than its typed answer (420 B against 297 B, the 0.7x in the table above). On every other typed row
-`worst` is the typed half, and on a text-only one like `execute` there is only the one channel — so
+than its typed answer — 423 B against 301 B, the 0.7x in the table above. On every other typed row
+`worst` is the typed half, and on a text-only one like `execute` there is only the one channel, so
 everywhere else the new assertion restates the one that was already there and the column reads the
 same as `model`.
 
 What it does **not** say is which ceiling a growing rendering trips first. That depends on the room
-each row has left in each, and the margins are small: growing text alone, `session_status` reaches
-its model ceiling 197 B before `wire` and `crash_triage` 1,026 B before, while `open_dump` reaches
-it 263 B after and `backtrace` 56 B after — and those last two are figures measured against a
-different dump on a different architecture, which is well inside 56 B of noise. The rule is a floor
-under a channel, not a prediction about which assertion speaks first.
+each row has left in each, and the two orders interleave. Growing text alone, measured on the run
+that landed this:
+
+| tool | its model ceiling, relative to `wire` |
+|---|---|
+| `crash_triage` | reached 1,034 B **before** |
+| `session_status` | reached 192 B **before** |
+| `backtrace` | reached 56 B after |
+| `disassemble` | reached 138 B after |
+| `open_dump` | reached 315 B after |
+| `registers` | reached 2,592 B after |
+| `modules` | reached 4,442 B after |
+
+So the rule is a floor under a channel, not a prediction about which assertion speaks first — and
+`backtrace`'s 56 B is close enough to a tie that the order there is not worth relying on either.
+
+Those margins are stable rather than noisy, which is worth knowing before anyone re-derives them.
+`target_tier()` hands every row the **x64** sample whatever the host is, so this table is the same
+dump on both CI runners — and both printed it byte for byte identically, ARM64 included. That is
+not true of the baseline table further up, three of whose rows were re-measured on the ARM64 bench
+against the ARM64 dump; the two tables are read differently for that reason.

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -6026,8 +6026,8 @@ fn an_open_summarises_the_target_instead_of_listing_its_modules() {
 /// only half it can read. That was settled by reading the revision list, not by measuring anyone.
 ///
 /// It changes what one row is measured against. `session_status` is the only typed tool here
-/// whose rendering is larger than its typed answer (420 B against 297 B when this was measured),
-/// so it is the only place the ceiling now reads a number the old assertion never saw; on every
+/// whose rendering is larger than its typed answer (423 B against 301 B, on both CI runners), so
+/// it is the only place the ceiling now reads a number the old assertion never saw; on every
 /// other typed row the typed half is the larger one, and a text-only tool has the one channel
 /// either way. That is what a rule stated as a floor looks like while nothing has broken it — the
 /// ratio rule beneath is the same shape, and `registers` is the row it was written for.
@@ -6054,8 +6054,9 @@ fn tool_results_stay_within_their_budget() {
     // The model ceiling is charged against **each** channel a result carries, so it has to be
     // sized for the larger of the two rather than for the half this client reads. It moved no
     // number here — `session_status` is the one row whose rendering is the bigger half, and its
-    // 600 already covers the 420 B measured — but it is why raising one of these is a decision
-    // about every client rather than about ours, and why that row is the one to watch.
+    // 600 already covers the 423 B both CI runners measure — but it is why raising one of these
+    // is a decision about every client rather than about ours, and why that row is the one to
+    // watch.
     //
     // Only calls that succeed on a *kernel* dump are listed. `threads` is deliberately absent: `~`
     // is a user-mode question and answers with a tool error here, which would measure the size of


### PR DESCRIPTION
Follow-up to #264, which was squash-merged 24 seconds before this commit was pushed — so the branch
carried it and `main` never got it. Content-identical cherry-pick onto `main`; no new work.

#264 shipped the per-channel result budget with its margins derived **arithmetically** from the
recorded baseline, because the debugger tier needs Windows and a real engine and the change was
written on a Mac. That PR then went green — three debugger tiers — and the table it prints replaces
every estimate.

## The estimates held

`session_status` is **423 B** of text against **301 B** of typed answer, predicted at ~420 B by
counting `describe_session`'s format strings. It is the one row where `worst` differs from `model`,
and its 600 B ceiling covers it with 42% headroom. Every other typed row has the typed half larger,
so `worst` equals `model` there — as the rule predicted.

## What moves

Published margins were each off by a few bytes and are now measured, with the three rows that table
was missing added:

| tool | its model ceiling, relative to `wire` | published |
|---|---|---|
| `crash_triage` | reached 1,034 B **before** | 1,026 B |
| `session_status` | reached 192 B **before** | 197 B |
| `backtrace` | reached 56 B after | 56 B |
| `disassemble` | reached 138 B after | — |
| `open_dump` | reached 315 B after | 263 B |
| `registers` | reached 2,592 B after | — |
| `modules` | reached 4,442 B after | — |

## And one sentence beside them was wrong

It called `backtrace` and `open_dump` *"figures measured against a different dump on a different
architecture, which is well inside 56 B of noise"* — imported from the prose about the **baseline**
table further up the same file, where three rows really were re-measured on the ARM64 bench against
the ARM64 dump.

This tier does not work that way: `target_tier()` hands every row `SAMPLE_DUMP`, the x64 sample,
whatever the host is. Both CI runners printed the table **byte for byte identically**, ARM64
included — which is what caught it. So the margins are stable, and the caution about their order is
about how small they are, not about noise. The docs now say which of the two tables is read which
way, since they sit a few paragraphs apart and only one varies by host.

## Verification

`cargo fmt --all --check`, `cargo check --target x86_64-pc-windows-msvc --all-targets` and CI's
markdownlint at its pinned version, all green here. The measurements themselves come from #264's own
green debugger-tier runs (jobs `99298672188` x64 and `99298672216` arm64); no assertion or ceiling
changes in this PR, so the tier's behaviour is unchanged — it is docs plus two comment figures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CZu3mUSEzwtjPod3n88vhD
