### PR TITLE
fix: a heartbeat is not a milestone, and counting both made a test a stopwatch

### DIFF
--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -6685,7 +6685,8 @@ fn a_malformed_disassemble_address_is_refused_as_a_typed_error() {
 ///
 /// It asserts the milestones and not the *whole* notification stream, because those are two claims
 /// and only the first belongs to an open. A slow one also emits heartbeats, which is the heartbeat
-/// working rather than the open misbehaving — see the filter below.
+/// working rather than the open misbehaving — `src/progress.rs`'s paused-clock tests are where that
+/// half is pinned, and the filter below is what keeps the two apart.
 ///
 /// Needs a real target because the sequence is the point. A failed open reports the first milestone
 /// and stops, which proves the route and not the order.
@@ -6711,19 +6712,15 @@ fn an_open_reports_its_milestones_before_it_answers() {
         .filter_map(|s| s["params"]["message"].as_str())
         .collect();
 
-    // **A heartbeat is not a milestone**, and counting every message made this a stopwatch rather
-    // than an assertion. [`crate::progress::HEARTBEAT`]'s ten seconds of silence is a bound this
-    // open has no reason to respect — a dump load that reaches a symbol server takes as long as the
-    // network does — so `still running (…)` legitimately interleaves with the three
-    // [`Step`](../src/progress.rs) messages. It failed exactly that way on a slow CI runner: a 36s
-    // open, three heartbeats, six messages against an expected three, and a panic that named the
-    // milestones while the thing that had changed was the clock. What an open *promises* is the
-    // three steps in order; how often it says it is still working is the heartbeat's business, and
-    // `src/progress.rs`'s own paused-clock tests are where that is pinned.
+    // **A heartbeat is not a milestone.** `progress::HEARTBEAT` fires after ten seconds of silence,
+    // and an open has no reason to respect that bound — a dump load reaching a symbol server takes
+    // as long as the network does — so `still running (…)` interleaves with the three `Step`
+    // messages on a slow target. Counting every notification made this a stopwatch instead, which
+    // is how it failed on a slow CI runner rather than on any change to what an open reports.
     //
     // Filtering on the text couples this to the heartbeat's wording, which is the price of a
-    // notification carrying no kind of its own — and it fails **loudly** if that wording moves,
-    // because an unfiltered heartbeat lands on the count below rather than passing quietly.
+    // notification carrying no kind of its own. It fails **loudly** if that wording moves — an
+    // unfiltered heartbeat lands on the count below rather than passing quietly.
     let milestones: Vec<&str> = said
         .iter()
         .copied()

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -6683,6 +6683,10 @@ fn a_malformed_disassemble_address_is_refused_as_a_typed_error() {
 /// mapping onto MCP, which is the only part a client can see: one notification per milestone, on
 /// the token the call supplied, all of them **before** the result rather than summarised after it.
 ///
+/// It asserts the milestones and not the *whole* notification stream, because those are two claims
+/// and only the first belongs to an open. A slow one also emits heartbeats, which is the heartbeat
+/// working rather than the open misbehaving — see the filter below.
+///
 /// Needs a real target because the sequence is the point. A failed open reports the first milestone
 /// and stops, which proves the route and not the order.
 #[test]
@@ -6706,14 +6710,33 @@ fn an_open_reports_its_milestones_before_it_answers() {
         .iter()
         .filter_map(|s| s["params"]["message"].as_str())
         .collect();
+
+    // **A heartbeat is not a milestone**, and counting every message made this a stopwatch rather
+    // than an assertion. [`crate::progress::HEARTBEAT`]'s ten seconds of silence is a bound this
+    // open has no reason to respect — a dump load that reaches a symbol server takes as long as the
+    // network does — so `still running (…)` legitimately interleaves with the three
+    // [`Step`](../src/progress.rs) messages. It failed exactly that way on a slow CI runner: a 36s
+    // open, three heartbeats, six messages against an expected three, and a panic that named the
+    // milestones while the thing that had changed was the clock. What an open *promises* is the
+    // three steps in order; how often it says it is still working is the heartbeat's business, and
+    // `src/progress.rs`'s own paused-clock tests are where that is pinned.
+    //
+    // Filtering on the text couples this to the heartbeat's wording, which is the price of a
+    // notification carrying no kind of its own — and it fails **loudly** if that wording moves,
+    // because an unfiltered heartbeat lands on the count below rather than passing quietly.
+    let milestones: Vec<&str> = said
+        .iter()
+        .copied()
+        .filter(|m| !m.starts_with("still running"))
+        .collect();
     assert_eq!(
-        said.len(),
+        milestones.len(),
         3,
         "an open has three milestones — worker up, target claimed, target open: {steps:?}"
     );
-    assert!(said[0].contains("engine worker started"), "{said:?}");
-    assert!(said[1].contains("created or claimed"), "{said:?}");
-    assert!(said[2].contains("target is open"), "{said:?}");
+    assert!(milestones[0].contains("engine worker started"), "{said:?}");
+    assert!(milestones[1].contains("created or claimed"), "{said:?}");
+    assert!(milestones[2].contains("target is open"), "{said:?}");
 
     // Seconds elapsed, strictly increasing, and no `total` — the budget differs per tool and an
     // opener spends time outside it, so a denominator here would be a number the server cannot


### PR DESCRIPTION
A latent flake in `an_open_reports_its_milestones_before_it_answers`, found when it failed the
`arm64` smoke job on #290. Independent of that PR — it touches a different test and branches off
`main`, so the two merge in either order.

## What it is

The test asserted an open emits **exactly three** progress notifications. It emits three
*milestones* — worker up, target claimed, target open — and, whenever the call goes quiet for
`progress::HEARTBEAT`, a `still running (…)` beside them. Those are two different claims, and only
the first belongs to an open: how long a dump load takes is the symbol server's business.

So the assertion was really a stopwatch — it held only while the open stayed under ten seconds. On
the runner that caught it the open took **36.3s**, three heartbeats fired, and six messages arrived
against an expected three:

```text
engine worker started (pid 8628); opening the target
the target has been created or claimed; waiting for it to break in
still running (10.1s)
still running (20.1s)
still running (30.1s)
the target is open; reading its report
```

The panic named the milestones while the thing that had changed was the clock, which is what makes
this worth fixing rather than re-running: the same job passed on the previous run, at half the
wall-clock.

## The change

The milestones are filtered out of the stream and counted on their own. The progress-monotonic and
absent-`total` assertions still run over **every** notification, heartbeats included, because those
claims really are about the whole stream.

## Verified both ways, not by watching it go green

It passes locally in 1.1s — which exercises none of this, since no heartbeat fires — so neither
direction was taken on trust:

- **It handles the case it is for.** Applied to the exact six-message payload above, the filter
  yields the three milestones in order; the old assertion fails on it.
- **It has not been weakened.** Renaming a milestone in `src/progress.rs` (`the target is open` →
  `the target is ready`) still fails the test, so this is not now an assertion that would pass on a
  stream with no milestones in it at all.

The heartbeat's own timing stays pinned where it already was, by `src/progress.rs`'s paused-clock
unit tests — which is the right split, and the reason this test should never have been counting
them.

## One known cost

Filtering on the message text couples the test to the heartbeat's wording, which is the price of a
progress notification carrying no kind of its own. It fails *loudly* if that wording moves: an
unfiltered heartbeat lands on the milestone count rather than passing quietly.

## Verification

`cargo fmt --all --check` and `cargo clippy --all-targets` clean. **695 unit + 104 smoke tests pass,
0 failures** with the dump tier enabled (`WINDBG_MCP_SMOKE_DUMP=1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ayv1beKpAVkmDJDLfYqoyf
