### PR TITLE
ci: wire Authenticode signing into the release, inert until a certificate exists

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,6 +79,111 @@ jobs:
       - name: Test
         run: cargo test --locked
 
+      # ---- Authenticode signing (FOLLOWUPS.md item 50) --------------------------
+      #
+      # **Placed here on purpose, and this is the half that is easy to get wrong.**
+      # Both artifacts embed both exes, `SHA256SUMS.txt` covers those archives,
+      # `server.json` carries the .mcpb's hash and the provenance attestation is
+      # taken over both — so signing anywhere after `Package` would publish
+      # checksums and an attestation for bytes nobody downloads. Signing is of the
+      # two **executables**; a .zip and a .mcpb are archives, which Authenticode
+      # does not cover at all, and what stands behind those is the checksum file
+      # and the attestation.
+      #
+      # It is **inert until the secrets exist**, which is the state this repo is in
+      # today: no certificate has been obtained yet, and a fork never has secrets.
+      # Nothing downstream changes when it is unconfigured, so this cannot break a
+      # release by sitting here — it can only fail loudly once it is switched on.
+      #
+      # **The credential shape below is the one part that may not survive contact
+      # with the certificate**, and it is worth knowing before buying one rather
+      # than after. A `.pfx` in a secret is the simplest and most reviewable shape,
+      # and it is also the one the CA/Browser Forum has required issuers to stop
+      # handing out: since June 2023 a code-signing private key must be generated
+      # and held on FIPS 140-2 Level 2 hardware or an equivalent cloud HSM, so a
+      # new OV certificate normally arrives on a **token** or as a **cloud signing**
+      # service rather than as a file. That matters here in one specific way — a
+      # physical token cannot be reached from a GitHub-hosted runner at all, so a
+      # token-only certificate means signing by hand or standing up a self-hosted
+      # runner, and the cloud option is the one that keeps this workflow working.
+      #
+      # If it turns out to be cloud signing, exactly one thing below changes: the
+      # `signtool sign` invocation swaps `/f <pfx> /p <password>` for the provider
+      # flags that vendor documents (typically `/csp`/`/kc`, or `/dlib` with their
+      # KSP). The gating, the placement before `Package`, the two targets and the
+      # verification step are all unaffected — which is why they are written and
+      # reviewed now and that one line is not.
+      - name: Is signing configured?
+        id: signing
+        shell: bash
+        env:
+          PFX: ${{ secrets.CODE_SIGNING_PFX }}
+        run: |
+          # Through an env var and an output rather than `if: secrets.X != ''`,
+          # because the `secrets` context is not available in a step-level `if`:
+          # that condition evaluates false for ever and says nothing, which is the
+          # failure mode a gate must not have.
+          if [ -n "$PFX" ]; then
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::No code-signing certificate is configured; this build's binaries are unsigned."
+          fi
+
+      - name: Sign the binaries
+        # Runs on dry runs too, deliberately: a `workflow_dispatch` is where the
+        # signing path gets exercised without cutting a release. If the eventual
+        # certificate meters signatures, add `github.event_name == 'push'` here.
+        if: steps.signing.outputs.configured == 'true'
+        shell: pwsh
+        env:
+          PFX: ${{ secrets.CODE_SIGNING_PFX }}
+          PFX_PASSWORD: ${{ secrets.CODE_SIGNING_PFX_PASSWORD }}
+          # RFC 3161. Without a timestamp the signature dies with the certificate,
+          # so this is not optional; `verify /tw` below is what enforces it.
+          TIMESTAMP_URL: ${{ vars.CODE_SIGNING_TIMESTAMP_URL || 'http://timestamp.digicert.com' }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+
+          # signtool ships with the Windows SDK and is not on PATH. Take the
+          # newest x64 one rather than a fixed version, which moves with the image.
+          $signtool = Get-ChildItem "C:\Program Files (x86)\Windows Kits\10\bin\*\x64\signtool.exe" -ErrorAction SilentlyContinue |
+                      Sort-Object { [version]$_.Directory.Parent.Name } | Select-Object -Last 1
+          if (-not $signtool) { throw "signtool.exe not found in the Windows SDK on this runner" }
+
+          # The certificate exists only in this runner's temp directory and only
+          # for this step.
+          $pfx = Join-Path $env:RUNNER_TEMP "code-signing.pfx"
+          [IO.File]::WriteAllBytes($pfx, [Convert]::FromBase64String($env:PFX))
+          try {
+            foreach ($exe in @("target/release/windbg-mcp.exe",
+                               "target/i686-pc-windows-msvc/release/windbg-mcp.exe")) {
+              & $signtool.FullName sign /v /fd SHA256 /f $pfx /p $env:PFX_PASSWORD /tr $env:TIMESTAMP_URL /td SHA256 $exe
+              if ($LASTEXITCODE -ne 0) { throw "signtool sign failed for $exe" }
+            }
+          } finally {
+            Remove-Item $pfx -Force -ErrorAction SilentlyContinue
+          }
+
+      - name: Verify the signatures
+        # A separate step, and not decoration. `signtool sign` reporting success
+        # is not Windows accepting the result: a chain the machine cannot build,
+        # or a timestamp that silently did not attach, both leave an exe that
+        # signed "fine" and warns on a user's machine. `/pa` asks under the
+        # Authenticode policy, which is the one the shell and SmartScreen use, and
+        # `/tw` makes an untimestamped signature a failure rather than a warning.
+        if: steps.signing.outputs.configured == 'true'
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $signtool = Get-ChildItem "C:\Program Files (x86)\Windows Kits\10\bin\*\x64\signtool.exe" -ErrorAction SilentlyContinue |
+                      Sort-Object { [version]$_.Directory.Parent.Name } | Select-Object -Last 1
+          foreach ($exe in @("target/release/windbg-mcp.exe",
+                             "target/i686-pc-windows-msvc/release/windbg-mcp.exe")) {
+            & $signtool.FullName verify /pa /tw /v $exe
+            if ($LASTEXITCODE -ne 0) { throw "signature verification failed for $exe" }
+          }
+
       - name: Package
         shell: pwsh
         run: |

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -593,8 +593,16 @@ question `serverInfo.version` does. Four things that entry did not see:
   says nothing about the next, since an `!ml` verdict is scored on the file in front of it — and it
   is a human action with an account behind it, so it belongs in `docs/releasing.md` (where it now
   is) rather than in a workflow.
-- **Authenticode signing** in `release.yml`, which is the standing fix and the part that needs a
-  decision. Two things about it are easy to get backwards. It **does not guarantee** an `!ml`
+- **Authenticode signing** in `release.yml`. **The plumbing has landed and only the certificate is
+  missing**, which is the whole of what is left here: the sign and verify steps sit between `Test`
+  and `Package` — before the archives that embed the exes, the checksum file, `server.json`'s hash
+  and the provenance attestation, all of which would otherwise describe unsigned bytes — gated on
+  `CODE_SIGNING_PFX` being set, so they skip with a build-log notice until it is. Two secrets switch
+  them on; [`docs/releasing.md`](./docs/releasing.md) has the names and the dry-run check. The
+  verification step is not decoration: `signtool verify /pa /tw` was confirmed to **fail on the
+  current unsigned exe**, so a signing step that silently no-ops cannot pass a release through.
+
+  Two things about signing are easy to get backwards. It **does not guarantee** an `!ml`
   detection goes away — Microsoft's own issue files signing under a later tier than the metadata —
   and it is not a prerequisite for the submission above; what it buys is a *stable identity for
   reputation to attach to*, so the submission stops starting from nothing each release, plus the fix
@@ -610,15 +618,23 @@ question `serverInfo.version` does. Four things that entry did not see:
     than accumulating it, and it is also the one a solo maintainer cannot buy: EV issuance requires
     a registered legal entity, so it is a company-formation decision before it is a few hundred a
     year.
-  - **SignPath's Foundation programme** signs open-source projects for free and has no such
-    geographic or entity bar, which makes it the first ask.
-  - **Certum's open-source code-signing certificates** are the paid fallback — aimed at EU
-    individual developers, around a hundred euros for several years, on a token or their cloud
-    signing.
+  - **SignPath's Foundation programme** signs open-source projects for free and has no geographic
+    or entity bar — it was the first ask here, and on 2026-09-04 the maintainer ruled it out: its
+    criteria require the project to be **findable at the top of a web search for its name**, and
+    this one is both small and named generically enough that it is not. That is not a bar effort
+    closes, so it is crossed off rather than deferred.
+  - **Certum's open-source code-signing certificates** are therefore the route being taken, not a
+    fallback — aimed at EU individual developers, around a hundred euros for several years. **Take
+    the cloud signing rather than the token**: a physical token cannot be reached from a
+    GitHub-hosted runner, which would mean signing by hand or a self-hosted runner, and since June
+    2023 the CA/Browser Forum has required code-signing keys to be on FIPS 140-2 Level 2 hardware
+    or an equivalent cloud HSM, so a plain `.pfx` is unlikely to be on offer at all. That changes
+    exactly one line of the workflow — `signtool sign`'s `/f`/`/p` become the vendor's provider
+    flags — and nothing around it.
 
-  So the reachable options are both OV-class, and reputation accumulates rather than arriving — which
-  is an argument for doing the per-release submission above *regardless* of what gets signed, not
-  for treating signing as the thing that makes it unnecessary. Prices and programme terms move;
+  So the one option left standing is OV-class, and reputation accumulates rather than arriving —
+  which is an argument for doing the per-release submission above *regardless* of what gets signed,
+  not for treating signing as the thing that makes it unnecessary. Prices and programme terms move;
   treat these as the shape of the choice, not as quotes. Note also what the release *does* carry and why it does not help here:
   `release.yml` produces a Sigstore build-provenance attestation, which is a supply-chain claim a
   user verifies deliberately with `gh attestation verify`. Nothing on the machine reads it, and it

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -126,3 +126,30 @@ before it having been cleared says nothing, since an `!ml` verdict is scored on 
 it. And it is the step that gets *shorter* once the binary is signed: a signature is a stable
 identity for the reputation to attach to, where an unsigned build starts from nothing each time.
 Worth doing pre-emptively on a release rather than waiting for the first report.
+
+### Switching signing on
+
+The workflow already has the steps; they are skipped while no certificate is configured, and the
+build log says so (`No code-signing certificate is configured`). Two repository secrets turn them
+on, and nothing else needs editing:
+
+| name | what it holds |
+|---|---|
+| `CODE_SIGNING_PFX` | the `.pfx`, base64-encoded (`[Convert]::ToBase64String([IO.File]::ReadAllBytes('cert.pfx'))`) |
+| `CODE_SIGNING_PFX_PASSWORD` | its password |
+
+Optionally `CODE_SIGNING_TIMESTAMP_URL` as a repository **variable**, if the issuer wants its own
+RFC 3161 timestamp server rather than the default.
+
+Check it with a **`workflow_dispatch` dry run** before tagging: signing is deliberately not limited
+to tag pushes, so a dry run exercises the whole path and uploads the artifact without publishing
+anything.
+
+**A certificate bought today probably is not a `.pfx`.** Since June 2023 the CA/Browser Forum has
+required code-signing private keys to live on FIPS 140-2 Level 2 hardware or an equivalent cloud
+HSM, so an OV certificate normally arrives on a **token** or as a **cloud signing** service. A
+physical token cannot be reached from a GitHub-hosted runner at all — that would mean signing by
+hand or running a self-hosted runner — so if the choice is open, take the cloud option. Switching to
+one changes a single line in `release.yml`: the `signtool sign` invocation swaps `/f`/`/p` for the
+provider flags the vendor documents. Everything around it — where the steps sit relative to
+packaging, which files are signed, and the verification — is unaffected.


### PR DESCRIPTION
`FOLLOWUPS.md` item 50's remaining half is a **certificate, not plumbing**. This builds the plumbing
now, so it can be reviewed on its own rather than in the same change as the first signed release,
and so that adding two secrets is all that is left.

Nothing observable changes: with no certificate configured the two new steps skip and the build log
says why.

## Where the steps sit is the part worth reviewing

Not the `signtool` line — the placement. Both artifacts embed both exes, `SHA256SUMS.txt` covers
those archives, `server.json` carries the `.mcpb`'s hash, and the provenance attestation is taken
over both. Signing anywhere **after** `Package` would publish checksums and an attestation
describing bytes nobody downloads. So the steps go between `Test` and `Package`.

What is signed is the two **executables**. A `.zip` and a `.mcpb` are archives, which Authenticode
does not cover at all; the checksum file and the attestation are what stand behind those, and that
is now said in a comment so nobody later assumes the archives are signed.

## Two things checked rather than assumed

**The gate does not use `if: secrets.X != ''`.** The `secrets` context is not available in a
step-level `if`, so that condition evaluates false for ever and reports nothing — which is the one
failure mode a gate must not have. It reads the secret into an env var in a prior step and conditions
on that step's output instead.

**`signtool verify /pa /tw` fails on the current unsigned exe** — exit 1, `Number of files
successfully Verified: 0`, measured on the dev bench. That is what makes the verification step load-
bearing rather than decorative: a signing step that silently no-ops cannot pass a release through.
`/tw` is what turns a missing timestamp into a failure rather than a warning, and without a timestamp
the signature would expire with the certificate.

Verification is a **separate step** so that "signing failed" and "Windows will not accept the result"
are distinguishable in the log. `signtool sign` reporting success is not the same as a chain the
machine can build.

## Verified by a dry run, not by reading

`workflow_dispatch` against this branch
([run 33881029264](https://github.com/glslang/windbg-mcp/actions/runs/33881029264), success):

| step | outcome |
|---|---|
| Is signing configured? | success — `##[notice]No code-signing certificate is configured; this build's binaries are unsigned.` |
| Sign the binaries | skipped |
| Verify the signatures | skipped |
| Package, Prepare release notes, Upload artifact | success |
| Attest, Publish release, Publish to registry | skipped (dry run) |

So the gate ran, took the unconfigured branch, **said so rather than skipping silently**, and nothing
downstream moved. That is also the fork case, where secrets are never exposed.

Signing is deliberately **not** limited to tag pushes, which is what makes that dry run possible; if
the eventual certificate meters signatures, add `github.event_name == 'push'` to the gate.

**What is still unproven** is the `signtool sign` invocation itself — everything around it is
exercised, that one line has never run, and it cannot run until a certificate exists.

## The credential shape may not survive contact with the certificate

Documented in the workflow and in `docs/releasing.md` rather than left to be discovered. A `.pfx` in
a secret is the simplest and most reviewable shape, and also the one issuers have had to stop
handing out: since June 2023 the CA/Browser Forum has required code-signing private keys to be
generated and held on FIPS 140-2 Level 2 hardware or an equivalent cloud HSM, so an OV certificate
normally arrives on a **token** or as a **cloud signing** service.

That matters here in one specific way: a physical token cannot be reached from a GitHub-hosted
runner at all, so a token-only certificate means signing by hand or a self-hosted runner. If the
choice is open, take the cloud option — it changes exactly one line here (`/f`/`/p` become the
vendor's provider flags) and nothing around it.

## Handoff docs

- **`FOLLOWUPS.md` item 50** narrows to the certificate, and records that **SignPath's Foundation
  programme is out**. It was "the first ask" in that entry; its criteria require the project to be
  findable at the top of a web search for its name, which this one is not and cannot become by
  effort — a cross-off rather than a deferral. Certum is now the route rather than the fallback, with
  the cloud-vs-token note. The summary sentence that said "the reachable options are **both**
  OV-class" is corrected, since one of the two is gone.
- **`docs/releasing.md`** gains a *Switching signing on* section: the two secret names, the optional
  timestamp variable, and the dry-run check.
- `CLAUDE.md`, `DONE.md`, `docs/smoke-test.md` — nothing. Item 50 is half-landed, so by this repo's
  own rule it stays in `FOLLOWUPS.md` narrowed to what is left rather than moving; no test count
  moved; nothing about editing this repo changed.
- No `CHANGELOG.md` entry: nothing a user of a release can observe has changed, and that entry
  belongs with the release that is actually signed.

Refs `FOLLOWUPS.md` item 50

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HyRDk1yX5UqRkdpGgodrMY
