### PR TITLE
Bring dbgscope's session fuzz up to this server's surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **A session fuzz in the debugger tier** — dbgscope's `examples/session_fuzz.rs` brought up to
+  this server's surface. That example drives randomised command sequences straight at a
+  `DebugEngine` and checks, after every one of them, that the session either still holds a target
+  and answers or says it holds none; it exists because the three defects behind
+  [#242](https://github.com/glslang/windbg-mcp/issues/242) were each found by hand, one sequence at
+  a time, and none of them is about a *command* — they are about the state the previous command
+  left behind, and there are more ways to reach a given state than anyone enumerates.
+
+  What the port adds is everything between that engine and a caller. A **third state**, since
+  `continue_async` leaves a target moving with nobody waiting and reads are then refused
+  `target_running` — the supervisor's state machine
+  ([#83](https://github.com/glslang/windbg-mcp/issues/83)), which the example cannot reach. The
+  **category** a refusal carries rather than merely that it refused. A **bystander session** on the
+  same server, never named by a step and asked after every round, which is the process-per-session
+  claim no in-process test can make. And reclamation of whatever the sequence left.
+
+  Its oracle is a **scale rather than an agreement**: a bounded run can stop between one road into
+  the session and the next, so what is forbidden is a road moving back down
+  `Moving → Holding → Gone` — `stale_session` and then an answer is the half-dead session, while an
+  answer and then `stale_session` is a program that finished a millisecond ago. The seed is fixed,
+  so CI walks one short deterministic sequence on all three of its `dbgeng.dll`s; the fuzz proper
+  is a soak of the same test, and the run prints the states it reached and asserts it reached the
+  terminal one, because a walk that never left `Holding` would pass without asking the question.
+  `docs/smoke-test.md` has the soak command and what it does and does not assert.
+
+  It found one thing on the second seed it ran under, left standing as `FOLLOWUPS.md` item 55: a
+  handle that a raw `execute` has **retired** cannot release its own session, while the `execute`
+  that retires it appends "`end_session` releases it" — and the recovery its refusal names, omitting
+  the handle, routes to the *newest* session instead. Measured on the release build with two
+  launches, the older retired by `qd`.
+
 ## [0.14.0] - 2026-08-30
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -212,7 +212,7 @@ It checks *same-file* fragments only, so a cross-file `../README.md#some-heading
 verify by hand.
 
 **The pass count does not say which tiers ran.** Each gate is inside its test, so the `mcp_smoke`
-harness reports the same **94 passed** with the debugger tier off as with it on — that harness's own
+harness reports the same **95 passed** with the debugger tier off as with it on — that harness's own
 result line, since a plain `cargo test` runs the crate's several hundred unit tests beside it and
 prints a result line per binary. What differs between the two runs is the runtime (measured on the
 ARM64 bench 2026-08-23: **1.6s against 61s** for `cargo test --test mcp_smoke`) and the `SKIPPED`
@@ -221,9 +221,9 @@ debugger claim. The count moves whenever a test is added — it was 69 until #19
 until item 37, 79 until the TTD tier, 84 until item 50's version-resource test, 85 until
 item 48's two endings, 87 until item 49's live 32-bit target, 88 until item 51's
 attach teardown, 89 until the 32-bit worker's version resource, 90 until #66's symbol-path default,
-91 until #83's two asynchronous-execution tests and 93 until #85's module-inventory refresh — and
-it said 83 while it was 84, and 90 while it was 91, which is the usual state of it, so re-derive it
-rather than trusting this sentence.
+91 until #83's two asynchronous-execution tests, 93 until #85's module-inventory refresh and 94
+until the session fuzz — and it said 83 while it was 84, 90 while it was 91, and 93 while it was
+94, which is the usual state of it, so re-derive it rather than trusting this sentence.
 
 **And a gate can be a *directory beside the exe*, which prints no `SKIPPED` line at all.** The
 debugger tier's `!analyze` assertions are inside `if analysis["ran"] == true`, and `ran` is false
@@ -744,6 +744,24 @@ Two consequences worth carrying:
 was already on the bounded wait; a dump cannot `go`, and no tier launched a process. The debugger
 tier now does (`launch_tier`, two tests in `tests/mcp_smoke.rs`). The one target type still
 unmeasured on this path is **TTD replay** — `FOLLOWUPS.md` item 47.
+
+**And after touching anything in this seam, run the fuzz** —
+`a_randomised_command_sequence_leaves_the_session_in_one_state_and_the_server_serving`, which is
+dbgscope's `examples/session_fuzz.rs` brought up to this server's surface. Every defect above was
+found by hand, one sequence at a time, and none of them is about a *command*: they are about the
+state the previous one left behind, and the number of ways to reach a given state is larger than
+anyone enumerates. It rides the debugger tier on a fixed seed, so CI walks one short deterministic
+sequence on three real `dbgeng.dll`s; the fuzz proper is a soak of the same test, and
+`docs/smoke-test.md` has the command and what the oracle does and does not assert. Two things to
+know before editing it. **The oracle is a scale rather than an agreement** — a bounded run can stop
+between one road and the next, so what is forbidden is a road moving *back* down
+`Moving → Holding → Gone`, not two roads differing. And a walk that never leaves `Holding` asks
+nothing, which is why the run prints the states it reached and asserts it reached `Gone`; a corpus
+edit reshuffles the walk, so read that line rather than the green tick.
+
+It has already paid for itself: the second seed it ran under found that a handle the raw hatch has
+retired cannot release its own session, while the `execute` that retires it says `end_session` will
+(`FOLLOWUPS.md` item 55).
 
 **Its blocker moved rather than lifted, and which host it is about is the whole of the distinction.**
 Item 47 defers on "replay does not work on this host at all", and the sentence before it names the

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -1,6 +1,6 @@
 # Follow-ups
 
-Deferred work, in twenty-eight clusters: items 1–6 come from the reachability-confirmation effort (path
+Deferred work, in twenty-nine clusters: items 1–6 come from the reachability-confirmation effort (path
 recipe + `run_to_address`, merged 2026-07-04), items 7–11 from surveying this server against the
 MCP `2026-07-28` extensions (tasks, apps), item 12 from the opener split
 (glslang/dbgscope#71, 2026-08-01), items 13–14 from the bounded-command coverage review
@@ -58,7 +58,9 @@ half the prose a client is served (2026-08-29), and where a break arriving in th
 after a run built its stop is recorded in that result's prose and not in its flag (2026-08-30),
 and item 54 from
 [#85](https://github.com/glslang/windbg-mcp/issues/85)'s module-inventory refresh, whose engine
-call no watchdog in either crate can currently cut short (2026-08-30).
+call no watchdog in either crate can currently cut short (2026-08-30), and item 55 from bringing
+dbgscope's session fuzz up to this server's surface, where the second seed it was run under found
+that a handle the raw hatch has retired cannot release its own session (2026-08-31).
 Each item notes its repo, why it was deferred, and where it picks up. See [`DECISIONS.md`](./DECISIONS.md) for the design rationale (D1–D5) items 1–6 extend,
 and the 2026-08-02 entries that items 13–14 and item 10 extend.
 
@@ -3728,3 +3730,53 @@ deadline.
 **Where it picks up.** `worker::resynchronise` and `EngineOp::Modules` in `src/proto.rs`,
 `DebugEngine::reload_symbols` and `Watchdog` in dbgscope's `src/dbgeng.rs`, and
 `execute_command_bounded` beside it for the shape a bounded direct call takes here.
+
+## 55. [windbg-mcp] A **retired** handle cannot release its own session
+
+**What it is.** A raw `execute` that replaces or releases the target — `qd`, `q`, `.detach`,
+`.kill`, `.opendump` — retires the handle naming that session (`changes_debug_target` →
+`SessionState::Retired`). Retirement refuses every call that *supplies* the handle while leaving
+the worker live and reachable by a call that supplies none
+(`a_retired_handle_is_refused_but_still_the_default_target`), and `end_session` is not exempt: it
+resolves through `Sessions::resolve` like every other tool. Two things then fail to line up.
+
+The `execute` that retires the handle appends "`end_session` releases it" — and `end_session` with
+that handle is refused, which is the server contradicting its own instruction one call later. And
+the refusal's own advice, "omit `session_id` to operate on it anyway", routes to the **current**
+session, which is the newest one `accepts_default` admits. With anything newer open that is a
+different session, so the retired one cannot be released by its owner at all: it comes back when
+everything newer has gone, or on a client disconnect, or on a lease expiry. Until then it holds one
+of the four slots and a live engine process with a live target.
+
+**Measured** on the release build, 2026-08-31, through the shipped MCP transport rather than from
+the source: two launches, the older retired with `execute { "command": "qd" }`. `end_session` by
+handle was refused with the retirement message; `session_status` then reported that session
+`live: true, current: false` holding its own `engine_pid`, and the *newer* one `current: true` — so
+an un-handled `end_session` would have taken the wrong session. Ending the newer one first made the
+retired one current, and an un-handled `end_session` released it.
+
+**Why it was deferred.** It was found by the session fuzz
+(`a_randomised_command_sequence_leaves_the_session_in_one_state_and_the_server_serving`, seed 2) on
+the round-teardown path rather than in the fuzz's own oracle, and a test is the wrong place to
+decide what `end_session` should do about a handle the server has deliberately stopped honouring.
+There is a real argument for today's behaviour — the handle no longer names what it was issued for,
+and honouring it for one tool is a hole in the rule every other tool keeps — so the fix has to pick
+a side rather than patch a sentence.
+
+**What would close it.** Either of two, and they are not the same claim:
+
+- **Exempt `end_session` from retirement.** It does not read the target, it releases the worker,
+  and it is the answer every other refusal on this session gives — the same argument that already
+  exempts it from `worker::refuse_when_the_target_is_gone`. Cheapest, and it makes the note
+  `execute` already appends true.
+- **Or keep the refusal and fix what it promises.** "Omit `session_id`" is a recovery only while
+  nothing newer is open, so the refusal should not offer it unconditionally — and there is then no
+  way at all to release *that* session by name, which is the part worth not shipping.
+
+The first is what `execute`'s own output already tells a caller, so it is the one to take unless
+someone argues for the second.
+
+**Where it picks up.** `end_session` and `changes_debug_target` in `src/server.rs`,
+`SessionState::Retired` with `accepts_handle`/`accepts_default` and `Sessions::resolve` in
+`src/engine.rs`, and `fuzz_reclaim` in `tests/mcp_smoke.rs` — whose fallback branch is what should
+stop being needed.

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -3756,7 +3756,7 @@ an un-handled `end_session` would have taken the wrong session. Ending the newer
 retired one current, and an un-handled `end_session` released it.
 
 **Why it was deferred.** It was found by the session fuzz
-(`a_randomised_command_sequence_leaves_the_session_in_one_state_and_the_server_serving`, seed 2) on
+(`a_randomised_command_sequence_leaves_the_session_in_one_state_and_the_server_serving`) on
 the round-teardown path rather than in the fuzz's own oracle, and a test is the wrong place to
 decide what `end_session` should do about a handle the server has deliberately stopped honouring.
 There is a real argument for today's behaviour — the handle no longer names what it was issued for,

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -984,6 +984,17 @@ away while it does. So the rule is that a probe's roads never move **back** down
 `Moving → Holding → Gone`: `stale_session` and then an answer is the half-dead session, while an
 answer and then `stale_session` is a program that finished a millisecond ago.
 
+**A tool error is data; a protocol error is a failure.** A step's tool result is discarded on
+purpose — `bp` on an unresolvable symbol and a `break_in` for a run that has finished are ordinary,
+and what is checked is the state left behind. A top-level JSON-RPC error is not that: it means the
+request never reached a debugger, which is a schema or transport regression and is what this
+harness exists for. So every call the fuzz makes goes through one `fuzz_call`, which refuses one.
+Discarded, it would leave the session readable, every probe passing, the run green, and a whole
+corpus entry silently doing nothing — the same vacuity the `Gone` assertion stops, arriving through
+the wire rather than through the walk. It matters here more than in the tests above because this is
+the widest set of tools the harness drives from one place: nine, with argument shapes nothing else
+exercises.
+
 **The seed is fixed, so CI runs one deterministic walk.** Drawing from the clock would fail on a
 sequence nobody could reproduce. The default (seed 3, 3 rounds of 6 steps, ~1s) is chosen because
 its walk reaches all three states; how long a round lasts depends on whether it draws an unbounded

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -15,12 +15,12 @@ $env:WINDBG_MCP_SMOKE_TTD  = "1"; cargo test --test mcp_smoke   # + the TTD tier
 
 It builds and runs against `target/debug`, so it never touches the `target/release` exe a
 connected MCP client holds a lock on (see [`CLAUDE.md`](../CLAUDE.md)). The protocol tier is ~2s;
-adding the debugger tier takes it to ~50s, almost all of it two tests waiting out real timers — a
-lease grace, and a call staying silent long enough to have to report that it is still running.
+adding the debugger tier takes it to ~60s, most of it two tests waiting out real timers — a lease
+grace, and a call staying silent long enough to have to report that it is still running.
 
 **The pass count is the same either way**, because each gate is inside its own test: `cargo test
---test mcp_smoke` reports the same number passed with the tier off as with it on — 87 on 2026-08-26,
-against ~2s and ~55s respectively, but it moves whenever a test is added, so re-derive it rather
+--test mcp_smoke` reports the same number passed with the tier off as with it on — 95 on 2026-08-31,
+against ~2s and ~60s respectively, but it moves whenever a test is added, so re-derive it rather
 than reading it here. (A plain `cargo test` runs the unit tests beside it and prints a result line
 per binary, so it is this harness's own line to read.) The runtime is what tells the two runs apart,
 and `--nocapture` is what prints the `SKIPPED` reason — a run that reports every test green having
@@ -31,7 +31,7 @@ taken a second covered no debugger claim at all.
 | Tier | Gate | Needs | Catches |
 | --- | --- | --- | --- |
 | **Protocol** | always | no debugger, no target, and no network off this machine — it does bind a loopback port for the listener | transport, revision negotiation, tool-surface drift, and the listener's lease up to the point a session is opened |
-| **Debugger** | `WINDBG_MCP_SMOKE_DUMP=1` | `dbgeng.dll`, the checked-in sample dump, and a live user-mode target for the seven that want one — `cmd.exe` for the six that launch, `ping` for the one that attaches | `dbgscope` / DbgEng regressions, a lease expiry releasing a real engine worker, driving execution on a live user-mode target synchronously and asynchronously, and what ending a session does to it |
+| **Debugger** | `WINDBG_MCP_SMOKE_DUMP=1` | `dbgeng.dll`, the checked-in sample dump, and a live user-mode target for the eight that want one — `cmd.exe` for the seven that launch, `ping` for the one that attaches | `dbgscope` / DbgEng regressions, a lease expiry releasing a real engine worker, driving execution on a live user-mode target synchronously and asynchronously, what ending a session does to it, and — over a seeded randomised sequence — that a session is always in one of its three states and never half-answering |
 | **Bounded command** | `--ignored` | `dbgeng.dll`, the sample dump, ~1 minute | the watchdog wiring, which now spans two processes |
 | **Live kernel** | `--ignored` + `WINDBG_MCP_SMOKE_KERNEL` | a live kernel target you can freeze — KDNET, or serial | that a kernel attach *lands*, coexists, and is let go — by `end_session` and by a disconnect; and that a `debug_batch` which patches a byte of the running kernel puts it back |
 | **MessageManager CTF** | `--ignored` + live-kernel gate + `WINDBG_MCP_SMOKE_CTF=1` | the challenge VM, WinRM, full `nt` symbols | the real driver and retained `Tgsm` pool objects through the shipped MCP transport |
@@ -953,6 +953,62 @@ revision — and the run below is what you do on that PR, not only on a bump you
 3. Re-read the stateless assertions in `discover_opens_a_session_without_initialize` against the new
    revision's `_meta` requirements — that is where per-request metadata rules land.
 4. Update the revision list in `README.md` and this file's list above to match what actually passes.
+
+## The session fuzz
+
+`a_randomised_command_sequence_leaves_the_session_in_one_state_and_the_server_serving`, inside the
+debugger tier rather than beside it — it needs an engine and a live user-mode target, which is that
+gate exactly. It is **dbgscope's `examples/session_fuzz.rs` at this server's surface**: that example
+drives randomised sequences straight at a `DebugEngine` and checks, after every one, that the
+session either still holds a target and answers or says it holds none. It exists because the three
+defects behind [#242](https://github.com/glslang/windbg-mcp/issues/242) were each found by hand, one
+sequence at a time, and none of them is about a *command* — they are about the state the previous
+command left behind, and there are more ways to reach a given state than anyone enumerates.
+
+What the port adds is everything between that engine and a caller:
+
+- **A third state.** `continue_async` leaves a target moving with nobody waiting, and reads are then
+  refused `target_running`. That state machine is the supervisor's
+  ([#83](https://github.com/glslang/windbg-mcp/issues/83)) and the example cannot reach it.
+- **The category a refusal carries**, not merely that it refused — `engine::engine_error`'s `_` arm
+  folded "no target left" into `debugger` once, which tells a caller to change what it asked instead
+  of to release the session.
+- **A bystander session** on the same server, never named by a step and asked after every round:
+  one worker driven into any state at all must leave the supervisor serving and the *other* worker
+  holding its own target. No in-process test can state that.
+- **Reclamation** of whatever the sequence left.
+
+**The oracle is a scale, not an agreement.** The example calls any disagreement between two roads a
+violation; here a run bounded at 1.5s can stop *between* one road and the next, and a target can go
+away while it does. So the rule is that a probe's roads never move **back** down
+`Moving → Holding → Gone`: `stale_session` and then an answer is the half-dead session, while an
+answer and then `stale_session` is a program that finished a millisecond ago.
+
+**The seed is fixed, so CI runs one deterministic walk.** Drawing from the clock would fail on a
+sequence nobody could reproduce. The default (seed 2, 3 rounds of 6 steps, ~1s) is chosen because
+its walk reaches all three states; how long a round lasts depends on whether it draws an unbounded
+`g`, which runs the target to its own ending, so a corpus edit reshuffles both the coverage and the
+runtime. The run prints the states it reached, and **asserts it reached `Gone` at least once** —
+every check is of the form "if the session is in state X it must say so", so a walk that never left
+`Holding` would pass without asking the question. `Moving` is reported and not asserted: it needs a
+run still going one probe later, which is a race on a loaded runner.
+
+The fuzz proper is the soak, and it is the same test:
+
+```pwsh
+$env:WINDBG_MCP_SMOKE_DUMP = "1"
+$env:WINDBG_MCP_SMOKE_FUZZ_SEED = "7"
+$env:WINDBG_MCP_SMOKE_FUZZ_ROUNDS = "50"; $env:WINDBG_MCP_SMOKE_FUZZ_STEPS = "10"
+cargo test --test mcp_smoke -- --nocapture randomised
+```
+
+Run it after touching anything in the wait/settle/guard seam, or in the execution slot. A failing
+seed replays exactly and the panic names it, with the sequence that got there.
+
+**It has already found one thing**, on the second seed it was run under: a handle the raw hatch has
+retired cannot release its own session, and the `execute` that retires it says otherwise in the same
+breath (`FOLLOWUPS.md` item 55). That is left standing rather than fixed — `fuzz_reclaim` takes the
+documented fallback and asserts the session that went is the one it named.
 
 ## The bounded-command tier
 

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -985,10 +985,12 @@ away while it does. So the rule is that a probe's roads never move **back** down
 answer and then `stale_session` is a program that finished a millisecond ago.
 
 **The seed is fixed, so CI runs one deterministic walk.** Drawing from the clock would fail on a
-sequence nobody could reproduce. The default (seed 2, 3 rounds of 6 steps, ~1s) is chosen because
+sequence nobody could reproduce. The default (seed 3, 3 rounds of 6 steps, ~1s) is chosen because
 its walk reaches all three states; how long a round lasts depends on whether it draws an unbounded
-`g`, which runs the target to its own ending, so a corpus edit reshuffles both the coverage and the
-runtime. The run prints the states it reached, and **asserts it reached `Gone` at least once** —
+`g`, which runs the target to its own ending, so anything that reshuffles the walk — a corpus edit,
+or a change to `Rng::new` — reshuffles both the coverage and the runtime, and the number is
+re-derived by scanning rather than kept. The run prints the states it reached, and **asserts it
+reached `Gone` at least once** —
 every check is of the form "if the session is in state X it must say so", so a walk that never left
 `Holding` would pass without asking the question. `Moving` is reported and not asserted: it needs a
 run still going one probe later, which is a race on a loaded runner.

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -5415,7 +5415,16 @@ fn a_randomised_command_sequence_leaves_the_session_in_one_state_and_the_server_
 
         for _ in 0..steps {
             let step = FUZZ_CORPUS[rng.below(FUZZ_CORPUS.len() as u64) as usize];
-            sequence.push(fuzz_step(&mut server, &session, step, &mut execution));
+            // The walk so far, rendered before the step runs so a call that fails at the wire can
+            // name what led to it. The step being drawn is in the panic beside this.
+            let context = format!("round {round}, {}\n{replay}", sequence.join(" -> "));
+            sequence.push(fuzz_step(
+                &mut server,
+                &session,
+                step,
+                &mut execution,
+                &context,
+            ));
             let held = fuzz_probe(&mut server, &session, round, &sequence, &replay);
             *reached.entry(held).or_default() += 1;
             if held == Held::Gone {
@@ -5430,10 +5439,11 @@ fn a_randomised_command_sequence_leaves_the_session_in_one_state_and_the_server_
         fuzz_reclaim(&mut server, &session, round, &sequence, &replay);
 
         // And the session that was never fuzzed still holds its own target.
-        let sibling = server.call_tool(
+        let sibling = fuzz_call(
+            &mut server,
             "registers",
             json!({ "session_id": &bystander, "filter": "pc" }),
-            TARGET_STEP,
+            &format!("round {round}, {}\n{replay}", sequence.join(" -> ")),
         );
         assert!(
             !is_tool_error(&sibling),
@@ -5443,10 +5453,11 @@ fn a_randomised_command_sequence_leaves_the_session_in_one_state_and_the_server_
         );
     }
 
-    server.call_tool(
+    fuzz_call(
+        &mut server,
         "end_session",
         json!({ "session_id": &bystander }),
-        TARGET_STEP,
+        "releasing the bystander at the end of the run",
     );
 
     // **Which states this walk actually reached**, and the assertion is the point rather than the
@@ -5499,7 +5510,12 @@ fn a_randomised_command_sequence_leaves_the_session_in_one_state_and_the_server_
 fn fuzz_reclaim(server: &mut Server, session: &str, round: u64, sequence: &[String], replay: &str) {
     let context = || format!("{}\n{replay}", sequence.join(" -> "));
 
-    let ended = server.call_tool("end_session", json!({ "session_id": session }), TARGET_STEP);
+    let ended = fuzz_call(
+        server,
+        "end_session",
+        json!({ "session_id": session }),
+        &context(),
+    );
     let report = &ended["result"]["structuredContent"];
     if report["released"] == json!(true) {
         return;
@@ -5516,7 +5532,7 @@ fn fuzz_reclaim(server: &mut Server, session: &str, round: u64, sequence: &[Stri
     // The retirement's own documented route. Guarded rather than trusted: it routes by *current*,
     // so a version of this test where the round's session is not the newest would silently end
     // the bystander instead and the assertion below is what would say so.
-    let anyway = server.call_tool("end_session", json!({}), TARGET_STEP);
+    let anyway = fuzz_call(server, "end_session", json!({}), &context());
     let report = &anyway["result"]["structuredContent"];
     assert_eq!(
         report["released"],
@@ -5546,49 +5562,54 @@ fn fuzz_step(
     session: &str,
     step: FuzzStep,
     execution: &mut Option<String>,
+    context: &str,
 ) -> String {
     match step {
         FuzzStep::Raw(command) => {
-            server.call_tool(
+            fuzz_call(
+                server,
                 "execute",
                 json!({ "session_id": session, "command": command }),
-                TARGET_STEP,
+                context,
             );
             format!("execute `{command}`")
         }
         FuzzStep::Bounded(command) => {
-            server.call_tool(
+            fuzz_call(
+                server,
                 "debug_batch",
                 json!({
                     "session_id": session,
                     "steps": [{ "op": "resume", "command": command, "timeout_ms": FUZZ_WAIT_MS }],
                     "timeout_ms": 20000,
                 }),
-                TARGET_STEP,
+                context,
             );
             format!("batch resume `{command}`")
         }
         FuzzStep::Typed(tool) => {
-            server.call_tool(tool, json!({ "session_id": session }), TARGET_STEP);
+            fuzz_call(server, tool, json!({ "session_id": session }), context);
             tool.to_string()
         }
         FuzzStep::RunTo(symbol) => {
-            server.call_tool(
+            fuzz_call(
+                server,
                 "run_to_address",
                 json!({
                     "session_id": session,
                     "address": symbol,
                     "timeout_ms": FUZZ_WAIT_MS,
                 }),
-                TARGET_STEP,
+                context,
             );
             format!("run_to_address {symbol}")
         }
         FuzzStep::Async => {
-            let started = server.call_tool(
+            let started = fuzz_call(
+                server,
                 "continue_async",
                 json!({ "session_id": session, "max_run_ms": FUZZ_WAIT_MS }),
-                TARGET_STEP,
+                context,
             );
             // Kept only when one was minted. A refused `continue_async` — the slot is taken, the
             // target is gone — must not overwrite the handle a later `break_in` is for, and a
@@ -5618,14 +5639,48 @@ fn fuzz_step(
                     }),
                 )
             };
-            server.call_tool(tool, args, TARGET_STEP);
+            fuzz_call(server, tool, args, context);
             format!("{tool} {handle}")
         }
         FuzzStep::Interrupt => {
-            server.call_tool("interrupt", json!({ "session_id": session }), TARGET_STEP);
+            fuzz_call(
+                server,
+                "interrupt",
+                json!({ "session_id": session }),
+                context,
+            );
             "interrupt".to_string()
         }
     }
+}
+
+/// Every call this fuzz makes, so that **a failure of the transport is never mistaken for a
+/// failure of the debugger**.
+///
+/// A step's tool result is discarded on purpose — `bp` on an unresolvable symbol and a `break_in`
+/// for a run that has finished are ordinary, and the state left behind is what is checked. A
+/// top-level JSON-RPC error is not that. It means the request never reached a debugger: a schema
+/// that stopped deserializing after a `schemars` bump, a tool rmcp no longer routes, an internal
+/// error surfaced as `-32603`. Discarded along with the tool result, one of those leaves the
+/// session perfectly readable, every probe passing, and the fuzz green while a whole corpus entry
+/// has silently stopped doing anything — which is the same vacuity the `Gone` assertion exists to
+/// stop, arriving through the wire instead of through the walk.
+///
+/// It matters most **here** rather than in the tests above because this is the widest set of tools
+/// the harness drives from one place: nine of them, with argument shapes nothing else exercises.
+/// And transport hygiene is what this harness is *for* — it exists for the two moments a
+/// dependency moves and the spec revs, both of which change the bytes on the wire while the Rust
+/// API stays identical.
+fn fuzz_call(server: &mut Server, tool: &str, args: Value, context: &str) -> Value {
+    let response = server.call_tool(tool, args, TARGET_STEP);
+    assert!(
+        response["error"].is_null(),
+        "`{tool}` came back as a JSON-RPC error rather than as a tool result. That is a transport \
+         or schema failure rather than a debugger one, so it is a regression in what this harness \
+         exists for — and it would otherwise be discarded with the tool result and leave this run \
+         green. Drawn after: {context}\n{response}"
+    );
+    response
 }
 
 /// The invariant, asked of the session after every step.
@@ -5709,8 +5764,7 @@ fn fuzz_probe(
 /// Not [`Server::tool_data`] or [`Server::tool_failure`]: each asserts an outcome, and which
 /// outcome is right here is precisely the question.
 fn fuzz_road(server: &mut Server, tool: &str, args: Value) -> (Option<Held>, String) {
-    let response = server.call_tool(tool, args, TARGET_STEP);
-    assert_no_error(&response, &format!("tools/call {tool}"));
+    let response = fuzz_call(server, tool, args, "a probe of the session's state");
     let rendered = text_of(&response["result"]);
     if !is_tool_error(&response) {
         return (Some(Held::Holding), rendered);

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -5380,13 +5380,14 @@ fn a_randomised_command_sequence_leaves_the_session_in_one_state_and_the_server_
     if !launch_tier() {
         return;
     }
-    // **Why this seed.** Its walk reaches all three of [`Held`]'s states, which only one of them
-    // is asserted below — and it does so in about a second, where seed 1's takes twenty. Both
-    // halves are the seed's doing rather than the corpus's: how long a round lasts is decided by
-    // whether it draws an unbounded `g`, which runs the target to its own ending. So a corpus edit
-    // reshuffles the walk and may reshuffle both, and the assertion on `Gone` is what says so
-    // rather than leaving it to whoever notices the runtime.
-    let seed = fuzz_setting("WINDBG_MCP_SMOKE_FUZZ_SEED", 2);
+    // **Why this seed.** Its walk reaches all three of [`Held`]'s states, only one of which is
+    // asserted below — and it does so in about a second, where seed 1's takes twenty. Both halves
+    // are the seed's doing rather than the corpus's: how long a round lasts is decided by whether
+    // it draws an unbounded `g`, which runs the target to its own ending. So anything that
+    // reshuffles the walk — a corpus edit, or a change to `Rng::new` — reshuffles both, and this
+    // number is re-derived by scanning rather than kept. The assertion on `Gone` is what says a
+    // reshuffle cost coverage, instead of leaving it to whoever notices the runtime.
+    let seed = fuzz_setting("WINDBG_MCP_SMOKE_FUZZ_SEED", 3);
     let rounds = fuzz_setting("WINDBG_MCP_SMOKE_FUZZ_ROUNDS", 3);
     let steps = fuzz_setting("WINDBG_MCP_SMOKE_FUZZ_STEPS", 6);
     let replay = format!(
@@ -5758,8 +5759,29 @@ fn fuzz_road(server: &mut Server, tool: &str, args: Value) -> (Option<Held>, Str
 struct Rng(u64);
 
 impl Rng {
+    /// **The forbidden state is zero, not "even".**
+    ///
+    /// This was `seed | 1`, carried over from the example, and that quietly folded every even seed
+    /// onto the odd one above it: `2` and `3` were one run, `6` and `7` were one run, and half of
+    /// the seed space named nothing new. It is a defect *here* in a way it is not there, because
+    /// there the seed defaults to a nanosecond clock reading while here it is a small integer an
+    /// operator types while exploring — and the evidence was already in this branch's own seed
+    /// scan, where `2` and `3` both reported `{Moving: 3, Holding: 7, Gone: 2}` and `4` and `5`
+    /// both `{Holding: 1, Gone: 3}`. Two pairs of "different" runs, read past twice.
+    ///
+    /// Measured over the first 512 seeds, drawing a target and ten corpus steps each: `seed | 1`
+    /// gives **256** distinct walks, and this gives **512**. Running a SplitMix64 finalizer over
+    /// the seed first also gives 512 and was dropped — adjacent seeds already walk differently
+    /// without it, so it would be machinery bought with nothing.
+    ///
+    /// The one collision left is `0` against this constant, which is the state xorshift64* cannot
+    /// be given rather than a pair of ordinary seeds.
     fn new(seed: u64) -> Self {
-        Self(seed | 1)
+        Self(if seed == 0 {
+            0x243F_6A88_85A3_08D3
+        } else {
+            seed
+        })
     }
 
     fn next(&mut self) -> u64 {

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -64,7 +64,7 @@
 //!
 //! See `docs/smoke-test.md` for the runbook.
 
-use std::collections::VecDeque;
+use std::collections::{BTreeMap, VecDeque};
 use std::io::{BufRead, BufReader, Write};
 use std::panic::{AssertUnwindSafe, catch_unwind, resume_unwind};
 use std::process::{Child, ChildStdin, Command, Stdio};
@@ -5185,6 +5185,593 @@ fn ending_a_session_leaves_a_process_this_server_only_attached_to_running() {
     let _ = target.kill();
     let _ = target.wait();
     ran("the attach-teardown tier");
+}
+
+// ---- tier 2: the session fuzz -------------------------------------------------
+
+/// Every wait this fuzz issues, and the bound on every run it starts.
+///
+/// Short on purpose, and for dbgscope's reason: a resume that reaches no stop is a state worth
+/// generating rather than one to avoid, so the interesting draws are the ones that *reach* this
+/// bound. It also keeps a round to seconds.
+const FUZZ_WAIT_MS: u32 = 1_500;
+
+/// The two targets, and the difference between them is the point.
+///
+/// The short one is over on the first resume, so its exit races whatever is pumping it — issue
+/// [#242](https://github.com/glslang/windbg-mcp/issues/242)'s case. The long one outlives a
+/// bounded wait, so a resume with nothing to stop it is broken in and the session has to survive
+/// that repeatedly.
+///
+/// Ten seconds rather than [`LIVE_TARGET`]'s thirty, because this is what bounds the corpus's
+/// **unbounded** draws: a raw `execute { "command": "g" }` with no breakpoint armed runs until the
+/// target ends, and `raw_command` caps that at `EXEC_WAIT_MS` — a minute. The target's own
+/// lifetime is the shorter clock, and making it the shorter clock is what keeps an unlucky draw
+/// from costing the tier a minute.
+const FUZZ_TARGETS: &[&str] = &["cmd.exe /c exit", "cmd.exe /c ping -n 10 127.0.0.1"];
+
+/// One thing the fuzz can do to a session, named by the **tool** rather than by the command —
+/// which is the whole difference from the example this comes from.
+#[derive(Clone, Copy, Debug)]
+enum FuzzStep {
+    /// The raw hatch: `execute`, which is `Execute` and then `settle` inside the worker. Both
+    /// halves, because the bug they were written for lives in the seam between them.
+    Raw(&'static str),
+    /// A resume with an explicit bound, through `debug_batch`'s `resume` op — the same
+    /// `execute_and_wait` that `go` is built on, with a clock this test picks.
+    Bounded(&'static str),
+    /// The typed steps, which complete on their own next instruction on every architecture.
+    ///
+    /// `go` is deliberately **not** here: its wait is a fixed minute, so every draw of it would
+    /// run to the target's own ending, and what it adds over [`Self::Bounded`] is the argument
+    /// plumbing that
+    /// [`a_target_that_ends_during_a_resume_is_an_ending_and_the_session_says_so`] already pins.
+    Typed(&'static str),
+    /// `run_to_address`, the third wait, at a symbol that may or may not be reached.
+    RunTo(&'static str),
+    /// `continue_async`: the state the example cannot reach at all — a target moving with nobody
+    /// waiting for it, which is the supervisor's state machine rather than the engine's (#83).
+    Async,
+    /// `break_in` on the run in flight, which is the bound named per *job*.
+    BreakIn,
+    /// `wait_for_stop`, short enough to run out on a target that is not going to stop — running
+    /// out is a poll, not a cancellation, and the run has to survive it.
+    WaitStop,
+    /// `interrupt`, which names a *session* rather than a run and can therefore land on whatever
+    /// that session is doing.
+    Interrupt,
+}
+
+/// The corpus.
+///
+/// Deliberately not a grammar over command text — these are the shapes that have produced a state
+/// worth being in. The `Raw` half is dbgscope's, unchanged, because it is the half about the
+/// engine; everything below it is this server's own surface, and is what the example has no way
+/// to reach.
+const FUZZ_CORPUS: &[FuzzStep] = &[
+    FuzzStep::Raw("g"),
+    FuzzStep::Raw("p"),
+    FuzzStep::Raw("t"),
+    // Two resumes in one string: the second meets an engine that is already running, which is
+    // where DbgEng answers 0x8000FFFF and is *right* to.
+    FuzzStep::Raw("g; g"),
+    // Execution reached without a command name saying so — the reason none of the guards reads
+    // the text.
+    FuzzStep::Raw(".if (1) { g }"),
+    FuzzStep::Raw("bp ntdll!NtCreateFile \".echo FUZZ-HIT; g\""),
+    FuzzStep::Raw("bp ntdll!NtCreateFile"),
+    FuzzStep::Raw("bc *"),
+    FuzzStep::Raw("k 3"),
+    FuzzStep::Raw("r"),
+    FuzzStep::Raw("lm"),
+    FuzzStep::Raw(".lastevent"),
+    FuzzStep::Raw("sxe ld:ntdll.dll"),
+    // The four that take the target away, each by a different route: two immediately, one on the
+    // next resume, one by ending the debugger's session.
+    FuzzStep::Raw(".detach"),
+    FuzzStep::Raw(".kill"),
+    FuzzStep::Raw("q"),
+    FuzzStep::Raw("qd"),
+    FuzzStep::Bounded("g"),
+    FuzzStep::Bounded("gu"),
+    FuzzStep::Typed("step_over"),
+    FuzzStep::Typed("step_into"),
+    FuzzStep::RunTo("ntdll!NtCreateFile"),
+    FuzzStep::RunTo("ntdll!NtTerminateProcess"),
+    FuzzStep::Async,
+    FuzzStep::BreakIn,
+    FuzzStep::WaitStop,
+    FuzzStep::Interrupt,
+];
+
+/// What a session's target is doing, read from the outside — the fuzz's oracle.
+///
+/// **Ordered, and the order is load-bearing.** The example this comes from asks every road the
+/// same question and calls any disagreement a violation, which it can do because its two states
+/// are reached only by a step it took itself. Here a third state exists that ends *on its own*: a
+/// run bounded at [`FUZZ_WAIT_MS`] can stop between one road and the next, and a target can go
+/// away while it does. So the rule is that a probe's roads never move **back** down this scale —
+/// `stale_session` and then an answer is the half-dead session #242 is about, while an answer and
+/// then `stale_session` is a program that finished a millisecond ago.
+///
+/// It permits one transition that cannot happen (a stopped target cannot exit unasked, so
+/// `Holding` never becomes `Gone` inside a probe). Keeping the scale total is worth more than
+/// pinning that: the violation this exists to catch is a *decrease*, and no ordering hides one.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug)]
+enum Held {
+    /// A run is in flight. Every tool that reads the target is refused, and says which.
+    Moving,
+    /// Stopped, and answering.
+    Holding,
+    /// The handle names nothing this server will run a call against, on every road in. Terminal:
+    /// the round ends here.
+    ///
+    /// **Two paths, one state.** The target *ended* — the program ran to completion, or a command
+    /// released it — or the handle was **retired**, which is what a raw `execute` replacing or
+    /// releasing the target does to the handle naming it. They carry different sentences and the
+    /// same `stale_session`, and a caller holding the handle has the same move either way: release
+    /// it and open again. [`fuzz_road`] has what pinning them apart cost.
+    Gone,
+}
+
+/// A setting the soak run overrides and CI does not.
+fn fuzz_setting(name: &str, default: u64) -> u64 {
+    let Some(raw) = std::env::var_os(name) else {
+        return default;
+    };
+    raw.to_str()
+        .and_then(|text| text.trim().parse().ok())
+        .unwrap_or_else(|| panic!("{name} is set to {raw:?}, which is not a number"))
+}
+
+/// **dbgscope's `examples/session_fuzz.rs`, at this server's surface.**
+///
+/// That example drives randomised sequences straight at a `DebugEngine` and checks, after every
+/// one of them, the single property a session has to keep: it either still holds a target and
+/// answers, or it says it holds none. It was written because the three defects behind
+/// [#242](https://github.com/glslang/windbg-mcp/issues/242) were each found by hand, one sequence
+/// at a time, and none of them is about a *command* — they are about the state the previous
+/// command left the engine in, and the number of ways to reach a given state is larger than
+/// anyone enumerates. An alias, a `.if` branch and `dx …ExecuteCommand("g")` all reach execution
+/// without saying so, which is why the fixes ask the engine rather than reading the text.
+///
+/// **What this adds is everything between that engine and a caller**, which is where this repo's
+/// own near-misses have been:
+///
+/// - **A third state.** `continue_async` leaves a target moving with nobody waiting for it, and
+///   every read is then refused `target_running`. That state machine is the supervisor's (#83),
+///   the example has no way to reach it, and `CLAUDE.md` records three orderings inside it that
+///   shipped wrong once each.
+/// - **The category a refusal carries**, not just that it refused. `engine::engine_error`'s `_`
+///   arm folded "no target left" into `debugger` — the exact failure its own doc comment warns
+///   about — and a caller branching on that is told to change what it asked instead of to release
+///   the session. The engine has one way to say this; the mapping is ours.
+/// - **The supervisor and a sibling.** A wrecked worker must take nothing else down, which is
+///   what process-per-session is for and what no in-process test can state. The bystander session
+///   below is never touched by a step and is asked after every round.
+/// - **`end_session` reclaiming whatever was left** — a target moving, a target gone, an engine
+///   in whatever state a run of `Raw` draws found.
+///
+/// **The seed is fixed and the sequence is therefore one sequence.** A CI test that drew from the
+/// clock would fail on a sequence nobody could reproduce, which is worse than not running. What
+/// runs here is a short deterministic walk over the corpus on three real `dbgeng.dll`s; the fuzz
+/// proper is the soak, and it is the same test:
+///
+/// ```pwsh
+/// $env:WINDBG_MCP_SMOKE_DUMP = "1"
+/// $env:WINDBG_MCP_SMOKE_FUZZ_SEED = "7"
+/// $env:WINDBG_MCP_SMOKE_FUZZ_ROUNDS = "50"; $env:WINDBG_MCP_SMOKE_FUZZ_STEPS = "10"
+/// cargo test --test mcp_smoke -- --nocapture randomised
+/// ```
+///
+/// Run it after touching anything in the wait/settle/guard seam, or in the execution slot. A
+/// failing seed replays exactly, and the panic names it. That soak is the one measured rather
+/// than an illustration: on the x64 bench, 2026-08-31, it walked 173 probes across 50 rounds in
+/// 127s and reached `{Moving: 22, Holding: 104, Gone: 47}` clean.
+///
+/// **The sequence is accumulated rather than printed per step**, which is where this departs from
+/// the example's own advice. There it must print as it goes, because the failure it hunts kills
+/// the process it is running in and the last line on the terminal is the whole report. Here the
+/// process that can die is the *server*, and its death is already a readable panic from
+/// [`Server::await_id`] — so the sequence goes in the message instead, where a captured test run
+/// still shows it.
+#[test]
+fn a_randomised_command_sequence_leaves_the_session_in_one_state_and_the_server_serving() {
+    if !launch_tier() {
+        return;
+    }
+    // **Why this seed.** Its walk reaches all three of [`Held`]'s states, which only one of them
+    // is asserted below — and it does so in about a second, where seed 1's takes twenty. Both
+    // halves are the seed's doing rather than the corpus's: how long a round lasts is decided by
+    // whether it draws an unbounded `g`, which runs the target to its own ending. So a corpus edit
+    // reshuffles the walk and may reshuffle both, and the assertion on `Gone` is what says so
+    // rather than leaving it to whoever notices the runtime.
+    let seed = fuzz_setting("WINDBG_MCP_SMOKE_FUZZ_SEED", 2);
+    let rounds = fuzz_setting("WINDBG_MCP_SMOKE_FUZZ_ROUNDS", 3);
+    let steps = fuzz_setting("WINDBG_MCP_SMOKE_FUZZ_STEPS", 6);
+    let replay = format!(
+        "replay with WINDBG_MCP_SMOKE_FUZZ_SEED={seed} \
+         WINDBG_MCP_SMOKE_FUZZ_ROUNDS={rounds} WINDBG_MCP_SMOKE_FUZZ_STEPS={steps}"
+    );
+
+    let mut server = Server::started();
+    // The bystander, opened before anything is fuzzed and never named by a step. What it is for is
+    // the claim no engine-level test can make: one worker driven into any state at all leaves the
+    // supervisor serving, and leaves the *other* worker holding its own target.
+    let bystander = server.open_session(
+        "launch",
+        json!({ "command_line": LONG_LIVE_TARGET }),
+        TARGET_STEP,
+    );
+
+    let mut rng = Rng::new(seed);
+    let mut reached: BTreeMap<Held, u32> = BTreeMap::new();
+    for round in 1..=rounds {
+        let target = FUZZ_TARGETS[rng.below(FUZZ_TARGETS.len() as u64) as usize];
+        let session = server.open_session("launch", json!({ "command_line": target }), TARGET_STEP);
+        let mut sequence = vec![format!("launch {target}")];
+        let mut execution: Option<String> = None;
+
+        for _ in 0..steps {
+            let step = FUZZ_CORPUS[rng.below(FUZZ_CORPUS.len() as u64) as usize];
+            sequence.push(fuzz_step(&mut server, &session, step, &mut execution));
+            let held = fuzz_probe(&mut server, &session, round, &sequence, &replay);
+            *reached.entry(held).or_default() += 1;
+            if held == Held::Gone {
+                break;
+            }
+        }
+
+        // Whatever the sequence left — a target moving, a target gone, an engine any number of raw
+        // commands into a state nobody named — the session is reclaimable. `released` rather than
+        // the call succeeding: a teardown that killed the worker also "succeeds", and the
+        // difference between the two is a live kernel left halted.
+        fuzz_reclaim(&mut server, &session, round, &sequence, &replay);
+
+        // And the session that was never fuzzed still holds its own target.
+        let sibling = server.call_tool(
+            "registers",
+            json!({ "session_id": &bystander, "filter": "pc" }),
+            TARGET_STEP,
+        );
+        assert!(
+            !is_tool_error(&sibling),
+            "round {round} took the bystander session down with it after {}\n{replay}\n{}",
+            sequence.join(" -> "),
+            text_of(&sibling["result"])
+        );
+    }
+
+    server.call_tool(
+        "end_session",
+        json!({ "session_id": &bystander }),
+        TARGET_STEP,
+    );
+
+    // **Which states this walk actually reached**, and the assertion is the point rather than the
+    // print. Every check above is of the form "if the session is in state X it must say so", so a
+    // run that never left [`Held::Holding`] passes without having asked the question the fuzz
+    // exists for — the guard that refuses a session with no target is reached only by a draw that
+    // takes the target away. That is the same vacuity `ran` and `SKIPPED` are for, one level in:
+    // libtest cannot tell a walk that exercised the guard from one that never met it.
+    //
+    // Deterministic, because the seed is: a corpus edited until this seed no longer takes a target
+    // away fails here rather than quietly covering less. `Moving` is **not** asserted — it needs a
+    // `continue_async` draw whose run is still going one probe later, which is a race this test
+    // must not be the judge of, and the async surface has three tests of its own.
+    assert!(
+        reached.contains_key(&Held::Gone),
+        "no round reached a target that was gone, so nothing checked the refusal every road has \
+         to give — the corpus or the seed has drifted. States reached: {reached:?}\n{replay}"
+    );
+    ran(&format!(
+        "the session fuzz ({rounds} rounds, seed {seed}); states reached: {reached:?}"
+    ));
+}
+
+/// Releases the round's session, whatever the sequence left it in, and asserts it was **this**
+/// session that went.
+///
+/// **The by-handle call is not always enough, and finding that out is the first thing this fuzz
+/// did.** A raw `execute` that releases or replaces the target — `qd`, `q`, `.detach`, `.kill`,
+/// `.opendump` — *retires* the handle: `SessionState::Retired` refuses every call that supplies
+/// it while the worker stays live, so a call that named the session is refused and one that names
+/// none still reaches it (`a_retired_handle_is_refused_but_still_the_default_target`). That is by
+/// design and `end_session` is not exempt from it, so the recovery is the one the refusal names —
+/// omit the handle.
+///
+/// **Which is where a defect lives, measured on the release build 2026-08-31 and left alone here
+/// because a test is the wrong place to fix it** (`FOLLOWUPS.md` item 55). Two things do not line
+/// up. The `execute` that retires the handle appends "`end_session` releases it", and
+/// `end_session` with that handle is then refused — the server contradicting its own instruction.
+/// And "omit `session_id`" routes to the *current* session, which is the newest live one: with a
+/// newer session open, the retired one cannot be released by its owner at all. Measured with two
+/// launches, the older retired by `qd` — `end_session` by handle refused, the retired session
+/// reported `live: true, current: false` holding its own engine pid, and the newer one was what
+/// an un-handled `end_session` would have taken. It comes back only when everything newer has
+/// gone, or on a disconnect or a lease expiry. Until then it holds one of the four slots and a
+/// live target.
+///
+/// So this asserts what the server *does* guarantee — the session goes, by one road or the other,
+/// and the one that went is the one named — rather than the stronger claim the note in `execute`'s
+/// own output makes. If item 55 is taken, the fallback branch is what should stop being needed.
+fn fuzz_reclaim(server: &mut Server, session: &str, round: u64, sequence: &[String], replay: &str) {
+    let context = || format!("{}\n{replay}", sequence.join(" -> "));
+
+    let ended = server.call_tool("end_session", json!({ "session_id": session }), TARGET_STEP);
+    let report = &ended["result"]["structuredContent"];
+    if report["released"] == json!(true) {
+        return;
+    }
+    assert_eq!(
+        report["error"]["category"],
+        json!("stale_session"),
+        "round {round}: `end_session` neither released the session nor refused it as a handle \
+         that no longer names one, after {}\n{}",
+        context(),
+        text_of(&ended["result"])
+    );
+
+    // The retirement's own documented route. Guarded rather than trusted: it routes by *current*,
+    // so a version of this test where the round's session is not the newest would silently end
+    // the bystander instead and the assertion below is what would say so.
+    let anyway = server.call_tool("end_session", json!({}), TARGET_STEP);
+    let report = &anyway["result"]["structuredContent"];
+    assert_eq!(
+        report["released"],
+        json!(true),
+        "round {round}: the handle was retired and the route its refusal names did not release \
+         anything either, so the worker is stranded, after {}\n{}",
+        context(),
+        text_of(&anyway["result"])
+    );
+    assert_eq!(
+        report["session_id"],
+        json!(session),
+        "round {round}: releasing without a handle took a different session than the one this \
+         round opened, after {}\n{report}",
+        context()
+    );
+}
+
+/// Runs one step, and hands back how to describe it in a failure message.
+///
+/// Every result is discarded on purpose: a call failing is not a violation. `bp` on an
+/// unresolvable symbol, a `g` refused because the engine is already running, a `break_in` for a
+/// run that has finished and a `run_to_address` that never arrives are all ordinary. What is
+/// checked is the state left behind, by [`fuzz_probe`].
+fn fuzz_step(
+    server: &mut Server,
+    session: &str,
+    step: FuzzStep,
+    execution: &mut Option<String>,
+) -> String {
+    match step {
+        FuzzStep::Raw(command) => {
+            server.call_tool(
+                "execute",
+                json!({ "session_id": session, "command": command }),
+                TARGET_STEP,
+            );
+            format!("execute `{command}`")
+        }
+        FuzzStep::Bounded(command) => {
+            server.call_tool(
+                "debug_batch",
+                json!({
+                    "session_id": session,
+                    "steps": [{ "op": "resume", "command": command, "timeout_ms": FUZZ_WAIT_MS }],
+                    "timeout_ms": 20000,
+                }),
+                TARGET_STEP,
+            );
+            format!("batch resume `{command}`")
+        }
+        FuzzStep::Typed(tool) => {
+            server.call_tool(tool, json!({ "session_id": session }), TARGET_STEP);
+            tool.to_string()
+        }
+        FuzzStep::RunTo(symbol) => {
+            server.call_tool(
+                "run_to_address",
+                json!({
+                    "session_id": session,
+                    "address": symbol,
+                    "timeout_ms": FUZZ_WAIT_MS,
+                }),
+                TARGET_STEP,
+            );
+            format!("run_to_address {symbol}")
+        }
+        FuzzStep::Async => {
+            let started = server.call_tool(
+                "continue_async",
+                json!({ "session_id": session, "max_run_ms": FUZZ_WAIT_MS }),
+                TARGET_STEP,
+            );
+            // Kept only when one was minted. A refused `continue_async` — the slot is taken, the
+            // target is gone — must not overwrite the handle a later `break_in` is for, and a
+            // handle for a run that has since been *replaced* is exactly what `break_in`'s
+            // `Stale` answer is about, so an old one is worth keeping.
+            if let Some(handle) = started["result"]["structuredContent"]["execution"].as_str() {
+                *execution = Some(handle.to_string());
+            }
+            "continue_async".to_string()
+        }
+        FuzzStep::BreakIn | FuzzStep::WaitStop => {
+            let Some(handle) = execution.clone() else {
+                return format!("{step:?} (no run to name)");
+            };
+            let (tool, args) = if matches!(step, FuzzStep::BreakIn) {
+                (
+                    "break_in",
+                    json!({ "session_id": session, "execution": &handle }),
+                )
+            } else {
+                (
+                    "wait_for_stop",
+                    json!({
+                        "session_id": session,
+                        "execution": &handle,
+                        "timeout_ms": FUZZ_WAIT_MS,
+                    }),
+                )
+            };
+            server.call_tool(tool, args, TARGET_STEP);
+            format!("{tool} {handle}")
+        }
+        FuzzStep::Interrupt => {
+            server.call_tool("interrupt", json!({ "session_id": session }), TARGET_STEP);
+            "interrupt".to_string()
+        }
+    }
+}
+
+/// The invariant, asked of the session after every step.
+fn fuzz_probe(
+    server: &mut Server,
+    session: &str,
+    round: u64,
+    sequence: &[String],
+    replay: &str,
+) -> Held {
+    let violation = |what: &str| -> String {
+        format!(
+            "round {round}: {what}\n  sequence: {}\n  {replay}",
+            sequence.join(" -> ")
+        )
+    };
+
+    // Two roads that fail by different routes — `registers` through the engine's own interfaces,
+    // `execute` through `Execute` — because before #242 each said something different about one
+    // fact. `.echo` rather than `k`, since a target can legitimately be somewhere with no stack
+    // to walk while the session is perfectly healthy.
+    let mut held = Held::Moving;
+    for (tool, args) in [
+        (
+            "registers",
+            json!({ "session_id": session, "filter": "pc" }),
+        ),
+        (
+            "execute",
+            json!({ "session_id": session, "command": ".echo alive" }),
+        ),
+    ] {
+        let (road, why) = fuzz_road(server, tool, args);
+        let Some(road) = road else {
+            panic!("{}", violation(&why));
+        };
+        assert!(
+            road >= held,
+            "{}",
+            violation(&format!(
+                "`{tool}` said {road:?} after an earlier road said {held:?}, which is a session \
+                 answering on one road and refusing on another"
+            ))
+        );
+        held = road;
+    }
+    if held != Held::Gone {
+        return held;
+    }
+
+    // Gone, so every road in has to give the same answer — this is the half-dead session itself,
+    // and one road that still answers is the whole of it. Two more, and the reason they are only
+    // asked here is that a *healthy* session may refuse them for its own reasons.
+    for (tool, args) in [
+        ("backtrace", json!({ "session_id": session })),
+        (
+            "execute",
+            json!({ "session_id": session, "command": "k 3" }),
+        ),
+    ] {
+        let (road, why) = fuzz_road(server, tool, args);
+        assert_eq!(
+            road,
+            Some(Held::Gone),
+            "{}",
+            violation(&format!(
+                "the target is gone and `{tool}` did not say so: {why}"
+            ))
+        );
+    }
+    Held::Gone
+}
+
+/// One road into the session, and what it says the target is doing.
+///
+/// `None` is a violation rather than a state, and the second half of the pair says why — a
+/// category no session state explains. That is not hypothetical tidiness: the refusal for a target
+/// that has gone shipped as `debugger`, which tells a caller to change what it asked rather than
+/// to release the session, and only an assertion on the **category** could see it.
+///
+/// Not [`Server::tool_data`] or [`Server::tool_failure`]: each asserts an outcome, and which
+/// outcome is right here is precisely the question.
+fn fuzz_road(server: &mut Server, tool: &str, args: Value) -> (Option<Held>, String) {
+    let response = server.call_tool(tool, args, TARGET_STEP);
+    assert_no_error(&response, &format!("tools/call {tool}"));
+    let rendered = text_of(&response["result"]);
+    if !is_tool_error(&response) {
+        return (Some(Held::Holding), rendered);
+    }
+    let error = &response["result"]["structuredContent"]["error"];
+    match error["category"].as_str() {
+        Some("target_running") => (Some(Held::Moving), rendered),
+        Some("stale_session") => {
+            // The text half has to carry the refusal too, because a client that drops
+            // `structuredContent` sees only `isError` and this string — an empty one is a call
+            // that failed and said nothing.
+            //
+            // **Its wording is deliberately not pinned here, and the first draft pinned it.** It
+            // asserted #242's sentence, "no target left", which is what a target that *ended*
+            // gets — and the fuzz immediately drew `execute { "command": "qd" }`, which reaches
+            // the same terminal answer down the other road this server has: the raw hatch
+            // released the target, so the **handle is retired** and the refusal says so instead.
+            // Both are right, both are `stale_session`, and from a caller holding the handle they
+            // are one state with one next move. Which sentence belongs to which path is a
+            // targeted test's claim (see the ending tests above); a fuzz that pins prose across
+            // paths it did not enumerate is pinning renderings rather than contracts, and would
+            // fail on the next correct way to lose a target.
+            if rendered.trim().is_empty() {
+                (
+                    None,
+                    format!("`{tool}` refused with an empty message: {response}"),
+                )
+            } else {
+                (Some(Held::Gone), rendered)
+            }
+        }
+        other => (
+            None,
+            format!(
+                "`{tool}` failed with category {other:?}, which no session state explains: \
+                 {rendered}"
+            ),
+        ),
+    }
+}
+
+/// xorshift64*, so a seed replays a run and no dependency is added for it.
+///
+/// Randomness quality is beside the point: what the seed buys is a failing sequence someone else
+/// can reproduce, which a `HashMap`-ordering-style "random" would not.
+struct Rng(u64);
+
+impl Rng {
+    fn new(seed: u64) -> Self {
+        Self(seed | 1)
+    }
+
+    fn next(&mut self) -> u64 {
+        self.0 ^= self.0 >> 12;
+        self.0 ^= self.0 << 25;
+        self.0 ^= self.0 >> 27;
+        self.0.wrapping_mul(0x2545_F491_4F6C_DD1D)
+    }
+
+    fn below(&mut self, bound: u64) -> u64 {
+        self.next() % bound.max(1)
+    }
 }
 
 /// The same gate for a test that reads a **target's memory** rather than the structure of the dump


### PR DESCRIPTION
dbgscope's `examples/session_fuzz.rs` drives randomised command sequences straight at a
`DebugEngine` and checks, after every one of them, the single property a session has to keep: it
either still holds a target and answers, or it says it holds none. It exists because the three
defects behind [#242](https://github.com/glslang/windbg-mcp/issues/242) were each found by hand,
one sequence at a time, and none of them is about a *command* — they are about the state the
previous command left behind, and there are more ways to reach a given state than anyone
enumerates.

Everything between that engine and a caller was unfuzzed, and that is where this repo's own
near-misses have been. This brings it up to the tool surface as
`a_randomised_command_sequence_leaves_the_session_in_one_state_and_the_server_serving`, inside the
debugger tier — so it rides CI on all three of its `dbgeng.dll`s.

## What the port adds

The corpus is named by **tool** rather than by command, and four claims come with it that no
in-process test can make:

- **A third state.** `continue_async` leaves a target moving with nobody waiting for it, and reads
  are then refused `target_running`. That state machine is the supervisor's
  ([#83](https://github.com/glslang/windbg-mcp/issues/83)); `CLAUDE.md` records three orderings
  inside it that each shipped wrong once.
- **The category a refusal carries**, not merely that it refused. `engine::engine_error`'s `_` arm
  folded "no target left" into `debugger` once — the exact failure its own doc comment warns about
  — and a caller branching on that is told to change what it asked instead of to release the
  session.
- **A bystander session** on the same server, never named by a step and asked after every round.
  One worker driven into any state at all must leave the supervisor serving and the *other* worker
  holding its own target, which is what process-per-session is for.
- **Reclamation** of whatever the sequence left.

## The oracle is a scale, not an agreement

The one real departure from the example. It calls any disagreement between two roads a violation,
which it can do because both its states are reached only by a step it took itself. Here a run
bounded at 1.5s can stop **between** one road and the next, and a target can go away while it does
— so the rule is that a probe's roads never move *back* down `Moving → Holding → Gone`. A refusal
and then an answer is the half-dead session #242 is about; an answer and then a refusal is a
program that finished a millisecond ago.

## Why the seed is fixed, and what stops that being vacuous

A CI test drawing from the clock would fail on a sequence nobody could reproduce, which is worse
than not running. So what rides the tier is one short deterministic walk, and the fuzz proper is a
soak of the same test (`docs/smoke-test.md` has the command).

Every check is of the form "if the session is in state X it must say so", so a walk that never
left `Holding` would pass **without asking the question**. The run therefore prints the states it
reached and asserts it reached `Gone` — a corpus edit that reshuffles the walk fails there rather
than quietly covering less. `Moving` is reported and deliberately not asserted: it needs a run
still going one probe later, which is a race on a loaded runner.

Every resume carries an explicit bound and the long target lives ten seconds, which together keep
an unlucky draw from costing the tier a minute: `raw_command` caps an unbounded `g` at
`EXEC_WAIT_MS`, so the target's own lifetime has to be the shorter clock. `go` is not in the
corpus for that reason, and what it would add over the bounded path is already pinned by the two
ending tests.

## Measured

x64 bench, 2026-08-31:

| | |
| --- | --- |
| Tier cost of the default seed | ~50s → ~60s, and it reaches all three states |
| Default settings, five seeds | all pass |
| Soak, seed 7 | 173 probes over 50 rounds in 127s, clean — `{Moving: 22, Holding: 104, Gone: 47}` |
| `cargo test --test mcp_smoke` | 95 passed, tier off and tier on |
| fmt / clippy / markdownlint | clean |

## Two things it found

**One is this PR's.** The first draft pinned the terminal refusal's wording to #242's "no target
left", and the fuzz immediately drew `execute { "command": "qd" }` — which reaches the same
terminal answer down the *other* road this server has, retiring the handle and saying so instead.
Both are right and both are `stale_session`. Which sentence belongs to which path is a targeted
test's claim; a fuzz that pins prose across paths it did not enumerate is pinning renderings
rather than contracts. It now asserts the category and a non-empty message.

**One is not, and is left standing as `FOLLOWUPS.md` item 55** — a test is the wrong place to
decide what `end_session` should do about a handle the server has deliberately stopped honouring,
and there is a real argument for today's behaviour.

> **A retired handle cannot release its own session.** `end_session` resolves through
> `Sessions::resolve` like every other tool, so a handle retired by a raw `execute` is refused —
> while the `execute` that retired it appends "`end_session` releases it", and the refusal's own
> advice to omit `session_id` routes to the **newest** session. With anything newer open the
> retired one cannot be released by its owner at all: it holds one of the four slots and a live
> engine process until everything newer has gone, or a disconnect, or a lease expiry.

Measured through the shipped transport rather than read off the source: two launches, the older
retired by `qd`; `end_session` by handle refused, `session_status` reporting it
`live: true, current: false` with its own `engine_pid` while the newer one was `current: true`.
Item 55 carries both candidate fixes. `fuzz_reclaim` takes the documented fallback and asserts the
session that went is the one it named, so **its fallback branch is what should stop being needed**
if the item is taken.

## Also updated

`CLAUDE.md` (run the fuzz after touching the wait/settle/guard seam; pass count 94 → 95),
`docs/smoke-test.md` (tier table, a section on the fuzz, refreshed runtime figures),
`CHANGELOG.md`, `FOLLOWUPS.md` (item 55 and its header line).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WhhF5x9fE4bdd1jiKBvhNa
