### PR TITLE
docs: plan BN6 similarity with Personal external BinDiff support

### DIFF
--- a/docs/binja-windbg-mcp-plan.md
+++ b/docs/binja-windbg-mcp-plan.md
@@ -83,7 +83,7 @@ not stop the process-wide listener or end a debugger session.
 
 Generate a 32-byte bearer token. Validate HTTP host and origin information. Store credentials and named WinDbg profiles in a user-only `profiles.json` under Binary Ninja's per-user data directory, with macOS mode `0600`. Tokens never appear in tool arguments, logs, or BNDB metadata. WinDbg connections use loopback/tunneled HTTP or authenticated HTTPS, with certificate verification and no credential-bearing redirects.
 
-Expose 16 tools with startup-configured groups:
+Expose 22 tools with startup-configured groups:
 
 | Group | Tools |
 |---|---|
@@ -92,8 +92,9 @@ Expose 16 tools with startup-configured groups:
 | `evidence` | `add_evidence` |
 | `pair` | `pair_windbg`, `windbg_pair_status`, `unpair_windbg` |
 | `debug` | `set_breakpoint_here`, `run_to_here`, `compare_runtime_bytes` |
+| `similarity` | `similarity_start`, `similarity_status`, `similarity_results`, `similarity_diff`, `similarity_cancel`, `similarity_close` |
 
-All groups are enabled by default. `workspace` is always included; selecting `debug` also includes `pair`. Each tool belongs to exactly one group.
+The default `groups: "all"` enables every group, including `similarity`. An explicit group list enables `similarity` only when named. `workspace` is always included; selecting `debug` also includes `pair`. Each tool belongs to exactly one group.
 
 ### Workspace and analysis behavior
 

--- a/docs/binja-windbg-mcp-plan.md
+++ b/docs/binja-windbg-mcp-plan.md
@@ -10,6 +10,12 @@ The MCP host orchestrates both servers through `(module, PE identity, RVA)` coor
 
 V1 supports driver analysis, navigation, and evidence capture. Breakpoint installation and run-to execution are the only direct debugger mutations exposed by this plugin. Automatic execution, arbitrary debugger commands, memory/register writes, exploitation, vulnerability verdicts, and report submission are outside V1.
 
+The [BN6 similarity extension plan](binja6-similarity-plan.md) specifies an optional
+Ultimate feature for comparing two open PE builds, inspecting matches and disassembly
+differences, and navigating candidates into the existing guarded debugger workflow.
+The companion implementation has automated coverage; native Ultimate acceptance
+remains pending. The Personal companion remains supported.
+
 ## Native MCP integration (revised 2026-09-06)
 
 The [installed Binary Ninja 6 test drive](binja6-native-mcp-test-drive.md) established the

--- a/docs/binja-windbg-mcp-plan.md
+++ b/docs/binja-windbg-mcp-plan.md
@@ -11,9 +11,9 @@ The MCP host orchestrates both servers through `(module, PE identity, RVA)` coor
 V1 supports driver analysis, navigation, and evidence capture. Breakpoint installation and run-to execution are the only direct debugger mutations exposed by this plugin. Automatic execution, arbitrary debugger commands, memory/register writes, exploitation, vulnerability verdicts, and report submission are outside V1.
 
 The [BN6 similarity extension plan](binja6-similarity-plan.md) specifies an optional
-Ultimate feature for comparing two open PE builds, inspecting matches and disassembly
+Personal/external BinDiff and Ultimate/native feature for comparing two open PE builds, inspecting matches and disassembly
 differences, and navigating candidates into the existing guarded debugger workflow.
-The companion implementation has automated coverage; native Ultimate acceptance
+The companion has automated coverage and real Personal GUI comparison acceptance; native Ultimate acceptance
 remains pending. The Personal companion remains supported.
 
 ## Native MCP integration (revised 2026-09-06)

--- a/docs/binja6-similarity-plan.md
+++ b/docs/binja6-similarity-plan.md
@@ -1,26 +1,26 @@
 # BN6 similarity in the Binary Ninja–WinDbg companion
 
-Status: implemented in the companion checkout, 2026-09-07. The six tools, background
-comparison lifecycle, textual differences, and capture runner have automated
-coverage. Native Ultimate execution, real similarity captures, and the live
-similarity-to-debugger acceptance workflow remain release gates. This document
-retains the agreed design; it does not claim Ultimate validation.
+Status: revised and implemented 2026-09-08 in the companion. Personal GUI exports,
+real external BinDiff comparisons, textual differences, and target navigation passed
+on synthetic identical, relocated and changed PE fixtures. The changed fixture's
+additional function was reported unmatched. Names, types, comments, bytes,
+generations, identities and modification flags stayed unchanged.
 
