### PR TITLE
A retired handle still names the session it opened

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A session handle that a raw `execute` retired can still end its own session.** `qd`, `q`,
+  `.detach`, `.kill` and `.opendump` release or replace the target, which *retires* the handle
+  naming that session: every later call supplying it is refused, while the worker stays live and
+  reachable by a call supplying none. `end_session` was not exempt, and two things did not line
+  up. The `execute` that retires the handle appends "`end_session` releases it", and `end_session`
+  with that handle was refused one call later — the server contradicting its own instruction. And
+  the recovery the refusal named, omitting `session_id`, routes to whichever session is *current*,
+  so with anything newer open it reached a different one. The retired session could then not be
+  released by its owner at all: it held one of the four sessions and a live engine process with a
+  live target until everything newer had gone, or a client disconnect, or a lease expiry.
+
+  A teardown does not touch the target retirement is about — it releases the **session**, which
+  the handle still names exactly — so it is now admitted, through a
+  `SessionState::accepts_teardown` of its own rather than a second caller of `accepts_default`,
+  whose set is the same today but whose question is different. Both places a handle is checked had
+  to widen together, the caller-side `Sessions::resolve` and the `Gate` at the front of the
+  session's queue; backing either half out alone was tried and fails the same way, because
+  widening one only moves the refusal to a place with no caller to explain it to.
+
+  The refusal's own text changed with it: it names `end_session` **with the handle in it** as the
+  recovery that always works, and mentions omitting `session_id` second and qualified — "only
+  while this is still your current session" — since unqualified it reads as a way back to this
+  target and is a way to act on another.
+
+  Found by the session fuzz added below, on the second seed it ran under, and covered by
+  `a_handle_a_raw_command_retired_can_still_end_its_own_session`. The second launch in that test
+  is the test rather than scenery: with one session open the retired one is still current, so an
+  un-handled `end_session` reaches it and the defect is invisible — which is why no
+  single-session test had ever seen it.
+
 ### Added
 
 - **A session fuzz in the debugger tier** — dbgscope's `examples/session_fuzz.rs` brought up to

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -212,7 +212,7 @@ It checks *same-file* fragments only, so a cross-file `../README.md#some-heading
 verify by hand.
 
 **The pass count does not say which tiers ran.** Each gate is inside its test, so the `mcp_smoke`
-harness reports the same **95 passed** with the debugger tier off as with it on — that harness's own
+harness reports the same **96 passed** with the debugger tier off as with it on — that harness's own
 result line, since a plain `cargo test` runs the crate's several hundred unit tests beside it and
 prints a result line per binary. What differs between the two runs is the runtime (measured on the
 ARM64 bench 2026-08-23: **1.6s against 61s** for `cargo test --test mcp_smoke`) and the `SKIPPED`
@@ -221,9 +221,10 @@ debugger claim. The count moves whenever a test is added — it was 69 until #19
 until item 37, 79 until the TTD tier, 84 until item 50's version-resource test, 85 until
 item 48's two endings, 87 until item 49's live 32-bit target, 88 until item 51's
 attach teardown, 89 until the 32-bit worker's version resource, 90 until #66's symbol-path default,
-91 until #83's two asynchronous-execution tests, 93 until #85's module-inventory refresh and 94
-until the session fuzz — and it said 83 while it was 84, 90 while it was 91, and 93 while it was
-94, which is the usual state of it, so re-derive it rather than trusting this sentence.
+91 until #83's two asynchronous-execution tests, 93 until #85's module-inventory refresh, 94 until
+the session fuzz and 95 until item 55's retired-handle teardown — and it said 83 while it was 84,
+90 while it was 91, and 93 while it was 94, which is the usual state of it, so re-derive it rather
+than trusting this sentence.
 
 **And a gate can be a *directory beside the exe*, which prints no `SKIPPED` line at all.** The
 debugger tier's `!analyze` assertions are inside `if analysis["ran"] == true`, and `ran` is false
@@ -760,8 +761,12 @@ nothing, which is why the run prints the states it reached and asserts it reache
 edit reshuffles the walk, so read that line rather than the green tick.
 
 It has already paid for itself: the second seed it ran under found that a handle the raw hatch has
-retired cannot release its own session, while the `execute` that retires it says `end_session` will
-(`FOLLOWUPS.md` item 55).
+retired could not release its own session, while the `execute` that retires it says `end_session`
+will. Fixed the same day (`FOLLOWUPS.md` item 55) — and worth reading before touching handle
+routing, because it is the case where the two gates a handle passes have to widen **together**:
+`Sessions::resolve` on the caller's side and `Gate::admits` at the front of the session's queue.
+Backing either half out alone was tried, and the end-to-end test fails identically both ways, since
+widening one only moves the refusal to a place with no caller to explain it to.
 
 **Its blocker moved rather than lifted, and which host it is about is the whole of the distinction.**
 Item 47 defers on "replay does not work on this host at all", and the sentence before it names the
@@ -1033,6 +1038,13 @@ A dump or a trace is closed. A live kernel is resumed and actively detached. A p
 terminated with the session. All of it happens inside dbgscope's `end_session`, from what the
 **opener** recorded — DbgEng cannot be asked, since `GetDebuggeeType` answers
 `DEBUG_USER_WINDOWS_PROCESS` for a launch and an attach alike.
+
+**And it accepts a handle no other tool will (`FOLLOWUPS.md` item 55).** A raw `execute` that
+replaces or releases the target *retires* the handle naming that session, and every other call
+supplying it is refused — but a teardown does not touch the target, it releases the **session**,
+which the handle still names exactly. That is `SessionState::accepts_teardown`, and it is widened
+in *both* the places a handle is checked (`Sessions::resolve_for_teardown` and `On::Teardown` at
+the front of the queue) because widening one alone only moves the refusal.
 
 **And it is per process, not per session**, which is where two rounds of review drove it. DbgEng
 holds several user-mode targets in one session (`|` lists them, saying `attach` or `create` against

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -60,7 +60,8 @@ and item 54 from
 [#85](https://github.com/glslang/windbg-mcp/issues/85)'s module-inventory refresh, whose engine
 call no watchdog in either crate can currently cut short (2026-08-30), and item 55 from bringing
 dbgscope's session fuzz up to this server's surface, where the second seed it was run under found
-that a handle the raw hatch has retired cannot release its own session (2026-08-31).
+that a handle the raw hatch has retired cannot release its own session (2026-08-31, and **landed**
+the same day).
 Each item notes its repo, why it was deferred, and where it picks up. See [`DECISIONS.md`](./DECISIONS.md) for the design rationale (D1–D5) items 1–6 extend,
 and the 2026-08-02 entries that items 13–14 and item 10 extend.
 
@@ -3731,7 +3732,7 @@ deadline.
 `DebugEngine::reload_symbols` and `Watchdog` in dbgscope's `src/dbgeng.rs`, and
 `execute_command_bounded` beside it for the shape a bounded direct call takes here.
 
-## 55. [windbg-mcp] A **retired** handle cannot release its own session
+## 55. [windbg-mcp] A **retired** handle cannot release its own session — **done** (2026-08-31)
 
 **What it is.** A raw `execute` that replaces or releases the target — `qd`, `q`, `.detach`,
 `.kill`, `.opendump` — retires the handle naming that session (`changes_debug_target` →
@@ -3776,7 +3777,40 @@ a side rather than patch a sentence.
 The first is what `execute`'s own output already tells a caller, so it is the one to take unless
 someone argues for the second.
 
+**What was done.** Both, because the second was not an alternative to the first once the first was
+taken — it is the sentence the fix leaves behind.
+
+`SessionState::accepts_teardown` is a third predicate beside `accepts_handle` and
+`accepts_default`, admitting the same set as the latter and answering a different question:
+retirement says the handle no longer names the *target* it was issued for, and a teardown does not
+touch the target — it releases the **session**, which the handle still names exactly. Its own
+predicate rather than a second caller of `accepts_default`, whose set is the same today, because a
+state that ever wants one without the other should be a change there rather than a surprise.
+
+**Both gates had to widen, and that is measured rather than reasoned.** There is a caller-side
+check (`Sessions::resolve`, now `resolve_for_teardown` beside it) and a queue-front one
+(`Gate::admits`, reached through the new `On::Teardown` and `Call::releasing`). Backing out either
+half alone was tried, and the end-to-end test fails identically both ways: widening only the
+resolve trades the refusal for the same refusal a moment later, from a place with no caller to
+explain it to. `a_teardown_gate_admits_exactly_what_a_teardown_resolve_does` is the unit-level
+join that says they agree on every state.
+
+The refusal text changed too. It now names `end_session` **with the handle in it** as the recovery
+that always works, and mentions omitting `session_id` second and *qualified* — "only while this is
+still your current session" — because unqualified it reads as a way back to this target and is a
+way to act on another.
+
+**Covered by `a_handle_a_raw_command_retired_can_still_end_its_own_session`**, and the second
+launch in it is the test rather than scenery: with one session open the retired one is still
+current, so an un-handled `end_session` reaches it and the defect is invisible. That is why the
+fuzz found this on its round teardown and no single-session test ever did. It asserts both
+directions — a tool that reads the target is *still* refused, so the widening did not delete the
+guarantee — and it was checked by backing the fix out, where it fails.
+
+`fuzz_reclaim` lost its fallback: a round that cannot release by name is now a regression rather
+than a documented detour, over a 50-round soak that draws every retiring command in the corpus.
+
 **Where it picks up.** `end_session` and `changes_debug_target` in `src/server.rs`,
-`SessionState::Retired` with `accepts_handle`/`accepts_default` and `Sessions::resolve` in
-`src/engine.rs`, and `fuzz_reclaim` in `tests/mcp_smoke.rs` — whose fallback branch is what should
-stop being needed.
+`SessionState::accepts_teardown` with `accepts_handle`/`accepts_default`, `On::Teardown`,
+`Call::releasing` and `Sessions::resolve_for_teardown` in `src/engine.rs`, and `fuzz_reclaim` in
+`tests/mcp_smoke.rs`.

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -19,7 +19,7 @@ adding the debugger tier takes it to ~60s, most of it two tests waiting out real
 grace, and a call staying silent long enough to have to report that it is still running.
 
 **The pass count is the same either way**, because each gate is inside its own test: `cargo test
