### PR TITLE
chore: repoint dbgscope at the scoped break request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **A break this server asks for is now scoped to the engine operation it will stop.** dbgscope's
+  interrupt was an engine-wide flag that each bounded operation cleared as it opened, so a request
+  lodged between that clear and the wait it was meant for was erased while its `SetInterrupt` was
+  still on the way — and the synthetic Ctrl+Break that then arrived was reported as the target's
+  own stop. This server reaches that path: `interrupt`/`break_in` raise the break from the request
+  reader, off the engine thread, while a live open runs on it.
+
+  Closed upstream by [dbgscope#135](https://github.com/glslang/dbgscope/issues/135) /
+  [#136](https://github.com/glslang/dbgscope/issues/136) stage 2: the request is filed against the
+  operation running at that instant, under the same lock that delivers `SetInterrupt`, and there is
+  no clear anywhere. Nothing about this server's tool surface changes —
+  `worker::interrupt_running` now logs which operation the break was filed against, and
+  deliberately does **not** turn that into a different answer for the caller: `NothingRunning`
+  means the *engine* had no bounded operation to file against (a typed getter, a plain
+  `execute_command`), not that the session is idle, and the break is delivered either way.
+
 - **`set_breakpoint` no longer runs `bp` as text**, and its result is a different shape as a result.
   It now goes through dbgscope's typed breakpoint API
   ([dbgscope#126](https://github.com/glslang/dbgscope/issues/126)), which hands back the breakpoint

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -756,9 +756,18 @@ Two consequences worth carrying:
   `Watchdog` now wakes on a condvar, so a disarm is immediate and the bound costs nothing until it
   is reached. That trade-off is retired rather than worked around; the criterion in `DECISIONS.md`
   still stands, but its price has changed.
-- **The origin of a break is the watchdog's own flag, not `interrupt_raised`** — which the watchdog
-  sets too, since that is what `InterruptHandle::interrupt` does. Reading the shared flag alone
-  reports the crate's own deadline as "a host asked".
+- **The origin of a break is the watchdog's own flag**, which used to need saying because the
+  watchdog reached the engine through `InterruptHandle::interrupt` like any host and so raised the
+  same engine-wide flag — reading that flag alone reported the crate's own deadline as "a host
+  asked". Since [dbgscope#136](https://github.com/glslang/dbgscope/issues/136) stage 2 the watchdog
+  goes through a private `break_in_only` and files nothing, so the two origins are independent
+  signals and there is no shared flag to misread. A host's request is instead filed against the
+  **operation** it will stop, under the same lock that delivers `SetInterrupt` — which is what
+  closed dbgscope#135: an operation clearing the flag as it opened could erase a request whose
+  break was still on the way, and the synthetic stop was then reported as the target's own.
+  `InterruptHandle::interrupt` answers a `BreakRequest` saying which operation it reached, or
+  `NothingRunning`; `worker::interrupt_running` logs that and deliberately does not turn it into a
+  different answer for the caller — see the comment there.
 
 **Why nothing caught any of it.** Every tier that drives execution was the live-kernel one, which
 was already on the bounded wait; a dump cannot `go`, and no tier launched a process. The debugger

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,7 +164,7 @@ dependencies = [
 [[package]]
 name = "dbgscope"
 version = "0.1.0"
-source = "git+https://github.com/glslang/dbgscope?rev=4a89c09d680b798a7952084ba48fa72e4b528ce3#4a89c09d680b798a7952084ba48fa72e4b528ce3"
+source = "git+https://github.com/glslang/dbgscope?rev=fb5828c5f9f62e2e00aed20190ee37fa60b1791e#fb5828c5f9f62e2e00aed20190ee37fa60b1791e"
 dependencies = [
  "hex",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/glslang/windbg-mcp"
 license = "MIT"
 
 [dependencies]
-dbgscope = { git = "https://github.com/glslang/dbgscope", rev = "4a89c09d680b798a7952084ba48fa72e4b528ce3" }
+dbgscope = { git = "https://github.com/glslang/dbgscope", rev = "fb5828c5f9f62e2e00aed20190ee37fa60b1791e" }
 # 3.1.1 is a floor, not a preference: every 3.x before it generates a `tools/list` that omits
 # SEP-2549's required `ttlMs`/`cacheScope`, which a spec-strict `2026-07-28` client rejects
 # outright — the server connects and appears to expose no tools at all (upstream issue #1114).

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -1355,12 +1355,19 @@ fn interrupt_running(bound: Option<u64>) -> Result<(Interrupted, String), String
                 .to_string(),
         );
     };
-    handle.interrupt().map_err(es)?;
+    let filed = handle.interrupt().map_err(es)?;
     // Recorded only once the raise succeeded: a failed one has left nothing pending, and claiming
     // otherwise would have the engine thread drain an interrupt that was never lodged and label a
     // complete result as cut short.
     running.interrupt_raised();
-    tracing::info!("worker: interrupt raised for job {job}");
+    // Logged, and deliberately not turned into a different answer for the caller.
+    // `BreakRequest::NothingRunning` says the *engine* had no bounded operation to file the request
+    // against — a typed getter, or a plain `execute_command`, neither of which is one — and not
+    // that this session is idle: the job the caller named is running either way, and the break was
+    // delivered either way, since `SetInterrupt` is engine-wide. What it does tell you, in a log
+    // read after the fact, is whether the break had anything to be reported by, which is the
+    // difference between an operation that will come back `cut_short` and one that will not.
+    tracing::info!("worker: interrupt raised for job {job}, filed as {filed:?}");
     Ok((
         Interrupted::Raised,
         "Interrupted. Ctrl+Break was raised on this session's engine, so the operation it was \


### PR DESCRIPTION
Repoints `dbgscope` at `main` now that [dbgscope#138](https://github.com/glslang/dbgscope/pull/138)
(#136 stage 2, closing #135) has merged.

## The pin

`fb5828c5f9f62e2e00aed20190ee37fa60b1791e` — dbgscope's `main`, **not** any of the branch's four
commits, none of which survived at its own SHA: #138 was rebase-merged. Checked rather than assumed:

```console
$ git -C ../dbgscope merge-base --is-ancestor fb5828c origin/main && echo ok
ok
$ git -C ../dbgscope diff --stat refactor/scope-a-break-request-to-an-operation origin/main
(empty — identical trees)
```

`Cargo.toml`'s `rev` edited and `cargo update -p dbgscope` run; both committed.

## What lands with it

A break request is now filed against the bounded engine operation it will stop, **under the same
lock that delivers `SetInterrupt`**, and no operation clears an engine-wide flag as it opens any
more.

The race that closes is one **this server reaches**: `interrupt` and `break_in` raise the break from
the request reader, off the engine thread, while a live open runs on it. A request lodged between an
operation's clear and the wait it was meant for was erased while its `SetInterrupt` was still on the
way — and the cost was not a misreported `cut_short` but a synthetic Ctrl+Break written into
dbgscope's `stopped_on` as a target's *initial break*, after which a guard's `wait()` returned `Ok`
for a process that never reached one, for the rest of the session.

## What changes here

One line of behaviour, and it is a log line. `InterruptHandle::interrupt` answers a `BreakRequest`,
so `worker::interrupt_running` records which operation the break was filed against.

**Deliberately not turned into a different answer for the caller**, and the comment at the site says
why: `BreakRequest::NothingRunning` means the *engine* had no bounded operation to file against — a
typed getter, or a plain `execute_command`, neither of which is one — and **not** that this session
is idle. The job the caller named is running either way, and the break is delivered either way,
since `SetInterrupt` is engine-wide and cannot be aimed. What it tells a reader of the log after the
fact is whether the break had anything to be *reported* by, which is the difference between an
operation that comes back `cut_short` and one that does not.

No tool's answer, schema or description moves.

## Handoff docs

- `CLAUDE.md` — the *Driving execution* bullet "the origin of a break is the watchdog's own flag,
  not `interrupt_raised` — which the watchdog sets too" is no longer true: the watchdog goes through
  a private `break_in_only` and files nothing, so the two origins are independent signals and there
  is no shared flag to misread. Rewritten rather than deleted, because the sentence it replaces is
  the reason the old rule existed.
- `CHANGELOG.md` under Unreleased → Changed. Folded into the existing `### Changed` rather than
  opening a second one, which MD024 (`siblings_only`) rejects.
- `FOLLOWUPS.md`, `DONE.md`, `docs/smoke-test.md` — nothing. Item 47's `SetInterrupt` references are
  still accurate (delivery is unchanged; only attribution moved), `DONE.md`'s are a dated record,
  and no test count moved.

## Verification

`644 passed` unit and `99 passed` smoke with `WINDBG_MCP_SMOKE_DUMP=1`, on a bench with the engine
DLLs and `winext\` bundled and the 32-bit worker rebuilt for this tree. `cargo fmt --all --check`,
`cargo clippy --all-targets` and
`npx markdownlint-cli2@0.23.2 README.md CHANGELOG.md "docs/**/*.md" "skills/**/*.md"` all clean.

Refs [glslang/dbgscope#135](https://github.com/glslang/dbgscope/issues/135),
[glslang/dbgscope#136](https://github.com/glslang/dbgscope/issues/136)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HyRDk1yX5UqRkdpGgodrMY
