### PR TITLE
Hold the drop-conservation drain until a record is refused

### DIFF
--- a/src/logbridge.rs
+++ b/src/logbridge.rs
@@ -957,9 +957,23 @@ mod tests {
         let (tx, rx) = sync_channel::<(Entry, u32)>(4);
         DROPPED.store(0, Ordering::Relaxed);
 
+        // Eight writers against four slots do not *guarantee* a refusal — when the drain keeps up,
+        // every attempt is taken and the run asserts conservation over the one path it exists to
+        // cover. That is a vacuous pass rather than a wrong one, and it was a flake at roughly one
+        // run in twenty-five. So the drain is held until a record has actually been turned away.
+        //
+        // A rendezvous and not a nap: with nothing draining, a queue of four must refuse the fifth
+        // `enqueue`, so the gate is opened by the very thing it waits for and cannot hang — where
+        // a sleep would only make the refusal *likely*, and would trade the flake for a slower
+        // test that still has one.
+        let (refused_tx, refused_rx) = sync_channel::<()>(1);
+
         // Drains as the writers work, so slots keep freeing and the full/not-full boundary is
         // crossed constantly rather than once.
         let drained = std::thread::spawn(move || {
+            // `Err` only if every writer finished without one refusal, which the gate above makes
+            // impossible; either way the drain proceeds and the assertions below decide.
+            let _ = refused_rx.recv();
             let mut received = 0u64;
             let mut reported = 0u64;
             while let Ok((_, carried)) = rx.recv() {
@@ -972,9 +986,10 @@ mod tests {
         let writers: Vec<_> = (0..THREADS)
             .map(|thread| {
                 let tx = tx.clone();
+                let refused = refused_tx.clone();
                 std::thread::spawn(move || {
                     for n in 0..EACH {
-                        enqueue(
+                        let queued = enqueue(
                             Some(&tx),
                             Entry {
                                 seq: 0,
@@ -985,6 +1000,11 @@ mod tests {
                                 message: format!("thread {thread} record {n}"),
                             },
                         );
+                        if !queued {
+                            // One slot and a non-blocking send, so the first refusal opens the
+                            // gate and every later one costs nothing and blocks nobody.
+                            let _ = refused.try_send(());
+                        }
                     }
                 })
             })
@@ -1007,8 +1027,8 @@ mod tests {
         );
         assert!(
             reported + outstanding > 0,
-            "a queue of 4 against {THREADS} threads must have refused something, or this test is \
-             asserting conservation over a path it never took"
+            "the drain was held until a record was turned away, so refusing nothing means that \
+             gate has stopped working and this is asserting conservation over a path it never took"
         );
     }
 


### PR DESCRIPTION
`no_record_is_lost_or_counted_twice_when_threads_log_at_once` fails on roughly **one run in
twenty-five**. Found while running the suite for the 0.14.0 release; it is pre-existing and the
tree it reproduces on is clean.

## It is the guard, not the property

The conservation assertion — `received + reported + outstanding == 2000` — held on every run,
including the failing ones. What trips is the vacuity guard beneath it:

```
a queue of 4 against 8 threads must have refused something,
or this test is asserting conservation over a path it never took
```

Eight writers against four slots do not *guarantee* a refusal. `enqueue` uses a non-blocking
`try_send`, so when the drain thread keeps up, all 2000 attempts are taken, `DROPPED` is never
incremented, and `reported + outstanding` is zero. The guard is right to exist — a run that refuses
nothing covers none of the arithmetic the test is for — it just had nothing making it true.

## The fix

The drain is held on a one-slot rendezvous channel until a writer has actually been turned away.
That makes the refusal **deterministic rather than likely**: with nothing draining, a queue of four
must refuse the fifth of 2000 enqueues, so the gate is opened by exactly the event it waits for and
cannot hang.

Once open, the drain runs freely for the remaining records, so the full/not-full boundary is still
crossed constantly rather than once — the property the original comment describes, and the one a
permanently-blocked drain would have destroyed. All the gate adds is a guaranteed floor of one
refusal at the start.

**Deliberately not a sleep.** A nap only makes the refusal probable, so it would trade the flake for
a slower test that still has one.

## Verification

| | Result |
|---|---|
| Before | 2 failures / 26 runs (~8%) |
| After (shipped form) | **0 / 100** |
| Strict gate (`recv().expect(...)`, temporary) | **0 / 20**, `recv()` returned `Ok` every time |

The guard assertion is itself the instrument: a run that passes is a run where a refusal provably
happened. The strict-gate run is the positive check that the gate is what changed things rather than
luck — had the drain ever started unblocked, `recv()` would have returned `Err` and panicked. The
tolerant `let _ = refused_rx.recv();` is what ships, because a panicking drain thread surfaces as an
opaque `join` failure where falling through to the guard gives the reader the actual diagnosis.

The guard's message is reworded to match: it now reads as "the gate has stopped working" rather than
"eight threads must have refused something", which is the thing that would actually be true.

## Scope

Test-only, inside `#[cfg(test)]` in `src/logbridge.rs`; no shipping code path changes, so no
CHANGELOG entry (this file is user-facing: Added/Fixed/Changed/Documentation/Security).
`cargo fmt --all --check` and `cargo clippy --all-targets` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WhhF5x9fE4bdd1jiKBvhNa