---test mcp_smoke` reports the same number passed with the tier off as with it on — 95 on 2026-08-31,
+--test mcp_smoke` reports the same number passed with the tier off as with it on — 96 on 2026-08-31,
 against ~2s and ~60s respectively, but it moves whenever a test is added, so re-derive it rather
 than reading it here. (A plain `cargo test` runs the unit tests beside it and prints a result line
 per binary, so it is this harness's own line to read.) The runtime is what tells the two runs apart,
@@ -31,7 +31,7 @@ taken a second covered no debugger claim at all.
 | Tier | Gate | Needs | Catches |
 | --- | --- | --- | --- |
 | **Protocol** | always | no debugger, no target, and no network off this machine — it does bind a loopback port for the listener | transport, revision negotiation, tool-surface drift, and the listener's lease up to the point a session is opened |
-| **Debugger** | `WINDBG_MCP_SMOKE_DUMP=1` | `dbgeng.dll`, the checked-in sample dump, and a live user-mode target for the eight that want one — `cmd.exe` for the seven that launch, `ping` for the one that attaches | `dbgscope` / DbgEng regressions, a lease expiry releasing a real engine worker, driving execution on a live user-mode target synchronously and asynchronously, what ending a session does to it, and — over a seeded randomised sequence — that a session is always in one of its three states and never half-answering |
+| **Debugger** | `WINDBG_MCP_SMOKE_DUMP=1` | `dbgeng.dll`, the checked-in sample dump, and a live user-mode target for the nine that want one — `cmd.exe` for the eight that launch, `ping` for the one that attaches | `dbgscope` / DbgEng regressions, a lease expiry releasing a real engine worker, driving execution on a live user-mode target synchronously and asynchronously, what ending a session does to it, and — over a seeded randomised sequence — that a session is always in one of its three states and never half-answering |
 | **Bounded command** | `--ignored` | `dbgeng.dll`, the sample dump, ~1 minute | the watchdog wiring, which now spans two processes |
 | **Live kernel** | `--ignored` + `WINDBG_MCP_SMOKE_KERNEL` | a live kernel target you can freeze — KDNET, or serial | that a kernel attach *lands*, coexists, and is let go — by `end_session` and by a disconnect; and that a `debug_batch` which patches a byte of the running kernel puts it back |
 | **MessageManager CTF** | `--ignored` + live-kernel gate + `WINDBG_MCP_SMOKE_CTF=1` | the challenge VM, WinRM, full `nt` symbols | the real driver and retained `Tgsm` pool objects through the shipped MCP transport |
@@ -1018,10 +1018,15 @@ cargo test --test mcp_smoke -- --nocapture randomised
 Run it after touching anything in the wait/settle/guard seam, or in the execution slot. A failing
 seed replays exactly and the panic names it, with the sequence that got there.
 
-**It has already found one thing**, on the second seed it was run under: a handle the raw hatch has
-retired cannot release its own session, and the `execute` that retires it says otherwise in the same
-breath (`FOLLOWUPS.md` item 55). That is left standing rather than fixed — `fuzz_reclaim` takes the
-documented fallback and asserts the session that went is the one it named.
+**It has already found one thing**, on the second seed it was run under: a handle the raw hatch had
+retired could not release its own session, while the `execute` that retires it says otherwise in the
+same breath. Fixed the same day (`FOLLOWUPS.md` item 55), so `fuzz_reclaim` no longer has a
+fallback — however a round leaves its session, the handle that opened it ends it, and a round that
+cannot is a regression rather than a documented detour.
+`a_handle_a_raw_command_retired_can_still_end_its_own_session` is the targeted test that came out
+of it, and the second launch in it is the test rather than scenery: with one session open the
+retired one is still current, so an un-handled `end_session` reaches it and the defect is
+invisible. That is why the fuzz found this on its round teardown and no single-session test did.
 
 ## The bounded-command tier
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -405,6 +405,29 @@ impl SessionState {
         self.accepts_handle() || matches!(self, Self::Retired(_))
     }
 
+    /// May a call that names this session by handle **release** it?
+    ///
+    /// Broader than [`Self::accepts_handle`] by the same one state, and for a reason that is not
+    /// the same reason: retirement says the handle no longer names the *target* it was issued
+    /// for, and a teardown does not touch the target — it releases the **session**, which the
+    /// handle still names exactly.
+    ///
+    /// Refusing it was `FOLLOWUPS.md` item 55, found by the session fuzz. Two things did not line
+    /// up. A raw `execute` that retires a handle appends "`end_session` releases it" and
+    /// `end_session` with that handle was then refused, so the server contradicted its own
+    /// instruction one call later. And the recovery the refusal named — omit `session_id` — routes
+    /// to whichever session is *current*, so with anything newer open the retired one could not be
+    /// released by its owner at all: it held one of the four slots and a live engine process until
+    /// everything newer had gone, or a disconnect, or a lease expiry.
+    ///
+    /// Its own predicate rather than a second caller of [`Self::accepts_default`], whose set is
+    /// the same today. They answer different questions — "where does an unaddressed call go" and
+    /// "may this handle end its session" — and a state that ever wants one without the other
+    /// should be a change here rather than a surprise there.
+    fn accepts_teardown(&self) -> bool {
+        self.accepts_handle() || matches!(self, Self::Retired(_))
+    }
+
     /// Whether the session still owns a worker process.
     pub fn is_live(&self) -> bool {
         !matches!(self, Self::Failed(_) | Self::Closed(_))
@@ -1092,6 +1115,11 @@ enum On {
     /// A caller who supplied none, and so accepts whatever the current session holds — the
     /// behaviour from before handles existed.
     Default,
+    /// A caller who supplied `session_id` and is **releasing** the session rather than working
+    /// on its target. Admitted where [`Self::Handle`] is, plus a retired handle: retirement is
+    /// about the target the handle no longer names, and a teardown does not touch the target.
+    /// See [`SessionState::accepts_teardown`] and `FOLLOWUPS.md` item 55.
+    Teardown,
     /// The supervisor's own teardown. There is no handle to honour and no caller to protect, so
     /// it runs against a session already marked closed. Reclamation needs this: it has to mark
     /// its victim before releasing it, or two opens racing at the session limit both pick the
@@ -1124,6 +1152,7 @@ impl Gate {
         match self.on {
             On::Handle => state.accepts_handle(),
             On::Default => state.accepts_default(),
+            On::Teardown => state.accepts_teardown(),
             On::Supervisor => true,
         }
     }
@@ -1164,6 +1193,13 @@ impl Call {
     /// Records whether the caller supplied `session_id`; see [`On`].
     pub fn named(mut self, named: bool) -> Self {
         self.gate.on = if named { On::Handle } else { On::Default };
+        self
+    }
+
+    /// The same, for a call that **releases** the session rather than working on its target, so a
+    /// retired handle is still good enough to end what it names. See [`On::Teardown`].
+    fn releasing(mut self, named: bool) -> Self {
+        self.gate.on = if named { On::Teardown } else { On::Default };
         self
     }
 
@@ -1500,6 +1536,27 @@ impl Sessions {
     /// `end_session` — and recording at the funnel is what stops them, and the next one like
     /// them, from being missed.
     pub fn resolve(&self, supplied: Option<&str>) -> Result<Arc<Session>, EngineError> {
+        self.resolve_admitting(supplied, SessionState::accepts_handle)
+    }
+
+    /// [`Self::resolve`] for a call that **releases** the session rather than working on its
+    /// target, so a retired handle still resolves.
+    ///
+    /// Both halves have to agree: this is the caller-side check, and [`Call::releasing`] is the
+    /// same widening at the front of the queue. Widening one alone would trade the refusal here
+    /// for the same refusal a moment later, from a place with no caller to explain it to.
+    pub fn resolve_for_teardown(
+        &self,
+        supplied: Option<&str>,
+    ) -> Result<Arc<Session>, EngineError> {
+        self.resolve_admitting(supplied, SessionState::accepts_teardown)
+    }
+
+    fn resolve_admitting(
+        &self,
+        supplied: Option<&str>,
+        admits: fn(&SessionState) -> bool,
+    ) -> Result<Arc<Session>, EngineError> {
         let registry = self.registry();
         let caller = crate::client::current();
         let Some(want) = supplied else {
@@ -1522,7 +1579,7 @@ impl Sessions {
             Some(session) if session.owner != caller => {
                 Err(EngineError::Stale(unknown_handle(want)))
             }
-            Some(session) if session.state().accepts_handle() => {
+            Some(session) if admits(&session.state()) => {
                 crate::record::routed_to(&session.id);
                 Ok(session)
             }
@@ -2352,7 +2409,7 @@ impl Sessions {
     /// under process-per-session it costs nothing else.
     pub async fn end(&self, session: &Arc<Session>, named: bool) -> Result<Output, EngineError> {
         let call = Call::new(EngineOp::EndSession)
-            .named(named)
+            .releasing(named)
             .closing(END_SESSION_CLOSING);
         let outcome = self.release(session, call, END_SESSION_TIMEOUT).await;
         // Read before the rendering, from the outcome rather than from the message it produces:
@@ -3011,11 +3068,19 @@ fn stale_handle(want: &str, state: &SessionState) -> String {
             "session `{want}` never opened:\n  {why}\n\nOpening again is how you get a target — \
              but read the reason first, since some failures leave one behind."
         ),
+        // The recovery named here is the one that always works: `end_session` accepts a retired
+        // handle, because the handle still names the session even though it no longer names a
+        // target (`SessionState::accepts_teardown`). Omitting `session_id` is mentioned second
+        // and **qualified**, which was the other half of `FOLLOWUPS.md` item 55: it routes to
+        // whichever session is current, so with anything newer open it reaches a different one —
+        // advice that reads as a way back to this target and is a way to act on another.
         SessionState::Retired(why) => format!(
             "session handle `{want}` has been retired: {why}. The worker still holds a target, \
              but it is not the one this handle names, so the guarantee the handle buys no longer \
-             applies. Omit `session_id` to operate on it anyway, or open again for a handle that \
-             means something."
+             applies. Open again for a handle that means something, or `end_session \
+             {{ \"session_id\": \"{want}\" }}` to release this worker — that still takes this \
+             handle. Omitting `session_id` reaches the worker only while this is still your \
+             current session, so it is not a way back to it once you have opened another."
         ),
         SessionState::Closed(why) => format!(
             "session `{want}` is closed: {why}. Open a target again with open_dump / open_trace \
@@ -4330,11 +4395,18 @@ mod tests {
     /// only while its session can still make good on it, and the one state that parts company
     /// with that is `Retired` — the worker is alive, so a caller who asked for no guarantee
     /// still reaches it.
+    ///
+    /// **And a teardown is honoured there too** (`FOLLOWUPS.md` item 55). Retirement says the
+    /// handle no longer names the *target*; `end_session` does not touch the target, it releases
+    /// the session, which the handle still names exactly. Refused, a caller with anything newer
+    /// open could not release their own worker at all — omitting `session_id` reaches whichever
+    /// session is current, which is then a different one.
     #[test]
-    fn a_retired_handle_is_refused_but_still_the_default_target() {
+    fn a_retired_handle_is_refused_but_can_still_be_defaulted_to_and_ended() {
         let retired = SessionState::Retired("a raw command replaced the target".to_string());
         assert!(!retired.accepts_handle());
         assert!(retired.accepts_default());
+        assert!(retired.accepts_teardown());
         assert!(retired.is_live());
     }
 
@@ -4347,6 +4419,7 @@ mod tests {
         ] {
             assert!(state.accepts_handle(), "{state:?} should accept its handle");
             assert!(state.accepts_default());
+            assert!(state.accepts_teardown(), "{state:?} should be endable");
         }
     }
 
@@ -4358,7 +4431,39 @@ mod tests {
         ] {
             assert!(!state.accepts_handle(), "{state:?}");
             assert!(!state.accepts_default(), "{state:?}");
+            // A teardown is widened by exactly one state, not into "always". There is nothing
+            // left to release here, and answering a second `end_session` with a release would
+            // report work that did not happen.
+            assert!(!state.accepts_teardown(), "{state:?}");
             assert!(!state.is_live(), "{state:?}");
+        }
+    }
+
+    /// The gate at the front of the queue agrees with the caller-side resolve, on every state.
+    ///
+    /// Both have to widen together: widening one alone trades the refusal in `resolve` for the
+    /// same refusal a moment later from [`Gate`], which has no caller to explain it to. This is
+    /// the join that says they did.
+    #[test]
+    fn a_teardown_gate_admits_exactly_what_a_teardown_resolve_does() {
+        let gate = Gate {
+            on: On::Teardown,
+            retires: None,
+            closes: None,
+        };
+        for state in [
+            SessionState::Opening,
+            SessionState::Attaching,
+            SessionState::Open,
+            SessionState::Retired("`.opendump`".to_string()),
+            SessionState::Failed("boom".to_string()),
+            SessionState::Closed("ended".to_string()),
+        ] {
+            assert_eq!(
+                gate.admits(&state),
+                state.accepts_teardown(),
+                "the queue-front gate and the caller-side check disagree about {state:?}"
+            );
         }
     }
 
@@ -4372,7 +4477,17 @@ mod tests {
 
         let retired = stale_handle("sess-1", &SessionState::Retired("`.opendump`".to_string()));
         assert!(retired.contains("retired"), "{retired}");
-        assert!(retired.contains("Omit `session_id`"), "{retired}");
+        // It names the recovery that always works, and names the handle in it — a retired handle
+        // still ends its own session. It used to offer "Omit `session_id`" unqualified, which
+        // routes to whichever session is current and is therefore a way to act on a *different*
+        // one (`FOLLOWUPS.md` item 55).
+        assert!(retired.contains("end_session"), "{retired}");
+        assert!(retired.contains("sess-1"), "{retired}");
+        assert!(
+            retired.contains("only while this is still your current session"),
+            "the fallback has to carry its condition, or it reads as a way back to this \
+             target: {retired}"
+        );
 
         let closed = stale_handle("sess-1", &SessionState::Closed("ended".to_string()));
         assert!(closed.contains("closed"), "{closed}");

--- a/src/server.rs
+++ b/src/server.rs
@@ -3762,7 +3762,11 @@ impl WindbgServer {
         Parameters(args): Parameters<SessionArgs>,
     ) -> Result<CallToolResult, ErrorData> {
         let session_id = args.session_id.as_deref();
-        let session = match self.sessions.resolve(session_id) {
+        // `resolve_for_teardown`, not `resolve`: a **retired** handle still names this session,
+        // and releasing a session is not touching the target retirement is about. Refusing it was
+        // `FOLLOWUPS.md` item 55 — with anything newer open, a caller whose handle a raw
+        // `execute` had retired could not release their own worker at all.
+        let session = match self.sessions.resolve_for_teardown(session_id) {
             Ok(session) => session,
             Err(e) => return engine_result_for(session_id, Err(e)),
         };

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -5187,6 +5187,105 @@ fn ending_a_session_leaves_a_process_this_server_only_attached_to_running() {
     ran("the attach-teardown tier");
 }
 
+/// **`FOLLOWUPS.md` item 55: a handle a raw command retired can still end its own session.**
+///
+/// A raw `execute` that replaces or releases the target — `qd`, `q`, `.detach`, `.kill`,
+/// `.opendump` — retires the handle naming that session, and retirement refuses every call that
+/// supplies it. `end_session` was not exempt, so two things did not line up: the `execute` that
+/// retired the handle appends "`end_session` releases it", and `end_session` with that handle was
+/// refused one call later; and the recovery the refusal named, omitting `session_id`, routes to
+/// whichever session is **current**. With anything newer open that is a different session, so the
+/// retired one could not be released by its owner at all — it held one of the four slots and a
+/// live engine process until everything newer had gone, or a disconnect, or a lease expiry.
+///
+/// **The second launch is the test, not scenery.** With one session open the retired one is still
+/// current, so an un-handled `end_session` reaches it and the defect is invisible; it takes a
+/// newer session to make the handle the only way back. That is why the fuzz found this on its
+/// round teardown and no single-session test ever did.
+///
+/// Both directions are asserted, because widening the wrong amount passes half of this. A tool
+/// that reads the **target** is still refused — retirement is doing its job, and a fix that let
+/// everything through would have deleted the guarantee rather than the defect — while the
+/// teardown goes through, because the handle still names the *session* whatever became of its
+/// target.
+#[test]
+fn a_handle_a_raw_command_retired_can_still_end_its_own_session() {
+    if !launch_tier() {
+        return;
+    }
+    let mut server = Server::started();
+    let retired = server.open_session(
+        "launch",
+        json!({ "command_line": LIVE_TARGET }),
+        TARGET_STEP,
+    );
+    // Opened *after*, so the session under test is not the current one and `end_session {}` would
+    // reach this instead. Without it this test passes on the unfixed server.
+    let newer = server.open_session(
+        "launch",
+        json!({ "command_line": LIVE_TARGET }),
+        TARGET_STEP,
+    );
+
+    // `qd` — quit and detach — releases the target through the raw hatch, which is what retires
+    // the handle.
+    let released = server.call_tool(
+        "execute",
+        json!({ "session_id": &retired, "command": "qd" }),
+        TARGET_STEP,
+    );
+    assert!(
+        !is_tool_error(&released),
+        "`qd` through the raw hatch reported a failure: {}",
+        text_of(&released["result"])
+    );
+
+    // Retirement still bites for ordinary work, and the refusal names the recovery that works.
+    let refused = server.call_tool("registers", json!({ "session_id": &retired }), TARGET_STEP);
+    let said = text_of(&refused["result"]);
+    assert!(
+        is_tool_error(&refused),
+        "a retired handle answered a call that reads its target: {said}"
+    );
+    assert!(
+        said.contains("end_session"),
+        "the refusal must name the recovery that still takes this handle: {said}"
+    );
+
+    // And the claim. `released` rather than the call merely succeeding: a teardown that killed the
+    // worker also "succeeds", and the difference is what this whole area is about.
+    let ended = server.tool_data(
+        "end_session",
+        json!({ "session_id": &retired }),
+        TARGET_STEP,
+    );
+    assert_eq!(
+        ended["released"],
+        json!(true),
+        "a retired handle could not release its own session, so its worker is stranded behind the \
+         newer one: {ended}"
+    );
+    assert_eq!(
+        ended["session_id"],
+        json!(&retired),
+        "the teardown released a different session than the handle named: {ended}"
+    );
+
+    // The newer session is untouched — this released one worker, not whichever was current.
+    let sibling = server.call_tool(
+        "registers",
+        json!({ "session_id": &newer, "filter": "pc" }),
+        TARGET_STEP,
+    );
+    assert!(
+        !is_tool_error(&sibling),
+        "ending the retired session took the newer one with it: {}",
+        text_of(&sibling["result"])
+    );
+    server.call_tool("end_session", json!({ "session_id": &newer }), TARGET_STEP);
+    ran("the retired-handle teardown");
+}
+
 // ---- tier 2: the session fuzz -------------------------------------------------
 
 /// Every wait this fuzz issues, and the bound on every run it starts.
@@ -5484,70 +5583,42 @@ fn a_randomised_command_sequence_leaves_the_session_in_one_state_and_the_server_
 /// Releases the round's session, whatever the sequence left it in, and asserts it was **this**
 /// session that went.
 ///
-/// **The by-handle call is not always enough, and finding that out is the first thing this fuzz
-/// did.** A raw `execute` that releases or replaces the target — `qd`, `q`, `.detach`, `.kill`,
-/// `.opendump` — *retires* the handle: `SessionState::Retired` refuses every call that supplies
-/// it while the worker stays live, so a call that named the session is refused and one that names
-/// none still reaches it (`a_retired_handle_is_refused_but_still_the_default_target`). That is by
-/// design and `end_session` is not exempt from it, so the recovery is the one the refusal names —
-/// omit the handle.
+/// **This used to need a fallback, and the fallback is what the fuzz was really reporting.** A raw
+/// `execute` that releases or replaces the target — `qd`, `q`, `.detach`, `.kill`, `.opendump` —
+/// *retires* the handle, and retirement refuses every call that supplies it. `end_session` was not
+/// exempt, so a round that drew one of those could not release its session by name; this asked
+/// again without the handle, which routes to whichever session is **current** and only worked here
+/// because the round's session happened to be the newest. That was `FOLLOWUPS.md` item 55, and it
+/// is fixed: a retired handle still names the session even though it no longer names a target, so
+/// `SessionState::accepts_teardown` admits it and there is one road again.
 ///
-/// **Which is where a defect lives, measured on the release build 2026-08-31 and left alone here
-/// because a test is the wrong place to fix it** (`FOLLOWUPS.md` item 55). Two things do not line
-/// up. The `execute` that retires the handle appends "`end_session` releases it", and
-/// `end_session` with that handle is then refused — the server contradicting its own instruction.
-/// And "omit `session_id`" routes to the *current* session, which is the newest live one: with a
-/// newer session open, the retired one cannot be released by its owner at all. Measured with two
-/// launches, the older retired by `qd` — `end_session` by handle refused, the retired session
-/// reported `live: true, current: false` holding its own engine pid, and the newer one was what
-/// an un-handled `end_session` would have taken. It comes back only when everything newer has
-/// gone, or on a disconnect or a lease expiry. Until then it holds one of the four slots and a
-/// live target.
-///
-/// So this asserts what the server *does* guarantee — the session goes, by one road or the other,
-/// and the one that went is the one named — rather than the stronger claim the note in `execute`'s
-/// own output makes. If item 55 is taken, the fallback branch is what should stop being needed.
+/// Which makes this the assertion the fuzz wanted in the first place — **however the sequence left
+/// the session, the handle that opened it ends it** — and it is deliberately not written to accept
+/// a refusal any more. A round that cannot release by name is now a regression rather than a
+/// documented detour.
 fn fuzz_reclaim(server: &mut Server, session: &str, round: u64, sequence: &[String], replay: &str) {
-    let context = || format!("{}\n{replay}", sequence.join(" -> "));
+    let context = format!("{}\n{replay}", sequence.join(" -> "));
 
     let ended = fuzz_call(
         server,
         "end_session",
         json!({ "session_id": session }),
-        &context(),
+        &context,
     );
     let report = &ended["result"]["structuredContent"];
-    if report["released"] == json!(true) {
-        return;
-    }
-    assert_eq!(
-        report["error"]["category"],
-        json!("stale_session"),
-        "round {round}: `end_session` neither released the session nor refused it as a handle \
-         that no longer names one, after {}\n{}",
-        context(),
-        text_of(&ended["result"])
-    );
-
-    // The retirement's own documented route. Guarded rather than trusted: it routes by *current*,
-    // so a version of this test where the round's session is not the newest would silently end
-    // the bystander instead and the assertion below is what would say so.
-    let anyway = fuzz_call(server, "end_session", json!({}), &context());
-    let report = &anyway["result"]["structuredContent"];
+    // `released` rather than the call succeeding: a teardown that killed the worker also
+    // "succeeds", and the difference between the two is a live kernel left halted.
     assert_eq!(
         report["released"],
         json!(true),
-        "round {round}: the handle was retired and the route its refusal names did not release \
-         anything either, so the worker is stranded, after {}\n{}",
-        context(),
-        text_of(&anyway["result"])
+        "round {round}: the handle that opened this session could not release it, after {context}\n{}",
+        text_of(&ended["result"])
     );
     assert_eq!(
         report["session_id"],
         json!(session),
-        "round {round}: releasing without a handle took a different session than the one this \
-         round opened, after {}\n{report}",
-        context()
+        "round {round}: the teardown released a different session than the handle named, after \
+         {context}\n{report}"
     );
 }
 


### PR DESCRIPTION
Closes `FOLLOWUPS.md` item 55, which the session fuzz found in #268 and which was left standing
there because a test is the wrong place to decide what `end_session` should do about a handle the
server has deliberately stopped honouring.

## The defect

A raw `execute` that replaces or releases the target — `qd`, `q`, `.detach`, `.kill`, `.opendump`
— *retires* the handle naming that session. Every later call supplying it is refused, while the
worker stays live and reachable by a call supplying none. `end_session` was not exempt, and two
things did not line up:

- the `execute` that retires the handle appends **"`end_session` releases it"**, and `end_session`
  with that handle was refused one call later — the server contradicting its own instruction;
- the recovery that refusal named, *omit `session_id`*, routes to whichever session is **current**,
  so with anything newer open it reached a different one.

The retired session could then not be released by its owner at all. It held one of the four
sessions and a live engine process with a live target until everything newer had gone, or a client
disconnect, or a lease expiry.

## The fix

A teardown does not touch the target retirement is about — it releases the **session**, which the
handle still names exactly. So `SessionState::accepts_teardown` admits it.

It is a predicate of its own rather than a second caller of `accepts_default`, whose set is
identical today. They answer different questions — *where does an unaddressed call go* against *may
this handle end its session* — and a state that ever wants one without the other should be a change
there rather than a surprise here.

**Both places a handle is checked had to widen, and that is measured rather than reasoned.** There
is a caller-side check (`Sessions::resolve`, now `resolve_for_teardown` beside it) and a queue-front
one (`Gate::admits`, via the new `On::Teardown` and `Call::releasing`). Backing out either half
alone was tried, and the end-to-end test fails identically both ways — widening one only moves the
refusal to a place with no caller to explain it to.
`a_teardown_gate_admits_exactly_what_a_teardown_resolve_does` is the unit-level join that says they
agree on every state, so a future divergence is a failure rather than a discovery.

The refusal's text changed with it, which was item 55's other half. It names `end_session` **with
the handle in it** as the recovery that always works, and mentions omitting `session_id` second and
*qualified* — "only while this is still your current session" — because unqualified it reads as a
way back to this target and is a way to act on another.

## How it is covered

`a_handle_a_raw_command_retired_can_still_end_its_own_session`. **The second launch in it is the
test rather than scenery**: with one session open the retired one is still current, so an un-handled
`end_session` reaches it and the defect is invisible. That is why the fuzz found this on its round
teardown and no single-session test ever did.

Both directions are asserted, because widening the wrong amount passes half of it — a tool that
reads the *target* is still refused, so the guarantee retirement buys is intact.

Checked by backing the fix out, where it fails; and again with only one of the two gates restored,
where it fails the same way.

`fuzz_reclaim` loses its fallback: however a round leaves its session, the handle that opened it
ends it, and a round that cannot is now a regression rather than a documented detour.

## Verified

| | |
| --- | --- |
| `cargo test` | 635 unit + **96** smoke, tier on and off |
| Fuzz soak, 50 rounds seed 7 | `{Moving: 22, Holding: 104, Gone: 47}` in 127.2s — 47 rounds ended with the target gone, every one released **by name** |
| fmt / clippy / markdownlint | clean |

Docs updated: `FOLLOWUPS.md` (item 55 closed, with what was done and why both gates), `CLAUDE.md`
(the `end_session` section and the fuzz section), `docs/smoke-test.md`, `CHANGELOG.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WhhF5x9fE4bdd1jiKBvhNa
