### PR TITLE
docs: re-derive every tool-surface figure, and date them

### DIFF
--- a/.claude/rules/tool-surface.md
+++ b/.claude/rules/tool-surface.md
@@ -21,7 +21,7 @@ test, because `Toolset::parse` resolves group names first and would decide it si
 
 Four rules worth knowing before touching it. **`session` is in every surface** whatever the spec
 says, because every other tool routes by a `session_id` this server alone issues — so `--tools
-crash` is eleven tools and 11,714 B is the floor. **Output schemas carry no prose at all**
+crash` is thirteen tools and 11,714 B is the floor. **Output schemas carry no prose at all**
 (`src/schema.rs`): declare one with `schema::constraints_of`, never rmcp's `schema_for_output`, or
 the tool ships every doc comment in its `$defs` closure and the wire ceiling notices. That call is
 also what supplies the root `type: "object"` a discriminated union does not generate and rmcp does
@@ -42,8 +42,8 @@ tool but the always-served ones, and `no_description_names_a_tool_the_client_can
 build if a new tool's prose points at one its own single-tool spec does not serve. Three
 consequences when you add one. The invariant is checked on `--tools <that tool>` and nowhere else,
 because that is the tightest surface it can be served on and every wider one is covered by
-construction. **Group bytes no longer add up to a surface's**: `crash` is 14,587 B against the
-15,753 its two groups sum to in `docs/token-budget.md`, since narrowing shortens what stays as well
+construction. **Group bytes no longer add up to a surface's**: `crash` is 19,078 B against the
+20,244 its two groups sum to in `docs/token-budget.md` (2026-09-07), since narrowing shortens what stays as well
 as dropping what goes. And the check for "names a tool" is deliberately not word containment — this
 prose says frames are "attributed to modules" and that a stuck session "does not let go", while a
 TTD description quotes `dx @$cursession.TTD.Calls(...)`, which is the debugger command and not the

--- a/.claude/rules/tool-surface.md
+++ b/.claude/rules/tool-surface.md
@@ -44,7 +44,16 @@ consequences when you add one. The invariant is checked on `--tools <that tool>`
 because that is the tightest surface it can be served on and every wider one is covered by
 construction. **Group bytes no longer add up to a surface's**: `crash` is 19,078 B against the
 20,244 its two groups sum to in `docs/token-budget.md` (2026-09-07), since narrowing shortens what stays as well
-as dropping what goes. And the check for "names a tool" is deliberately not word containment — this
+as dropping what goes. Neither of those two figures is worth checking by hand:
+`every_documented_surface_figure_matches_the_served_surface` reads the tables in `src/toolset.rs`,
+`docs/tool-surface.md` and `docs/token-budget.md` and compares every count, byte total and
+percentage in them against a server it starts — so a group that grows fails `cargo test` with the
+row and the right number, and the way to update a table is to run it and paste what it says. It
+derives group membership from the server rather than from `GROUPS`, so it cannot agree with a table
+by sharing its mistake. **Prose is not swept, deliberately** — a text search for anything
+surface-shaped was prototyped and measured at 63 lines to triage, most of them neither stale nor
+about the surface — so a figure written into a *sentence* is still yours to re-derive, and the
+tables are where to re-derive it from. And the check for "names a tool" is deliberately not word containment — this
 prose says frames are "attributed to modules" and that a stuck session "does not let go", while a
 TTD description quotes `dx @$cursession.TTD.Calls(...)`, which is the debugger command and not the
 `dx` tool; the rule is a code span that *is* the name or opens a call with it, plus bare-if-it-has-

--- a/README.md
+++ b/README.md
@@ -117,9 +117,9 @@ Fifty-seven tools in eight `--tools` groups; the rows below split some of those 
 | Structure walk | `allocator` | `walk_memory` |
 | Raw     | `inspect` | `execute` — run any debugger command, returns full text output |
 
-All of them are served unless you say otherwise, and the definitions cost the model **80,579 bytes —
-about 20k tokens — before it has asked anything** (measured 2026-09-05). `--tools
-session,inspect,crash` cuts that to 29,744 B for twenty-two tools, and a `--listen` client can be
+All of them are served unless you say otherwise, and the definitions cost the model **84,506 bytes —
+about 21k tokens — before it has asked anything** (measured 2026-09-07). `--tools
+session,inspect,crash` cuts that to 32,322 B for twenty-three tools, and a `--listen` client can be
 given a narrower surface than the run's default. [`docs/tool-surface.md`](docs/tool-surface.md) has the arithmetic, the rule that `session`
 is always included, and what a typed operand may not contain.
 

--- a/docs/local-model.md
+++ b/docs/local-model.md
@@ -220,8 +220,8 @@ setx WINDBG_MCP_LISTEN_TOKEN_DRIVER "<another long random string>"
 setx WINDBG_MCP_TOOLS_DRIVER        "session,inspect,crash"
 ```
 
-The second line is what makes this work on a listener the editor also uses: the driver is served 20
-tools and 26,305 B while every other client on that listener keeps all 54. Leave it out and the
+The second line is what makes this work on a listener the editor also uses: the driver is served 23
+tools and 32,322 B while every other client on that listener keeps all 57. Leave it out and the
 driver is served whatever the listener was started with, which is the older behaviour and is the
 right one when the listener is the driver's own.
 
@@ -288,9 +288,9 @@ spec. Re-read them rather than trusting this table, which has been stale before.
 
 | | bytes | ≈tokens |
 |---|---|---|
-| The tool surface, paid once per conversation | 80,579 (56 tools) | ~20k |
-| — the same surface as `--tools session,inspect,crash` | 26,305 (20 tools) | ~6.5k |
-| — as `--tools crash` | 18,780 (13 tools) | ~4.5k |
+| The tool surface, paid once per conversation | 84,506 (57 tools) | ~21k |
+| — the same surface as `--tools session,inspect,crash` | 32,322 (23 tools) | ~8k |
+| — as `--tools crash` | 19,078 (13 tools) | ~4.5k |
 | Its worst single tool (`debug_batch`) | 10,021 | ~2.5k |
 | The largest answer this server gives (`modules`) | 53,875 | ~13k |
 | `read_memory` at its design limit | ~4 MiB of hex | ~1M |
@@ -464,10 +464,11 @@ budget, a text-or-data content switch. **Two of the three now exist, and neither
 client-side.**
 
 - **The tool-surface profile is `--tools`** (2026-08-22). Start the listener with
-  `--tools session,inspect,crash` and the surface is 20 tools and 25,465 B instead of 51 and
-  68,893 — `--tools crash` is 13 and 18,780 B, which is the difference between "roughly twice an 8k
-  window" and "half of one". The tools that remain are the tools they were, less the sentences
-  pointing at ones that went (item 41).
+  `--tools session,inspect,crash` and the surface is 23 tools and 32,322 B instead of 57 and
+  84,506 — `--tools crash` is 13 and 19,078 B, which is the difference between "roughly twice an 8k
+  window" and "half of one" (re-measured 2026-09-07; it was 20 tools and 25,465 B against 51 and
+  68,893 when the flag landed, and every one of those figures moves with the surface). The tools
+  that remain are the tools they were, less the sentences pointing at ones that went (item 41).
   The whole table is in [`token-budget.md`](./token-budget.md) under finding 8, and the README has
   the operator's half. **And it is per client as well as per run** (2026-08-22): a listener's
   clients are named already, so `WINDBG_MCP_TOOLS_<NAME>` beside the token gives one of them its

--- a/docs/remote-listener.md
+++ b/docs/remote-listener.md
@@ -6,7 +6,7 @@ the machine DbgEng needs — a Mac driving a Windows VM, say.
 
 **`--tools` works here exactly as it does on stdio**, and matters more: the client at the far end
 may be a local model whose window is bought in RAM. `--listen 127.0.0.1:8765 --tools
