### PR TITLE
docs: record similarity lifecycle acceptance and shutdown failures

### DIFF
--- a/docs/binja6-similarity-plan.md
+++ b/docs/binja6-similarity-plan.md
@@ -184,6 +184,13 @@ Full coverage would require further exporter investigation; the guards remain
 unchanged. The captures and exact omissions are in the
 [follow-up acceptance record](cve-patch-diff-acceptance.md#arm64-generation-follow-up--2026-09-10).
 
+The [2026-09-10 lifecycle follow-up](similarity-lifecycle-acceptance.md) recorded
+successful cancellation during export and matching, active comparison closure,
+and comment-edit invalidation after a missing metadata notification was fixed.
+Rebase and tab-close acceptance remain incomplete. Normal quit failed with
+repeatable native widget-destruction aborts; further GUI runs stopped pending
+isolation of that crash. Listener restart and guarded WinDbg handoff remain unrun.
+
 ## Assumptions and defaults
 
 V1 targets Apple Silicon macOS, BN6/Python 3.13, two open PE views, and agent-readable

--- a/docs/cve-patch-diff-acceptance.md
+++ b/docs/cve-patch-diff-acceptance.md
@@ -167,7 +167,10 @@ and partial [securekernel capture](samples/cve-2026-83498-arm64-securekernel-fol
 preserve all comparison results and strict before/after checks. Earlier failed
 captures remain available above. Neither run attributes a function to the CVE fix.
 
-Both disposable processes exited after completed capture and cleanup. This does
+Both disposable processes exited after completed capture and cleanup. Subsequent
+inspection found a native shutdown crash report for the vertdll process, so exit
+alone did not establish clean shutdown; see the
+[lifecycle follow-up](similarity-lifecycle-acceptance.md). This does
 not close active-comparison quit/cancellation/race acceptance. Live WinDbg handoff
 remains unrun; Ultimate remains tentative. Fourteen offline helper tests, Ruff,
 skill validation, formatting and documentation lint pass with the preparation option.

--- a/docs/samples/similarity-lifecycle-20260910.json
+++ b/docs/samples/similarity-lifecycle-20260910.json
@@ -1,0 +1,13479 @@
+{
+  "recorded_date": "2026-09-10",
+  "bn_version": "6.0.10601 Personal",
+  "companion_base": "0742c5e",
+  "cases": {
+    "cancel_export-v1": {
+      "capture_source_sha256": "7debb061f31b69ffe699a6e7f8682d31f5cd7e8c786b08b5496b0231b02bd90d",
+      "capture": {
+        "case": "cancel_export",
+        "bn_version": "6.0.10601 Personal",
+        "ok": true,
+        "inputs": [
+          {
+            "file_sha256": "65a014d83be9d2262e913d020425dc9bf0a301b6403dffa13e6fe7ae5460a57b",
+            "hash_source": "original Raw view",
+            "image_name": "securekernel.exe",
+            "binary_id": "reference-binary",
+            "path": "reference/securekernel.exe",
+            "display_name": "securekernel.exe",
+            "active": false,
+            "architecture": "aarch64",
+            "analysis_state": "IdleState",
+            "image_base": "0x0000000140000000",
+            "identity": {
+              "timestamp": 3350698326,
+              "size": 1245184,
+              "pdb": {
+                "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                "age": 1
+              }
+            },
+            "generation": [
+              "reference-binary",
+              5368709120,
+              14999
+            ],
+            "modified": false
+          },
+          {
+            "file_sha256": "9a2eeb0e4a3d76aa9a6bfaf287540f5f1f7562d814e8ecb3c3f6df6b57a557b6",
+            "hash_source": "original Raw view",
+            "image_name": "securekernel.exe",
+            "binary_id": "target-binary",
+            "path": "target/securekernel.exe",
+            "display_name": "securekernel.exe",
+            "active": true,
+            "architecture": "aarch64",
+            "analysis_state": "IdleState",
+            "image_base": "0x0000000140000000",
+            "identity": {
+              "timestamp": 1188430604,
+              "size": 1290240,
+              "pdb": {
+                "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                "age": 1
+              }
+            },
+            "generation": [
+              "target-binary",
+              5368709120,
+              15050
+            ],
+            "modified": false
+          }
+        ],
+        "before_action": {
+          "comparison_id": "cancel_export-v1-comparison",
+          "state": "running",
+          "active": true,
+          "closing": false,
+          "progress": null,
+          "stop_reason": null,
+          "providers": [
+            "Google BinDiff"
+          ],
+          "backend": "external",
+          "stage": "exporting",
+          "omitted_functions": {},
+          "binary_ids": {
+            "reference": "reference-binary",
+            "target": "target-binary"
+          },
+          "snapshots": {
+            "reference": {
+              "file_sha256": "65a014d83be9d2262e913d020425dc9bf0a301b6403dffa13e6fe7ae5460a57b",
+              "hash_source": "original Raw view",
+              "image_name": "securekernel.exe",
+              "binary_id": "reference-binary",
+              "path": "reference/securekernel.exe",
+              "display_name": "securekernel.exe",
+              "active": false,
+              "architecture": "aarch64",
+              "analysis_state": "IdleState",
+              "image_base": "0x0000000140000000",
+              "identity": {
+                "timestamp": 3350698326,
+                "size": 1245184,
+                "pdb": {
+                  "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                  "age": 1
+                }
+              },
+              "generation": [
+                "reference-binary",
+                5368709120,
+                14999
+              ],
+              "modified": false
+            },
+            "target": {
+              "file_sha256": "9a2eeb0e4a3d76aa9a6bfaf287540f5f1f7562d814e8ecb3c3f6df6b57a557b6",
+              "hash_source": "original Raw view",
+              "image_name": "securekernel.exe",
+              "binary_id": "target-binary",
+              "path": "target/securekernel.exe",
+              "display_name": "securekernel.exe",
+              "active": true,
+              "architecture": "aarch64",
+              "analysis_state": "IdleState",
+              "image_base": "0x0000000140000000",
+              "identity": {
+                "timestamp": 1188430604,
+                "size": 1290240,
+                "pdb": {
+                  "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                  "age": 1
+                }
+              },
+              "generation": [
+                "target-binary",
+                5368709120,
+                15050
+              ],
+              "modified": false
+            }
+          },
+          "match_count": 0,
+          "coverage_complete": false,
+          "unresolved_results": 0,
+          "error": null
+        },
+        "observed_stage": "exporting",
+        "active_process_before": {
+          "export_thread_alive": true,
+          "temporary_directory_exists": true,
+          "process_created": false,
+          "process_returncode": null,
+          "output_reader_alive": false
+        },
+        "heartbeat_before_action": 6,
+        "action": {
+          "comparison_id": "cancel_export-v1-comparison",
+          "state": "running",
+          "active": true,
+          "closing": false,
+          "progress": null,
+          "stop_reason": "cancelled",
+          "providers": [
+            "Google BinDiff"
+          ],
+          "backend": "external",
+          "stage": "exporting",
+          "omitted_functions": {},
+          "binary_ids": {
+            "reference": "reference-binary",
+            "target": "target-binary"
+          },
+          "snapshots": {
+            "reference": {
+              "file_sha256": "65a014d83be9d2262e913d020425dc9bf0a301b6403dffa13e6fe7ae5460a57b",
+              "hash_source": "original Raw view",
+              "image_name": "securekernel.exe",
+              "binary_id": "reference-binary",
+              "path": "reference/securekernel.exe",
+              "display_name": "securekernel.exe",
+              "active": false,
+              "architecture": "aarch64",
+              "analysis_state": "IdleState",
+              "image_base": "0x0000000140000000",
+              "identity": {
+                "timestamp": 3350698326,
+                "size": 1245184,
+                "pdb": {
+                  "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                  "age": 1
+                }
+              },
+              "generation": [
+                "reference-binary",
+                5368709120,
+                14999
+              ],
+              "modified": false
+            },
+            "target": {
+              "file_sha256": "9a2eeb0e4a3d76aa9a6bfaf287540f5f1f7562d814e8ecb3c3f6df6b57a557b6",
+              "hash_source": "original Raw view",
+              "image_name": "securekernel.exe",
+              "binary_id": "target-binary",
+              "path": "target/securekernel.exe",
+              "display_name": "securekernel.exe",
+              "active": true,
+              "architecture": "aarch64",
+              "analysis_state": "IdleState",
+              "image_base": "0x0000000140000000",
+              "identity": {
+                "timestamp": 1188430604,
+                "size": 1290240,
+                "pdb": {
+                  "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                  "age": 1
+                }
+              },
+              "generation": [
+                "target-binary",
+                5368709120,
+                15050
+              ],
+              "modified": false
+            }
+          },
+          "match_count": 0,
+          "coverage_complete": false,
+          "unresolved_results": 0,
+          "error": null
+        },
+        "job_reason": "cancelled",
+        "job_phase": "cancelled",
+        "after_cleanup": {
+          "export_thread_alive": false,
+          "temporary_directory_exists": false,
+          "process_created": false,
+          "process_returncode": null,
+          "output_reader_alive": false
+        },
+        "results_after": {
+          "comparison_id": "cancel_export-v1-comparison",
+          "state": "cancelled",
+          "active": false,
+          "closing": false,
+          "progress": null,
+          "stop_reason": "cancelled",
+          "providers": [
+            "Google BinDiff"
+          ],
+          "backend": "external",
+          "stage": "exporting",
+          "omitted_functions": {},
+          "binary_ids": {
+            "reference": "reference-binary",
+            "target": "target-binary"
+          },
+          "snapshots": {
+            "reference": {
+              "file_sha256": "65a014d83be9d2262e913d020425dc9bf0a301b6403dffa13e6fe7ae5460a57b",
+              "hash_source": "original Raw view",
+              "image_name": "securekernel.exe",
+              "binary_id": "reference-binary",
+              "path": "reference/securekernel.exe",
+              "display_name": "securekernel.exe",
+              "active": false,
+              "architecture": "aarch64",
+              "analysis_state": "IdleState",
+              "image_base": "0x0000000140000000",
+              "identity": {
+                "timestamp": 3350698326,
+                "size": 1245184,
+                "pdb": {
+                  "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                  "age": 1
+                }
+              },
+              "generation": [
+                "reference-binary",
+                5368709120,
+                14999
+              ],
+              "modified": false
+            },
+            "target": {
+              "file_sha256": "9a2eeb0e4a3d76aa9a6bfaf287540f5f1f7562d814e8ecb3c3f6df6b57a557b6",
+              "hash_source": "original Raw view",
+              "image_name": "securekernel.exe",
+              "binary_id": "target-binary",
+              "path": "target/securekernel.exe",
+              "display_name": "securekernel.exe",
+              "active": true,
+              "architecture": "aarch64",
+              "analysis_state": "IdleState",
+              "image_base": "0x0000000140000000",
+              "identity": {
+                "timestamp": 1188430604,
+                "size": 1290240,
+                "pdb": {
+                  "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                  "age": 1
+                }
+              },
+              "generation": [
+                "target-binary",
+                5368709120,
+                15050
+              ],
+              "modified": false
+            }
+          },
+          "match_count": 0,
+          "coverage_complete": false,
+          "unresolved_results": 0,
+          "error": {
+            "code": "cancelled",
+            "message": "comparison stop requested"
+          },
+          "side": "target",
+          "kind": "matches",
+          "items": [],
+          "total": 0,
+          "next_offset": null,
+          "truncated": false
+        },
+        "heartbeat_total": 8
+      },
+      "gui_exit": {
+        "exited": true,
+        "forced": true,
+        "returncode": -15
+      },
+      "companion_metadata_fix_applied": false
+    },
+    "cancel_matching-v2": {
+      "capture_source_sha256": "17239bb0deb48004a1d16970a1b09afc5fcb9d308565470c4a961174977974b9",
+      "capture": {
+        "case": "cancel_matching",
+        "bn_version": "6.0.10601 Personal",
+        "ok": true,
+        "inputs": [
+          {
+            "file_sha256": "9a2eeb0e4a3d76aa9a6bfaf287540f5f1f7562d814e8ecb3c3f6df6b57a557b6",
+            "hash_source": "original Raw view",
+            "image_name": "securekernel.exe",
+            "binary_id": "target-binary",
+            "path": "target/securekernel.exe",
+            "display_name": "securekernel.exe",
+            "active": true,
+            "architecture": "aarch64",
+            "analysis_state": "IdleState",
+            "image_base": "0x0000000140000000",
+            "identity": {
+              "timestamp": 1188430604,
+              "size": 1290240,
+              "pdb": {
+                "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                "age": 1
+              }
+            },
+            "generation": [
+              "target-binary",
+              5368709120,
+              14980
+            ],
+            "modified": false
+          },
+          {
+            "file_sha256": "65a014d83be9d2262e913d020425dc9bf0a301b6403dffa13e6fe7ae5460a57b",
+            "hash_source": "original Raw view",
+            "image_name": "securekernel.exe",
+            "binary_id": "reference-binary",
+            "path": "reference/securekernel.exe",
+            "display_name": "securekernel.exe",
+            "active": false,
+            "architecture": "aarch64",
+            "analysis_state": "IdleState",
+            "image_base": "0x0000000140000000",
+            "identity": {
+              "timestamp": 3350698326,
+              "size": 1245184,
+              "pdb": {
+                "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                "age": 1
+              }
+            },
+            "generation": [
+              "reference-binary",
+              5368709120,
+              14892
+            ],
+            "modified": false
+          }
+        ],
+        "before_action": {
+          "comparison_id": "cancel_matching-v2-comparison",
+          "state": "running",
+          "active": true,
+          "closing": false,
+          "progress": null,
+          "stop_reason": null,
+          "providers": [
+            "Google BinDiff"
+          ],
+          "backend": "external",
+          "stage": "matching",
+          "omitted_functions": {},
+          "binary_ids": {
+            "reference": "reference-binary",
+            "target": "target-binary"
+          },
+          "snapshots": {
+            "reference": {
+              "file_sha256": "65a014d83be9d2262e913d020425dc9bf0a301b6403dffa13e6fe7ae5460a57b",
+              "hash_source": "original Raw view",
+              "image_name": "securekernel.exe",
+              "binary_id": "reference-binary",
+              "path": "reference/securekernel.exe",
+              "display_name": "securekernel.exe",
+              "active": false,
+              "architecture": "aarch64",
+              "analysis_state": "IdleState",
+              "image_base": "0x0000000140000000",
+              "identity": {
+                "timestamp": 3350698326,
+                "size": 1245184,
+                "pdb": {
+                  "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                  "age": 1
+                }
+              },
+              "generation": [
+                "reference-binary",
+                5368709120,
+                14892
+              ],
+              "modified": false
+            },
+            "target": {
+              "file_sha256": "9a2eeb0e4a3d76aa9a6bfaf287540f5f1f7562d814e8ecb3c3f6df6b57a557b6",
+              "hash_source": "original Raw view",
+              "image_name": "securekernel.exe",
+              "binary_id": "target-binary",
+              "path": "target/securekernel.exe",
+              "display_name": "securekernel.exe",
+              "active": true,
+              "architecture": "aarch64",
+              "analysis_state": "IdleState",
+              "image_base": "0x0000000140000000",
+              "identity": {
+                "timestamp": 1188430604,
+                "size": 1290240,
+                "pdb": {
+                  "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                  "age": 1
+                }
+              },
+              "generation": [
+                "target-binary",
+                5368709120,
+                14980
+              ],
+              "modified": false
+            }
+          },
+          "match_count": 0,
+          "coverage_complete": false,
+          "unresolved_results": 0,
+          "error": null
+        },
+        "observed_stage": "matching",
+        "active_process_before": {
+          "export_thread_alive": true,
+          "temporary_directory_exists": true,
+          "process_created": true,
+          "process_returncode": null,
+          "output_reader_alive": true
+        },
+        "heartbeat_before_action": 47,
+        "action": {
+          "comparison_id": "cancel_matching-v2-comparison",
+          "state": "running",
+          "active": true,
+          "closing": false,
+          "progress": null,
+          "stop_reason": "cancelled",
+          "providers": [
+            "Google BinDiff"
+          ],
+          "backend": "external",
+          "stage": "matching",
+          "omitted_functions": {},
+          "binary_ids": {
+            "reference": "reference-binary",
+            "target": "target-binary"
+          },
+          "snapshots": {
+            "reference": {
+              "file_sha256": "65a014d83be9d2262e913d020425dc9bf0a301b6403dffa13e6fe7ae5460a57b",
+              "hash_source": "original Raw view",
+              "image_name": "securekernel.exe",
+              "binary_id": "reference-binary",
+              "path": "reference/securekernel.exe",
+              "display_name": "securekernel.exe",
+              "active": false,
+              "architecture": "aarch64",
+              "analysis_state": "IdleState",
+              "image_base": "0x0000000140000000",
+              "identity": {
+                "timestamp": 3350698326,
+                "size": 1245184,
+                "pdb": {
+                  "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                  "age": 1
+                }
+              },
+              "generation": [
+                "reference-binary",
+                5368709120,
+                14892
+              ],
+              "modified": false
+            },
+            "target": {
+              "file_sha256": "9a2eeb0e4a3d76aa9a6bfaf287540f5f1f7562d814e8ecb3c3f6df6b57a557b6",
+              "hash_source": "original Raw view",
+              "image_name": "securekernel.exe",
+              "binary_id": "target-binary",
+              "path": "target/securekernel.exe",
+              "display_name": "securekernel.exe",
+              "active": true,
+              "architecture": "aarch64",
+              "analysis_state": "IdleState",
+              "image_base": "0x0000000140000000",
+              "identity": {
+                "timestamp": 1188430604,
+                "size": 1290240,
+                "pdb": {
+                  "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                  "age": 1
+                }
+              },
+              "generation": [
+                "target-binary",
+                5368709120,
+                14980
+              ],
+              "modified": false
+            }
+          },
+          "match_count": 0,
+          "coverage_complete": false,
+          "unresolved_results": 0,
+          "error": null
+        },
+        "job_reason": "cancelled",
+        "job_phase": "cancelled",
+        "after_cleanup": {
+          "export_thread_alive": false,
+          "temporary_directory_exists": false,
+          "process_created": true,
+          "process_returncode": -15,
+          "output_reader_alive": false
+        },
+        "results_after": {
+          "comparison_id": "cancel_matching-v2-comparison",
+          "state": "cancelled",
+          "active": false,
+          "closing": false,
+          "progress": null,
+          "stop_reason": "cancelled",
+          "providers": [
+            "Google BinDiff"
+          ],
+          "backend": "external",
+          "stage": "matching",
+          "omitted_functions": {
+            "reference": 8,
+            "target": 8
+          },
+          "binary_ids": {
+            "reference": "reference-binary",
+            "target": "target-binary"
+          },
+          "snapshots": {
+            "reference": {
+              "file_sha256": "65a014d83be9d2262e913d020425dc9bf0a301b6403dffa13e6fe7ae5460a57b",
+              "hash_source": "original Raw view",
+              "image_name": "securekernel.exe",
+              "binary_id": "reference-binary",
+              "path": "reference/securekernel.exe",
+              "display_name": "securekernel.exe",
+              "active": false,
+              "architecture": "aarch64",
+              "analysis_state": "IdleState",
+              "image_base": "0x0000000140000000",
+              "identity": {
+                "timestamp": 3350698326,
+                "size": 1245184,
+                "pdb": {
+                  "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                  "age": 1
+                }
+              },
+              "generation": [
+                "reference-binary",
+                5368709120,
+                14892
+              ],
+              "modified": false
+            },
+            "target": {
+              "file_sha256": "9a2eeb0e4a3d76aa9a6bfaf287540f5f1f7562d814e8ecb3c3f6df6b57a557b6",
+              "hash_source": "original Raw view",
+              "image_name": "securekernel.exe",
+              "binary_id": "target-binary",
+              "path": "target/securekernel.exe",
+              "display_name": "securekernel.exe",
+              "active": true,
+              "architecture": "aarch64",
+              "analysis_state": "IdleState",
+              "image_base": "0x0000000140000000",
+              "identity": {
+                "timestamp": 1188430604,
+                "size": 1290240,
+                "pdb": {
+                  "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                  "age": 1
+                }
+              },
+              "generation": [
+                "target-binary",
+                5368709120,
+                14980
+              ],
+              "modified": false
+            }
+          },
+          "match_count": 0,
+          "coverage_complete": false,
+          "unresolved_results": 0,
+          "error": {
+            "code": "comparison_failed",
+            "message": "PermissionError"
+          },
+          "side": "target",
+          "kind": "matches",
+          "items": [],
+          "total": 0,
+          "next_offset": null,
+          "truncated": false
+        },
+        "heartbeat_total": 50
+      },
+      "gui_exit": {
+        "exited": true,
+        "forced": true,
+        "returncode": -15
+      },
+      "companion_metadata_fix_applied": false
+    },
+    "close-v1": {
+      "capture_source_sha256": "c49f2de7cfbc692a43c5d64c36a30db42f4a61d30c7efb8891106658a7b9f7a5",
+      "capture": {
+        "case": "close",
+        "bn_version": "6.0.10601 Personal",
+        "ok": true,
+        "inputs": [
+          {
+            "file_sha256": "9a2eeb0e4a3d76aa9a6bfaf287540f5f1f7562d814e8ecb3c3f6df6b57a557b6",
+            "hash_source": "original Raw view",
+            "image_name": "securekernel.exe",
+            "binary_id": "target-binary",
+            "path": "target/securekernel.exe",
+            "display_name": "securekernel.exe",
+            "active": true,
+            "architecture": "aarch64",
+            "analysis_state": "IdleState",
+            "image_base": "0x0000000140000000",
+            "identity": {
+              "timestamp": 1188430604,
+              "size": 1290240,
+              "pdb": {
+                "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                "age": 1
+              }
+            },
+            "generation": [
+              "target-binary",
+              5368709120,
+              14939
+            ],
+            "modified": false
+          },
+          {
+            "file_sha256": "65a014d83be9d2262e913d020425dc9bf0a301b6403dffa13e6fe7ae5460a57b",
+            "hash_source": "original Raw view",
+            "image_name": "securekernel.exe",
+            "binary_id": "reference-binary",
+            "path": "reference/securekernel.exe",
+            "display_name": "securekernel.exe",
+            "active": false,
+            "architecture": "aarch64",
+            "analysis_state": "IdleState",
+            "image_base": "0x0000000140000000",
+            "identity": {
+              "timestamp": 3350698326,
+              "size": 1245184,
+              "pdb": {
+                "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                "age": 1
+              }
+            },
+            "generation": [
+              "reference-binary",
+              5368709120,
+              14894
+            ],
+            "modified": false
+          }
+        ],
+        "before_action": {
+          "comparison_id": "close-v1-comparison",
+          "state": "running",
+          "active": true,
+          "closing": false,
+          "progress": null,
+          "stop_reason": null,
+          "providers": [
+            "Google BinDiff"
+          ],
+          "backend": "external",
+          "stage": "matching",
+          "omitted_functions": {},
+          "binary_ids": {
+            "reference": "reference-binary",
+            "target": "target-binary"
+          },
+          "snapshots": {
+            "reference": {
+              "file_sha256": "65a014d83be9d2262e913d020425dc9bf0a301b6403dffa13e6fe7ae5460a57b",
+              "hash_source": "original Raw view",
+              "image_name": "securekernel.exe",
+              "binary_id": "reference-binary",
+              "path": "reference/securekernel.exe",
+              "display_name": "securekernel.exe",
+              "active": false,
+              "architecture": "aarch64",
+              "analysis_state": "IdleState",
+              "image_base": "0x0000000140000000",
+              "identity": {
+                "timestamp": 3350698326,
+                "size": 1245184,
+                "pdb": {
+                  "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                  "age": 1
+                }
+              },
+              "generation": [
+                "reference-binary",
+                5368709120,
+                14894
+              ],
+              "modified": false
+            },
+            "target": {
+              "file_sha256": "9a2eeb0e4a3d76aa9a6bfaf287540f5f1f7562d814e8ecb3c3f6df6b57a557b6",
+              "hash_source": "original Raw view",
+              "image_name": "securekernel.exe",
+              "binary_id": "target-binary",
+              "path": "target/securekernel.exe",
+              "display_name": "securekernel.exe",
+              "active": true,
+              "architecture": "aarch64",
+              "analysis_state": "IdleState",
+              "image_base": "0x0000000140000000",
+              "identity": {
+                "timestamp": 1188430604,
+                "size": 1290240,
+                "pdb": {
+                  "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                  "age": 1
+                }
+              },
+              "generation": [
+                "target-binary",
+                5368709120,
+                14939
+              ],
+              "modified": false
+            }
+          },
+          "match_count": 0,
+          "coverage_complete": false,
+          "unresolved_results": 0,
+          "error": null
+        },
+        "observed_stage": "matching",
+        "active_process_before": {
+          "export_thread_alive": true,
+          "temporary_directory_exists": true,
+          "process_created": true,
+          "process_returncode": null,
+          "output_reader_alive": true
+        },
+        "heartbeat_before_action": 46,
+        "action": {
+          "comparison_id": "close-v1-comparison",
+          "state": "running",
+          "active": true,
+          "closing": true,
+          "progress": null,
+          "stop_reason": "closed",
+          "providers": [
+            "Google BinDiff"
+          ],
+          "backend": "external",
+          "stage": "matching",
+          "omitted_functions": {},
+          "binary_ids": {
+            "reference": "reference-binary",
+            "target": "target-binary"
+          },
+          "snapshots": {
+            "reference": {
+              "file_sha256": "65a014d83be9d2262e913d020425dc9bf0a301b6403dffa13e6fe7ae5460a57b",
+              "hash_source": "original Raw view",
+              "image_name": "securekernel.exe",
+              "binary_id": "reference-binary",
+              "path": "reference/securekernel.exe",
+              "display_name": "securekernel.exe",
+              "active": false,
+              "architecture": "aarch64",
+              "analysis_state": "IdleState",
+              "image_base": "0x0000000140000000",
+              "identity": {
+                "timestamp": 3350698326,
+                "size": 1245184,
+                "pdb": {
+                  "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                  "age": 1
+                }
+              },
+              "generation": [
+                "reference-binary",
+                5368709120,
+                14894
+              ],
+              "modified": false
+            },
+            "target": {
+              "file_sha256": "9a2eeb0e4a3d76aa9a6bfaf287540f5f1f7562d814e8ecb3c3f6df6b57a557b6",
+              "hash_source": "original Raw view",
+              "image_name": "securekernel.exe",
+              "binary_id": "target-binary",
+              "path": "target/securekernel.exe",
+              "display_name": "securekernel.exe",
+              "active": true,
+              "architecture": "aarch64",
+              "analysis_state": "IdleState",
+              "image_base": "0x0000000140000000",
+              "identity": {
+                "timestamp": 1188430604,
+                "size": 1290240,
+                "pdb": {
+                  "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                  "age": 1
+                }
+              },
+              "generation": [
+                "target-binary",
+                5368709120,
+                14939
+              ],
+              "modified": false
+            }
+          },
+          "match_count": 0,
+          "coverage_complete": false,
+          "unresolved_results": 0,
+          "error": null
+        },
+        "job_reason": "closed",
+        "job_phase": "closed",
+        "after_cleanup": {
+          "export_thread_alive": false,
+          "temporary_directory_exists": false,
+          "process_created": true,
+          "process_returncode": -15,
+          "output_reader_alive": false
+        },
+        "results_error": {
+          "type": "SimilarityError",
+          "code": "unknown_comparison"
+        },
+        "heartbeat_total": 48,
+        "quit_action_available": true
+      },
+      "gui_exit": {
+        "exited": true,
+        "forced": false,
+        "returncode": -6
+      },
+      "companion_metadata_fix_applied": false
+    },
+    "edit-v1": {
+      "capture_source_sha256": "fb80314540d62ffcd8b6be7b35e8e016a0b3d50ee5f71e210968e17a884daa3a",
+      "capture": {
+        "case": "edit",
+        "bn_version": "6.0.10601 Personal",
+        "ok": false,
+        "inputs": [
+          {
+            "file_sha256": "65a014d83be9d2262e913d020425dc9bf0a301b6403dffa13e6fe7ae5460a57b",
+            "hash_source": "original Raw view",
+            "image_name": "securekernel.exe",
+            "binary_id": "reference-binary",
+            "path": "reference/securekernel.exe",
+            "display_name": "securekernel.exe",
+            "active": false,
+            "architecture": "aarch64",
+            "analysis_state": "IdleState",
+            "image_base": "0x0000000140000000",
+            "identity": {
+              "timestamp": 3350698326,
+              "size": 1245184,
+              "pdb": {
+                "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                "age": 1
+              }
+            },
+            "generation": [
+              "reference-binary",
+              5368709120,
+              14976
+            ],
+            "modified": false
+          },
+          {
+            "file_sha256": "9a2eeb0e4a3d76aa9a6bfaf287540f5f1f7562d814e8ecb3c3f6df6b57a557b6",
+            "hash_source": "original Raw view",
+            "image_name": "securekernel.exe",
+            "binary_id": "target-binary",
+            "path": "target/securekernel.exe",
+            "display_name": "securekernel.exe",
+            "active": true,
+            "architecture": "aarch64",
+            "analysis_state": "IdleState",
+            "image_base": "0x0000000140000000",
+            "identity": {
+              "timestamp": 1188430604,
+              "size": 1290240,
+              "pdb": {
+                "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                "age": 1
+              }
+            },
+            "generation": [
+              "target-binary",
+              5368709120,
+              15090
+            ],
+            "modified": false
+          }
+        ],
+        "before_action": {
+          "comparison_id": "edit-v1-comparison",
+          "state": "running",
+          "active": true,
+          "closing": false,
+          "progress": null,
+          "stop_reason": null,
+          "providers": [
+            "Google BinDiff"
+          ],
+          "backend": "external",
+          "stage": "exporting",
+          "omitted_functions": {},
+          "binary_ids": {
+            "reference": "reference-binary",
+            "target": "target-binary"
+          },
+          "snapshots": {
+            "reference": {
+              "file_sha256": "65a014d83be9d2262e913d020425dc9bf0a301b6403dffa13e6fe7ae5460a57b",
+              "hash_source": "original Raw view",
+              "image_name": "securekernel.exe",
+              "binary_id": "reference-binary",
+              "path": "reference/securekernel.exe",
+              "display_name": "securekernel.exe",
+              "active": false,
+              "architecture": "aarch64",
+              "analysis_state": "IdleState",
+              "image_base": "0x0000000140000000",
+              "identity": {
+                "timestamp": 3350698326,
+                "size": 1245184,
+                "pdb": {
+                  "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                  "age": 1
+                }
+              },
+              "generation": [
+                "reference-binary",
+                5368709120,
+                14976
+              ],
+              "modified": false
+            },
+            "target": {
+              "file_sha256": "9a2eeb0e4a3d76aa9a6bfaf287540f5f1f7562d814e8ecb3c3f6df6b57a557b6",
+              "hash_source": "original Raw view",
+              "image_name": "securekernel.exe",
+              "binary_id": "target-binary",
+              "path": "target/securekernel.exe",
+              "display_name": "securekernel.exe",
+              "active": true,
+              "architecture": "aarch64",
+              "analysis_state": "IdleState",
+              "image_base": "0x0000000140000000",
+              "identity": {
+                "timestamp": 1188430604,
+                "size": 1290240,
+                "pdb": {
+                  "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                  "age": 1
+                }
+              },
+              "generation": [
+                "target-binary",
+                5368709120,
+                15090
+              ],
+              "modified": false
+            }
+          },
+          "match_count": 0,
+          "coverage_complete": false,
+          "unresolved_results": 0,
+          "error": null
+        },
+        "observed_stage": "exporting",
+        "active_process_before": {
+          "export_thread_alive": true,
+          "temporary_directory_exists": true,
+          "process_created": false,
+          "process_returncode": null,
+          "output_reader_alive": false
+        },
+        "heartbeat_before_action": 5,
+        "job_reason": null,
+        "job_phase": "partial",
+        "after_cleanup": {
+          "export_thread_alive": false,
+          "temporary_directory_exists": false,
+          "process_created": true,
+          "process_returncode": 0,
+          "output_reader_alive": false
+        },
+        "results_after": {
+          "comparison_id": "edit-v1-comparison",
+          "state": "partial",
+          "active": false,
+          "closing": false,
+          "progress": null,
+          "stop_reason": null,
+          "providers": [
+            "Google BinDiff"
+          ],
+          "backend": "external",
+          "stage": "importing",
+          "omitted_functions": {
+            "reference": 8,
+            "target": 8
+          },
+          "binary_ids": {
+            "reference": "reference-binary",
+            "target": "target-binary"
+          },
+          "snapshots": {
+            "reference": {
+              "file_sha256": "65a014d83be9d2262e913d020425dc9bf0a301b6403dffa13e6fe7ae5460a57b",
+              "hash_source": "original Raw view",
+              "image_name": "securekernel.exe",
+              "binary_id": "reference-binary",
+              "path": "reference/securekernel.exe",
+              "display_name": "securekernel.exe",
+              "active": false,
+              "architecture": "aarch64",
+              "analysis_state": "IdleState",
+              "image_base": "0x0000000140000000",
+              "identity": {
+                "timestamp": 3350698326,
+                "size": 1245184,
+                "pdb": {
+                  "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                  "age": 1
+                }
+              },
+              "generation": [
+                "reference-binary",
+                5368709120,
+                14976
+              ],
+              "modified": false
+            },
+            "target": {
+              "file_sha256": "9a2eeb0e4a3d76aa9a6bfaf287540f5f1f7562d814e8ecb3c3f6df6b57a557b6",
+              "hash_source": "original Raw view",
+              "image_name": "securekernel.exe",
+              "binary_id": "target-binary",
+              "path": "target/securekernel.exe",
+              "display_name": "securekernel.exe",
+              "active": true,
+              "architecture": "aarch64",
+              "analysis_state": "IdleState",
+              "image_base": "0x0000000140000000",
+              "identity": {
+                "timestamp": 1188430604,
+                "size": 1290240,
+                "pdb": {
+                  "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                  "age": 1
+                }
+              },
+              "generation": [
+                "target-binary",
+                5368709120,
+                15090
+              ],
+              "modified": false
+            }
+          },
+          "match_count": 3109,
+          "coverage_complete": false,
+          "unresolved_results": 8,
+          "error": null,
+          "side": "target",
+          "kind": "matches",
+          "items": [
+            {
+              "result_id": "match_1",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 253,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9933071490757153,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14976
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x28028"
+                },
+                "address": "0x0000000140028028",
+                "name": "SkmiKsrMapPfnDatabaseEntry"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15090
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x28028"
+                },
+                "address": "0x0000000140028028",
+                "name": "SkmiKsrMapPfnDatabaseEntry"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_2",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 253,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9933071490757153,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14976
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x28170"
+                },
+                "address": "0x0000000140028170",
+                "name": "SkmiKsrPageMayContainSecrets"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15090
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x28170"
+                },
+                "address": "0x0000000140028170",
+                "name": "SkmiKsrPageMayContainSecrets"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_3",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 253,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9933071490757153,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14976
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x28180"
+                },
+                "address": "0x0000000140028180",
+                "name": "SkmmKsrEnumerateSecurePages"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15090
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x28180"
+                },
+                "address": "0x0000000140028180",
+                "name": "SkmmKsrEnumerateSecurePages"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_4",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 248,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9706877692486436,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14976
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x60000"
+                },
+                "address": "0x0000000140060000",
+                "name": "MxtKernelSp0ExceptionHandler"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15090
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x60000"
+                },
+                "address": "0x0000000140060000",
+                "name": "MxtKernelSp0ExceptionHandler"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_5",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 248,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9706877692486436,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14976
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x60080"
+                },
+                "address": "0x0000000140060080",
+                "name": "MxtKernelSp0InterruptHandler"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15090
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x60080"
+                },
+                "address": "0x0000000140060080",
+                "name": "MxtKernelSp0InterruptHandler"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_6",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 248,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9706877692486436,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14976
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x60100"
+                },
+                "address": "0x0000000140060100",
+                "name": "MxtKernelSp0FiqHandler"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15090
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x60100"
+                },
+                "address": "0x0000000140060100",
+                "name": "MxtKernelSp0FiqHandler"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_7",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 248,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9706877692486436,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14976
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x60180"
+                },
+                "address": "0x0000000140060180",
+                "name": "MxtKernelSp0SystemErrorHandler"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15090
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x60180"
+                },
+                "address": "0x0000000140060180",
+                "name": "MxtKernelSp0SystemErrorHandler"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_8",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 248,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9706877692486436,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14976
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x60200"
+                },
+                "address": "0x0000000140060200",
+                "name": "MxtKernelExceptionHandler"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15090
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x60200"
+                },
+                "address": "0x0000000140060200",
+                "name": "MxtKernelExceptionHandler"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_9",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 248,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9706877692486436,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14976
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x60280"
+                },
+                "address": "0x0000000140060280",
+                "name": "MxtKernelInterruptHandler"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15090
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x60280"
+                },
+                "address": "0x0000000140060280",
+                "name": "MxtKernelInterruptHandler"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_10",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 248,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9706877692486436,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14976
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x60300"
+                },
+                "address": "0x0000000140060300",
+                "name": "MxtKernelFiqHandler"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15090
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x60300"
+                },
+                "address": "0x0000000140060300",
+                "name": "MxtKernelFiqHandler"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_11",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 248,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9706877692486436,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14976
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x60380"
+                },
+                "address": "0x0000000140060380",
+                "name": "MxtKernelSystemErrorHandler"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15090
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x60380"
+                },
+                "address": "0x0000000140060380",
+                "name": "MxtKernelSystemErrorHandler"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_12",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 248,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9706877692486436,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14976
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x60400"
+                },
+                "address": "0x0000000140060400",
+                "name": "MxtUserExceptionHandler"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15090
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x60400"
+                },
+                "address": "0x0000000140060400",
+                "name": "MxtUserExceptionHandler"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_13",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 248,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9706877692486436,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14976
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x60480"
+                },
+                "address": "0x0000000140060480",
+                "name": "MxtUserInterruptHandler"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15090
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x60480"
+                },
+                "address": "0x0000000140060480",
+                "name": "MxtUserInterruptHandler"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_14",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 248,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9706877692486436,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14976
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x60500"
+                },
+                "address": "0x0000000140060500",
+                "name": "MxtUserFiqHandler"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15090
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x60500"
+                },
+                "address": "0x0000000140060500",
+                "name": "MxtUserFiqHandler"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_15",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 248,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9706877692486436,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14976
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x60580"
+                },
+                "address": "0x0000000140060580",
+                "name": "MxtUserSystemErrorHandler"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15090
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x60580"
+                },
+                "address": "0x0000000140060580",
+                "name": "MxtUserSystemErrorHandler"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_16",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 248,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9706877692486436,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14976
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x60600"
+                },
+                "address": "0x0000000140060600",
+                "name": "MxtUser32ExceptionHandler"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15090
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x60600"
+                },
+                "address": "0x0000000140060600",
+                "name": "MxtUser32ExceptionHandler"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_17",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 248,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9706877692486436,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14976
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x60680"
+                },
+                "address": "0x0000000140060680",
+                "name": "MxtUser32InterruptHandler"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15090
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x60680"
+                },
+                "address": "0x0000000140060680",
+                "name": "MxtUser32InterruptHandler"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_18",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 248,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9706877692486436,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14976
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x60700"
+                },
+                "address": "0x0000000140060700",
+                "name": "MxtUser32FiqHandler"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15090
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x60700"
+                },
+                "address": "0x0000000140060700",
+                "name": "MxtUser32FiqHandler"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_19",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 248,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9706877692486436,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14976
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x60780"
+                },
+                "address": "0x0000000140060780",
+                "name": "MxtUser32SystemErrorHandler"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15090
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x60780"
+                },
+                "address": "0x0000000140060780",
+                "name": "MxtUser32SystemErrorHandler"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_20",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 253,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9933071490757153,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14976
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x60800"
+                },
+                "address": "0x0000000140060800",
+                "name": "MxtFlushCurrentTb"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15090
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x60800"
+                },
+                "address": "0x0000000140060800",
+                "name": "MxtFlushCurrentTb"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_21",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 253,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9933071490757153,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14976
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x60830"
+                },
+                "address": "0x0000000140060830",
+                "name": "SkpPerformMicroExecWork"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15090
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x60830"
+                },
+                "address": "0x0000000140060830",
+                "name": "SkpPerformMicroExecWork"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_22",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 253,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9933071490757153,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14976
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61000"
+                },
+                "address": "0x0000000140061000",
+                "name": "SkCallNormalMode"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15090
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61000"
+                },
+                "address": "0x0000000140061000",
+                "name": "SkCallNormalMode"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_23",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 253,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9933071490757153,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14976
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61380"
+                },
+                "address": "0x0000000140061380",
+                "name": "SkeExitThreadWithReturn"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15090
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61380"
+                },
+                "address": "0x0000000140061380",
+                "name": "SkeExitThreadWithReturn"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_24",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 253,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9933071490757153,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14976
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x613c4"
+                },
+                "address": "0x00000001400613c4",
+                "name": "SkeExitThread"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15090
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x613c4"
+                },
+                "address": "0x00000001400613c4",
+                "name": "SkeExitThread"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_25",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 252,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9890130573694068,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14976
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61430"
+                },
+                "address": "0x0000000140061430",
+                "name": "SkpUserThreadStartup"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15090
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61430"
+                },
+                "address": "0x0000000140061430",
+                "name": "SkpUserThreadStartup"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_26",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 252,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9890130573694068,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14976
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61444"
+                },
+                "address": "0x0000000140061444",
+                "name": "SkpVtl0ResumeEntry"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15090
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61444"
+                },
+                "address": "0x0000000140061444",
+                "name": "SkpVtl0ResumeEntry"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_27",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 253,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9933071490757153,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14976
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61480"
+                },
+                "address": "0x0000000140061480",
+                "name": "SkpVtl1ResumeEntry"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15090
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61480"
+                },
+                "address": "0x0000000140061480",
+                "name": "SkpVtl1ResumeEntry"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_28",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 253,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9933071490757153,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14976
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x615c0"
+                },
+                "address": "0x00000001400615c0",
+                "name": "SkpVtl1ResumeStartup"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15090
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x615c0"
+                },
+                "address": "0x00000001400615c0",
+                "name": "SkpVtl1ResumeStartup"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_29",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 252,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9890130573694068,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14976
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61680"
+                },
+                "address": "0x0000000140061680",
+                "name": "SkpVtl1ResumeAp"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15090
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61680"
+                },
+                "address": "0x0000000140061680",
+                "name": "SkpVtl1ResumeAp"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_30",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 253,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9933071490757153,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14976
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61780"
+                },
+                "address": "0x0000000140061780",
+                "name": "SkSwitchToLimitedDispatchLoop"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15090
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61780"
+                },
+                "address": "0x0000000140061780",
+                "name": "SkSwitchToLimitedDispatchLoop"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_31",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 253,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9933071490757153,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14976
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x617c0"
+                },
+                "address": "0x00000001400617c0",
+                "name": "SkpSwitchToLimitedDispatchLoopPrcb"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15090
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x617c0"
+                },
+                "address": "0x00000001400617c0",
+                "name": "SkpSwitchToLimitedDispatchLoopPrcb"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_32",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 253,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9933071490757153,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14976
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x619c0"
+                },
+                "address": "0x00000001400619c0",
+                "name": "IumGenericSyscall"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15090
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x619c0"
+                },
+                "address": "0x00000001400619c0",
+                "name": "IumGenericSyscall"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_33",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 248,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9706877692486436,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14976
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x619f0"
+                },
+                "address": "0x00000001400619f0",
+                "name": "ZwWorkerFactoryWorkerReady"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15090
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x619f0"
+                },
+                "address": "0x00000001400619f0",
+                "name": "ZwWorkerFactoryWorkerReady"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_34",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14976
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61a00"
+                },
+                "address": "0x0000000140061a00",
+                "name": "ZwWaitForSingleObject"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15090
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61a00"
+                },
+                "address": "0x0000000140061a00",
+                "name": "ZwWaitForSingleObject"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_35",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14976
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61a10"
+                },
+                "address": "0x0000000140061a10",
+                "name": "ZwReleaseSemaphore"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15090
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61a10"
+                },
+                "address": "0x0000000140061a10",
+                "name": "ZwReleaseSemaphore"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_36",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14976
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61a20"
+                },
+                "address": "0x0000000140061a20",
+                "name": "ZwSetInformationThread"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15090
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61a20"
+                },
+                "address": "0x0000000140061a20",
+                "name": "ZwSetInformationThread"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_37",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14976
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61a30"
+                },
+                "address": "0x0000000140061a30",
+                "name": "ZwSetEvent"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15090
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61a30"
+                },
+                "address": "0x0000000140061a30",
+                "name": "ZwSetEvent"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_38",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14976
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61a40"
+                },
+                "address": "0x0000000140061a40",
+                "name": "ZwClose"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15090
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61a40"
+                },
+                "address": "0x0000000140061a40",
+                "name": "ZwClose"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_39",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14976
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61a50"
+                },
+                "address": "0x0000000140061a50",
+                "name": "ZwOpenKey"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15090
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61a50"
+                },
+                "address": "0x0000000140061a50",
+                "name": "ZwOpenKey"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_40",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14976
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61a60"
+                },
+                "address": "0x0000000140061a60",
+                "name": "ZwAllocateVirtualMemory"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15090
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61a60"
+                },
+                "address": "0x0000000140061a60",
+                "name": "ZwAllocateVirtualMemory"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_41",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14976
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61a70"
+                },
+                "address": "0x0000000140061a70",
+                "name": "ZwQueryInformationProcess"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15090
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61a70"
+                },
+                "address": "0x0000000140061a70",
+                "name": "ZwQueryInformationProcess"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_42",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14976
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61a80"
+                },
+                "address": "0x0000000140061a80",
+                "name": "ZwSetInformationProcess"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15090
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61a80"
+                },
+                "address": "0x0000000140061a80",
+                "name": "ZwSetInformationProcess"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_43",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14976
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61a90"
+                },
+                "address": "0x0000000140061a90",
+                "name": "ZwFreeVirtualMemory"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15090
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61a90"
+                },
+                "address": "0x0000000140061a90",
+                "name": "ZwFreeVirtualMemory"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_44",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14976
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61aa0"
+                },
+                "address": "0x0000000140061aa0",
+                "name": "ZwQueryInformationToken"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15090
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61aa0"
+                },
+                "address": "0x0000000140061aa0",
+                "name": "ZwQueryInformationToken"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_45",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14976
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61ab0"
+                },
+                "address": "0x0000000140061ab0",
+                "name": "ZwQueryVirtualMemory"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15090
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61ab0"
+                },
+                "address": "0x0000000140061ab0",
+                "name": "ZwQueryVirtualMemory"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_46",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14976
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61ac0"
+                },
+                "address": "0x0000000140061ac0",
+                "name": "ZwOpenThreadToken"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15090
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61ac0"
+                },
+                "address": "0x0000000140061ac0",
+                "name": "ZwOpenThreadToken"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_47",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14976
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61ad0"
+                },
+                "address": "0x0000000140061ad0",
+                "name": "ZwQueryInformationThread"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15090
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61ad0"
+                },
+                "address": "0x0000000140061ad0",
+                "name": "ZwQueryInformationThread"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_48",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14976
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61ae0"
+                },
+                "address": "0x0000000140061ae0",
+                "name": "ZwMapViewOfSection"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15090
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61ae0"
+                },
+                "address": "0x0000000140061ae0",
+                "name": "ZwMapViewOfSection"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_49",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14976
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61af0"
+                },
+                "address": "0x0000000140061af0",
+                "name": "ZwUnmapViewOfSection"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15090
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61af0"
+                },
+                "address": "0x0000000140061af0",
+                "name": "ZwUnmapViewOfSection"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_50",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14976
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61b00"
+                },
+                "address": "0x0000000140061b00",
+                "name": "ZwTerminateProcess"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15090
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61b00"
+                },
+                "address": "0x0000000140061b00",
+                "name": "ZwTerminateProcess"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_51",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14976
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61b10"
+                },
+                "address": "0x0000000140061b10",
+                "name": "ZwQueryPerformanceCounter"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15090
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61b10"
+                },
+                "address": "0x0000000140061b10",
+                "name": "ZwQueryPerformanceCounter"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_52",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14976
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61b20"
+                },
+                "address": "0x0000000140061b20",
+                "name": "ZwOpenFile"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15090
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61b20"
+                },
+                "address": "0x0000000140061b20",
+                "name": "ZwOpenFile"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_53",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14976
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61b30"
+                },
+                "address": "0x0000000140061b30",
+                "name": "ZwDelayExecution"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15090
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61b30"
+                },
+                "address": "0x0000000140061b30",
+                "name": "ZwDelayExecution"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_54",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14976
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61b40"
+                },
+                "address": "0x0000000140061b40",
+                "name": "ZwQuerySystemInformation"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15090
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61b40"
+                },
+                "address": "0x0000000140061b40",
+                "name": "ZwQuerySystemInformation"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_55",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14976
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61b50"
+                },
+                "address": "0x0000000140061b50",
+                "name": "ZwDuplicateObject"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15090
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61b50"
+                },
+                "address": "0x0000000140061b50",
+                "name": "ZwDuplicateObject"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_56",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14976
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61b60"
+                },
+                "address": "0x0000000140061b60",
+                "name": "ZwQueryAttributesFile"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15090
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61b60"
+                },
+                "address": "0x0000000140061b60",
+                "name": "ZwQueryAttributesFile"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_57",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14976
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61b70"
+                },
+                "address": "0x0000000140061b70",
+                "name": "ZwClearEvent"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15090
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61b70"
+                },
+                "address": "0x0000000140061b70",
+                "name": "ZwClearEvent"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_58",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14976
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61b80"
+                },
+                "address": "0x0000000140061b80",
+                "name": "ZwOpenEvent"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15090
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61b80"
+                },
+                "address": "0x0000000140061b80",
+                "name": "ZwOpenEvent"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_59",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14976
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61b90"
+                },
+                "address": "0x0000000140061b90",
+                "name": "ZwContinue"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15090
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61b90"
+                },
+                "address": "0x0000000140061b90",
+                "name": "ZwContinue"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_60",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14976
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61ba0"
+                },
+                "address": "0x0000000140061ba0",
+                "name": "ZwCreateEvent"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15090
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61ba0"
+                },
+                "address": "0x0000000140061ba0",
+                "name": "ZwCreateEvent"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_61",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14976
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61bb0"
+                },
+                "address": "0x0000000140061bb0",
+                "name": "ZwQueryVolumeInformationFile"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15090
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61bb0"
+                },
+                "address": "0x0000000140061bb0",
+                "name": "ZwQueryVolumeInformationFile"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_62",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14976
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61bc0"
+                },
+                "address": "0x0000000140061bc0",
+                "name": "ZwCreateSection"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15090
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61bc0"
+                },
+                "address": "0x0000000140061bc0",
+                "name": "ZwCreateSection"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_63",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14976
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61bd0"
+                },
+                "address": "0x0000000140061bd0",
+                "name": "ZwProtectVirtualMemory"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15090
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61bd0"
+                },
+                "address": "0x0000000140061bd0",
+                "name": "ZwProtectVirtualMemory"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_64",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14976
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61be0"
+                },
+                "address": "0x0000000140061be0",
+                "name": "ZwTerminateThread"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15090
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61be0"
+                },
+                "address": "0x0000000140061be0",
+                "name": "ZwTerminateThread"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_65",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14976
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61bf0"
+                },
+                "address": "0x0000000140061bf0",
+                "name": "ZwOpenDirectoryObject"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15090
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61bf0"
+                },
+                "address": "0x0000000140061bf0",
+                "name": "ZwOpenDirectoryObject"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_66",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14976
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61c00"
+                },
+                "address": "0x0000000140061c00",
+                "name": "ZwTraceEvent"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15090
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61c00"
+                },
+                "address": "0x0000000140061c00",
+                "name": "ZwTraceEvent"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_67",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14976
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61c10"
+                },
+                "address": "0x0000000140061c10",
+                "name": "ZwAlertMultipleThreadByThreadId"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15090
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61c10"
+                },
+                "address": "0x0000000140061c10",
+                "name": "ZwAlertMultipleThreadByThreadId"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_68",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14976
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61c20"
+                },
+                "address": "0x0000000140061c20",
+                "name": "ZwAlertThreadByThreadId"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15090
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61c20"
+                },
+                "address": "0x0000000140061c20",
+                "name": "ZwAlertThreadByThreadId"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_69",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14976
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61c30"
+                },
+                "address": "0x0000000140061c30",
+                "name": "ZwAlertThreadByThreadIdEx"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15090
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61c30"
+                },
+                "address": "0x0000000140061c30",
+                "name": "ZwAlertThreadByThreadIdEx"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_70",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14976
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61c40"
+                },
+                "address": "0x0000000140061c40",
+                "name": "ZwAllocateVirtualMemoryEx"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15090
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61c40"
+                },
+                "address": "0x0000000140061c40",
+                "name": "ZwAllocateVirtualMemoryEx"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_71",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14976
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61c50"
+                },
+                "address": "0x0000000140061c50",
+                "name": "ZwAlpcAcceptConnectPort"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15090
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61c50"
+                },
+                "address": "0x0000000140061c50",
+                "name": "ZwAlpcAcceptConnectPort"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_72",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14976
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61c60"
+                },
+                "address": "0x0000000140061c60",
+                "name": "ZwAlpcConnectPort"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15090
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61c60"
+                },
+                "address": "0x0000000140061c60",
+                "name": "ZwAlpcConnectPort"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_73",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14976
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61c70"
+                },
+                "address": "0x0000000140061c70",
+                "name": "ZwAlpcCreatePort"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15090
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61c70"
+                },
+                "address": "0x0000000140061c70",
+                "name": "ZwAlpcCreatePort"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_74",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14976
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61c80"
+                },
+                "address": "0x0000000140061c80",
+                "name": "ZwAlpcImpersonateClientOfPort"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15090
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61c80"
+                },
+                "address": "0x0000000140061c80",
+                "name": "ZwAlpcImpersonateClientOfPort"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_75",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14976
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61c90"
+                },
+                "address": "0x0000000140061c90",
+                "name": "ZwAlpcQueryInformation"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15090
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61c90"
+                },
+                "address": "0x0000000140061c90",
+                "name": "ZwAlpcQueryInformation"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_76",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 248,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9706877692486436,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14976
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61ca0"
+                },
+                "address": "0x0000000140061ca0",
+                "name": "ZwAlpcSendWaitReceivePort"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15090
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61ca0"
+                },
+                "address": "0x0000000140061ca0",
+                "name": "ZwAlpcSendWaitReceivePort"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_77",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14976
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61cb0"
+                },
+                "address": "0x0000000140061cb0",
+                "name": "ZwAlpcSetInformation"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15090
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61cb0"
+                },
+                "address": "0x0000000140061cb0",
+                "name": "ZwAlpcSetInformation"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_78",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14976
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61cc0"
+                },
+                "address": "0x0000000140061cc0",
+                "name": "ZwAreMappedFilesTheSame"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15090
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61cc0"
+                },
+                "address": "0x0000000140061cc0",
+                "name": "ZwAreMappedFilesTheSame"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_79",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14976
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61cd0"
+                },
+                "address": "0x0000000140061cd0",
+                "name": "ZwAssociateWaitCompletionPacket"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15090
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61cd0"
+                },
+                "address": "0x0000000140061cd0",
+                "name": "ZwAssociateWaitCompletionPacket"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_80",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14976
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61ce0"
+                },
+                "address": "0x0000000140061ce0",
+                "name": "ZwCallEnclave"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15090
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61ce0"
+                },
+                "address": "0x0000000140061ce0",
+                "name": "ZwCallEnclave"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_81",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14976
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61cf0"
+                },
+                "address": "0x0000000140061cf0",
+                "name": "ZwCancelTimer2"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15090
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61cf0"
+                },
+                "address": "0x0000000140061cf0",
+                "name": "ZwCancelTimer2"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_82",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14976
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61d00"
+                },
+                "address": "0x0000000140061d00",
+                "name": "ZwCancelWaitCompletionPacket"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15090
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61d00"
+                },
+                "address": "0x0000000140061d00",
+                "name": "ZwCancelWaitCompletionPacket"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_83",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14976
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61d10"
+                },
+                "address": "0x0000000140061d10",
+                "name": "ZwContinueEx"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15090
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61d10"
+                },
+                "address": "0x0000000140061d10",
+                "name": "ZwContinueEx"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_84",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14976
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61d20"
+                },
+                "address": "0x0000000140061d20",
+                "name": "ZwCreateIoCompletion"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15090
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61d20"
+                },
+                "address": "0x0000000140061d20",
+                "name": "ZwCreateIoCompletion"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_85",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14976
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61d30"
+                },
+                "address": "0x0000000140061d30",
+                "name": "ZwCreateSemaphore"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15090
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61d30"
+                },
+                "address": "0x0000000140061d30",
+                "name": "ZwCreateSemaphore"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_86",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14976
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61d40"
+                },
+                "address": "0x0000000140061d40",
+                "name": "ZwCreateThreadEx"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15090
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61d40"
+                },
+                "address": "0x0000000140061d40",
+                "name": "ZwCreateThreadEx"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_87",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14976
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61d50"
+                },
+                "address": "0x0000000140061d50",
+                "name": "ZwCreateTimer2"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15090
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61d50"
+                },
+                "address": "0x0000000140061d50",
+                "name": "ZwCreateTimer2"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_88",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14976
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61d60"
+                },
+                "address": "0x0000000140061d60",
+                "name": "ZwCreateWaitCompletionPacket"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15090
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61d60"
+                },
+                "address": "0x0000000140061d60",
+                "name": "ZwCreateWaitCompletionPacket"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_89",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14976
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61d70"
+                },
+                "address": "0x0000000140061d70",
+                "name": "ZwCreateWorkerFactory"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15090
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61d70"
+                },
+                "address": "0x0000000140061d70",
+                "name": "ZwCreateWorkerFactory"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_90",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 248,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9706877692486436,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14976
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61d80"
+                },
+                "address": "0x0000000140061d80",
+                "name": "ZwGetCurrentProcessorNumber"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15090
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61d80"
+                },
+                "address": "0x0000000140061d80",
+                "name": "ZwGetCurrentProcessorNumber"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_91",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14976
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61d90"
+                },
+                "address": "0x0000000140061d90",
+                "name": "ZwGetCurrentProcessorNumberEx"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15090
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61d90"
+                },
+                "address": "0x0000000140061d90",
+                "name": "ZwGetCurrentProcessorNumberEx"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_92",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14976
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61da0"
+                },
+                "address": "0x0000000140061da0",
+                "name": "ZwGetNlsSectionPtr"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15090
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61da0"
+                },
+                "address": "0x0000000140061da0",
+                "name": "ZwGetNlsSectionPtr"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_93",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14976
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61db0"
+                },
+                "address": "0x0000000140061db0",
+                "name": "ZwManageHotPatch"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15090
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61db0"
+                },
+                "address": "0x0000000140061db0",
+                "name": "ZwManageHotPatch"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_94",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14976
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61dc0"
+                },
+                "address": "0x0000000140061dc0",
+                "name": "ZwOpenKeyEx"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15090
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61dc0"
+                },
+                "address": "0x0000000140061dc0",
+                "name": "ZwOpenKeyEx"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_95",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14976
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61dd0"
+                },
+                "address": "0x0000000140061dd0",
+                "name": "ZwOpenProcessToken"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15090
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61dd0"
+                },
+                "address": "0x0000000140061dd0",
+                "name": "ZwOpenProcessToken"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_96",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14976
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61de0"
+                },
+                "address": "0x0000000140061de0",
+                "name": "ZwQueryDebugFilterState"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15090
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61de0"
+                },
+                "address": "0x0000000140061de0",
+                "name": "ZwQueryDebugFilterState"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_97",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14976
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61df0"
+                },
+                "address": "0x0000000140061df0",
+                "name": "ZwQuerySecurityObject"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15090
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61df0"
+                },
+                "address": "0x0000000140061df0",
+                "name": "ZwQuerySecurityObject"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_98",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14976
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61e00"
+                },
+                "address": "0x0000000140061e00",
+                "name": "ZwQuerySystemInformationEx"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15090
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61e00"
+                },
+                "address": "0x0000000140061e00",
+                "name": "ZwQuerySystemInformationEx"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_99",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14976
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61e10"
+                },
+                "address": "0x0000000140061e10",
+                "name": "ZwRaiseException"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15090
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61e10"
+                },
+                "address": "0x0000000140061e10",
+                "name": "ZwRaiseException"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_100",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14976
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61e20"
+                },
+                "address": "0x0000000140061e20",
+                "name": "ZwReleaseWorkerFactoryWorker"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15090
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61e20"
+                },
+                "address": "0x0000000140061e20",
+                "name": "ZwReleaseWorkerFactoryWorker"
+              },
+              "backend": "external"
+            }
+          ],
+          "total": 3109,
+          "next_offset": 100,
+          "truncated": true
+        },
+        "error": "Traceback (most recent call last):\n  File \"probe/similarity_lifecycle.py\", line 161, in run\n    assert job.reason == expected, (job.reason, expected)\n           ^^^^^^^^^^^^^^^^^^^^^^\nAssertionError: (None, 'stale')\n",
+        "quit_action_available": true
+      },
+      "gui_exit": {
+        "exited": true,
+        "forced": true,
+        "returncode": -15
+      },
+      "companion_metadata_fix_applied": false
+    },
+    "edit-v2": {
+      "capture_source_sha256": "484e0f1af12f02b2439241a9c74d7d8b08ecebe7418166e9ba17730f605b8ab4",
+      "capture": {
+        "case": "edit",
+        "bn_version": "6.0.10601 Personal",
+        "ok": true,
+        "inputs": [
+          {
+            "file_sha256": "9a2eeb0e4a3d76aa9a6bfaf287540f5f1f7562d814e8ecb3c3f6df6b57a557b6",
+            "hash_source": "original Raw view",
+            "image_name": "securekernel.exe",
+            "binary_id": "target-binary",
+            "path": "target/securekernel.exe",
+            "display_name": "securekernel.exe",
+            "active": true,
+            "architecture": "aarch64",
+            "analysis_state": "IdleState",
+            "image_base": "0x0000000140000000",
+            "identity": {
+              "timestamp": 1188430604,
+              "size": 1290240,
+              "pdb": {
+                "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                "age": 1
+              }
+            },
+            "generation": [
+              "target-binary",
+              5368709120,
+              15065
+            ],
+            "modified": false
+          },
+          {
+            "file_sha256": "65a014d83be9d2262e913d020425dc9bf0a301b6403dffa13e6fe7ae5460a57b",
+            "hash_source": "original Raw view",
+            "image_name": "securekernel.exe",
+            "binary_id": "reference-binary",
+            "path": "reference/securekernel.exe",
+            "display_name": "securekernel.exe",
+            "active": false,
+            "architecture": "aarch64",
+            "analysis_state": "IdleState",
+            "image_base": "0x0000000140000000",
+            "identity": {
+              "timestamp": 3350698326,
+              "size": 1245184,
+              "pdb": {
+                "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                "age": 1
+              }
+            },
+            "generation": [
+              "reference-binary",
+              5368709120,
+              14973
+            ],
+            "modified": false
+          }
+        ],
+        "before_action": {
+          "comparison_id": "edit-v2-comparison",
+          "state": "running",
+          "active": true,
+          "closing": false,
+          "progress": null,
+          "stop_reason": null,
+          "providers": [
+            "Google BinDiff"
+          ],
+          "backend": "external",
+          "stage": "exporting",
+          "omitted_functions": {},
+          "binary_ids": {
+            "reference": "reference-binary",
+            "target": "target-binary"
+          },
+          "snapshots": {
+            "reference": {
+              "file_sha256": "65a014d83be9d2262e913d020425dc9bf0a301b6403dffa13e6fe7ae5460a57b",
+              "hash_source": "original Raw view",
+              "image_name": "securekernel.exe",
+              "binary_id": "reference-binary",
+              "path": "reference/securekernel.exe",
+              "display_name": "securekernel.exe",
+              "active": false,
+              "architecture": "aarch64",
+              "analysis_state": "IdleState",
+              "image_base": "0x0000000140000000",
+              "identity": {
+                "timestamp": 3350698326,
+                "size": 1245184,
+                "pdb": {
+                  "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                  "age": 1
+                }
+              },
+              "generation": [
+                "reference-binary",
+                5368709120,
+                14973
+              ],
+              "modified": false
+            },
+            "target": {
+              "file_sha256": "9a2eeb0e4a3d76aa9a6bfaf287540f5f1f7562d814e8ecb3c3f6df6b57a557b6",
+              "hash_source": "original Raw view",
+              "image_name": "securekernel.exe",
+              "binary_id": "target-binary",
+              "path": "target/securekernel.exe",
+              "display_name": "securekernel.exe",
+              "active": true,
+              "architecture": "aarch64",
+              "analysis_state": "IdleState",
+              "image_base": "0x0000000140000000",
+              "identity": {
+                "timestamp": 1188430604,
+                "size": 1290240,
+                "pdb": {
+                  "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                  "age": 1
+                }
+              },
+              "generation": [
+                "target-binary",
+                5368709120,
+                15065
+              ],
+              "modified": false
+            }
+          },
+          "match_count": 0,
+          "coverage_complete": false,
+          "unresolved_results": 0,
+          "error": null
+        },
+        "observed_stage": "exporting",
+        "active_process_before": {
+          "export_thread_alive": true,
+          "temporary_directory_exists": true,
+          "process_created": false,
+          "process_returncode": null,
+          "output_reader_alive": false
+        },
+        "heartbeat_before_action": 7,
+        "job_reason": "stale",
+        "job_phase": "stale",
+        "after_cleanup": {
+          "export_thread_alive": false,
+          "temporary_directory_exists": false,
+          "process_created": false,
+          "process_returncode": null,
+          "output_reader_alive": false
+        },
+        "results_after": {
+          "comparison_id": "edit-v2-comparison",
+          "state": "stale",
+          "active": false,
+          "closing": false,
+          "progress": null,
+          "stop_reason": "stale",
+          "providers": [
+            "Google BinDiff"
+          ],
+          "backend": "external",
+          "stage": "exporting",
+          "omitted_functions": {},
+          "binary_ids": {
+            "reference": "reference-binary",
+            "target": "target-binary"
+          },
+          "snapshots": {
+            "reference": {
+              "file_sha256": "65a014d83be9d2262e913d020425dc9bf0a301b6403dffa13e6fe7ae5460a57b",
+              "hash_source": "original Raw view",
+              "image_name": "securekernel.exe",
+              "binary_id": "reference-binary",
+              "path": "reference/securekernel.exe",
+              "display_name": "securekernel.exe",
+              "active": false,
+              "architecture": "aarch64",
+              "analysis_state": "IdleState",
+              "image_base": "0x0000000140000000",
+              "identity": {
+                "timestamp": 3350698326,
+                "size": 1245184,
+                "pdb": {
+                  "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                  "age": 1
+                }
+              },
+              "generation": [
+                "reference-binary",
+                5368709120,
+                14973
+              ],
+              "modified": false
+            },
+            "target": {
+              "file_sha256": "9a2eeb0e4a3d76aa9a6bfaf287540f5f1f7562d814e8ecb3c3f6df6b57a557b6",
+              "hash_source": "original Raw view",
+              "image_name": "securekernel.exe",
+              "binary_id": "target-binary",
+              "path": "target/securekernel.exe",
+              "display_name": "securekernel.exe",
+              "active": true,
+              "architecture": "aarch64",
+              "analysis_state": "IdleState",
+              "image_base": "0x0000000140000000",
+              "identity": {
+                "timestamp": 1188430604,
+                "size": 1290240,
+                "pdb": {
+                  "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                  "age": 1
+                }
+              },
+              "generation": [
+                "target-binary",
+                5368709120,
+                15065
+              ],
+              "modified": false
+            }
+          },
+          "match_count": 0,
+          "coverage_complete": false,
+          "unresolved_results": 0,
+          "error": {
+            "code": "stale",
+            "message": "comparison stop requested"
+          },
+          "side": "target",
+          "kind": "matches",
+          "items": [],
+          "total": 0,
+          "next_offset": null,
+          "truncated": false
+        },
+        "stale_navigation_refusal": "view generation changed",
+        "heartbeat_total": 10,
+        "quit_action_available": true
+      },
+      "gui_exit": {
+        "exited": true,
+        "forced": false,
+        "returncode": -15,
+        "termination_note": "The parent agent sent SIGTERM after testing stopped; forced=false only means the launcher did not send it."
+      },
+      "companion_metadata_fix_applied": true
+    },
+    "rebase-v1": {
+      "capture_source_sha256": "8f8305f082b0fbb6dc61f8138537f625881095a0171b9d2ced4f4756abba2be6",
+      "capture": {
+        "case": "rebase",
+        "bn_version": "6.0.10601 Personal",
+        "ok": false,
+        "inputs": [
+          {
+            "file_sha256": "65a014d83be9d2262e913d020425dc9bf0a301b6403dffa13e6fe7ae5460a57b",
+            "hash_source": "original Raw view",
+            "image_name": "securekernel.exe",
+            "binary_id": "reference-binary",
+            "path": "reference/securekernel.exe",
+            "display_name": "securekernel.exe",
+            "active": false,
+            "architecture": "aarch64",
+            "analysis_state": "IdleState",
+            "image_base": "0x0000000140000000",
+            "identity": {
+              "timestamp": 3350698326,
+              "size": 1245184,
+              "pdb": {
+                "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                "age": 1
+              }
+            },
+            "generation": [
+              "reference-binary",
+              5368709120,
+              14967
+            ],
+            "modified": false
+          },
+          {
+            "file_sha256": "9a2eeb0e4a3d76aa9a6bfaf287540f5f1f7562d814e8ecb3c3f6df6b57a557b6",
+            "hash_source": "original Raw view",
+            "image_name": "securekernel.exe",
+            "binary_id": "target-binary",
+            "path": "target/securekernel.exe",
+            "display_name": "securekernel.exe",
+            "active": true,
+            "architecture": "aarch64",
+            "analysis_state": "IdleState",
+            "image_base": "0x0000000140000000",
+            "identity": {
+              "timestamp": 1188430604,
+              "size": 1290240,
+              "pdb": {
+                "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                "age": 1
+              }
+            },
+            "generation": [
+              "target-binary",
+              5368709120,
+              15039
+            ],
+            "modified": false
+          }
+        ],
+        "before_action": {
+          "comparison_id": "rebase-v1-comparison",
+          "state": "running",
+          "active": true,
+          "closing": false,
+          "progress": null,
+          "stop_reason": null,
+          "providers": [
+            "Google BinDiff"
+          ],
+          "backend": "external",
+          "stage": "exporting",
+          "omitted_functions": {},
+          "binary_ids": {
+            "reference": "reference-binary",
+            "target": "target-binary"
+          },
+          "snapshots": {
+            "reference": {
+              "file_sha256": "65a014d83be9d2262e913d020425dc9bf0a301b6403dffa13e6fe7ae5460a57b",
+              "hash_source": "original Raw view",
+              "image_name": "securekernel.exe",
+              "binary_id": "reference-binary",
+              "path": "reference/securekernel.exe",
+              "display_name": "securekernel.exe",
+              "active": false,
+              "architecture": "aarch64",
+              "analysis_state": "IdleState",
+              "image_base": "0x0000000140000000",
+              "identity": {
+                "timestamp": 3350698326,
+                "size": 1245184,
+                "pdb": {
+                  "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                  "age": 1
+                }
+              },
+              "generation": [
+                "reference-binary",
+                5368709120,
+                14967
+              ],
+              "modified": false
+            },
+            "target": {
+              "file_sha256": "9a2eeb0e4a3d76aa9a6bfaf287540f5f1f7562d814e8ecb3c3f6df6b57a557b6",
+              "hash_source": "original Raw view",
+              "image_name": "securekernel.exe",
+              "binary_id": "target-binary",
+              "path": "target/securekernel.exe",
+              "display_name": "securekernel.exe",
+              "active": true,
+              "architecture": "aarch64",
+              "analysis_state": "IdleState",
+              "image_base": "0x0000000140000000",
+              "identity": {
+                "timestamp": 1188430604,
+                "size": 1290240,
+                "pdb": {
+                  "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                  "age": 1
+                }
+              },
+              "generation": [
+                "target-binary",
+                5368709120,
+                15039
+              ],
+              "modified": false
+            }
+          },
+          "match_count": 0,
+          "coverage_complete": false,
+          "unresolved_results": 0,
+          "error": null
+        },
+        "observed_stage": "exporting",
+        "active_process_before": {
+          "export_thread_alive": true,
+          "temporary_directory_exists": true,
+          "process_created": false,
+          "process_returncode": null,
+          "output_reader_alive": false
+        },
+        "heartbeat_before_action": 6,
+        "job_reason": "stale",
+        "job_phase": "stale",
+        "after_cleanup": {
+          "export_thread_alive": false,
+          "temporary_directory_exists": false,
+          "process_created": false,
+          "process_returncode": null,
+          "output_reader_alive": false
+        },
+        "results_after": {
+          "comparison_id": "rebase-v1-comparison",
+          "state": "stale",
+          "active": false,
+          "closing": false,
+          "progress": null,
+          "stop_reason": "stale",
+          "providers": [
+            "Google BinDiff"
+          ],
+          "backend": "external",
+          "stage": "exporting",
+          "omitted_functions": {
+            "reference": 8
+          },
+          "binary_ids": {
+            "reference": "reference-binary",
+            "target": "target-binary"
+          },
+          "snapshots": {
+            "reference": {
+              "file_sha256": "65a014d83be9d2262e913d020425dc9bf0a301b6403dffa13e6fe7ae5460a57b",
+              "hash_source": "original Raw view",
+              "image_name": "securekernel.exe",
+              "binary_id": "reference-binary",
+              "path": "reference/securekernel.exe",
+              "display_name": "securekernel.exe",
+              "active": false,
+              "architecture": "aarch64",
+              "analysis_state": "IdleState",
+              "image_base": "0x0000000140000000",
+              "identity": {
+                "timestamp": 3350698326,
+                "size": 1245184,
+                "pdb": {
+                  "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                  "age": 1
+                }
+              },
+              "generation": [
+                "reference-binary",
+                5368709120,
+                14967
+              ],
+              "modified": false
+            },
+            "target": {
+              "file_sha256": "9a2eeb0e4a3d76aa9a6bfaf287540f5f1f7562d814e8ecb3c3f6df6b57a557b6",
+              "hash_source": "original Raw view",
+              "image_name": "securekernel.exe",
+              "binary_id": "target-binary",
+              "path": "target/securekernel.exe",
+              "display_name": "securekernel.exe",
+              "active": true,
+              "architecture": "aarch64",
+              "analysis_state": "IdleState",
+              "image_base": "0x0000000140000000",
+              "identity": {
+                "timestamp": 1188430604,
+                "size": 1290240,
+                "pdb": {
+                  "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                  "age": 1
+                }
+              },
+              "generation": [
+                "target-binary",
+                5368709120,
+                15039
+              ],
+              "modified": false
+            }
+          },
+          "match_count": 0,
+          "coverage_complete": false,
+          "unresolved_results": 0,
+          "error": {
+            "code": "stale",
+            "message": "comparison stop requested"
+          },
+          "side": "target",
+          "kind": "matches",
+          "items": [],
+          "total": 0,
+          "next_offset": null,
+          "truncated": false
+        },
+        "error": "Traceback (most recent call last):\n  File \"probe/similarity_lifecycle.py\", line 163, in run\n    assert report.get('results_error', {}).get('code') == 'stale', report.get('results_error')\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\nAssertionError: None\n",
+        "quit_action_available": true
+      },
+      "gui_exit": {
+        "exited": true,
+        "forced": false,
+        "returncode": -6
+      },
+      "companion_metadata_fix_applied": false
+    },
+    "close_view-v2": {
+      "capture_source_sha256": "767268ab0ffeab86c92002c8679011e36998fa15b1f2ad9be2614180eefeef9f",
+      "capture": {
+        "case": "close_view",
+        "bn_version": "6.0.10601 Personal",
+        "ok": false,
+        "inputs": [
+          {
+            "file_sha256": "9a2eeb0e4a3d76aa9a6bfaf287540f5f1f7562d814e8ecb3c3f6df6b57a557b6",
+            "hash_source": "original Raw view",
+            "image_name": "securekernel.exe",
+            "binary_id": "target-binary",
+            "path": "target/securekernel.exe",
+            "display_name": "securekernel.exe",
+            "active": true,
+            "architecture": "aarch64",
+            "analysis_state": "IdleState",
+            "image_base": "0x0000000140000000",
+            "identity": {
+              "timestamp": 1188430604,
+              "size": 1290240,
+              "pdb": {
+                "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                "age": 1
+              }
+            },
+            "generation": [
+              "target-binary",
+              5368709120,
+              15058
+            ],
+            "modified": false
+          },
+          {
+            "file_sha256": "65a014d83be9d2262e913d020425dc9bf0a301b6403dffa13e6fe7ae5460a57b",
+            "hash_source": "original Raw view",
+            "image_name": "securekernel.exe",
+            "binary_id": "reference-binary",
+            "path": "reference/securekernel.exe",
+            "display_name": "securekernel.exe",
+            "active": false,
+            "architecture": "aarch64",
+            "analysis_state": "IdleState",
+            "image_base": "0x0000000140000000",
+            "identity": {
+              "timestamp": 3350698326,
+              "size": 1245184,
+              "pdb": {
+                "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                "age": 1
+              }
+            },
+            "generation": [
+              "reference-binary",
+              5368709120,
+              14901
+            ],
+            "modified": false
+          }
+        ],
+        "before_action": {
+          "comparison_id": "close_view-v2-comparison",
+          "state": "running",
+          "active": true,
+          "closing": false,
+          "progress": null,
+          "stop_reason": null,
+          "providers": [
+            "Google BinDiff"
+          ],
+          "backend": "external",
+          "stage": "exporting",
+          "omitted_functions": {},
+          "binary_ids": {
+            "reference": "reference-binary",
+            "target": "target-binary"
+          },
+          "snapshots": {
+            "reference": {
+              "file_sha256": "65a014d83be9d2262e913d020425dc9bf0a301b6403dffa13e6fe7ae5460a57b",
+              "hash_source": "original Raw view",
+              "image_name": "securekernel.exe",
+              "binary_id": "reference-binary",
+              "path": "reference/securekernel.exe",
+              "display_name": "securekernel.exe",
+              "active": false,
+              "architecture": "aarch64",
+              "analysis_state": "IdleState",
+              "image_base": "0x0000000140000000",
+              "identity": {
+                "timestamp": 3350698326,
+                "size": 1245184,
+                "pdb": {
+                  "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                  "age": 1
+                }
+              },
+              "generation": [
+                "reference-binary",
+                5368709120,
+                14901
+              ],
+              "modified": false
+            },
+            "target": {
+              "file_sha256": "9a2eeb0e4a3d76aa9a6bfaf287540f5f1f7562d814e8ecb3c3f6df6b57a557b6",
+              "hash_source": "original Raw view",
+              "image_name": "securekernel.exe",
+              "binary_id": "target-binary",
+              "path": "target/securekernel.exe",
+              "display_name": "securekernel.exe",
+              "active": true,
+              "architecture": "aarch64",
+              "analysis_state": "IdleState",
+              "image_base": "0x0000000140000000",
+              "identity": {
+                "timestamp": 1188430604,
+                "size": 1290240,
+                "pdb": {
+                  "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                  "age": 1
+                }
+              },
+              "generation": [
+                "target-binary",
+                5368709120,
+                15058
+              ],
+              "modified": false
+            }
+          },
+          "match_count": 0,
+          "coverage_complete": false,
+          "unresolved_results": 0,
+          "error": null
+        },
+        "observed_stage": "exporting",
+        "active_process_before": {
+          "export_thread_alive": true,
+          "temporary_directory_exists": true,
+          "process_created": false,
+          "process_returncode": null,
+          "output_reader_alive": false
+        },
+        "heartbeat_before_action": 7,
+        "job_reason": null,
+        "job_phase": "partial",
+        "after_cleanup": {
+          "export_thread_alive": false,
+          "temporary_directory_exists": false,
+          "process_created": true,
+          "process_returncode": 0,
+          "output_reader_alive": false
+        },
+        "results_after": {
+          "comparison_id": "close_view-v2-comparison",
+          "state": "partial",
+          "active": false,
+          "closing": false,
+          "progress": null,
+          "stop_reason": null,
+          "providers": [
+            "Google BinDiff"
+          ],
+          "backend": "external",
+          "stage": "importing",
+          "omitted_functions": {
+            "reference": 8,
+            "target": 8
+          },
+          "binary_ids": {
+            "reference": "reference-binary",
+            "target": "target-binary"
+          },
+          "snapshots": {
+            "reference": {
+              "file_sha256": "65a014d83be9d2262e913d020425dc9bf0a301b6403dffa13e6fe7ae5460a57b",
+              "hash_source": "original Raw view",
+              "image_name": "securekernel.exe",
+              "binary_id": "reference-binary",
+              "path": "reference/securekernel.exe",
+              "display_name": "securekernel.exe",
+              "active": false,
+              "architecture": "aarch64",
+              "analysis_state": "IdleState",
+              "image_base": "0x0000000140000000",
+              "identity": {
+                "timestamp": 3350698326,
+                "size": 1245184,
+                "pdb": {
+                  "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                  "age": 1
+                }
+              },
+              "generation": [
+                "reference-binary",
+                5368709120,
+                14901
+              ],
+              "modified": false
+            },
+            "target": {
+              "file_sha256": "9a2eeb0e4a3d76aa9a6bfaf287540f5f1f7562d814e8ecb3c3f6df6b57a557b6",
+              "hash_source": "original Raw view",
+              "image_name": "securekernel.exe",
+              "binary_id": "target-binary",
+              "path": "target/securekernel.exe",
+              "display_name": "securekernel.exe",
+              "active": true,
+              "architecture": "aarch64",
+              "analysis_state": "IdleState",
+              "image_base": "0x0000000140000000",
+              "identity": {
+                "timestamp": 1188430604,
+                "size": 1290240,
+                "pdb": {
+                  "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                  "age": 1
+                }
+              },
+              "generation": [
+                "target-binary",
+                5368709120,
+                15058
+              ],
+              "modified": false
+            }
+          },
+          "match_count": 3109,
+          "coverage_complete": false,
+          "unresolved_results": 8,
+          "error": null,
+          "side": "target",
+          "kind": "matches",
+          "items": [
+            {
+              "result_id": "match_1",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 253,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9933071490757153,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14901
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x28028"
+                },
+                "address": "0x0000000140028028",
+                "name": "SkmiKsrMapPfnDatabaseEntry"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15058
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x28028"
+                },
+                "address": "0x0000000140028028",
+                "name": "SkmiKsrMapPfnDatabaseEntry"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_2",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 253,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9933071490757153,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14901
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x28170"
+                },
+                "address": "0x0000000140028170",
+                "name": "SkmiKsrPageMayContainSecrets"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15058
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x28170"
+                },
+                "address": "0x0000000140028170",
+                "name": "SkmiKsrPageMayContainSecrets"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_3",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 253,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9933071490757153,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14901
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x28180"
+                },
+                "address": "0x0000000140028180",
+                "name": "SkmmKsrEnumerateSecurePages"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15058
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x28180"
+                },
+                "address": "0x0000000140028180",
+                "name": "SkmmKsrEnumerateSecurePages"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_4",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 248,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9706877692486436,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14901
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x60000"
+                },
+                "address": "0x0000000140060000",
+                "name": "MxtKernelSp0ExceptionHandler"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15058
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x60000"
+                },
+                "address": "0x0000000140060000",
+                "name": "MxtKernelSp0ExceptionHandler"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_5",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 248,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9706877692486436,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14901
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x60080"
+                },
+                "address": "0x0000000140060080",
+                "name": "MxtKernelSp0InterruptHandler"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15058
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x60080"
+                },
+                "address": "0x0000000140060080",
+                "name": "MxtKernelSp0InterruptHandler"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_6",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 248,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9706877692486436,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14901
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x60100"
+                },
+                "address": "0x0000000140060100",
+                "name": "MxtKernelSp0FiqHandler"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15058
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x60100"
+                },
+                "address": "0x0000000140060100",
+                "name": "MxtKernelSp0FiqHandler"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_7",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 248,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9706877692486436,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14901
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x60180"
+                },
+                "address": "0x0000000140060180",
+                "name": "MxtKernelSp0SystemErrorHandler"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15058
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x60180"
+                },
+                "address": "0x0000000140060180",
+                "name": "MxtKernelSp0SystemErrorHandler"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_8",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 248,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9706877692486436,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14901
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x60200"
+                },
+                "address": "0x0000000140060200",
+                "name": "MxtKernelExceptionHandler"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15058
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x60200"
+                },
+                "address": "0x0000000140060200",
+                "name": "MxtKernelExceptionHandler"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_9",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 248,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9706877692486436,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14901
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x60280"
+                },
+                "address": "0x0000000140060280",
+                "name": "MxtKernelInterruptHandler"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15058
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x60280"
+                },
+                "address": "0x0000000140060280",
+                "name": "MxtKernelInterruptHandler"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_10",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 248,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9706877692486436,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14901
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x60300"
+                },
+                "address": "0x0000000140060300",
+                "name": "MxtKernelFiqHandler"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15058
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x60300"
+                },
+                "address": "0x0000000140060300",
+                "name": "MxtKernelFiqHandler"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_11",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 248,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9706877692486436,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14901
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x60380"
+                },
+                "address": "0x0000000140060380",
+                "name": "MxtKernelSystemErrorHandler"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15058
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x60380"
+                },
+                "address": "0x0000000140060380",
+                "name": "MxtKernelSystemErrorHandler"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_12",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 248,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9706877692486436,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14901
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x60400"
+                },
+                "address": "0x0000000140060400",
+                "name": "MxtUserExceptionHandler"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15058
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x60400"
+                },
+                "address": "0x0000000140060400",
+                "name": "MxtUserExceptionHandler"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_13",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 248,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9706877692486436,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14901
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x60480"
+                },
+                "address": "0x0000000140060480",
+                "name": "MxtUserInterruptHandler"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15058
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x60480"
+                },
+                "address": "0x0000000140060480",
+                "name": "MxtUserInterruptHandler"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_14",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 248,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9706877692486436,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14901
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x60500"
+                },
+                "address": "0x0000000140060500",
+                "name": "MxtUserFiqHandler"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15058
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x60500"
+                },
+                "address": "0x0000000140060500",
+                "name": "MxtUserFiqHandler"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_15",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 248,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9706877692486436,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14901
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x60580"
+                },
+                "address": "0x0000000140060580",
+                "name": "MxtUserSystemErrorHandler"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15058
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x60580"
+                },
+                "address": "0x0000000140060580",
+                "name": "MxtUserSystemErrorHandler"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_16",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 248,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9706877692486436,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14901
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x60600"
+                },
+                "address": "0x0000000140060600",
+                "name": "MxtUser32ExceptionHandler"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15058
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x60600"
+                },
+                "address": "0x0000000140060600",
+                "name": "MxtUser32ExceptionHandler"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_17",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 248,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9706877692486436,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14901
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x60680"
+                },
+                "address": "0x0000000140060680",
+                "name": "MxtUser32InterruptHandler"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15058
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x60680"
+                },
+                "address": "0x0000000140060680",
+                "name": "MxtUser32InterruptHandler"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_18",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 248,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9706877692486436,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14901
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x60700"
+                },
+                "address": "0x0000000140060700",
+                "name": "MxtUser32FiqHandler"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15058
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x60700"
+                },
+                "address": "0x0000000140060700",
+                "name": "MxtUser32FiqHandler"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_19",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 248,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9706877692486436,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14901
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x60780"
+                },
+                "address": "0x0000000140060780",
+                "name": "MxtUser32SystemErrorHandler"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15058
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x60780"
+                },
+                "address": "0x0000000140060780",
+                "name": "MxtUser32SystemErrorHandler"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_20",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 253,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9933071490757153,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14901
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x60800"
+                },
+                "address": "0x0000000140060800",
+                "name": "MxtFlushCurrentTb"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15058
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x60800"
+                },
+                "address": "0x0000000140060800",
+                "name": "MxtFlushCurrentTb"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_21",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 253,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9933071490757153,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14901
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x60830"
+                },
+                "address": "0x0000000140060830",
+                "name": "SkpPerformMicroExecWork"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15058
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x60830"
+                },
+                "address": "0x0000000140060830",
+                "name": "SkpPerformMicroExecWork"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_22",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 253,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9933071490757153,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14901
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61000"
+                },
+                "address": "0x0000000140061000",
+                "name": "SkCallNormalMode"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15058
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61000"
+                },
+                "address": "0x0000000140061000",
+                "name": "SkCallNormalMode"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_23",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 253,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9933071490757153,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14901
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61380"
+                },
+                "address": "0x0000000140061380",
+                "name": "SkeExitThreadWithReturn"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15058
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61380"
+                },
+                "address": "0x0000000140061380",
+                "name": "SkeExitThreadWithReturn"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_24",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 253,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9933071490757153,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14901
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x613c4"
+                },
+                "address": "0x00000001400613c4",
+                "name": "SkeExitThread"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15058
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x613c4"
+                },
+                "address": "0x00000001400613c4",
+                "name": "SkeExitThread"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_25",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 252,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9890130573694068,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14901
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61430"
+                },
+                "address": "0x0000000140061430",
+                "name": "SkpUserThreadStartup"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15058
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61430"
+                },
+                "address": "0x0000000140061430",
+                "name": "SkpUserThreadStartup"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_26",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 252,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9890130573694068,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14901
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61444"
+                },
+                "address": "0x0000000140061444",
+                "name": "SkpVtl0ResumeEntry"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15058
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61444"
+                },
+                "address": "0x0000000140061444",
+                "name": "SkpVtl0ResumeEntry"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_27",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 253,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9933071490757153,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14901
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61480"
+                },
+                "address": "0x0000000140061480",
+                "name": "SkpVtl1ResumeEntry"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15058
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61480"
+                },
+                "address": "0x0000000140061480",
+                "name": "SkpVtl1ResumeEntry"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_28",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 253,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9933071490757153,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14901
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x615c0"
+                },
+                "address": "0x00000001400615c0",
+                "name": "SkpVtl1ResumeStartup"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15058
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x615c0"
+                },
+                "address": "0x00000001400615c0",
+                "name": "SkpVtl1ResumeStartup"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_29",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 252,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9890130573694068,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14901
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61680"
+                },
+                "address": "0x0000000140061680",
+                "name": "SkpVtl1ResumeAp"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15058
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61680"
+                },
+                "address": "0x0000000140061680",
+                "name": "SkpVtl1ResumeAp"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_30",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 253,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9933071490757153,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14901
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61780"
+                },
+                "address": "0x0000000140061780",
+                "name": "SkSwitchToLimitedDispatchLoop"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15058
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61780"
+                },
+                "address": "0x0000000140061780",
+                "name": "SkSwitchToLimitedDispatchLoop"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_31",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 253,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9933071490757153,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14901
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x617c0"
+                },
+                "address": "0x00000001400617c0",
+                "name": "SkpSwitchToLimitedDispatchLoopPrcb"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15058
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x617c0"
+                },
+                "address": "0x00000001400617c0",
+                "name": "SkpSwitchToLimitedDispatchLoopPrcb"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_32",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 253,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9933071490757153,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14901
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x619c0"
+                },
+                "address": "0x00000001400619c0",
+                "name": "IumGenericSyscall"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15058
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x619c0"
+                },
+                "address": "0x00000001400619c0",
+                "name": "IumGenericSyscall"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_33",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 248,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9706877692486436,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14901
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x619f0"
+                },
+                "address": "0x00000001400619f0",
+                "name": "ZwWorkerFactoryWorkerReady"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15058
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x619f0"
+                },
+                "address": "0x00000001400619f0",
+                "name": "ZwWorkerFactoryWorkerReady"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_34",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14901
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61a00"
+                },
+                "address": "0x0000000140061a00",
+                "name": "ZwWaitForSingleObject"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15058
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61a00"
+                },
+                "address": "0x0000000140061a00",
+                "name": "ZwWaitForSingleObject"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_35",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14901
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61a10"
+                },
+                "address": "0x0000000140061a10",
+                "name": "ZwReleaseSemaphore"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15058
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61a10"
+                },
+                "address": "0x0000000140061a10",
+                "name": "ZwReleaseSemaphore"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_36",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14901
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61a20"
+                },
+                "address": "0x0000000140061a20",
+                "name": "ZwSetInformationThread"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15058
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61a20"
+                },
+                "address": "0x0000000140061a20",
+                "name": "ZwSetInformationThread"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_37",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14901
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61a30"
+                },
+                "address": "0x0000000140061a30",
+                "name": "ZwSetEvent"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15058
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61a30"
+                },
+                "address": "0x0000000140061a30",
+                "name": "ZwSetEvent"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_38",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14901
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61a40"
+                },
+                "address": "0x0000000140061a40",
+                "name": "ZwClose"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15058
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61a40"
+                },
+                "address": "0x0000000140061a40",
+                "name": "ZwClose"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_39",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14901
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61a50"
+                },
+                "address": "0x0000000140061a50",
+                "name": "ZwOpenKey"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15058
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61a50"
+                },
+                "address": "0x0000000140061a50",
+                "name": "ZwOpenKey"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_40",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14901
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61a60"
+                },
+                "address": "0x0000000140061a60",
+                "name": "ZwAllocateVirtualMemory"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15058
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61a60"
+                },
+                "address": "0x0000000140061a60",
+                "name": "ZwAllocateVirtualMemory"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_41",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14901
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61a70"
+                },
+                "address": "0x0000000140061a70",
+                "name": "ZwQueryInformationProcess"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15058
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61a70"
+                },
+                "address": "0x0000000140061a70",
+                "name": "ZwQueryInformationProcess"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_42",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14901
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61a80"
+                },
+                "address": "0x0000000140061a80",
+                "name": "ZwSetInformationProcess"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15058
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61a80"
+                },
+                "address": "0x0000000140061a80",
+                "name": "ZwSetInformationProcess"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_43",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14901
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61a90"
+                },
+                "address": "0x0000000140061a90",
+                "name": "ZwFreeVirtualMemory"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15058
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61a90"
+                },
+                "address": "0x0000000140061a90",
+                "name": "ZwFreeVirtualMemory"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_44",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14901
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61aa0"
+                },
+                "address": "0x0000000140061aa0",
+                "name": "ZwQueryInformationToken"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15058
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61aa0"
+                },
+                "address": "0x0000000140061aa0",
+                "name": "ZwQueryInformationToken"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_45",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14901
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61ab0"
+                },
+                "address": "0x0000000140061ab0",
+                "name": "ZwQueryVirtualMemory"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15058
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61ab0"
+                },
+                "address": "0x0000000140061ab0",
+                "name": "ZwQueryVirtualMemory"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_46",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14901
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61ac0"
+                },
+                "address": "0x0000000140061ac0",
+                "name": "ZwOpenThreadToken"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15058
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61ac0"
+                },
+                "address": "0x0000000140061ac0",
+                "name": "ZwOpenThreadToken"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_47",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14901
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61ad0"
+                },
+                "address": "0x0000000140061ad0",
+                "name": "ZwQueryInformationThread"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15058
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61ad0"
+                },
+                "address": "0x0000000140061ad0",
+                "name": "ZwQueryInformationThread"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_48",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14901
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61ae0"
+                },
+                "address": "0x0000000140061ae0",
+                "name": "ZwMapViewOfSection"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15058
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61ae0"
+                },
+                "address": "0x0000000140061ae0",
+                "name": "ZwMapViewOfSection"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_49",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14901
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61af0"
+                },
+                "address": "0x0000000140061af0",
+                "name": "ZwUnmapViewOfSection"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15058
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61af0"
+                },
+                "address": "0x0000000140061af0",
+                "name": "ZwUnmapViewOfSection"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_50",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14901
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61b00"
+                },
+                "address": "0x0000000140061b00",
+                "name": "ZwTerminateProcess"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15058
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61b00"
+                },
+                "address": "0x0000000140061b00",
+                "name": "ZwTerminateProcess"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_51",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14901
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61b10"
+                },
+                "address": "0x0000000140061b10",
+                "name": "ZwQueryPerformanceCounter"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15058
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61b10"
+                },
+                "address": "0x0000000140061b10",
+                "name": "ZwQueryPerformanceCounter"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_52",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14901
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61b20"
+                },
+                "address": "0x0000000140061b20",
+                "name": "ZwOpenFile"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15058
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61b20"
+                },
+                "address": "0x0000000140061b20",
+                "name": "ZwOpenFile"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_53",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14901
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61b30"
+                },
+                "address": "0x0000000140061b30",
+                "name": "ZwDelayExecution"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15058
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61b30"
+                },
+                "address": "0x0000000140061b30",
+                "name": "ZwDelayExecution"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_54",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14901
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61b40"
+                },
+                "address": "0x0000000140061b40",
+                "name": "ZwQuerySystemInformation"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15058
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61b40"
+                },
+                "address": "0x0000000140061b40",
+                "name": "ZwQuerySystemInformation"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_55",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14901
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61b50"
+                },
+                "address": "0x0000000140061b50",
+                "name": "ZwDuplicateObject"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15058
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61b50"
+                },
+                "address": "0x0000000140061b50",
+                "name": "ZwDuplicateObject"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_56",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14901
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61b60"
+                },
+                "address": "0x0000000140061b60",
+                "name": "ZwQueryAttributesFile"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15058
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61b60"
+                },
+                "address": "0x0000000140061b60",
+                "name": "ZwQueryAttributesFile"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_57",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14901
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61b70"
+                },
+                "address": "0x0000000140061b70",
+                "name": "ZwClearEvent"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15058
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61b70"
+                },
+                "address": "0x0000000140061b70",
+                "name": "ZwClearEvent"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_58",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14901
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61b80"
+                },
+                "address": "0x0000000140061b80",
+                "name": "ZwOpenEvent"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15058
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61b80"
+                },
+                "address": "0x0000000140061b80",
+                "name": "ZwOpenEvent"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_59",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14901
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61b90"
+                },
+                "address": "0x0000000140061b90",
+                "name": "ZwContinue"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15058
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61b90"
+                },
+                "address": "0x0000000140061b90",
+                "name": "ZwContinue"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_60",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14901
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61ba0"
+                },
+                "address": "0x0000000140061ba0",
+                "name": "ZwCreateEvent"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15058
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61ba0"
+                },
+                "address": "0x0000000140061ba0",
+                "name": "ZwCreateEvent"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_61",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14901
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61bb0"
+                },
+                "address": "0x0000000140061bb0",
+                "name": "ZwQueryVolumeInformationFile"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15058
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61bb0"
+                },
+                "address": "0x0000000140061bb0",
+                "name": "ZwQueryVolumeInformationFile"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_62",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14901
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61bc0"
+                },
+                "address": "0x0000000140061bc0",
+                "name": "ZwCreateSection"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15058
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61bc0"
+                },
+                "address": "0x0000000140061bc0",
+                "name": "ZwCreateSection"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_63",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14901
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61bd0"
+                },
+                "address": "0x0000000140061bd0",
+                "name": "ZwProtectVirtualMemory"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15058
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61bd0"
+                },
+                "address": "0x0000000140061bd0",
+                "name": "ZwProtectVirtualMemory"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_64",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14901
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61be0"
+                },
+                "address": "0x0000000140061be0",
+                "name": "ZwTerminateThread"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15058
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61be0"
+                },
+                "address": "0x0000000140061be0",
+                "name": "ZwTerminateThread"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_65",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14901
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61bf0"
+                },
+                "address": "0x0000000140061bf0",
+                "name": "ZwOpenDirectoryObject"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15058
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61bf0"
+                },
+                "address": "0x0000000140061bf0",
+                "name": "ZwOpenDirectoryObject"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_66",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14901
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61c00"
+                },
+                "address": "0x0000000140061c00",
+                "name": "ZwTraceEvent"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15058
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61c00"
+                },
+                "address": "0x0000000140061c00",
+                "name": "ZwTraceEvent"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_67",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14901
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61c10"
+                },
+                "address": "0x0000000140061c10",
+                "name": "ZwAlertMultipleThreadByThreadId"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15058
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61c10"
+                },
+                "address": "0x0000000140061c10",
+                "name": "ZwAlertMultipleThreadByThreadId"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_68",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14901
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61c20"
+                },
+                "address": "0x0000000140061c20",
+                "name": "ZwAlertThreadByThreadId"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15058
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61c20"
+                },
+                "address": "0x0000000140061c20",
+                "name": "ZwAlertThreadByThreadId"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_69",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14901
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61c30"
+                },
+                "address": "0x0000000140061c30",
+                "name": "ZwAlertThreadByThreadIdEx"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15058
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61c30"
+                },
+                "address": "0x0000000140061c30",
+                "name": "ZwAlertThreadByThreadIdEx"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_70",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14901
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61c40"
+                },
+                "address": "0x0000000140061c40",
+                "name": "ZwAllocateVirtualMemoryEx"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15058
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61c40"
+                },
+                "address": "0x0000000140061c40",
+                "name": "ZwAllocateVirtualMemoryEx"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_71",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14901
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61c50"
+                },
+                "address": "0x0000000140061c50",
+                "name": "ZwAlpcAcceptConnectPort"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15058
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61c50"
+                },
+                "address": "0x0000000140061c50",
+                "name": "ZwAlpcAcceptConnectPort"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_72",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14901
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61c60"
+                },
+                "address": "0x0000000140061c60",
+                "name": "ZwAlpcConnectPort"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15058
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61c60"
+                },
+                "address": "0x0000000140061c60",
+                "name": "ZwAlpcConnectPort"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_73",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14901
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61c70"
+                },
+                "address": "0x0000000140061c70",
+                "name": "ZwAlpcCreatePort"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15058
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61c70"
+                },
+                "address": "0x0000000140061c70",
+                "name": "ZwAlpcCreatePort"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_74",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14901
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61c80"
+                },
+                "address": "0x0000000140061c80",
+                "name": "ZwAlpcImpersonateClientOfPort"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15058
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61c80"
+                },
+                "address": "0x0000000140061c80",
+                "name": "ZwAlpcImpersonateClientOfPort"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_75",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14901
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61c90"
+                },
+                "address": "0x0000000140061c90",
+                "name": "ZwAlpcQueryInformation"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15058
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61c90"
+                },
+                "address": "0x0000000140061c90",
+                "name": "ZwAlpcQueryInformation"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_76",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 248,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9706877692486436,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14901
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61ca0"
+                },
+                "address": "0x0000000140061ca0",
+                "name": "ZwAlpcSendWaitReceivePort"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15058
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61ca0"
+                },
+                "address": "0x0000000140061ca0",
+                "name": "ZwAlpcSendWaitReceivePort"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_77",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14901
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61cb0"
+                },
+                "address": "0x0000000140061cb0",
+                "name": "ZwAlpcSetInformation"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15058
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61cb0"
+                },
+                "address": "0x0000000140061cb0",
+                "name": "ZwAlpcSetInformation"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_78",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14901
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61cc0"
+                },
+                "address": "0x0000000140061cc0",
+                "name": "ZwAreMappedFilesTheSame"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15058
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61cc0"
+                },
+                "address": "0x0000000140061cc0",
+                "name": "ZwAreMappedFilesTheSame"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_79",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14901
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61cd0"
+                },
+                "address": "0x0000000140061cd0",
+                "name": "ZwAssociateWaitCompletionPacket"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15058
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61cd0"
+                },
+                "address": "0x0000000140061cd0",
+                "name": "ZwAssociateWaitCompletionPacket"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_80",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14901
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61ce0"
+                },
+                "address": "0x0000000140061ce0",
+                "name": "ZwCallEnclave"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15058
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61ce0"
+                },
+                "address": "0x0000000140061ce0",
+                "name": "ZwCallEnclave"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_81",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14901
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61cf0"
+                },
+                "address": "0x0000000140061cf0",
+                "name": "ZwCancelTimer2"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15058
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61cf0"
+                },
+                "address": "0x0000000140061cf0",
+                "name": "ZwCancelTimer2"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_82",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14901
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61d00"
+                },
+                "address": "0x0000000140061d00",
+                "name": "ZwCancelWaitCompletionPacket"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15058
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61d00"
+                },
+                "address": "0x0000000140061d00",
+                "name": "ZwCancelWaitCompletionPacket"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_83",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14901
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61d10"
+                },
+                "address": "0x0000000140061d10",
+                "name": "ZwContinueEx"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15058
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61d10"
+                },
+                "address": "0x0000000140061d10",
+                "name": "ZwContinueEx"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_84",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14901
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61d20"
+                },
+                "address": "0x0000000140061d20",
+                "name": "ZwCreateIoCompletion"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15058
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61d20"
+                },
+                "address": "0x0000000140061d20",
+                "name": "ZwCreateIoCompletion"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_85",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14901
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61d30"
+                },
+                "address": "0x0000000140061d30",
+                "name": "ZwCreateSemaphore"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15058
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61d30"
+                },
+                "address": "0x0000000140061d30",
+                "name": "ZwCreateSemaphore"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_86",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14901
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61d40"
+                },
+                "address": "0x0000000140061d40",
+                "name": "ZwCreateThreadEx"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15058
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61d40"
+                },
+                "address": "0x0000000140061d40",
+                "name": "ZwCreateThreadEx"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_87",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14901
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61d50"
+                },
+                "address": "0x0000000140061d50",
+                "name": "ZwCreateTimer2"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15058
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61d50"
+                },
+                "address": "0x0000000140061d50",
+                "name": "ZwCreateTimer2"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_88",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14901
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61d60"
+                },
+                "address": "0x0000000140061d60",
+                "name": "ZwCreateWaitCompletionPacket"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15058
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61d60"
+                },
+                "address": "0x0000000140061d60",
+                "name": "ZwCreateWaitCompletionPacket"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_89",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14901
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61d70"
+                },
+                "address": "0x0000000140061d70",
+                "name": "ZwCreateWorkerFactory"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15058
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61d70"
+                },
+                "address": "0x0000000140061d70",
+                "name": "ZwCreateWorkerFactory"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_90",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 248,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9706877692486436,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14901
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61d80"
+                },
+                "address": "0x0000000140061d80",
+                "name": "ZwGetCurrentProcessorNumber"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15058
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61d80"
+                },
+                "address": "0x0000000140061d80",
+                "name": "ZwGetCurrentProcessorNumber"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_91",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14901
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61d90"
+                },
+                "address": "0x0000000140061d90",
+                "name": "ZwGetCurrentProcessorNumberEx"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15058
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61d90"
+                },
+                "address": "0x0000000140061d90",
+                "name": "ZwGetCurrentProcessorNumberEx"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_92",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14901
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61da0"
+                },
+                "address": "0x0000000140061da0",
+                "name": "ZwGetNlsSectionPtr"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15058
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61da0"
+                },
+                "address": "0x0000000140061da0",
+                "name": "ZwGetNlsSectionPtr"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_93",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14901
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61db0"
+                },
+                "address": "0x0000000140061db0",
+                "name": "ZwManageHotPatch"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15058
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61db0"
+                },
+                "address": "0x0000000140061db0",
+                "name": "ZwManageHotPatch"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_94",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14901
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61dc0"
+                },
+                "address": "0x0000000140061dc0",
+                "name": "ZwOpenKeyEx"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15058
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61dc0"
+                },
+                "address": "0x0000000140061dc0",
+                "name": "ZwOpenKeyEx"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_95",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14901
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61dd0"
+                },
+                "address": "0x0000000140061dd0",
+                "name": "ZwOpenProcessToken"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15058
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61dd0"
+                },
+                "address": "0x0000000140061dd0",
+                "name": "ZwOpenProcessToken"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_96",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14901
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61de0"
+                },
+                "address": "0x0000000140061de0",
+                "name": "ZwQueryDebugFilterState"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15058
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61de0"
+                },
+                "address": "0x0000000140061de0",
+                "name": "ZwQueryDebugFilterState"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_97",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14901
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61df0"
+                },
+                "address": "0x0000000140061df0",
+                "name": "ZwQuerySecurityObject"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15058
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61df0"
+                },
+                "address": "0x0000000140061df0",
+                "name": "ZwQuerySecurityObject"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_98",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14901
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61e00"
+                },
+                "address": "0x0000000140061e00",
+                "name": "ZwQuerySystemInformationEx"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15058
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61e00"
+                },
+                "address": "0x0000000140061e00",
+                "name": "ZwQuerySystemInformationEx"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_99",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14901
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61e10"
+                },
+                "address": "0x0000000140061e10",
+                "name": "ZwRaiseException"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15058
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61e10"
+                },
+                "address": "0x0000000140061e10",
+                "name": "ZwRaiseException"
+              },
+              "backend": "external"
+            },
+            {
+              "result_id": "match_100",
+              "provider": "Google BinDiff",
+              "similarity": 255,
+              "confidence": 250,
+              "raw_similarity": 1.0,
+              "raw_confidence": 0.9820137900379085,
+              "reference": {
+                "binary_id": "reference-binary",
+                "generation": [
+                  "reference-binary",
+                  5368709120,
+                  14901
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 3350698326,
+                    "size": 1245184,
+                    "pdb": {
+                      "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61e20"
+                },
+                "address": "0x0000000140061e20",
+                "name": "ZwReleaseWorkerFactoryWorker"
+              },
+              "target": {
+                "binary_id": "target-binary",
+                "generation": [
+                  "target-binary",
+                  5368709120,
+                  15058
+                ],
+                "coordinate": {
+                  "module": "securekernel",
+                  "image_name": "securekernel.exe",
+                  "identity": {
+                    "timestamp": 1188430604,
+                    "size": 1290240,
+                    "pdb": {
+                      "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                      "age": 1
+                    }
+                  },
+                  "rva": "0x61e20"
+                },
+                "address": "0x0000000140061e20",
+                "name": "ZwReleaseWorkerFactoryWorker"
+              },
+              "backend": "external"
+            }
+          ],
+          "total": 3109,
+          "next_offset": 100,
+          "truncated": true
+        },
+        "error": "Traceback (most recent call last):\n  File \"probe/similarity_lifecycle.py\", line 166, in run\n    assert job.reason == expected, (job.reason, expected)\n           ^^^^^^^^^^^^^^^^^^^^^^\nAssertionError: (None, 'stale')\n",
+        "quit_action_available": true,
+        "close_file_contexts_before_count": 2,
+        "close_file_contexts_after_count": 2
+      },
+      "gui_exit": {
+        "exited": true,
+        "forced": false,
+        "returncode": -6
+      },
+      "companion_metadata_fix_applied": false
+    },
+    "quit-v1": {
+      "capture_source_sha256": "73dbc91aefd56ebcaa71232b8c70d05eac59355c0471d8ed7fcc8892675a11f1",
+      "capture": {
+        "case": "quit",
+        "bn_version": "6.0.10601 Personal",
+        "ok": false,
+        "inputs": [
+          {
+            "file_sha256": "9a2eeb0e4a3d76aa9a6bfaf287540f5f1f7562d814e8ecb3c3f6df6b57a557b6",
+            "hash_source": "original Raw view",
+            "image_name": "securekernel.exe",
+            "binary_id": "target-binary",
+            "path": "target/securekernel.exe",
+            "display_name": "securekernel.exe",
+            "active": true,
+            "architecture": "aarch64",
+            "analysis_state": "IdleState",
+            "image_base": "0x0000000140000000",
+            "identity": {
+              "timestamp": 1188430604,
+              "size": 1290240,
+              "pdb": {
+                "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                "age": 1
+              }
+            },
+            "generation": [
+              "target-binary",
+              5368709120,
+              15084
+            ],
+            "modified": false
+          },
+          {
+            "file_sha256": "65a014d83be9d2262e913d020425dc9bf0a301b6403dffa13e6fe7ae5460a57b",
+            "hash_source": "original Raw view",
+            "image_name": "securekernel.exe",
+            "binary_id": "reference-binary",
+            "path": "reference/securekernel.exe",
+            "display_name": "securekernel.exe",
+            "active": false,
+            "architecture": "aarch64",
+            "analysis_state": "IdleState",
+            "image_base": "0x0000000140000000",
+            "identity": {
+              "timestamp": 3350698326,
+              "size": 1245184,
+              "pdb": {
+                "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                "age": 1
+              }
+            },
+            "generation": [
+              "reference-binary",
+              5368709120,
+              14987
+            ],
+            "modified": false
+          }
+        ],
+        "before_action": {
+          "comparison_id": "quit-v1-comparison",
+          "state": "running",
+          "active": true,
+          "closing": false,
+          "progress": null,
+          "stop_reason": null,
+          "providers": [
+            "Google BinDiff"
+          ],
+          "backend": "external",
+          "stage": "exporting",
+          "omitted_functions": {},
+          "binary_ids": {
+            "reference": "reference-binary",
+            "target": "target-binary"
+          },
+          "snapshots": {
+            "reference": {
+              "file_sha256": "65a014d83be9d2262e913d020425dc9bf0a301b6403dffa13e6fe7ae5460a57b",
+              "hash_source": "original Raw view",
+              "image_name": "securekernel.exe",
+              "binary_id": "reference-binary",
+              "path": "reference/securekernel.exe",
+              "display_name": "securekernel.exe",
+              "active": false,
+              "architecture": "aarch64",
+              "analysis_state": "IdleState",
+              "image_base": "0x0000000140000000",
+              "identity": {
+                "timestamp": 3350698326,
+                "size": 1245184,
+                "pdb": {
+                  "guid": "A10DC4DA2F667E4D5B50AA2DDBB5A323",
+                  "age": 1
+                }
+              },
+              "generation": [
+                "reference-binary",
+                5368709120,
+                14987
+              ],
+              "modified": false
+            },
+            "target": {
+              "file_sha256": "9a2eeb0e4a3d76aa9a6bfaf287540f5f1f7562d814e8ecb3c3f6df6b57a557b6",
+              "hash_source": "original Raw view",
+              "image_name": "securekernel.exe",
+              "binary_id": "target-binary",
+              "path": "target/securekernel.exe",
+              "display_name": "securekernel.exe",
+              "active": true,
+              "architecture": "aarch64",
+              "analysis_state": "IdleState",
+              "image_base": "0x0000000140000000",
+              "identity": {
+                "timestamp": 1188430604,
+                "size": 1290240,
+                "pdb": {
+                  "guid": "0A49C8CF92C9F8EC65C6D61180FDAE51",
+                  "age": 1
+                }
+              },
+              "generation": [
+                "target-binary",
+                5368709120,
+                15084
+              ],
+              "modified": false
+            }
+          },
+          "match_count": 0,
+          "coverage_complete": false,
+          "unresolved_results": 0,
+          "error": null
+        },
+        "observed_stage": "exporting",
+        "active_process_before": {
+          "export_thread_alive": true,
+          "temporary_directory_exists": true,
+          "process_created": false,
+          "process_returncode": null,
+          "output_reader_alive": false
+        },
+        "heartbeat_before_action": 5
+      },
+      "gui_exit": {
+        "exited": true,
+        "forced": true,
+        "returncode": -15
+      },
+      "companion_metadata_fix_applied": false
+    }
+  },
+  "crashes": [
+    {
+      "source_file": "binaryninja-2026-09-10-191354.ips",
+      "source_sha256": "2bfa5acf0a826c672c9ec975d98fca77e3281885e1f2a1195dfc18d9aeab1f37",
+      "pid": 7840,
+      "exception": {
+        "codes": "0x0000000000000000, 0x0000000000000000",
+        "rawCodes": [
+          0,
+          0
+        ],
+        "type": "EXC_CRASH",
+        "signal": "SIGABRT"
+      },
+      "frames": [
+        {
+          "symbol": "__pthread_kill",
+          "image": "libsystem_kernel.dylib",
+          "image_offset": 38376
+        },
+        {
+          "symbol": "pthread_kill",
+          "image": "libsystem_pthread.dylib",
+          "image_offset": 26840
+        },
+        {
+          "symbol": "abort",
+          "image": "libsystem_c.dylib",
+          "image_offset": 493944
+        },
+        {
+          "symbol": "malloc_vreport",
+          "image": "libsystem_malloc.dylib",
+          "image_offset": 55884
+        },
+        {
+          "symbol": "malloc_report",
+          "image": "libsystem_malloc.dylib",
+          "image_offset": 70312
+        },
+        {
+          "symbol": "___BUG_IN_CLIENT_OF_LIBMALLOC_POINTER_BEING_FREED_WAS_NOT_ALLOCATED",
+          "image": "libsystem_malloc.dylib",
+          "image_offset": 91796
+        },
+        {
+          "symbol": "QObjectPrivate::deleteChildren()",
+          "image": "QtCore",
+          "image_offset": 944424
+        },
+        {
+          "symbol": "QWidget::~QWidget()",
+          "image": "QtWidgets",
+          "image_offset": 297504
+        },
+        {
+          "symbol": null,
+          "image": "binaryninja",
+          "image_offset": 1027800
+        },
+        {
+          "symbol": null,
+          "image": "binaryninja",
+          "image_offset": 1028260
+        },
+        {
+          "symbol": "QObject::event(QEvent*)",
+          "image": "QtCore",
+          "image_offset": 948020
+        },
+        {
+          "symbol": "QWidget::event(QEvent*)",
+          "image": "QtWidgets",
+          "image_offset": 371712
+        },
+        {
+          "symbol": "QMainWindow::event(QEvent*)",
+          "image": "QtWidgets",
+          "image_offset": 1539024
+        },
+        {
+          "symbol": "QApplicationPrivate::notify_helper(QObject*, QEvent*)",
+          "image": "QtWidgets",
+          "image_offset": 51908
+        },
+        {
+          "symbol": "QApplication::notify(QObject*, QEvent*)",
+          "image": "QtWidgets",
+          "image_offset": 56132
+        },
+        {
+          "symbol": "QCoreApplicationPrivate::sendPostedEvents(QObject*, int, QThreadData*)",
+          "image": "QtCore",
+          "image_offset": 639960
+        }
+      ]
+    },
+    {
+      "source_file": "binaryninja-2026-09-10-212519.ips",
+      "source_sha256": "41e21e39bcee98c02bb052b62d899d646d3749cebea0f01aca5a2b9cda1cf138",
+      "pid": 11077,
+      "exception": {
+        "codes": "0x0000000000000000, 0x0000000000000000",
+        "rawCodes": [
+          0,
+          0
+        ],
+        "type": "EXC_CRASH",
+        "signal": "SIGABRT"
+      },
+      "frames": [
+        {
+          "symbol": "__pthread_kill",
+          "image": "libsystem_kernel.dylib",
+          "image_offset": 38376
+        },
+        {
+          "symbol": "pthread_kill",
+          "image": "libsystem_pthread.dylib",
+          "image_offset": 26840
+        },
+        {
+          "symbol": "abort",
+          "image": "libsystem_c.dylib",
+          "image_offset": 493944
+        },
+        {
+          "symbol": "malloc_vreport",
+          "image": "libsystem_malloc.dylib",
+          "image_offset": 55884
+        },
+        {
+          "symbol": "malloc_report",
+          "image": "libsystem_malloc.dylib",
+          "image_offset": 70312
+        },
+        {
+          "symbol": "___BUG_IN_CLIENT_OF_LIBMALLOC_POINTER_BEING_FREED_WAS_NOT_ALLOCATED",
+          "image": "libsystem_malloc.dylib",
+          "image_offset": 91796
+        },
+        {
+          "symbol": "QObjectPrivate::deleteChildren()",
+          "image": "QtCore",
+          "image_offset": 944424
+        },
+        {
+          "symbol": "QWidget::~QWidget()",
+          "image": "QtWidgets",
+          "image_offset": 297504
+        },
+        {
+          "symbol": null,
+          "image": "binaryninja",
+          "image_offset": 1027800
+        },
+        {
+          "symbol": null,
+          "image": "binaryninja",
+          "image_offset": 1028260
+        },
+        {
+          "symbol": "QObject::event(QEvent*)",
+          "image": "QtCore",
+          "image_offset": 948020
+        },
+        {
+          "symbol": "QWidget::event(QEvent*)",
+          "image": "QtWidgets",
+          "image_offset": 371712
+        },
+        {
+          "symbol": "QMainWindow::event(QEvent*)",
+          "image": "QtWidgets",
+          "image_offset": 1539024
+        },
+        {
+          "symbol": "QApplicationPrivate::notify_helper(QObject*, QEvent*)",
+          "image": "QtWidgets",
+          "image_offset": 51908
+        },
+        {
+          "symbol": "QApplication::notify(QObject*, QEvent*)",
+          "image": "QtWidgets",
+          "image_offset": 56132
+        },
+        {
+          "symbol": "QCoreApplicationPrivate::sendPostedEvents(QObject*, int, QThreadData*)",
+          "image": "QtCore",
+          "image_offset": 639960
+        }
+      ]
+    },
+    {
+      "source_file": "binaryninja-2026-09-10-212602.ips",
+      "source_sha256": "4acc69e96d9a98be19597b1c2791151de87a8dffe139c0eb656c245a62d78da3",
+      "pid": 11091,
+      "exception": {
+        "codes": "0x0000000000000000, 0x0000000000000000",
+        "rawCodes": [
+          0,
+          0
+        ],
+        "type": "EXC_CRASH",
+        "signal": "SIGABRT"
+      },
+      "frames": [
+        {
+          "symbol": "__pthread_kill",
+          "image": "libsystem_kernel.dylib",
+          "image_offset": 38376
+        },
+        {
+          "symbol": "pthread_kill",
+          "image": "libsystem_pthread.dylib",
+          "image_offset": 26840
+        },
+        {
+          "symbol": "abort",
+          "image": "libsystem_c.dylib",
+          "image_offset": 493944
+        },
+        {
+          "symbol": "malloc_vreport",
+          "image": "libsystem_malloc.dylib",
+          "image_offset": 55884
+        },
+        {
+          "symbol": "malloc_report",
+          "image": "libsystem_malloc.dylib",
+          "image_offset": 70312
+        },
+        {
+          "symbol": "___BUG_IN_CLIENT_OF_LIBMALLOC_POINTER_BEING_FREED_WAS_NOT_ALLOCATED",
+          "image": "libsystem_malloc.dylib",
+          "image_offset": 91796
+        },
+        {
+          "symbol": "QObjectPrivate::deleteChildren()",
+          "image": "QtCore",
+          "image_offset": 944424
+        },
+        {
+          "symbol": "QWidget::~QWidget()",
+          "image": "QtWidgets",
+          "image_offset": 297504
+        },
+        {
+          "symbol": null,
+          "image": "binaryninja",
+          "image_offset": 1027800
+        },
+        {
+          "symbol": null,
+          "image": "binaryninja",
+          "image_offset": 1028260
+        },
+        {
+          "symbol": "QObject::event(QEvent*)",
+          "image": "QtCore",
+          "image_offset": 948020
+        },
+        {
+          "symbol": "QWidget::event(QEvent*)",
+          "image": "QtWidgets",
+          "image_offset": 371712
+        },
+        {
+          "symbol": "QMainWindow::event(QEvent*)",
+          "image": "QtWidgets",
+          "image_offset": 1539024
+        },
+        {
+          "symbol": "QApplicationPrivate::notify_helper(QObject*, QEvent*)",
+          "image": "QtWidgets",
+          "image_offset": 51908
+        },
+        {
+          "symbol": "QApplication::notify(QObject*, QEvent*)",
+          "image": "QtWidgets",
+          "image_offset": 56132
+        },
+        {
+          "symbol": "QCoreApplicationPrivate::sendPostedEvents(QObject*, int, QThreadData*)",
+          "image": "QtCore",
+          "image_offset": 639960
+        }
+      ]
+    },
+    {
+      "source_file": "binaryninja-2026-09-10-212858.ips",
+      "source_sha256": "7c52e709a1df673d482e09046493bda239a9943d3b9f2a7188632914174784c9",
+      "pid": 11203,
+      "exception": {
+        "codes": "0x0000000000000000, 0x0000000000000000",
+        "rawCodes": [
+          0,
+          0
+        ],
+        "type": "EXC_CRASH",
+        "signal": "SIGABRT"
+      },
+      "frames": [
+        {
+          "symbol": "__pthread_kill",
+          "image": "libsystem_kernel.dylib",
+          "image_offset": 38376
+        },
+        {
+          "symbol": "pthread_kill",
+          "image": "libsystem_pthread.dylib",
+          "image_offset": 26840
+        },
+        {
+          "symbol": "abort",
+          "image": "libsystem_c.dylib",
+          "image_offset": 493944
+        },
+        {
+          "symbol": "malloc_vreport",
+          "image": "libsystem_malloc.dylib",
+          "image_offset": 55884
+        },
+        {
+          "symbol": "malloc_report",
+          "image": "libsystem_malloc.dylib",
+          "image_offset": 70312
+        },
+        {
+          "symbol": "___BUG_IN_CLIENT_OF_LIBMALLOC_POINTER_BEING_FREED_WAS_NOT_ALLOCATED",
+          "image": "libsystem_malloc.dylib",
+          "image_offset": 91796
+        },
+        {
+          "symbol": "QObjectPrivate::deleteChildren()",
+          "image": "QtCore",
+          "image_offset": 944424
+        },
+        {
+          "symbol": "QWidget::~QWidget()",
+          "image": "QtWidgets",
+          "image_offset": 297504
+        },
+        {
+          "symbol": null,
+          "image": "binaryninja",
+          "image_offset": 1027800
+        },
+        {
+          "symbol": null,
+          "image": "binaryninja",
+          "image_offset": 1028260
+        },
+        {
+          "symbol": "QObject::event(QEvent*)",
+          "image": "QtCore",
+          "image_offset": 948020
+        },
+        {
+          "symbol": "QWidget::event(QEvent*)",
+          "image": "QtWidgets",
+          "image_offset": 371712
+        },
+        {
+          "symbol": "QMainWindow::event(QEvent*)",
+          "image": "QtWidgets",
+          "image_offset": 1539024
+        },
+        {
+          "symbol": "QApplicationPrivate::notify_helper(QObject*, QEvent*)",
+          "image": "QtWidgets",
+          "image_offset": 51908
+        },
+        {
+          "symbol": "QApplication::notify(QObject*, QEvent*)",
+          "image": "QtWidgets",
+          "image_offset": 56132
+        },
+        {
+          "symbol": "QCoreApplicationPrivate::sendPostedEvents(QObject*, int, QThreadData*)",
+          "image": "QtCore",
+          "image_offset": 639960
+        }
+      ]
+    }
+  ],
+  "handoff": {
+    "status_source_sha256": "e70e8b444910467fcdae308bade35dc463ed24c089c735be4052eeab1cfebab0",
+    "status": {
+      "status": "stopped_before_execution",
+      "acceptance": "not_run",
+      "binary_ninja": {
+        "launched": false,
+        "owned_pids": [],
+        "profiles": []
+      },
+      "windbg": {
+        "dump_session_opened": false,
+        "owned_sessions": []
+      },
+      "transfer": {
+        "source": "docs/samples/052126-34312-01.dmp",
+        "completed": false,
+        "destination_exists_after_interrupt": false
+      },
+      "transport": {
+        "previous_owned_tunnel_pid": 10773,
+        "status": "exited"
+      },
+      "cleanup_complete": true
+    }
+  },
+  "limitations": [
+    "Probe ok flags describe in-process assertions and do not prove normal GUI exit.",
+    "Direct Qt quit failed to exit; several application Quit attempts aborted during widget destruction.",
+    "The cause of the invalid free has not been isolated to Binary Ninja, the companion or the probe.",
+    "Rebase staleness was observed, but the initial probe incorrectly expected stale result retrieval to throw.",
+    "Tab-close probes did not establish completed view closure before comparison completion.",
+    "Listener restart was not run after GUI testing was stopped."
+  ]
+}

