### PR TITLE
fix: the spawn-lock rule counts a process created by `output`, not only by `spawn`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   window from DbgEng rather than from here; that is
   [dbgscope#129](https://github.com/glslang/dbgscope/issues/129), fixed there.
 
+- **The rule that no process is created without the spawn lock was checked by a marker that could
+  not see half of them.** `Command` spawns and waits in one call through `output()` and `status()`
+  as well as through `spawn()`, and `service::icacls` used the first of those — so
+  `every_process_spawn_in_this_crate_takes_the_spawn_lock` reported no unguarded spawns over a
+  source tree that created a process it could not see. Its own name was half of why that stayed
+  invisible — the rule is about a *process being created*, and `spawn` is only the spelling that
+  says so — so it is now `every_process_created_in_this_crate_takes_the_spawn_lock`.
+
+  Harmless where it stood — `icacls` runs from the install and client-editing commands, in a
+  process that serves no session and spawns no worker — but that is a property of today's call
+  sites rather than of the rule, and the lock exists because a handle is inheritable **process-wide**
+  from the moment it is marked: a child started inside a worker's spawn window inherits that
+  worker's protocol channel and keeps the pipe from ever reporting EOF, so the session never
+  settles. `icacls` now takes the guard, and the marker counts the two fused calls.
+
+  They are matched **only inside a function that also constructs a `Command`**, because
+  `response.status()` is an HTTP status in `listen::gate` and an unanchored marker demands the
+  spawn lock there — verified by removing the anchor, which lights up both lines. `spawn()` stays
+  unanchored: it is specific enough alone, and anchoring it would open that same hole in the half
+  that is load-bearing today. Each half is counted and asserted separately, since a marker that
+  matches nothing passes.
+
 - **A session handle that a raw `execute` retired can still end its own session.** `qd`, `q`,
   `.detach`, `.kill` and `.opendump` release or replace the target, which *retires* the handle
   naming that session: every later call supplying it is refused, while the worker stays live and

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -246,10 +246,12 @@ and no other spawn site needs to know the rule exists.
   — and tokio exposes the inner command through `Command::as_std_mut()`, so on stabilization this
   is a handful of lines in `spawn_worker` with tokio's `Child` intact. **That stabilization is the
   trigger**; there is no reason to hand-roll it first.
-- **Meanwhile:** `every_process_spawn_in_this_crate_takes_the_spawn_lock` (`src/engine.rs`) reads
-  the crate's own source and fails if a `.spawn()` appears without `spawn_guard` held in the same
-  function. The convention is pinned rather than merely documented, which is what makes this an
-  improvement to *how* the property is held rather than a fix to a live hole.
+- **Meanwhile:** `every_process_created_in_this_crate_takes_the_spawn_lock` (`src/engine.rs`) reads
+  the crate's own source and fails if a process is created without `spawn_guard` held in the same
+  function — `.spawn()` anywhere, and `.output()`/`.status()`, which fuse the spawn with the wait,
+  in a function that also builds a `Command`. The convention is pinned rather than merely
+  documented, which is what makes this an improvement to *how* the property is held rather than a
+  fix to a live hole.
 
 ## 19. [windbg-mcp] Let a `debug_batch` step walk a structure
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -3577,14 +3577,21 @@ struct Channel {
 ///
 /// std holds a lock of its own across the same window for the stdio handles it prepares, which is
 /// the same reasoning applied to the same hazard; this one covers the handles std knows nothing
-/// about. **A new `Command::spawn` anywhere in this crate has to take it** — see [`spawn_guard`].
+/// about. **A new process created anywhere in this crate has to take it** — `spawn`, and equally
+/// `output` and `status`, which spawn and wait in one call. See [`spawn_guard`].
 static SPAWN_LOCK: Mutex<()> = Mutex::new(());
 
-/// Claims [`SPAWN_LOCK`] for the caller's own `spawn()`. Hold it across the call and no longer.
+/// Claims [`SPAWN_LOCK`] for the caller's own process creation. Hold it across that and no longer.
 ///
 /// Every process creation in this server goes through here, including ones that have nothing to do
 /// with debug sessions: the flag is a property of the *process*, not of the spawn that set it, so a
 /// child started for any reason during the window inherits whatever is marked.
+///
+/// "And no longer" is a rule about the **creation**, which `Command::output` and `Command::status`
+/// fuse with the wait — so a caller using either holds this across the child's whole run, and that
+/// is only acceptable for a child that exits in milliseconds (`service::icacls` is the one). For
+/// anything longer, `spawn` under the guard and wait after it: every other process creation in
+/// this server queues behind this lock.
 pub(crate) fn spawn_guard() -> std::sync::MutexGuard<'static, ()> {
     SPAWN_LOCK.lock().unwrap_or_else(|e| e.into_inner())
 }
@@ -4364,8 +4371,32 @@ mod tests {
     /// `.spawn()` with empty parentheses is a reliable marker for a *process* spawn here: a
     /// thread spawn always takes a closure, and `tokio::spawn` a future. The count is asserted
     /// too, so a refactor that stops matching fails loudly instead of quietly checking nothing.
+    ///
+    /// **`.spawn()` alone is not the whole of process creation, and the gap was live**: `Command`
+    /// also has `output()` and `status()`, which spawn and wait in one call, and `service::icacls`
+    /// used the first of those — so this test read "no unguarded spawns" over a source file that
+    /// creates a process the marker could not see. Its own name was half of why that stayed
+    /// invisible, and is why this is `every_process_created…` rather than `every_process_spawn…`:
+    /// what the rule is about is a *process being created*, and `spawn` is only the spelling that
+    /// says so.
+    ///
+    /// The two fused calls are matched **only in a function that also constructs a `Command`**,
+    /// which `.spawn()` needs and they do. `.status()` is the reason: `response.status()` is an
+    /// HTTP status in `listen::gate`, twice, and an unanchored marker would demand the spawn lock
+    /// there. What the anchor costs is a fused call on a `Command` some *other* function built —
+    /// nothing does that here, and a marker that is wrong about `listen.rs` on every run is worse
+    /// than one that could miss a shape this crate has never had. `.spawn()` stays unanchored,
+    /// since it is specific enough on its own and anchoring it would open exactly that hole in the
+    /// half that is load-bearing today.
+    ///
+    /// Each half is counted separately and each is asserted, because a marker that matches nothing
+    /// passes: the fused half rests on `icacls` being the one site, and if that call moves to
+    /// `spawn` the assertion says so rather than quietly checking nothing.
+    ///
+    /// A raw `CreateProcessW` through `windows-sys` would be outside all of this. Nothing in this
+    /// crate creates a process that way, and the rule for one that did is the same rule.
     #[test]
-    fn every_process_spawn_in_this_crate_takes_the_spawn_lock() {
+    fn every_process_created_in_this_crate_takes_the_spawn_lock() {
         // Assembled at run time rather than written as literals, because this function is *in* the
         // source it reads. Written out, the two lines below would each match themselves: the
         // matcher would count as a spawn site, and — the guard's name being on the line above it —
@@ -4375,14 +4406,21 @@ mod tests {
         // itself, which is what leaves the floor counting only real spawns.
         let a_spawn = [".spawn", "()"].concat();
         let the_guard = ["spawn_", "guard()"].concat();
+        // Split for the same reason, and one more: written out, `Command::new(` would make this
+        // function count as one that builds a command, and the two fused markers below are matched
+        // only inside such a function.
+        let a_command = ["Command", "::new("].concat();
+        let fused = [[".output", "()"].concat(), [".status", "()"].concat()];
 
-        let mut sites = 0;
+        let mut spawns = 0;
+        let mut fused_sites = 0;
         let mut unguarded = Vec::new();
         for file in rust_sources(&PathBuf::from(concat!(env!("CARGO_MANIFEST_DIR"), "/src"))) {
             let text = std::fs::read_to_string(&file).expect("read a source file");
             // Reset at each function, so "guarded" means guarded *here* rather than anywhere
             // earlier in the file. Comments are skipped: prose about a `fn` is not one.
             let mut guarded = false;
+            let mut builds_a_command = false;
             for (n, line) in text.lines().enumerate() {
                 let code = line.trim_start();
                 if code.starts_with("//") {
@@ -4390,15 +4428,20 @@ mod tests {
                 }
                 if code.starts_with("fn ") || code.contains(" fn ") {
                     guarded = false;
+                    builds_a_command = false;
                 }
                 if code.contains(&the_guard) {
                     guarded = true;
                 }
-                if code.contains(&a_spawn) {
-                    sites += 1;
-                    if !guarded {
-                        unguarded.push(format!("{}:{}", file.display(), n + 1));
-                    }
+                if code.contains(&a_command) {
+                    builds_a_command = true;
+                }
+                let spawns_here = code.contains(&a_spawn);
+                let fused_here = builds_a_command && fused.iter().any(|f| code.contains(f));
+                spawns += usize::from(spawns_here);
+                fused_sites += usize::from(fused_here);
+                if (spawns_here || fused_here) && !guarded {
+                    unguarded.push(format!("{}:{}", file.display(), n + 1));
                 }
             }
         }
@@ -4406,15 +4449,21 @@ mod tests {
             unguarded.is_empty(),
             // `engine::spawn_guard` without its parentheses, for the reason above: written in
             // full it would be one more line the checker sees as a guard.
-            "these spawn a process without holding `engine::spawn_guard` in the same function, \
+            "these create a process without holding `engine::spawn_guard` in the same function, \
              so a child started there can inherit a worker's protocol channel and keep it from \
              ever reporting EOF: {unguarded:?}"
         );
         assert!(
-            sites >= 3,
+            spawns >= 3,
             "expected to find the known process spawns (the worker, the TTD recorder, the test \
-             stand-in) and found {sites} — the marker no longer matches, so this test is checking \
+             stand-in) and found {spawns} — the marker no longer matches, so this test is checking \
              nothing"
+        );
+        assert!(
+            fused_sites >= 1,
+            "expected to find the spawn-and-wait in `service::icacls` and found none, so the half \
+             of this marker that covers `output`/`status` is checking nothing — if that call is \
+             now a `spawn`, this floor is what needs re-deriving"
         );
     }
 

--- a/src/service.rs
+++ b/src/service.rs
@@ -380,12 +380,28 @@ const SYSTEM_SID: &str = "*S-1-5-18";
 const ADMINISTRATORS_SID: &str = "*S-1-5-32-544";
 
 /// Runs one `icacls` invocation, or says which one failed and why.
+///
+/// Under [`crate::engine::spawn_guard`], like every other process this crate creates. Nothing here
+/// wants an inherited handle — but a handle is inheritable **process-wide** from the moment it is
+/// marked, so a child started inside a worker's spawn window inherits that worker's protocol
+/// channel and keeps the pipe from ever reporting EOF. That this particular caller cannot collide
+/// (these are operator commands, in a process that serves no session and spawns no worker) is a
+/// property of today's call sites rather than of the rule, and it is the kind of exception the next
+/// person has to re-derive; taking the lock costs an uncontended acquire.
+///
+/// **The guard spans the wait as well as the spawn here**, which `output()` fuses and only a
+/// rewrite to `spawn` + `wait_with_output` would separate. That is right for `icacls`, which exits
+/// in milliseconds, and would be wrong for a long-running child: this lock is what every worker
+/// spawn queues behind. A new shell-out that is not near-instant wants the split form.
 fn icacls(path: &std::path::Path, args: &[&str]) -> Result<()> {
-    let out = std::process::Command::new("icacls")
-        .arg(path)
-        .args(args)
-        .output()
-        .with_context(|| format!("cannot run `icacls {}`", args.join(" ")))?;
+    let out = {
+        let _one_spawn_at_a_time = crate::engine::spawn_guard();
+        std::process::Command::new("icacls")
+            .arg(path)
+            .args(args)
+            .output()
+    }
+    .with_context(|| format!("cannot run `icacls {}`", args.join(" ")))?;
     if !out.status.success() {
         bail!(
             "`icacls {} {}` failed: {}",


### PR DESCRIPTION
Noticed while fixing #273 and deliberately kept out of that PR, since it is a hole in an invariant's marker rather than a console window. Independent of #274 — this branch is off `main` and does not move the dbgscope pin.

## The hole

`every_process_spawn_in_this_crate_takes_the_spawn_lock` reads the crate's own source for `.spawn()` and fails on any that has no `spawn_guard` held in the same function. It reported no unguarded spawns over a tree that creates a process it could not see: `Command` also spawns through **`output()`** and **`status()`**, which fuse the spawn with the wait, and `service::icacls` used the first of those with no guard.

The test's own name was half of why that stayed invisible, so it is now `every_process_created_in_this_crate_takes_the_spawn_lock`. The rule is about a process being *created*; `spawn` is only the spelling that says so.

## Why it matters, and why it was still harmless

Harmless **where it stood**: `icacls` runs from `--install-service` and the client-editing commands, in a process that serves no session and spawns no worker. But that is a property of today's call sites rather than of the rule, and it is exactly the kind of exception the next person has to re-derive from scratch.

The lock is not about who spawns. A handle is inheritable **process-wide** from the moment it is marked, so any child started inside a worker's spawn window inherits that worker's protocol channel and keeps the pipe from ever reporting EOF — the session then never settles and its callers never hear back. `icacls` now takes the guard; the acquire is uncontended.

## The anchor, which is load-bearing rather than tidiness

The two fused calls are matched **only inside a function that also builds a `Command`**. `response.status()` is an HTTP status in `listen::gate`, twice, and without the anchor this test demands the spawn lock there. What the anchor costs is a fused call on a `Command` some *other* function built — nothing here does that, and a marker that is wrong about `listen.rs` on every run is worse than one that could miss a shape this crate has never had. `.spawn()` stays unanchored: it is specific enough alone, and anchoring it would open that same hole in the half that carries the weight today.

Each half is counted and asserted separately, because a marker that matches nothing passes.

## Checked by mutation, three ways

| mutation | result |
|---|---|
| drop the guard from `icacls` | fails: `["…/src/service.rs:400"]` |
| remove the `Command` anchor | fails: `["…/src/listen.rs:946", "…/src/listen.rs:961"]` |
| fused marker matches nothing | fails the new floor rather than passing |

## Prose that was narrower than the rule it states

`SPAWN_LOCK` said *"a new `Command::spawn` anywhere in this crate has to take it"* and `spawn_guard` said *"hold it across the call and no longer"*. Both now say what the guard is for and what "no longer" means when a call fuses the creation with the wait: acceptable for a child that exits in milliseconds, wrong for one that does not, since every other process creation in the server queues behind this lock. `FOLLOWUPS.md`'s item 18 described the marker as `.spawn()`-only; corrected there too.

## Verification

- `WINDBG_MCP_SMOKE_DUMP=1 cargo test` — **642 unit + 98 smoke passed, 0 failed** (12 ignored), with the 32-bit worker rebuilt.
- `cargo fmt --all --check`, `cargo clippy --all-targets`, `markdownlint-cli2@0.23.2` over the CI globs: clean.
- No behaviour change to any served path: `icacls` runs only from the operator commands, and the rest is a test and four doc comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WhhF5x9fE4bdd1jiKBvhNa
