### PR TITLE
chore: repoint dbgscope at `main` now that #136 stage 4 has merged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **The debug engine no longer claims to cross threads.** dbgscope
+  [#136](https://github.com/glslang/dbgscope/issues/136) stage 4, the last of that refactor, deletes
+  `unsafe impl Send` and `unsafe impl Sync for DebugEngine`. Both asserted the opposite of what that
+  crate says about itself — `SetInterrupt` is the one DbgEng call documented as safe from any thread
+  *because the rest of the engine is single-thread-affine* — and neither carried a safety comment,
+  because neither could have been given a true one. `InterruptHandle` is now its only `Send + Sync`
+  type: one `SetInterrupt`, from anywhere, and nothing else.
+
+  **A breaking change upstream that this server does not feel**, which is worth separating from "no
+  behaviour changed": a worker builds its engine in `worker::build_engine`, on the engine thread
+  that then uses it for the whole of that worker's life, so it never needed either bound. That was
+  measured before the change rather than after — removing each and building leaves this crate
+  compiling unchanged.
+
 - **The engine's arrival bookkeeping is a delivery register rather than an engine-wide record.**
   dbgscope [#136](https://github.com/glslang/dbgscope/issues/136) stage 3: an open registers what it
   is waiting for, a stop is routed to the first open that wants it and has nothing yet, and the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,7 +164,7 @@ dependencies = [
 [[package]]
 name = "dbgscope"
 version = "0.1.0"
-source = "git+https://github.com/glslang/dbgscope?rev=f86a57c6b5dd2633b2fe1f6506e23b5ddda17f31#f86a57c6b5dd2633b2fe1f6506e23b5ddda17f31"
+source = "git+https://github.com/glslang/dbgscope?rev=0c85989df0606d10b0a0dba8685ea5553ceb8ea7#0c85989df0606d10b0a0dba8685ea5553ceb8ea7"
 dependencies = [
  "hex",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/glslang/windbg-mcp"
 license = "MIT"
 
 [dependencies]
-dbgscope = { git = "https://github.com/glslang/dbgscope", rev = "f86a57c6b5dd2633b2fe1f6506e23b5ddda17f31" }
+dbgscope = { git = "https://github.com/glslang/dbgscope", rev = "0c85989df0606d10b0a0dba8685ea5553ceb8ea7" }
 # 3.1.1 is a floor, not a preference: every 3.x before it generates a `tools/list` that omits
 # SEP-2549's required `ttlMs`/`cacheScope`, which a spec-strict `2026-07-28` client rejects
 # outright — the server connects and appears to expose no tools at all (upstream issue #1114).


### PR DESCRIPTION
Repoints `dbgscope` at `main` now that [dbgscope#142](https://github.com/glslang/dbgscope/pull/142)
(#136 stage 4) has merged. That closes dbgscope#136 — all four stages are in.

## The pin

`0c85989df0606d10b0a0dba8685ea5553ceb8ea7` — dbgscope's `main`, **not** the branch head, which is an
ancestor of nothing: #142 was rebase-merged, as #139 and #138 were. Checked rather than assumed, and
the trees compared as well as the ancestry:

```console
$ git -C ../dbgscope merge-base --is-ancestor d67c831 origin/main || echo "not an ancestor"
not an ancestor
$ git -C ../dbgscope diff --stat d67c831 origin/main -- src/ tests/
(empty — identical source)
```

`Cargo.toml`'s `rev` edited and `cargo update -p dbgscope` run; both committed.

## What lands with it

`unsafe impl Send` and `unsafe impl Sync for DebugEngine` are **deleted**. Both asserted the opposite
of what that crate says about itself — `SetInterrupt` is the one DbgEng call documented as safe from
any thread *because the rest of the engine is single-thread-affine* — and neither carried a safety
comment, because neither could have been given a true one. `InterruptHandle` is now dbgscope's only
`Send + Sync` type: one `SetInterrupt`, from anywhere, and nothing else.

## What changes here

Nothing — but this one is worth stating more carefully than the last repoint, because **upstream it
is a breaking change** and "breaking" and "this server is affected" are different questions.

A worker builds its engine in `worker::build_engine`, on the engine thread that then uses it for the
whole of that worker's life. It never moved one between threads and never shared one, so it never
needed either bound. That was measured upstream *before* the impls were removed — removing each and
building leaves this crate compiling unchanged — rather than discovered here afterwards.

No public API this server calls moved, so the repoint is the pin alone.

## Handoff docs

- `CHANGELOG.md` under Unreleased → Changed, folded into the existing `### Changed`, which MD024
  (`siblings_only`) requires.
- `CLAUDE.md`, `FOLLOWUPS.md`, `DONE.md`, `docs/smoke-test.md` — **nothing**, checked rather than
  skipped. Nothing in `CLAUDE.md` claims the engine crosses threads; its "engine thread" references
  are all consistent with the model that is now enforced by the types. `FOLLOWUPS.md` item 47's
  `dbgscope#136` citation is about stage 1's pump fold and is still accurate. No test count moved.

## Verification

Run against the new pin rather than carried over: `644 passed` unit and `99 passed` smoke with
`WINDBG_MCP_SMOKE_DUMP=1`, on a bench with the engine DLLs bundled and the 32-bit worker rebuilt for
this tree. `cargo fmt --all --check`, `cargo clippy --all-targets` and
`npx markdownlint-cli2@0.23.2 README.md CHANGELOG.md "docs/**/*.md" "skills/**/*.md"` all clean.

Upstream, #142 was additionally checked with a **dispatched Miri run against its branch**
([run 33874565623](https://github.com/glslang/dbgscope/actions/runs/33874565623), success), since
dbgscope's Miri does not run on pull requests and that change touches unsafe code.

## Still open upstream

[dbgscope#141](https://github.com/glslang/dbgscope/issues/141) — a launch abandoned before delivery
leaves its process to the next launch. Pre-existing, and unreachable from here: each opener in
`worker.rs` creates one `PendingTarget` and waits on it inside the same closure, so there is no
abandoned guard and never two opens pending at once.

Refs [glslang/dbgscope#136](https://github.com/glslang/dbgscope/issues/136)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HyRDk1yX5UqRkdpGgodrMY
