### PR TITLE
docs: a test can pass because a neighbouring rule covers it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -372,6 +372,38 @@ stayed green — a passing test is not evidence that a deleted check was doing n
 nothing covered it. Before deleting, name every property the code provides; after deleting, assert
 the ones you meant to keep.
 
+**A test can stage exactly the right scenario, run, and pass because a *neighbouring* rule covers
+it.** Not a vacuous assertion — the paragraph above about capability gates is the case that never
+runs; this one runs, asserts the right thing, and is green for the wrong reason, so reading it tells
+you nothing. The only way to find out is to **break the rule the test claims to pin and confirm that
+test fails**. If it stays green it is riding on something else; find what, and pick a construction
+that other rule cannot reach.
+
+The evidence is [dbgscope#139](https://github.com/glslang/dbgscope/pull/139) (2026-09-04), eight
+review rounds and eleven findings on one 700-line module. **Four of them were invisible to a suite
+that already covered the mechanism**, each needing one specific construction to become visible:
+
+| what was missed | what made it visible |
+|---|---|
+| a departed claim reopening the open that held it | **two attaches** — with a launch, an unrelated rule protects it either way |
+| a claim handed along a chain rather than broadcast | **three** launches — with two, both readings agree |
+| an arrived claim believed without re-reading the session | a **second process** keeping the session alive |
+| a finished attach blocking a launch on a reused pid | a departed attach **whose guard is still held** |
+
+Two of the four were regressions introduced by that PR and two were pre-existing, which is the point:
+the split is invisible from the test results, because *every* one of them was green before and after.
+The reviewer found them and the suite could not, and that is a property of the constructions rather
+than of the reviewer — so the answer is not "review harder" but **mutation-verify each new rule
+against the mutation it is for**, one at a time, and treat "the whole suite still passes" as the
+thing to be suspicious of. Two of that PR's own commits shipped a fix whose test passed with the fix
+backed out, until exactly that was done.
+
+A corollary worth having in front of you when a reviewer says a scenario is unreachable: **measure it
+rather than arguing.** Round nine of that PR claimed two live attaches on one pid could starve each
+other. One probe settled it — the kernel gives a process one debug port and refuses the second with
+`0xD0000048 STATUS_PORT_ALREADY_SET` — and the measurement went into the code beside the rule, where
+the next round will find it.
+
 `cargo test` includes `tests/mcp_smoke.rs`, which spawns the **dev** binary (via
 `CARGO_BIN_EXE_windbg-mcp`) and drives it over stdio — so it is also clear of the release lock.
 After a dependency bump (`rmcp`, `schemars`, `tokio`, `cargo update -p dbgscope`) or an MCP spec

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -398,11 +398,13 @@ against the mutation it is for**, one at a time, and treat "the whole suite stil
 thing to be suspicious of. Two of that PR's own commits shipped a fix whose test passed with the fix
 backed out, until exactly that was done.
 
-A corollary worth having in front of you when a reviewer says a scenario is unreachable: **measure it
-rather than arguing.** Round nine of that PR claimed two live attaches on one pid could starve each
-other. One probe settled it — the kernel gives a process one debug port and refuses the second with
-`0xD0000048 STATUS_PORT_ALREADY_SET` — and the measurement went into the code beside the rule, where
-the next round will find it.
+A corollary for the other direction, which is the one you are in more often: **when you are about to
+tell a reviewer their scenario is unreachable, measure it first.** Round nine of that PR said two
+live attaches on one pid could starve each other, and the reply forming in my head was that they
+cannot. That reply happened to be right — the kernel gives a process one debug port and refuses the
+second with `0xD0000048 STATUS_PORT_ALREADY_SET` — but it was worth nothing until a probe said so,
+and the probe is what could be put in the code beside the rule for the next round to find. A
+dismissal you have not measured is indistinguishable, to you, from one you have.
 
 `cargo test` includes `tests/mcp_smoke.rs`, which spawns the **dev** binary (via
 `CARGO_BIN_EXE_windbg-mcp`) and drives it over stdio — so it is also clear of the release lock.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -379,9 +379,12 @@ you nothing. The only way to find out is to **break the rule the test claims to 
 test fails**. If it stays green it is riding on something else; find what, and pick a construction
 that other rule cannot reach.
 
-The evidence is [dbgscope#139](https://github.com/glslang/dbgscope/pull/139) (2026-09-04), eight
-review rounds and eleven findings on one 700-line module. **Four of them were invisible to a suite
-that already covered the mechanism**, each needing one specific construction to become visible:
+The evidence is [dbgscope#139](https://github.com/glslang/dbgscope/pull/139) (2026-09-04), **nine
+review rounds and fourteen findings** on one 700-line module — counted from
+`gh api repos/<owner>/<repo>/pulls/<n>/reviews` and `.../comments`, because the first draft of this
+paragraph said eight and eleven from memory and was caught by a reviewer noticing it disagreed with
+its own "round nine" two paragraphs down. Four of the fourteen were invisible to a suite that
+already covered the mechanism, each needing one specific construction to become visible:
 
 | what was missed | what made it visible |
 |---|---|


### PR DESCRIPTION
Records the review pattern [dbgscope#139](https://github.com/glslang/dbgscope/pull/139) produced,
beside the two rules in `CLAUDE.md` it completes.

**Nine review rounds and fourteen findings** on one 700-line module, and four of them were invisible
to a suite that already covered the mechanism. Each needed one specific construction to become
visible:

| what was missed | what made it visible |
|---|---|
| a departed claim reopening the open that held it | **two attaches** — with a launch, an unrelated rule protects it either way |
| a claim handed along a chain rather than broadcast | **three** launches — with two, both readings agree |
| an arrived claim believed without re-reading the session | a **second process** keeping the session alive |
| a finished attach blocking a launch on a reused pid | a departed attach **whose guard is still held** |

## Why it is a new rule rather than a restatement

It sits between two that are already there and is neither. The capability-gate paragraph is a test
that passes **by never running**; the delete-what-was-load-bearing paragraph is about a check removed
with nothing covering it. This is the third case: the test **runs**, asserts the right thing, and is
green for the wrong reason — a neighbouring rule covers its scenario — so reading it tells you
nothing, and only breaking the rule it claims to pin does.

Two of the four were that PR's own regressions and two were pre-existing. That is the argument rather
than a detail: the split is invisible from the test results, because every one of them was green
before and after. So the conclusion is not "review harder" but mutation-verify each new rule against
the mutation it is for, and treat a wholly-passing suite as the thing to be suspicious of. Two
commits on that PR shipped a fix whose test passed with the fix backed out, until exactly that was
done.

Plus a corollary, and its first draft had it backwards: it is about the case where **you** are
about to call a reviewer's scenario unreachable. Round nine of that PR asserted two live attaches on
one pid could starve each other, and the reply forming in my head was that they cannot. That reply
happened to be right — `0xD0000048 STATUS_PORT_ALREADY_SET` — but was worth nothing until a probe
said so, and the probe is what could be left in the code beside the rule.

## Two review findings on this PR, both taken

- **The corollary was inverted** (reviewer asserting reachable, me about to dismiss) — rewritten.
- **The totals disagreed with the "round nine" reference** — they did, and both were wrong. Counted
  from `pulls/139/reviews` (nine) and `pulls/139/comments` (fourteen); the corrected sentence names
  where the counts come from, since this is the second miscount in one session and the section's own
  subject is re-deriving numbers rather than carrying them.

## Scope

`CLAUDE.md` only, which is not in CI's markdownlint globs, so a clean docs-lint run says nothing
about it either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HyRDk1yX5UqRkdpGgodrMY