### PR TITLE
Take the spawn flags from `windows-sys`, rather than declaring them again

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -166,7 +166,14 @@ fn release_handoff(
 ///
 /// With the flag, Ctrl+C is disabled for the worker's group. The supervisor still dies, its handles
 /// still close, and the worker meets the EOF path that knows how to let go.
-const CREATE_NEW_PROCESS_GROUP: u32 = 0x0000_0200;
+///
+/// Imported rather than hand-declared, here and for [`CREATE_NO_WINDOW`] below: `windows-sys`
+/// types these as `PROCESS_CREATION_FLAGS`, which is a plain `u32` alias rather than the `windows`
+/// crate's newtype, so they are the exact type [`std::os::windows::process::CommandExt::creation_flags`]
+/// takes — and they are in `Win32_System_Threading`, which this crate already enables for
+/// `IsWow64Process2` ([`crate::target`]). A local copy would buy only somewhere to put this
+/// comment, which a `use` carries just as well.
+use windows_sys::Win32::System::Threading::CREATE_NEW_PROCESS_GROUP;
 
 /// `CREATE_NO_WINDOW`, passed only to a child this process has no console to hand down.
 ///
@@ -190,7 +197,7 @@ const CREATE_NEW_PROCESS_GROUP: u32 = 0x0000_0200;
 /// So it goes on exactly where it changes something. With no console there is nothing to inherit
 /// and nothing for stderr to lose — it is a pipe or a file, which is inherited unchanged
 /// (measured) — and with one, the worker shares it and opens no window anyway.
-const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+use windows_sys::Win32::System::Threading::CREATE_NO_WINDOW;
 
 /// [`CREATE_NO_WINDOW`] when this process has no console, and no flag at all when it has one.
 ///


### PR DESCRIPTION
`engine.rs` hand-declared `CREATE_NEW_PROCESS_GROUP` and `CREATE_NO_WINDOW` as `u32` literals. Both are in `windows_sys::Win32::System::Threading`, under `Win32_System_Threading` — a feature this crate already enables for `IsWow64Process2` (`src/target.rs`) — so neither costs a feature to import.

And `windows-sys` types them as `PROCESS_CREATION_FLAGS`, which is `pub type PROCESS_CREATION_FLAGS = u32`: a plain alias rather than the `windows` crate's newtype. They are therefore the exact type `CommandExt::creation_flags` takes, and every use site is unchanged.

For contrast, and because the question comes up: dbgscope keeps its own copies for a real reason. It uses the `windows` crate, where the same constant is `PROCESS_CREATION_FLAGS(134217728u32)` — a newtype needing `.0` against `CreateProcessWide`'s bare `u32` — and it lives in a feature that crate's library dependency does *not* enable, so importing it would widen a library's dependency surface for one integer.

The doc comments are the whole value of the local copies, so they move onto the `use` items rather than being deleted. A doc comment attaches to a `use`, which keeps every intra-doc link — `attached_to_a_console`'s, the console test's — and `worker.rs`'s reference resolving with no edit to any of them. The diff is nine lines added, two removed.

## Verification

- **the values were checked, not assumed**: `const _: () = assert!(CREATE_NO_WINDOW == 0x0800_0000);` and the same for `CREATE_NEW_PROCESS_GROUP` compiled (then removed). Worth doing, because on a console-bearing host `without_a_console_window` returns `0` and nothing compares `CREATE_NO_WINDOW` at run time
- `cargo fmt --all --check` clean, `cargo clippy --all-targets` clean
- rustdoc warnings unchanged against a stashed baseline — 16 either way, so no link came undone
- **643 unit + 99 smoke tests green** with `WINDBG_MCP_SMOKE_DUMP=1`, including `a_worker_shares_this_processs_console_or_gets_a_windowless_one` and `a_session_worker_opens_no_console_window_of_its_own`, both of which still fail if the flag is made unconditional (checked)

No `CHANGELOG.md` entry: where a constant comes from is not a change a user of this server can observe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011EDZjq5kECT6ozwsWZm877
