### PR TITLE
docs: record completed Binary Ninja companion plan

### DIFF
--- a/docs/binja-windbg-mcp-plan.md
+++ b/docs/binja-windbg-mcp-plan.md
@@ -1,8 +1,31 @@
 # Binary Ninja–WinDbg MCP Companion
 
+## Status — 2026-09-12
+
+Core V1 implementation and acceptance are complete for the identified ARM64 HEVD and
+mountmgr fixtures on Binary Ninja 6.0.10601 Personal. Personal/external BinDiff
+similarity, lifecycle checks and the generic guarded WinDbg handoff are also complete.
+The sections below retain the design contract and regression requirements; they are
+not a list of unfinished implementation tasks.
+
+| Deliverable | Recorded result |
+|---|---|
+| Official SDK, dependencies and UI lifecycle | Passed native dependency installation, authenticated HTTP, menus, analysis cancellation, invalidation and paired shutdown. See [bridge validation](binja-windbg-mcp-validation.md). |
+| WinDbg coordinates and structured memory | Implemented; Windows tests, enabled debugger smoke, guarded operations, surface goldens and result budgets passed. See [WinDbg verification](binja-windbg-mcp-validation.md#windbg-verification-2026-09-05). |
+| Driver analysis, evidence and pairing | HEVD and mountmgr static mappings, evidence undo, runtime access observations, focused actions, reconnect and module-replacement refusals passed. See [identified-driver acceptance](binja-windbg-mcp-validation.md#mountmgr-and-remaining-live-acceptance-2026-09-06). |
+| Personal similarity | GUI export/comparison, unchanged analysis, cancellation/edit/rebase/close/restart/quit and guarded debugger handoff passed. See [similarity acceptance](binja6-similarity-plan.md). |
+| Structured dispatch reachability | Implemented on 2026-09-10; text is preserved alongside paths, branch recipes and worker-attributed image coordinates. See [completed item 60](../DONE.md#60-windbg-mcp-structured-dispatch-reachability-paths-for-the-binary-ninja-bridge--done-2026-09-10). |
+
+[Follow-ups 61–65](../FOLLOWUPS.md#61-windbg-mcp-attribute-the-cve-2026-83498-fix-independently-of-similarity-scores)
+track CVE-fix attribution, a live securekernel handoff, upstream CLRBHB decoding,
+the upstream first-run-wizard shutdown fix, and native Ultimate validation. They do
+not gate Personal delivery. Ultimate remains deferred due to cost; the generic
+ARM64 handoff does not establish a securekernel/CVE-specific handoff. Publication
+is separate from implementation acceptance and was not requested for this delivery.
+
 ## Summary
 
-Create `binja-windbg-mcp`, a macOS-first Binary Ninja Python UI plugin exposing authenticated Streamable HTTP MCP. Initial support targets Apple Silicon macOS, Binary Ninja 6.0 Personal, and its Python 3.13 environment.
+`binja-windbg-mcp` is a macOS-first Binary Ninja Python UI plugin exposing authenticated Streamable HTTP MCP. Initial support targets Apple Silicon macOS, Binary Ninja 6.0 Personal, and its Python 3.13 environment.
 
 Use the official [modelcontextprotocol/python-sdk](https://github.com/modelcontextprotocol/python-sdk), distributed as `mcp`, for both the server and outbound WinDbg client. Pin a tested v2 release and its dependencies. Use its protocol and transport implementation; exclude third-party MCP frameworks and bridge projects.
 
@@ -136,9 +159,9 @@ Evidence edits are explicit, undoable, and append to existing comments. Evidence
 
 ## Verification and delivery
 
-Deliver in this order: official-SDK/UI compatibility proof; coordinate and memory contracts; explicit PE workspace and structured driver analysis; evidence edits; direct pairing and focused actions. Keep the existing host-orchestrated workflow usable throughout.
+Completed core deliverables comprise: official-SDK/UI compatibility proof; coordinate and memory contracts; explicit PE workspace and structured driver analysis; evidence edits; direct pairing and focused actions. The host-orchestrated workflow remains supported.
 
-Verification must cover:
+The recorded acceptance above covers the following requirements. Retain them as regression gates for relevant future changes; dated captures establish only their documented builds and environments:
 
 - **WinDbg:** mapped/unmapped/failed-attribution locations, running-target refusals, memory boundaries and partial reads, batch compatibility, structured errors, group membership, both surface goldens, and result budgets. Test module replacement between pairing and action: guarded operations must refuse without applying changes.
 - **Binary Ninja core:** rebased coordinates, duplicate views, identity mismatch, CTL decoding, conditional sizes, compare chains, jump tables, unresolved KMDF dispatch, missing types, bounded sink paths, partial composite results, and cache invalidation.
@@ -147,6 +170,6 @@ Verification must cover:
 - **End-to-end validation:** rerun the HEVD and mountmgr workflows against identified builds. Verify HEVD's actual dispatch mapping rather than a published table. Establish a complete mountmgr fixture separately from its abbreviated walkthrough, and compare static security evidence with independently observed runtime access.
 - **Required checks:** formatting and documentation lint; Windows-target checks/clippy from macOS; Windows `cargo test` and the explicitly enabled debugger smoke tier. Manually validate on Binary Ninja 6 Personal and a Windows WinDbg VM.
 
-Keep structured `reachable_from_dispatch` output as a separate follow-up: preserve text, expose paths and branch recipes, and perform worker-side module attribution for coordinate-bearing addresses. Tracked as windbg-mcp FOLLOWUPS.md item 60.
+Structured `reachable_from_dispatch` shipped separately from the original bridge, completing item 60 on 2026-09-10. It preserves text and exposes paths and branch recipes, with worker-side module attribution. Image identities are carried once in `images[]`; locations carry module names and RVAs. See [the coordinate contract](coordinates.md) and [completed item 60](../DONE.md#60-windbg-mcp-structured-dispatch-reachability-paths-for-the-binary-ninja-bridge--done-2026-09-10).
 
-Defer automatic binary acquisition, bulk runtime coverage import and report export. Any later coverage import must describe observed execution only; an unobserved location is not proof of unreachability.
+Automatic binary acquisition remains outside the plugin; the separate [MSRC patch-diff skill](../skills/msrc-patch-diff/SKILL.md) supplies the CVE-driven acquisition workflow. Bulk runtime coverage import and report export remain deferred. Any later coverage import must describe observed execution only; an unobserved location is not proof of unreachability.

--- a/docs/binja-windbg-mcp-validation.md
+++ b/docs/binja-windbg-mcp-validation.md
@@ -8,10 +8,10 @@ current companion exposes 22 tools after adding similarity; Personal comparison,
 lifecycle and generic WinDbg handoff acceptance are recorded in the
 [similarity plan](binja6-similarity-plan.md). The companion's
 [2026-09-12 preparation-race follow-up](https://github.com/glslang/binja-windbg-mcp/blob/main/docs/binja-windbg-mcp-validation.md#preparation-race-review-follow-up--2026-09-12)
-records 187 passing tests and Ruff checks after the final race fixes. A fresh
-2026-09-12 run against companion source `81f473e` also passed all 187 tests, with no
-skips, using a cached `uv` test environment whose 28 runtime packages matched the
-pinned requirements. The companion's runtime-only `.venv` lacked pytest; the
+records 187 passing tests and Ruff checks after the final race fixes. A post-rebase
+2026-09-12 run also passed all 187 tests, with no skips. Its companion runtime/test
+sources match merged baseline [`6fc0e44`](https://github.com/glslang/binja-windbg-mcp/commit/6fc0e44beab8ac53a66fc4dd9f24d356a3bd397d).
+The cached `uv` test environment matched all 28 pinned runtime package versions. The companion's runtime-only `.venv` lacked pytest; the
 [companion verification instructions](https://github.com/glslang/binja-windbg-mcp/blob/main/README.md#verification)
 now explicitly supply development tools. HTTP tests require loopback socket access.
 

--- a/docs/binja-windbg-mcp-validation.md
+++ b/docs/binja-windbg-mcp-validation.md
@@ -1,5 +1,25 @@
 # Binary Ninja bridge validation
 
+## Current acceptance status — 2026-09-12
+
+The core bridge acceptance below is complete for the identified HEVD/mountmgr
+builds. Its 16-tool counts and test totals are dated baseline measurements. The
+current companion exposes 22 tools after adding similarity; Personal comparison,
+lifecycle and generic WinDbg handoff acceptance are recorded in the
+[similarity plan](binja6-similarity-plan.md). The companion's
+[2026-09-12 preparation-race follow-up](https://github.com/glslang/binja-windbg-mcp/blob/main/docs/binja-windbg-mcp-validation.md#preparation-race-review-follow-up--2026-09-12)
+records 187 passing tests and Ruff checks after the final race fixes. A fresh
+2026-09-12 run against companion source `81f473e` also passed all 187 tests, with no
+skips, using a cached `uv` test environment whose 28 runtime packages matched the
+pinned requirements. The companion's runtime-only `.venv` lacked pytest; the
+[companion verification instructions](https://github.com/glslang/binja-windbg-mcp/blob/main/README.md#verification)
+now explicitly supply development tools. HTTP tests require loopback socket access.
+
+Structured dispatch reachability completed item 60 on 2026-09-10. The
+[integration plan](binja-windbg-mcp-plan.md#status--2026-09-12) distinguishes completed
+delivery from optional investigations and deferred Ultimate acceptance. The dated
+results below are historical evidence, not fresh Windows or GUI test runs.
+
 ## Companion 0.2 refactor (2026-09-06)
 
 The companion targets Binary Ninja 6.0.10601 Personal and Python 3.13. Its reduced surface
@@ -194,5 +214,6 @@ identified ARM64 HEVD/mountmgr builds in Binary Ninja 6.0.10601 Personal. These 
 not establish recovery for other builds, runtime execution of every static case, silo
 runtime behavior, force-quit cleanup, or other Windows security configurations. Partial
 security recovery and bounded sink traversal remain explicit supported outcomes.
-Structured `reachable_from_dispatch` remains follow-up #60; broader coverage import and
-report export remain deferred as specified in the [plan](binja-windbg-mcp-plan.md).
+Structured `reachable_from_dispatch` subsequently completed item 60 on 2026-09-10;
+broader coverage import and report export remain deferred as specified in the
+[plan](binja-windbg-mcp-plan.md).


### PR DESCRIPTION
The Binary Ninja integration plan still reads as unfinished work and defers structured dispatch reachability even though item #60 is complete. Add a dated delivery-status table with acceptance links, identify follow-ups #61–65 as outside Personal delivery gates, and clarify that CVE acquisition belongs to the separate skill while plugin acquisition, coverage import and report export remain outside the delivered scope.

Update the validation overview to distinguish historical baseline counts from the current 22-tool companion and record the fresh 187-test Python run. Preserve the original Windows and GUI acceptance scope. No Rust or runtime behavior changes.

Validation:

- `cargo fmt --all --check` passed.
- Markdown lint passed across README, changelog, docs and shipped skills; `git diff --check` passed.
- Cross-document links checked against both local repositories.
- Companion regression suite passed all 187 tests with loopback access, using a cached `uv` test environment matching all 28 runtime pins.
- Windows `cargo test` and live Binary Ninja/WinDbg captures were not rerun for this documentation-only change.

Follows #309; records completion of item #60 and retains follow-ups #61–65.

Companion documentation PR: https://github.com/glslang/binja-windbg-mcp/pull/6.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the implementation plan to record completed deliverables and acceptance results.
  - Documented structured dispatch reachability as completed, including image identity details.
  - Clarified remaining deferred work around automatic binary acquisition and broader coverage reporting.
  - Added validation results covering bridge acceptance, 22 tools, and 187 passing tests.
  - Updated verification guidance so recorded acceptance results serve as regression gates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->