### PR TITLE
chore: repoint dbgscope at `main` now that #136 stage 3 has merged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **The engine's arrival bookkeeping is a delivery register rather than an engine-wide record.**
+  dbgscope [#136](https://github.com/glslang/dbgscope/issues/136) stage 3: an open registers what it
+  is waiting for, a stop is routed to the first open that wants it and has nothing yet, and the
+  entry dies with the guard that made it. That deletes the three lifecycle rules the record it
+  replaces needed — pruned at both openers for pid reuse, cleared where a session is replaced and
+  cleared again where one is ended — because nothing outlives its reader any more. It also makes two
+  opens pending at once exact where they were ambiguous, which the type it replaces had documented
+  as an accepted cost.
+
+  **No behaviour of this server moves**, which is worth stating rather than leaving to be inferred
+  from a green suite: a worker holds one target for its whole life and `EngineOp` has no second
+  opener, so every case the register newly tells apart is one this server cannot reach. What the
+  bump buys is the correctness of the layer underneath, and the shapes it makes safe to add. No
+  public API changed either, so this is the pin alone.
+
 - **A break this server asks for is now scoped to the engine operation it will stop.** dbgscope's
   interrupt was an engine-wide flag that each bounded operation cleared as it opened, so a request
   lodged between that clear and the wait it was meant for was erased while its `SetInterrupt` was

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,7 +164,7 @@ dependencies = [
 [[package]]
 name = "dbgscope"
 version = "0.1.0"
-source = "git+https://github.com/glslang/dbgscope?rev=fb5828c5f9f62e2e00aed20190ee37fa60b1791e#fb5828c5f9f62e2e00aed20190ee37fa60b1791e"
+source = "git+https://github.com/glslang/dbgscope?rev=f86a57c6b5dd2633b2fe1f6506e23b5ddda17f31#f86a57c6b5dd2633b2fe1f6506e23b5ddda17f31"
 dependencies = [
  "hex",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/glslang/windbg-mcp"
 license = "MIT"
 
 [dependencies]
-dbgscope = { git = "https://github.com/glslang/dbgscope", rev = "fb5828c5f9f62e2e00aed20190ee37fa60b1791e" }
+dbgscope = { git = "https://github.com/glslang/dbgscope", rev = "f86a57c6b5dd2633b2fe1f6506e23b5ddda17f31" }
 # 3.1.1 is a floor, not a preference: every 3.x before it generates a `tools/list` that omits
 # SEP-2549's required `ttlMs`/`cacheScope`, which a spec-strict `2026-07-28` client rejects
 # outright — the server connects and appears to expose no tools at all (upstream issue #1114).


### PR DESCRIPTION
Repoints `dbgscope` at `main` now that [dbgscope#139](https://github.com/glslang/dbgscope/pull/139)
(#136 stage 3) has merged. Stage 4 is the last one and is independent of this.

## The pin

`f86a57c6b5dd2633b2fe1f6506e23b5ddda17f31` — dbgscope's `main`, **not** the branch head, which is an
ancestor of nothing: #139 was rebase-merged, as #138 was before it. Checked rather than assumed, and
the trees compared as well as the ancestry:

```console
$ git -C ../dbgscope merge-base --is-ancestor de9707a origin/main || echo "not an ancestor"
not an ancestor
$ git -C ../dbgscope merge-base --is-ancestor f86a57c origin/main && echo ok
ok
$ git -C ../dbgscope diff --stat de9707a origin/main -- src/ tests/
(empty — identical source)
```

`Cargo.toml`'s `rev` edited and `cargo update -p dbgscope` run; both committed.

## What lands with it

The engine's arrival bookkeeping is a **delivery register** rather than an engine-wide record. An
open registers what it is waiting for, a stop is routed to the first open that wants it and has
nothing yet, and the entry dies with the guard that made it.

What that deletes is a lifecycle. The record it replaces was every `(engine id, system pid)` the
engine had ever stopped on: every wait wrote into it, every guard polled it, and because it outlived
the opens that read it, it needed pruning at both openers for pid reuse, clearing where a session
was replaced, and clearing again where one was ended — three rules that each arrived as a review
finding rather than as a design. Nothing outlives its reader now, so there is nothing to prune or
clear.

It also makes two opens pending at once **exact** where they were ambiguous, which is a cost the
type it replaces had documented as accepted.

## What changes here

Nothing, and the reason is a property of this server rather than luck: **a worker holds one target
for its whole life and `EngineOp` has no second opener**, so every case the register newly tells
apart needs two opens pending at once and cannot arise. Each opener in `worker.rs` creates one
`PendingTarget` and waits on it inside the same closure, so there is no abandoned guard either.

No public API moved — the new types are private to `dbgeng.rs` — so this is the pin alone.

Saying so explicitly rather than leaving it to be read off a green suite, because "no behaviour
change" and "no test covers the behaviour that changed" look identical from the outside, and here it
is the first.

## Handoff docs

- `CHANGELOG.md` under Unreleased → Changed. Folded into the existing `### Changed` rather than
  opening a second one, which MD024 (`siblings_only`) rejects.
- `CLAUDE.md`, `FOLLOWUPS.md`, `DONE.md`, `docs/smoke-test.md` — **nothing**, checked rather than
  skipped. Nothing about editing this repo moved; item 47's `dbgscope#136` citation is about stage
  1's pump fold and is still accurate; no test count moved.

## Verification

Run against the new pin rather than carried over from the branch: `644 passed` unit and `99 passed`
smoke with `WINDBG_MCP_SMOKE_DUMP=1`, on a bench with the engine DLLs bundled and the 32-bit worker
rebuilt for this tree. `cargo fmt --all --check`, `cargo clippy --all-targets` and
`npx markdownlint-cli2@0.23.2 README.md CHANGELOG.md "docs/**/*.md" "skills/**/*.md"` all clean.

## One thing left upstream

[dbgscope#141](https://github.com/glslang/dbgscope/issues/141) — a launch abandoned *before* it is
delivered anything still leaves its process to the next launch. Pre-existing, unreachable from here
for the same reason as everything else above, and deferred deliberately: the obvious remedy swaps a
wrong `Ok` for a wrong timeout, because nothing retires an entry whose guard is gone.

Refs [glslang/dbgscope#136](https://github.com/glslang/dbgscope/issues/136)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HyRDk1yX5UqRkdpGgodrMY
