### PR TITLE
fix: initialize is a legacy handshake whatever revision it names (supersedes #288)

### DIFF
--- a/.claude/rules/listener-clients.md
+++ b/.claude/rules/listener-clients.md
@@ -119,13 +119,19 @@ property the epochs and claim generations were protecting one layer above, and i
 enforced.
 
 **What rmcp does with session ids, which the ownership answer now leans on.** Two facts, both in
-`…/rmcp-3.1.2/src/transport/streamable_http_server/tower.rs`:
+`<rmcp>/src/transport/streamable_http_server/tower.rs` — `<rmcp>` being the directory `cargo
+metadata` reports for the pinned version, never a path assembled by hand, for the reason
+`.claude/rules/cargo-and-dependencies.md` gives (this line named `rmcp-3.1.2` for three releases
+after the pin had moved past it):
 
 - a legacy `initialize` **always** mints one — `create_session()` then `spawn_session_worker`, with no
   check on who is asking — so nothing but this server ever refused a credential a second MCP session,
   and now nothing does. Hence a client's ids are a **set** (an id this server stops recording is one
   any credential may present) and an expiry closes **every** one of them (each abandoned handshake
-  otherwise leaves a live service task behind).
+  otherwise leaves a live service task behind). **And since 3.2.0 every `initialize` is a legacy
+  one**, whatever revision its body names: `is_legacy_version` gates the negotiation, so a handshake
+  offering `2026-07-28` settles on `2025-11-25` and mints an id like the rest. A client is on the
+  sessionless revision because of the *opener it sends*, never because of a version string.
 - an id the service does not know — never issued, closed by a `DELETE`, or closed by the sweep —
   comes back `404 Not Found: Session not found`. That is deliberately the same status
   `Admission::NotYours` answers with: from the caller's side "not yours" and "not a session here"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -156,6 +156,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   It names `exception_triage` now, which that caller has.
 - The tool surface is **56 tools and 80,579 B** of model context, from 54 and 75,547 (measured
   2026-09-05). `--tools crash` is 13 tools and 18,780 B.