-The companion suite passed 125 tests with no skips, including 31 similarity cases
-and the HTTP tool golden. Ruff lint/format checks and documentation lint passed.
-
-The companion's `docs/similarity.md` documents the implementation, limits, and
-opt-in acceptance procedure.
+The helper built on Apple Silicon against BN6 ABI 187. Personal capture and
+reproduction instructions are in the companion's `docs/similarity.md`. Native
+Ultimate execution and the live similarity-to-WinDbg operation remain unvalidated;
+they are tracked separately from the completed Personal comparison acceptance.
 
 ## Summary
 
-Extend `binja-windbg-mcp` with an optional Ultimate feature that compares two open
+Extend `binja-windbg-mcp` with optional Personal and Ultimate backends comparing two open
 Windows PE views or BNDBs. Support BinDiff structural matching, WARP exact matching,
 agent-readable disassembly differences, and navigation into the existing debugging
 workflow.
 
-Use BN6's Python similarity API directly. The framework requires Ultimate; existing
-Personal workflows remain supported. See the
+Personal automatically exports views inside the running GUI and invokes a
+user-installed external BinDiff. Ultimate retains the native Python similarity
+API with BinDiff and WARP. Native similarity requires Ultimate. See the
 [BN6 announcement](https://binary.ninja/2026/09/03/binary-ninja-6.0-krypton.html#binary-similarity)
 and the [existing companion integration plan](binja-windbg-mcp-plan.md).
 
@@ -37,18 +37,55 @@ Add a `similarity` tool group, included by `groups: "all"`:
 | `similarity_cancel` | Request cancellation while retaining completed results. |
 | `similarity_close` | Release a comparison; request cancellation first if it is running. |
 
-On Personal, status explains that Ultimate is required; comparison requests return
-a structured unavailable result without affecting other tools.
+Add `backend="auto" | "native" | "external"` to `similarity_start`. With omitted
+providers, auto prefers native BinDiff plus WARP when both are available; otherwise
+it selects external BinDiff. Explicit providers must all be supported by one
+backend, preferring native under auto. Explicit external WARP is unavailable.
+Never switch backends after execution begins.
+
+Status reports availability, versions, providers, and setup errors separately for
+each backend. Status and results record backend provenance. Local optional
+`similarity.bindiff_path` takes precedence over PATH discovery; do not download or
+install BinDiff automatically.
 
 Extend existing `navigate` with an optional expected generation, reusing the
 adapter's existing generation check. Similarity results supply the coordinate and
 generation for either side.
 
-## Implementation
+## External backend implementation
+
+- Build a small helper from pinned open-source BinExport and the BN6 public SDK.
+  Expose a versioned C interface accepting an existing BinaryView and an explicit
+  destination, returning export metadata or an error. Package an Apple Silicon
+  build, reproducible build instructions, and required license notices.
+- Run inside Personal's GUI process on the comparison background thread. Serialize
+  exports, retain view ownership, validate ABI compatibility, and propagate write
+  failures. Do not invoke save dialogs or launch BN headlessly. See the
+  [BinExport source](https://github.com/google/binexport/blob/main/binaryninja/main_plugin.cc).
+- Use private temporary files per job. Capture generations, identities, image
+  bases, function inventories, export metadata and hashes. Check both generations
+  before and after export and before publishing results.
+- Invoke external BinDiff using an argument array, explicit primary/reference and
+  secondary/target exports, output directory, binary format, and disabled UI.
+  Target the [BinDiff 8 CLI](https://github.com/google/bindiff/blob/v8/main_portable.cc).
+- Read completed `.BinDiff` output using read-only SQLite. Validate schema and input
+  ownership. Map addresses directly to captured functions, recovering unsigned
+  64-bit addresses. Preserve raw similarity/confidence and map validated `0–1`
+  scores to existing `0–255` fields using `floor(score * 255 + 0.5)`.
+- Derive unmatched from exported eligible functions. Report omitted and unresolved
+  functions separately; missing export coverage must not imply unmatched functions.
+- Report export, matching and import stages without invented percentages. Bound
+  retained stdout/stderr. Cancel, timeout, invalidation and shutdown terminate only
+  the owned process group, escalate if necessary, and reap before deleting files.
+- Export cancellation is cooperative: retain views until the in-process exporter
+  returns. Never read an interrupted database; preserve only validated partial
+  records. Neither backend transfers annotations or changes analysis.
+
+## Shared and native implementation
 
 - **Inputs and providers:** Require two distinct, analyzed PE views of the same
   architecture. Use existing companion IDs, metadata, hashes, and generation stamps.
-  Default to both providers; report unavailable requested providers explicitly.
+  Default providers depend on the selected backend; report unavailable providers explicitly.
   Use session-local provider settings without changing global WARP configuration
   or enabling network services.
 - **Matching:** Create a reference-to-target session graph with no resolvers and
@@ -91,20 +128,24 @@ tool or worker-protocol changes are required.
 
 ## Validation and delivery
 
-1. Verify provider discovery, session execution, result references, and cancellation
-   in BN6 Ultimate using disposable PE fixtures.
+1. Validate GUI export and external BinDiff on BN6 Personal using disposable PE
+   fixtures. Verify native provider discovery, sessions and cancellation separately
+   in Ultimate.
 2. Add offline tests for score preservation, competing matches, reversed result
    ownership, unmatched functions, pagination, text differences, and partial results.
-3. Test Personal availability reporting, busy analysis, stale generations,
+3. Test backend selection, missing/incompatible dependencies, exporter failures,
+   corrupt SQLite, input ownership, high addresses, score conversion, omitted
+   functions, paths with spaces, process cleanup, busy analysis, stale generations,
    close/rebase races, cancellation, listener restart, and shutdown. Verify
    comparison leaves names, types, comments, and bytes unchanged.
-4. Capture Ultimate results for identical, relocated, changed, and unmatched
+4. Adapt the capture runner to select backend/providers. Capture Personal results for identical, relocated, changed, and unmatched
    functions; replay immutable captures in ordinary tests.
 5. Exercise comparison → target navigation → existing guarded debugger action,
    including wrong-build refusal.
 6. Run the companion's pytest, Ruff, transport/golden, and documentation checks.
-   Ultimate execution acceptance remains a release requirement; mocks alone do not
-   establish it.
+   Build/check the helper and update existing PR descriptions. Personal release
+   requires real GUI export and BinDiff execution; mocks alone do not establish it.
+   Track Ultimate acceptance independently.
 
 ## Assumptions and defaults
 

--- a/docs/binja6-similarity-plan.md
+++ b/docs/binja6-similarity-plan.md
@@ -1,0 +1,114 @@
+# BN6 similarity in the Binary Ninja–WinDbg companion
+
+Status: implemented in the companion checkout, 2026-09-07. The six tools, background
+comparison lifecycle, textual differences, and capture runner have automated
+coverage. Native Ultimate execution, real similarity captures, and the live
+similarity-to-debugger acceptance workflow remain release gates. This document
+retains the agreed design; it does not claim Ultimate validation.
+
+The companion suite passed 125 tests with no skips, including 31 similarity cases
+and the HTTP tool golden. Ruff lint/format checks and documentation lint passed.
+
+The companion's `docs/similarity.md` documents the implementation, limits, and
+opt-in acceptance procedure.
+
+## Summary
+
+Extend `binja-windbg-mcp` with an optional Ultimate feature that compares two open
+Windows PE views or BNDBs. Support BinDiff structural matching, WARP exact matching,
+agent-readable disassembly differences, and navigation into the existing debugging
+workflow.
+
+Use BN6's Python similarity API directly. The framework requires Ultimate; existing
+Personal workflows remain supported. See the
+[BN6 announcement](https://binary.ninja/2026/09/03/binary-ninja-6.0-krypton.html#binary-similarity)
+and the [existing companion integration plan](binja-windbg-mcp-plan.md).
+
+## Public interface
+
+Add a `similarity` tool group, included by `groups: "all"`:
+
+| Tool | Behavior |
+|---|---|
+| `similarity_start` | Accept reference and target companion binary IDs, provider selection, and timeout; return a comparison ID. |
+| `similarity_status` | Return progress and state; without an ID, report capabilities and retained comparisons. |
+| `similarity_results` | Page through matches or unmatched functions, with side, provider, and score filters. |
+| `similarity_diff` | Return paginated paired disassembly differences for a selected match. |
+| `similarity_cancel` | Request cancellation while retaining completed results. |
+| `similarity_close` | Release a comparison; request cancellation first if it is running. |
+
+On Personal, status explains that Ultimate is required; comparison requests return
+a structured unavailable result without affecting other tools.
+
+Extend existing `navigate` with an optional expected generation, reusing the
+adapter's existing generation check. Similarity results supply the coordinate and
+generation for either side.
+
+## Implementation
+
+- **Inputs and providers:** Require two distinct, analyzed PE views of the same
+  architecture. Use existing companion IDs, metadata, hashes, and generation stamps.
+  Default to both providers; report unavailable requested providers explicitly.
+  Use session-local provider settings without changing global WARP configuration
+  or enabling network services.
+- **Matching:** Create a reference-to-target session graph with no resolvers and
+  never call provider application methods. BN documents that resolvers can transfer
+  analysis during a run. See the
+  [similarity guide](https://docs.binary.ninja/guide/similarity.html#providers-and-resolvers).
+- **Execution:** Run preparation and result extraction outside the UI/network
+  loops. Track BN's background completion object and cooperative stop requests.
+  Allow one active comparison and four retained comparisons; require explicit
+  closure when full. Default deadline: 120 seconds, configurable up to 600 seconds.
+- **Lifecycle:** Connect comparisons to workspace invalidation and listener
+  shutdown. Edits, reanalysis, rebase, replacement, or closure mark affected
+  comparisons stale and request cancellation. Retain native objects until execution
+  finishes; cancellation must not free objects still in use. Results are
+  process-local and disappear on restart.
+- **Results:** Freeze terminal results into immutable records containing both
+  functions' coordinates, names, captured generations, provider, and separate
+  similarity/confidence scores. Preserve BN's documented `0–255` scores and
+  competing candidates. Resolve node/entity references directly; never infer
+  correspondence from names or equal RVAs. See the
+  [Python API](https://api.binary.ninja/binaryninja.similarity-module.html).
+- **Pagination:** Return 100 records by default, maximum 500, with deterministic
+  ordering and continuation information. Preserve partial results after
+  cancellation or failure. Describe unmatched functions as unmatched under the
+  selected providers, without asserting that they were added or removed.
+- **Disassembly differences:** Read instruction tokens directly from both BN
+  functions and align instruction text using
+  `difflib.SequenceMatcher(autojunk=False)`. Exclude each instruction's own address
+  from comparison while retaining addresses and RVAs in output. Return
+  equal/insert/delete/replace groups, bounded to 2,000 instructions per side, with
+  explicit truncation. Label this as a textual comparison; provider scores remain
+  independent.
+- **Debugging:** Navigate explicitly to the chosen build, then reuse pairing,
+  breakpoint, run-to, and runtime-byte tools. Each build retains its own identity
+  and RVA. Similarity never substitutes for WinDbg's loaded-module identity checks.
+
+Keep implementation in the companion repository. Update its README, tool golden,
+and workflow documentation, plus the integration plan in this repository. No Rust
+tool or worker-protocol changes are required.
+
+## Validation and delivery
+
+1. Verify provider discovery, session execution, result references, and cancellation
+   in BN6 Ultimate using disposable PE fixtures.
+2. Add offline tests for score preservation, competing matches, reversed result
+   ownership, unmatched functions, pagination, text differences, and partial results.
+3. Test Personal availability reporting, busy analysis, stale generations,
+   close/rebase races, cancellation, listener restart, and shutdown. Verify
+   comparison leaves names, types, comments, and bytes unchanged.
+4. Capture Ultimate results for identical, relocated, changed, and unmatched
+   functions; replay immutable captures in ordinary tests.
+5. Exercise comparison → target navigation → existing guarded debugger action,
+   including wrong-build refusal.
+6. Run the companion's pytest, Ruff, transport/golden, and documentation checks.
+   Ultimate execution acceptance remains a release requirement; mocks alone do not
+   establish it.
+
+## Assumptions and defaults
+
+V1 targets Apple Silicon macOS, BN6/Python 3.13, two open PE views, and agent-readable
+differences. Annotation transfer, native visual comparison, arbitrary file loading,
+cross-architecture matching, persistent comparison storage, and multi-build corpora
+are deferred.


### PR DESCRIPTION
Record the companion's BN6 similarity design and implementation status, including Personal support through automatic BinExport and user-installed external BinDiff. Ultimate retains native BinDiff/WARP, with explicit backend selection and unchanged debugger identity guards.

The plan specifies the six-tool interface, export helper, validated SQLite import, lifecycle/cleanup, limits and acceptance criteria. Personal GUI export, real comparisons, textual differences and target navigation passed; Ultimate execution and the live WinDbg handoff remain separate pending checks.

Validation: documentation lint and cargo fmt --all --check passed. Companion validation includes 172 tests, helper build/packaging and reviewed synthetic Personal captures.

Implementation: https://github.com/glslang/binja-windbg-mcp/pull/2
