### PR TITLE
fix: a dump that had not finished loading is no longer an open that worked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A dump or trace that had not finished loading is no longer reported as an open that worked.**
+  `open_dump` and `open_trace` defer the real work to the next `WaitForEvent`, so
+  `wait_for_event(LOAD_WAIT_MS)` *is* the load — and dbgscope's finite wait used to answer
+  `Result<(), _>`, flattening `S_FALSE` (the 60-second bound passing with the load still going) into
+  the same `Ok` a completed load gets. A dump too large, or a symbol path too cold, to finish inside
+  that bound therefore came back as a successful open, and whatever the caller did next failed for a
+  reason nothing connected to it. Nothing here could have caught it: the fact was discarded inside
+  the wait.
+
+  dbgscope now returns a `WaitOutcome` ([dbgscope#136](https://github.com/glslang/dbgscope/issues/136)
+  stage 1) and `worker::load_completed` reads it — only `Stopped` is a load that finished. The
+  failure is reported **post-commit**, which is what the `commit()` already sitting above the wait
+  was for: the caller is told the session holds the target, so `end_session` is the recovery and
+  opening again would claim a second one. A host interrupting the load reports the same way. The
+  `Expired` arm is **unmeasured against a real engine** — holding a dump load past sixty seconds is
+  not something a test can arrange — so `a_load_that_did_not_finish_is_not_an_open_that_worked`
+  asserts the mapping, and nothing claims how often it fires.
+
 - **A session no longer opens a console window on the desktop.** Windows gives a console-subsystem
   child of a console-*less* parent a brand-new, *visible* console — and a GUI MCP client starts a
   stdio server without one — so every engine worker this server spawned put a window on the desktop,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -729,6 +729,24 @@ was written and used the bounded INFINITE wait for every target type; only this 
 does, and a forced break at the bound is reported (`Interruption::Deadline` → `StopReport.timed_out`)
 rather than passing for a stop.
 
+**The last two finite waits are the openers', and they had the same defect for the same reason.**
+`open_dump` and `open_trace` defer the load to the next `WaitForEvent`, so
+`wait_for_event(LOAD_WAIT_MS)` *is* the load — and until
+[dbgscope#136](https://github.com/glslang/dbgscope/issues/136) that call answered `Result<(), _>`,
+flattening `S_FALSE` and `S_OK` into one `Ok`. A dump too large or a symbol path too cold to finish
+inside 60s was therefore reported as an open that worked, and whatever the caller did next failed
+with nothing connecting it to the open. It could not have been caught here: the fact was thrown away
+inside the wait. dbgscope now returns a `WaitOutcome`, `worker::load_completed` reads it, and only
+`Stopped` is a load that finished. Three things about it. The failure is deliberately **post-commit**
+— `commit()` already sat above the wait, and the two comments there have said "a load wait that times
+out still leaves DbgEng holding the dump" since they were written, so the caller is told the session
+holds the target and that `end_session` is the recovery rather than another open. `Deadline` is
+unreachable there (a finite bound arms no watchdog) and shares the `OnRequest` arm rather than
+getting a message nothing can produce. And **the `Expired` arm is unmeasured against a real engine**:
+holding a dump load past sixty seconds is not something a test can arrange, so
+`a_load_that_did_not_finish_is_not_an_open_that_worked` asserts the mapping and nothing claims how
+often it fires.
+
 Two consequences worth carrying:
 
 - **The reason the finite wait looked attractive was a sleep.** Both dbgscope watchdogs polled a

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,7 +164,7 @@ dependencies = [
 [[package]]
 name = "dbgscope"
 version = "0.1.0"
-source = "git+https://github.com/glslang/dbgscope?rev=7d77c72444679a23981cecef03efa979847e371d#7d77c72444679a23981cecef03efa979847e371d"
+source = "git+https://github.com/glslang/dbgscope?rev=4a89c09d680b798a7952084ba48fa72e4b528ce3#4a89c09d680b798a7952084ba48fa72e4b528ce3"
 dependencies = [
  "hex",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/glslang/windbg-mcp"
 license = "MIT"
 
 [dependencies]
-dbgscope = { git = "https://github.com/glslang/dbgscope", rev = "7d77c72444679a23981cecef03efa979847e371d" }
+dbgscope = { git = "https://github.com/glslang/dbgscope", rev = "4a89c09d680b798a7952084ba48fa72e4b528ce3" }
 # 3.1.1 is a floor, not a preference: every 3.x before it generates a `tools/list` that omits
 # SEP-2549's required `ttlMs`/`cacheScope`, which a spec-strict `2026-07-28` client rejects
 # outright — the server connects and appears to expose no tools at all (upstream issue #1114).

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -478,7 +478,7 @@ Two smaller things the same run left open:
 ## 47. [windbg-mcp + dbgscope] The bounded wait is unmeasured on a TTD replay target
 
 **What changed under it.** Fixing [#226](https://github.com/glslang/windbg-mcp/issues/226) made
-`execute_and_wait` use `wait_for_event_bounded` — `WaitForEvent(INFINITE)` with a watchdog that
+`execute_and_wait` use the watchdog-bounded wait — `WaitForEvent(INFINITE)` with a watchdog that
 `SetInterrupt`s at the bound — for **every** target type, where before only a live kernel took it
 and everything else took a finite `WaitForEvent`. That was not a tidy-up: the finite wait returns
 `S_FALSE` on expiry with the target still running and the engine holding no current process/thread,
@@ -535,8 +535,10 @@ timeout path is *unreachable* on this target type rather than untested — which
 an answer rather than as a test, and is worth writing down either way. Deciding that costs one
 measurement and is what the next person should do before writing anything.
 
-**Where it picks up.** `dbgscope`'s `DebugEngine::execute_and_wait` and `wait_for_event_bounded`
-(`src/dbgeng.rs`); `worker::resumed`; and the pair
+**Where it picks up.** `dbgscope`'s `DebugEngine::execute_and_wait` and `DebugEngine::pump`
+(`src/dbgeng.rs` — `wait_for_event_bounded` was folded into that one pump by
+[dbgscope#136](https://github.com/glslang/dbgscope/issues/136), and what this item wants to see on a
+replay target is now a `WaitOutcome::Deadline`); `worker::resumed`; and the pair
 `a_raw_execution_control_command_moves_the_target_instead_of_wedging_the_session` /
 `a_resume_that_reaches_no_stop_says_so_and_leaves_the_session_usable` in `tests/mcp_smoke.rs`,
 which are the shape a TTD one would copy.

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -45,7 +45,7 @@ use std::time::{Duration, Instant};
 
 use dbgscope::dbgeng::{
     BreakpointAt, BreakpointSpec, CommandRun, DebugEngine, InterruptHandle, Interruption,
-    RunToOutcome,
+    RunToOutcome, WaitOutcome,
 };
 use dbgscope::heap::{self as heap_query, HeapAllocation, HeapBackend, HeapState, HeapWalk};
 use dbgscope::pool::query::{self, PoolPageFilter, PoolWalk};
@@ -136,6 +136,49 @@ fn stop_inheriting(handle: RawHandle) -> std::io::Result<()> {
 /// `PendingTarget::wait` ignores this for that one case. That unbounded wait is the reason
 /// sessions live in their own process.
 const LOAD_WAIT_MS: u32 = 60_000;
+
+/// Whether the wait that *is* the load finished it, as an opener's `transition` reads it.
+///
+/// `open_dump` and `open_trace` defer the real work to the next `WaitForEvent`, so this wait is
+/// not a wait *for* the load — it is the load. Only [`WaitOutcome::Stopped`] is one that finished:
+/// the engine processed the target and stopped on it.
+///
+/// **[`WaitOutcome::Expired`] is the one this was silently passing**, and it could not have done
+/// otherwise: until [dbgscope#136] a finite wait answered `Result<(), _>`, and `S_FALSE` — the
+/// bound passing with the load still going — was flattened by the generated wrapper into the same
+/// `Ok` a stop gets. So a dump too large, or a symbol path too cold, to finish inside
+/// [`LOAD_WAIT_MS`] was reported as an open that worked, and whatever the caller did next failed
+/// for a reason nothing connected to the open. The two comments at the call sites have said "a
+/// load wait that times out still leaves DbgEng holding the dump" since they were written; that is
+/// what `commit()` above the wait is for, and this is the other half of it finally arriving — the
+/// caller is told the session holds the target, so `end_session` is the recovery and opening again
+/// would claim a second one.
+///
+/// [`WaitOutcome::OnRequest`] is a host interrupting the load through `interrupt`. Not an error
+/// about the target, but not a finished load either, and the same advice applies.
+/// [`WaitOutcome::Deadline`] cannot arise — a finite bound arms no watchdog — so it shares that
+/// arm rather than being given a message this cannot produce.
+///
+/// **The reachability of `Expired` here is argued, not measured.** dbgscope measured a finite
+/// expiry on a *running* target (`S_FALSE` at 312 ms for a 300 ms bound); nothing has held a dump
+/// load past sixty seconds on purpose. So this is unit-tested as a mapping, and what is not
+/// claimed is how often the mapping fires.
+///
+/// [dbgscope#136]: https://github.com/glslang/dbgscope/issues/136
+fn load_completed(outcome: WaitOutcome, target: &str) -> Result<(), String> {
+    match outcome {
+        WaitOutcome::Stopped { .. } => Ok(()),
+        WaitOutcome::Expired => Err(format!(
+            "the {target} had not finished loading after {LOAD_WAIT_MS} ms. The session holds it, \
+             so end_session releases it; opening it again would claim a second target. A large \
+             dump or a cold symbol path is the usual cause."
+        )),
+        WaitOutcome::OnRequest | WaitOutcome::Deadline => Err(format!(
+            "loading the {target} was interrupted before it finished. The session holds it, so \
+             end_session releases it; opening it again would claim a second target."
+        )),
+    }
+}
 
 /// Most bytes a single `read_memory` will fetch.
 ///
@@ -1416,7 +1459,7 @@ fn execute(e: &DebugEngine, id: u64, op: EngineOp, queued: Duration) -> Result<O
                 // load wait that times out still leaves DbgEng holding the dump.
                 e.open_dump(&path).map_err(es)?;
                 commit();
-                e.wait_for_event(LOAD_WAIT_MS).map_err(es)
+                load_completed(e.wait_for_event(LOAD_WAIT_MS).map_err(es)?, "dump")
             },
             || {
                 // Load the WinDbg extension DLL so `!`-extension commands resolve — most
@@ -1442,7 +1485,7 @@ fn execute(e: &DebugEngine, id: u64, op: EngineOp, queued: Duration) -> Result<O
                 // still leaves DbgEng holding the trace.
                 e.open_trace(&path).map_err(trace_open_failure)?;
                 commit();
-                e.wait_for_event(LOAD_WAIT_MS).map_err(es)
+                load_completed(e.wait_for_event(LOAD_WAIT_MS).map_err(es)?, "trace")
             },
             || {
                 // Check the index state *before* any data-model query: `!ttdext.index -status`
@@ -8934,5 +8977,47 @@ mod tests {
             !explained.contains("Nothing about the trace or the path needs changing"),
             "never the unconditional claim, which a mistyped path would falsify: {explained}"
         );
+    }
+
+    /// **A load wait that did not load is a failure**, which is what the wait answering a value
+    /// rather than `Result<(), _>` bought (dbgscope#136).
+    ///
+    /// The gap this closes was structural rather than an oversight: `S_FALSE` and `S_OK` were one
+    /// `Ok(())`, so an opener could not tell a dump that finished loading from one still loading
+    /// at the bound, and reported both as an open that worked. The commit above the wait was
+    /// already placed for this — the target exists, so the recovery is `end_session` and not
+    /// another open — and the two comments saying so predate any code that could reach it.
+    ///
+    /// Asserted as a mapping, because that is the whole of what this host can check: holding a
+    /// real dump load past sixty seconds is not something a test can arrange. So the `Expired` arm
+    /// is unmeasured against a real engine, and says so where it is defined.
+    #[test]
+    fn a_load_that_did_not_finish_is_not_an_open_that_worked() {
+        assert!(
+            load_completed(WaitOutcome::Stopped { process: None }, "dump").is_ok(),
+            "a load that stopped on its target is the one outcome that finished it"
+        );
+
+        let expired = load_completed(WaitOutcome::Expired, "dump")
+            .expect_err("a bound that passed with the load still going is not a finished load");
+        assert!(
+            expired.contains("end_session"),
+            "the advice names the recovery for a target the session already holds: {expired}"
+        );
+        assert!(
+            expired.contains(&LOAD_WAIT_MS.to_string()),
+            "and says what bound it was measured against, or the number is folklore: {expired}"
+        );
+
+        // Both breaks, because the reason is that the load did not finish and not which origin
+        // stopped it -- and the `Deadline` arm is unreachable on a finite bound, so this is the
+        // only place it is exercised at all.
+        for broke_in in [WaitOutcome::OnRequest, WaitOutcome::Deadline] {
+            let interrupted = load_completed(broke_in, "trace").unwrap_err();
+            assert!(
+                interrupted.contains("trace") && interrupted.contains("end_session"),
+                "{broke_in:?} names the target it left half-open and the recovery: {interrupted}"
+            );
+        }
     }
 }


### PR DESCRIPTION
Repoints `dbgscope` at `main` now that [dbgscope#137](https://github.com/glslang/dbgscope/pull/137)
(#136 stage 1) has merged, and takes the one behaviour that bump makes reachable.

## The pin

`4a89c09d680b798a7952084ba48fa72e4b528ce3` — dbgscope's `main`, **not** the branch head. #137 was
rebase-merged, so `5978f5e` is an ancestor of nothing there; checked rather than assumed:

```console
$ git -C ../dbgscope merge-base --is-ancestor 4a89c09 origin/main && echo ok
ok
$ git -C ../dbgscope diff --stat refactor/a-wait-returns-its-outcome origin/main
(empty — identical trees)
```

`Cargo.toml`'s `rev` edited and `cargo update -p dbgscope` run; both committed.

## The behaviour

`open_dump` and `open_trace` defer the real work to the next `WaitForEvent`, so
`wait_for_event(LOAD_WAIT_MS)` **is** the load. dbgscope's finite wait used to answer
`Result<(), _>`, and the generated wrapper flattens `S_FALSE` — the 60-second bound passing with the
load still going — into the same `Ok` a completed load gets.

So a dump too large, or a symbol path too cold, to finish inside that bound was reported as **an
open that worked**, and whatever the caller did next failed for a reason nothing connected to the
open. This side could not have caught it: the fact was thrown away inside the wait, which is the
whole of what #136 is about. `worker::load_completed` reads the `WaitOutcome` now, and only
`Stopped` is a load that finished.

Three things about it:

- **The failure is post-commit**, which is what the `commit()` already sitting above the wait was
  for. Both call-site comments have said *"a load wait that times out still leaves DbgEng holding
  the dump"* since they were written — that half was in place and the other half had nothing to
  report with. The caller is told the session holds the target, so `end_session` is the recovery
  and opening again would claim a second one.
- **`Deadline` is unreachable** on a finite bound, which arms no watchdog, so it shares the
  `OnRequest` arm rather than getting a message nothing can produce.
- **The `Expired` arm is unmeasured against a real engine.** Holding a dump load past sixty seconds
  is not something a test can arrange, so `a_load_that_did_not_finish_is_not_an_open_that_worked`
  asserts the *mapping* — verified by mutation, `Expired => Ok(())` fails it — and nothing claims
  how often the mapping fires. Said so where the function is defined, not only here.

## Handoff docs

- `CLAUDE.md` — a paragraph in *Driving execution* saying these were the last two finite waits and
  had the same defect as the `execute_and_wait` one recorded above it, which closes that family.
- `FOLLOWUPS.md` item 47 cited `wait_for_event_bounded` **twice**, once in the "where it picks up"
  section that tells the next person which code to open. That function is gone, folded into one
  `pump`. Retargeted, because the item is open and a pointer to nothing is the kind of prose
  problem this repo acts on; the item's number and text are otherwise untouched. `DONE.md`'s
  mention and the released `CHANGELOG` entries' are **left alone** — they are a dated record of
  what was true then.
- `CHANGELOG.md` under Unreleased → Fixed.
- `docs/smoke-test.md` — nothing. The new test is a unit test, so the `mcp_smoke` count is
  unchanged at 99.

## Verification

`644 passed` unit (643 + the new one) and `99 passed` smoke with `WINDBG_MCP_SMOKE_DUMP=1`, on a
bench with the engine DLLs and `winext\` bundled and the 32-bit worker rebuilt for this tree.
`cargo fmt --all --check`, `cargo clippy --all-targets` and
`npx markdownlint-cli2@0.23.2 README.md CHANGELOG.md "docs/**/*.md" "skills/**/*.md"` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HyRDk1yX5UqRkdpGgodrMY