+- **A client that offers `2026-07-28` to `initialize` is now answered with `2025-11-25`**, which is
+  the SDK's rule rather than this server's. SEP-2567 abolished the handshake in `2026-07-28` — the
+  revision travels in per-request `_meta`, and a client on it opens with `server/discover` — so
+  `rmcp` 3.2.0 settles every `initialize` on a revision that still has one
+  ([upstream #1228](https://github.com/modelcontextprotocol/rust-sdk/pull/1228)). Earlier 3.x echoed
+  the offer back, so one client saw two different answers depending on which patch release a
+  resolver happened to pick; the dependency floor moves to `rmcp = "3.2.0"` for that reason.
+
+  **Nothing changed for a client that opens the way `2026-07-28` prescribes.** `server/discover` and
+  per-request `_meta` are served exactly as before, and so are `tools/list` and `tools/call` on that
+  path over `--listen`. What changed is the answer to a *handshake*, and two things follow from it.
+  SEP-2549's `ttlMs`/`cacheScope` accompany the revision actually in force, so they no longer appear
+  after a handshake that negotiated down — the `tools/list` payload is 216,839 B against 216,895,
+  which is those three fields' 56 bytes and nothing else. And on `--listen` such a handshake now
+  mints an `Mcp-Session-Id` and is leased like the legacy client it is. So "a client on
+  `2026-07-28`" means one that opens the way that revision prescribes, never one that merely names
+  it somewhere.
 
 [dbgscope#144]: https://github.com/glslang/dbgscope/pull/144
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -359,9 +359,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
+checksum = "27b501faa50e7a26c3d3560ca625132f4078a17771f4810baf70475ae48cbe43"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -611,9 +611,9 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rmcp"
-version = "3.1.4"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a15bc53261a9dc37e105df006e4656c598379a8f9581f8950debb130f27a7cf"
+checksum = "42b6914fac0be956fe704a38239c3f44a9f841d1b06a5713d2f638065593f5b5"
 dependencies = [
  "async-trait",
  "base64",
@@ -643,9 +643,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "3.1.4"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a85d45508e9b4ba024fe996c2638799635d75b6dd0ba8f32ccf08f8026f0c780"
+checksum = "cdf1c49bd4d52014b94db0877410db273c2008f01628b0252a2e9460ad9b7fda"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,14 @@ license = "MIT"
 
 [dependencies]
 dbgscope = { git = "https://github.com/glslang/dbgscope", rev = "bb26d44cacff77113fe4f6c049c62249054ccf6d" }
-# 3.1.1 is a floor, not a preference: every 3.x before it generates a `tools/list` that omits
-# SEP-2549's required `ttlMs`/`cacheScope`, which a spec-strict `2026-07-28` client rejects
-# outright — the server connects and appears to expose no tools at all (upstream issue #1114).
-rmcp = { version = "3.1.1", features = [
+# 3.2.0 is a floor, not a preference, and by now for two unrelated reasons. Every 3.x before 3.1.1
+# generates a `tools/list` that omits SEP-2549's required `ttlMs`/`cacheScope`, which a spec-strict
+# `2026-07-28` client rejects outright — the server connects and appears to expose no tools at all
+# (upstream issue #1114). And every 3.x before 3.2.0 echoes `2026-07-28` straight back out of
+# `initialize`; 3.2.0 settles that handshake on a revision which still *has* a handshake (upstream
+# #1228, `is_legacy_version`). The smoke tier asserts the second behaviour, so a build that resolved
+# 3.1.x would fail it rather than merely serve the older shape — which is what makes this a floor.
+rmcp = { version = "3.2.0", features = [
     "server",
     "transport-io",
     "macros",

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -55,10 +55,23 @@ process. Two things follow, and they are why it is built this way:
 **MCP protocol revision:** built on `rmcp` 3.x, this server accepts every revision that SDK knows —
 `2026-07-28` and the `initialize`-handshake ("legacy") era before it (`2025-11-25`, `2025-06-18`,
 `2025-03-26`, `2024-11-05`) — and serves whichever the client selects. A `2026-07-28` client gets the
-stateless, per-request model (`server/discover`, `resultType`, per-request `_meta`) and may open with
-`server/discover` instead of `initialize`; older clients keep the handshake, and a client that offers
-an unknown revision is answered with `2025-11-25`. That revision also makes SEP-2549's cache fields
-mandatory on a paginated result, so `tools/list` answers a `2026-07-28` client with `ttlMs: 0` and
-`cacheScope: public`, and omits both for the older revisions, which never defined them. This is why
-the `rmcp` dependency has a `3.1.1` floor: every 3.x before it omitted the fields on every revision,
-and a client that validates against the spec schema then rejects the whole tool list.
+stateless, per-request model (`server/discover`, `resultType`, per-request `_meta`) and opens with
+`server/discover` rather than `initialize`; older clients keep the handshake, and a client that
+offers an unknown revision is answered with `2025-11-25`.
+
+**How a client selects it is not the same question on both sides of that line**, and it is worth
+being exact because the two look alike from the outside. `2026-07-28` did not add an option to the
+handshake — [SEP-2567](https://modelcontextprotocol.io/seps/2567-sessionless-mcp) *abolished* the
+handshake, moving what it settled into per-request `_meta`. So the revision is selected per request
+by a client on `2026-07-28`, and by `initialize` for the legacy era; and an `initialize` that names
+`2026-07-28` anyway is answered with `2025-11-25`, because a handshake cannot negotiate its way to a
+revision that has none. That is `rmcp` 3.2.0's rule rather than this server's (upstream #1228), and
+it is why the dependency carries a `3.2.0` floor — earlier 3.x echoed the offer back, so the same
+client saw a different answer depending on which patch release was resolved.
+
+`2026-07-28` also makes SEP-2549's cache fields mandatory on a paginated result, so `tools/list`
+answers a client **on** that revision with `ttlMs: 0` and `cacheScope: public`, and omits both for
+the older revisions, which never defined them. Since the fields follow the revision actually in
+force, they appear on the stateless path and not after a handshake that negotiated down. This is the
+other half of why `rmcp` has a floor at all: every 3.x before `3.1.1` omitted the fields on every
+revision, and a client that validates against the spec schema then rejects the whole tool list.

--- a/docs/local-model.md
+++ b/docs/local-model.md
@@ -427,7 +427,9 @@ thinking one is. Nothing here has been throttled yet, so that is a prediction ra
 measurement; the keepalive costs nothing either way, which is why it stays on by default.
 
 **And it is the driver's answer, not everyone's.** This whole failure is a *lease* failure, and the
-driver is leased because it negotiates `2025-06-18`. A client on `2026-07-28` is never leased at
+driver is leased because it negotiates `2025-06-18`. A client that opens the `2026-07-28` way —
+`server/discover` and per-request `_meta`, rather than an `initialize` naming it, which is a legacy
+handshake and *is* leased — is never leased at
 all: its targets are reclaimed by the 30-minute per-session idle release instead, which a ping
 cannot refresh — only a call that reaches that session's engine counts, so `session_status` polling
 does not either. A keepalive fitted to such a client keeps nothing alive.

--- a/docs/remote-listener.md
+++ b/docs/remote-listener.md
@@ -176,6 +176,13 @@ held until this process exits, which for a live kernel means a machine owned by 
 [#162](https://github.com/glslang/windbg-mcp/issues/162) for the whole of it; this is the half that
 needs no client identity and so keeps working whatever the transport does.
 
+**"A client on `2026-07-28`" throughout this document means one that behaves like it** — opening
+with `server/discover` and carrying its revision in per-request `_meta` — and not merely one that
+names the revision somewhere. The distinction has teeth since `rmcp` 3.2.0: an `initialize` is a
+legacy request whatever version it offers, so a client that opens with one negotiates down to
+`2025-11-25`, is minted an `Mcp-Session-Id`, and **is** leased like any other legacy client. What
+decides whether a clock is armed is the session, and what decides the session is the opener.
+
 **Not fixed by arming the lease from the credential instead**, which is now what identifies a
 client and could perfectly well carry a clock. The two mechanisms answer different questions on
 purpose. A lease releases *everything* that credential holds, busy sessions included, on the

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -158,13 +158,20 @@ teeth: a disconnect must also take every **engine worker** process with it, whic
 checks by pid.
 
 **Protocol revisions.** Every revision the README promises — `2026-07-28`, `2025-11-25`,
-`2025-06-18`, `2025-03-26`, `2024-11-05` — is offered a handshake, served *that* revision, and can
-reach `tools/list` — whose reply carries SEP-2549's `ttlMs`/`cacheScope` on `2026-07-28` and omits
-them on the revisions that predate the fields. Those come from the SDK, so the assertion guards the
-`rmcp = "3.1.1"` floor: earlier 3.x omitted them everywhere, and a client validating against the
+`2025-06-18`, `2025-03-26`, `2024-11-05` — is offered a handshake and can reach `tools/list`. What
+it is *served* splits at `2026-07-28`: the legacy revisions are echoed back, while a handshake
+naming `2026-07-28` settles on `2025-11-25`, since SEP-2567 abolished the handshake and it cannot
+negotiate a revision that has none (`rmcp` 3.2.0, upstream #1228). That revision is served over
+`server/discover` instead, which is the opener a client on it actually sends.
+
+The `tools/list` reply carries SEP-2549's `ttlMs`/`cacheScope` on `2026-07-28` and omits them on the
+revisions that predate the fields. Those come from the SDK, so the assertion guards the
+`rmcp` floor: earlier 3.x omitted them everywhere, and a client validating against the
 spec schema then rejects the *whole* list, leaving a server that connects and appears to have no
 tools. The reply is a valid JSON-RPC result either way, so no error-shaped assertion can see it.
-An unknown revision negotiates down to `2025-11-25`. `server/discover` opens a
+**The fields follow the revision in force, so that guard now lives on the stateless path alone** —
+key it on an *offered* revision and it inverts into a check that the fields are absent, which every
+broken SDK also passes. An unknown revision negotiates down to `2025-11-25`. `server/discover` opens a
 session with no handshake at all, and — the rule that is easy to get wrong — in that stateless mode
 **every** request must carry the `_meta` protocol keys, not just the opener; a request without them
 is refused with `-32602`.
@@ -734,11 +741,15 @@ everything](#two-clients-two-of-everything) below are what closed it:
   the id it left with is served; after a `DELETE` that id is not. The second half used to be read off
   the `409` a second `initialize` got while the first was held, which is exactly what no longer
   happens.
-- *`2026-07-28` is served — the handshake **and** everything after it.* The revision current clients
+- *`2026-07-28` is served — the opening **and** everything after it.* The revision current clients
   negotiate has no session id
   ([SEP-2567](https://modelcontextprotocol.io/seps/2567-sessionless-mcp)), so it exercises the
-  listener as a client that never presents one: the handshake mints nothing, and a `tools/list` and
-  a `tools/call` after it are answered. It exists because
+  listener as a client that never presents one: a `tools/list` and a `tools/call` carrying only
+  per-request `_meta` are answered. The opening is the other half and is deliberately *not* like
+  them — an `initialize` is a legacy request whatever revision it names, so it negotiates down to
+  `2025-11-25` and mints a session id the requests after it then ignore. #168's failure lived in
+  exactly that seam, so making both halves agree would stop the test driving the shape that broke.
+  It exists because
   [#168](https://github.com/glslang/windbg-mcp/issues/168) reported the opposite from a hand-rolled
   probe, so it spells the revision the way it has to be spelled — the `MCP-Protocol-Version`
   header, `params._meta` carrying the protocol version and the client's capabilities, and
@@ -759,9 +770,9 @@ Three more need no debugger either, and none of them is about the lease:
   boundary unreachable in the deployment `docs/remote-listener.md` recommends (item 31). The parse
   and precedence rules are unit-tested in [`client.rs`](../src/client.rs); what this reaches is the
   call site, a real listener reading a real file.
-- *A `2026-07-28` handshake may **omit** `MCP-Protocol-Version`, and the client is ordinary
-  afterwards.* It is the one request of that revision which may — `initialize` *establishes* the
-  revision — and it was the likeliest shape a real client sends and the only one nothing drove:
+- *A handshake naming `2026-07-28` may **omit** `MCP-Protocol-Version`, and the client is ordinary
+  afterwards.* It is the one request the listener exempts — `initialize` *establishes* the
+  revision — and it was the likeliest opening a real client sends and the only one nothing drove:
   stdio has no headers to omit, and the harness's own stateless opener sends one. The hazard it
   used to carry is deleted rather than covered (a headerless handshake was classified as an opener
   and armed a deadline that would release the client's own targets one grace later), so what this

--- a/docs/token-budget.md
+++ b/docs/token-budget.md
@@ -96,8 +96,8 @@ whole `StepAction`/`Check` vocabulary out of `src/batch.rs`.
 
 The payload is measured as the **serialized result**, not as the sum of its tools, and the 118-byte
 gap between those two is the reason. Result-level fields live in it, and on `2026-07-28` those are
-SEP-2549's `ttlMs`/`cacheScope` — the fields the `rmcp = "3.1.1"` floor exists for. Asking the same
-server at two revisions shows what a sum would miss:
+SEP-2549's `ttlMs`/`cacheScope` — the fields the `rmcp` floor exists for. Asking the same server at
+two revisions shows what a sum would miss:
 
 | Revision | payload | sum of tools | result-level |
 |---|---:|---:|---|
@@ -106,6 +106,13 @@ server at two revisions shows what a sum would miss:
 
 The sum is **identical** across the two; only the payload figure can tell them apart. The golden
 records both, so the gap stays visible.
+
+**Reaching the top row takes the stateless path**, and that is a change from when these were
+measured. Since `rmcp` 3.2.0 an `initialize` naming `2026-07-28` negotiates down to `2025-11-25`, so
+a handshake now lands on the *bottom* row's shape whichever revision it offers; the fields come back
+only for a client that carries its revision per request. The golden moved by exactly that difference
+when the SDK bumped — 216,895 → 216,839, the 56 bytes this table already prices — which is the
+measurement working rather than a budget being spent.
 
 ### Results, against `docs/samples/052126-34312-01.dmp`
 

--- a/src/listen.rs
+++ b/src/listen.rs
@@ -258,7 +258,9 @@ struct Presence {
     /// so this mirrors rather than accumulates — and an expiry closes the lot.
     ///
     /// Empty for a `2026-07-28` client, which is sent no id at all — and so is never given a clock
-    /// either. Abandonment there is [`IDLE_RELEASE`]'s, per session and far longer.
+    /// either. Abandonment there is [`IDLE_RELEASE`]'s, per session and far longer. *A client on
+    /// that revision* means one that opens the way it prescribes; an `initialize` naming it is a
+    /// legacy handshake since rmcp 3.2.0, and it mints an id here like any other.
     mcp: BTreeSet<String>,
     /// This credential's lease has run out and its sessions are being released.
     ///
@@ -1494,13 +1496,18 @@ mod tests {
     /// **Nothing arms a clock before an MCP session exists**, which is the trap the reservation
     /// took with it.
     ///
-    /// A `2026-07-28` `initialize` may omit the `MCP-Protocol-Version` header — it is the request
-    /// that establishes the revision — so it arrives looking like any other request and mints
-    /// nothing at all. Reserving armed a deadline on arrival, and one that took nothing had to hand
+    /// A request on the stateless revision arrives looking like any other and mints nothing at all.
+    /// Reserving armed a deadline on arrival, and one that took nothing had to hand
     /// that deadline back or it would start a teardown one grace later against a credential holding
     /// nothing, release whatever it had since opened, and refuse its next request while it was
     /// working normally. There is no arrival-time deadline to hand back any more; this pins that it
     /// stays that way.
+    ///
+    /// The example this used to give was a headerless `2026-07-28` `initialize`, which is no longer
+    /// one: since rmcp 3.2.0 a handshake is a legacy request whatever revision it names, so it
+    /// negotiates down and *does* mint a session. The invariant is unchanged — it was never about
+    /// the handshake, only about a request that takes nothing — and the requests that take nothing
+    /// are now exactly the stateless ones.
     #[test]
     fn nothing_arms_a_clock_before_an_mcp_session_exists() {
         let lease = lease();

--- a/tests/golden/tool_budget.json
+++ b/tests/golden/tool_budget.json
@@ -521,7 +521,7 @@
     "instructions": 1983,
     "modelVisible": 84506,
     "outputSchema": 124715,
-    "payload": 216895,
+    "payload": 216839,
     "tools": 57,
     "wire": 216771,
     "worstTool": "debug_batch",

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -98,6 +98,32 @@ const SUPPORTED_REVISIONS: &[&str] = &[
 /// What a client offering something the SDK does not know gets answered with.
 const FALLBACK_REVISION: &str = "2025-11-25";
 
+/// The first revision with **no `initialize` handshake at all**.
+///
+/// [SEP-2567] replaced the handshake with per-request `_meta`, so a client on this revision opens
+/// with `server/discover` and never sends `initialize`. rmcp 3.2.0 turned that from a convention
+/// into a rule (upstream #1228): `initialize` selects legacy semantics *whatever version it names*,
+/// so a handshake naming this revision or later is answered with the newest revision that still has
+/// one. Every 3.x before it echoed the offer back, which is the behaviour the `rmcp = "3.2.0"` floor
+/// in `Cargo.toml` exists to keep out — a handshake cannot negotiate a revision that abolished it.
+///
+/// [SEP-2567]: https://modelcontextprotocol.io/seps/2567-sessionless-mcp
+const POST_HANDSHAKE_REVISION: &str = "2026-07-28";
+
+/// What `initialize` answers a client that offered `revision`.
+///
+/// A revision from the handshake era is echoed; one from after it negotiates down to
+/// [`FALLBACK_REVISION`]. ISO-8601 dates sort lexicographically, which is how the SDK decides it
+/// too (`rmcp::service::is_legacy_version` is this same comparison) — so this is the rule restated,
+/// not a list of cases that has to be extended when the spec revs.
+fn handshake_answer(revision: &str) -> &str {
+    if revision < POST_HANDSHAKE_REVISION {
+        revision
+    } else {
+        FALLBACK_REVISION
+    }
+}
+
 const GOLDEN: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/golden/tools_list.json");
 /// Companion to [`GOLDEN`], and deliberately the thing it is blind to. That one digests the tool
 /// surface down to its *shape* — `digest_tool` drops every `description` on purpose — which is
@@ -1063,6 +1089,15 @@ fn read_version_field(exe: &str, field: &str) -> String {
 
 /// `docs/architecture.md` names the revisions this server speaks. When the spec revs, this is the
 /// list to extend — and the test that says whether the SDK bump actually delivered it.
+///
+/// **Being served a revision is not the same as negotiating it in the handshake**, and
+/// [`POST_HANDSHAKE_REVISION`] is where the two part company: `2026-07-28` abolished `initialize`,
+/// so there is no handshake for it to be the outcome of, and a client naming it here is answered
+/// with the newest revision that still has one. That revision is served all the same — over
+/// `server/discover` and per-request `_meta`, which is what a client on it actually sends, and what
+/// [`discover_opens_a_session_without_initialize`] and the listener's stateless tier cover. So this
+/// test asserts the handshake's rule ([`handshake_answer`]) rather than an echo, and the revisions
+/// with no handshake are covered by the tests that drive the opener they really use.
 #[test]
 fn every_documented_protocol_revision_is_served() {
     for revision in SUPPORTED_REVISIONS {
@@ -1072,9 +1107,11 @@ fn every_documented_protocol_revision_is_served() {
         let served = result["protocolVersion"]
             .as_str()
             .unwrap_or_else(|| panic!("initialize({revision}) returned no protocolVersion"));
+        let expected = handshake_answer(revision);
         assert_eq!(
-            served, *revision,
-            "a client offering `{revision}` must be served that revision, not `{served}`"
+            served, expected,
+            "a client offering `{revision}` to `initialize` must be served `{expected}`, not \
+             `{served}`"
         );
         assert!(
             !result["capabilities"]["tools"].is_null(),
@@ -1116,7 +1153,9 @@ fn every_documented_protocol_revision_is_served() {
                 .is_some_and(|t| !t.is_empty()),
             "tools/list must be non-empty on {revision}"
         );
-        assert_cache_fields_match_revision(&tools["result"], revision, "tools/list");
+        // Keyed on what was **negotiated**, not on what was offered: the cache fields follow the
+        // revision actually in force, and those are no longer the same thing for `2026-07-28`.
+        assert_cache_fields_match_revision(&tools["result"], expected, "tools/list");
     }
 }
 
@@ -1126,9 +1165,17 @@ fn every_documented_protocol_revision_is_served() {
 /// reply when they are missing — the server reads as connected with zero tools. That is not
 /// hypothetical: every `rmcp` before 3.1.1 generated exactly that response from the documented
 /// macro path, and it shipped (upstream issue #1114, fixed by #1120). The fields come from the
-/// SDK, so this is a guard on the dependency floor in `Cargo.toml` — the one test that fails if
-/// a resolver ever picks an older 3.x. Older revisions never defined the fields and must not be
+/// SDK, so this is a guard on the dependency floor in `Cargo.toml` — what fails if a resolver ever
+/// picks an older 3.x. Older revisions never defined the fields and must not be
 /// served them. `assert_no_error` sees none of this: both shapes are valid JSON-RPC results.
+///
+/// **`revision` is the revision *negotiated*, never the one a client offered** — and since rmcp
+/// 3.2.0 those differ for precisely the revision this guard is about, a handshake naming
+/// `2026-07-28` settling on [`FALLBACK_REVISION`] instead. So the branch that does the guarding is
+/// now reached from the stateless caller in [`discover_opens_a_session_without_initialize`] alone,
+/// where the revision arrives per-request and is therefore really in force. Hand this an *offered*
+/// revision and the floor guard quietly inverts into a check that the fields are absent — which the
+/// broken SDKs it exists to catch would pass just as happily.
 fn assert_cache_fields_match_revision(result: &Value, revision: &str, what: &str) {
     if revision >= "2026-07-28" {
         assert_eq!(
@@ -3062,10 +3109,16 @@ const LEASE_REVISION: &str = "2025-06-18";
 
 /// The revision that removed the session id, and therefore the lease's grip on a client.
 ///
-/// [SEP-2567] made `2026-07-28` stateless: the handshake mints no `Mcp-Session-Id`, so a client on
-/// this revision never becomes a holder and never sends an id back. It is also the revision current
-/// clients negotiate, which is why "answered the handshake and then refused everything after it"
-/// was worth a tier of its own.
+/// [SEP-2567] made `2026-07-28` stateless by removing the handshake itself: a client on this
+/// revision opens with `server/discover` and carries its context in per-request `_meta`, so it is
+/// minted no `Mcp-Session-Id`, never becomes a holder, and never sends an id back. It is also the
+/// revision current clients negotiate, which is why "answered the opening and then refused
+/// everything after it" was worth a tier of its own.
+///
+/// **The statelessness belongs to the request path, not to `initialize`.** Since rmcp 3.2.0 a
+/// handshake that merely *names* this revision is a legacy one — it negotiates down and mints an id
+/// like any other (see [`POST_HANDSHAKE_REVISION`]). What stays stateless is everything after it,
+/// and that is what this constant builds.
 ///
 /// [SEP-2567]: https://modelcontextprotocol.io/seps/2567-sessionless-mcp
 const STATELESS_REVISION: &str = "2026-07-28";
@@ -3715,10 +3768,12 @@ impl Listener {
         stream
     }
 
-    /// The `2026-07-28` handshake, which mints nothing and is therefore not a session.
+    /// An `initialize` naming `2026-07-28` — which, since rmcp 3.2.0, is a *legacy* handshake
+    /// whatever it names: it negotiates down to [`FALLBACK_REVISION`] and mints a session id.
     ///
-    /// Sent for the same reason a stateless client sends it: to learn what the server is. Nothing
-    /// afterwards depends on it having happened, which is the property being asserted.
+    /// Sent for the reason a client that has not been told otherwise sends it: to learn what the
+    /// server is. Nothing afterwards depends on it having happened, or on what it settled on, which
+    /// is the property being asserted — the stateless requests that follow carry no id of their own.
     fn stateless_opening(&mut self) -> Reply {
         self.stateless_opening_with(&[("MCP-Protocol-Version", STATELESS_REVISION)])
     }
@@ -4260,7 +4315,7 @@ fn a_second_session_for_one_credential_is_served_alongside_the_first() {
     );
 }
 
-/// The listener serves `2026-07-28` — the handshake *and* everything after it.
+/// The listener serves `2026-07-28` — the opening *and* everything after it.
 ///
 /// [#168](https://github.com/glslang/windbg-mcp/issues/168) reported the opposite: the handshake
 /// answered `200` and the next request `400`, which would leave `--listen` usable only by clients
@@ -4269,6 +4324,12 @@ fn a_second_session_for_one_credential_is_served_alongside_the_first() {
 /// what it found was the server enforcing the spec rather than failing to implement it. This is the
 /// same sequence, spelled the way the revision requires — and it is the reason
 /// [`Listener::stateless`] carries three things instead of one.
+///
+/// **The opening is a legacy handshake and the requests after it are not**, which is not a muddle
+/// but the point: since rmcp 3.2.0 an `initialize` naming `2026-07-28` negotiates down and opens an
+/// ordinary session (see [`POST_HANDSHAKE_REVISION`]), and the client goes on to send stateless
+/// requests carrying no id at all. #168's failure lived exactly in that seam, so a test that made
+/// both halves agree would no longer be driving the shape that broke.
 #[test]
 fn the_listener_serves_the_stateless_revision_it_negotiates() {
     let mut server = Listener::start(&[]);
@@ -4284,16 +4345,18 @@ fn the_listener_serves_the_stateless_revision_it_negotiates() {
     );
     assert_eq!(
         opening.result("initialize")["protocolVersion"],
-        json!(STATELESS_REVISION),
-        "the handshake must negotiate the revision it was offered: {}",
+        json!(FALLBACK_REVISION),
+        "the handshake must settle on a revision that still has one: {}",
         opening.body
     );
-    // SEP-2567 removed the session id, so there is nothing here for a lease to be armed by.
-    // Asserted rather than assumed: ownership is what the listener still reads this header for,
-    // and its absence is what makes the rest of this test a different client to the ones above.
+    // And it is an ordinary session, because it is an ordinary handshake: `initialize` is a legacy
+    // request whatever revision it names, so the listener mints an id and arms a lease off it just
+    // as it would for a client that had named `2025-11-25` outright. Asserted rather than shrugged
+    // at, because it is the half of this sequence that the next few requests do *not* use — what
+    // makes them a stateless client is that they carry none of it.
     assert!(
-        opening.session.is_none(),
-        "{STATELESS_REVISION} must mint no Mcp-Session-Id: {}",
+        opening.session.is_some(),
+        "a handshake that negotiated {FALLBACK_REVISION} mints an Mcp-Session-Id: {}",
         opening.body
     );
 
@@ -4338,10 +4401,11 @@ fn the_listener_serves_the_stateless_revision_it_negotiates() {
 
 /// The handshake may omit `MCP-Protocol-Version`, and the client is ordinary afterwards.
 ///
-/// It is the one request of `2026-07-28` that may: `initialize` *establishes* the revision, so rmcp
-/// does not require the header that restates it. Nothing here drove that shape until now — stdio
-/// has no headers to omit and [`Listener::stateless_opening`] sends one — which left the likeliest
-/// handshake a real client sends as the only one untested.
+/// It is the one request the listener exempts: `initialize` *establishes* the revision — it is the
+/// request that settles which one is in force — so rmcp does not require the header that would
+/// restate it. Nothing here drove that shape until now — stdio has no headers to omit and
+/// [`Listener::stateless_opening`] sends one — which left the likeliest opening a real client sends
+/// as the only one untested.
 ///
 /// **The hazard it carried has been deleted rather than covered**, and that is why this asserts
 /// what it does. The listener used to classify a request by that header, so a headerless handshake
@@ -4364,15 +4428,18 @@ fn a_stateless_handshake_may_omit_the_protocol_header() {
         opening.body,
         server.stderr()
     );
+    // The route that omits the header has to reach the same place as the route that sends it —
+    // that is the whole claim — so this restates the outcome the test above asserts rather than
+    // adding a rule of its own: negotiated down, and a session minted.
     assert_eq!(
         opening.result("initialize")["protocolVersion"],
-        json!(STATELESS_REVISION),
-        "the handshake must negotiate the revision its body offered, header or no header: {}",
+        json!(FALLBACK_REVISION),
+        "the handshake must settle where its body's offer sends it, header or no header: {}",
         opening.body
     );
     assert!(
-        opening.session.is_none(),
-        "{STATELESS_REVISION} mints no Mcp-Session-Id, however it arrives: {}",
+        opening.session.is_some(),
+        "a handshake mints an Mcp-Session-Id however it arrives: {}",
         opening.body
     );
 


### PR DESCRIPTION
Supersedes #288, which is this dependency bump with the four CI failures it caused left unfixed. The
bump commit is carried here unchanged; the fix is on top of it.

## What broke, and why it is not a dependency bug

rmcp 3.2.0 makes `initialize` **legacy-only**, deliberately and with upstream tests of its own
([#1228](https://github.com/modelcontextprotocol/rust-sdk/pull/1228)). SEP-2567 abolished the
handshake in `2026-07-28` — the revision travels in per-request `_meta`, and a client on it opens
with `server/discover` — so a handshake naming that revision or later is now answered with the
newest revision that still has one. Upstream ships
`stateless_init_naming_a_post_handshake_version_negotiates_down` and
`stateful_init_naming_a_post_handshake_version_opens_a_legacy_session` for exactly this.

There is no opt-out: `is_legacy_version` gates it on the stdio path (`service/server.rs`) and the
listener path (`transport/streamable_http_server/tower.rs`) alike, and both overwrite whatever the
handler set. hyper 1.11.0 → 1.11.1 is innocent.

All four failures are that one change:

| Test | Cause |
|---|---|
| `every_documented_protocol_revision_is_served` | asserted `initialize` echoes each revision |
| `the_listener_serves_the_stateless_revision_it_negotiates` | same, over `--listen` |
| `a_stateless_handshake_may_omit_the_protocol_header` | same |
| `tool_surface_stays_within_its_token_budget` | payload −56 B |

The budget failure is the same cause one step removed: negotiation falls back to `2025-11-25`, so
the result-level fields stop being emitted. Measured directly — the served `tools/list` now carries
no result-level fields at all and the payload−wire gap is 124 → 68. `docs/token-budget.md` already
prices `resultType`/`ttlMs`/`cacheScope` at 177,460 − 177,404 = **56 bytes**, so the golden's
216,895 → 216,839 is that table working rather than a budget being spent.

## What did not break

The path a real `2026-07-28` client uses. `discover_opens_a_session_without_initialize` passes
untouched, and over `--listen` the stateless per-request `_meta` path still serves `tools/list` and
`tools/call` — verified rather than assumed, by relaxing *only* the two handshake assertions and
watching both listener tests pass in full.

## The change

- **`Cargo.toml`** — rmcp floor `3.1.1` → `3.2.0`. The asserted behaviour exists only there, so a
  resolver picking 3.1.x would fail the tier rather than serve an older shape.
- **`tests/mcp_smoke.rs`** — a `POST_HANDSHAKE_REVISION` constant and a `handshake_answer()` helper
  that restate the SDK's rule (the same lexicographic date compare `is_legacy_version` makes) rather
  than listing cases that would need extending when the spec revs. The listener tests now assert a
  session id **is** minted, which is what happens.
- **`tests/golden/tool_budget.json`** — one line, `payload` only. `tools_list.json` untouched.
- **Docs** — `architecture.md`, `smoke-test.md`, `token-budget.md`, `remote-listener.md`,
  `local-model.md`, `src/listen.rs`, the `listener-clients.md` rule, and a `CHANGELOG.md` entry.

## The part worth reviewing closely

Keying the SEP-2549 cache-field guard on the *offered* revision would have silently inverted it.
Since every handshake now negotiates down, the positive branch would never run and the check would
become "the fields are absent" — which every SDK the `rmcp` floor exists to catch would also pass.
It is keyed on the **negotiated** revision instead, and mutation-tested: breaking the positive
branch is caught by `discover_opens_a_session_without_initialize` and, tellingly, *not* by the
revision loop. So the floor guard now rests entirely on the stateless caller, which is stated at the
helper and in `docs/smoke-test.md`.

## Second-order change, recorded rather than designed around

On the stateful listener a handshake naming `2026-07-28` now mints an `Mcp-Session-Id` and is leased
like any other legacy client, where before it minted none. That is consistent — it *is* a legacy
client by the SDK's definition — and the stateless path is untouched, so the prose is corrected
rather than the behaviour: "a client on `2026-07-28`" means one that opens the way that revision
prescribes, never one that merely names it. If it should not be leased, that is a `listen.rs` change
and a separate call.

## Verification

`cargo fmt --all --check`, `cargo clippy --all-targets` and markdownlint over CI's globs are clean.
**695 unit + 104 smoke tests pass, 0 failures**, 12 ignored (the gated tiers).

Three 32-bit-tier tests failed on the first local run from a stale `x86\windbg-mcp.exe` — the
build-identity trap `.claude/rules/worker-architecture.md` documents, not anything in this change.
Rebuilt and re-copied after committing, since the commit itself moves the identity; all three pass.

Also fixes a stale `rmcp-3.1.2` path in `listener-clients.md` that had outlived three pin moves —
the rule's own advice is to take that path from `cargo metadata`, so it now says so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ayv1beKpAVkmDJDLfYqoyf
