### PR TITLE
chore: repoint dbgscope at `main` now that #141's accounting half has merged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **An abandoned launch no longer leaves its process to the next one.** dbgscope
+  [#141](https://github.com/glslang/dbgscope/issues/141): dropping a launch guard before anything
+  pumps does not un-queue its `CreateProcessWide`, so that process still arrived and was claimed by
+  whichever launch asked next — whose `wait()` then returned for a target it never asked for. The
+  entry now stays until its own create is accounted for, and a launch whose wait timed out is
+  discarded rather than kept.
+
+  **Unreachable from here, and that is a property rather than luck**: each opener in `worker.rs`
+  creates one `PendingTarget` and waits on it inside the same closure, so this server never abandons
+  a launch guard and never has two launches pending at once. The bump is the pin alone. What is
+  still open upstream is *identification* — which of two simultaneous launches gets which process —
+  declined there for the same reason it cannot arise here.
+
 - **The debug engine no longer claims to cross threads.** dbgscope
   [#136](https://github.com/glslang/dbgscope/issues/136) stage 4, the last of that refactor, deletes
   `unsafe impl Send` and `unsafe impl Sync for DebugEngine`. Both asserted the opposite of what that

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,7 +164,7 @@ dependencies = [
 [[package]]
 name = "dbgscope"
 version = "0.1.0"
-source = "git+https://github.com/glslang/dbgscope?rev=0c85989df0606d10b0a0dba8685ea5553ceb8ea7#0c85989df0606d10b0a0dba8685ea5553ceb8ea7"
+source = "git+https://github.com/glslang/dbgscope?rev=b259566d0d1e5b4b4962a7c249e0680ac8349bff#b259566d0d1e5b4b4962a7c249e0680ac8349bff"
 dependencies = [
  "hex",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/glslang/windbg-mcp"
 license = "MIT"
 
 [dependencies]
-dbgscope = { git = "https://github.com/glslang/dbgscope", rev = "0c85989df0606d10b0a0dba8685ea5553ceb8ea7" }
+dbgscope = { git = "https://github.com/glslang/dbgscope", rev = "b259566d0d1e5b4b4962a7c249e0680ac8349bff" }
 # 3.1.1 is a floor, not a preference: every 3.x before it generates a `tools/list` that omits
 # SEP-2549's required `ttlMs`/`cacheScope`, which a spec-strict `2026-07-28` client rejects
 # outright — the server connects and appears to expose no tools at all (upstream issue #1114).


### PR DESCRIPTION
Repoints `dbgscope` at `main` now that [dbgscope#143](https://github.com/glslang/dbgscope/pull/143)
(the accounting half of #141) and its review follow-up have merged.

## The pin

`b259566d0d1e5b4b4962a7c249e0680ac8349bff` — dbgscope's `main`, **not** either branch head, neither
of which survived at its own SHA: #143 was rebase-merged like every one before it. Checked rather
than assumed, and the trees compared as well as the ancestry:

```console
$ git -C ../dbgscope merge-base --is-ancestor c10a2ed origin/main || echo "not an ancestor"
not an ancestor
$ git -C ../dbgscope diff --stat c10a2ed origin/main -- src/ examples/
(empty — identical source)
```

## What lands with it

Dropping a launch guard before anything pumps does not un-queue its `CreateProcessWide`, so that
process still arrived and was claimed by whichever launch asked next — whose `wait()` then returned
for a target it never asked for. The entry now stays until its own create is accounted for.

Plus the review follow-up: a launch whose wait *timed out* is discarded rather than kept, which was
a regression the first commit introduced — a kept entry then survives to take the next launch's
stop, the very failure keeping it exists to prevent, reached from the other side.

## What changes here

Nothing, and the reason is structural rather than lucky: **each opener in `worker.rs` creates one
`PendingTarget` and waits on it inside the same closure**, so this server never abandons a launch
guard and never has two launches pending at once. No public API moved — the register is private — so
this is the pin alone.

## Still open upstream, and declined after measuring

[dbgscope#141](https://github.com/glslang/dbgscope/issues/141) keeps the *identification* half: which
of two simultaneous launches gets which process. `deliver` offers in registration order and one
`WaitForEvent` realises both queued creates, so which one the event names is a coin flip. It is
declined there for reasons that also explain why it cannot matter here — no caller can produce two
pending launches, `CreateProcessWide` hands back no pid to match on, and
`PendingTarget::wait(self) -> Result<(), _>` gives its caller no identity a fix could be observed
through. The issue records the two triggers that would make it worth building.

## Verification

`644 passed` unit and `99 passed` smoke with `WINDBG_MCP_SMOKE_DUMP=1`, on a bench with the engine
DLLs bundled and the 32-bit worker rebuilt for this tree. `cargo fmt --all --check`,
`cargo clippy --all-targets` and
`npx markdownlint-cli2@0.23.2 README.md CHANGELOG.md "docs/**/*.md" "skills/**/*.md"` all clean.

The first smoke run failed 59 tests on `os error 225` — Defender quarantining the freshly built
debug exe, which is `FOLLOWUPS.md` item 50 and the third occurrence today. It passed after the
documented remove-and-rebuild, with no code change.

## Handoff docs

`CHANGELOG.md` under Unreleased → Changed. `CLAUDE.md`, `FOLLOWUPS.md`, `DONE.md` and
`docs/smoke-test.md` — nothing, checked rather than skipped: no test count moved and nothing about
editing this repo changed.

Refs [glslang/dbgscope#141](https://github.com/glslang/dbgscope/issues/141)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HyRDk1yX5UqRkdpGgodrMY