-session,inspect,crash` serves 22 tools and 30,498 B of model context instead of 56 and 80,579 — the
+session,inspect,crash` serves 23 tools and 32,322 B of model context instead of 57 and 84,506 — the
 README has the table, and [`local-model.md`](./local-model.md) is the runbook it was measured for.
 It is this listener's **default**: a client may be given a surface of its own, which is what lets
 one server hold a local model and a hosted client at once — see [A tool surface per
@@ -295,8 +295,8 @@ setx WINDBG_MCP_LISTEN_TOKEN_BENCH "<a long random string>"   # the client named
 setx WINDBG_MCP_TOOLS_BENCH        "session,inspect,crash"    # …and what it is served
 ```
 
-This is what lets one listener serve a local model that can hold twenty tools beside a hosted client
-that can hold fifty-six, against the same debug sessions on the same box. A client with no spec of
+This is what lets one listener serve a local model that can hold twenty-three tools beside a hosted
+client that can hold fifty-seven, against the same debug sessions on the same box. A client with no spec of
 its own is served whatever the run serves — `--tools` on the listener's command line, or every tool
 if it has none — so **the run's flag is the default rather than a ceiling**: a client's own spec
 replaces it, wider or narrower, because an intersection would produce a surface neither of you

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -780,7 +780,7 @@ Three more need no debugger either, and none of them is about the lease:
 - *A run started with `--tools` advertises the narrowed surface **over HTTP**.* stdio builds one
   `WindbgServer` in `main` and the listener builds one per MCP session in its service factory, so
   the narrowing is applied on two different lines and only one of them is the one that has been
-  wrong before. `--tools crash` is asserted as the eleven tools it is — `crash_triage` and the
+  wrong before. `--tools crash` is asserted as the thirteen tools it is — `crash_triage` and the
   openers present, `debug_batch` absent — and the startup line as the surface it ended up with,
   which is not the spec that was typed.
 
@@ -844,7 +844,7 @@ passed, because each supplies the identity itself.
   and no description `bench` is served names `modules`, `debug_batch`, `go` or `backtrace` (item
   41), while `local`'s `open_dump` still says which tool lists the module table. Both directions
   are asserted, because deleting the cross-references outright would satisfy the first and lose the
-  pointer the fifty-one-tool client is the one that can use. Backticked names, not bare ones: this
+  pointer the fifty-seven-tool client is the one that can use. Backticked names, not bare ones: this
   surface says frames are "attributed to modules" and that a stuck session "does not let go", and
   neither sentence points anywhere.
 - *A **token file** naming two clients serves both* — the item-31 test in the list further up,

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -783,6 +783,16 @@ Three more need no debugger either, and none of them is about the lease:
   wrong before. `--tools crash` is asserted as the thirteen tools it is — `crash_triage` and the
   openers present, `debug_batch` absent — and the startup line as the surface it ended up with,
   which is not the spec that was typed.
+- *Every documented surface figure is the served one.* The tables in `src/toolset.rs`,
+  [`tool-surface.md`](tool-surface.md) and [`token-budget.md`](token-budget.md) are read back and
+  compared — 24 figures, being each group's share of the whole surface and what each documented
+  `--tools` spec actually serves, plus the percentage column where a table carries one. Group
+  membership is derived from the server (`--tools <group>` less `--tools session`) rather than read
+  out of `GROUPS`, so a table cannot pass by sharing the code's mistake, and a table that loses a
+  row fails on the row count rather than passing with less to disagree with. When it fails, the
+  server is right: paste the numbers it prints. It exists because these figures went stale in seven
+  files at once and three review rounds on #293 each found more of them; the test's own doc comment
+  records why the prose around the tables is deliberately not swept.
 
 Two more of the lease's own assertions are in the debugger tier, because each needs a real engine
 worker.

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -791,13 +791,20 @@ Three more need no debugger either, and none of them is about the lease:
   group **names** — an invalid `--tools` spec lists them — rather than either being read out of
   `GROUPS`, so a table cannot pass by sharing the code's mistake and a ninth group arrives here
   with nothing added. Each file **declares which tables it carries**, each declared table has to
-  state its whole set of labels, and a row whose label is neither a group nor a measured spec is a
-  failure rather than a skip. Those last three were review findings rather than design, and each
-  was a way to pass while checking less: the first version counted observed group rows only, so
-  deleting `tool-surface.md`'s spec rows (23 of 24 still checked) and deleting `toolset.rs`'s group
-  table outright (16 of 24) both passed; the second skipped unrecognised rows, so an invented
-  `network` row with wrong figures passed. When it fails, the server is right: paste the numbers it
-  prints. It exists because these figures went stale in seven
+  state its whole set of labels, no label may appear twice, a row whose label is neither a group
+  nor a measured spec is a failure rather than a skip, and a table whose **header** declares a
+  share column must carry a percentage on every row — the header, because a row that lost its `%`
+  would otherwise be asked whether it had one and believed. Every one of those was a review finding
+  rather than a design, and each was a way to pass while checking less: the first version counted
+  observed group rows only, so deleting `tool-surface.md`'s spec rows (23 of 24 still checked) and
+  deleting `toolset.rs`'s group table outright (16 of 24) both passed; the second skipped
+  unrecognised rows, so an invented `network` row with wrong figures passed; the third ignored
+  `BTreeSet::insert`'s answer and read the share off the row, so a duplicated row passed (25 of 24)
+  and a stripped `%` took a figure out of the check. **The pattern is worth more than any of the
+  fixes**: a row that is missing, duplicated, unrecognised or malformed disagrees with nothing, so
+  the comparison can only ever reach figures still written down — every guard that matters is on
+  the *set and shape* of the rows rather than on their contents. When it fails, the server is
+  right: paste the numbers it prints. It exists because these figures went stale in seven
   files at once and three review rounds on #293 each found more of them; the test's own doc comment
   records why the prose around the tables is deliberately not swept.
 

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -787,14 +787,17 @@ Three more need no debugger either, and none of them is about the lease:
   [`tool-surface.md`](tool-surface.md) and [`token-budget.md`](token-budget.md) are read back and
   compared — 24 figures, being each group's share of the whole surface and what each documented
   `--tools` spec actually serves, plus the percentage column where a table carries one. Group
-  membership is derived from the server (`--tools <group>` less `--tools session`) rather than read
-  out of `GROUPS`, so a table cannot pass by sharing the code's mistake. Each file **declares which
-  tables it carries**, and each declared table has to state its whole set of labels — a row that is
-  absent disagrees with nothing, so counting the rows a file turns out to have asks nothing of a
-  table that was deleted or reformatted past recognition. That was a review finding rather than a
-  design: the first version counted observed group rows only, and both deleting
-  `tool-surface.md`'s spec rows and deleting `toolset.rs`'s group table outright passed it. When it
-  fails, the server is right: paste the numbers it prints. It exists because these figures went stale in seven
+  membership is derived from the server (`--tools <group>` less `--tools session`), and so are the
+  group **names** — an invalid `--tools` spec lists them — rather than either being read out of
+  `GROUPS`, so a table cannot pass by sharing the code's mistake and a ninth group arrives here
+  with nothing added. Each file **declares which tables it carries**, each declared table has to
+  state its whole set of labels, and a row whose label is neither a group nor a measured spec is a
+  failure rather than a skip. Those last three were review findings rather than design, and each
+  was a way to pass while checking less: the first version counted observed group rows only, so
+  deleting `tool-surface.md`'s spec rows (23 of 24 still checked) and deleting `toolset.rs`'s group
+  table outright (16 of 24) both passed; the second skipped unrecognised rows, so an invented
+  `network` row with wrong figures passed. When it fails, the server is right: paste the numbers it
+  prints. It exists because these figures went stale in seven
   files at once and three review rounds on #293 each found more of them; the test's own doc comment
   records why the prose around the tables is deliberately not swept.
 

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -788,9 +788,13 @@ Three more need no debugger either, and none of them is about the lease:
   compared — 24 figures, being each group's share of the whole surface and what each documented
   `--tools` spec actually serves, plus the percentage column where a table carries one. Group
   membership is derived from the server (`--tools <group>` less `--tools session`) rather than read
-  out of `GROUPS`, so a table cannot pass by sharing the code's mistake, and a table that loses a
-  row fails on the row count rather than passing with less to disagree with. When it fails, the
-  server is right: paste the numbers it prints. It exists because these figures went stale in seven
+  out of `GROUPS`, so a table cannot pass by sharing the code's mistake. Each file **declares which
+  tables it carries**, and each declared table has to state its whole set of labels — a row that is
+  absent disagrees with nothing, so counting the rows a file turns out to have asks nothing of a
+  table that was deleted or reformatted past recognition. That was a review finding rather than a
+  design: the first version counted observed group rows only, and both deleting
+  `tool-surface.md`'s spec rows and deleting `toolset.rs`'s group table outright passed it. When it
+  fails, the server is right: paste the numbers it prints. It exists because these figures went stale in seven
   files at once and three review rounds on #293 each found more of them; the test's own doc comment
   records why the prose around the tables is deliberately not swept.
 

--- a/docs/token-budget.md
+++ b/docs/token-budget.md
@@ -294,10 +294,14 @@ None of these is a bug. They are recorded because they were invisible, and
    `debug_batch` alone is 10,021 B — 12% of everything a model is given before it asks anything — of
    which 7,980 B is the `StepAction`/`Check` vocabulary its schema pulls out of `src/batch.rs`.
    Then `walk_memory` 4,080, `crash_triage` 2,936, `reachable_from_dispatch` 2,628, `server_log`
-   2,599: **22,264 B**, against a median tool of 1,029 B. (Re-measured 2026-09-07: none of the five
-   has moved a byte since 2026-08-22, and the sum was recorded as 21,989 then, which its own five
-   rows never summed to. The *share* is what actually went stale — 33% of the 54-tool surface,
-   26.3% of today's 57 tools and 84,506 B. A share is the half that does.)
+   2,599: **22,264 B**, against a median tool of 1,029 B (measured 2026-09-07). Two things this
+   paragraph got wrong, both worth leaving on the record. The **33%** was never a share of *this*
+   surface: it is 21,961 B of the 51-tool, 67,076 B surface the finding was first recorded against
+   on 2026-08-18, where today the five are 26.3% of 84,506 B. And the total read **21,989** — right
+   when it was written and right when four of the five were re-measured on 2026-08-24, then 275 B
+   short from 2026-08-30, when `debug_batch`'s own figure above was updated 9,746 → 10,021 and the
+   line adding it up was not. The share at least carried a date saying it moved; the total looked
+   like arithmetic and so nobody re-added it.
 
    This is where the weight is, and it is a different kind of problem from findings 1–4. Those were
    duplication and waste — the same string paid for repeatedly, or a tail nobody reads. This is one

--- a/docs/token-budget.md
+++ b/docs/token-budget.md
@@ -291,12 +291,13 @@ None of these is a bug. They are recorded because they were invisible, and
    even covers `w29`.
 8. **Five tools are a third of the model-visible surface**, and it is their *input* schemas rather
    than their prose — **answered** (2026-08-22) by serving fewer tools rather than smaller ones.
-   `debug_batch` alone is 10,021 B — 13% of everything a model is given before it asks anything — of
+   `debug_batch` alone is 10,021 B — 12% of everything a model is given before it asks anything — of
    which 7,980 B is the `StepAction`/`Check` vocabulary its schema pulls out of `src/batch.rs`.
    Then `walk_memory` 4,080, `crash_triage` 2,936, `reachable_from_dispatch` 2,628, `server_log`
-   2,599: **21,989 B, 33%**, against a median tool of 900 B. (Those per-tool figures are of
-   2026-08-22; the surface has since grown to 56 tools and 80,579 B, so the *share* is now 27.3%
-   while none of the tools named has changed. A share is the half that goes stale.)
+   2,599: **22,264 B**, against a median tool of 1,029 B. (Re-measured 2026-09-07: none of the five
+   has moved a byte since 2026-08-22, and the sum was recorded as 21,989 then, which its own five
+   rows never summed to. The *share* is what actually went stale — 33% of the 54-tool surface,
+   26.3% of today's 57 tools and 84,506 B. A share is the half that does.)
 
    This is where the weight is, and it is a different kind of problem from findings 1–4. Those were
    duplication and waste — the same string paid for repeatedly, or a tail nobody reads. This is one
@@ -329,29 +330,29 @@ None of these is a bug. They are recorded because they were invisible, and
    and, since item 41, for the sentences the tools it keeps used to spend on pointing at them.
    Where the bytes sit, and what each profile costs:
 
-   Both tables are measurements of **2026-09-05** and move with any edit to a description.
+   Both tables are measurements of **2026-09-07** and move with any edit to a description.
 
    | group | tools | bytes | share |
    |---|---:|---:|---:|
-   | `allocator` | 10 | 16,457 | 20.4% |
-   | `session` | 10 | 12,817 | 15.9% |
-   | `inspect` | 9 | 11,626 | 14.4% |
-   | `batch` | 1 | 10,021 | 12.4% |
-   | `exec` | 8 | 9,206 | 11.4% |
-   | `crash` | 3 | 7,129 | 8.8% |
-   | `ttd` | 9 | 6,829 | 8.5% |
-   | `ioctl` | 6 | 6,494 | 8.1% |
+   | `allocator` | 10 | 16,457 | 19.5% |
+   | `inspect` | 10 | 13,152 | 15.6% |
+   | `session` | 10 | 12,817 | 15.2% |
+   | `exec` | 8 | 11,309 | 13.4% |
+   | `batch` | 1 | 10,021 | 11.9% |
+   | `crash` | 3 | 7,427 | 8.8% |
+   | `ttd` | 9 | 6,829 | 8.1% |
+   | `ioctl` | 6 | 6,494 | 7.7% |
 
    | `--tools` | tools | model |
    |---|---:|---:|
-   | *(absent)* | 56 | 80,579 |
-   | `session,inspect,exec,crash` | 30 | 39,857 |
-   | `session,inspect,crash` | 22 | 30,498 |
-   | `crash` | 13 | 18,780 |
+   | *(absent)* | 57 | 84,506 |
+   | `session,inspect,exec,crash` | 31 | 43,784 |
+   | `session,inspect,crash` | 23 | 32,322 |
+   | `crash` | 13 | 19,078 |
 
    **The two tables do not reconcile, and that is the point of item 41.** The first is each group's
    share of the whole surface; the second is what a spec actually serves, which is less — `crash`
-   is 18,780 rather than the 19,946 its two rows sum to, because the cross-references leave with
+   is 19,078 rather than the 20,244 its two rows sum to, because the cross-references leave with
    the tools they name — 1,166 B of them, pointing at `modules`, `debug_batch`, `backtrace`,
    `continue_async` and `break_in`.
 
@@ -381,7 +382,7 @@ put in a group would vanish from every narrowed surface without a word — the d
 still carry it, so nothing else would notice. And
 `a_narrowed_tool_surface_serves_only_what_it_was_asked_for` starts a server with `--tools crash` and
 checks the three things that makes true: thirteen tools, a refusal by name for a tool that exists
-and is not served, and a figure under half the whole surface (it prints 18,780 B).
+and is not served, and a figure under half the whole surface (it prints 19,078 B).
 
 Beside them, `output_schemas_carry_constraints_not_prose` is the
 assertion that finding 1 stays fixed. It reads `tools/list` off the wire, so it catches the way that

--- a/docs/tool-surface.md
+++ b/docs/tool-surface.md
@@ -5,9 +5,9 @@ how much of that surface a run serves, and three behaviours the table has no roo
 
 ## Serving fewer tools (`--tools`)
 
-All fifty-six tools are served unless you say otherwise, and their definitions cost the model
-**80,579 bytes — about 20k tokens — before it has asked anything**, once per conversation. Every
-figure on this page is a measurement of 2026-09-05 rather than an invariant: any edit to a tool's
+All fifty-seven tools are served unless you say otherwise, and their definitions cost the model
+**84,506 bytes — about 21k tokens — before it has asked anything**, once per conversation. Every
+figure on this page is a measurement of 2026-09-07 rather than an invariant: any edit to a tool's
 description moves it, so re-derive before quoting one. Seven
 tenths of that is the prose that tells a model how to drive them, so it cannot be trimmed without
 making the tools harder to use correctly (see
@@ -20,10 +20,10 @@ windbg-mcp.exe --tools session,inspect,crash
 
 | `--tools` | Tools | Model context |
 |---|---:|---:|
-| *(absent)* — every tool | 56 | 80,579 B |
-| `session,inspect,exec,crash` | 30 | 39,103 B |
-| `session,inspect,crash` | 22 | 29,744 B |
-| `crash` | 13 | 18,780 B |
+| *(absent)* — every tool | 57 | 84,506 B |
+| `session,inspect,exec,crash` | 31 | 43,784 B |
+| `session,inspect,crash` | 23 | 32,322 B |
+| `crash` | 13 | 19,078 B |
 
 The spec is a comma-separated list of the group names in the [tool table](../README.md#tools), of
 individual tool names, or `all`.
@@ -56,8 +56,8 @@ is written into the command line the SCM stores, and read back at every start). 
 **run's** surface, and under stdio it is the whole story: one process, one client.
 
 A `--listen` server names its clients, and **a client may be served a surface of its own** — which
-is what lets one listener hold a local model that can fit twenty tools beside a hosted client that
-can hold fifty-six, against the same debug sessions:
+is what lets one listener hold a local model that can fit twenty-three tools beside a hosted client
+that can hold fifty-seven, against the same debug sessions:
 
 ```pwsh
 setx WINDBG_MCP_LISTEN_TOKEN_BENCH "<a long random string>"

--- a/docs/tool-surface.md
+++ b/docs/tool-surface.md
@@ -34,7 +34,7 @@ Two things worth knowing:
 
 - **`session` is always included**, whatever the spec says. Every other tool routes by a
   `session_id`, and this server is the only thing that issues one, so a surface with `registers`
-  and no opener cannot be used at all. That is why `--tools crash` is eleven tools rather than one.
+  and no opener cannot be used at all. That is why `--tools crash` is thirteen tools rather than three.
   The startup log line names the surface it ended up with.
 - **The prose narrows with the list.** A client is told about the tools it has and no others: the
   `instructions` sent at `initialize` are assembled from the surface, and a tool's description

--- a/skills/windbg-debugging/setup.md
+++ b/skills/windbg-debugging/setup.md
@@ -731,8 +731,8 @@ Four things decide whether the ollama route works, and none of them is about the
   needs real work, a longer `WINDBG_MCP_SESSION_IDLE_SECS`, or nothing at all — thirty minutes of
   thinking is a much rarer thing than the lease's grace, and a session with a call still outstanding
   is spared either way.
-- **The surface is the fixed cost and a single answer is the variable one.** All 51 tools are about
-  70 kB of JSON, paid once per conversation and narrowable per client with `--tools`; one careless
+- **The surface is the fixed cost and a single answer is the variable one.** All 57 tools are about
+  85 kB of JSON, paid once per conversation and narrowable per client with `--tools`; one careless
   `read_memory` is up to ~4 MiB, paid on the spot. Narrowing costs fewer *answers* than it does
   tools — most facts here are reachable by more than one route — so it is a real option rather than
   a mutilation.

--- a/src/client.rs
+++ b/src/client.rs
@@ -37,7 +37,7 @@
 //!
 //! A **tool surface of its own**. A client is a budget as much as it is a boundary: the
 //! arrangement this listener was built for is a local model that can hold twenty-three tools beside a
-//! hosted client that can hold fifty-one, on the same box and against the same debug sessions. So
+//! hosted client that can hold fifty-seven, on the same box and against the same debug sessions. So
 //! a credential may carry a [`crate::toolset::Toolset`] as well as a name — configured beside the
 //! token, under the same variable prefix or in the same file entry — and a client that names none
 //! is served whatever the run serves. That is `FOLLOWUPS.md` item 36, and the identity above is
@@ -1907,7 +1907,7 @@ mod tests {
     /// **`None` rather than every tool** is the half worth asserting: a listener started with
     /// `--tools crash` and one client given `inspect` serves that client `inspect` and everybody
     /// else `crash`, which only works if "no surface configured" stays distinguishable from "all
-    /// fifty-one".
+    /// fifty-seven".
     #[test]
     fn a_client_may_be_configured_with_a_surface_of_its_own() {
         let configured = &[

--- a/src/client.rs
+++ b/src/client.rs
@@ -36,7 +36,7 @@
 //! # What a name buys besides isolation
 //!
 //! A **tool surface of its own**. A client is a budget as much as it is a boundary: the
-//! arrangement this listener was built for is a local model that can hold twenty tools beside a
+//! arrangement this listener was built for is a local model that can hold twenty-three tools beside a
 //! hosted client that can hold fifty-one, on the same box and against the same debug sessions. So
 //! a credential may carry a [`crate::toolset::Toolset`] as well as a name — configured beside the
 //! token, under the same variable prefix or in the same file entry — and a client that names none

--- a/src/listen.rs
+++ b/src/listen.rs
@@ -752,7 +752,7 @@ pub async fn serve(
                 let client = crate::client::current();
                 // **And the one moment its surface is knowable, for the same reason.** A client
                 // configured with a spec of its own is served that; every other client is served
-                // whatever this run serves, which is `--tools` or all fifty-one. The run's flag is
+                // whatever this run serves, which is `--tools` or all fifty-seven. The run's flag is
                 // the default rather than a ceiling — see [`crate::toolset`], which also says why
                 // a change here reaches a client the next time it is identified and not before.
                 let (surface, chosen) = match credentials.surface_for(&client) {

--- a/src/server.rs
+++ b/src/server.rs
@@ -2962,7 +2962,7 @@ impl WindbgServer {
     /// the cross-references this surface may read.
     ///
     /// Built per call, which is what `Self::tool_router()` already was — the schemas underneath it
-    /// are cached by type, so this is a map of fifty-six `Arc` clones and a `retain`.
+    /// are cached by type, so this is a map of fifty-seven `Arc` clones and a `retain`.
     ///
     /// It is also the path `call_tool` takes, which pays for [`Self::annotate`] on every call and
     /// reads none of it. That is deliberate: `list_tools` and `get_tool` are the macro's and take
@@ -5619,7 +5619,7 @@ const TOOL_NOTES: &[ToolNote] = &[
     // `list_tools` and `get_tool` come from the macro; what they list is this instance's router
     // rather than the crate-wide one, which is what makes `--tools` visible on the wire. The
     // default here is `Self::tool_router()`, and leaving it would have narrowed the calls a tool
-    // may make (`dispatch`) while still advertising all fifty-six.
+    // may make (`dispatch`) while still advertising all fifty-seven.
     //
     // `name` and `instructions` used to be here too. They moved into the hand-written `get_info`
     // below, which the macro yields to - the instructions are now assembled for the client's own

--- a/src/toolset.rs
+++ b/src/toolset.rs
@@ -1,7 +1,7 @@
 //! Which of this server's fifty-seven tools a run advertises.
 //!
 //! The tool surface is paid **once per conversation, before anything is debugged**, and it is
-//! 79,825 bytes — roughly 20k tokens (measured 2026-09-05; every figure here moves with any edit
+//! 84,506 bytes — roughly 21k tokens (measured 2026-09-07; every figure here moves with any edit
 //! to a description, so re-derive rather than cite). Seven tenths of that is prose, and the prose is what tells
 //! a model how to drive the tools, so there is no strip here the way there was in
 //! [`crate::schema`]: `FOLLOWUPS.md` item 24 measured it and the only honest lever left is the one
@@ -365,7 +365,7 @@ impl Toolset {
     }
 
     /// What this surface is, for the startup log. Names the groups it covers whole, then whatever
-    /// is left over, so `--tools crash` reads as the eleven tools it is.
+    /// is left over, so `--tools crash` reads as the thirteen tools it is.
     pub fn summary(&self) -> String {
         let Some(included) = &self.included else {
             return format!("all {} tools", Self::total());

--- a/src/toolset.rs
+++ b/src/toolset.rs
@@ -1,4 +1,4 @@
-//! Which of this server's fifty-six tools a run advertises.
+//! Which of this server's fifty-seven tools a run advertises.
 //!
 //! The tool surface is paid **once per conversation, before anything is debugged**, and it is
 //! 79,825 bytes — roughly 20k tokens (measured 2026-09-05; every figure here moves with any edit
@@ -21,17 +21,20 @@
 //! ```text
 //!   group      tools   bytes   what it is for
 //!   allocator     10   16,457  pool and heap walks, and `walk_memory`
+//!   inspect       10   13,152  registers, stacks, memory, modules, symbols, location, raw commands
 //!   session       10   12,817  opening a target, ending it, and watching this server
-//!   inspect        9   11,626  registers, stacks, memory, modules, symbols, raw commands
+//!   exec           8   11,309  breakpoints and execution control
 //!   batch          1   10,021  `debug_batch`
-//!   exec           8    9,206  breakpoints and execution control
+//!   crash          3    7,427  a bug check, a user-mode fault, and an error code
 //!   ttd            9    6,829  recording, indexing and querying a Time Travel trace
 //!   ioctl          6    6,494  driver objects, IRP stacks, and dispatch reachability
-//!   crash          3    6,375  a bug check, a user-mode fault, and an error code
 //! ```
 //!
+//! Those bytes are a measurement of **2026-09-07** and move with any edit to a description — the
+//! whole surface they are shares of is 57 tools and 84,506 B. Re-derive rather than quoting them.
+//!
 //! **Those are shares of the whole surface, and they do not sum to a narrowed one.** `crash` reads
-//! 18,026 bytes, not the 19,192 its two rows add to, because the thirteen tools it keeps also stop
+//! 19,078 bytes, not the 20,244 its two rows add to, because the thirteen tools it keeps also stop
 //! carrying the sentences that pointed at `modules`, `debug_batch`, `backtrace`, `continue_async`
 //! and `break_in` — 1,166 bytes of them. A spec is always cheaper than its rows suggest, never
 //! dearer.
@@ -51,8 +54,8 @@
 //! the flag is right there on the command line that started it.
 //!
 //! A listener names its clients already ([`crate::client`]), and they do not have one budget
-//! between them: the arrangement this exists for is a local model that can hold twenty tools and a
-//! hosted client that can hold fifty-six, pointed at the same Windows box and the same debug
+//! between them: the arrangement this exists for is a local model that can hold twenty-three tools
+//! and a hosted client that can hold fifty-seven, pointed at the same Windows box and the same debug
 //! sessions and told apart by their bearer tokens. So a client may be configured with a spec of
 //! its own — `WINDBG_MCP_TOOLS_<NAME>`, or a `tools` field in the credential file — and is served
 //! that instead of the run's. The run's `--tools` is the **default**, not a ceiling: a client's
@@ -253,7 +256,7 @@ impl Toolset {
             named_anything = true;
             if entry == ALL {
                 // Noted and carried on with, not returned on. Returning here would stop validating
-                // the rest, so `all,ttdd` served all 56 tools while `ttdd,all` was refused — the
+                // the rest, so `all,ttdd` served all 57 tools while `ttdd,all` was refused — the
                 // same spec, judged by where the typo happened to sit. A refusal that depends on
                 // entry order is worse than no refusal, because it is the one nobody reproduces.
                 everything = true;

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -1865,11 +1865,12 @@ fn budget_report(result: &Value, instructions: &str) -> Value {
 const MODEL_VISIBLE_CEILING: usize = 88_000;
 
 /// Ceiling on the whole `tools/list` payload — the serialized result, not the sum of its tools, so
-/// the array's own punctuation and every result-level field are inside it. 192,971 bytes today,
-/// 58% of that `outputSchema` no model reads, which is why this is a separate and much looser
-/// number rather than a scaled version of the one above. (The figure said 177,460 until
-/// 2026-08-30 — a payload measured two re-recordings ago, which is the way a number in a doc
-/// comment goes stale: nothing reads it, so nothing notices.)
+/// the array's own punctuation and every result-level field are inside it. 216,839 bytes as of
+/// 2026-09-07, 58% of that `outputSchema` no model reads, which is why this is a separate and much
+/// looser number rather than a scaled version of the one above. (The figure said 177,460 until
+/// 2026-08-30 and 192,971 until this line was re-derived — a payload measured several
+/// re-recordings ago each time, which is the way a number in a doc comment goes stale: nothing
+/// reads it, so nothing notices.)
 ///
 /// It is a client-side parse and memory cost, and it is the one that grows silently: `schemars`
 /// inlines `$defs` per tool, so adding one shared type to one more output shape still lands here

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -2405,6 +2405,43 @@ fn documented_rows(text: &str) -> Vec<DocumentedRow> {
     rows
 }
 
+/// Every group name, taken from **the server's own refusal** rather than from a list here.
+///
+/// `--tools <nonsense>` answers `Groups: session, inspect, …`, which is `src/toolset.rs`'s `GROUPS`
+/// rendered by the code that owns it. A ninth group therefore arrives in this test with nothing
+/// added to it, and its row in the tables is checked from the first run — where a list written out
+/// here would leave that row unrecognised, and an unrecognised row was being skipped in silence.
+/// Deriving it is half the answer; the other half is that an unknown label is now a failure.
+fn group_names() -> Vec<String> {
+    let out = Command::new(EXE)
+        .args(["--tools", "windbg-mcp-smoke-no-such-group"])
+        .output()
+        .expect("run the server with an invalid `--tools` spec");
+    let said = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let listed = said
+        .split_once("Groups:")
+        .unwrap_or_else(|| panic!("an invalid `--tools` spec should list the groups:\n{said}"))
+        .1;
+    let groups: Vec<String> = listed
+        .split(['(', ';', '\n'])
+        .next()
+        .unwrap_or_default()
+        .split(',')
+        .map(|name| name.trim().to_string())
+        .filter(|name| !name.is_empty())
+        .collect();
+    assert!(
+        groups.iter().any(|g| g == "session"),
+        "`session` is in every surface, so a group list without it is a parse of the wrong \
+         sentence: {groups:?} out of\n{said}"
+    );
+    groups
+}
+
 /// The integer a table cell states, ignoring thousands separators and any trailing unit.
 fn documented_number(cell: &str) -> usize {
     cell.chars()
@@ -2472,24 +2509,15 @@ fn every_documented_surface_figure_matches_the_served_surface() {
 
     // Each group's share of the whole surface: its tools, sized as the whole surface sizes them.
     let mut group_share: BTreeMap<String, (usize, usize)> = BTreeMap::new();
-    for group in [
-        "session",
-        "inspect",
-        "exec",
-        "ttd",
-        "ioctl",
-        "allocator",
-        "crash",
-        "batch",
-    ] {
-        let served = names(&listing(Some(group)));
+    for group in group_names() {
+        let served = names(&listing(Some(&group)));
         let members: Vec<String> = if group == "session" {
             served
         } else {
             served.into_iter().filter(|n| !always.contains(n)).collect()
         };
         let bytes = members.iter().map(|n| size_of[n.as_str()]).sum::<usize>();
-        group_share.insert(group.to_string(), (members.len(), bytes));
+        group_share.insert(group, (members.len(), bytes));
     }
 
     // What each documented spec actually serves, which is less than its groups' rows add to.
@@ -2522,7 +2550,27 @@ fn every_documented_surface_figure_matches_the_served_surface() {
                 TableKind::Groups => group_share.get(&row.label),
                 TableKind::Specs => spec_cost.get(&row.label),
             };
+            // An unrecognised row is a failure and not a skip. Skipping it meant a table could
+            // gain a row — a ninth group, a fifth `--tools` profile — and have it checked by
+            // nothing, while the completeness pass below stayed happy because every label it knew
+            // about was still there. Measured on the version before this one: a `network` row
+            // invented with wrong figures passed.
             let Some(&(tools, bytes)) = expected else {
+                let remedy = match row.kind {
+                    TableKind::Groups => {
+                        "this server has no such group — the names come from its \
+                                          own `--tools` refusal, so correct the row or add the \
+                                          group to `src/toolset.rs`"
+                    }
+                    TableKind::Specs => {
+                        "this test measures no such spec — add it to \
+                                         `DOCUMENTED_SPECS` so the row is checked, or correct it"
+                    }
+                };
+                wrong.push(format!(
+                    "{file}:{}  `{}` is a row in a {:?} table that nothing checks: {remedy}",
+                    row.line, row.label, row.kind
+                ));
                 continue;
             };
             if let Some(seen) = found.get_mut(&(file, row.kind)) {

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -2280,6 +2280,285 @@ fn a_narrowed_tool_surface_serves_only_what_it_was_asked_for() {
     );
 }
 
+// ---- the documented surface tables, checked against the served one ------------------------
+
+/// The files carrying a table of what the tool surface costs.
+///
+/// Three copies rather than one, deliberately: they answer different questions for different
+/// readers — the module's own summary, the operator's page, and the budget analysis — and a
+/// *checked* copy is not the failure mode. An unchecked one is.
+const SURFACE_TABLES: &[&str] = &[
+    "src/toolset.rs",
+    "docs/tool-surface.md",
+    "docs/token-budget.md",
+];
+
+/// The `--tools` specs the tables quote, `None` being the whole surface.
+const DOCUMENTED_SPECS: &[Option<&str>] = &[
+    None,
+    Some("session,inspect,exec,crash"),
+    Some("session,inspect,crash"),
+    Some("crash"),
+];
+
+/// Which table a row was found in. The two carry different columns and one label — `crash` — that
+/// means a group in the first and a spec in the second, so the row alone cannot say.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum TableKind {
+    /// Each group's share of the *whole* surface: name, tools, bytes, and sometimes a percentage.
+    Groups,
+    /// What a `--tools` spec actually serves, which is less. See `src/toolset.rs`.
+    Specs,
+}
+
+/// One row of a documented table: its label, and every number after it, in order.
+#[derive(Debug)]
+struct DocumentedRow {
+    line: usize,
+    kind: TableKind,
+    label: String,
+    numbers: Vec<String>,
+}
+
+/// Splits a table row into cells, for the two shapes these tables come in.
+///
+/// A markdown row is pipe-delimited; `src/toolset.rs`'s is a fenced text table aligned with runs
+/// of spaces. Taking both here rather than writing two parsers is what lets one expectation check
+/// a figure wherever it is written down.
+fn table_cells(line: &str) -> Vec<String> {
+    let cells: Vec<String> = if line.starts_with('|') {
+        line.split('|').map(|c| c.trim().to_string()).collect()
+    } else {
+        line.split("  ").map(|c| c.trim().to_string()).collect()
+    };
+    cells.into_iter().filter(|c| !c.is_empty()).collect()
+}
+
+/// A cell's label, normalised to the thing it names: backticks and emphasis off, and any trailing
+/// gloss (`*(absent)* — every tool`) dropped at the dash.
+fn row_label(cell: &str) -> String {
+    let cell = cell.split(" — ").next().unwrap_or(cell);
+    cell.trim()
+        .trim_matches(|c| c == '`' || c == '*' || c == ' ')
+        .to_ascii_lowercase()
+}
+
+/// Every row of every surface table in one file, tagged with which table it came from.
+///
+/// The table is identified by its **header**, not by the row — `crash` is a group in one and a
+/// spec in the other, and reading a spec row as a group's share is exactly the confusion the two
+/// tables exist to keep apart (`FOLLOWUPS.md` item 41).
+fn documented_rows(text: &str) -> Vec<DocumentedRow> {
+    let mut rows = Vec::new();
+    let mut kind = None;
+    for (index, raw) in text.lines().enumerate() {
+        let line = raw.trim().trim_start_matches("//!").trim();
+        if line.is_empty() || line.starts_with("```") {
+            kind = None;
+            continue;
+        }
+        let cells = table_cells(line);
+        let Some(first) = cells.first() else {
+            kind = None;
+            continue;
+        };
+        let label = row_label(first);
+        match label.as_str() {
+            "group" => {
+                kind = Some(TableKind::Groups);
+                continue;
+            }
+            "--tools" => {
+                kind = Some(TableKind::Specs);
+                continue;
+            }
+            _ => {}
+        }
+        let Some(kind) = kind else { continue };
+        // A markdown separator row, and anything else with no figures in it.
+        let numbers: Vec<String> = cells[1..]
+            .iter()
+            .filter(|c| c.starts_with(|c: char| c.is_ascii_digit()))
+            .map(|c| c.to_string())
+            .collect();
+        if numbers.is_empty() {
+            continue;
+        }
+        rows.push(DocumentedRow {
+            line: index + 1,
+            kind,
+            label,
+            numbers,
+        });
+    }
+    rows
+}
+
+/// The integer a table cell states, ignoring thousands separators and any trailing unit.
+fn documented_number(cell: &str) -> usize {
+    cell.chars()
+        .take_while(|c| c.is_ascii_digit() || *c == ',')
+        .filter(|c| *c != ',')
+        .collect::<String>()
+        .parse()
+        .unwrap_or_else(|_| panic!("`{cell}` should begin with a number"))
+}
+
+/// **Every documented tool-surface figure is checked against the surface actually served.**
+///
+/// This exists because the figures went stale in seven files at once, and three consecutive review
+/// rounds on [#293](https://github.com/glslang/windbg-mcp/pull/293) each found more of them — every
+/// finding locally real, every fix locally correct, and the count of wrong numbers going *up* each
+/// round. The thing generating them was a measurement hand-copied into prose that nothing reads,
+/// so no amount of care at the copying end was going to end it.
+///
+/// **What is checked is the tables, not the prose, and that is the whole design.** A sweep over
+/// text for anything that looks like a surface figure was prototyped first and measured: 63 lines
+/// would have to be triaged, none of which carried a date, and most of which are neither stale nor
+/// even about the surface — `15,610 B` is a wire cost, `53,933 B` is a `modules` *result*, and
+/// `CHANGELOG.md` and `DONE.md` are records that must never be updated at all. A test with that
+/// false-positive rate would file findings of its own, which is the failure it was meant to end.
+/// A table row states one quantity, in one place, and can be compared exactly — so the tables are
+/// checked here and the loose restatements were deleted rather than made checkable.
+///
+/// Group membership is **derived from the server** rather than read out of `src/toolset.rs`, so
+/// this cannot agree with a table by sharing its mistake: `session` is in every surface, so a
+/// group's tools are what `--tools <group>` serves that `--tools session` does not.
+#[test]
+fn every_documented_surface_figure_matches_the_served_surface() {
+    let listing = |spec: Option<&str>| -> Vec<Value> {
+        let mut server = match spec {
+            None => Server::started(),
+            Some(spec) => Server::started_with_args(&[], &["--tools", spec]),
+        };
+        let response = server.request("tools/list", json!({}), STEP);
+        assert_no_error(&response, "tools/list");
+        response["result"]["tools"]
+            .as_array()
+            .expect("tools/list returns an array")
+            .clone()
+    };
+
+    let whole = listing(None);
+    let size_of: BTreeMap<&str, usize> = whole
+        .iter()
+        .map(|t| {
+            (
+                t["name"].as_str().expect("a tool has a name"),
+                model_visible_bytes(t),
+            )
+        })
+        .collect();
+    let whole_bytes: usize = size_of.values().sum();
+
+    let names = |tools: &[Value]| -> Vec<String> {
+        tools
+            .iter()
+            .map(|t| t["name"].as_str().unwrap_or_default().to_string())
+            .collect()
+    };
+    let always = names(&listing(Some("session")));
+
+    // Each group's share of the whole surface: its tools, sized as the whole surface sizes them.
+    let mut group_share: BTreeMap<String, (usize, usize)> = BTreeMap::new();
+    for group in [
+        "session",
+        "inspect",
+        "exec",
+        "ttd",
+        "ioctl",
+        "allocator",
+        "crash",
+        "batch",
+    ] {
+        let served = names(&listing(Some(group)));
+        let members: Vec<String> = if group == "session" {
+            served
+        } else {
+            served.into_iter().filter(|n| !always.contains(n)).collect()
+        };
+        let bytes = members.iter().map(|n| size_of[n.as_str()]).sum::<usize>();
+        group_share.insert(group.to_string(), (members.len(), bytes));
+    }
+
+    // What each documented spec actually serves, which is less than its groups' rows add to.
+    let mut spec_cost: BTreeMap<String, (usize, usize)> = BTreeMap::new();
+    for spec in DOCUMENTED_SPECS {
+        let served = listing(*spec);
+        let bytes: usize = served.iter().map(model_visible_bytes).sum();
+        let label = spec.map_or("(absent)".to_string(), str::to_string);
+        spec_cost.insert(label, (served.len(), bytes));
+    }
+
+    let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+    let mut checked = 0usize;
+    let mut wrong: Vec<String> = Vec::new();
+    let mut seen_groups: BTreeMap<&str, usize> = BTreeMap::new();
+
+    for file in SURFACE_TABLES {
+        let text =
+            std::fs::read_to_string(root.join(file)).unwrap_or_else(|e| panic!("read {file}: {e}"));
+        for row in documented_rows(&text) {
+            let expected = match row.kind {
+                TableKind::Groups => group_share.get(&row.label),
+                TableKind::Specs => spec_cost.get(&row.label),
+            };
+            let Some(&(tools, bytes)) = expected else {
+                continue;
+            };
+            if row.kind == TableKind::Groups {
+                *seen_groups.entry(file).or_default() += 1;
+            }
+            checked += 1;
+            let stated_tools = documented_number(&row.numbers[0]);
+            let stated_bytes = documented_number(&row.numbers[1]);
+            if stated_tools != tools || stated_bytes != bytes {
+                wrong.push(format!(
+                    "{file}:{}  `{}` says {stated_tools} tools and {stated_bytes} B; \
+                     the server serves {tools} and {bytes}",
+                    row.line, row.label
+                ));
+            }
+            // A percentage column, where the table carries one. Shares move when *any* group
+            // does, so this is the column most likely to be left behind by an edit elsewhere.
+            if let Some(share) = row.numbers.get(2).filter(|c| c.ends_with('%')) {
+                let stated: f64 = share.trim_end_matches('%').parse().unwrap_or(-1.0);
+                let actual = (bytes as f64 * 1000.0 / whole_bytes as f64).round() / 10.0;
+                if (stated - actual).abs() > 0.05 {
+                    wrong.push(format!(
+                        "{file}:{}  `{}` says {stated}% of the surface; it is {actual}%",
+                        row.line, row.label
+                    ));
+                }
+            }
+        }
+    }
+
+    assert!(
+        wrong.is_empty(),
+        "the documented tool surface disagrees with the served one. The server is right; \
+         `docs/token-budget.md` says how these are measured.\n  {}",
+        wrong.join("\n  ")
+    );
+
+    // A table that lost a row would otherwise pass by having nothing left to disagree with.
+    for (file, found) in &seen_groups {
+        assert_eq!(
+            *found,
+            group_share.len(),
+            "{file} has a group table with {found} of the {} groups in it — a row that goes \
+             missing takes its figure out of this check with it",
+            group_share.len()
+        );
+    }
+    assert!(
+        checked >= SURFACE_TABLES.len(),
+        "no surface table was found in {SURFACE_TABLES:?} — this test passed by reading nothing, \
+         which is what a moved or reformatted table looks like from here"
+    );
+    eprintln!("RAN: {checked} documented surface figures against the served surface");
+}
+
 /// A tool that declares an `outputSchema` must return `structuredContent` — on **both** paths.
 ///
 /// The spec's requirement is on the success path, and the failure path is where this would break

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -2329,6 +2329,11 @@ struct DocumentedRow {
     kind: TableKind,
     label: String,
     numbers: Vec<String>,
+    /// Whether this row's **table** declares a share column, read off its header rather than off
+    /// the row. A row is not asked whether it has a percentage — it is told that its table has
+    /// one, because a row that lost its `%` would otherwise answer no and be believed: measured,
+    /// stripping one `%` from `docs/token-budget.md` left the share unchecked and the test green.
+    share_expected: bool,
 }
 
 /// Splits a table row into cells, for the two shapes these tables come in.
@@ -2361,31 +2366,35 @@ fn row_label(cell: &str) -> String {
 /// tables exist to keep apart (`FOLLOWUPS.md` item 41).
 fn documented_rows(text: &str) -> Vec<DocumentedRow> {
     let mut rows = Vec::new();
-    let mut kind = None;
+    // The table now open: its kind, and whether its header declared a `share` column.
+    let mut table: Option<(TableKind, bool)> = None;
     for (index, raw) in text.lines().enumerate() {
         let line = raw.trim().trim_start_matches("//!").trim();
         if line.is_empty() || line.starts_with("```") {
-            kind = None;
+            table = None;
             continue;
         }
         let cells = table_cells(line);
         let Some(first) = cells.first() else {
-            kind = None;
+            table = None;
             continue;
         };
         let label = row_label(first);
+        let shares = cells.iter().any(|c| row_label(c) == "share");
         match label.as_str() {
             "group" => {
-                kind = Some(TableKind::Groups);
+                table = Some((TableKind::Groups, shares));
                 continue;
             }
             "--tools" => {
-                kind = Some(TableKind::Specs);
+                table = Some((TableKind::Specs, shares));
                 continue;
             }
             _ => {}
         }
-        let Some(kind) = kind else { continue };
+        let Some((kind, share_expected)) = table else {
+            continue;
+        };
         // A markdown separator row, and anything else with no figures in it.
         let numbers: Vec<String> = cells[1..]
             .iter()
@@ -2400,6 +2409,7 @@ fn documented_rows(text: &str) -> Vec<DocumentedRow> {
             kind,
             label,
             numbers,
+            share_expected,
         });
     }
     rows
@@ -2573,8 +2583,17 @@ fn every_documented_surface_figure_matches_the_served_surface() {
                 ));
                 continue;
             };
-            if let Some(seen) = found.get_mut(&(file, row.kind)) {
-                seen.insert(row.label.clone());
+            // A label stated twice is not caught by the completeness pass below, since a set that
+            // already holds it is still complete — so it is caught here, where the second row is
+            // still in hand. A duplicate is worth failing on rather than tolerating: two rows for
+            // one quantity are one edit away from disagreeing, and only one of them would be read.
+            if let Some(seen) = found.get_mut(&(file, row.kind))
+                && !seen.insert(row.label.clone())
+            {
+                wrong.push(format!(
+                    "{file}:{}  `{}` has more than one row in its {:?} table",
+                    row.line, row.label, row.kind
+                ));
             }
             checked += 1;
             let stated_tools = documented_number(&row.numbers[0]);
@@ -2586,17 +2605,27 @@ fn every_documented_surface_figure_matches_the_served_surface() {
                     row.line, row.label
                 ));
             }
-            // A percentage column, where the table carries one. Shares move when *any* group
-            // does, so this is the column most likely to be left behind by an edit elsewhere.
-            if let Some(share) = row.numbers.get(2).filter(|c| c.ends_with('%')) {
-                let stated: f64 = share.trim_end_matches('%').parse().unwrap_or(-1.0);
-                let actual = (bytes as f64 * 1000.0 / whole_bytes as f64).round() / 10.0;
-                if (stated - actual).abs() > 0.05 {
-                    wrong.push(format!(
-                        "{file}:{}  `{}` says {stated}% of the surface; it is {actual}%",
-                        row.line, row.label
-                    ));
+            // The share column, required of every row of a table whose header declares one.
+            // Shares move when *any* group does, so this is the figure most likely to be left
+            // behind by an edit elsewhere — and asking the row whether it has one would let a row
+            // that lost its `%` excuse itself from the check.
+            let share = row.numbers.get(2).filter(|c| c.ends_with('%'));
+            match (row.share_expected, share) {
+                (true, None) => wrong.push(format!(
+                    "{file}:{}  `{}` is in a table with a share column and states no percentage",
+                    row.line, row.label
+                )),
+                (_, Some(share)) => {
+                    let stated: f64 = share.trim_end_matches('%').parse().unwrap_or(-1.0);
+                    let actual = (bytes as f64 * 1000.0 / whole_bytes as f64).round() / 10.0;
+                    if (stated - actual).abs() > 0.05 {
+                        wrong.push(format!(
+                            "{file}:{}  `{}` says {stated}% of the surface; it is {actual}%",
+                            row.line, row.label
+                        ));
+                    }
                 }
+                (false, None) => {}
             }
         }
     }

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -64,7 +64,7 @@
 //!
 //! See `docs/smoke-test.md` for the runbook.
 
-use std::collections::{BTreeMap, VecDeque};
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::io::{BufRead, BufReader, Write};
 use std::panic::{AssertUnwindSafe, catch_unwind, resume_unwind};
 use std::process::{Child, ChildStdin, Command, Stdio};
@@ -2287,10 +2287,21 @@ fn a_narrowed_tool_surface_serves_only_what_it_was_asked_for() {
 /// Three copies rather than one, deliberately: they answer different questions for different
 /// readers — the module's own summary, the operator's page, and the budget analysis — and a
 /// *checked* copy is not the failure mode. An unchecked one is.
-const SURFACE_TABLES: &[&str] = &[
-    "src/toolset.rs",
-    "docs/tool-surface.md",
-    "docs/token-budget.md",
+/// Each file, and **which tables it must carry** — not merely which it happens to contain.
+///
+/// The pair is what makes a deletion fail. Counting the rows a file turns out to have asks nothing
+/// of a file that has none, so a table removed wholesale, or reformatted past recognition, passed
+/// the first version of this test with the remaining figures still agreeing: measured, deleting
+/// `docs/tool-surface.md`'s four spec rows left 23 of 24 checked and green, and deleting
+/// `src/toolset.rs`'s group table outright left 16. A **declared** table that goes missing has an
+/// expected set of labels to be missing from.
+const SURFACE_TABLES: &[(&str, &[TableKind])] = &[
+    ("src/toolset.rs", &[TableKind::Groups]),
+    ("docs/tool-surface.md", &[TableKind::Specs]),
+    (
+        "docs/token-budget.md",
+        &[TableKind::Groups, TableKind::Specs],
+    ),
 ];
 
 /// The `--tools` specs the tables quote, `None` being the whole surface.
@@ -2303,7 +2314,7 @@ const DOCUMENTED_SPECS: &[Option<&str>] = &[
 
 /// Which table a row was found in. The two carry different columns and one label — `crash` — that
 /// means a group in the first and a spec in the second, so the row alone cannot say.
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug)]
 enum TableKind {
     /// Each group's share of the *whole* surface: name, tools, bytes, and sometimes a percentage.
     Groups,
@@ -2493,9 +2504,17 @@ fn every_documented_surface_figure_matches_the_served_surface() {
     let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
     let mut checked = 0usize;
     let mut wrong: Vec<String> = Vec::new();
-    let mut seen_groups: BTreeMap<&str, usize> = BTreeMap::new();
+    // What each declared table was actually found to state, so a row that is *not* there is as
+    // visible as one that is wrong. Keyed by file and kind, and a set rather than a count: eight
+    // rows naming seven groups twice is the shape a count waves through.
+    let mut found: BTreeMap<(&str, TableKind), BTreeSet<String>> = BTreeMap::new();
+    for (file, kinds) in SURFACE_TABLES {
+        for kind in *kinds {
+            found.entry((file, *kind)).or_default();
+        }
+    }
 
-    for file in SURFACE_TABLES {
+    for (file, _) in SURFACE_TABLES {
         let text =
             std::fs::read_to_string(root.join(file)).unwrap_or_else(|e| panic!("read {file}: {e}"));
         for row in documented_rows(&text) {
@@ -2506,8 +2525,8 @@ fn every_documented_surface_figure_matches_the_served_surface() {
             let Some(&(tools, bytes)) = expected else {
                 continue;
             };
-            if row.kind == TableKind::Groups {
-                *seen_groups.entry(file).or_default() += 1;
+            if let Some(seen) = found.get_mut(&(file, row.kind)) {
+                seen.insert(row.label.clone());
             }
             checked += 1;
             let stated_tools = documented_number(&row.numbers[0]);
@@ -2541,21 +2560,32 @@ fn every_documented_surface_figure_matches_the_served_surface() {
         wrong.join("\n  ")
     );
 
-    // A table that lost a row would otherwise pass by having nothing left to disagree with.
-    for (file, found) in &seen_groups {
-        assert_eq!(
-            *found,
-            group_share.len(),
-            "{file} has a group table with {found} of the {} groups in it — a row that goes \
-             missing takes its figure out of this check with it",
-            group_share.len()
-        );
+    // A row that is absent disagrees with nothing, so every declared table is required to state
+    // its whole set of labels. This is the half that has to be complete: the comparison above only
+    // ever reaches figures that are still written down.
+    let mut missing: Vec<String> = Vec::new();
+    for ((file, kind), seen) in &found {
+        let expected: BTreeSet<String> = match kind {
+            TableKind::Groups => group_share.keys().cloned().collect(),
+            TableKind::Specs => spec_cost.keys().cloned().collect(),
+        };
+        let absent: Vec<&String> = expected.difference(seen).collect();
+        if !absent.is_empty() {
+            missing.push(format!(
+                "{file} declares a {kind:?} table and does not state {absent:?} in it \
+                 ({} of {} rows found)",
+                seen.len(),
+                expected.len()
+            ));
+        }
     }
     assert!(
-        checked >= SURFACE_TABLES.len(),
-        "no surface table was found in {SURFACE_TABLES:?} — this test passed by reading nothing, \
-         which is what a moved or reformatted table looks like from here"
+        missing.is_empty(),
+        "a documented surface table has lost rows, which takes their figures out of this check \
+         rather than failing it.\n  {}",
+        missing.join("\n  ")
     );
+
     eprintln!("RAN: {checked} documented surface figures against the served surface");
 }
 


### PR DESCRIPTION
Found while preparing v0.16.0: the CHANGELOG's surface figures were stale, and fixing them there
turned up the same numbers wrong in seven more files. The release carried the corrected CHANGELOG;
this is the rest.

## What was wrong

The surface is **57 tools and 84,506 B** of model context. Seven files said 56 and 80,579 — and
two of them disagreed with the other five about what a narrowed surface costs:

| claim | README.md, docs/tool-surface.md | docs/token-budget.md, docs/remote-listener.md | measured today |
|---|---:|---:|---:|
| `session,inspect,exec,crash` | 30 tools, 39,103 B | 30 tools, 39,857 B | **31 tools, 43,784 B** |
| `session,inspect,crash` | 22 tools, 29,744 B | 22 tools, 30,498 B | **23 tools, 32,322 B** |
| `crash` | 13 tools, 18,780 B | 13 tools, 18,780 B | **13 tools, 19,078 B** |

`src/toolset.rs`'s own module table was a third snapshot again (`crash` 6,375 B, `inspect` 9 tools).
Nothing reads any of these, so nothing noticed.

## How the numbers were derived

Not by scaling the old ones. The surface was measured with `model_visible_bytes`'s own metric —
serde_json's compact encoding of `{name, description, inputSchema}` — driven against
`target\debug\windbg-mcp.exe` over stdio, once per `--tools` spec. The replication was checked
against the budget test **before** any share was computed from it: it reproduces the test's 84,506 B
total exactly, and the test's own `--tools crash` line prints the 19,078 B this PR writes down.

| group | tools | bytes | share |
|---|---:|---:|---:|
| `allocator` | 10 | 16,457 | 19.5% |
| `inspect` | 10 | 13,152 | 15.6% |
| `session` | 10 | 12,817 | 15.2% |
| `exec` | 8 | 11,309 | 13.4% |
| `batch` | 1 | 10,021 | 11.9% |
| `crash` | 3 | 7,427 | 8.8% |
| `ttd` | 9 | 6,829 | 8.1% |
| `ioctl` | 6 | 6,494 | 7.7% |

`inspect` gained `current_location`, which is what moved it above `session`.

## Two things re-deriving turned up that substituting would have missed

**The reconciliation sentence was right about the mechanism and wrong about both operands.**
`crash` serves 19,078 B where its two rows sum to 20,244 — and the difference is the same
**1,166 B** of cross-references (`modules`, `debug_batch`, `backtrace`, `continue_async`,
`break_in`) it has always been. The delta was never stale; the numbers either side of it were.

**Finding 8's "21,989 B" never summed its own five rows.** They come to 22,264, and none of the
five has moved a byte since 2026-08-22 — so that was an arithmetic error when written, not drift
since. Its share is 26.3% of today's surface rather than the 27.3% claimed.

## What was deliberately left alone

Figures whose sentence already frames them as history: `docs/token-budget.md`'s "all 54 tools of
the day" and its dated Binary Ninja section, and `MODEL_VISIBLE_CEILING`'s account of how it was
first sized. Every figure that *was* touched now carries the date it was measured, per
`.claude/skills/handoff`'s rule that a byte figure in prose is a measurement rather than an
invariant.

## Verification

`cargo fmt --all --check` · `cargo clippy --all-targets` · `cargo test` with
`WINDBG_MCP_SMOKE_DUMP=1` — **695 unit and 104 smoke passed**, all 7 `RAN:` markers, with the
32-bit worker rebuilt from this tree so that tier ran rather than failing on a build-identity
mismatch · markdownlint over CI's four globs.

The surface goldens are untouched, which is the check that this changed the prose and not the thing
the prose is about.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ayv1beKpAVkmDJDLfYqoyf
