### PR TITLE
fix: a session no longer opens a console window on the desktop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A session no longer opens a console window on the desktop.** Windows gives a console-subsystem
+  child of a console-*less* parent a brand-new, *visible* console — and a GUI MCP client starts a
+  stdio server without one — so every engine worker this server spawned put a window on the desktop,
+  titled with the exe's path and taking the foreground as it appeared. At the rate a model opens and
+  ends sessions (`MAX_SESSIONS` is 4, so a fifth open reclaims one) that is a machine nobody can
+  work at, which is [#273](https://github.com/glslang/windbg-mcp/issues/273). The worker and the
+  `TTD.exe` recorder are now spawned with `CREATE_NO_WINDOW`.
+
+  **Only when this process has no console of its own**, which is not a refinement but the whole of
+  it. The flag does not suppress a console — it suppresses the *window*, by giving the child a
+  console of its own — and a worker's stderr is *inherited*. A console handle passed to a process
+  attached to a different console is re-bound to that one: measured here, such a child's write
+  reports success, bytes written and no error, and the text lands in its own invisible console
+  rather than in the terminal. Applied unconditionally the flag would therefore delete every worker
+  log line from a terminal-run server, silently, and make the log ring's "they are still on the
+  server's stderr" untrue. So it goes on exactly where it changes something: with no console there
+  is nothing to inherit and nothing for stderr to lose (a pipe or a file is inherited unchanged),
+  and with one the worker shares it and opens no window anyway. `attached_to_a_console` asks
+  `GetConsoleProcessList` rather than `GetConsoleWindow`, which answers "no console" for a ConPTY —
+  Windows Terminal, and this repo's own harness — and would apply the flag to a worker holding a
+  live console handle.
+
+  Two assertions, and the unconditional version fails both: `engine.rs` checks that a child spawned
+  with a worker's flags **joins this process's console**, and the debugger tier checks the same of a
+  real session's engine pid, read from `session_status`. A *debuggee* launched by `launch` gets its
+  window from DbgEng rather than from here; that is
+  [dbgscope#129](https://github.com/glslang/dbgscope/issues/129), fixed there.
+
 - **A session handle that a raw `execute` retired can still end its own session.** `qd`, `q`,
   `.detach`, `.kill` and `.opendump` release or replace the target, which *retires* the handle
   naming that session: every later call supplying it is refused, while the worker stays live and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -212,7 +212,7 @@ It checks *same-file* fragments only, so a cross-file `../README.md#some-heading
 verify by hand.
 
 **The pass count does not say which tiers ran.** Each gate is inside its test, so the `mcp_smoke`
-harness reports the same **97 passed** with the debugger tier off as with it on — that harness's own
+harness reports the same **99 passed** with the debugger tier off as with it on — that harness's own
 result line, since a plain `cargo test` runs the crate's several hundred unit tests beside it and
 prints a result line per binary. What differs between the two runs is the runtime (measured on the
 ARM64 bench 2026-08-23: **1.6s against 61s** for `cargo test --test mcp_smoke`) and the `SKIPPED`
@@ -222,10 +222,10 @@ until item 37, 79 until the TTD tier, 84 until item 50's version-resource test, 
 item 48's two endings, 87 until item 49's live 32-bit target, 88 until item 51's
 attach teardown, 89 until the 32-bit worker's version resource, 90 until #66's symbol-path default,
 91 until #83's two asynchronous-execution tests, 93 until #85's module-inventory refresh, 94 until
-the session fuzz, 95 until item 55's retired-handle teardown and 96 until item 14's watchdog-cost
-guard — and it said 83 while it was 84,
-90 while it was 91, and 93 while it was 94, which is the usual state of it, so re-derive it rather
-than trusting this sentence.
+the session fuzz, 95 until item 55's retired-handle teardown, 96 until item 14's watchdog-cost
+guard and 98 until #273's worker-console assertion — and it said 83 while it was 84,
+90 while it was 91, 93 while it was 94, and 97 while it was 98, which is the usual state of it, so
+re-derive it rather than trusting this sentence.
 
 **And a gate can be a *directory beside the exe*, which prints no `SKIPPED` line at all.** The
 debugger tier's `!analyze` assertions are inside `if analysis["ran"] == true`, and `ran` is false
@@ -1086,6 +1086,71 @@ Four things to know before touching this.
 Keeping a `launch`ed process alive past its session is a real request and is **not** built: it is a
 question about the tool surface (an argument on `launch` or on `end_session`), not about a flag, and
 nothing has asked for it yet.
+
+## The console a spawned child is given (`engine::without_a_console_window`)
+
+**A console-subsystem child of a console-*less* parent gets a brand-new, visible console**, and a
+GUI MCP client starts a stdio server without a console — so until #273 every worker spawn put a
+window on the desktop, titled with the exe's path, taking the foreground as it appeared. Measured
+here, both halves: a plain child of a console-less parent comes back with a window handle and the
+title `C:\WINDOWS\system32\cmd.exe`, and the same child under `CREATE_NO_WINDOW` comes back with
+none.
+
+**The flag is conditional, and that is the whole of the change rather than a nicety.**
+`CREATE_NO_WINDOW` does not suppress a console — it suppresses the *window*, by giving the child a
+console of its **own** — and a worker's stderr is inherited. A console handle handed to a process
+attached to a different console is re-bound to that one: measured, the child's `WriteFile` reports
+success with bytes written and no error, and the text lands in its own invisible console instead of
+the terminal, while a child that inherits the console writes where the operator is looking.
+Unconditional, the flag therefore deletes every worker log line from a terminal-run server —
+silently, and against the workflow this file documents ("leave stderr inherited; it lands in your
+terminal") — and makes `logbridge`'s "they are still on the server's stderr" untrue. So it goes on
+exactly where it changes something.
+
+Four things to know before touching it.
+
+- **The flag gives the child a console, and the docs say otherwise.** `CREATE_NO_WINDOW`'s own
+  documentation — "the console handle for the application is not set" — reads as *no console*, and
+  a reviewer will read it that way. Measured against a probe that allocates none of its own (a
+  reading taken through `powershell.exe` does not count; a console host may allocate one):
+  `CREATE_NO_WINDOW` leaves the child alone in a console of its own with no window and console
+  APIs working, while `DETACHED_PROCESS` is the flag that leaves it with none —
+  `GetConsoleProcessList` failing `ERROR_INVALID_HANDLE`, `GetConsoleCP` zero, no standard
+  handles. The four-flag table is in the dbgscope commit that added its `mode con` assertion,
+  which is where the same doubt was raised as a P1 review finding.
+- **`GetConsoleWindow` is the wrong question**, and it is the one everybody reaches for. A console
+  with no window is ordinary: a ConPTY has none — Windows Terminal, and this repo's own test
+  harness, where the call answers 0 for a process attached to a live console with three processes
+  in it — and neither has a console created by `CREATE_NO_WINDOW` one level up. It would apply the
+  flag to precisely the worker whose stderr would then be lost. `GetConsoleProcessList` answers the
+  question actually being asked, and returns 0 with `ERROR_INVALID_HANDLE` where there is no
+  console (measured from a GUI-subsystem process, which Windows gives none).
+- **A test that only looks for a window waves the unconditional version through**, since it opens
+  none either. So both tests assert the child **joined this process's console** —
+  `engine::tests::a_worker_shares_this_processs_console_or_gets_a_windowless_one` on a stand-in
+  spawned with a worker's flags, and `mcp_smoke`'s `a_session_worker_opens_no_console_window_of_its_own`
+  on a real session's `engine_pid`. Both fail against the unconditional flag; that was checked by
+  making the change and running them.
+- **The host decides which branch runs, so test the one you are not on.** A host spawning the
+  server with `CREATE_NO_WINDOW` (node's `windowsHide`) leaves it a *hidden console*, so the worker
+  inherits and the bug never appears; one spawning it with `DETACHED_PROCESS` (node's `detached`)
+  leaves it console-less, which is the reported case. A stand-in host for this is 30 lines and is
+  the only way to see either from a terminal, where everything has a console and nothing reproduces.
+
+**A `launch`ed debuggee's window comes from somewhere else** — dbgscope's `CreateProcessWide`, which
+passed `CREATE_NEW_CONSOLE` and now passes `CREATE_NO_WINDOW`
+([dbgscope#129](https://github.com/glslang/dbgscope/issues/129)). Unconditional there, and rightly:
+the debuggee must *never* inherit this process's console, because its stdout would then be the MCP
+channel — measured, with a `STARTUPINFO` carrying no `STARTF_USESTDHANDLES`, which is the shape
+DbgEng uses. The only question there was whether that console is on the desktop.
+
+**And a service is a third answer to the same problem, at the deployment layer.** A service runs in
+**session 0** (measured on this host: every service process is `SessionId 0` against an interactive
+shell's 2), which has no interactive window station — so nothing the server tree opens can reach the
+desktop or take the foreground, including windows from processes this repo does not control: a GUI
+debuggee, an extension DLL, `TTD.exe`'s target. It is not a substitute for the flags, since it also
+means a launched debuggee cannot interact with the desktop and `--listen` moves the transport off
+stdio; it is what to reach for when something *else* starts opening windows.
 
 ## A worker of the target's architecture (`src/target.rs`, `engine::worker_images`)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,7 +164,7 @@ dependencies = [
 [[package]]
 name = "dbgscope"
 version = "0.1.0"
-source = "git+https://github.com/glslang/dbgscope?rev=879cbb1f5a5b15a0cdeaca41930c1420ea32b24a#879cbb1f5a5b15a0cdeaca41930c1420ea32b24a"
+source = "git+https://github.com/glslang/dbgscope?rev=c97d70f27bfbddab016fa9448d4096b84592ff8c#c97d70f27bfbddab016fa9448d4096b84592ff8c"
 dependencies = [
  "hex",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,7 +164,7 @@ dependencies = [
 [[package]]
 name = "dbgscope"
 version = "0.1.0"
-source = "git+https://github.com/glslang/dbgscope?rev=c97d70f27bfbddab016fa9448d4096b84592ff8c#c97d70f27bfbddab016fa9448d4096b84592ff8c"
+source = "git+https://github.com/glslang/dbgscope?rev=7d77c72444679a23981cecef03efa979847e371d#7d77c72444679a23981cecef03efa979847e371d"
 dependencies = [
  "hex",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/glslang/windbg-mcp"
 license = "MIT"
 
 [dependencies]
-dbgscope = { git = "https://github.com/glslang/dbgscope", rev = "c97d70f27bfbddab016fa9448d4096b84592ff8c" }
+dbgscope = { git = "https://github.com/glslang/dbgscope", rev = "7d77c72444679a23981cecef03efa979847e371d" }
 # 3.1.1 is a floor, not a preference: every 3.x before it generates a `tools/list` that omits
 # SEP-2549's required `ttlMs`/`cacheScope`, which a spec-strict `2026-07-28` client rejects
 # outright — the server connects and appears to expose no tools at all (upstream issue #1114).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/glslang/windbg-mcp"
 license = "MIT"
 
 [dependencies]
-dbgscope = { git = "https://github.com/glslang/dbgscope", rev = "879cbb1f5a5b15a0cdeaca41930c1420ea32b24a" }
+dbgscope = { git = "https://github.com/glslang/dbgscope", rev = "c97d70f27bfbddab016fa9448d4096b84592ff8c" }
 # 3.1.1 is a floor, not a preference: every 3.x before it generates a `tools/list` that omits
 # SEP-2549's required `ttlMs`/`cacheScope`, which a spec-strict `2026-07-28` client rejects
 # outright — the server connects and appears to expose no tools at all (upstream issue #1114).
@@ -49,6 +49,11 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 windows-sys = { version = "0.61", features = [
     "Win32_Foundation",
     "Win32_Security_Cryptography",
+    # `GetConsoleProcessList`, which is how `engine::attached_to_a_console` answers whether a
+    # child this server spawns has a console to inherit — and therefore whether it would open a
+    # window of its own. The obvious `GetConsoleWindow` is in the same feature and is the wrong
+    # call: a ConPTY console has no window (issue #273).
+    "Win32_System_Console",
     "Win32_System_Threading",
     # `IsWow64Process2`, which is how `src/target.rs` reads the architecture of a *live* process
     # before a worker is spawned for it. The call itself is in `Win32_System_Threading` above; this
@@ -75,7 +80,12 @@ winresource = { version = "0.1", default-features = false }
 # resource back off the exe it just built. A dev-dependency rather than a feature on the entry
 # above: the edition-2024 resolver does not unify these into a normal build, so the shipped
 # binary's `windows-sys` surface is unchanged by a test wanting to check the metadata.
-windows-sys = { version = "0.61", features = ["Win32_Storage_FileSystem"] }
+windows-sys = { version = "0.61", features = [
+    "Win32_Storage_FileSystem",
+    # `GetConsoleProcessList`, so the debugger tier can assert that a real session's engine
+    # worker is attached to *this* console rather than one of its own (issue #273).
+    "Win32_System_Console",
+] }
 # `test-util` only, and only for the tests: `src/progress.rs` asserts on a heartbeat measured in
 # tens of seconds, and the alternative — real sleeps shrunk to milliseconds — is a test that fails
 # on a loaded runner for reasons that have nothing to do with the code. A paused clock makes the

--- a/docs/remote-listener.md
+++ b/docs/remote-listener.md
@@ -489,6 +489,17 @@ because the SCM registers a service once and a bad credential then fails it at e
 `windbg-mcp.exe --uninstall-service` removes it, stopping it first and waiting for it — a delete
 issued against a running service only marks it, and this one has debug targets to let go of.
 
+**A service also puts the whole server tree in session 0, where nothing it starts can reach your
+desktop.** That is worth knowing because a debugger starts processes it does not control the windows
+of: a launched debuggee's own GUI, an extension DLL, `TTD.exe`'s recorded target. Session 0 has no
+interactive window station, so a window any of them opens is invisible and cannot take the
+foreground — which was the complaint in
+[#273](https://github.com/glslang/windbg-mcp/issues/273), where every session opened a console
+window on the desktop. The windows this server and its engine were themselves responsible for are
+fixed in the code and need none of this. What a service adds is the rest of the class, and the cost
+is the same isolation seen from the other side: a `launch`ed debuggee runs in session 0 too, so it
+cannot show a window to you or read one from your desktop.
+
 **Upgrading means replacing the exe *and restarting* — and running the client commands from the
 binary the service actually runs.** The credential file gained a shape in 0.11.0 that an earlier
 service refuses (an entry that is an object, carrying a client's `--tools` beside its token), so a

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -506,6 +506,14 @@ processes, so they need real ones:
 - *No worker outlives the connection.* Reads the engine pid out of `session_status`, disconnects,
   and checks the process is gone — otherwise every disconnect leaks a debugger process, and for a
   launch or an attach, a debuggee with it.
+- *No worker opens a console window of its own.* Reads the same engine pid and checks it is in
+  **this harness's** console process list. A console child of a console-*less* parent is given a
+  brand-new visible console, which is what a GUI MCP client's server spawns for every session
+  ([#273](https://github.com/glslang/windbg-mcp/issues/273)) — so the fix is a creation flag
+  applied only where there is no console to inherit, and this is the assertion that refuses the
+  simpler unconditional version: that one opens no window either, and silently moves a worker's
+  stderr to a console nobody reads. It stands down on a harness with no console, where the flag is
+  applied and there is no sharing to observe; `engine.rs` covers that branch.
 - *A batch commits or fails, and its rollback runs either way.* `src/batch.rs` proves the executor
   over a scripted debuggee; this proves the wiring — argument schema, the op crossing the pipe, the
   engine seam, the report coming back — by running one batch to `COMMITTED` (with a capture bound

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -36,6 +36,7 @@ use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::{Child, ChildStdout, Command};
 use tokio::sync::{mpsc, oneshot};
 use windows_sys::Win32::Foundation::{HANDLE_FLAG_INHERIT, SetHandleInformation};
+use windows_sys::Win32::System::Console::GetConsoleProcessList;
 
 use crate::kdconn;
 use crate::proto::{EngineOp, Output, SymbolPathSetting, WorkerMessage, WorkerRequest};
@@ -166,6 +167,60 @@ fn release_handoff(
 /// With the flag, Ctrl+C is disabled for the worker's group. The supervisor still dies, its handles
 /// still close, and the worker meets the EOF path that knows how to let go.
 const CREATE_NEW_PROCESS_GROUP: u32 = 0x0000_0200;
+
+/// `CREATE_NO_WINDOW`, passed only to a child this process has no console to hand down.
+///
+/// A console-subsystem child spawned with neither this flag nor `CREATE_NEW_CONSOLE` inherits its
+/// parent's console — and where the parent has **none**, Windows gives the child a brand-new,
+/// *visible* one instead, titled with the exe's path and taking the foreground as it appears. A
+/// GUI MCP client has no console to pass on, so on the hosts this server is actually used from,
+/// every worker spawn opened a window; at the rate a model opens and ends sessions that is a
+/// desktop nobody can work at ([#273](https://github.com/glslang/windbg-mcp/issues/273)).
+///
+/// **It is conditional because the flag does not suppress a console — it suppresses the window,
+/// by giving the child a console of its own**, and a worker's stderr is *inherited*
+/// ([`spawn_worker`]). A console handle handed to a process attached to a different console is
+/// re-bound to that one: measured on this bench, such a child's `WriteFile` reports success —
+/// bytes written, no error — and the text lands in its own invisible console instead of in the
+/// terminal, while a child that inherits the console writes where the operator is looking.
+/// Applied unconditionally this would therefore delete every worker log line from a terminal-run
+/// server, silently, and make [`crate::logbridge`]'s "they are still on the server's stderr"
+/// untrue.
+///
+/// So it goes on exactly where it changes something. With no console there is nothing to inherit
+/// and nothing for stderr to lose — it is a pipe or a file, which is inherited unchanged
+/// (measured) — and with one, the worker shares it and opens no window anyway.
+const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+
+/// [`CREATE_NO_WINDOW`] when this process has no console, and no flag at all when it has one.
+///
+/// Shared with [`crate::ttd::record_launch`], the other process this server creates: a recorder
+/// window is the same window, and the recorded target inherits whatever console the recorder was
+/// given.
+pub(crate) fn without_a_console_window() -> u32 {
+    if attached_to_a_console() {
+        0
+    } else {
+        CREATE_NO_WINDOW
+    }
+}
+
+/// Whether this process is attached to a console at all.
+///
+/// **Not `GetConsoleWindow() != NULL`**, which is the usual spelling of this question and is
+/// wrong here: a console with no window is an ordinary thing — a ConPTY (Windows Terminal, and
+/// this repo's own test harness) has none, and neither has a console created by
+/// [`CREATE_NO_WINDOW`] one level up — so that call answers "no console" for a process holding a
+/// live console handle, which is the one case where passing the flag on costs something.
+/// `GetConsoleProcessList` counts the processes sharing this process's console and fails with
+/// `ERROR_INVALID_HANDLE` when there is no console; both halves measured on this bench.
+fn attached_to_a_console() -> bool {
+    // The count, not the identifiers: a buffer too small for all of them is not a failure — the
+    // call answers how many there are and stores none — so one element is enough to ask with.
+    let mut one = [0u32; 1];
+    // SAFETY: a valid, writable one-element buffer, described to the call as one element.
+    unsafe { GetConsoleProcessList(one.as_mut_ptr(), 1) != 0 }
+}
 
 /// Counter behind [`mint_session_id`]. Only needs to be unique within this process.
 static SESSION_SEQ: AtomicU64 = AtomicU64::new(1);
@@ -3624,7 +3679,12 @@ fn spawn_worker(
         // Which is why the worker also gets its own process group: see
         // [`CREATE_NEW_PROCESS_GROUP`]. EOF cannot be the teardown if a console Ctrl+C ends the
         // worker before its channel ever closes.
-        .creation_flags(CREATE_NEW_PROCESS_GROUP)
+        //
+        // And [`without_a_console_window`], which is nothing at all when this process has a
+        // console to hand down — the two flags are independent, and the Ctrl+C guarantee rests on
+        // the group rather than on a side effect of the other, which is documented as ignored for
+        // a child that is not a console application.
+        .creation_flags(CREATE_NEW_PROCESS_GROUP | without_a_console_window())
         .spawn()?;
     // Explicitly, and before the lock is released rather than at the end of the function: the
     // child has its copies, and these are the ones that would otherwise stay inheritable — and
@@ -4173,13 +4233,18 @@ mod tests {
         let (mut child, channel) =
             spawn_worker(Path::new("cmd.exe"), None).expect("spawn a stand-in worker");
         let mut stdout = child.stdout.take().expect("a worker's stdout is piped");
-        let mut printed = String::new();
-        tokio::time::timeout(Duration::from_secs(10), stdout.read_to_string(&mut printed))
+        // **Bytes, not a `String`.** `cmd.exe` writes its banner in the code page of whatever
+        // console it ended up attached to, which is the *host's* business and not this test's: on
+        // a system whose OEM code page is GBK the banner is not UTF-8, and reading it as one fails
+        // the test for a property it does not hold an opinion about. What is under test is whether
+        // those bytes reached the protocol channel.
+        let mut printed = Vec::new();
+        tokio::time::timeout(Duration::from_secs(10), stdout.read_to_end(&mut printed))
             .await
             .expect("the stand-in's stdout closed within 10s")
             .expect("read the stand-in's stdout");
         assert!(
-            !printed.trim().is_empty(),
+            printed.iter().any(|b| !b.is_ascii_whitespace()),
             "the stand-in printed nothing to stdout, so this test would pass whatever the \
              channel did with it"
         );
@@ -4198,6 +4263,91 @@ mod tests {
              supervisor's own copy of the child's end left open looks like"
         );
         let _ = child.wait().await;
+    }
+
+    /// The processes attached to this process's console, or nothing when it has none.
+    fn console_process_list() -> Vec<u32> {
+        let mut buf = vec![0u32; 64];
+        loop {
+            // SAFETY: a valid, writable buffer, described to the call at its true length.
+            let n = unsafe { GetConsoleProcessList(buf.as_mut_ptr(), buf.len() as u32) } as usize;
+            if n == 0 {
+                return Vec::new(); // No console: `ERROR_INVALID_HANDLE`.
+            }
+            if n <= buf.len() {
+                buf.truncate(n);
+                return buf;
+            }
+            // Too small — the call stored nothing and answered how many there are.
+            buf = vec![0u32; n];
+        }
+    }
+
+    /// A child spawned the way a worker is opens **no console window of its own**, and the half of
+    /// that with teeth is the console branch.
+    ///
+    /// Passing `CREATE_NO_WINDOW` unconditionally also leaves no window anywhere, so a test that
+    /// only looked for a window would wave through the simplification this conditional exists to
+    /// refuse — and that simplification silently sends a worker's stderr to a console nobody is
+    /// looking at ([`CREATE_NO_WINDOW`]). So where this process has a console, the assertion is
+    /// that the child **joined it**, which is what keeps its log lines in the terminal.
+    ///
+    /// Spawned here rather than through [`spawn_worker`] for one reason only: a stand-in handed a
+    /// worker's command line exits in milliseconds, and this has to read a list the child is still
+    /// in. The shipped call site is asserted end to end by `mcp_smoke`, against a real session's
+    /// engine pid.
+    #[tokio::test]
+    async fn a_worker_shares_this_processs_console_or_gets_a_windowless_one() {
+        let flags = without_a_console_window();
+        if console_process_list().is_empty() {
+            assert_eq!(
+                flags, CREATE_NO_WINDOW,
+                "with no console to inherit, a worker would be given a brand-new visible one"
+            );
+            eprintln!(
+                "SKIPPED: this process has no console, so there is no sharing to observe — the \
+                 flag is asserted instead"
+            );
+            return;
+        }
+
+        assert_eq!(
+            flags, 0,
+            "a console this process can hand down is one the worker must inherit, so that its              stderr keeps reaching the terminal"
+        );
+
+        let mut child = {
+            let _one_spawn_at_a_time = spawn_guard();
+            Command::new("cmd")
+                .args(["/c", "ping", "-n", "30", "127.0.0.1"])
+                .stdout(Stdio::null())
+                .kill_on_drop(true)
+                .creation_flags(CREATE_NEW_PROCESS_GROUP | flags)
+                .spawn()
+                .expect("spawn a stand-in child")
+        };
+        let pid = child.id().expect("a freshly spawned child has a pid");
+
+        // Polled: a child joins its console during its own startup, not when `CreateProcess`
+        // returns, so the list can legitimately not name it yet.
+        let deadline = Instant::now() + Duration::from_secs(10);
+        let joined = loop {
+            if console_process_list().contains(&pid) {
+                break true;
+            }
+            if Instant::now() >= deadline {
+                break false;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        };
+        let _ = child.kill().await;
+        assert!(
+            joined,
+            "pid {pid} never appeared in this process's console ({:?}), so it opened a console of \
+             its own — which off a console-bearing parent is a visible window, and takes the \
+             worker's stderr with it",
+            console_process_list()
+        );
     }
 
     /// The rule [`SPAWN_LOCK`] rests on, checked against the source rather than asserted in a doc

--- a/src/ttd.rs
+++ b/src/ttd.rs
@@ -4,6 +4,7 @@
 //! standalone recorder). Replay of the resulting `.run` trace is done through the
 //! normal engine path ([`crate::engine`] → `open_trace`).
 
+use std::os::windows::process::CommandExt;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::time::{Duration, Instant, SystemTime};
@@ -231,7 +232,13 @@ pub fn record_launch(
         .arg("-launch")
         .args(&argv)
         .stdout(Stdio::from(log))
-        .stderr(Stdio::from(log_err));
+        .stderr(Stdio::from(log_err))
+        // The same rule as a worker's, and here it covers two processes: the recorder, and the
+        // target *it* launches with the console it was given. Nothing is lost by it either way —
+        // both halves of this recorder's output are the log file above, which is inherited as a
+        // handle whatever console the process ends up in. See
+        // [`crate::engine::without_a_console_window`].
+        .creation_flags(crate::engine::without_a_console_window());
     // Configured kernel connections do not reach the recorder. TTD.exe launches `target` with
     // this environment inherited, and the recorded target is an arbitrary binary — frequently the
     // least trustworthy program on the machine, which is usually *why* it is being recorded. Same

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -9066,6 +9066,71 @@ fn engine_pid_of(status: &Value, session_id: &str) -> u32 {
         .unwrap_or_else(|| panic!("`{session_id}` reports no engine pid: {session}")) as u32
 }
 
+/// The processes attached to this harness's console, or nothing when it has none.
+fn console_process_list() -> Vec<u32> {
+    use windows_sys::Win32::System::Console::GetConsoleProcessList;
+    let mut buf = vec![0u32; 64];
+    loop {
+        // SAFETY: a valid, writable buffer, described to the call at its true length.
+        let n = unsafe { GetConsoleProcessList(buf.as_mut_ptr(), buf.len() as u32) } as usize;
+        if n == 0 {
+            return Vec::new(); // No console: `ERROR_INVALID_HANDLE`.
+        }
+        if n <= buf.len() {
+            buf.truncate(n);
+            return buf;
+        }
+        buf = vec![0u32; n];
+    }
+}
+
+/// A real session's engine worker opens **no console window of its own**
+/// ([#273](https://github.com/glslang/windbg-mcp/issues/273)).
+///
+/// A console-subsystem child of a console-*less* parent is given a brand-new, visible console,
+/// and a GUI MCP client starts this server without one — so on the hosts this is used from, every
+/// session open put a window on the desktop and took the foreground with it. The fix is a
+/// creation flag applied to a child that has no console to inherit, and `engine.rs` covers the
+/// flag itself and a stand-in spawned with it.
+///
+/// What only the shipped binary can say is that the worker `spawn_worker` actually creates — the
+/// supervisor re-executing its own image, several layers below any unit test — is in **this**
+/// console rather than one of its own. Which is also the assertion that refuses the obvious
+/// simplification: passing the flag unconditionally opens no window either, and silently takes
+/// the worker's stderr off the terminal with it.
+#[test]
+fn a_session_worker_opens_no_console_window_of_its_own() {
+    let Some(dump) = target_tier() else { return };
+    let ours = console_process_list();
+    if ours.is_empty() {
+        skip("this harness has no console, so a worker's console is windowless by construction");
+        return;
+    }
+
+    let mut server = Server::started();
+    let server_pid = server.child.id();
+    // The precondition, asserted rather than assumed: if the *server* did not inherit this
+    // console, nothing below is about the worker. It is the harness that spawned it, with no
+    // creation flags, so this failing means the shape of the test has moved.
+    assert!(
+        console_process_list().contains(&server_pid),
+        "the server ({server_pid}) is not in this harness's console, so this test cannot say \
+         anything about its worker"
+    );
+
+    let session = server.open_session("open_dump", json!({ "path": dump }), TARGET_STEP);
+    let status = server.tool_data("session_status", json!({}), TARGET_STEP);
+    let worker = engine_pid_of(&status, &session);
+    let sharing = console_process_list();
+    assert!(
+        sharing.contains(&worker),
+        "the engine worker ({worker}) is not attached to this console ({sharing:?}), so it was \
+         given one of its own — which off a console-less parent is a visible window on the \
+         desktop, and which takes its stderr off the terminal either way"
+    );
+    ran("a session's engine worker shares this console rather than opening one");
+}
+
 /// Sessions are independent processes, so opening a second target must not disturb the first.
 ///
 /// Under the single-engine design this was impossible by construction — one process, one DbgEng


### PR DESCRIPTION
Closes #273. The dbgscope half is glslang/dbgscope#131, now merged.

## The bug, reproduced

Windows gives a console-subsystem child of a console-**less** parent a brand-new, *visible* console, and a GUI MCP client starts a stdio server without one. So every engine worker put a window on the desktop and took the foreground as it appeared; at four sessions with reclamation on the fifth open, that is a machine nobody can work at while the model works.

Reproduced against the real binary with a 40-line stand-in host that spawns the server the way a GUI client does (`DETACHED_PROCESS`, stdio on pipes), then opens a dump:

```text
before                                    after
  Id MainWindowHandle Title                 Id MainWindowHandle
9432       18941092  ...\windbg-mcp.exe   2968                0   <- supervisor
11420             0                       11776                0   <- engine worker
```

The window is the *worker's*; the supervisor has none, exactly as the issue reports.

## The fix, and why it is conditional

The worker and the `TTD.exe` recorder now take `CREATE_NO_WINDOW` — **but only when this process has no console of its own**, which is the whole of the change rather than a refinement of it.

`CREATE_NO_WINDOW` does not suppress a console. It suppresses the *window*, by giving the child a console of its own — and a worker's stderr is **inherited**. A console handle handed to a process attached to a different console is re-bound to that one. Measured, spawning a child with stderr inherited from a console-bearing parent:

| child spawned | its `WriteFile` to stderr | did the text reach the parent's console? |
|---|---|---|
| no flags (inherits the console) | ok, 21 bytes | **yes** |
| `CREATE_NO_WINDOW` | ok, 20 bytes, no error | **no** — it went to its own invisible console |

So the unconditional version proposed in the issue deletes every worker log line from a terminal-run server, silently, against the workflow `CLAUDE.md` documents ("leave stderr inherited — it lands in your terminal") and making `logbridge`'s *"they are still on the server's stderr"* untrue. The flag now goes on exactly where it changes something: with no console there is nothing to inherit and nothing for stderr to lose (a pipe or a file is inherited unchanged, measured), and with one the worker shares it and opens no window anyway.

`attached_to_a_console` asks `GetConsoleProcessList`, **not** `GetConsoleWindow`. The obvious call answers 0 for a ConPTY — Windows Terminal, and this repo's own harness, where it says 0 for a process attached to a live console with three processes in it — so it would apply the flag to precisely the worker whose stderr would then be lost.

## Tests

A test that only looked for a window would wave the unconditional version through: it opens none either. So both assert the child **joined this process's console**.

- `engine::tests::a_worker_shares_this_processs_console_or_gets_a_windowless_one` — a stand-in spawned with a worker's exact flags. On a harness with no console it asserts the flag instead and says so.
- `mcp_smoke::a_session_worker_opens_no_console_window_of_its_own` (debugger tier) — a real session's `engine_pid` from `session_status`, which is the only way to reach the shipped `spawn_worker`.

Both were checked by making the unconditional change: each fails, the second with *"the engine worker (1212) is not attached to this console"*.

Also here: the stand-in worker's stdout is read as **bytes**. `cmd.exe` writes its banner in the code page of whatever console it ends up in — the host's business, not this test's — and on a system whose OEM code page is GBK, reading it as a `String` fails the test for a property it holds no opinion about. Reported by @daiaji on #273.

## The dbgscope pin

A *debuggee* launched by `launch` gets its console from DbgEng's `CreateProcessWide`, not from here; that is glslang/dbgscope#129, fixed in glslang/dbgscope#131 and merged.

This pins dbgscope's `main` (`7d77c72`) rather than that PR's branch head, and it had to be repointed rather than left alone: #131 was **rebase-merged**, so its commits landed under new SHAs and the branch head is an ancestor of nothing on `main`.

```console
git -C ../dbgscope merge-base --is-ancestor c97d70f origin/main   # 1 — dangling
```

A pin like that builds only while the merged branch survives, and breaks on the ordinary tidy of deleting it. The tree at `main` is byte-identical to the one this was verified against before the merge, and both worker images were rebuilt on it.

## What this does not fix, deliberately

A **service** (`--install-service --listen`) puts the whole tree in session 0, which has no interactive window station — so nothing it starts can reach the desktop, including windows from processes this repo does not control (a GUI debuggee, an extension DLL, `TTD.exe`'s target). That is a deployment answer rather than a substitute, and it costs a launched debuggee any interaction with your desktop; `docs/remote-listener.md` now says so where the service is set up.

## Verification

- `WINDBG_MCP_SMOKE_DUMP=1 cargo test` against the merged dbgscope rev — **643 unit + 99 smoke passed, 0 failed** (12 ignored), with the 32-bit worker rebuilt.
- `WINDBG_MCP_SMOKE_TTD=1 cargo test --test mcp_smoke -- ttd` — 4 passed, recording real traces, which is what exercises the recorder's new flag.
- `cargo fmt --all --check`, `cargo clippy --all-targets`, `markdownlint-cli2@0.23.2` over the CI globs: all clean.
- End to end from a console-less host against the built binary: dump opened, `launch` driven — no window from the supervisor, the worker, or the debuggee.
- Not run: the live-kernel tier (unrelated to this seam) and CI's own runners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WhhF5x9fE4bdd1jiKBvhNa