--- a/docs/similarity-lifecycle-acceptance.md
+++ b/docs/similarity-lifecycle-acceptance.md
@@ -1,0 +1,71 @@
+# Similarity lifecycle acceptance — 2026-09-10
+
+The follow-up exercised BN 6.0.10601 Personal with the external BinDiff 8 backend
+against the verified ARM64 securekernel pair from the
+[CVE capture](cve-patch-diff-acceptance.md). Each case used an isolated GUI profile
+and an owned loopback listener. Tests observed a real active exporter or BinDiff
+process before issuing the action. No Windows binary was executed.
+
+The companion baseline is `0742c5e` (the same tree as the earlier `82f2d3a` capture).
+The comment-edit rerun also includes the `data_metadata_updated` notification fix
+and its regression test, now committed as `2eb95c5` in
+[companion PR #3](https://github.com/glslang/binja-windbg-mcp/pull/3).
+No other companion behavior was changed.
+
+## Recorded outcomes
+
+| Check | Result | Evidence and limits |
+|---|---|---|
+| Cancel during native export | Passed | Active export stopped; thread ended; temporary directory removed |
+| Cancel during external matching | Passed | Live BinDiff process reaped with SIGTERM; output reader stopped; temporary directory removed |
+| Close an active comparison | Passed | Matching process and temporary resources cleaned up; comparison removed |
+| Invalidate after a view comment edit | Passed with fix | Baseline missed the metadata notification; rerun staled the comparison and refused navigation with the old generation |
+| Rebase during export | Partial evidence | Comparison became stale; probe subsequently used an incorrect assertion about retained stale results |
+| Close a view during export | Not established | Probe did not establish completed view closure before comparison completion |
+| Listener restart during comparison | Not run | Further GUI testing stopped after repeated shutdown crashes |
+| Normal application quit | Failed | Direct Qt quit left processes alive; application Quit produced repeatable native aborts |
+| Guarded WinDbg handoff | Not run | Reachable WinDbg service reported zero sessions; dump-based follow-up stopped before opening a session |
+
+Cancelled/stale result retrieval may preserve partial evidence. Stale navigation
+must refuse the old generation; requiring every results call to throw was a probe
+error, not the companion contract. The rebase run is therefore retained as partial
+evidence rather than counted as full acceptance.
+
+The metadata fix handles `BinaryDataNotification.data_metadata_updated`, which
+view-level comment changes emit. It invalidates cached analysis, advances the view
+generation, and requests cancellation of affected comparisons. The real rerun
+refused stale navigation, and all 180 companion tests plus Ruff passed. This fix
+does not address the separate native shutdown crash.
+
+## Shutdown crash and process cleanup
+
+The recorded native crashes terminate with `SIGABRT` after an invalid-free report
+from the allocator, through `QObjectPrivate::deleteChildren()` and
+`QWidget::~QWidget()`. Repeated reports have the same leading stack frames and BN
+image offsets. The loaded Qt/PySide libraries in the inspected report come from
+the BN application bundle; no second Qt installation was observed there.
+
+The cause is not yet isolated to Binary Ninja, the companion, or the probe.
+An earlier ARM64 capture process (PID 7840) also has this crash signature, so
+observing that a process has exited is insufficient evidence of clean shutdown.
+Its completed comparison data remains valid; normal-quit acceptance does not.
+
+All owned GUI probes were stopped and a subsequent process check found no running
+Binary Ninja processes. No new GUI runs were launched after the user flagged the
+crashes and multiple instances. The handoff investigation left no owned debugger
+session or tunnel open. Further GUI acceptance should first isolate the crash in
+one disposable instance and verify its actual exit status.
+
+## Evidence
+
+[Sanitized lifecycle evidence](samples/similarity-lifecycle-20260910.json) contains
+eight case captures, process-exit outcomes, handoff cleanup status, and selected
+native crash frames with source hashes. A probe's `ok` flag covers its in-process
+assertions only; consult the separate `gui_exit` record before drawing shutdown
+conclusions. The edit rerun was terminated by the parent agent; its launcher's
+`forced: false` does not indicate a normal exit. Original
+failed probes were retained, including the assertions that need correction.
+
+These runs use the companion API and real GUI/listener lifecycle, rather than an
+additional MCP transport capture. They do not establish live WinDbg handoff,
+active listener restart, full view-close acceptance, or native Ultimate support.


### PR DESCRIPTION
Record the BN 6 Personal/external BinDiff ARM64 lifecycle acceptance results and update the similarity plan. Cancellation during export and matching, active comparison closure, and comment-edit invalidation have recorded evidence; the metadata invalidation fix is in https://github.com/glslang/binja-windbg-mcp/pull/3.

Preserve eight sanitized case captures, process exit outcomes, handoff cleanup status, and four native crash summaries. Correct the earlier ARM64 record: completed comparison captures do not establish clean application shutdown. Native shutdown aborts remain unisolated; rebase, view close, listener restart, and guarded WinDbg handoff acceptance remain incomplete. Ultimate remains tentative.

Validation:
- Markdown lint across README, changelog, docs and shipped skills: passed.
- `cargo fmt --all --check`, `git diff --check`, and evidence JSON/path checks: passed.
- Companion fix: 180 tests and Ruff passed; real comment-edit rerun rejected stale navigation.
- `cargo test --locked` attempted on macOS; compilation stopped in `windows-future` because Windows-only symbols (`IMarshal`, `marshaler`, `submit`) are unavailable on the host. No Rust source changed.

All owned GUI probes were stopped. No further GUI runs were performed for this PR.
